### PR TITLE
Verify exception handling logic when multiple particiant throw

### DIFF
--- a/test/Transactions/Orleans.Transactions.Tests/Grains/ITransactionCoordinatorGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Grains/ITransactionCoordinatorGrain.cs
@@ -22,7 +22,7 @@ namespace Orleans.Transactions.Tests
         Task AddAndThrow(ITransactionTestGrain grain, int numberToAdd);
 
         [Transaction(TransactionOption.Create)]
-        Task MultiGrainAddAndThrow(ITransactionTestGrain grain, List<ITransactionTestGrain> grains, int numberToAdd);
+        Task MultiGrainAddAndThrow(List<ITransactionTestGrain> grain, List<ITransactionTestGrain> grains, int numberToAdd);
 
         [Transaction(TransactionOption.Create)]
         Task MultiGrainSetBit(List<ITransactionalBitArrayGrain> grains, int bitIndex);

--- a/test/Transactions/Orleans.Transactions.Tests/Grains/MultiStateTransactionalGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Grains/MultiStateTransactionalGrain.cs
@@ -2,6 +2,7 @@
 using Orleans.Transactions.Abstractions;
 using System;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 namespace Orleans.Transactions.Tests
@@ -123,13 +124,28 @@ namespace Orleans.Transactions.Tests
         public async Task AddAndThrow(int numberToAdd)
         {
             await Add(numberToAdd);
-            throw new Exception($"{GetType().Name} test exception");
+            throw new AddAndThrowException($"{GetType().Name} test exception");
         }
 
         public Task Deactivate()
         {
             DeactivateOnIdle();
             return Task.CompletedTask;
+        }
+    }
+
+    [Serializable]
+    public class AddAndThrowException : Exception
+    {
+        public AddAndThrowException() : base("Unexpected error.") { }
+
+        public AddAndThrowException(string message) : base(message) { }
+
+        public AddAndThrowException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected AddAndThrowException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }

--- a/test/Transactions/Orleans.Transactions.Tests/Grains/TransactionCoordinatorGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Grains/TransactionCoordinatorGrain.cs
@@ -37,10 +37,10 @@ namespace Orleans.Transactions.Tests
             throw new Exception("This should abort the transaction");
         }
 
-        public async Task MultiGrainAddAndThrow(ITransactionTestGrain throwGrain, List<ITransactionTestGrain> grains, int numberToAdd)
+        public async Task MultiGrainAddAndThrow(List<ITransactionTestGrain> throwGrains, List<ITransactionTestGrain> grains, int numberToAdd)
         {
             await Task.WhenAll(grains.Select(g => g.Add(numberToAdd)));
-            await throwGrain.AddAndThrow(numberToAdd);
+            await Task.WhenAll(throwGrains.Select(tg => tg.AddAndThrow(numberToAdd)));
         }
 
         public Task MultiGrainSetBit(List<ITransactionalBitArrayGrain> grains, int bitIndex)


### PR DESCRIPTION
Verify exception handling logic when multiple particiant throw. The expected logic is only one exception is picked as the inner exception of OrleansTransactionAbortException