### PR TITLE
Revert GrainReference.FromKeyString() back to internal

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -397,7 +397,7 @@ namespace Orleans.Runtime
             return String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString());
         }
         
-        public static GrainReference FromKeyString(string key, IGrainReferenceRuntime runtime)
+        internal static GrainReference FromKeyString(string key, IGrainReferenceRuntime runtime)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException("key", "GrainReference.FromKeyString cannot parse null key");
             
@@ -438,7 +438,6 @@ namespace Orleans.Runtime
                 grainIdStr = trimmed.Substring(grainIdIndex);
                 return FromGrainId(GrainId.FromParsableString(grainIdStr), runtime);
             }
-            //return FromGrainId(GrainId.FromParsableString(grainIdStr), generic);
         }
 
 

--- a/src/Orleans.Core/Utils/Utils.cs
+++ b/src/Orleans.Core/Utils/Utils.cs
@@ -363,5 +363,10 @@ namespace Orleans.Runtime
             return new System.Diagnostics.StackTrace(skipFrames).ToString();
 #endif
         }
+
+        public static GrainReference FromKeyString(string key, IGrainReferenceRuntime runtime)
+        {
+            return GrainReference.FromKeyString(key, runtime);
+        }
     }
 }

--- a/src/Orleans.Transactions/DistributedTM/Protocol/TransactionParticipantExtensionExtensions.cs
+++ b/src/Orleans.Transactions/DistributedTM/Protocol/TransactionParticipantExtensionExtensions.cs
@@ -153,7 +153,7 @@ namespace Orleans.Transactions.DistributedTM
                     var key = (string)jobj["grain"];
                     var resourceId = (string)jobj["facet"];
 
-                    var grainref = GrainReference.FromKeyString(key, null);
+                    var grainref = Utils.FromKeyString(key, null);
                     this.grainFactory.BindGrainReference(grainref);
                     var extension = grainref.AsReference<ITransactionParticipantExtension>();
 


### PR DESCRIPTION
Revert `GrainReference.FromKeyString()` back to internal and expose it via `Utils.FromKeyString()` instead, so that Orleans.Abstractions don't need to get updated.

This is a follow-up to #3820. It changed `GrainReference.FromKeyString()` from `internal` to `public`, and that now requires us to update the `Core.Abstractions` package, which we'd prefer not to.

This change is a workaround that allows us to avoid updating abstractions unnecessarily.