### PR TITLE
Update Client and Server packages to 2.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -138,8 +138,8 @@
     <OrleansServiceFabricVersion>2.0.0</OrleansServiceFabricVersion>
     <OrleansSerializersVersion>2.0.0</OrleansSerializersVersion>
     <OrleansToolsVersion>2.0.0</OrleansToolsVersion>
-    <OrleansClientVersion>2.0.0</OrleansClientVersion>
-    <OrleansServerVersion>2.0.0</OrleansServerVersion>
+    <OrleansClientVersion>2.0.3</OrleansClientVersion>
+    <OrleansServerVersion>2.0.3</OrleansServerVersion>
     <OrleansCodegenVersion>2.0.3</OrleansCodegenVersion>
     <OrleansEventHubProviderVersion>2.0.3</OrleansEventHubProviderVersion>
   </PropertyGroup>

--- a/src/Orleans.Client/Directory.Build.props
+++ b/src/Orleans.Client/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansClientVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Orleans.Client/Directory.Build.props
+++ b/src/Orleans.Client/Directory.Build.props
@@ -20,6 +20,19 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansServerVersion)">
+      <ItemGroup >
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
+  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansCoreVersion)">
       <ItemGroup >
         <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Orleans.Server/Directory.Build.props
+++ b/src/Orleans.Server/Directory.Build.props
@@ -27,7 +27,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansServerVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansProvidersVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -40,7 +40,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansServerVersion)"/>
+        <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansRuntimeVersion)"/>
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Fixes #4601.

With this, we should be able to publish just 2.0.3 versions of the Client and Server meta-packages without incrementing version to 2.0.4.