### PR TITLE
Make azure queue name configurable

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -4,6 +4,7 @@ using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Streams;
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans;
 
 namespace Orleans.Streaming
@@ -31,15 +32,10 @@ namespace Orleans.Streaming
             this.Configure<AzureQueueOptions>(configureOptions);
             return this;
         }
+
         public SiloAzureQueueStreamConfigurator<TDataAdapter> ConfigureCache(int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
         {
             this.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
-            return this;
-        }
-
-        public SiloAzureQueueStreamConfigurator<TDataAdapter> ConfigurePartitioning(int numOfPartition = HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES)
-        {
-            this.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = numOfPartition));
             return this;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -3,6 +3,7 @@ using Orleans.Hosting;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Streams;
 using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans;
@@ -25,6 +26,16 @@ namespace Orleans.Streaming
                         .AddTransient<IConfigurationValidator>(sp => new SimpleQueueCacheOptionsValidator(sp.GetOptionsByName<SimpleQueueCacheOptions>(name), name))
                         .ConfigureNamedOptionForLogging<HashRingStreamQueueMapperOptions>(name);
                 });
+            //configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId,
+                            this.name);
+                }
+            }));
         }
 
         public SiloAzureQueueStreamConfigurator<TDataAdapter> ConfigureAzureQueue(Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
@@ -39,7 +50,7 @@ namespace Orleans.Streaming
             return this;
         }
     }
-
+    
     public class ClusterClientAzureQueueStreamConfigurator<TDataAdapter> : ClusterClientPersistentStreamConfigurator
           where TDataAdapter : IAzureQueueDataAdapter
     {
@@ -51,18 +62,21 @@ namespace Orleans.Streaming
                     services.ConfigureNamedOptionForLogging<AzureQueueOptions>(name)
                     .AddTransient<IConfigurationValidator>(sp => new AzureQueueOptionsValidator(sp.GetOptionsByName<AzureQueueOptions>(name), name))
                     .ConfigureNamedOptionForLogging<HashRingStreamQueueMapperOptions>(name));
-               
+
+            //configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId, this.name);
+                }
+            }));
         }
 
         public ClusterClientAzureQueueStreamConfigurator<TDataAdapter> ConfigureAzureQueue(Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
             this.Configure<AzureQueueOptions>(configureOptions);
-            return this;
-        }
-
-        public ClusterClientAzureQueueStreamConfigurator<TDataAdapter> ConfigurePartitioning(int numOfPartition = HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES)
-        {
-            this.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = numOfPartition));
             return this;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs
