### PR TITLE
[WIP] Tx load shedding based on lock queue length

### DIFF
--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -47,7 +47,7 @@ namespace Orleans
                     Stopwatch stopWatch = Stopwatch.StartNew();
                     await Task.WhenAll(observerGroup.Select(orderedObserver => WrapExecution(ct, orderedObserver.Observer.OnStart)));
                     stopWatch.Stop();
-                    this.logger?.Info(ErrorCode.SiloStartPerfMeasure, $"Starting lifecycle stage {this.highStage} took {stopWatch.ElapsedMilliseconds} Milliseconds");
+                    //this.logger?.Info(ErrorCode.SiloStartPerfMeasure, $"Starting lifecycle stage {this.highStage} took {stopWatch.ElapsedMilliseconds} Milliseconds");
                 }
             }
             catch (Exception ex)
@@ -74,7 +74,7 @@ namespace Orleans
                     Stopwatch stopWatch = Stopwatch.StartNew();
                     await Task.WhenAll(observerGroup.Select(orderedObserver => WrapExecution(ct, orderedObserver.Observer.OnStop)));
                     stopWatch.Stop();
-                    this.logger?.Info(ErrorCode.SiloStartPerfMeasure, $"Stopping lifecycle stage {this.highStage} took {stopWatch.ElapsedMilliseconds} Milliseconds");
+                    //this.logger?.Info(ErrorCode.SiloStartPerfMeasure, $"Stopping lifecycle stage {this.highStage} took {stopWatch.ElapsedMilliseconds} Milliseconds");
                 }
                 catch (Exception ex)
                 {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -14,6 +8,12 @@ using Orleans.GrainDirectory;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Scheduler;
 using Orleans.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Orleans.Runtime
 {

--- a/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
@@ -25,12 +25,8 @@ namespace Orleans.Hosting
         {
             services.TryAddSingleton<IClock,Clock>();
             services.TryAddSingleton<TransactionAgentStatistics>();
-<<<<<<< 2125111a0a59977a70386e590b380d971a933926
             services.TryAddSingleton<ITransactionOverloadDetector,TransactionOverloadDetector>();
-=======
-            services.TryAddSingleton<TransactionStateStatistics>();
-            services.TryAddSingleton<ITransactionOverloadDetector, TransactionOverloadDetector>();
->>>>>>> load shedding based on lock waiting time
+            services.TryAddTransient<TransactionStateStatistics>();
             services.AddSingleton<ITransactionAgent, TransactionAgent>();
             services.TryAddSingleton(typeof(ITransactionDataCopier<>), typeof(DefaultTransactionDataCopier<>));
             services.AddSingleton<IAttributeToFactoryMapper<TransactionalStateAttribute>, TransactionalStateAttributeMapper>();

--- a/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
@@ -25,7 +25,12 @@ namespace Orleans.Hosting
         {
             services.TryAddSingleton<IClock,Clock>();
             services.TryAddSingleton<TransactionAgentStatistics>();
+<<<<<<< 2125111a0a59977a70386e590b380d971a933926
             services.TryAddSingleton<ITransactionOverloadDetector,TransactionOverloadDetector>();
+=======
+            services.TryAddSingleton<TransactionStateStatistics>();
+            services.TryAddSingleton<ITransactionOverloadDetector, TransactionOverloadDetector>();
+>>>>>>> load shedding based on lock waiting time
             services.AddSingleton<ITransactionAgent, TransactionAgent>();
             services.TryAddSingleton(typeof(ITransactionDataCopier<>), typeof(DefaultTransactionDataCopier<>));
             services.AddSingleton<IAttributeToFactoryMapper<TransactionalStateAttribute>, TransactionalStateAttributeMapper>();

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -46,7 +46,7 @@ namespace Orleans.Transactions
                 ? 0
                 : lockQueueLengthCounter / lockQueueLengthReportCounter;
             this.telemetryProducer.TrackMetric(AvgLockQueueLength, avgLockQueueLength);
-            //record snapshot data of this report
+            // reset the counters
             lockQueueLengthCounter = 0;
             lockQueueLengthReportCounter = 0;
         }
@@ -65,11 +65,6 @@ namespace Orleans.Transactions
         private Guid cachedMinId;
 
         private int lockQueueLength = 0;
-        private TransactionStateStatistics statistics;
-        public TransactionalState(TransactionStateStatistics statistics)
-        {
-            this.statistics = statistics;
-        }
 
         // group of non-conflicting transactions collectively acquiring/releasing the lock
         private class LockGroup : Dictionary<Guid, TransactionRecord<TState>>
@@ -307,7 +302,7 @@ namespace Orleans.Transactions
 
         }
 
-        private const int QueueLengthHardLimit = Int32.MaxValue;
+        private const int QueueLengthHardLimit = 10;
         private bool Find(Guid guid, bool isRead, out LockGroup group, out TransactionRecord<TState> record)
         {
             if (currentGroup == null)
@@ -351,7 +346,6 @@ namespace Orleans.Transactions
                             this.lockQueueLength++;
                             this.statistics.ReportLockQueueLengthChange(this.lockQueueLength);
                         }
-
                         return false;
                     }
                     pos = pos.Next;

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -88,7 +88,7 @@ namespace Orleans.Transactions
         private BatchWorker confirmationWorker;
 
         private CausalClock clock;
-
+        private TransactionStateStatistics statistics;
         // collection tasks
         private Dictionary<DateTime, PMessages> unprocessedPreparedMessages;
         private class PMessages
@@ -106,7 +106,8 @@ namespace Orleans.Transactions
             ILoggerFactory loggerFactory, 
             ITypeResolver typeResolver,
             IGrainFactory grainFactory,
-            IClock clock
+            IClock clock,
+            TransactionStateStatistics statistics
             )
         {
             this.config = transactionalStateConfiguration;
@@ -116,7 +117,7 @@ namespace Orleans.Transactions
             this.runtime = runtime;
             this.loggerFactory = loggerFactory;
             this.clock = new CausalClock(clock);
-
+            this.statistics = statistics;
             lockWorker = new BatchWorkerFromDelegate(LockWork);
             storageWorker = new BatchWorkerFromDelegate(StorageWork);
             confirmationWorker = new BatchWorkerFromDelegate(ConfirmationWork);

--- a/test/Benchmarks/Properties/launchSettings.json
+++ b/test/Benchmarks/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Benchmarks": {
+      "commandName": "Project",
+      "commandLineArgs": "Transactions.Azure"
+    }
+  }
+}

