### PR TITLE
Add serviceId parameters to ClientBuilder/ServiceHostBuilder helper methods

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -13,6 +13,11 @@ namespace Orleans.Configuration
         internal const string DevelopmentClusterId = "dev";
 
         /// <summary>
+        /// Default service id for development clusters.
+        /// </summary>
+        internal const string DevelopmentServiceId = "dev-service";
+
+        /// <summary>
         /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
         /// </summary>
         public string ClusterId { get; set; }

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -166,15 +166,18 @@ namespace Orleans
         /// <param name="builder"></param>
         /// <param name="gatewayPort">The local silo's gateway port.</param>
         /// <param name="clusterId">Cluster ID to use</param>
+        /// <param name="serviceId">Service ID to use</param>
         public static IClientBuilder UseLocalhostClustering(
             this IClientBuilder builder,
             int gatewayPort = 30000,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            string clusterId = ClusterOptions.DevelopmentClusterId,
+            string serviceId = ClusterOptions.DevelopmentServiceId)
         {
             return builder.UseStaticClustering(new IPEndPoint(IPAddress.Loopback, gatewayPort))
                 .Configure<ClusterOptions>(options =>
                 {
-                    if (!string.IsNullOrWhiteSpace(clusterId)) options.ClusterId = clusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ClusterId)) options.ClusterId = clusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ServiceId)) options.ServiceId = serviceId;
                 });
         }
 
@@ -188,7 +191,8 @@ namespace Orleans
             return builder.UseStaticClustering(gatewayPorts.Select(p => new IPEndPoint(IPAddress.Loopback, p)).ToArray())
                 .Configure<ClusterOptions>(options =>
                 {
-                    options.ClusterId = ClusterOptions.DevelopmentClusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ClusterId)) options.ClusterId = ClusterOptions.DevelopmentClusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ServiceId)) options.ServiceId = ClusterOptions.DevelopmentServiceId;
                 });
         }
 

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -48,13 +48,15 @@ namespace Orleans.Hosting
         /// The endpoint of the primary silo, or <see langword="null"/> to use this silo as the primary.
         /// </param>
         /// <param name="clusterId">Cluster ID</param>
+        /// <param name="serviceId">Service ID</param>
         /// <returns>The silo builder.</returns>
         public static ISiloHostBuilder UseLocalhostClustering(
             this ISiloHostBuilder builder,
             int siloPort = EndpointOptions.DEFAULT_SILO_PORT,
             int gatewayPort = EndpointOptions.DEFAULT_GATEWAY_PORT,
             IPEndPoint primarySiloEndpoint = null,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            string clusterId = ClusterOptions.DevelopmentClusterId,
+            string serviceId = ClusterOptions.DevelopmentServiceId)
         {
             builder.Configure<EndpointOptions>(options =>
             {
@@ -64,7 +66,11 @@ namespace Orleans.Hosting
             });
 
             builder.UseDevelopmentClustering(primarySiloEndpoint ?? new IPEndPoint(IPAddress.Loopback, siloPort));
-            builder.Configure<ClusterOptions>(options => options.ClusterId = clusterId);
+            builder.Configure<ClusterOptions>(options => 
+            {
+                if (!string.IsNullOrWhiteSpace(options.ClusterId)) options.ClusterId = clusterId;
+                if (!string.IsNullOrWhiteSpace(options.ServiceId)) options.ServiceId = serviceId;
+            });
             builder.Configure<ClusterMembershipOptions>(options => options.ExpectedClusterSize = 1);
 
             return builder;
@@ -89,10 +95,15 @@ namespace Orleans.Hosting
         public static ISiloHostBuilder UseDevelopmentClustering(
             this ISiloHostBuilder builder,
             Action<DevelopmentClusterMembershipOptions> configureOptions,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            string clusterId = ClusterOptions.DevelopmentClusterId,
+            string serviceId = ClusterOptions.DevelopmentServiceId)
         {
             return builder
-                .Configure<ClusterOptions>(options => options.ClusterId = clusterId)
+                .Configure<ClusterOptions>(options =>
+                {
+                    if (!string.IsNullOrWhiteSpace(options.ClusterId)) options.ClusterId = clusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ServiceId)) options.ServiceId = serviceId;
+                })
                 .ConfigureServices(
                 services =>
                 {
@@ -114,9 +125,16 @@ namespace Orleans.Hosting
         public static ISiloHostBuilder UseDevelopmentClustering(
             this ISiloHostBuilder builder,
             Action<OptionsBuilder<DevelopmentClusterMembershipOptions>> configureOptions,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            string clusterId = ClusterOptions.DevelopmentClusterId,
+            string serviceId = ClusterOptions.DevelopmentServiceId)
         {
-            return builder.ConfigureServices(
+            return builder
+                .Configure<ClusterOptions>(options =>
+                {
+                    if (!string.IsNullOrWhiteSpace(options.ClusterId)) options.ClusterId = clusterId;
+                    if (!string.IsNullOrWhiteSpace(options.ServiceId)) options.ServiceId = serviceId;
+                })
+                .ConfigureServices(
                 services =>
                 {
                     configureOptions?.Invoke(services.AddOptions<DevelopmentClusterMembershipOptions>());


### PR DESCRIPTION
Fix for #4468 

With this PR, test failures from PR #4450 should be gone.

I added check to not override ClusterId/ServiceId set from this methods if they were set explicitely by a call to `Configure<ClusterOptions>` before calling them.