### PR TITLE
Disable multilevel lookup

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -9,6 +9,9 @@ if not defined BuildConfiguration SET BuildConfiguration=Debug
 :: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
 set Platform=
 
+:: Disable multilevel lookup https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/multilevel-sharedfx-lookup.md
+set DOTNET_MULTILEVEL_LOOKUP=0 
+
 call Ensure-DotNetSdk.cmd
 
 SET SOLUTION=%CMDHOME%\Orleans.sln

--- a/Test.cmd
+++ b/Test.cmd
@@ -7,6 +7,9 @@ SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
 set CMDHOME=%CMDHOME:~0,-1%
 
+:: Disable multilevel lookup https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/multilevel-sharedfx-lookup.md
+set DOTNET_MULTILEVEL_LOOKUP=0 
+
 call Ensure-DotNetSdk.cmd
 
 pushd "%CMDHOME%"


### PR DESCRIPTION
Currently, if a recent sdk version is installed, the latest version will be used instead of the version specified in the `DotnetCLIVersion.txt`. Setting `DOTNET_MULTILEVEL_LOOKUP` to 0 fix this issue