### PR TITLE
fix(dynamo): fix grain storage when an exception has occured

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -303,7 +303,7 @@ namespace Orleans.Storage
 
             try
             {
-                // Try to rehydrate
+                // rehydrate
                 if (binaryData?.Length > 0)
                 {
                     return this.serializationManager.DeserializeFromByteArray<object>(binaryData);


### PR DESCRIPTION
This was done to address https://github.com/dotnet/orleans/issues/4482#issuecomment-383768677

Fix for when using `UseJson` and an exception was thrown it was causing a null reference
Also included a minor refactor