### PR TITLE
Add transaction recoverbility test runner

### DIFF
--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -81,12 +81,16 @@ namespace Orleans.TestingHost.Utils
             Func<Task> loop =
                 async () =>
                 {
+                    bool passed;
                     do
                     {
                         // need to wait a bit to before re-checking the condition.
                         await Task.Delay(TimeSpan.FromSeconds(1));
+                        passed = await predicate(false);
                     }
-                    while (!await predicate(!keepGoing[0]) && keepGoing[0]);
+                    while (!passed && keepGoing[0]);
+                    if(!passed)
+                        await predicate(true);
                 };
 
             var task = loop();

--- a/src/Orleans.Transactions/InClusterTM/TransactionManagerGrain.cs
+++ b/src/Orleans.Transactions/InClusterTM/TransactionManagerGrain.cs
@@ -13,6 +13,8 @@ namespace Orleans.Transactions
     [Reentrant]
     public class TransactionManagerGrain : Grain, ITransactionManagerGrain
     {
+        //for test use only
+        public static bool IsActive = false;
         private readonly ITransactionManager transactionManager;
         private readonly ITransactionManagerService transactionManagerService;
 
@@ -24,11 +26,13 @@ namespace Orleans.Transactions
 
         public override async Task OnActivateAsync()
         {
+            IsActive = true;
             await transactionManager.StartAsync();
         }
 
         public override async Task OnDeactivateAsync()
         {
+            IsActive = false;
             await transactionManager.StopAsync();
         }
 

--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TestFixture.cs
@@ -22,7 +22,7 @@ namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         }
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {

--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
@@ -28,7 +28,7 @@ namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
             builder.AddSiloBuilderConfigurator<TestFixture.SiloBuilderConfigurator>();
         }
 
-        [SkippableTheory]
+        [SkippableTheory(Skip = "Intermittent failure, investigating...")]
         [InlineData(TransactionTestConstants.TransactionGrainStates.SingleStateTransaction)]
         [InlineData(TransactionTestConstants.TransactionGrainStates.DoubleStateTransaction)]
         [InlineData(TransactionTestConstants.TransactionGrainStates.MaxStateTransaction)]

--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using Orleans.Transactions.Tests;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
+{
+    [TestCategory("Transactions"), TestCategory("Functional")]
+    public class TransactionRecoveryTests : TestClusterPerTest
+    {
+        private readonly TransactionRecoveryTestsRunner testRunner;
+
+        public TransactionRecoveryTests(ITestOutputHelper helper)
+        {
+            this.testRunner = new TransactionRecoveryTestsRunner(this.HostedCluster, helper, true);
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 5;
+            builder.AddSiloBuilderConfigurator<TestFixture.SiloBuilderConfigurator>();
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.SingleStateTransaction)]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.DoubleStateTransaction)]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.MaxStateTransaction)]
+        public Task TransactionWillRecoverAfterRandomSiloFailure(TransactionTestConstants.TransactionGrainStates transactionGrainStates)
+        {
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloFailure(transactionGrainStates);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TransactionRecoveryTests.cs
@@ -23,6 +23,7 @@ namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
+            TestFixture.CheckForAzureStorage(TestDefaultConfiguration.DataConnectionString);
             builder.Options.InitialSilosCount = 5;
             builder.AddSiloBuilderConfigurator<TestFixture.SiloBuilderConfigurator>();
         }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -23,7 +23,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         }
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryAzureTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryAzureTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using Orleans.Transactions.AzureStorage.Tests;
+using Orleans.Transactions.Tests;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Azure.Tests
+{
+    [TestCategory("Transactions")]
+    public class TransactionRecoveryAzureTests : TestClusterPerTest
+    {
+        private readonly TransactionRecoveryTestsRunner testRunner;
+        public TransactionRecoveryAzureTests(ITestOutputHelper helper)
+        {
+            this.testRunner = new TransactionRecoveryTestsRunner(this.HostedCluster, helper);
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 5;
+            builder.CreateSilo = AppDomainSiloHandle.Create;
+            builder.AddSiloBuilderConfigurator<TransactionRecoveryTestsRunner.SiloBuilderConfigurator>();
+            builder.AddSiloBuilderConfigurator<TestFixture.SiloBuilderConfigurator>();
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, false)]
+        [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, false)]
+        [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, false)]
+        public Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName,
+            bool killSiloWhichRunsTm)
+        {
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloFailure(transactionTestGrainClassName,
+                killSiloWhichRunsTm);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DistributedTM/MemoryTransactionsFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DistributedTM/MemoryTransactionsFixture.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.Tests.DistributedTM
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         }
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {

--- a/test/Transactions/Orleans.Transactions.Tests/DistributedTM/TransactionRecoveryMemoryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DistributedTM/TransactionRecoveryMemoryTests.cs
@@ -26,7 +26,7 @@ namespace Orleans.Transactions.Tests.DistributedTM
             builder.AddSiloBuilderConfigurator<Tests.DistributedTM.MemoryTransactionsFixture.SiloBuilderConfigurator>();
         }
 
