### PR TITLE
Fix serialization benchmarks

### DIFF
--- a/test/Benchmarks/Serialization/SerializationBenchmarks.cs
+++ b/test/Benchmarks/Serialization/SerializationBenchmarks.cs
@@ -44,7 +44,7 @@ namespace Benchmarks.Serialization
             }
 
             var client = new ClientBuilder()
-                .ConfigureDefaults()
+                .UseLocalhostClustering()
                 .Configure<ClusterOptions>(options =>
                 {
                     options.ClusterId = nameof(SerializationBenchmarks);


### PR DESCRIPTION
Serialization benchmarks will throw `Orleans.Runtime.OrleansConfigurationException` for lack of clustering configuration.