--- a/test/Benchmarks/Transactions/LogTelemetryConsumer.cs
+++ b/test/Benchmarks/Transactions/LogTelemetryConsumer.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Benchmarks.Transactions
+{
+    public class LogMetricsTelemetryConsumer : IMetricTelemetryConsumer
+    {
+        private ILogger logger;
+        public LogMetricsTelemetryConsumer(ILogger<LogMetricsTelemetryConsumer> logger)
+        {
+            this.logger = logger;
+        }
+
+        public void Close()
+        {
+            //do nothing
+        }
+
+        public void DecrementMetric(string name)
+        {
+            //do nothing
+        }
+
+        public void DecrementMetric(string name, double value)
+        {
+            //do nothing
+        }
+
+        public void Flush()
+        {
+            //do nothing
+        }
+
+        public void IncrementMetric(string name)
+        {
+            //do nothing
+        }
+
+        public void IncrementMetric(string name, double value)
+        {
+            //do nothing
+        }
+
+        public void TrackMetric(string name, double value, IDictionary<string, string> properties = null)
+        {
+            if (!name.Contains("Transaction"))
+                return;
+            if (properties != null)
+            {
+                foreach (var property in properties)
+                {
+                    this.logger.LogInformation($"{property.Key}:{property.Value}");
+                }
+            }
+
+            this.logger.LogInformation($"{name}={value}");
+
+        }
+
+        public void TrackMetric(string name, TimeSpan value, IDictionary<string, string> properties = null)
+        {
+            if (!name.Contains("Transaction"))
+                return;
+            if (properties != null)
+            {
+                foreach (var property in properties)
+                {
+                    this.logger.LogInformation($"{property.Key}:{property.Value}");
+                }
+            }
+
+            this.logger.LogInformation($"{name}={value}");
+        }
+    }
+}

--- a/test/Benchmarks/Transactions/TransactionBenchmark.cs
+++ b/test/Benchmarks/Transactions/TransactionBenchmark.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using BenchmarkGrainInterfaces.Transaction;
+using Orleans.Configuration;
 using TestExtensions;
 
 namespace Benchmarks.Transactions
@@ -59,7 +60,7 @@ namespace Benchmarks.Transactions
 
         private async Task FullRunAsync()
         {
-            Report[] reports = await Task.WhenAll(Enumerable.Range(0, 10).Select(i => RunAsync(i, 2000, 500)));
+            Report[] reports = await Task.WhenAll(Enumerable.Range(0, 10).Select(i => RunAsync(i, 6000, 2000)));
             Report finalReport = new Report();
             foreach (Report report in reports)
             {
@@ -99,7 +100,8 @@ namespace Benchmarks.Transactions
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseDistributedTM();
+                hostBuilder.UseDistributedTM()
+                    .Configure<TelemetryOptions>(options => options.AddConsumer<LogMetricsTelemetryConsumer>());
             }
         }
     }


### PR DESCRIPTION
Here is my wip for load shedding based on read-write lock on transactional state. 
Rough algorithm:
- keep track of the `LockGroup` queue length in variable `lockQueueLength `
- reject new tx enqueue `LockGroup` if its length is larger than `QueueLengthHardLimit` 

Main problem for this algorithm is that it is hard to test it right now, the test actually hit the azure storage limit first than hit the queue length limit. Based on the statistics I record, the queue length is around 0.5 in average when hit storage throttling limit. I tried with memory storage too and it is similar issue.  So submit this WIP so more people can have an eye on this, in case I got the implementation wrong. 

Note:
- `QueueLengthHardLimit ` is currently hard coded, but should be configurable in the future
- I added `TransactionStateStatistics ` just to find out what's the proper value for `QueueLengthHardLimit`, by observing `LockGroup` queue length when tx runtime is overloaded with this load shedding turned off. I understand it may not be an optimal implementation for `TransactionStateStatistics`. We need to refactor it before check it in. One problem is reporting statistic on a per state level is too verbose. But if all state share the same `TransactionStateStatistics` singleton, it become a bottle neck. But refactoring it is not the main thing I want to talk about in this WIP. we can get to it in a later point 