@@ -2,6 +2,7 @@
 using Orleans.Runtime;
 using Orleans.Streams;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Configuration
 {
@@ -13,22 +14,31 @@ namespace Orleans.Configuration
         [RedactConnectionString]
         public string ConnectionString { get; set; }
 
-        public TimeSpan? MessageVisibilityTimeout { get; set; }   
+        public TimeSpan? MessageVisibilityTimeout { get; set; }
+
+        public List<string> QueueNames { get; set; }
     }
 
     public class AzureQueueOptionsValidator : IConfigurationValidator
     {
         private readonly AzureQueueOptions options;
         private readonly string name;
+
         public AzureQueueOptionsValidator(AzureQueueOptions options, string name)
         {
             this.options = options;
             this.name = name;
         }
+
         public void ValidateConfiguration()
         {
             if (String.IsNullOrEmpty(options.ConnectionString))
-                throw new OrleansConfigurationException($"{nameof(AzureQueueOptions)} on stream provider {this.name} is invalid. {nameof(AzureQueueOptions.ConnectionString)} is invalid");
+                throw new OrleansConfigurationException(
+                    $"{nameof(AzureQueueOptions)} on stream provider {this.name} is invalid. {nameof(AzureQueueOptions.ConnectionString)} is invalid");
+
+            if (options.QueueNames == null || options.QueueNames?.Count == 0)
+                throw new OrleansConfigurationException(
+                    $"{nameof(AzureQueueOptions)} on stream provider {this.name} is invalid. {nameof(AzureQueueOptions.QueueNames)} is invalid");
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.AzureUtils;
 using Orleans.Configuration;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.AzureQueue
@@ -17,52 +18,36 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// Helper method for testing. Deletes all the queues used by the specifed stream provider.
         /// </summary>
         /// <param name="loggerFactory">logger factory to use</param>
-        /// <param name="providerName">The Azure Queue stream privider name.</param>
-        /// <param name="deploymentId">The deployment ID hosting the stream provider.</param>
+        /// <param name="azureQueueNames">azure queue names to be deleted.</param>
         /// <param name="storageConnectionString">The azure storage connection string.</param>
-        public static async Task DeleteAllUsedAzureQueues(ILoggerFactory loggerFactory, string providerName, string deploymentId, string storageConnectionString)
+        public static async Task DeleteAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, string storageConnectionString)
         {
-            if (deploymentId != null)
+            var deleteTasks = new List<Task>();
+            foreach (var queueName in azureQueueNames)
             {
-                // TODO: Do not assume defaults !? - jbragg
-                var queueMapper = new HashRingBasedStreamQueueMapper(new HashRingStreamQueueMapperOptions(), providerName);
-                List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
-
-                var deleteTasks = new List<Task>();
-                foreach (var queueId in allQueues)
-                {
-                    var manager = new AzureQueueDataManager(loggerFactory, queueId.ToString(), deploymentId, storageConnectionString);
-                    deleteTasks.Add(manager.DeleteQueue());
-                }
-
-                await Task.WhenAll(deleteTasks);
+                var manager = new AzureQueueDataManager(loggerFactory, queueName, storageConnectionString);
+                deleteTasks.Add(manager.DeleteQueue());
             }
+
+            await Task.WhenAll(deleteTasks);
         }
 
         /// <summary>
         /// Helper method for testing. Clears all messages in all the queues used by the specifed stream provider.
         /// </summary>
         /// <param name="loggerFactory">logger factory to use</param>
-        /// <param name="providerName">The Azure Queue stream privider name.</param>
-        /// <param name="deploymentId">The deployment ID hosting the stream provider.</param>
+        /// <param name="azureQueueNames">The deployment ID hosting the stream provider.</param>
         /// <param name="storageConnectionString">The azure storage connection string.</param>
-        public static async Task ClearAllUsedAzureQueues(ILoggerFactory loggerFactory, string providerName, string deploymentId, string storageConnectionString)
+        public static async Task ClearAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, string storageConnectionString)
         {
-            if (deploymentId != null)
+            var deleteTasks = new List<Task>();
+            foreach (var queueName in azureQueueNames)
             {
-                // TODO: Do not assume defaults !? - jbragg
-                var queueMapper = new HashRingBasedStreamQueueMapper(new HashRingStreamQueueMapperOptions(), providerName);
-                List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
-
-                var deleteTasks = new List<Task>();
-                foreach (var queueId in allQueues)
-                {
-                    var manager = new AzureQueueDataManager(loggerFactory, queueId.ToString(), deploymentId, storageConnectionString);
-                    deleteTasks.Add(manager.ClearQueue());
-                }
-
-                await Task.WhenAll(deleteTasks);
+                var manager = new AzureQueueDataManager(loggerFactory, queueName, storageConnectionString);
+                deleteTasks.Add(manager.ClearQueue());
             }
+
+            await Task.WhenAll(deleteTasks);
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -15,6 +15,19 @@ namespace Orleans.Providers.Streams.AzureQueue
     public class AzureQueueStreamProviderUtils
     {
         /// <summary>
+        /// Generate default azure queue names 
+        /// </summary>
+        /// <param name="serviceId"></param>
+        /// <param name="providerName"></param>
+        /// <returns></returns>
+        public static List<string> GenerateDefaultAzureQueueNames(string serviceId, string providerName)
+        {
+            var defaultQueueMapper = new HashRingBasedStreamQueueMapper(new HashRingStreamQueueMapperOptions(), providerName);
+            return defaultQueueMapper.GetAllQueues()
+                .Select(queueName => $"{serviceId}-{queueName}").ToList();
+        }
+
+        /// <summary>
         /// Helper method for testing. Deletes all the queues used by the specifed stream provider.
         /// </summary>
         /// <param name="loggerFactory">logger factory to use</param>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureStreamQueueMapper.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureStreamQueueMapper.cs
@@ -1,0 +1,69 @@
+﻿using Orleans.Streams;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Orleans.Configuration;
+
+namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue
+{
+    public interface IAzureStreamQueueMapper : IStreamQueueMapper
+    {
+        /// <summary>
+        /// Gets the Azure queue name by partition
+        /// </summary>
+        /// <param name="queue"></param>
+        /// <returns></returns>
+        string PartitionToAzureQueue(QueueId queue);
+    }
+
+    public class AzureStreamQueueMapper : HashRingBasedStreamQueueMapper, IAzureStreamQueueMapper
+    {
+        private readonly Dictionary<QueueId, string> partitionDictionary = new Dictionary<QueueId, string>();
+        private static HashRingStreamQueueMapperOptions GetHashRingStreamQueueMapperOptions(List<string> azureQueueNames)
+        {
+            var options = new HashRingStreamQueueMapperOptions();
+            options.TotalQueueCount = azureQueueNames.Count;
+            return options;
+        }
+        /// <summary>
+        /// Queue mapper that tracks which Azure queue was mapped to which queueId
+        /// </summary>
+        /// <param name="azureQueueNames">List of EventHubPartitions</param>
+        /// <param name="queueNamePrefix">Prefix for queueIds.  Must be unique per stream provider</param>
+        public AzureStreamQueueMapper(List<string> azureQueueNames, string queueNamePrefix)
+            : base(GetHashRingStreamQueueMapperOptions(azureQueueNames), queueNamePrefix)
+        {
+            QueueId[] queues = GetAllQueues().ToArray();
+            if (queues.Length != azureQueueNames.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(azureQueueNames), "Azure queue names and Queues do not line up");
+            }
+            for (int i = 0; i < queues.Length; i++)
+            {
+                partitionDictionary.Add(queues[i], azureQueueNames[i]);
+            }
+        }
+
+        /// <summary>
+        /// Gets the Azure queue by partition
+        /// </summary>
+        /// <param name="queue"></param>
+        /// <returns></returns>
+        public string PartitionToAzureQueue(QueueId queue)
+        {
+            if (queue == null)
+            {
+                throw new ArgumentNullException(nameof(queue));
+            }
+
+            string partitionId;
+            if (!partitionDictionary.TryGetValue(queue, out partitionId))
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "queue {0}", queue.ToStringWithHashCode()));
+            }
+            return partitionId;
+        }
+    }
+}

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -82,30 +82,6 @@ namespace Orleans.AzureUtils
         }
 
         /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="queueName">Name of the queue to be connected to.</param>
