### PR TITLE
Changed link to documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Then either restart VS, or go to the task manager and kill the processes that st
 Documentation
 =============
 
-Documentation is located [here](http://dotnet.github.io/orleans/)
+Documentation is located [here](http://dotnet.github.io/orleans/Documentation/Introduction.html)
 
 Code Examples
 =============


### PR DESCRIPTION
Changed link to go directly to Documentation Intro page, skipping "secondary" page