### PR TITLE
Fix TransactionParticipantExtensionWrapper serialization issues

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -10,6 +10,7 @@ using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Abstractions.Extensions;
 
 namespace Orleans.Transactions.AzureStorage
 {
@@ -33,7 +34,9 @@ namespace Orleans.Transactions.AzureStorage
             this.name = name;
             this.options = options;
             this.clusterOptions = clusterOptions.Value;
-            this.jsonSettings = OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory);
+            this.jsonSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(
+                typeResolver,
+                grainFactory);
             this.loggerFactory = loggerFactory;
         }
 

--- a/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
+++ b/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
@@ -7,8 +7,6 @@ using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Serialization;
 
-[assembly: GenerateSerializer(typeof(Orleans.Transactions.Abstractions.Extensions.TransactionParticipantExtensionExtensions.TransactionParticipantExtensionWrapper))]
-
 namespace Orleans.Transactions.Abstractions.Extensions
 {
     public static class TransactionParticipantExtensionExtensions
@@ -27,7 +25,6 @@ namespace Orleans.Transactions.Abstractions.Extensions
         public static JsonSerializerSettings GetJsonSerializerSettings(ITypeResolver typeResolver, IGrainFactory grainFactory)
         {
             var serializerSettings = OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory);
-            serializerSettings.TypeNameHandling = TypeNameHandling.Auto;
             serializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.None;
             return serializerSettings;
         }
