### PR TITLE
Proposal for fine-grain control of package versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -115,6 +115,51 @@
     <VersionSuffix Condition=" '$(VersionDateSuffix)'!='' ">$(VersionSuffix)-$(VersionDateSuffix)</VersionSuffix>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" $(FullBuild)=='' ">
+    <FullBuild>true</FullBuild>
+  </PropertyGroup>
+
+  <!-- Inner dependency versions -->
+  <PropertyGroup Condition="$(FullBuild) != 'true'">
+    <OrleansCoreAbstractionsVersion>2.0.0</OrleansCoreAbstractionsVersion>
+    <OrleansRuntimeAbstractionsVersion>2.0.0</OrleansRuntimeAbstractionsVersion>
+    <OrleansCoreVersion>2.0.0</OrleansCoreVersion>
+    <OrleansRuntimeVersion>2.0.0</OrleansRuntimeVersion>
+    <OrleansCoreLegacyVersion>2.0.0</OrleansCoreLegacyVersion>
+    <OrleansRuntimeLegacyVersion>2.0.0</OrleansRuntimeLegacyVersion>
+    <OrleansProvidersVersion>2.0.0</OrleansProvidersVersion>
+    <OrleansExtensionsVersion>2.0.0</OrleansExtensionsVersion>
+    <OrleansEventSourcingVersion>2.0.0</OrleansEventSourcingVersion>
+    <OrleansAdoNetVersion>2.0.0</OrleansAdoNetVersion>
+    <OrleansAWSVersion>2.0.0</OrleansAWSVersion>
+    <OrleansAzureVersion>2.0.0</OrleansAzureVersion>
+    <OrleansTestingHostVersion>2.0.0</OrleansTestingHostVersion>
+    <OrleansTransactionsVersion>2.0.0</OrleansTransactionsVersion>
+    <OrleansServiceFabricVersion>2.0.0</OrleansServiceFabricVersion>
+    <OrleansSerializersVersion>2.0.0</OrleansSerializersVersion>
+    <OrleansToolsVersion>2.0.0</OrleansToolsVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(FullBuild) == 'true'">
+    <OrleansCoreAbstractionsVersion>$(VersionPrefix)</OrleansCoreAbstractionsVersion>
+    <OrleansRuntimeAbstractionsVersion>$(VersionPrefix)</OrleansRuntimeAbstractionsVersion>
+    <OrleansCoreVersion>$(VersionPrefix)</OrleansCoreVersion>
+    <OrleansRuntimeVersion>$(VersionPrefix)</OrleansRuntimeVersion>
+    <OrleansCoreLegacyVersion>$(VersionPrefix)</OrleansCoreLegacyVersion>
+    <OrleansRuntimeLegacyVersion>$(VersionPrefix)</OrleansRuntimeLegacyVersion>
+    <OrleansProvidersVersion>$(VersionPrefix)</OrleansProvidersVersion>
+    <OrleansExtensionsVersion>$(VersionPrefix)</OrleansExtensionsVersion>
+    <OrleansEventSourcingVersion>$(VersionPrefix)</OrleansEventSourcingVersion>
+    <OrleansAdoNetVersion>$(VersionPrefix)</OrleansAdoNetVersion>
+    <OrleansAWSVersion>$(VersionPrefix)</OrleansAWSVersion>
+    <OrleansAzureVersion>$(VersionPrefix)</OrleansAzureVersion>
+    <OrleansTestingHostVersion>$(VersionPrefix)</OrleansTestingHostVersion>
+    <OrleansTransactionsVersion>$(VersionPrefix)</OrleansTransactionsVersion>
+    <OrleansServiceFabricVersion>$(VersionPrefix)</OrleansServiceFabricVersion>
+    <OrleansSerializersVersion>$(VersionPrefix)</OrleansSerializersVersion>
+    <OrleansToolsVersion>$(VersionPrefix)</OrleansToolsVersion>
+  </PropertyGroup>
+
   <!-- Set output folder for created NuGet packages -->
   <PropertyGroup>
     <PackageOutputPath Condition=" '$(PackageOutputPath)'=='' ">$(SourceRoot)/Artifacts/$(Configuration)</PackageOutputPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,7 +106,7 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.0.3</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.1.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->