-        /// <param name="serviceId">The service id of the silo. It will be concatenated to the queueName.</param>
-        /// <param name="storageConnectionString">Connection string for the Azure storage account used to host this table.</param>
-        /// <param name="visibilityTimeout">A TimeSpan specifying the visibility timeout interval</param>
-        /// <param name="loggerFactory">logger factory used to create loggers</param>
-        public AzureQueueDataManager(ILoggerFactory loggerFactory, string queueName, string serviceId, string storageConnectionString, TimeSpan? visibilityTimeout = null)
-        {
-            logger = loggerFactory.CreateLogger<AzureQueueDataManager>();
-            QueueName = serviceId + "-" + queueName;
-            QueueName = SanitizeQueueName(QueueName);
-            ValidateQueueName(QueueName);
-            connectionString = storageConnectionString;
-            messageVisibilityTimeout = visibilityTimeout;
-
-            queueOperationsClient = GetCloudQueueClient(
-                connectionString,
-                AzureQueueDefaultPolicies.QueueOperationRetryPolicy,
-                AzureQueueDefaultPolicies.QueueOperationTimeout,
-                logger);
-        }
-
-        /// <summary>
         /// Initializes the connection to the queue.
         /// </summary>
         public async Task InitQueueAsync()

--- a/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -38,7 +38,7 @@ namespace Tester.AzureUtils
 
         private async Task<AzureQueueDataManager> GetTableManager(string qName, TimeSpan? visibilityTimeout = null)
         {
-            AzureQueueDataManager manager = new AzureQueueDataManager(this.loggerFactory, qName, DeploymentId, TestDefaultConfiguration.DataConnectionString, visibilityTimeout);
+            AzureQueueDataManager manager = new AzureQueueDataManager(this.loggerFactory, $"{qName}-{DeploymentId}", TestDefaultConfiguration.DataConnectionString, visibilityTimeout);
             await manager.InitQueueAsync();
             return manager;
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -16,6 +18,7 @@ namespace Tester.AzureUtils.Streaming
     [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Functional"), TestCategory("AQStreaming")]
     public class AQProgrammaticSubscribeTest : ProgrammaticSubcribeTestsRunner, IClassFixture<AQProgrammaticSubscribeTest.Fixture>
     {
+        private const int queueCount = 8;
         public class Fixture : BaseAzureTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -28,24 +31,31 @@ namespace Tester.AzureUtils.Streaming
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamProviderName2, ob=>ob.Configure(options => options.ConnectionString = TestDefaultConfiguration.DataConnectionString))
-                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamProviderName, ob => ob.Configure(
-                            options =>
+                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamProviderName2, ob=>ob.Configure<IOptions<ClusterOptions>>(
+                            (options, dep) =>
                             {
                                 options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                            }));
+                                options.QueueNames = AzureQueueUtilities.GenerateQueueNames($"{dep.Value.ClusterId}2", queueCount);
+                        }))
+                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamProviderName, ob => ob.Configure<IOptions<ClusterOptions>>(
+                            (options, dep) =>
+                            {
+                                options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                                options.QueueNames = AzureQueueUtilities.GenerateQueueNames(dep.Value.ClusterId, queueCount);
+                        }));
                     hostBuilder
                         .AddMemoryGrainStorageAsDefault()
                         .AddMemoryGrainStorage("PubSubStore");
                 }
             }
 
