### PR TITLE
Remove saving of minidumps

### DIFF
--- a/src/Orleans.Core/Logging/CrashUtils.cs
+++ b/src/Orleans.Core/Logging/CrashUtils.cs
@@ -21,81 +21,9 @@ namespace Orleans.Runtime
         // This is used by Performance Counter code to know which grains to create counters for.
         internal static IList<string> GrainTypes = null;
 
-        /// <summary>
-        /// Create a mini-dump file for the current state of this process
-        /// </summary>
-        /// <param name="dumpType">Type of mini-dump to create</param>
-        /// <returns><c>FileInfo</c> for the location of the newly created mini-dump file</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle")]
-        internal static FileInfo CreateMiniDump(MiniDumpType dumpType = MiniDumpType.MiniDumpNormal)
-        {
-            const string dateFormat = "yyyy-MM-dd-HH-mm-ss-fffZ"; // Example: 2010-09-02-09-50-43-341Z
-
-            var thisAssembly = Assembly.GetEntryAssembly()
-                ?? Assembly.GetCallingAssembly()
-                ?? typeof(CrashUtils)
-                .GetTypeInfo().Assembly;
-
-            var dumpFileName = $@"{thisAssembly.GetName().Name}-MiniDump-{DateTime.UtcNow.ToString(dateFormat,
-                    CultureInfo.InvariantCulture)}.dmp";
-
-            using (var stream = File.Create(dumpFileName))
-            {
-                var process = Process.GetCurrentProcess();
-
-                // It is safe to call DangerousGetHandle() here because the process is already crashing.
-                var handle = GetProcessHandle(process);
-                NativeMethods.MiniDumpWriteDump(
-                    handle,
-                    process.Id,
-                    stream.SafeFileHandle.DangerousGetHandle(),
-                    dumpType,
-                    IntPtr.Zero,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-            }
-
-            return new FileInfo(dumpFileName);
-        }
-
         private static IntPtr GetProcessHandle(Process process)
         {
             return process.Handle;
         }
-
-        private static class NativeMethods
-        {
-            [DllImport("Dbghelp.dll")]
-            public static extern bool MiniDumpWriteDump(
-                IntPtr hProcess,
-                int processId,
-                IntPtr hFile,
-                MiniDumpType dumpType,
-                IntPtr exceptionParam,
-                IntPtr userStreamParam,
-                IntPtr callbackParam);
-        }
-    }
-
-    internal enum MiniDumpType
-    {
-        // ReSharper disable UnusedMember.Global
-        MiniDumpNormal = 0x00000000,
-        MiniDumpWithDataSegs = 0x00000001,
-        MiniDumpWithFullMemory = 0x00000002,
-        MiniDumpWithHandleData = 0x00000004,
-        MiniDumpFilterMemory = 0x00000008,
-        MiniDumpScanMemory = 0x00000010,
-        MiniDumpWithUnloadedModules = 0x00000020,
-        MiniDumpWithIndirectlyReferencedMemory = 0x00000040,
-        MiniDumpFilterModulePaths = 0x00000080,
-        MiniDumpWithProcessThreadData = 0x00000100,
-        MiniDumpWithPrivateReadWriteMemory = 0x00000200,
-        MiniDumpWithoutOptionalData = 0x00000400,
-        MiniDumpWithFullMemoryInfo = 0x00000800,
-        MiniDumpWithThreadInfo = 0x00001000,
-        MiniDumpWithCodeSegs = 0x00002000,
-        MiniDumpWithoutManagedState = 0x00004000,
-        // ReSharper restore UnusedMember.Global
     }
 }

--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -839,7 +839,6 @@ namespace Orleans
         Watchdog_HealthCheckFailure             = WatchdogBase + 3,
 
         LoggerBase                              = Runtime + 2700,
-        Logger_MiniDumpCreated                  = Runtime_Error_100001, // Backward compatability
         Logger_ProcessCrashing                  = Runtime_Error_100002, // Backward compatability
         Logger_LogMessageTruncated              = LoggerBase + 1,
 

--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -266,10 +266,6 @@ namespace Orleans.Runtime
 
             logger.Error(errorCode, "INTERNAL FAILURE! About to crash! Fail message is: " + message + Environment.NewLine + Environment.StackTrace);
 
-            // Create mini-dump of this failure, for later diagnosis
-            var dumpFile = CrashUtils.CreateMiniDump();
-            logger.Error(ErrorCode.Logger_MiniDumpCreated, "INTERNAL FAILURE! Application mini-dump written to file " + dumpFile.FullName);
-
             // Kill process
             if (Debugger.IsAttached)
             {


### PR DESCRIPTION
Fixes #4545.

Remove saving of minidumps because that functionality is platform specific.