### PR TITLE
When deactivating a grain, do not stop timers if there are running requests 

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -388,7 +388,8 @@ namespace Orleans.Runtime
         {
             SetState(ActivationState.Deactivating);
             deactivationStartTime = DateTime.UtcNow;
-            StopAllTimers();
+            if (!IsCurrentlyExecuting)
+                StopAllTimers();
         }
 
         /// <summary>

--- a/test/Grains/TestGrainInterfaces/ITimerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITimerGrain.cs
@@ -24,4 +24,11 @@ namespace UnitTests.GrainInterfaces
         Task StartTimer(string name, TimeSpan delay);
         Task StopTimer(string name);
     }
+
+    public interface ITimerRequestGrain : IGrainWithIntegerKey
+    {
+        Task StartAndWaitTimerTick(TimeSpan dueTime);
+
+        Task<string> GetRuntimeInstanceId();
+    }
 }

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -248,4 +248,27 @@ namespace UnitTestGrains
                         Thread.CurrentThread.Name);
         }
     }
+
+    public class TimerRequestGrain : Grain, ITimerRequestGrain
+    {
+        private TaskCompletionSource<int> completionSource;
+
+        public Task<string> GetRuntimeInstanceId()
+        {
+            return Task.FromResult(this.RuntimeIdentity);
+        }
+
+        public async Task StartAndWaitTimerTick(TimeSpan dueTime)
+        {
+            this.completionSource = new TaskCompletionSource<int>();
+            var timer = this.RegisterTimer(TimerTick, null, dueTime, TimeSpan.FromMilliseconds(-1));
+            await this.completionSource.Task;
+        }
+
+        private Task TimerTick(object state)
+        {
+            this.completionSource.SetResult(1);
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/test/Tester/Forwarding/ShutdownSiloTests.cs
+++ b/test/Tester/Forwarding/ShutdownSiloTests.cs
@@ -15,21 +15,9 @@ namespace Tester.Forwarding
     {
         public const int NumberOfSilos = 2;
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
-        {
-            public void Configure(ISiloHostBuilder hostBuilder)
-            {
-                hostBuilder.AddAzureBlobGrainStorage("MemoryStore", (AzureBlobStorageOptions options) =>
-                {
-                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                });
-            }
-        }
-
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             Assert.True(StorageEmulator.TryStart());
-            builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             builder.Options.InitialSilosCount = NumberOfSilos;
             builder.ConfigureLegacyConfiguration(legacy =>
             {


### PR DESCRIPTION
Fix for #4774 

Thanks @yevhen , I was able to repro this issue 100% with this test. Like said in the issue, this will fix only part of the issue.