### PR TITLE
Remove unused settings MaxPendingWorkItemsHardLimit in SchedulingOptions

### DIFF
--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -201,7 +201,6 @@ namespace Orleans.Hosting
                     options.EnableWorkerThreadInjection = nodeConfig.EnableWorkerThreadInjection;
                     LimitValue itemLimit = nodeConfig.LimitManager.GetLimit(LimitNames.LIMIT_MAX_PENDING_ITEMS);
                     options.MaxPendingWorkItemsSoftLimit = itemLimit.SoftLimitThreshold;
-                    options.MaxPendingWorkItemsHardLimit = itemLimit.HardLimitThreshold;
                 });
 
             services.AddOptions<GrainCollectionOptions>().Configure<GlobalConfiguration>((options, config) =>

--- a/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
@@ -56,14 +56,6 @@ namespace Orleans.Configuration
         public const int DEFAULT_MAX_PENDING_ITEMS_SOFT_LIMIT = 0;
 
         /// <summary>
-        /// Per work group limit of how many items can be queued up before work is rejected.
-        /// NOTE: This setting is not in effect.
-        /// TODO: Remove this setting - jbragg
-        /// </summary>
-        public int MaxPendingWorkItemsHardLimit { get; set; } = DEFAULT_MAX_PENDING_ITEMS_HARD_LIMIT;
-        public const int DEFAULT_MAX_PENDING_ITEMS_HARD_LIMIT = 0;
-
-        /// <summary>
         /// For test use only.  Do not alter from default in production services
         /// </summary>
         public bool EnableWorkerThreadInjection { get; set; } = DEFAULT_ENABLE_WORKER_THREAD_INJECTION;

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -35,7 +35,6 @@ namespace Orleans.Runtime.Scheduler
 
         // This is the maximum number of pending work items for a single activation before we write a warning log.
         internal int MaxPendingItemsSoftLimit { get; private set; }
-        internal int MaxPendingItemsHardLimit { get; private set; }
 
         public int RunQueueLength => systemAgent.Count + mainAgent.Count;
         
@@ -55,7 +54,6 @@ namespace Orleans.Runtime.Scheduler
             applicationTurnsStopped = false;
             TurnWarningLengthThreshold = options.Value.TurnWarningLengthThreshold;
             this.MaxPendingItemsSoftLimit = options.Value.MaxPendingWorkItemsSoftLimit;
-            this.MaxPendingItemsHardLimit = options.Value.MaxPendingWorkItemsHardLimit;
             workgroupDirectory = new ConcurrentDictionary<ISchedulingContext, WorkItemGroup>();
 
             const int maxSystemThreads = 2;


### PR DESCRIPTION
MaxPendingWorkItemsHardLimit is not used. No reason for it to be exposed through SchedulingOptions