### PR TITLE
Update samples to match docs for Observers (#4061)

### DIFF
--- a/Samples/1.x/Chirper/ChirperGrains/ChirperAccount.cs
+++ b/Samples/1.x/Chirper/ChirperGrains/ChirperAccount.cs
@@ -179,12 +179,18 @@ namespace Orleans.Samples.Chirper.Grains
         }
         public Task ViewerConnect(IChirperViewer viewer)
         {
-            viewers.Subscribe(viewer);
+            if (!viewers.IsSubscribed(viewer))
+            {
+                viewers.Subscribe(viewer);
+            }
             return TaskDone.Done;
         }
         public Task ViewerDisconnect(IChirperViewer viewer)
         {
-            viewers.Unsubscribe(viewer);
+            if (viewers.IsSubscribed(viewer))
+            {
+                viewers.Unsubscribe(viewer);
+            }
             return TaskDone.Done;
         }
         #endregion

--- a/Samples/1.x/Presence/PresenceGrains/GameGrain.cs
+++ b/Samples/1.x/Presence/PresenceGrains/GameGrain.cs
@@ -87,13 +87,19 @@ namespace PresenceGrains
 
         public Task SubscribeForGameUpdates(IGameObserver subscriber)
         {
-            subscribers.Subscribe(subscriber);
+            if (!subscribers.IsSubscribed(subscriber))
+            {
+                subscribers.Subscribe(subscriber);
+            }
             return TaskDone.Done;
         }
 
         public Task UnsubscribeForGameUpdates(IGameObserver subscriber)
         {
-            subscribers.Unsubscribe(subscriber);
+            if (subscribers.IsSubscribed(subscriber))
+            {
+                subscribers.Unsubscribe(subscriber);
+            }
             return TaskDone.Done;
         }
     }


### PR DESCRIPTION
This updates a couple of Samples to match the `IsSubscribed()` calls added to the docs in PR #4489. There wasn't a good Sample under 2.0, so maybe we still want to add a good Observer sample for 2.0, as I held off on updating too much of this 1.5 sample (such as updating all of the deprecated `TaskDone.Done` calls to `Task.CompletedTask`, which might make sense as part of a separate issue).