### PR TITLE
Transaction participant wrapper json serialization fix

### DIFF
--- a/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
+++ b/src/Orleans.Transactions/Abstractions/Extensions/TransactionParticipantExtensionExtensions.cs
@@ -33,6 +33,7 @@ namespace Orleans.Transactions.Abstractions.Extensions
         [Immutable]
         internal sealed class TransactionParticipantExtensionWrapper : ITransactionParticipant
         {
+            [JsonProperty]
             private readonly ITransactionParticipantExtension extension;
             [JsonProperty]
             private readonly string resourceId;


### PR DESCRIPTION
Transaction wrapper was not serializing the participant when using json.