### PR TITLE
Fix partial build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -121,7 +121,7 @@
 
   <!-- Inner dependency versions -->
   <PropertyGroup Condition="$(FullBuild) != 'true'">
-    <OrleansCoreAbstractionsVersion>2.0.0</OrleansCoreAbstractionsVersion>
+    <OrleansCoreAbstractionsVersion>2.1.0</OrleansCoreAbstractionsVersion>
     <OrleansRuntimeAbstractionsVersion>2.0.0</OrleansRuntimeAbstractionsVersion>
     <OrleansCoreVersion>2.1.0</OrleansCoreVersion>
     <OrleansRuntimeVersion>2.1.0</OrleansRuntimeVersion>


### PR DESCRIPTION
#4739  introduced breaking change in Orleans.Core.Abstraction, Orleans.Core, Orleans.Transaction without set the new package version correctly, which broke partial build. 