### PR TITLE
Generate correct serializer for TransactionParticipantExtensionWrapper

### DIFF
--- a/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
+++ b/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
@@ -3,9 +3,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Orleans.CodeGeneration;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Serialization;
+using Orleans.Transactions.Abstractions.Extensions;
+
+[assembly: GenerateSerializer(typeof(TransactionParticipantExtensionExtensions.TransactionParticipantExtensionWrapper))]
 
 namespace Orleans.Transactions.Abstractions.Extensions
 {


### PR DESCRIPTION
TransactionParticipantExtensionWrapper is serialized as part of StorageBatch Metadata, need to generate correct serializer for it otherwise gets serialization exception when trying to (de)serialization StorageBatch Metadata