### PR TITLE
Fix Transactional StorageProvider Wrapper

### DIFF
--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -57,13 +57,10 @@ namespace Orleans.Transactions
             // prepare
             if (statesToPrepare?.Count > 0)
             {
-                if (pendinglist.Count != 0)
+                // remove prepare records that are being overwritten
+                while (pendinglist.Count != 0 && pendinglist[pendinglist.Count - 1].SequenceId >= statesToPrepare[0].SequenceId)
                 {
-                    // remove prepare records that are being overwritten
-                    while (pendinglist[pendinglist.Count - 1].SequenceId >= statesToPrepare[0].SequenceId)
-                    {
-                        pendinglist.RemoveAt(pendinglist.Count - 1);
-                    }
+                    pendinglist.RemoveAt(pendinglist.Count - 1);
                 }
                 pendinglist.AddRange(statesToPrepare);
             }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -27,11 +27,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
-                    .ConfigureLogging(builder => builder.AddFilter("SingleStateTransactionalGrain.data", LogLevel.Trace))
-                    .ConfigureLogging(builder => builder.AddFilter("DoubleStateTransactionalGrain.data", LogLevel.Trace))
-                    .ConfigureLogging(builder => builder.AddFilter("MaxStateTransactionalGrain.data", LogLevel.Trace))
-                    .ConfigureLogging(builder => builder.AddFilter("TransactionAgent", LogLevel.Trace))
-                    .ConfigureLogging(builder => builder.AddFilter("Orleans.Transactions.AzureStorage.AzureTableTransactionalStateStorage", LogLevel.Trace))
+                    .ConfigureTracingForTransactionTests()
                     .AddAzureTableTransactionalStateStorage(TransactionTestConstants.TransactionStore, options =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
@@ -16,6 +16,7 @@ namespace Orleans.Transactions.Tests
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .ConfigureTracingForTransactionTests()
                     .AddMemoryGrainStorage(TransactionTestConstants.TransactionStore)
                     .UseDistributedTM();
             }

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionTestConstants.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionTestConstants.cs
@@ -1,4 +1,7 @@
 ﻿
+using Microsoft.Extensions.Logging;
+using Orleans.Hosting;
+
 namespace Orleans.Transactions.Tests
 {
     public static class TransactionTestConstants
@@ -16,5 +19,17 @@ namespace Orleans.Transactions.Tests
         public const string SingleStateTransactionalGrain = "Orleans.Transactions.Tests.SingleStateTransactionalGrain";
         public const string DoubleStateTransactionalGrain = "Orleans.Transactions.Tests.DoubleStateTransactionalGrain";
         public const string MaxStateTransactionalGrain = "Orleans.Transactions.Tests.MaxStateTransactionalGrain";
+
+
+        // control the tracing of the various components of the transaction mechanism
+        public static ISiloHostBuilder ConfigureTracingForTransactionTests(this ISiloHostBuilder hostBuilder)
+        {
+            return hostBuilder
+                 .ConfigureLogging(builder => builder.AddFilter("SingleStateTransactionalGrain.data", LogLevel.Trace))
+                 .ConfigureLogging(builder => builder.AddFilter("DoubleStateTransactionalGrain.data", LogLevel.Trace))
+                 .ConfigureLogging(builder => builder.AddFilter("MaxStateTransactionalGrain.data", LogLevel.Trace))
+                 .ConfigureLogging(builder => builder.AddFilter("TransactionAgent", LogLevel.Trace))
+                 .ConfigureLogging(builder => builder.AddFilter("Orleans.Transactions.AzureStorage.AzureTableTransactionalStateStorage", LogLevel.Trace));
+        }
     }
 }


### PR DESCRIPTION
Fix a bug in TransactionalStateStorageProviderWrapper. This was a very plain bug causing an IndexOutOfRangeException; interestingly, it made it past the original unit tests. 
This bug was caught yesterday by the concurrency tests (#4595). That's exactly why we need those.

In this same PR I am also making a small change to reorganize the tracing configuration for transaction test cases to make it easier to control.