### PR TITLE
Added support for priority transaction manager. 

### DIFF
--- a/src/Orleans.Transactions/Abstractions/ITransactionManager.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionManager.cs
@@ -8,16 +8,6 @@ namespace Orleans.Transactions.Abstractions
     public interface ITransactionManager
     {
         /// <summary>
-        /// Request sent by TA to all participants of a read-only transaction (one-phase commit). 
-        /// Participants respond after committing or aborting the read.
-        /// </summary>
-        /// <param name="transactionId">the id of the transaction to prepare</param>
-        /// <param name="accessCount">number of reads/writes performed on this participant by this transaction</param>
-        /// <param name="timeStamp">the commit timestamp for this transaction</param>
-        /// <returns></returns>
-        Task<TransactionalStatus> CommitReadOnly(Guid transactionId, AccessCounter accessCount, DateTime timeStamp);
-
-        /// <summary>
         /// Request sent by TA to TM. The TM responds after committing or aborting the transaction.
         /// </summary>
         /// <param name="transactionId">the id of the transaction to prepare</param>

--- a/src/Orleans.Transactions/Abstractions/ITransactionManagerExtension.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionManagerExtension.cs
@@ -10,10 +10,6 @@ namespace Orleans.Transactions.Abstractions
     {
         [AlwaysInterleave]
         [Transaction(TransactionOption.Suppress)]
-        Task<TransactionalStatus> CommitReadOnly(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp);
-
-        [AlwaysInterleave]
-        [Transaction(TransactionOption.Suppress)]
         Task<TransactionalStatus> PrepareAndCommit(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeResources, int totalParticipants);
 
         [AlwaysInterleave]

--- a/src/Orleans.Transactions/Abstractions/ITransactionalResource.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalResource.cs
@@ -9,6 +9,16 @@ namespace Orleans.Transactions.Abstractions
     public interface ITransactionalResource
     {
         /// <summary>
+        /// Request sent by TA to all participants of a read-only transaction (one-phase commit). 
+        /// Participants respond after committing or aborting the read.
+        /// </summary>
+        /// <param name="transactionId">the id of the transaction to prepare</param>
+        /// <param name="accessCount">number of reads/writes performed on this participant by this transaction</param>
+        /// <param name="timeStamp">the commit timestamp for this transaction</param>
+        /// <returns></returns>
+        Task<TransactionalStatus> CommitReadOnly(Guid transactionId, AccessCounter accessCount, DateTime timeStamp);
+
+        /// <summary>
         /// One-way message sent by TA to all participants except TM.  
         /// </summary>
         /// <param name="transactionId">the id of the transaction to prepare</param>

--- a/src/Orleans.Transactions/Abstractions/ITransactionalResourceExtension.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalResourceExtension.cs
@@ -9,6 +9,10 @@ namespace Orleans.Transactions.Abstractions
     {
         [AlwaysInterleave]
         [Transaction(TransactionOption.Suppress)]
+        Task<TransactionalStatus> CommitReadOnly(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp);
+
+        [AlwaysInterleave]
+        [Transaction(TransactionOption.Suppress)]
         [OneWay]
         Task Abort(string resourceId, Guid transactionId);
 

--- a/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
+++ b/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+
+namespace Orleans.Transactions
+{
+    [Serializable]
+    [Immutable]
+    public readonly struct ParticipantId
+    {
+        public static readonly IEqualityComparer<ParticipantId> Comparer = new IdComparer();
+
+        [Flags]
+        public enum Role
+        {
+            Resource = 1 << 0,
+            Manager = 1 << 1,
+            PriorityManager = 1 << 2
+        }
+
+        public string Name { get; }
+        public GrainReference Reference { get; }
+        public Role SupportedRoles { get; }
+
+        public ParticipantId(string name, GrainReference reference, Role supportedRoles)
+        {
+            this.Name = name;
+            this.Reference = reference;
+            this.SupportedRoles = supportedRoles;
+        }
+
+        public override string ToString()
+        {
+            return $"ParticipantId.{Name}.{Reference}";
+        }
+
+        private class IdComparer : IEqualityComparer<ParticipantId>
+        {
+            public bool Equals(ParticipantId x, ParticipantId y)
+            {
+                return string.CompareOrdinal(x.Name, y.Name) == 0 && Equals(x.Reference, y.Reference);
+            }
+
+            public int GetHashCode(ParticipantId obj)
+            {
+                unchecked
+                {
+                    var idHashCode = (obj.Name != null) ? obj.Name.GetHashCode() : 0;
+                    var referenceHashCode = (obj.Reference != null) ? obj.Reference.GetHashCode() : 0;
+                    return (idHashCode * 397) ^ (referenceHashCode);
+                }
+            }
+        }
+    }
+
+    public static class ParticipantRoleExtensions
+    {
+        public static bool SupportsRoles(this ParticipantId participant, ParticipantId.Role role)
+        {
+            return (participant.SupportedRoles & role) != 0;
+        }
+
+        public static bool IsResource(this ParticipantId participant)
+        {
+            return participant.SupportsRoles(ParticipantId.Role.Resource);
+        }
+
+        public static bool IsManager(this ParticipantId participant)
+        {
+            return participant.SupportsRoles(ParticipantId.Role.Manager);
+        }
+
+        public static bool IsPriorityManager(this ParticipantId participant)
+        {
+            return participant.SupportsRoles(ParticipantId.Role.PriorityManager);
+        }
+
+        public static IEnumerable<KeyValuePair<ParticipantId,AccessCounter>> SelectResources(this IEnumerable<KeyValuePair<ParticipantId, AccessCounter>> participants)
+        {
+            return participants.Where(p => p.Key.IsResource());
+        }
+
+        public static IEnumerable<KeyValuePair<ParticipantId, AccessCounter>> SelectManagers(this IEnumerable<KeyValuePair<ParticipantId, AccessCounter>> participants)
+        {
+            return participants.Where(p => p.Key.IsManager());
+        }
+
+        public static IEnumerable<KeyValuePair<ParticipantId, AccessCounter>> SelectPriorityManagers(this IEnumerable<KeyValuePair<ParticipantId, AccessCounter>> participants)
+        {
+            return participants.Where(p => p.Key.IsPriorityManager());
+        }
+    }
+}

--- a/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
@@ -1,5 +1,4 @@
-﻿using Orleans.Runtime;
-using Orleans.Transactions.Abstractions;
+﻿
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Orleans.Transactions/State/TransactionManager.cs
+++ b/src/Orleans.Transactions/State/TransactionManager.cs
@@ -15,28 +15,6 @@ namespace Orleans.Transactions.State
             this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
         }
 
-        public Task<TransactionalStatus> CommitReadOnly(Guid transactionId, AccessCounter accessCount, DateTime timeStamp)
-        {
-            // validate the lock
-            var valid = this.queue.RWLock.ValidateLock(transactionId, accessCount, out var status, out var record);
-
-            record.Timestamp = timeStamp;
-            record.Role = CommitRole.ReadOnly;
-            record.PromiseForTA = new TaskCompletionSource<TransactionalStatus>();
-
-            if (!valid)
-            {
-                this.queue.NotifyOfAbort(record, status);
-            }
-            else
-            {
-                this.queue.Clock.Merge(record.Timestamp);
-            }
-
-            this.queue.RWLock.Notify();
-            return record.PromiseForTA.Task;
-        }
-
         public Task<TransactionalStatus> PrepareAndCommit(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeResources, int totalResources)
         {
             // validate the lock

--- a/src/Orleans.Transactions/State/TransactionManagerExtension.cs
+++ b/src/Orleans.Transactions/State/TransactionManagerExtension.cs
@@ -19,11 +19,6 @@ namespace Orleans.Transactions
             this.managers = new Dictionary<string, ITransactionManager>();
         }
 
-        public Task<TransactionalStatus> CommitReadOnly(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp)
-        {
-            return GetManager(resourceId).CommitReadOnly(transactionId, accessCount, timeStamp);
-        }
-
         public Task Ping(string resourceId, Guid transactionId, DateTime timeStamp, ParticipantId resource)
         {
             return GetManager(resourceId).Ping(transactionId, timeStamp, resource);

--- a/src/Orleans.Transactions/State/TransactionalResourceExtension.cs
+++ b/src/Orleans.Transactions/State/TransactionalResourceExtension.cs
@@ -19,6 +19,11 @@ namespace Orleans.Transactions
             this.resources = new Dictionary<string, ITransactionalResource>();
         }
 
+        public Task<TransactionalStatus> CommitReadOnly(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp)
+        {
+            return GetResource(resourceId).CommitReadOnly(transactionId, accessCount, timeStamp);
+        }
+
         public Task Abort(string resourceId, Guid transactionId)
         {
             return GetResource(resourceId).Abort(transactionId);

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -169,17 +169,6 @@ namespace Orleans.Transactions
                     // record this write in the transaction info data structure
                     info.RecordWrite(this.participantId, record.Timestamp);
 
-                    // record this participant as a TM candidate
-                    if (info.TMCandidate.Reference == null || !info.TMCandidate.Equals(this.participantId.Reference))
-                    {
-                        int batchsize = this.queue.BatchableOperationsCount();
-                        if (info.TMCandidate.Reference == null || batchsize > info.TMBatchSize)
-                        {
-                            info.TMCandidate = this.participantId;
-                            info.TMBatchSize = batchsize;
-                        }
-                    }
-
                     // perform the write
                     try
                     {
@@ -207,7 +196,7 @@ namespace Orleans.Transactions
         {
             if (ct.IsCancellationRequested) return;
 
-            this.participantId = new ParticipantId(this.config.StateName, this.context.GrainInstance.GrainReference);
+            this.participantId = new ParticipantId(this.config.StateName, this.context.GrainInstance.GrainReference, ParticipantId.Role.Resource | ParticipantId.Role.Manager);
 
             this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.StateName}.{this.context.GrainIdentity.IdentityString}");
 

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
@@ -29,7 +29,7 @@ namespace Orleans.Transactions.Tests.Memory
             metaData.CommitRecords.Add(Guid.NewGuid(), new CommitRecord()
             {
                 Timestamp = DateTime.UtcNow,
-                WriteParticipants = new List<ParticipantId>() { new ParticipantId("bob", reference) }
+                WriteParticipants = new List<ParticipantId>() { new ParticipantId("bob", reference, ParticipantId.Role.Resource | ParticipantId.Role.Manager) }
             });
             JsonSerializerSettings serializerSettings = TransactionalStateFactory.GetJsonSerializerSettings(
                 this.fixture.Client.ServiceProvider.GetService<ITypeResolver>(),


### PR DESCRIPTION
Only one priority transaction manager is allowed per transaction.  Priority TM be used to detect TOC in future changes.

Also moved ReadonlyCommit to resource interface from tm interface.  Call was placed in wrong interface when split.