### PR TITLE
Fixes to transactional storage and recovery

### DIFF
--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -381,7 +381,8 @@ namespace Orleans.Transactions.State
                         TransactionManager = tm,
                         PrepareIsPersisted = true,
                         LastSent = default(DateTime),
-                        ConfirmationResponsePromise = null
+                        ConfirmationResponsePromise = null,
+                        NumberWrites = 1 // was a writing transaction
                     });
                 }
             }


### PR DESCRIPTION
Found two bugs using my consistency tests w/ randomized fault injection.

- fix bug in azure table transactional storage implementation: fails to recover state that was read, but never updated

- fix bug in transaction recovery: did not correctly restore the information in prepare records to indicate this transaction was updating the state

