### PR TITLE
fix orleans integration with third party DI solution which requires public constructor

### DIFF
--- a/src/Orleans.Core.Abstractions/Placement/StatelessWorkerPlacement.cs
+++ b/src/Orleans.Core.Abstractions/Placement/StatelessWorkerPlacement.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
 
         public int MaxLocal { get; private set; }
 
-        internal StatelessWorkerPlacement(int maxLocal = -1)
+        public StatelessWorkerPlacement(int maxLocal = -1)
         {
             // If maxLocal was not specified on the StatelessWorkerAttribute, 
             // we will use the defaultMaxStatelessWorkers, which is System.Environment.ProcessorCount.

--- a/test/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/test/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.4.0" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -15,6 +15,7 @@ using Orleans.Hosting;
 using Orleans.Providers.Streams.Common;
 using Orleans.ServiceBus.Providers.Testing;
 using Orleans.Configuration;
+using StructureMap;
 
 namespace ServiceBus.Tests.MonitorTests
 {
@@ -43,6 +44,12 @@ namespace ServiceBus.Tests.MonitorTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
+                        .UseServiceProviderFactory(services =>
+                        {
+                            var ctr = new Container();
+                            ctr.Populate(services);
+                            return ctr.GetInstance<IServiceProvider>();
+                        })
                         .AddPersistentStreams(StreamProviderName, EHStreamProviderForMonitorTestsAdapterFactory.Create, b=>b
                         .ConfigureComponent<IStreamQueueCheckpointerFactory>((s, n) => NoOpCheckpointerFactory.Instance)
                         .Configure<StreamStatisticOptions>(ob => ob.Configure(options => options.StatisticMonitorWriteInterval = monitorWriteInterval))


### PR DESCRIPTION
Third party DI solution, such as StructureMap, Autofac, requires services injected into DI have correct public constructor, which the runtime will be using to constructing them. We found a single instance of `StatelessWorkerPlacement`, which is injected into DI and doesn't have a public constructor. This prevent user to integrate Orleans with those third party DI solution.

Since there's no need for `StatelessWorkerPlacement` constructor to be internal, the class is already internal. So make the constructor public.

Also picked one of our test to use `StructureMap` as its DI solution, to test Orleans can integrate with third party DI solution, like `StructureMap`. Let me know if you want me to separate it into its own test. 

Fix for #4442 