@@ -123,8 +123,8 @@
   <PropertyGroup Condition="$(FullBuild) != 'true'">
     <OrleansCoreAbstractionsVersion>2.0.0</OrleansCoreAbstractionsVersion>
     <OrleansRuntimeAbstractionsVersion>2.0.0</OrleansRuntimeAbstractionsVersion>
-    <OrleansCoreVersion>2.0.0</OrleansCoreVersion>
-    <OrleansRuntimeVersion>2.0.0</OrleansRuntimeVersion>
+    <OrleansCoreVersion>2.1.0</OrleansCoreVersion>
+    <OrleansRuntimeVersion>2.1.0</OrleansRuntimeVersion>
     <OrleansCoreLegacyVersion>2.0.0</OrleansCoreLegacyVersion>
     <OrleansRuntimeLegacyVersion>2.0.0</OrleansRuntimeLegacyVersion>
     <OrleansProvidersVersion>2.0.0</OrleansProvidersVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -133,11 +133,14 @@
     <OrleansAdoNetVersion>2.0.0</OrleansAdoNetVersion>
     <OrleansAWSVersion>2.0.0</OrleansAWSVersion>
     <OrleansAzureVersion>2.0.0</OrleansAzureVersion>
-    <OrleansTestingHostVersion>2.0.0</OrleansTestingHostVersion>
+    <OrleansTestingHostVersion>2.1.0</OrleansTestingHostVersion>
     <OrleansTransactionsVersion>2.0.0</OrleansTransactionsVersion>
     <OrleansServiceFabricVersion>2.0.0</OrleansServiceFabricVersion>
     <OrleansSerializersVersion>2.0.0</OrleansSerializersVersion>
     <OrleansToolsVersion>2.0.0</OrleansToolsVersion>
+    <OrleansClientVersion>2.0.0</OrleansClientVersion>
+    <OrleansServerVersion>2.0.0</OrleansServerVersion>
+    <OrleansCodegenVersion>2.0.0</OrleansCodegenVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="$(FullBuild) == 'true'">
@@ -158,6 +161,9 @@
     <OrleansServiceFabricVersion>$(VersionPrefix)</OrleansServiceFabricVersion>
     <OrleansSerializersVersion>$(VersionPrefix)</OrleansSerializersVersion>
     <OrleansToolsVersion>$(VersionPrefix)</OrleansToolsVersion>
+    <OrleansClientVersion>$(VersionPrefix)</OrleansClientVersion>
+    <OrleansServerVersion>$(VersionPrefix)</OrleansServerVersion>
+    <OrleansCodegenVersion>$(VersionPrefix)</OrleansCodegenVersion>
   </PropertyGroup>
 
   <!-- Set output folder for created NuGet packages -->

--- a/src/AWS/Directory.Build.props
+++ b/src/AWS/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAWSVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAWSVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>

--- a/src/AWS/Directory.Build.props
+++ b/src/AWS/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansAWSVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
@@ -21,8 +21,4 @@
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="$(AWSSDKDynamoDBv2Version)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
@@ -22,11 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Storage\" />
   </ItemGroup>
 </Project>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
@@ -25,7 +25,4 @@
     <Folder Include="Storage" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/AWS/Orleans.Streaming.SQS/Orleans.Streaming.SQS.csproj
+++ b/src/AWS/Orleans.Streaming.SQS/Orleans.Streaming.SQS.csproj
@@ -20,9 +20,4 @@
     <PackageReference Include="AWSSDK.SQS" Version="$(AWSSDKSQSVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/AWS/Orleans.Transactions.DynamoDB/Directory.Build.props