@@ -36,7 +33,9 @@ namespace Orleans.Transactions.Abstractions.Extensions
         [Immutable]
         internal sealed class TransactionParticipantExtensionWrapper : ITransactionParticipant
         {
+            [JsonProperty]
             private readonly ITransactionParticipantExtension extension;
+            [JsonProperty]
             private readonly string resourceId;
 
             public TransactionParticipantExtensionWrapper(ITransactionParticipantExtension transactionalExtension, string resourceId)

--- a/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
+++ b/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
@@ -33,7 +33,6 @@ namespace Orleans.Transactions.Abstractions.Extensions
         [Immutable]
         internal sealed class TransactionParticipantExtensionWrapper : ITransactionParticipant
         {
-            [JsonProperty]
             private readonly ITransactionParticipantExtension extension;
             [JsonProperty]
             private readonly string resourceId;

--- a/src/Orleans.Transactions/State/StorageBatch.cs
+++ b/src/Orleans.Transactions/State/StorageBatch.cs
@@ -74,7 +74,7 @@ namespace Orleans.Transactions
         private int confirm = 0;
         private int collect = 0;
         private int cancel = 0;
-        public JsonSerializerSettings SerializerSettings { get; private set; }
+        private readonly JsonSerializerSettings serializerSettings;
         public MetaData MetaData { get; private set; }
 
         public string ETag { get; set; }
@@ -87,8 +87,8 @@ namespace Orleans.Transactions
 
         public StorageBatch(TransactionalStorageLoadResponse<TState> loadresponse, JsonSerializerSettings serializerSettings)
         {
-            this.SerializerSettings = serializerSettings??throw new ArgumentNullException(nameof(serializerSettings));
-            MetaData = ReadMetaData(loadresponse, this.SerializerSettings);
+            this.serializerSettings = serializerSettings ?? throw new ArgumentNullException(nameof(serializerSettings));
+            MetaData = ReadMetaData(loadresponse, this.serializerSettings);
             ETag = loadresponse.ETag;
             confirmUpTo = loadresponse.CommittedSequenceId;
             cancelAbove = loadresponse.PendingStates.LastOrDefault()?.SequenceId ?? loadresponse.CommittedSequenceId;
@@ -97,7 +97,7 @@ namespace Orleans.Transactions
 
         public StorageBatch(StorageBatch<TState> previous)
         {
-            this.SerializerSettings = previous.SerializerSettings;
+            this.serializerSettings = previous.serializerSettings;
             MetaData = previous.MetaData;
             confirmUpTo = previous.confirmUpTo;
             cancelAbove = previous.cancelAbove;
@@ -123,7 +123,7 @@ namespace Orleans.Transactions
 
         public Task<string> Store(ITransactionalStateStorage<TState> storage)
         {
-            var jsonMetaData = JsonConvert.SerializeObject(MetaData, this.SerializerSettings);
+            var jsonMetaData = JsonConvert.SerializeObject(MetaData, this.serializerSettings);
             var list = new List<PendingTransactionState<TState>>();
 
             if (prepares != null)
@@ -176,7 +176,7 @@ namespace Orleans.Transactions
                 prepares = new SortedDictionary<long, PendingTransactionState<TState>>();
 
             var tmstring = (transactionManager == null) ? null :
-                JsonConvert.SerializeObject(transactionManager, this.SerializerSettings);
+                JsonConvert.SerializeObject(transactionManager, this.serializerSettings);
 
             prepares[sequenceNumber] = new PendingTransactionState<TState>
             {

--- a/src/Orleans.Transactions/State/StorageBatch.cs
+++ b/src/Orleans.Transactions/State/StorageBatch.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Orleans.Concurrency;
 using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Abstractions.Extensions;
 
 namespace Orleans.Transactions
 {
@@ -35,8 +37,6 @@ namespace Orleans.Transactions
         public DateTime TimeStamp { get; set; }
 
         public Dictionary<Guid, CommitRecord> CommitRecords { get; set; }
-
-        public static JsonSerializerSettings SerializerSettings { get; set; }
     }
 
     [Serializable]
@@ -74,38 +74,43 @@ namespace Orleans.Transactions
         private int confirm = 0;
         private int collect = 0;
         private int cancel = 0;
-
+        private JsonSerializerSettings serializerSettings;
         public MetaData MetaData { get; private set; }
 
         public string ETag { get; set; }
 
         public int BatchSize => total;
-
         public override string ToString()
         {
             return $"batchsize={total} [{read}r {prepare}p {commit}c {confirm}cf {collect}cl {cancel}cc]";
         }
 
-        public StorageBatch(TransactionalStorageLoadResponse<TState> loadresponse)
+        public StorageBatch(TransactionalStorageLoadResponse<TState> loadresponse, JsonSerializerSettings settings)
         {
-            MetaData = ReadMetaData(loadresponse);
+            if(settings == null)
+                throw new ArgumentNullException(nameof(settings));
+            this.serializerSettings = settings;
+            MetaData = ReadMetaData(loadresponse, this.serializerSettings);
             ETag = loadresponse.ETag;
             confirmUpTo = loadresponse.CommittedSequenceId;
             cancelAbove = loadresponse.PendingStates.LastOrDefault()?.SequenceId ?? loadresponse.CommittedSequenceId;
             cancelAboveStart = cancelAbove;
         }
 
-        public StorageBatch(StorageBatch<TState> previous)
+        public StorageBatch(StorageBatch<TState> previous, JsonSerializerSettings settings)
         {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+            this.serializerSettings = settings;
             MetaData = previous.MetaData;
             confirmUpTo = previous.confirmUpTo;
             cancelAbove = previous.cancelAbove;
             cancelAboveStart = cancelAbove;
         }
 
-        private static MetaData ReadMetaData(TransactionalStorageLoadResponse<TState> loadresponse)
+        private static MetaData ReadMetaData(TransactionalStorageLoadResponse<TState> loadresponse, JsonSerializerSettings serializerSettings)
         {
-            if (string.IsNullOrEmpty(loadresponse.Metadata))
+            if (string.IsNullOrEmpty(loadresponse?.Metadata))
             {
                 // this thing is fresh... did not exist in storage yet
                 return new MetaData()
@@ -116,14 +121,13 @@ namespace Orleans.Transactions
             }
             else
             {
-                return JsonConvert.DeserializeObject<MetaData>(loadresponse.Metadata, MetaData.SerializerSettings);
+                return JsonConvert.DeserializeObject<MetaData>(loadresponse.Metadata, serializerSettings);
             }
         }
 
         public Task<string> Store(ITransactionalStateStorage<TState> storage)
         {
-            var jsonMetaData = JsonConvert.SerializeObject(MetaData, MetaData.SerializerSettings);
-
+            var jsonMetaData = JsonConvert.SerializeObject(MetaData, this.serializerSettings);
             var list = new List<PendingTransactionState<TState>>();
 
             if (prepares != null)
@@ -176,7 +180,7 @@ namespace Orleans.Transactions
                 prepares = new SortedDictionary<long, PendingTransactionState<TState>>();
 
             var tmstring = (transactionManager == null) ? null :
-                JsonConvert.SerializeObject(transactionManager, MetaData.SerializerSettings);
+                JsonConvert.SerializeObject(transactionManager, this.serializerSettings);
 
             prepares[sequenceNumber] = new PendingTransactionState<TState>
             {

--- a/src/Orleans.Transactions/State/TransactionParticipant.cs
+++ b/src/Orleans.Transactions/State/TransactionParticipant.cs
@@ -67,7 +67,7 @@ namespace Orleans.Transactions
                     {
                         // get the next batch in place so it can be filled while we store the old one
                         batchBeingSentToStorage = storageBatch;                  
-                        storageBatch = new StorageBatch<TState>(batchBeingSentToStorage, this.serializerSettings);
+                        storageBatch = new StorageBatch<TState>(batchBeingSentToStorage);
 
                         // perform the actual store, and record the e-tag
                         storageBatch.ETag = await batchBeingSentToStorage.Store(storage);

--- a/src/Orleans.Transactions/State/TransactionParticipant.cs
+++ b/src/Orleans.Transactions/State/TransactionParticipant.cs
@@ -67,7 +67,7 @@ namespace Orleans.Transactions
                     {
                         // get the next batch in place so it can be filled while we store the old one
                         batchBeingSentToStorage = storageBatch;                  
-                        storageBatch = new StorageBatch<TState>(batchBeingSentToStorage);
+                        storageBatch = new StorageBatch<TState>(batchBeingSentToStorage, this.serializerSettings);
 
                         // perform the actual store, and record the e-tag
                         storageBatch.ETag = await batchBeingSentToStorage.Store(storage);

--- a/src/Orleans.Transactions/State/TransactionParticipantExtension.cs
+++ b/src/Orleans.Transactions/State/TransactionParticipantExtension.cs
@@ -7,10 +7,8 @@ using Newtonsoft.Json;
 
 namespace Orleans.Transactions
 {
-    [Serializable]
     public class TransactionParticipantExtension : ITransactionParticipantExtension
     {
-        [JsonProperty]
         private readonly Dictionary<string, ITransactionParticipant> localParticipants = new Dictionary<string, ITransactionParticipant>();
 
         public void Register(string resourceId, ITransactionParticipant localTransactionParticipant)

--- a/src/Orleans.Transactions/State/TransactionParticipantExtension.cs
+++ b/src/Orleans.Transactions/State/TransactionParticipantExtension.cs
@@ -3,11 +3,14 @@ using Orleans.Transactions.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Orleans.Transactions
 {
+    [Serializable]
     public class TransactionParticipantExtension : ITransactionParticipantExtension
     {
+        [JsonProperty]
         private readonly Dictionary<string, ITransactionParticipant> localParticipants = new Dictionary<string, ITransactionParticipant>();
 
         public void Register(string resourceId, ITransactionParticipant localTransactionParticipant)

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -89,6 +89,7 @@ namespace Orleans.Transactions
 
         private CausalClock clock;
 
+        private JsonSerializerSettings serializerSettings;
         // collection tasks
         private Dictionary<DateTime, PMessages> unprocessedPreparedMessages;
         private class PMessages
@@ -120,11 +121,8 @@ namespace Orleans.Transactions
             lockWorker = new BatchWorkerFromDelegate(LockWork);
             storageWorker = new BatchWorkerFromDelegate(StorageWork);
             confirmationWorker = new BatchWorkerFromDelegate(ConfirmationWork);
-
-            if (MetaData.SerializerSettings == null)
-            {
-                MetaData.SerializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(typeResolver, grainFactory);
-            }
+            
+            this.serializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(typeResolver, grainFactory);
         }
 
         #region lifecycle
@@ -190,7 +188,8 @@ namespace Orleans.Transactions
 
             var loadresponse = await loadtask;
 
-            storageBatch = new StorageBatch<TState>(loadresponse);
+            storageBatch = new StorageBatch<TState>(loadresponse, this.serializerSettings);
+         
 
             stableState = loadresponse.CommittedState;
             stableSequenceNumber = loadresponse.CommittedSequenceId;
@@ -208,9 +207,8 @@ namespace Orleans.Transactions
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                         logger.Debug($"recover two-phase-commit {pr.TransactionId}");
-
                     var tm = (pr.TransactionManager == null) ? null :
-                        (ITransactionParticipant) JsonConvert.DeserializeObject<ITransactionParticipant>(pr.TransactionManager, MetaData.SerializerSettings);
+                        (ITransactionParticipant) JsonConvert.DeserializeObject<ITransactionParticipant>(pr.TransactionManager, this.serializerSettings);
 
                     commitQueue.Add(new TransactionRecord<TState>()
                     {

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -105,8 +105,7 @@ namespace Orleans.Transactions
             ITransactionAgent transactionAgent, 
             IProviderRuntime runtime, 
             ILoggerFactory loggerFactory, 
-            ITypeResolver typeResolver,
-            IGrainFactory grainFactory,
+            JsonSerializerSettings serializerSettings,
             IClock clock
             )
         {
@@ -121,8 +120,8 @@ namespace Orleans.Transactions
             lockWorker = new BatchWorkerFromDelegate(LockWork);
             storageWorker = new BatchWorkerFromDelegate(StorageWork);
             confirmationWorker = new BatchWorkerFromDelegate(ConfirmationWork);
-            
-            this.serializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(typeResolver, grainFactory);
+
+            this.serializerSettings = serializerSettings;
         }
 
         #region lifecycle

--- a/src/Orleans.Transactions/State/TransactionalStateFactory.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateFactory.cs
@@ -1,21 +1,25 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Abstractions.Extensions;
 
 namespace Orleans.Transactions
 {
     public class TransactionalStateFactory : ITransactionalStateFactory
     {
         private IGrainActivationContext context;
-
-        public TransactionalStateFactory(IGrainActivationContext context)
+        private JsonSerializerSettings serializerSettings;
+        public TransactionalStateFactory(IGrainActivationContext context, ITypeResolver typeResolver, IGrainFactory grainFactory)
         {
             this.context = context;
+            this.serializerSettings =
+                TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(typeResolver, grainFactory);
         }
 
         public ITransactionalState<TState> Create<TState>(ITransactionalStateConfiguration config) where TState : class, new()
         {
-            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, config, this.context);
+            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, config, this.serializerSettings, this.context);
             transactionalState.Participate(context.ObservableLifecycle);
             return transactionalState;
         }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -3,9 +3,7 @@ using Xunit;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Transactions.Tests;
-using Orleans.TestingHost.Utils;
 using TestExtensions;
-using Microsoft.Extensions.Logging;
 using Tester;
 
 namespace Orleans.Transactions.AzureStorage.Tests

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using Orleans.Providers;
 using Xunit;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -34,13 +36,13 @@ namespace Orleans.Transactions.Tests.Memory
                 Timestamp = DateTime.UtcNow,
                 WriteParticipants = new List<ITransactionParticipant>() { new TransactionParticipantExtension().AsTransactionParticipant("resourceId")}
             });
-            MetaData.SerializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(
+            var serializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(
                 this.environment.Client.ServiceProvider.GetService<ITypeResolver>(),
                 this.environment.GrainFactory);
             //should be able to serialize it
-            var jsonMetaData = JsonConvert.SerializeObject(metaData, MetaData.SerializerSettings);
+            var jsonMetaData = JsonConvert.SerializeObject(metaData, serializerSettings);
 
-            var deseriliazedMetaData = JsonConvert.DeserializeObject<MetaData>(jsonMetaData, MetaData.SerializerSettings);
+            var deseriliazedMetaData = JsonConvert.DeserializeObject<MetaData>(jsonMetaData, serializerSettings);
             Assert.Equal(metaData.TimeStamp, deseriliazedMetaData.TimeStamp);
         }
     }

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
@@ -11,34 +11,38 @@ using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.Abstractions.Extensions;
+using Orleans.Transactions.Tests.Correctness;
 using TestExtensions;
+using Xunit.Abstractions;
 
 namespace Orleans.Transactions.Tests.Memory
 {
     [TestCategory("BVT"), TestCategory("Transactions")]
-    public class SerializationTests
+    public class SerializationTests: TransactionTestRunnerBase, IClassFixture<MemoryTransactionsFixture>
     {
-        private SerializationTestEnvironment environment;
-        public SerializationTests()
+        private MemoryTransactionsFixture fixture;
+        public SerializationTests(MemoryTransactionsFixture fixture, ITestOutputHelper output)
+            :base(fixture.GrainFactory, output)
         {
-            var config = new ClientConfiguration { SerializationProviders = { typeof(OrleansJsonSerializer).GetTypeInfo() } };
-            this.environment = SerializationTestEnvironment.InitializeWithDefaults(config);
+            this.fixture = fixture;
         }
 
         [Fact]
         public void JsonConcertCanSerializeMetaData()
         {
+            var grainRef = this.RandomTestGrain(TransactionTestConstants.SingleStateTransactionalGrain);
+            var ext = grainRef.Cast<ITransactionParticipantExtension>();
             var metaData = new MetaData();
             metaData.TimeStamp = DateTime.UtcNow;
             metaData.CommitRecords = new Dictionary<Guid, CommitRecord>();
             metaData.CommitRecords.Add(Guid.NewGuid(), new CommitRecord()
             {
                 Timestamp = DateTime.UtcNow,
-                WriteParticipants = new List<ITransactionParticipant>() { new TransactionParticipantExtension().AsTransactionParticipant("resourceId")}
+                WriteParticipants = new List<ITransactionParticipant>() { ext.AsTransactionParticipant("resourceId")}
             });
             var serializerSettings = TransactionParticipantExtensionExtensions.GetJsonSerializerSettings(
-                this.environment.Client.ServiceProvider.GetService<ITypeResolver>(),
-                this.environment.GrainFactory);
+                this.fixture.Client.ServiceProvider.GetService<ITypeResolver>(),
+                this.grainFactory);
             //should be able to serialize it
             var jsonMetaData = JsonConvert.SerializeObject(metaData, serializerSettings);
 


### PR DESCRIPTION
- removed static `MetaData.SerializerSettings`. Now serializer settings are parsed through constructors
- fixed serialization settings. Should use `TypeNameHandling.All`, instead of `Auto`
- fixed inconsistent serialization settings used in `AzureTableTransactionStateStorage` and `TransactionalState`, `StorageBatch`
- add `[JsonProperty]` attr to `TransactionParticipantExtensionWrapper ` fields

The first bullet point is refactoring. The remaining is there to fix the issue of `TransactionParticipantExtensionWrapper` is serialized into a "{}" before persist into storage, which is a json string represents empty instance. This causes transaction recovery failing when restore transaction state from storage. 