-        public override void Dispose()
+            public override void Dispose()
             {
                 base.Dispose();
-                var clusterId = this.HostedCluster?.Options.ClusterId;
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName2, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, 
+                    AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount), TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount), TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
@@ -17,6 +18,7 @@ using Orleans.Hosting;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers.Streams.AzureQueue;
+using Tester.AzureUtils.Streaming;
 
 namespace UnitTests.StreamingTests
 {
@@ -37,7 +39,7 @@ namespace UnitTests.StreamingTests
 
         private string StreamNamespace;
         private readonly ITestOutputHelper output;
-
+        private const int queueCount = 8;
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             TestUtils.CheckForAzureStorage();
@@ -61,15 +63,17 @@ namespace UnitTests.StreamingTests
                         options.DeleteStateOnClear = true;
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }))
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName, ob => ob.Configure(
-                        options =>
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName, ob => ob.Configure<IOptions<ClusterOptions>>(
+                        (options, dep) =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.QueueNames = AzureQueueUtilities.GenerateQueueNames(dep.Value.ClusterId, queueCount);
                         }))
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>("AzureQueueProvider2", ob=>ob.Configure(
-                        options =>
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>("AzureQueueProvider2", ob=>ob.Configure<IOptions<ClusterOptions>>(
+                        (options, dep) =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.QueueNames = AzureQueueUtilities.GenerateQueueNames($"{dep.Value.ClusterId}2", queueCount);
                         }))
                     .AddMemoryGrainStorage("MemoryStore", options => options.NumStorageGrains = 1);
             }
@@ -81,7 +85,17 @@ namespace UnitTests.StreamingTests
             StreamNamespace = StreamTestsConstants.StreamLifecycleTestsNamespace;
             this.mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
         }
-        
+
+        public override void Dispose()
+        {
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
+                TestDefaultConfiguration.DataConnectionString).Wait();
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
+                TestDefaultConfiguration.DataConnectionString).Wait();
+            base.Dispose();
+        }
         [SkippableFact]
         public async Task SMS_Limits_FindMax_Consumers()
         {

--- a/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
+++ b/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Utilities\" />
     <Folder Include="Storage\" />
   </ItemGroup>
 </Project>

--- a/test/Extensions/TesterAzureUtils/Utilities/AzureQueueUtilities.cs
+++ b/test/Extensions/TesterAzureUtils/Utilities/AzureQueueUtilities.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tester.AzureUtils.Streaming
+{
+    public static class AzureQueueUtilities
+    {
+        public static List<string> GenerateQueueNames(string queueNamePrefix, int queueCount)
+        {
+            return Enumerable.Range(0, queueCount).Select(num => $"{queueNamePrefix}-{num}").ToList();
+        }
+    }
+}

--- a/test/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/test/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -18,7 +18,6 @@ namespace UnitTests.StreamingTests
     public class PullingAgentManagementTests : OrleansTestingBase, IClassFixture<PullingAgentManagementTests.Fixture>
     {
         private readonly Fixture fixture;
-
         public class Fixture : BaseTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -32,9 +31,10 @@ namespace UnitTests.StreamingTests
                 {
                     hostBuilder
                     .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME, b=>
-                        b.ConfigureAzureQueue(ob => ob.Configure(options =>
+                        b.ConfigureAzureQueue(ob => ob.Configure<IOptions<ClusterOptions>>((options, dep) =>
                            {
                                options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                               options.QueueNames = Enumerable.Range(0, 8).Select(num => $"{dep.Value.ClusterId}-{num}").ToList();
                            })));
 
                     hostBuilder.AddMemoryGrainStorage("PubSubStore");


### PR DESCRIPTION
-make azure queue name prefix configuration through `AzureQueueOptions`

-if not set, then default to its original value , which is serviceId-providerName

For issue #4577 