### PR TITLE
Copy elements in-place in InvokeMethodAsync

### DIFF
--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -59,15 +59,14 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public Task<T> InvokeMethodAsync<T>(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo)
         {
-            object[] argsDeepCopy = null;
             if (arguments != null)
             {
                 CheckForGrainArguments(arguments);
                 SetGrainCancellationTokensTarget(arguments, reference);
-                argsDeepCopy = (object[])this.serializationManager.DeepCopy(arguments);
+                this.serializationManager.DeepCopyElementsInPlace(arguments);
             }
 
-            var request = new InvokeMethodRequest(reference.InterfaceId, reference.InterfaceVersion, methodId, argsDeepCopy);
+            var request = new InvokeMethodRequest(reference.InterfaceId, reference.InterfaceVersion, methodId, arguments);
 
             if (IsUnordered(reference))
                 options |= InvokeMethodOptions.Unordered;

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -665,6 +665,31 @@ namespace Orleans.Serialization
             return copy;
         }
 
+        internal void DeepCopyElementsInPlace(object[] args)
+        {
+            var context = this.serializationContext.Value;
+            context.Reset();
+
+            Stopwatch timer = null;
+            if (StatisticsCollector.CollectSerializationStats)
+            {
+                timer = new Stopwatch();
+                timer.Start();
+                context.SerializationManager.Copies.Increment();
+            }
+
+            for (var i = 0; i < args.Length; i++) args[i] = DeepCopyInner(args[i], context);
+
+            context.Reset();
+
+
+            if (timer != null)
+            {
+                timer.Stop();
+                context.SerializationManager.CopyTimeStatistic.IncrementBy(timer.ElapsedTicks);
+            }
+        }
+
         /// <summary>
         /// <para>
         /// This method makes a deep copy of the object passed to it.


### PR DESCRIPTION
Arguments passed to `InvokeMethodAsync` (from generated GrainReference code) are copied in-place: i.e, without creating a new argument array. This saves some cost in making calls without breaking semantics (reference equality between arguments). It saves one allocation per call and avoids invoking DeepCopyHelper for the array.

The distributed tests are too noisy for such a minor fix:

| Test | Run 1 | Run 2 | Run 3 | Run 4 | Master
|-|-|-|-|-|-|
| NightlyLoadTest | 235957 | 233753 | 239428 | 244787 | 240383
| ActivationCollectorStressTest | 256907 | 253961 | 261432 | 260869 | 250575
| PingLoadTest_LocalReentrant | 151081 | 146504 | 151071 | 137274 | 151688
| PingLoadTest_RandomReentrant_MultiSilos | 474047 | 271112 | 270071 | 285268 | 338229

cc @dVakulen
