### PR TITLE
Add Client/SiloHost builder delegate to legacy GrainClient and SIlo/AzureSilo

### DIFF
--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureClient.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureClient.cs
@@ -25,6 +25,9 @@ namespace Orleans.Runtime.Host
         /// <summary> delegate to configure logging, default to none logger configured </summary>
         public static Action<ILoggingBuilder> ConfigureLoggingDelegate { get; set; } = builder => { };
 
+        /// <summary>delegate to add some configuration to the client</summary>
+        public static Action<IClientBuilder> ConfigureClientDelegate { get; set; } = builder => { };
+
         /// <summary>
         /// Whether the Orleans Azure client runtime has already been initialized
         /// </summary>
@@ -181,8 +184,8 @@ namespace Orleans.Runtime.Host
             {
                 try
                 {
-                    //parse through ConfigureLoggingDelegate to GrainClient
                     GrainClient.ConfigureLoggingDelegate = ConfigureLoggingDelegate;
+                    GrainClient.ConfigureClientDelegate = ConfigureClientDelegate;
                     // Initialize will throw if cannot find Gateways
                     GrainClient.Initialize(config);
                     initSucceeded = true;

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Logging;
 using Orleans.AzureUtils.Utilities;
 using Orleans.Hosting.AzureCloudServices;
+using Orleans.Hosting;
 
 namespace Orleans.Runtime.Host
 {
@@ -44,6 +45,9 @@ namespace Orleans.Runtime.Host
         /// Defaults to <c>OrleansProxyEndpoint</c>
         /// </summary>
         public string ProxyEndpointConfigurationKeyName { get; set; }
+
+        /// <summary>delegate to add some configuration to the client</summary>
+        public Action<ISiloHostBuilder> ConfigureSiloHostDelegate { get; set; }
 
         private SiloHost host;
         private OrleansSiloInstanceManager siloInstanceManager;
@@ -279,6 +283,8 @@ namespace Orleans.Runtime.Host
             host.SetDeploymentId(clusterId, connectionString);
             host.SetSiloEndpoint(myEndpoint, generation);
             host.SetProxyEndpoint(proxyEndpoint);
+
+            host.ConfigureSiloHostDelegate = ConfigureSiloHostDelegate;
 
             host.InitializeOrleansSilo();
             return StartSilo();

--- a/src/Orleans.Core.Legacy/Core/GrainClient.cs
+++ b/src/Orleans.Core.Legacy/Core/GrainClient.cs
@@ -38,6 +38,10 @@ namespace Orleans
 
         /// <summary>delegate to configure logging, default to none logger configured</summary>
         public static Action<ILoggingBuilder> ConfigureLoggingDelegate { get; set; } = builder => { };
+
+        /// <summary>delegate to add some configuration to the client</summary>
+        public static Action<IClientBuilder> ConfigureClientDelegate { get; set; } = builder => { };
+
         private static IGrainFactory GetGrainFactory()
         {
             if (!IsInitialized)
@@ -59,12 +63,7 @@ namespace Orleans
                 Console.WriteLine("Error loading standard client configuration file.");
                 throw new ArgumentException("Error loading standard client configuration file");
             }
-            var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
-                .UseConfiguration(config)
-                .ConfigureLogging(ConfigureLoggingDelegate)
-                .Build();
-            InternalInitialize(orleansClient);
+            InternalInitialize(config);
         }
 
         /// <summary>
@@ -100,12 +99,7 @@ namespace Orleans
                 Console.WriteLine("Error loading client configuration file {0}:", configFile.FullName);
                 throw new ArgumentException(string.Format("Error loading client configuration file {0}:", configFile.FullName), nameof(configFile));
             }
-            var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
-                .UseConfiguration(config)
-                .ConfigureLogging(ConfigureLoggingDelegate)
-                .Build();
-            InternalInitialize(orleansClient);
+            InternalInitialize(config);
         }
 
         /// <summary>