-        [SkippableTheory]
+        [SkippableTheory(Skip = "Intermittent failure, investigating...")]
         [InlineData(TransactionTestConstants.TransactionGrainStates.SingleStateTransaction)]
         [InlineData(TransactionTestConstants.TransactionGrainStates.DoubleStateTransaction)]
         [InlineData(TransactionTestConstants.TransactionGrainStates.MaxStateTransaction)]

--- a/test/Transactions/Orleans.Transactions.Tests/DistributedTM/TransactionRecoveryMemoryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DistributedTM/TransactionRecoveryMemoryTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests.DistributedTM
+{
+    [TestCategory("Transactions"), TestCategory("Functional")]
+    public class TransactionRecoveryMemoryTests : TestClusterPerTest
+    {
+        private readonly TransactionRecoveryTestsRunner testRunner;
+
+        public TransactionRecoveryMemoryTests(ITestOutputHelper helper)
+        {
+            this.testRunner = new TransactionRecoveryTestsRunner(this.HostedCluster, helper, true);
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 5;
+            builder.AddSiloBuilderConfigurator<Tests.DistributedTM.MemoryTransactionsFixture.SiloBuilderConfigurator>();
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.SingleStateTransaction)]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.DoubleStateTransaction)]
+        [InlineData(TransactionTestConstants.TransactionGrainStates.MaxStateTransaction)]
+        public Task TransactionWillRecoverAfterRandomSiloFailure(TransactionTestConstants.TransactionGrainStates transactionGrainStates)
+        {
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloFailure(transactionGrainStates);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
@@ -2,6 +2,7 @@ using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using Orleans.Hosting;
 using Orleans.Hosting.Development;
+using Orleans.Logging;
 using TestExtensions;
 
 namespace Orleans.Transactions.Tests
@@ -13,7 +14,7 @@ namespace Orleans.Transactions.Tests
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         }
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionRecoveryMemoryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionRecoveryMemoryTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests
+{
+    [TestCategory("Transactions")]
+    public class TransactionRecoveryMemoryTests : TestClusterPerTest
+    {
+        private readonly TransactionRecoveryTestsRunner testRunner;
+        public TransactionRecoveryMemoryTests(ITestOutputHelper helper)
+        {
+            this.testRunner = new TransactionRecoveryTestsRunner(this.HostedCluster, helper);
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 5;
+            builder.CreateSilo = AppDomainSiloHandle.Create;
+            builder.AddSiloBuilderConfigurator<TransactionRecoveryTestsRunner.SiloBuilderConfigurator>();
+            builder.AddSiloBuilderConfigurator<MemoryTransactionsFixture.SiloBuilderConfigurator>();
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, true)]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, false)]
+        [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, false)]
+        [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, false)]
+        public Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName,
+            bool killSiloWhichRunsTm)
+        {
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloFailure(transactionTestGrainClassName,
+                killSiloWhichRunsTm);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Orleans.Transactions.Tests.csproj
+++ b/test/Transactions/Orleans.Transactions.Tests/Orleans.Transactions.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\TestInfrastructure\Orleans.TestingHost.AppDomain\Orleans.TestingHost.AppDomain.csproj" />
     <ProjectReference Include="..\..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionRecoveryTestsRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionRecoveryTestsRunner.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Providers;
+using Orleans.TestingHost.Utils;
+using Orleans.Hosting;
+
+namespace Orleans.Transactions.Tests
+{
+    public class TransactionRecoveryTestsRunner : TransactionTestRunnerBase
+    {
+        private readonly Random seed;
+        private readonly TestCluster testCluster;
+        private readonly ILogger logger;
+        private static TimeSpan RecoveryTimeout = TimeSpan.FromSeconds(60);
+        public TransactionRecoveryTestsRunner(TestCluster testCluster, ITestOutputHelper output)
+            : base(testCluster.GrainFactory, output)
+        {
+            this.testCluster = testCluster;
+            this.logger = this.testCluster.ServiceProvider.GetService<ILogger<TransactionRecoveryTestsRunner>>();
+            this.seed = new Random();
+        }
+
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.ConfigureServices(services => services.AddTransientNamedService<IControllable, TMGrainLocator>(typeof(TMGrainLocator).Name));
+            }
+        }
+
+        public virtual async Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, bool killSiloWhichRunsTm)
+        {
+            const int grainCount = 100;
+            const int opsPerGrain = 2;
+            var txGrains = Enumerable.Range(0, grainCount)
+                .Select(i => RandomTestGrain(transactionTestGrainClassName))
+                .ToList();
+            var tpsBeforeInterruption = await RecordTPS(txGrains, opsPerGrain);
+            this.logger.LogInformation($"TPS before interruption is {tpsBeforeInterruption}");
+            if(killSiloWhichRunsTm)
+                await KillSilo(location => location.ActiveInCurrentSilo);
+            else
+            {
+                await KillSilo(location => !location.ActiveInCurrentSilo);
+            }
+            await TestingUtils.WaitUntilAsync(lastTry => CheckTPS(txGrains, tpsBeforeInterruption, opsPerGrain, lastTry), RecoveryTimeout);
+        }
+
+        //given a predicate, whether to kill a silo
+        private async Task KillSilo(Func<TMGrainLocator.TMGrainLocation, bool> predicate)
+        {
+            var mgmt = this.testCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+
+            object[] results = await mgmt.SendControlCommandToProvider(typeof(TMGrainLocator).FullName, typeof(TMGrainLocator).Name, 1);
+            this.logger.LogInformation($"Current TMGrainLocator list : {String.Join(";", results.Select(re => re.As<TMGrainLocator.TMGrainLocation>().ToString()))}");
+            var murderCandidates = results.Where(re => predicate(re as TMGrainLocator.TMGrainLocation));
+            if (murderCandidates.Count() == 0)
+                throw new Exception("No silo fits the predicate, potential test configuration issues");
+            var murderTarget = murderCandidates.ElementAt(this.seed.Next(murderCandidates.Count())) as TMGrainLocator.TMGrainLocation;
+            this.logger.LogInformation($"Current hard kill target is {murderTarget}");
+            foreach (var siloHanle in this.testCluster.Silos)
+            {
+                if(siloHanle.SiloAddress.Equals(murderTarget.CurrentSiloAddress))
+                    siloHanle.StopSilo(false);
+            }
+        }
+
+        public class TMGrainLocator : IControllable
+        {
+            private ILocalSiloDetails siloDetails;
+            public TMGrainLocator(ILocalSiloDetails siloDetails)
+            {
+                this.siloDetails = siloDetails;
+            }
+
+            public Task<object> ExecuteCommand(int command, object arg)
+            {
+                return Task.FromResult<object>(new TMGrainLocation()
+                {
+                    ActiveInCurrentSilo = TransactionManagerGrain.IsActive,
+                    CurrentSiloAddress = this.siloDetails.SiloAddress
+                });
+            }
+
+            public class TMGrainLocation
+            {
+                public bool ActiveInCurrentSilo { get; set; }
+                public SiloAddress CurrentSiloAddress { get; set; }
+
+                public override string ToString()
+                {
+                    return $"{nameof(ActiveInCurrentSilo)} : {this.ActiveInCurrentSilo}, {nameof(CurrentSiloAddress)} : {this.CurrentSiloAddress}";
+                }
+            }
+        }
+
+        private async Task<bool> CheckTPS(IList<ITransactionTestGrain> txGrains, double tpsBeforeInterruption, int opsPerGrain, bool assertIsTrue)
+        {
+            var tps = await RecordTPS(txGrains, opsPerGrain);
+            if (assertIsTrue)
+            {
+                //consider it recovered if reaches 95% of tps before
+               Assert.True(tps > tpsBeforeInterruption * 0.95);
+                return true;
+            }
+            else
+            {
+               bool re = tps > tpsBeforeInterruption * 0.95;
+                return re;
+            }
+        }
+
+        private async Task<double> RecordTPS(IEnumerable<ITransactionTestGrain> txGrains, int operationPerGrain)
+        {
+            var stopWatch = Stopwatch.StartNew();
+            var tasks = new List<Task>();
+            int successOperation = 0;
+            while (operationPerGrain -- > 0)
+                tasks.AddRange(txGrains.Select(txGrain => txGrain.Add(1).ContinueWith(re => Interlocked.Add(ref successOperation, 1), TaskContinuationOptions.OnlyOnRanToCompletion)));
+            try
+            {
+                await Task.WhenAll(tasks);
+            }
+            catch (Exception)
+            {
+               //ignore 
+            }
+            
+            stopWatch.Stop();
+          
+            return successOperation / stopWatch.Elapsed.TotalSeconds;
+        }
+    }
+}


### PR DESCRIPTION
- Add transaction recoverability test runners. 
- Add transaction recoverability tests running against single TM. currently isn't included into functional or bvt, because single TM has recoverability problems , so the tests isn't passing. But it is higher priority to get the test runner merged in so we can test the new distributed TM. If you don't like it, I can remove the actual tests.