### PR TITLE
Auto-installing grain extensions

### DIFF
--- a/src/Orleans.Runtime.Abstractions/Hosting/HostingGrainExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/HostingGrainExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Orleans.CodeGeneration;
+using Orleans.Runtime;
+
+namespace Orleans.Hosting
+{
+    public static class HostingGrainExtensions
+    {
+        public static ISiloHostBuilder AddGrainExtension<TExtensionInterface,TExtension>(this ISiloHostBuilder builder)
+            where TExtensionInterface : class, IGrainExtension
+            where TExtension : class, TExtensionInterface
+        {
+            int interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(typeof(TExtensionInterface));
+            return builder.ConfigureServices(services => services.AddTransientKeyedService<int, IGrainExtension, TExtension>(interfaceId));
+        }
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Hosting/HostingGrainExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/HostingGrainExtensions.cs
@@ -3,9 +3,17 @@ using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Methods for configuring <see cref="IGrainExtension"/>s on a silo.
+    /// </summary>
     public static class HostingGrainExtensions
     {
-        public static ISiloHostBuilder AddGrainExtension<TExtensionInterface,TExtension>(this ISiloHostBuilder builder)
+        /// <summary>
+        /// Registers a grain extension implementation for the specified interface.
+        /// </summary>
+        /// <typeparam name="TExtensionInterface">The <see cref="IGrainExtension"/> interface being registered.</typeparam>
+        /// <typeparam name="TExtension">The implementation of <typeparamref name="TExtensionInterface"/>.</typeparam>
+        public static ISiloHostBuilder AddGrainExtension<TExtensionInterface, TExtension>(this ISiloHostBuilder builder)
             where TExtensionInterface : class, IGrainExtension
             where TExtension : class, TExtensionInterface
         {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -239,7 +239,8 @@ namespace Orleans.Runtime
 
         internal bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension extension)
         {
-            if(extensionInvoker == null)
+            this.lastInvoker = null;
+            if (extensionInvoker == null)
                 extensionInvoker = new ExtensionInvoker();
 
             return extensionInvoker.TryAddExtension(invoker, extension);
@@ -247,6 +248,7 @@ namespace Orleans.Runtime
 
         internal void RemoveExtension(IGrainExtension extension)
         {
+            this.lastInvoker = null;
             if (extensionInvoker != null)
             {
                 if (extensionInvoker.Remove(extension))

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -325,8 +325,9 @@ namespace Orleans.Runtime
 
                     var invoker = invokable.GetInvoker(typeManager, request.InterfaceId, message.GenericGrainType);
 
-                    if (invoker is IGrainExtensionMethodInvoker
-                        && !(target is IGrainExtension))
+                    if (invoker is IGrainExtensionMethodInvoker &&
+                        !(target is IGrainExtension)                         &&
+                        !TryInstallExtension(request.InterfaceId, invokable, message.GenericGrainType, invoker, out invoker))
                     {
                         // We are trying the invoke a grain extension method on a grain 
                         // -- most likely reason is that the dynamic extension is not installed for this grain
@@ -462,6 +463,19 @@ namespace Orleans.Runtime
             {
                 TransactionContext.Clear();
             }
+        }
+
+        private bool TryInstallExtension(int interfaceId, IInvokable invokable, string genericGrainType, IGrainMethodInvoker defaultInvoker, out IGrainMethodInvoker invoker)
+        {
+            invoker = defaultInvoker;
+            ActivationData activationData = GetCurrentActivationData();
+            IGrainExtension extension = activationData.ActivationServices.GetServiceByKey<int,IGrainExtension>(interfaceId);
+            if (extension == null)
+                return false;
+            if (!TryAddExtension(extension))
+                return false;
+            invoker = invokable.GetInvoker(typeManager, interfaceId, genericGrainType);
+            return true;
         }
 
         private void SafeSendResponse(Message message, object resultObject)

--- a/test/DefaultCluster.Tests/ProviderTests.cs
+++ b/test/DefaultCluster.Tests/ProviderTests.cs
@@ -31,7 +31,7 @@ namespace DefaultCluster.Tests
             {
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
-                    hostBuilder.AddGrainExtension<IAutoExtension,AutoExtension>();
+                    hostBuilder.AddGrainExtension<IAutoExtension, AutoExtension>();
                 }
             }
         }

--- a/test/DefaultCluster.Tests/ProviderTests.cs
+++ b/test/DefaultCluster.Tests/ProviderTests.cs
@@ -1,23 +1,45 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Xunit;
 using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
+using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
-using Xunit;
+using UnitTests.Grains;
 
 namespace DefaultCluster.Tests
 {
-    public class ProviderTests : HostedTestClusterEnsureDefaultStarted
+    public class ProviderTests : OrleansTestingBase, IClassFixture<ProviderTests.Fixture>
     {
-        public ProviderTests(DefaultClusterFixture fixture) : base(fixture)
+        private readonly Fixture fixture;
+
+        public ProviderTests(Fixture fixture)
         {
+            this.fixture = fixture;
+        }
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<Configurator>();
+            }
+
+            private class Configurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddGrainExtension<IAutoExtension,AutoExtension>();
+                }
+            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Providers")]
         public void Providers_TestExtensions()
         {
-            IExtensionTestGrain grain = this.GrainFactory.GetGrain<IExtensionTestGrain>(GetRandomGrainId());
+            IExtensionTestGrain grain = this.fixture.GrainFactory.GetGrain<IExtensionTestGrain>(GetRandomGrainId());
             ITestExtension extension = grain.AsReference<ITestExtension>();
             bool exceptionThrown = true;
 
@@ -82,7 +104,7 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("Functional"), TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Providers_ActivateNonGenericExtensionOfGenericInterface()
         {
-            var grain = this.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
+            var grain = this.fixture.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
             var extension = grain.AsReference<ISimpleExtension>(); //generic base grain not yet activated - virt refs only
 
             try
@@ -99,7 +121,7 @@ namespace DefaultCluster.Tests
 
         [Fact, TestCategory("Functional"), TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Providers_ReferenceNonGenericExtensionOfGenericInterface() {
-            var grain = this.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
+            var grain = this.fixture.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
             await grain.DoSomething(); //original generic grain activates here
 
             var extension = grain.AsReference<ISimpleExtension>();
@@ -111,6 +133,16 @@ namespace DefaultCluster.Tests
             }
 
             Assert.True(true);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Providers")]
+        public async Task Providers_AutoInstallExtensionTest()
+        {
+            INoOpTestGrain grain = this.fixture.GrainFactory.GetGrain<INoOpTestGrain>(GetRandomGrainId());
+            ISimpleExtension uninstalled = grain.AsReference<ISimpleExtension>();
+            IAutoExtension autoInstalled = grain.AsReference<IAutoExtension>();
+            await Assert.ThrowsAsync<GrainExtensionNotInstalledException>(() => uninstalled.CheckExtension_1());
+            await autoInstalled.CheckExtension();
         }
     }
 }

--- a/test/Grains/TestGrainInterfaces/IExtensionTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExtensionTestGrain.cs
@@ -21,4 +21,8 @@ namespace UnitTests.GrainInterfaces
     {
         Task DoSomething();
     }
+
+    public interface INoOpTestGrain : IGrainWithIntegerKey
+    {
+    }
 }

--- a/test/Grains/TestGrainInterfaces/ITestExtension.cs
+++ b/test/Grains/TestGrainInterfaces/ITestExtension.cs
@@ -1,25 +1,29 @@
 ﻿using System.Threading.Tasks;
-using Orleans;
 using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
-    public interface ITestExtension : IGrainWithIntegerKey, IGrainExtension
+    public interface ITestExtension : IGrainExtension
     {
         Task<string> CheckExtension_1();
 
         Task<string> CheckExtension_2();
     }
 
-    public interface IGenericTestExtension<T> : IGrainWithIntegerKey, IGrainExtension
+    public interface IGenericTestExtension<T> : IGrainExtension
     {
         Task<T> CheckExtension_1();
 
         Task<string> CheckExtension_2();
     }
 
-    public interface ISimpleExtension : IGrainWithIntegerKey, IGrainExtension
+    public interface ISimpleExtension : IGrainExtension
     {
         Task<string> CheckExtension_1();
+    }
+
+    public interface IAutoExtension : IGrainExtension
+    {
+        Task<string> CheckExtension();
     }
 }

--- a/test/Grains/TestGrains/NoOpTestGrain.cs
+++ b/test/Grains/TestGrains/NoOpTestGrain.cs
@@ -1,0 +1,9 @@
+﻿using Orleans;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    public class NoOpTestGrain : Grain, INoOpTestGrain
+    {
+    }
+}

--- a/test/Grains/TestInternalGrains/TestExtension.cs
+++ b/test/Grains/TestInternalGrains/TestExtension.cs
@@ -42,6 +42,14 @@ namespace UnitTests.Grains
             return Task.FromResult(someString);
         }
     }
+    
+    public class AutoExtension : IAutoExtension
+    {
+        public Task<string> CheckExtension()
+        {
+            return Task.FromResult("whoot!");
+        }
+    }
 
     public class GenericTestExtension<T> : IGenericTestExtension<T>
     {


### PR DESCRIPTION
Grains can now load grain extension from the container upon request rather than requiring the grain to register them during activation.
