### PR TITLE
Azure table transactional storage for distributed TM

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.AzureStorage;
+
+namespace Orleans.Transactions.DistributedTM.AzureStorage
+{
+    public class AzureTableTransactionalStateStorage<TState> : ITransactionalStateStorage<TState>
+        where TState : class, new()
+    {
+        private readonly CloudTable table;
+        private readonly string partition;
+        private readonly JsonSerializerSettings jsonSettings;
+        private readonly ILogger logger;
+
+        private KeyEntity key;
+        private List<KeyValuePair<long, StateEntity>> states;
+
+        public AzureTableTransactionalStateStorage(CloudTable table, string partition, JsonSerializerSettings JsonSettings, ILogger<AzureTableTransactionalStateStorage<TState>> logger)
+        {
+            this.table = table;
+            this.partition = partition;
+            this.jsonSettings = JsonSettings;
+            this.logger = logger;
+        }
+
+        public async Task<TransactionalStorageLoadResponse<TState>> Load(string stateName)
+        {
+            try
+            {
+                var keyTask = ReadKey();
+                var statesTask = ReadStates();
+                key = await keyTask.ConfigureAwait(false);
+                states = await statesTask.ConfigureAwait(false);
+
+                if (string.IsNullOrEmpty(key.ETag))
+                {
+                    if (logger.IsEnabled(LogLevel.Trace))
+                        logger.LogTrace($"{partition} Loaded v0, fresh");
+
+                    // first time load
+                    return new TransactionalStorageLoadResponse<TState>();
+                }
+                else
+                {
+                    if (!FindState(this.key.CommittedSequenceId, out var pos))
+                    {
+                        var error = $"Storage state corrupted: no record for committed state";
+                        logger.LogCritical(error);
+                        throw new InvalidOperationException(error);
+                    }
+                    var committedState = states[pos].Value.GetState<TState>(this.jsonSettings);
+
+                    var PrepareRecordsToRecover = new List<PendingTransactionState<TState>>();
+                    for (int i = 0; i < states.Count; i++)
+                    {
+                        var kvp = states[i];
+
+                        // pending states for already committed transactions can be ignored
+                        if (kvp.Key <= key.CommittedSequenceId)
+                            continue;
+
+                        // upon recovery, local non-committed transactions are considered aborted
+                        if (kvp.Value.TransactionManager == null)
+                            break;
+
+                        PrepareRecordsToRecover.Add(new PendingTransactionState<TState>()
+                        {
+                            SequenceId = kvp.Key,
+                            State = kvp.Value.GetState<TState>(this.jsonSettings),
+                            TimeStamp = kvp.Value.TransactionTimestamp,
+                            TransactionId = kvp.Value.TransactionId,
+                            TransactionManager = kvp.Value.TransactionManager
+                        });
+                    }
+
+                    // clear the state strings... no longer needed, ok to GC now
+                    for (int i = 0; i < states.Count; i++)
+                    {
+                        states[i].Value.StateJson = null;
+                    }
+
+                    if (logger.IsEnabled(LogLevel.Trace))
+                        logger.LogTrace($"{partition} Loaded v{this.key.CommittedSequenceId} rows={string.Join(",", states.Select(s => s.Key.ToString("x16")))}");
+
+                    return new TransactionalStorageLoadResponse<TState>(this.key.ETag, committedState, this.key.CommittedSequenceId, this.key.Metadata, PrepareRecordsToRecover);
+                }
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError("Transactional state load failed {Exception}.", ex);
+                throw;
+            }
+        }
+
+
+        public async Task<string> Store(string stateName, string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
+        {
+            if (this.key.ETag != expectedETag)
+                throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+
+            // assemble all storage operations into a single batch
+            // these operations must commit in sequence, but not necessarily atomically
+            // so we can split this up if needed
+            var batchOperation = new TableBatchOperation();
+
+            // first, clean up aborted records
+            if (abortAfter.HasValue && states.Count != 0)
+            {
+                while (states.Count > 0 && states[states.Count - 1].Key > abortAfter)
+                {
+                    var entity = states[states.Count - 1].Value;
+                    batchOperation.Delete(entity);
+                    states.RemoveAt(states.Count - 1);
+
+                    if (logger.IsEnabled(LogLevel.Trace))
+                        logger.LogTrace($"{partition}.{states[states.Count - 1].Key:x16} Delete {entity.TransactionId}");
+                }
+            }
+
+            // second, persist non-obsolete prepare records
+            var obsoleteBefore = commitUpTo.HasValue ? commitUpTo.Value : key.CommittedSequenceId;
+            if (statesToPrepare != null)
+                foreach (var s in statesToPrepare)
+                    if (s.SequenceId >= obsoleteBefore)
+                    {
+                        if (FindState(s.SequenceId, out var pos))
+                        {
+                            // overwrite with new pending state
+                            var existing = states[pos].Value;
+                            existing.TransactionId = s.TransactionId;
+                            existing.TransactionTimestamp = s.TimeStamp;
+                            existing.TransactionManager = s.TransactionManager;
+                            existing.SetState(s.State, this.jsonSettings);
+                            batchOperation.Replace(existing);
+                            states.RemoveAt(pos);
+
+                            if (logger.IsEnabled(LogLevel.Trace))
+                                logger.LogTrace($"{partition}.{existing.SequenceId:x16} Update {existing.TransactionId}");
+                        }
+                        else
+                        {
+                            var entity = StateEntity.Create(this.jsonSettings, this.partition, s);
+                            batchOperation.Insert(entity);
+                            states.Insert(pos, new KeyValuePair<long, StateEntity>(s.SequenceId, entity));
+
+                            if (logger.IsEnabled(LogLevel.Trace))
+                                logger.LogTrace($"{partition}.{s.SequenceId:x16} Insert {entity.TransactionId}");
+                        }
+                    }
+
+            // third, persist metadata and commit position
+            key.Metadata = metadata;
+            if (commitUpTo.HasValue && commitUpTo.Value > key.CommittedSequenceId)
+            {
+                key.CommittedSequenceId = commitUpTo.Value;
+            }
+            if (string.IsNullOrEmpty(this.key.ETag))
+            {
+                batchOperation.Insert(this.key);
+
+                if (logger.IsEnabled(LogLevel.Trace))
+                    logger.LogTrace($"{partition}.k Insert");
+            }
+            else
+            {
+                batchOperation.Replace(this.key);
+
+                if (logger.IsEnabled(LogLevel.Trace))
+                    logger.LogTrace($"{partition}.k Update");
+            }
+
+            // fourth, remove obsolete records
+            if (states.Count > 0 && states[0].Key < obsoleteBefore)
+            {
+                FindState(obsoleteBefore, out var pos);
+                for (int i = 0; i < pos; i++)
+                {
+                    batchOperation.Delete(states[i].Value);
+
+                    if (logger.IsEnabled(LogLevel.Trace))
+                        logger.LogTrace($"{partition}.{states[i].Key:x16} Delete {states[i].Value.TransactionId}");
+                }
+                states.RemoveRange(0, pos);
+            }
+
+            if (logger.IsEnabled(LogLevel.Trace))
+                logger.LogTrace($"{partition} Storing v{this.key.CommittedSequenceId} {batchOperation.Count} table ops");
+
+            await StoreBatch(batchOperation).ConfigureAwait(false);
+
+            if (logger.IsEnabled(LogLevel.Trace))
+                logger.LogTrace($"{partition} Stored v{this.key.CommittedSequenceId} eTag={key.ETag}");
+
+            return key.ETag;
+        }
+
+        private bool FindState(long sequenceId, out int pos)
+        {
+            pos = 0;
+            while (pos < states.Count)
+            {
+                switch (states[pos].Key.CompareTo(sequenceId))
+                {
+                    case 0:
+                        return true;
+                    case -1:
+                        pos++;
+                        continue;
+                    case 1:
+                        break;
+                }
+            }
+            return false;
+        }
+
+        private async Task<KeyEntity> ReadKey()
+        {
+            var query = new TableQuery<KeyEntity>()
+                .Where(AzureStorageUtils.PointQuery(this.partition, KeyEntity.RK));
+            TableQuerySegment<KeyEntity> queryResult = await table.ExecuteQuerySegmentedAsync(query, null).ConfigureAwait(false);
+            return queryResult.Results.Count == 0
+                ? new KeyEntity() { PartitionKey = this.partition }
+                : queryResult.Results[0];
+        }
+
+        private async Task<List<KeyValuePair<long, StateEntity>>> ReadStates()
+        {
+            var query = new TableQuery<StateEntity>()
+                .Where(AzureStorageUtils.RangeQuery(this.partition, StateEntity.RK_MIN, StateEntity.RK_MAX));
+            TableContinuationToken continuationToken = null;
+            var results = new List<KeyValuePair<long, StateEntity>>();
+            do
+            {
+                TableQuerySegment<StateEntity> queryResult = await table.ExecuteQuerySegmentedAsync(query, continuationToken).ConfigureAwait(false);
+                foreach (var x in queryResult.Results)
+                {
+                    results.Add(new KeyValuePair<long, StateEntity>(x.SequenceId, x));
+                };
+                continuationToken = queryResult.ContinuationToken;
+            } while (continuationToken != null);
+            return results;
+        }
+
+        private async Task StoreBatch(TableBatchOperation batchOperation)
+        {
+            try
+            {
+                if (batchOperation.Count < AzureTableConstants.MaxBatchSize)
+                {
+                    await table.ExecuteBatchAsync(batchOperation).ConfigureAwait(false);
+                }
+                else
+                {
+                    var portion = new TableBatchOperation();
+                    var enumerator = batchOperation.GetEnumerator();
+                    while (enumerator.MoveNext())
+                    {
+                        portion.Add(enumerator.Current);
+                        if (portion.Count == AzureTableConstants.MaxBatchSize)
+                        {
+                            await table.ExecuteBatchAsync(portion).ConfigureAwait(false);
+                            portion.Clear();
+                        }
+                    }
+                    if (portion.Count > 0)
+                    {
+                        await table.ExecuteBatchAsync(portion).ConfigureAwait(false);
+                    }
+                }
+
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    for (int i = 0; i < batchOperation.Count; i++)
+                        logger.LogTrace($"batch-op ok     {i} PK={batchOperation[i].Entity.PartitionKey} RK={batchOperation[i].Entity.RowKey}");
+                }
+            }
+            catch (Exception ex)
+            {
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    for (int i = 0; i < batchOperation.Count; i++)
+                        logger.LogTrace($"batch-op failed {i} PK={batchOperation[i].Entity.PartitionKey} RK={batchOperation[i].Entity.RowKey}");
+                }
+
+                this.logger.LogError("Transactional state store failed {Exception}.", ex);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
@@ -15,21 +15,23 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
     {
         private readonly CloudTable table;
         private readonly string partition;
+        private readonly string stateName;
         private readonly JsonSerializerSettings jsonSettings;
         private readonly ILogger logger;
 
         private KeyEntity key;
         private List<KeyValuePair<long, StateEntity>> states;
 
-        public AzureTableTransactionalStateStorage(CloudTable table, string partition, JsonSerializerSettings JsonSettings, ILogger<AzureTableTransactionalStateStorage<TState>> logger)
+        public AzureTableTransactionalStateStorage(CloudTable table, string partition, string stateName, JsonSerializerSettings JsonSettings, ILogger<AzureTableTransactionalStateStorage<TState>> logger)
         {
             this.table = table;
             this.partition = partition;
+            this.stateName = stateName;
             this.jsonSettings = JsonSettings;
             this.logger = logger;
         }
 
-        public async Task<TransactionalStorageLoadResponse<TState>> Load(string stateName)
+        public async Task<TransactionalStorageLoadResponse<TState>> Load()
         {
             try
             {
@@ -99,7 +101,7 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
         }
 
 
-        public async Task<string> Store(string stateName, string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
+        public async Task<string> Store(string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
         {
             if (this.key.ETag != expectedETag)
                 throw new ArgumentException(nameof(expectedETag), "Etag does not match");

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorage.cs
@@ -42,8 +42,8 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
 
                 if (string.IsNullOrEmpty(key.ETag))
                 {
-                    if (logger.IsEnabled(LogLevel.Trace))
-                        logger.LogTrace($"{partition} Loaded v0, fresh");
+                    if (logger.IsEnabled(LogLevel.Debug))
+                        logger.LogDebug($"{partition} Loaded v0, fresh");
 
                     // first time load
                     return new TransactionalStorageLoadResponse<TState>();
@@ -87,8 +87,8 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
                         states[i].Value.StateJson = null;
                     }
 
-                    if (logger.IsEnabled(LogLevel.Trace))
-                        logger.LogTrace($"{partition} Loaded v{this.key.CommittedSequenceId} rows={string.Join(",", states.Select(s => s.Key.ToString("x16")))}");
+                    if (logger.IsEnabled(LogLevel.Debug))
+                        logger.LogDebug($"{partition} Loaded v{this.key.CommittedSequenceId} rows={string.Join(",", states.Select(s => s.Key.ToString("x16")))}");
 
                     return new TransactionalStorageLoadResponse<TState>(this.key.ETag, committedState, this.key.CommittedSequenceId, this.key.Metadata, PrepareRecordsToRecover);
                 }
@@ -191,13 +191,10 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
                 states.RemoveRange(0, pos);
             }
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace($"{partition} Storing v{this.key.CommittedSequenceId} {batchOperation.Count} table ops");
-
             await batchOperation.Flush().ConfigureAwait(false);
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace($"{partition} Stored v{this.key.CommittedSequenceId} eTag={key.ETag}");
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug($"{partition} Stored v{this.key.CommittedSequenceId} eTag={key.ETag}");
 
             return key.ETag;
         }

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorageFactory.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.AzureStorage;
+
+namespace Orleans.Transactions.DistributedTM.AzureStorage
+{
+    public class AzureTableTransactionalStateStorageFactory : ITransactionalStateStorageFactory, ILifecycleParticipant<ISiloLifecycle>
+    {
+        private readonly string name;
+        private readonly AzureTableTransactionalStateOptions options;
+        private readonly ClusterOptions clusterOptions;
+        private readonly JsonSerializerSettings jsonSettings;
+        private readonly ILoggerFactory loggerFactory;
+        private CloudTable table;
+
+        public static ITransactionalStateStorageFactory Create(IServiceProvider services, string name)
+        {
+            IOptionsSnapshot<AzureTableTransactionalStateOptions> optionsSnapshot = services.GetRequiredService<IOptionsSnapshot<AzureTableTransactionalStateOptions>>();
+            return ActivatorUtilities.CreateInstance<AzureTableTransactionalStateStorageFactory>(services, name, optionsSnapshot.Get(name));
+        }
+
+        public AzureTableTransactionalStateStorageFactory(string name, AzureTableTransactionalStateOptions options, IOptions<ClusterOptions> clusterOptions, ITypeResolver typeResolver, IGrainFactory grainFactory, ILoggerFactory loggerFactory)
+        {
+            this.name = name;
+            this.options = options;
+            this.clusterOptions = clusterOptions.Value;
+            this.jsonSettings = OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory);
+            this.loggerFactory = loggerFactory;
+        }
+
+        public ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainActivationContext context) where TState : class, new()
+        {
+            string partitionKey = MakePartitionKey(context, stateName);
+            return ActivatorUtilities.CreateInstance<AzureTableTransactionalStateStorage<TState>>(context.ActivationServices, this.table, partitionKey, this.jsonSettings);
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(OptionFormattingUtilities.Name<AzureTableTransactionalStateStorageFactory>(this.name), this.options.InitStage, Init);
+        }
+
+        private string MakePartitionKey(IGrainActivationContext context, string stateName)
+        {
+            string grainKey = context.GrainInstance.GrainReference.ToKeyString();
+            var key = $"ts_{this.clusterOptions.ServiceId}_{grainKey}_{stateName}";
+            return AzureStorageUtils.SanitizeTableProperty(key);
+        }
+
+        private async Task CreateTable()
+        {
+            var tableManager = new AzureTableDataManager<TableEntity>(this.options.TableName, this.options.ConnectionString, this.loggerFactory);
+            await tableManager.InitTableAsync().ConfigureAwait(false);
+            this.table = tableManager.Table;
+        }
+
+        private Task Init(CancellationToken cancellationToken)
+        {
+            return CreateTable();
+        }
+    }
+}

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/AzureTableTransactionalStateStorageFactory.cs
@@ -41,7 +41,7 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
         public ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainActivationContext context) where TState : class, new()
         {
             string partitionKey = MakePartitionKey(context, stateName);
-            return ActivatorUtilities.CreateInstance<AzureTableTransactionalStateStorage<TState>>(context.ActivationServices, this.table, partitionKey, this.jsonSettings);
+            return ActivatorUtilities.CreateInstance<AzureTableTransactionalStateStorage<TState>>(context.ActivationServices, this.table, partitionKey, stateName, this.jsonSettings);
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/KeyEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/KeyEntity.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Orleans.Transactions.DistributedTM.AzureStorage
+{
+    internal class KeyEntity : TableEntity
+    {
+        public const string RK = "k";
+
+        public KeyEntity()
+        {
+            this.RowKey = RK;
+        }
+
+        public long CommittedSequenceId { get; set; }
+        public string Metadata { get; set; }
+    }
+}

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/StateEntity.cs
@@ -9,14 +9,15 @@ namespace Orleans.Transactions.DistributedTM.AzureStorage
     {
         public static string MakeRowKey(long sequenceId)
         {
-            return sequenceId.ToString("x16");
+            return $"{RK_PREFIX}{sequenceId.ToString("x16")}";
         }
 
-        public long SequenceId => long.Parse(RowKey);
+        public long SequenceId => long.Parse(RowKey.Substring(RK_PREFIX.Length));
 
-        // row keys range from 0000000000000001 to 7fffffffffffffff
-        public const string RK_MIN = "0";
-        public const string RK_MAX = "8";
+        // row keys range from s0000000000000001 to s7fffffffffffffff
+        public const string RK_PREFIX = "s";
+        public const string RK_MIN = RK_PREFIX;
+        public const string RK_MAX = RK_PREFIX + "~";
 
         public string TransactionId { get; set; }
 

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/DistributedTM/StateEntity.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json;
+using Orleans.Transactions.Abstractions;
+using System;
+
+namespace Orleans.Transactions.DistributedTM.AzureStorage
+{
+    internal class StateEntity : TableEntity
+    {
+        public static string MakeRowKey(long sequenceId)
+        {
+            return sequenceId.ToString("x16");
+        }
+
+        public long SequenceId => long.Parse(RowKey);
+
+        // row keys range from 0000000000000001 to 7fffffffffffffff
+        public const string RK_MIN = "0";
+        public const string RK_MAX = "8";
+
+        public string TransactionId { get; set; }
+
+        public DateTime TransactionTimestamp { get; set; }
+
+        public string TransactionManager { get; set; }
+
+        public string StateJson { get; set; }
+
+        public static StateEntity Create<T>(JsonSerializerSettings JsonSettings,
+            string partitionKey, PendingTransactionState<T> pendingState)
+            where T : class, new()
+        {
+            return new StateEntity
+            {
+                PartitionKey = partitionKey,
+                RowKey = MakeRowKey(pendingState.SequenceId),
+                TransactionId = pendingState.TransactionId,
+                TransactionTimestamp = pendingState.TimeStamp,
+                TransactionManager = pendingState.TransactionManager,
+                StateJson = JsonConvert.SerializeObject(pendingState.State, JsonSettings)
+            };
+        }
+
+        public T GetState<T>(JsonSerializerSettings JsonSettings)
+        {
+            return JsonConvert.DeserializeObject<T>(this.StateJson, JsonSettings);
+        }
+        public void SetState<T>(T state, JsonSerializerSettings JsonSettings)
+        {
+            StateJson = JsonConvert.SerializeObject(state, JsonSettings);
+        }
+    }
+}

--- a/src/Orleans.Transactions/DistributedTM/Factories/INamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/DistributedTM/Factories/INamedTransactionalStateStorageFactory.cs
@@ -11,7 +11,8 @@ namespace Orleans.Transactions.DistributedTM
         /// </summary>
         /// <typeparam name="TState"></typeparam>
         /// <param name="storageName">Name of transaction state storage to create.</param>
+        /// <param name="stateName">Name of transaction state.</param>
         /// <returns>ITransactionalStateStorage, null if not found.</returns>
-        ITransactionalStateStorage<TState> Create<TState>(string storageName) where TState : class, new();
+        ITransactionalStateStorage<TState> Create<TState>(string storageName, string stateName) where TState : class, new();
     }
 }

--- a/src/Orleans.Transactions/DistributedTM/Factories/ITransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/DistributedTM/Factories/ITransactionalStateStorageFactory.cs
@@ -1,8 +1,10 @@
 ﻿
+using Orleans.Runtime;
+
 namespace Orleans.Transactions.DistributedTM
 {
     public interface ITransactionalStateStorageFactory
     {
-        ITransactionalStateStorage<TState> Create<TState>() where TState : class, new();
+        ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainActivationContext context) where TState : class, new();
     }
 }

--- a/src/Orleans.Transactions/DistributedTM/Factories/NamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/DistributedTM/Factories/NamedTransactionalStateStorageFactory.cs
@@ -10,26 +10,28 @@ namespace Orleans.Transactions.DistributedTM
     public class NamedTransactionalStateStorageFactory : INamedTransactionalStateStorageFactory
     {
         private readonly IGrainActivationContext context;
-        public NamedTransactionalStateStorageFactory(IGrainActivationContext context)
+        private readonly ILoggerFactory loggerFactory;
+
+        public NamedTransactionalStateStorageFactory(IGrainActivationContext context, ILoggerFactory loggerFactory)
         {
             this.context = context;
+            this.loggerFactory = loggerFactory;
         }
-        public ITransactionalStateStorage<TState> Create<TState>(string storageName)
+
+        public ITransactionalStateStorage<TState> Create<TState>(string storageName, string stateName)
             where TState : class, new()
         {
             // Try to get ITransactionalStateStorage from factory
             ITransactionalStateStorageFactory factory = string.IsNullOrEmpty(storageName)
                 ? this.context.ActivationServices.GetService<ITransactionalStateStorageFactory>()
                 : this.context.ActivationServices.GetServiceByName<ITransactionalStateStorageFactory>(storageName);
-            if (factory != null) return factory.Create<TState>();
+            if (factory != null) return factory.Create<TState>(stateName, context);
 
             // Else try to get storage provider and wrap it
             IGrainStorage grainStorage = string.IsNullOrEmpty(storageName)
                 ? this.context.ActivationServices.GetService<IGrainStorage>()
                 : this.context.ActivationServices.GetServiceByName<IGrainStorage>(storageName);
-            
-            if (grainStorage != null) return new TransactionalStateStorageProviderWrapper<TState>(grainStorage, context);
-
+            if (grainStorage != null) return new TransactionalStateStorageProviderWrapper<TState>(grainStorage, stateName, context, this.loggerFactory);
             throw (string.IsNullOrEmpty(storageName))
                 ? new InvalidOperationException($"No default {nameof(ITransactionalStateStorageFactory)} nor {nameof(IGrainStorage)} was found while attempting to create transactional state storage.")
                 : new InvalidOperationException($"No {nameof(ITransactionalStateStorageFactory)} nor {nameof(IGrainStorage)} with the name {storageName} was found while attempting to create transactional state storage.");

--- a/src/Orleans.Transactions/DistributedTM/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/DistributedTM/ITransactionalStateStorage.cs
@@ -38,7 +38,7 @@ namespace Orleans.Transactions.DistributedTM
         where TState : class, new()
     {
         /// <summary>
-        /// Transactions are given sequence numbers starting with 0.
+        /// Transactions are given dense local sequence numbers 1,2,3,4...
         /// If a new transaction is prepared with the same sequence number as a 
         /// previously prepared transaction, it replaces it.
         /// </summary>
@@ -73,10 +73,13 @@ namespace Orleans.Transactions.DistributedTM
     public class TransactionalStorageLoadResponse<TState>
         where TState : class, new()
     {
-        public TransactionalStorageLoadResponse(string etag, TState committedState, string metadata, IReadOnlyList<PendingTransactionState<TState>> pendingStates)
+        public TransactionalStorageLoadResponse() : this(null, new TState(), 0, null, Array.Empty<PendingTransactionState<TState>>()) { }
+
+        public TransactionalStorageLoadResponse(string etag, TState committedState, long committedSequenceId, string metadata, IReadOnlyList<PendingTransactionState<TState>> pendingStates)
         {
             this.ETag = etag;
             this.CommittedState = committedState;
+            this.CommittedSequenceId = committedSequenceId;
             this.Metadata = metadata;
             this.PendingStates = pendingStates;
         }
@@ -85,8 +88,19 @@ namespace Orleans.Transactions.DistributedTM
 
         public TState CommittedState { get; set; }
 
+        /// <summary>
+        /// The local sequence id of the last committed transaction, or zero if none
+        /// </summary>
+        public long CommittedSequenceId { get; set; }
+
+        /// <summary>
+        /// Additional state maintained by the transaction algorithm, such as commit records
+        /// </summary>
         public string Metadata { get; set; }
 
+        /// <summary>
+        /// List of pending states, ordered by sequence id
+        /// </summary>
         public IReadOnlyList<PendingTransactionState<TState>> PendingStates { get; set; }
     }
 }

--- a/src/Orleans.Transactions/DistributedTM/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/DistributedTM/ITransactionalStateStorage.cs
@@ -13,11 +13,10 @@ namespace Orleans.Transactions.DistributedTM
     public interface ITransactionalStateStorage<TState>
         where TState : class, new()
     {
-        Task<TransactionalStorageLoadResponse<TState>> Load(string stateName);
+        Task<TransactionalStorageLoadResponse<TState>> Load();
 
         Task<string> Store(
 
-            string stateName,
             string expectedETag,
             string metadata,
 

--- a/src/Orleans.Transactions/DistributedTM/Implementation/StorageBatch.cs
+++ b/src/Orleans.Transactions/DistributedTM/Implementation/StorageBatch.cs
@@ -122,7 +122,7 @@ namespace Orleans.Transactions.DistributedTM
             }
         }
 
-        public Task<string> Store(ITransactionalStateStorage<TState> storage, string stateName)
+        public Task<string> Store(ITransactionalStateStorage<TState> storage)
         {
             var jsonMetaData = JsonConvert.SerializeObject(MetaData, MetaData.SerializerSettings);
 
@@ -136,7 +136,7 @@ namespace Orleans.Transactions.DistributedTM
                 }
             }
 
-            return storage.Store(stateName, ETag, jsonMetaData, list,
+            return storage.Store(ETag, jsonMetaData, list,
                 (confirm > 0) ? confirmUpTo : (long?)null,
                 (cancelAbove < cancelAboveStart) ? cancelAbove : (long?)null);
         }

--- a/src/Orleans.Transactions/DistributedTM/Implementation/TransactionParticipant.cs
+++ b/src/Orleans.Transactions/DistributedTM/Implementation/TransactionParticipant.cs
@@ -73,7 +73,7 @@ namespace Orleans.Transactions.DistributedTM
                         // get the next batch in place so it can be filled while we store the old one
                         storageBatch = nextBatch;
 
-                        nextBatch.ETag = await thisBatch.Store(storage, config.StateName);
+                        nextBatch.ETag = await thisBatch.Store(storage);
 
                         if (committableEntries > 0)
                         {

--- a/src/Orleans.Transactions/DistributedTM/Implementation/TransactionalState.cs
+++ b/src/Orleans.Transactions/DistributedTM/Implementation/TransactionalState.cs
@@ -185,7 +185,7 @@ namespace Orleans.Transactions.DistributedTM
         private async Task Restore()
         {
             // start the load
-            var loadtask = this.storage.Load(this.config.StateName);
+            var loadtask = this.storage.Load();
 
             // abort active transactions, without waking up waiters just yet
             AbortExecutingTransactions("due to restore");

--- a/src/Orleans.Transactions/DistributedTM/Implementation/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/DistributedTM/Implementation/TransactionalStateStorageProviderWrapper.cs
@@ -33,13 +33,13 @@ namespace Orleans.Transactions.DistributedTM
             this.stateName = stateName;
         }
 
-        public async Task<TransactionalStorageLoadResponse<TState>> Load(string stateName)
+        public async Task<TransactionalStorageLoadResponse<TState>> Load()
         {
             await this.StateStorage.ReadStateAsync();
             return new TransactionalStorageLoadResponse<TState>(stateStorage.Etag, stateStorage.State.CommittedState, stateStorage.State.CommittedSequenceId, stateStorage.State.Metadata, stateStorage.State.PendingStates);
         }
 
-        public async Task<string> Store(string stateName, string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
+        public async Task<string> Store(string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
         {
             if (this.StateStorage.Etag != expectedETag)
                 throw new ArgumentException(nameof(expectedETag), "Etag does not match");

--- a/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/DistributedTM/TestFixture.cs
@@ -29,14 +29,18 @@ namespace Orleans.Transactions.AzureStorage.Tests.DistributedTM
                 var id = (uint)Guid.NewGuid().GetHashCode() % 100000;
                 hostBuilder
                     .ConfigureLogging(builder => builder.AddFilter("SingleStateTransactionalGrain.data", LogLevel.Trace))
+                    .ConfigureLogging(builder => builder.AddFilter("DoubleStateTransactionalGrain.data", LogLevel.Trace))
+                    .ConfigureLogging(builder => builder.AddFilter("MaxStateTransactionalGrain.data", LogLevel.Trace))
                     .ConfigureLogging(builder => builder.AddFilter("TransactionAgent", LogLevel.Trace))
-                    .AddAzureTableGrainStorage(TransactionTestConstants.TransactionStore, options =>
+                    .ConfigureLogging(builder => builder.AddFilter("Orleans.Transactions.DistributedTM.AzureStorage.AzureTableTransactionalStateStorage", LogLevel.Trace))
+                    .AddAzureTableTransactionalStateStorage(TransactionTestConstants.TransactionStore, options =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     })
                     .UseDistributedTM();
             }
         }
+        
 
         public static void CheckForAzureStorage(string dataConnectionString)
         {


### PR DESCRIPTION
New implementation for Azure table transactional storage for distributed TM.
Supports arbitrarily sized batches.

Passes existing transactions tests (NOTE: fails on devstorage, must use actual Azure table).
Testing is somewhat incomplete, we still need more tests to exercise all the recovery situations.