### PR TITLE
changed framework to netcoreapp2.0

### DIFF
--- a/Samples/2.0/ChatRoom/GrainImplementation/GrainImplementation.csproj
+++ b/Samples/2.0/ChatRoom/GrainImplementation/GrainImplementation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>GrainImplementation</AssemblyName>
     <PackageId>GrainImplementation</PackageId>
   </PropertyGroup>

--- a/Samples/2.0/ChatRoom/GrainInterfaces/GrainInterfaces.csproj
+++ b/Samples/2.0/ChatRoom/GrainInterfaces/GrainInterfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>GrainInterfaces</AssemblyName>
     <PackageId>GrainInterfaces</PackageId>
   </PropertyGroup>

--- a/Samples/2.0/ChatRoom/OrleansClient/OrleansClient.csproj
+++ b/Samples/2.0/ChatRoom/OrleansClient/OrleansClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>OrleansClient</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>OrleansClient</PackageId>

--- a/Samples/2.0/ChatRoom/OrleansServer/OrleansServer.csproj
+++ b/Samples/2.0/ChatRoom/OrleansServer/OrleansServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>OrleansServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>OrleansServer</PackageId>

--- a/Samples/2.0/ChatRoom/ReadMe.md
+++ b/Samples/2.0/ChatRoom/ReadMe.md
@@ -21,15 +21,16 @@ Alternatively, you can run from the command line:
 
 To start the silo
 ```
-OrleansServer\bin\Debug(Release)\net462\OrleansServer.exe
+cd OrleansServer
+dotnet run
 ```
 
 
 To start the client (you will have to use a different command window)
 ```
-OrleansClient\bin\Debug(Release)\net462\OrleansClient.exe
+cd OrleansClient
+dotnet run
 ```
-If you build the sample app in debug mode, the exe binary will be in Debug folder. If you build it in release mode, then the exe binary will be in Release folder.
 
 After the client started up, you will see instructions printed on the console, which tells you how to interact with a channel.
 

--- a/Samples/2.0/ChatRoom/Utils/Utils.csproj
+++ b/Samples/2.0/ChatRoom/Utils/Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Utils</AssemblyName>
     <PackageId>Utils</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
The example uses .NET Framework 4.6.2. Changing it makes it easier for
others to get started; updated readme to reflect changes.

Signed-off-by: Mike Lloyd <mike@reboot3times.org>