### PR TITLE
Disable multi-state transactional grain tests

### DIFF
--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/GrainFaultTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/GrainFaultTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 using Orleans.Transactions.Tests;
-using System;
 
 namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
 {

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionTestRunnerBase.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionTestRunnerBase.cs
@@ -52,10 +52,6 @@ namespace Orleans.Transactions.Tests
 
             if (grainStates == TransactionTestConstants.TransactionGrainStates.SingleStateTransaction)
                 return TransactionTestConstants.SingleStateTransactionalGrain;
-            if (grainStates == TransactionTestConstants.TransactionGrainStates.DoubleStateTransaction)
-                return TransactionTestConstants.DoubleStateTransactionalGrain;
-            if (grainStates == TransactionTestConstants.TransactionGrainStates.MaxStateTransaction)
-                return TransactionTestConstants.MaxStateTransactionalGrain;
             throw new SkipException($"{grainStates} not supported when using distributed transaction manager.");
         }
     }


### PR DESCRIPTION
Disable multi-state transactional grain tests for singleton transaction manager tests.