@@ -120,12 +114,7 @@ namespace Orleans
                 Console.WriteLine("Initialize was called with null ClientConfiguration object.");
                 throw new ArgumentException("Initialize was called with null ClientConfiguration object.", nameof(config));
             }
-            var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
-                .UseConfiguration(config)
-                .ConfigureLogging(ConfigureLoggingDelegate)
-                .Build();
-            InternalInitialize(orleansClient);
+            InternalInitialize(config);
         }
 
         /// <summary>
@@ -151,17 +140,20 @@ namespace Orleans
                 config.Gateways.Add(gatewayAddress);
             }
             config.PreferedGatewayIndex = config.Gateways.IndexOf(gatewayAddress);
-            var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
-                .UseConfiguration(config)
-                .ConfigureLogging(ConfigureLoggingDelegate)
-                .Build();
-            InternalInitialize(orleansClient);
+            InternalInitialize(config);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private static void InternalInitialize(IInternalClusterClient clusterClient)
+        private static void InternalInitialize(ClientConfiguration config)
         {
+            var builder = new ClientBuilder()
+                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
+                .UseConfiguration(config)
+                .ConfigureLogging(ConfigureLoggingDelegate);
+            ConfigureClientDelegate?.Invoke(builder);
+
+            var clusterClient = (IInternalClusterClient)builder.Build();
+
             if (TestOnlyNoConnect)
             {
                 Trace.TraceInformation("TestOnlyNoConnect - Returning before connecting to cluster.");

--- a/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
+++ b/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
@@ -39,6 +39,9 @@ namespace Orleans.Runtime.Host
         /// <summary> Configuration data for this silo. </summary>
         public NodeConfiguration NodeConfig { get; private set; }
 
+        /// <summary>delegate to add some configuration to the client</summary>
+        public Action<ISiloHostBuilder> ConfigureSiloHostDelegate { get; set; }
+
         /// <summary>
         /// Whether the silo config has been loaded and initializing it's runtime config.
         /// </summary>
@@ -111,6 +114,8 @@ namespace Orleans.Runtime.Host
                     builder.UseServiceProviderFactory(services =>
                         StartupBuilder.ConfigureStartup(this.Config.Defaults.StartupTypeName, services));
                 }
+
+                ConfigureSiloHostDelegate?.Invoke(builder);
 
                 var host = builder.Build();
 

--- a/test/TesterInternal/ClientInitTests.cs
+++ b/test/TesterInternal/ClientInitTests.cs
@@ -7,6 +7,8 @@ using Tester;
 using TestExtensions;
 using Xunit;
 using Orleans.Logging;
+using System.Threading.Tasks;
+using UnitTests.GrainInterfaces;
 
 #pragma warning disable CS0618 // Type or member is obsolete
 namespace UnitTests
@@ -14,6 +16,7 @@ namespace UnitTests
     public class ClientInitTests : OrleansTestingBase, IClassFixture<ClientInitTests.Fixture>
     {
         private readonly Fixture fixture;
+
 
         public class Fixture : BaseTestClusterFixture
         {
@@ -30,6 +33,7 @@ namespace UnitTests
             this.fixture = fixture;
             if (!GrainClient.IsInitialized)
             {
+                GrainClient.ConfigureClientDelegate = null;
                 GrainClient.Initialize(fixture.ClientConfiguration);
             }
         }
@@ -116,6 +120,15 @@ namespace UnitTests
 
             GrainClient.Uninitialize();
             Assert.False(GrainClient.IsInitialized);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Client")]
+        public void ClientInit_InitializeWithDelegate()
+        {
+            var wasCalled = false;
+            GrainClient.ConfigureClientDelegate = clientBuilder => wasCalled = true;
+            GrainClient.Initialize(this.fixture.ClientConfiguration);
+            Assert.True(wasCalled);
         }
     }
 }


### PR DESCRIPTION
Since now providers need to be configured using the builder pattern, developer stuck with the legacy Silo and GrainClient can no longer configure thingks like storage, or stream providers.

This PR enable them to configure it so transition is more easy.