+++ b/src/AWS/Orleans.Transactions.DynamoDB/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansTransactionsVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Transactions\Orleans.Transactions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Transactions" Version="$(OrleansTransactionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/AdoNet/Directory.Build.props
+++ b/src/AdoNet/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansAdoNetVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/AdoNet/Directory.Build.props
+++ b/src/AdoNet/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAdoNetVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAdoNetVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -34,11 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Storage\" />
   </ItemGroup>
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -34,12 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="MySQL-Persistence.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>true</Pack>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -84,7 +84,4 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Directory.Build.props
+++ b/src/Azure/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>

--- a/src/Azure/Directory.Build.props
+++ b/src/Azure/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansAzureVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -26,11 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Utilities\" />
     <Folder Include="Storage\" />
   </ItemGroup>

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Directory.Build.props
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Directory.Build.props
@@ -1,0 +1,61 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansAzureVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansRuntimeVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Directory.Build.props
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>
@@ -46,7 +46,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>

--- a/src/Azure/Orleans.Hosting.ServiceFabric/Directory.Build.props
+++ b/src/Azure/Orleans.Hosting.ServiceFabric/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansAzureVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Azure/Orleans.Hosting.ServiceFabric/Directory.Build.props
+++ b/src/Azure/Orleans.Hosting.ServiceFabric/Directory.Build.props
@@ -20,20 +20,20 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime" Version="$(OrleansAzureVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansAzureVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>

--- a/src/Azure/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
+++ b/src/Azure/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
@@ -18,7 +18,4 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime\Orleans.Runtime.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -26,12 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Utilities\" />
     <Folder Include="Storage\" />
   </ItemGroup>

--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
@@ -25,7 +25,4 @@
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
+++ b/src/Azure/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
@@ -8,7 +8,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Hosting.ServiceFabric" Version="2.0.0" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -26,11 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Utilities\" />
     <Folder Include="Storage\" />
   </ItemGroup>

--- a/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
+++ b/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
@@ -27,11 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Utilities\" />
     <Folder Include="Storage\" />
   </ItemGroup>

--- a/src/Azure/Orleans.Transactions.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansTransactionsVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Transactions\Orleans.Transactions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Transactions" Version="$(OrleansTransactionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Client/Directory.Build.props
+++ b/src/Orleans.Client/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Client/Directory.Build.props
+++ b/src/Orleans.Client/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
-  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+  <PropertyGroup Condition="$(OrleansClientVersion)!=$(VersionPrefix)">
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansCoreVersion)">
       <ItemGroup >
         <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansClientVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Client/Orleans.Client.csproj
+++ b/src/Orleans.Client/Orleans.Client.csproj
@@ -6,9 +6,4 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Clustering.Consul/Directory.Build.props
+++ b/src/Orleans.Clustering.Consul/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansExtensionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>

--- a/src/Orleans.Clustering.Consul/Directory.Build.props
+++ b/src/Orleans.Clustering.Consul/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansExtensionsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
+++ b/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
@@ -15,8 +15,4 @@
     <PackageReference Include="Consul" Version="$(ConsulVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Clustering.ZooKeeper/Directory.Build.props
+++ b/src/Orleans.Clustering.ZooKeeper/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansExtensionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>

--- a/src/Orleans.Clustering.ZooKeeper/Directory.Build.props
+++ b/src/Orleans.Clustering.ZooKeeper/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansExtensionsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
+++ b/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
@@ -15,8 +15,4 @@
     <PackageReference Include="ZooKeeperNetEx" Version="$(ZooKeeperNetExVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.CodeGeneration.Build/Directory.Build.props
+++ b/src/Orleans.CodeGeneration.Build/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
-  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+  <PropertyGroup Condition="$(OrleansCodegenVersion)!=$(VersionPrefix)">
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Orleans.CodeGeneration.Build/Directory.Build.props
+++ b/src/Orleans.CodeGeneration.Build/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+</Project>

--- a/src/Orleans.CodeGeneration/Directory.Build.props
+++ b/src/Orleans.CodeGeneration/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.CodeGeneration/Directory.Build.props
+++ b/src/Orleans.CodeGeneration/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
-  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+  <PropertyGroup Condition="$(OrleansCodegenVersion)!=$(VersionPrefix)">
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansCodegenVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCodegenVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
+++ b/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Core.Abstractions/Directory.Build.props
+++ b/src/Orleans.Core.Abstractions/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreAbstractionsVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+</Project>

--- a/src/Orleans.Core.Legacy/Directory.Build.props
+++ b/src/Orleans.Core.Legacy/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreLegacyVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Core.Legacy/Directory.Build.props
+++ b/src/Orleans.Core.Legacy/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreLegacyVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Core.Legacy/Directory.Build.props
+++ b/src/Orleans.Core.Legacy/Directory.Build.props
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansCoreLegacyVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreLegacyVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Core.Legacy/Orleans.Core.Legacy.csproj
+++ b/src/Orleans.Core.Legacy/Orleans.Core.Legacy.csproj
@@ -19,8 +19,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Core/Directory.Build.props
+++ b/src/Orleans.Core/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansCoreAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Core/Directory.Build.props
+++ b/src/Orleans.Core/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreAbstractionsVersion) == $(VersionPrefix) AND $(OrleansCoreAbstractionsVersion) == $(OrleansCoreVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
       </ItemGroup>

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -53,7 +53,4 @@
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.EventSourcing/Directory.Build.props
+++ b/src/Orleans.EventSourcing/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansEventSourcingVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -40,7 +40,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansEventSourcingVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.EventSourcing/Directory.Build.props
+++ b/src/Orleans.EventSourcing/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansEventSourcingVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansEventSourcingVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansEventSourcingVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.EventSourcing/Directory.Build.props
+++ b/src/Orleans.EventSourcing/Directory.Build.props
@@ -20,20 +20,20 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansEventSourcingVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansEventSourcingVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansEventSourcingVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>

--- a/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
+++ b/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
@@ -16,9 +16,4 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Hosting.ServiceFabric/Directory.Build.props
+++ b/src/Orleans.Hosting.ServiceFabric/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansServiceFabricVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansServiceFabricVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Hosting.ServiceFabric/Directory.Build.props
+++ b/src/Orleans.Hosting.ServiceFabric/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansServiceFabricVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>

--- a/src/Orleans.PowerShell/Directory.Build.props
+++ b/src/Orleans.PowerShell/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansToolsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansToolsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.PowerShell/Directory.Build.props
+++ b/src/Orleans.PowerShell/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix) AND $(OrleansCoreLegacyVersion) == $(OrleansToolsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
       </ItemGroup>

--- a/src/Orleans.PowerShell/Orleans.PowerShell.csproj
+++ b/src/Orleans.PowerShell/Orleans.PowerShell.csproj
@@ -24,12 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="Microsoft.Orleans.OrleansPSUtils.psd1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Orleans.Runtime.Abstractions/Directory.Build.props
+++ b/src/Orleans.Runtime.Abstractions/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Runtime.Abstractions/Directory.Build.props
+++ b/src/Orleans.Runtime.Abstractions/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansRuntimeAbstractionsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Runtime.Abstractions/Directory.Build.props
+++ b/src/Orleans.Runtime.Abstractions/Directory.Build.props
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansRuntimeAbstractionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansRuntimeAbstractionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Runtime.Abstractions/Orleans.Runtime.Abstractions.csproj
+++ b/src/Orleans.Runtime.Abstractions/Orleans.Runtime.Abstractions.csproj
@@ -15,7 +15,4 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Runtime.Legacy/Directory.Build.props
+++ b/src/Orleans.Runtime.Legacy/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix) AND $(OrleansRuntimeLegacyVersion) == $(OrleansRuntimeLegacyVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
   
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansRuntimeLegacyVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>

--- a/src/Orleans.Runtime.Legacy/Directory.Build.props
+++ b/src/Orleans.Runtime.Legacy/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansRuntimeLegacyVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Runtime.Legacy/Orleans.Runtime.Legacy.csproj
+++ b/src/Orleans.Runtime.Legacy/Orleans.Runtime.Legacy.csproj
@@ -11,10 +11,4 @@
     <RootNamespace>Orleans.Runtime.Legacy</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Runtime/Directory.Build.props
+++ b/src/Orleans.Runtime/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansRuntimeVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
@@ -33,7 +33,7 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansRuntimeVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>

--- a/src/Orleans.Runtime/Directory.Build.props
+++ b/src/Orleans.Runtime/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansRuntimeVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Runtime/Directory.Build.props
+++ b/src/Orleans.Runtime/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansRuntimeVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansRuntimeVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Runtime/Orleans.Runtime.csproj
+++ b/src/Orleans.Runtime/Orleans.Runtime.csproj
@@ -15,9 +15,4 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.Server/Directory.Build.props
+++ b/src/Orleans.Server/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansRuntimeVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansRuntimeVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Server/Directory.Build.props
+++ b/src/Orleans.Server/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
-  <PropertyGroup Condition="$(OrleansRuntimeVersion)!=$(VersionPrefix)">
+  <PropertyGroup Condition="$(OrleansServerVersion)!=$(VersionPrefix)">
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,27 +20,27 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansServerVersion)">
       <ItemGroup >
         <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansServerVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansServerVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansRuntimeVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansServerVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Server/Orleans.Server.csproj
+++ b/src/Orleans.Server/Orleans.Server.csproj
@@ -6,10 +6,4 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
-    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.ServiceFabric/Directory.Build.props
+++ b/src/Orleans.ServiceFabric/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansServiceFabricVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Hosting.ServiceFabric" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Orleans.Streaming.GCP/Directory.Build.props
+++ b/src/Orleans.Streaming.GCP/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
+++ b/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
@@ -20,9 +20,4 @@
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="$(GoogleCloudPubSubV1Version)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Orleans.TestingHost/Directory.Build.props
+++ b/src/Orleans.TestingHost/Directory.Build.props
@@ -20,33 +20,33 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansTestingHostVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansTestingHostVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansTestingHostVersion)">
       <ItemGroup >
         <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansTestingHostVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix) AND $(OrleansRuntimeVersion) == $(OrleansTestingHostVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>

--- a/src/Orleans.TestingHost/Directory.Build.props
+++ b/src/Orleans.TestingHost/Directory.Build.props
@@ -1,0 +1,61 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansTestingHostVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.TestingHost/Orleans.TestingHost.csproj
+++ b/src/Orleans.TestingHost/Orleans.TestingHost.csproj
@@ -17,13 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
-    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="ClientConfigurationForTesting.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Orleans.Transactions/Directory.Build.props
+++ b/src/Orleans.Transactions/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix) AND $(OrleansTransactionsVersion) == $(OrleansTransactionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
       </ItemGroup>

--- a/src/Orleans.Transactions/Directory.Build.props
+++ b/src/Orleans.Transactions/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansTransactionsVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansTransactionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Transactions/Orleans.Transactions.csproj
+++ b/src/Orleans.Transactions/Orleans.Transactions.csproj
@@ -12,9 +12,4 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/OrleansCounterControl/Directory.Build.props
+++ b/src/OrleansCounterControl/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansToolsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansExtensionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\TelemetryConsumers\Orleans.TelemetryConsumers.Counters\Orleans.TelemetryConsumers.Counters.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/OrleansCounterControl/Directory.Build.props
+++ b/src/OrleansCounterControl/Directory.Build.props
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansExtensionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansExtensionsVersion) == $(VersionPrefix) AND $(OrleansExtensionsVersion) == $(OrleansToolsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\TelemetryConsumers\Orleans.TelemetryConsumers.Counters\Orleans.TelemetryConsumers.Counters.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="$(OrleansExtensionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="$(OrleansToolsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/OrleansCounterControl/OrleansCounterControl.csproj
+++ b/src/OrleansCounterControl/OrleansCounterControl.csproj
@@ -18,12 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\TelemetryConsumers\Orleans.TelemetryConsumers.Counters\Orleans.TelemetryConsumers.Counters.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="app.manifest">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>

--- a/src/OrleansManager/Directory.Build.props
+++ b/src/OrleansManager/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansToolsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/OrleansManager/Directory.Build.props
+++ b/src/OrleansManager/Directory.Build.props
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix) AND $(OrleansCoreLegacyVersion) == $(OrleansToolsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansToolsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/OrleansManager/OrleansManager.csproj
+++ b/src/OrleansManager/OrleansManager.csproj
@@ -21,12 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="README.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/OrleansProviders/Directory.Build.props
+++ b/src/OrleansProviders/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansProvidersVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/OrleansProviders/Directory.Build.props
+++ b/src/OrleansProviders/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansProvidersVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -40,7 +40,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansProvidersVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/OrleansProviders/Directory.Build.props
+++ b/src/OrleansProviders/Directory.Build.props
@@ -20,27 +20,27 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansProvidersVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansProvidersVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansProvidersVersion)">
       <ItemGroup >
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansProvidersVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -11,9 +11,4 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Serializers/Directory.Build.props
+++ b/src/Serializers/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansSerializersVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansSerializersVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>

--- a/src/Serializers/Directory.Build.props
+++ b/src/Serializers/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansSerializersVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansSerializersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansSerializersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Serializers/Orleans.Serialization.Bond/Orleans.Serialization.Bond.csproj
+++ b/src/Serializers/Orleans.Serialization.Bond/Orleans.Serialization.Bond.csproj
@@ -15,7 +15,4 @@
     <PackageReference Include="Bond.Core.CSharp" Version="$(BondCoreCSharpVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Serializers/Orleans.Serialization.Protobuf/Orleans.Serialization.Protobuf.csproj
+++ b/src/Serializers/Orleans.Serialization.Protobuf/Orleans.Serialization.Protobuf.csproj
@@ -15,7 +15,4 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Serializers/Orleans.Serialization.ProtobufNet/Orleans.Serialization.ProtobufNet.csproj
+++ b/src/Serializers/Orleans.Serialization.ProtobufNet/Orleans.Serialization.ProtobufNet.csproj
@@ -15,7 +15,4 @@
     <PackageReference Include="protobuf-net" Version="$(ProtobufNetVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/TelemetryConsumers/Directory.Build.props
+++ b/src/TelemetryConsumers/Directory.Build.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansExtensionsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/TelemetryConsumers/Directory.Build.props
+++ b/src/TelemetryConsumers/Directory.Build.props
@@ -20,27 +20,27 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansExtensionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansExtensionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix)">
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansExtensionsVersion)">
       <ItemGroup >
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansExtensionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/TelemetryConsumers/Directory.Build.props
+++ b/src/TelemetryConsumers/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansExtensionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -40,7 +40,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansExtensionsVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/Orleans.TelemetryConsumers.AI.csproj
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/Orleans.TelemetryConsumers.AI.csproj
@@ -15,9 +15,4 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
@@ -22,12 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="OrleansPerformanceCounterInstaller.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.NewRelic/Orleans.TelemetryConsumers.NewRelic.csproj
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.NewRelic/Orleans.TelemetryConsumers.NewRelic.csproj
@@ -15,10 +15,5 @@
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent.Api" Version="$(NewRelicAgentApiVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-  </ItemGroup>
+  
 </Project>

--- a/test/Benchmarks/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks/Benchmarks.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Azure\Orleans.Transactions.AzureStorage\Orleans.Transactions.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\Serializers\Orleans.Serialization.ProtobufNet\Orleans.Serialization.ProtobufNet.csproj" />
     <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />

--- a/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
+++ b/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
@@ -6,7 +6,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core\Orleans.Core.csproj" />
-  </ItemGroup>
 </Project>

--- a/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
+++ b/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Transactions\Orleans.Transactions.csproj" />
     <ProjectReference Include="..\BenchmarkGrainInterfaces\BenchmarkGrainInterfaces.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Grains/BenchmarkGrains/Directory.Build.props
+++ b/test/Grains/BenchmarkGrains/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTransactionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Transactions\Orleans.Transactions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Transactions" Version="$(OrleansTransactionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/Grains/Directory.Build.props
+++ b/test/Grains/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansCoreAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/Grains/TestFSharp/TestFSharp.fsproj
+++ b/test/Grains/TestFSharp/TestFSharp.fsproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core\Orleans.Core.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
   </ItemGroup>
 

--- a/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\Misc\TestInterfaces\TestInterfaces.csproj" />
     <ProjectReference Include="..\..\Misc\TestFSharpInterfaces\TestFSharpInterfaces.fsproj" />
   </ItemGroup>

--- a/test/Grains/TestGrains/Directory.Build.props
+++ b/test/Grains/TestGrains/Directory.Build.props
@@ -1,0 +1,60 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansEventSourcingVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.EventSourcing" Version="$(OrleansEventSourcingVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/test/Grains/TestGrains/TestGrains.csproj
+++ b/test/Grains/TestGrains/TestGrains.csproj
@@ -13,9 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\..\..\src\OrleansProviders\OrleansProviders.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\..\Misc\TestInterfaces\TestInterfaces.csproj" />
     <ProjectReference Include="..\..\Misc\TestFSharpInterfaces\TestFSharpInterfaces.fsproj" />

--- a/test/Grains/TestInternalGrains/Directory.Build.props
+++ b/test/Grains/TestInternalGrains/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="$(OrleansRuntimeVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/Grains/TestInternalGrains/TestInternalGrains.csproj
+++ b/test/Grains/TestInternalGrains/TestInternalGrains.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Runtime\Orleans.Runtime.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestGrains\TestGrains.csproj" />
     <ProjectReference Include="..\..\Misc\TestInterfaces\TestInterfaces.csproj" />

--- a/test/Grains/TestVersionGrains/TestVersionGrains.csproj
+++ b/test/Grains/TestVersionGrains/TestVersionGrains.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />
     <ProjectReference Include="..\..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />

--- a/test/Grains/TestVersionGrains2/TestVersionGrains2.csproj
+++ b/test/Grains/TestVersionGrains2/TestVersionGrains2.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />
     <ProjectReference Include="..\..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />

--- a/test/NetCore.Tests/Directory.Build.props
+++ b/test/NetCore.Tests/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/NetCore.Tests/NetCore.Tests.csproj
+++ b/test/NetCore.Tests/NetCore.Tests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
     <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\Grains\TestGrains\TestGrains.csproj" />
   </ItemGroup>

--- a/test/NetCore.Tests/NetCore.Tests.csproj
+++ b/test/NetCore.Tests/NetCore.Tests.csproj
@@ -11,10 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
-    <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
-    <ProjectReference Include="..\Grains\TestGrains\TestGrains.csproj" />
+    <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
+    <ProjectReference Include="..\TestGrains\TestGrains.csproj" />
   </ItemGroup>
   
 </Project>

--- a/test/NetCore.Tests/NetCore.Tests.csproj
+++ b/test/NetCore.Tests/NetCore.Tests.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
-    <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
-    <ProjectReference Include="..\TestGrains\TestGrains.csproj" />
+    <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
+    <ProjectReference Include="..\Grains\TestGrains\TestGrains.csproj" />
   </ItemGroup>
   
 </Project>

--- a/test/NonSilo.Tests/Directory.Build.props
+++ b/test/NonSilo.Tests/Directory.Build.props
@@ -61,7 +61,7 @@
   <Choose>
     <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
       <ItemGroup >
-        <ProjectReference Include="..\..\src\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
+        <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/test/NonSilo.Tests/Directory.Build.props
+++ b/test/NonSilo.Tests/Directory.Build.props
@@ -1,0 +1,73 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreAbstractionsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansCoreAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansServiceBus" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/test/NonSilo.Tests/NonSilo.Tests.csproj
+++ b/test/NonSilo.Tests/NonSilo.Tests.csproj
@@ -5,9 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
-    <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
     <ProjectReference Include="..\Tester\Tester.csproj" />
     <ProjectReference Include="..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
     <ProjectReference Include="..\Grains\TestGrains\TestGrains.csproj" />

--- a/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Serialization
         }
 
         /// <summary>
-        /// Types with an ancestor marked with <see cref="KnownBaseTypeAttribute"/> should have serializers generated.
+        /// Types with an ancestor marked with KnownBaseTypeAttribute should have serializers generated.
         /// </summary>
         [Fact]
         public void SerializationTests_TypeWithWellKnownBaseClass()

--- a/test/Orleans.TestingHost.Legacy/Directory.Build.props
+++ b/test/Orleans.TestingHost.Legacy/Directory.Build.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/TestInfrastructure/Directory.Build.props
+++ b/test/TestInfrastructure/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/TestInfrastructure/Orleans.TestingHost.AppDomain/Orleans.TestingHost.AppDomain.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.AppDomain/Orleans.TestingHost.AppDomain.csproj
@@ -20,9 +20,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Runtime\Orleans.Runtime.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/test/TestInfrastructure/Orleans.TestingHost.Legacy/Directory.Build.props
+++ b/test/TestInfrastructure/Orleans.TestingHost.Legacy/Directory.Build.props
@@ -1,0 +1,61 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/TestInfrastructure/Orleans.TestingHost.Legacy/Orleans.TestingHost.Legacy.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.Legacy/Orleans.TestingHost.Legacy.csproj
@@ -16,10 +16,4 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\TestExtensions\TestExtensions.csproj" />
   </ItemGroup>
 

--- a/test/TestInfrastructure/TestExtensions/TestExtensions.csproj
+++ b/test/TestInfrastructure/TestExtensions/TestExtensions.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\Orleans.TestingHost.Legacy\Orleans.TestingHost.Legacy.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -19,7 +19,7 @@ namespace Tester.ClientConnectionTests
     public class ClusterClientTests : TestClusterPerTest
     {
         /// <summary>
-        /// Ensures that <see "ClusterClient.Connect" /> can be retried.
+        /// Ensures that ClusterClient.Connect can be retried.
         /// </summary>
         [Fact]
         public async Task ConnectIsRetryableTest()

--- a/test/Tester/Directory.Build.props
+++ b/test/Tester/Directory.Build.props
@@ -1,0 +1,138 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansServiceBus" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansEventSourcingVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.EventSourcing" Version="$(OrleansEventSourcingVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/test/Tester/Directory.Build.props
+++ b/test/Tester/Directory.Build.props
@@ -48,7 +48,7 @@
   <Choose>
     <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
       <ItemGroup >
-        <ProjectReference Include="..\..\src\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
+        <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.EventHubs\Orleans.Streaming.EventHubs.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -113,7 +113,7 @@
   <Choose>
     <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
       <ItemGroup >
-        <ProjectReference Include="..\..\src\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
+        <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -126,7 +126,7 @@
   <Choose>
     <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
       <ItemGroup >
-        <ProjectReference Include="..\..\src\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
+        <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -13,14 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
     <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
     <ProjectReference Include="..\..\src\Orleans.CodeGeneration\Orleans.CodeGeneration.csproj" />
     <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
     <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj" />
     <ProjectReference Include="..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -13,14 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Azure\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.CodeGeneration\Orleans.CodeGeneration.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
-    <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj" />
     <ProjectReference Include="..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />
     <ProjectReference Include="..\TestInfrastructure\Orleans.TestingHost.Legacy\Orleans.TestingHost.Legacy.csproj" />
     <ProjectReference Include="..\Grains\TestGrains\TestGrains.csproj" />

--- a/test/TesterInternal/Directory.Build.props
+++ b/test/TesterInternal/Directory.Build.props
@@ -1,0 +1,100 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansCoreVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansTestingHostVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="$(OrleansTestingHostVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansAzureVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="$(OrleansAzureVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansCoreLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansCoreLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeLegacyVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansRuntimeLegacyVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansToolsVersion) == $(VersionPrefix)">
+      <ItemGroup >
+        <ProjectReference Include="..\..\src\OrleansCounterControl\OrleansCounterControl.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.CounterControl" Version="$(OrleansToolsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
     <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\src\OrleansCounterControl\OrleansCounterControl.csproj" />

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -22,11 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
-    <ProjectReference Include="..\..\src\OrleansCounterControl\OrleansCounterControl.csproj" />
-    <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />
     <ProjectReference Include="..\TestInfrastructure\Orleans.TestingHost.Legacy\Orleans.TestingHost.Legacy.csproj" />
     <ProjectReference Include="..\Tester\Tester.csproj" />


### PR DESCRIPTION
This is a proposal for #4445.

https://github.com/dotnet/orleans/commit/4d9e8de210f8542a5b8533dd0f74b98be2825b78 defines the build variables.

https://github.com/dotnet/orleans/commit/0689e7ff27cb613eb257cae4325f84736795f7fd moves intra-solution project references from .csproj files into per-directory `Directory
.Build.props` files and conditions them to either point to a .csproj or to a NuGet package.

https://github.com/dotnet/orleans/commit/1c8c1574479b0b9a9a71a2142c87004dd0d97f42 sets the target version for `Core` and `Runtime` to 2.1.0 for the next minor release.