### PR TITLE
Increase diagnostic logging in code generator

### DIFF
--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -691,6 +691,11 @@ namespace Orleans.Runtime
 
         /// <summary>Returns a string representation of <paramref name="type"/>.</summary>
         /// <param name="type">The type.</param>
+        /// <returns>A string representation of the <paramref name="type"/>.</returns>
+        public static string GetLogFormat(this Type type) => type.GetParseableName(TypeFormattingOptions.LogFormat);
+
+        /// <summary>Returns a string representation of <paramref name="type"/>.</summary>
+        /// <param name="type">The type.</param>
         /// <param name="options">The type formatting options.</param>
         /// <param name="getNameFunc">The delegate used to get the unadorned, simple type name of <paramref name="type"/>.</param>
         /// <returns>A string representation of the <paramref name="type"/>.</returns>


### PR DESCRIPTION
Adds log lines to explain why a serializer is generated for a particular type.
Only enabled when logging is set to `Trace`, eg via the csproj property `<OrleansCodeGenLogLevel>Trace</OrleansCodeGenLogLevel>`