### PR TITLE
Add deactivation injection transaction tests 

### DIFF
--- a/src/Orleans.Transactions/Properties/AssemblyInfo.cs
+++ b/src/Orleans.Transactions/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Orleans.Transactions.Tests")]

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -3,6 +3,7 @@ using Xunit;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Transactions.Tests;
+using Orleans.Transactions.Tests.DeactivationTransaction;
 using TestExtensions;
 using Tester;
 
@@ -31,6 +32,35 @@ namespace Orleans.Transactions.AzureStorage.Tests
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     })
+                    .UseDistributedTM();
+            }
+        }
+    }
+
+    public class DeactivationTestFixture : BaseTestClusterFixture
+    {
+        protected override void CheckPreconditionsOrThrow()
+        {
+            base.CheckPreconditionsOrThrow();
+            TestUtils.CheckForAzureStorage();
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
+        }
+
+        public class SiloBuilderConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder
+                    .ConfigureTracingForTransactionTests()
+                    .AddAzureTableTransactionalStateStorage(TransactionTestConstants.TransactionStore, options =>
+                    {
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                    })
+                    .UseDeactivationTransactionState()
                     .UseDistributedTM();
             }
         }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionDeactivationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionDeactivationTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace Orleans.Transactions.Azure.Tests
 {
+    [TestCategory("Azure"), TestCategory("Transactions"), TestCategory("Functional")]
     public class TransactionDeactivationTests : GrainDeactivationTransactionTestRunner, IClassFixture<DeactivationTestFixture>
     {
         public TransactionDeactivationTests(DeactivationTestFixture fixture, ITestOutputHelper output)

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionDeactivationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionDeactivationTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Transactions.AzureStorage.Tests;
+using Orleans.Transactions.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Azure.Tests
+{
+    public class TransactionDeactivationTests : GrainDeactivationTransactionTestRunner, IClassFixture<DeactivationTestFixture>
+    {
+        public TransactionDeactivationTests(DeactivationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture.GrainFactory, output)
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivatingTransactionCoordinatorGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivatingTransactionCoordinatorGrain.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+
+namespace Orleans.Transactions.Tests.DeactivationTransaction
+{
+    public interface IDeactivatingTransactionCoordinatorGrain : IGrainWithGuidKey
+    {
+        [Transaction(TransactionOption.Create)]
+        Task MultiGrainSet(List<IDeactivatingTransactionTestGrain> grains, int numberToAdd);
+
+        [Transaction(TransactionOption.Create)]
+        Task MultiGrainAddAndDeactivate(List<IDeactivatingTransactionTestGrain> grains, int numberToAdd, 
+            TransactionDeactivationPhase deactivationPhase = TransactionDeactivationPhase.None);
+    }
+    public class DeactivatingTransactionCoordinatorGrain : Grain, IDeactivatingTransactionCoordinatorGrain
+    {
+        public Task MultiGrainSet(List<IDeactivatingTransactionTestGrain> grains, int newValue)
+        {
+            return Task.WhenAll(grains.Select(g => g.Set(newValue)));
+        }
+
+        public Task MultiGrainAddAndDeactivate(List<IDeactivatingTransactionTestGrain> grains, int numberToAdd, 
+            TransactionDeactivationPhase deactivationPhase = TransactionDeactivationPhase.None)
+        {
+            return Task.WhenAll(grains.Select(g => g.Add(numberToAdd, deactivationPhase)));
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionReource.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionReource.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.State;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+
+namespace Orleans.Transactions.Tests.DeactivatingInjection
+{
+    internal class DeactivationTransactionTransactionManager<TState> : ITransactionManager
+        where TState : class, new()
+    {
+        private TransactionManager<TState> tm;
+        private readonly IGrainRuntime grainRuntime;
+        private readonly IGrainActivationContext context;
+        private TransactionDeactivationPhaseReference deactivationPhaseReference;
+        private readonly ILogger logger;
+        public DeactivationTransactionTransactionManager(TransactionDeactivationPhaseReference deactivationPhaseReference, TransactionManager<TState> tm, IGrainActivationContext activationContext, ILogger logger, IGrainRuntime grainRuntime)
+        {
+            this.grainRuntime = grainRuntime;
+            this.tm = tm;
+            this.deactivationPhaseReference = deactivationPhaseReference;
+            this.logger = logger;
+            this.context = activationContext;
+        }
+
+        public async Task<TransactionalStatus> CommitReadOnly(Guid transactionId, AccessCounter accessCount, DateTime timeStamp)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started CommitReadOnly transaction {transactionId}");
+            var result = await this.tm.CommitReadOnly(transactionId, accessCount, timeStamp);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterCommitReadOnly)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} CommitReadOnly");
+            }
+            return result;
+        }
+
+        public async Task<TransactionalStatus> PrepareAndCommit(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeParticipants, int totalParticipants)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started PrepareAndCommit transaction {transactionId}");
+            var result = await this.tm.PrepareAndCommit(transactionId, accessCount, timeStamp, writeParticipants, totalParticipants);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterPrepareAndCommit)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} PrepareAndCommit");
+            }
+            return result;
+        }
+
+        public async Task Prepared(Guid transactionId, DateTime timeStamp, ParticipantId participant, TransactionalStatus status)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started Prepared transaction {transactionId}");
+            await this.tm.Prepared(transactionId, timeStamp, participant, status);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterPrepared)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepared");
+            }
+        }
+
+        public async Task Ping(Guid transactionId, DateTime timeStamp, ParticipantId participant)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started Ping transaction {transactionId}");
+            await this.tm.Ping(transactionId, timeStamp, participant);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterPing)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Ping");
+            }
+        }
+
+    }
+
+    internal class DeactivationTransactionalResource<TState> : ITransactionalResource
+        where TState : class, new()
+    {
+
+        private readonly IGrainRuntime grainRuntime;
+        private readonly IGrainActivationContext context;
+        private TransactionDeactivationPhaseReference deactivationPhaseReference;
+        private readonly TransactionalResource<TState> tResource;
+        private readonly ILogger logger;
+        public DeactivationTransactionalResource(TransactionDeactivationPhaseReference deactivationPhaseReference, TransactionalResource<TState> tResource, IGrainActivationContext activationContext, ILogger logger, IGrainRuntime grainRuntime)
+        {
+            this.grainRuntime = grainRuntime;
+            this.tResource = tResource;
+            this.deactivationPhaseReference = deactivationPhaseReference;
+            this.logger = logger;
+            this.context = activationContext;
+        }
+
+        public async Task Abort(Guid transactionId)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} aborting transaction {transactionId}");
+            await this.tResource.Abort(transactionId);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterAbort)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} abort");
+            }
+        }
+
+        public async Task Cancel(Guid transactionId, DateTime timeStamp, TransactionalStatus status)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} canceling transaction {transactionId}");
+            await this.tResource.Cancel(transactionId, timeStamp, status);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterCancel)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} cancel");
+            }
+        }
+
+        public async Task Confirm(Guid transactionId, DateTime timeStamp)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started Confirm transaction {transactionId}");
+            await this.tResource.Confirm(transactionId, timeStamp);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterConfirm)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Confirm");
+            }
+        }
+
+        public async Task Prepare(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, ParticipantId transactionManager)
+        {
+            this.logger.Info($"Grain {this.context.GrainInstance} started Prepare transaction {transactionId}");
+            await this.tResource.Prepare(transactionId, accessCount, timeStamp, transactionManager);
+            if (this.deactivationPhaseReference.DeactivationPhase == TransactionDeactivationPhase.AfterPrepare)
+            {
+                this.grainRuntime.DeactivateOnIdle((context.GrainInstance));
+                this.deactivationPhaseReference.DeactivationPhase = TransactionDeactivationPhase.None;
+                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepare");
+            }
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionState.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionState.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.State;
+
+namespace Orleans.Transactions.Tests.DeactivatingInjection
+{
+    // enum is a value type, so we need a reference type to pass TransactionDeactivationPhase from DeactivationTransactionalState facet to its transaction manager
+    // and transaction resource parts
+    internal class TransactionDeactivationPhaseReference
+    {
+        public TransactionDeactivationPhase DeactivationPhase = TransactionDeactivationPhase.None;
+    }
+
+    public enum TransactionDeactivationPhase
+    {
+        None,
+        AfterCommitReadOnly,
+        AfterPrepare,
+        AfterPrepareAndCommit,
+        AfterAbort,
+        AfterPrepared,
+        AfterCancel,
+        AfterConfirm,
+        AfterPing
+    }
+
+    public interface IDeactivationTransactionalState<TState> : ITransactionalState<TState> where TState : class, new()
+    {
+        TransactionDeactivationPhase DeactivationPhase { get; set; }
+    }
+
+    internal class DeactivationTransactionalState<TState> : IDeactivationTransactionalState<TState>, ILifecycleParticipant<IGrainLifecycle>
+        where TState : class, new()
+    {
+        private readonly IGrainRuntime grainRuntime;
+        private readonly TransactionalState<TState> txState;
+        private readonly ILogger logger;
+        private readonly IGrainActivationContext context;
+        private TransactionDeactivationPhaseReference deactivationPhaseReference;
+        public TransactionDeactivationPhase DeactivationPhase {
+            get =>  deactivationPhaseReference.DeactivationPhase;
+            set => deactivationPhaseReference.DeactivationPhase = value; 
+        }
+        public string CurrentTransactionId => this.txState.CurrentTransactionId;
+        public DeactivationTransactionalState(TransactionalState<TState> txState, IGrainActivationContext activationContext, IGrainRuntime grainRuntime, ILogger<DeactivationTransactionalState<TState>> logger)
+        {
+            this.grainRuntime = grainRuntime;
+            this.txState = txState;
+            this.logger = logger;
+            this.context = activationContext;
+            this.deactivationPhaseReference = new TransactionDeactivationPhaseReference();
+        }
+
+        public void Participate(IGrainLifecycle lifecycle)
+        {
+            lifecycle.Subscribe<DeactivationTransactionalState<TState>>(GrainLifecycleStage.SetupState,
+                (ct) => this.txState.OnSetupState(ct, this.SetupResourceFactory));
+        }
+
+        internal void SetupResourceFactory(IGrainActivationContext context, string stateName, TransactionQueue<TState> queue)
+        {
+            // Add resources factory to the grain context
+            context.RegisterResourceFactory<ITransactionalResource>(stateName, () => new DeactivationTransactionalResource<TState>(deactivationPhaseReference, new TransactionalResource<TState>(queue), context, logger,  grainRuntime));
+
+            // Add tm factory to the grain context
+            context.RegisterResourceFactory<ITransactionManager>(stateName, () => new DeactivationTransactionTransactionManager<TState>(deactivationPhaseReference, new TransactionManager<TState>(queue), context, logger, grainRuntime));
+        }
+
+        public Task<TResult> PerformRead<TResult>(Func<TState, TResult> readFunction)
+        {
+            return this.txState.PerformRead(readFunction);
+        }
+
+        public Task<TResult> PerformUpdate<TResult>(Func<TState, TResult> updateFunction)
+        {
+            return this.txState.PerformUpdate(updateFunction);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionStateAttribute.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/DeactivationTransactionStateAttribute.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+
+namespace Orleans.Transactions.Tests.DeactivationTransaction
+{
+    public interface IDeactivationTransactionalStateConfiguration : ITransactionalStateConfiguration
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class DeactivationTransactionalStateAttribute : Attribute, IFacetMetadata, IDeactivationTransactionalStateConfiguration
+    {
+        public string StateName { get; }
+        public string StorageName { get; }
+
+        public DeactivationTransactionalStateAttribute(string stateName, string storageName = null)
+        {
+            this.StateName = stateName;
+            this.StorageName = storageName;
+        }
+    }
+
+    public interface IDeactivationTransactionalStateFactory
+    {
+        IDeactivationTransactionalState<TState> Create<TState>(IDeactivationTransactionalStateConfiguration config) where TState : class, new();
+    }
+
+    public class DeactivationalTransactionalStateFactory : IDeactivationTransactionalStateFactory
+    {
+        private IGrainActivationContext context;
+        private JsonSerializerSettings serializerSettings;
+        public DeactivationalTransactionalStateFactory(IGrainActivationContext context, ITypeResolver typeResolver, IGrainFactory grainFactory)
+        {
+            this.context = context;
+            this.serializerSettings =
+                TransactionalStateFactory.GetJsonSerializerSettings(typeResolver, grainFactory);
+        }
+
+        public IDeactivationTransactionalState<TState> Create<TState>(IDeactivationTransactionalStateConfiguration config) where TState : class, new()
+        {
+            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, config as ITransactionalStateConfiguration, this.serializerSettings, this.context);
+            DeactivationTransactionalState<TState> deactivationTransactionalState = ActivatorUtilities.CreateInstance<DeactivationTransactionalState<TState>>(this.context.ActivationServices, transactionalState, this.context);
+            deactivationTransactionalState.Participate(context.ObservableLifecycle);
+            return deactivationTransactionalState;
+        }
+    }
+
+    public class DeactivationTransactionalStateAttributeMapper : IAttributeToFactoryMapper<DeactivationTransactionalStateAttribute>
+    {
+        private static readonly MethodInfo create =
+            typeof(IDeactivationTransactionalStateFactory).GetMethod("Create");
+        public Factory<IGrainActivationContext, object> GetFactory(ParameterInfo parameter, DeactivationTransactionalStateAttribute attribute)
+        {
+            IDeactivationTransactionalStateConfiguration config = attribute;
+            // use generic type args to define collection type.
+            MethodInfo genericCreate = create.MakeGenericMethod(parameter.ParameterType.GetGenericArguments());
+            object[] args = new object[] { config };
+            return context => Create(context, genericCreate, args);
+        }
+
+        private object Create(IGrainActivationContext context, MethodInfo genericCreate, object[] args)
+        {
+            IDeactivationTransactionalStateFactory factory = context.ActivationServices.GetRequiredService<IDeactivationTransactionalStateFactory>();
+            return genericCreate.Invoke(factory, args);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/HostingExtensions.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/HostingExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+
+namespace Orleans.Transactions.Tests.DeactivationTransaction
+{
+    public static class SiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure cluster to use the distributed TM algorithm
+        /// </summary>
+        public static ISiloHostBuilder UseDeactivationTransactionState(this ISiloHostBuilder builder)
+        {
+            return builder.ConfigureServices(services => services.UseDeactivationTransactionState());
+        }
+
+        /// <summary>
+        /// Configure cluster to use the distributed TM algorithm
+        /// </summary>
+        public static IServiceCollection UseDeactivationTransactionState(this IServiceCollection services)
+        {
+            services.AddSingleton<IAttributeToFactoryMapper<DeactivationTransactionalStateAttribute>, DeactivationTransactionalStateAttributeMapper>();
+            services.TryAddTransient<IDeactivationTransactionalStateFactory, DeactivationalTransactionalStateFactory>();
+            services.AddTransient(typeof(IDeactivationTransactionalState<>), typeof(DeactivationTransactionalState<>));
+            return services;
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/SingleStateDeactivatingTransactionalGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/DeactivationTransaction/SingleStateDeactivatingTransactionalGrain.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+
+namespace Orleans.Transactions.Tests.DeactivationTransaction
+{
+
+    public interface IDeactivatingTransactionTestGrain : IGrainWithGuidKey
+    {
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task Set(int newValue);
+
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task Add(int numberToAdd, TransactionDeactivationPhase deactivationPhase = TransactionDeactivationPhase.None);
+
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task<int> Get();
+
+        Task Deactivate();
+    }
+
+    public class SingleStateDeactivatingTransactionalGrain : Grain, IDeactivatingTransactionTestGrain
+    {
+        private readonly IDeactivationTransactionalState<GrainData> data;
+
+        public SingleStateDeactivatingTransactionalGrain(
+            [DeactivationTransactionalState("data", TransactionTestConstants.TransactionStore)]
+            IDeactivationTransactionalState<GrainData> data)
+        {
+            this.data = data;
+        }
+
+        public Task Set(int newValue)
+        {
+            return this.data.PerformUpdate(d => d.Value = newValue);
+        }
+
+        public Task Add(int numberToAdd, TransactionDeactivationPhase deactivationPhase = TransactionDeactivationPhase.None)
+        {
+            this.data.DeactivationPhase = deactivationPhase;
+            return this.data.PerformUpdate(d => d.Value += numberToAdd);
+        }
+
+        public Task<int> Get()
+        {
+            return this.data.PerformRead<int>(d => d.Value);
+        }
+
+        public Task Deactivate()
+        {
+            this.DeactivateOnIdle();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Transactions.Tests.DeactivatingInjection;
+using Orleans.Transactions.Tests.DeactivationTransaction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests
+{
+    public class GrainDeactivationTransactionTestRunner : TransactionTestRunnerBase
+    {
+        public GrainDeactivationTransactionTestRunner(IGrainFactory grainFactory, ITestOutputHelper output)
+         : base(grainFactory, output)
+        { }
+
+        [SkippableFact]
+        public async Task SingleGrainReadTransaction()
+        {
+            const int expected = 5;
+
+            IDeactivatingTransactionTestGrain grain = grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid());
+            await grain.Set(expected);
+            int actual = await grain.Get();
+            Assert.Equal(expected, actual);
+            await grain.Deactivate();
+            actual = await grain.Get();
+            Assert.Equal(expected, actual);
+        }
+
+        [SkippableFact]
+        public async Task SingleGrainWriteTransaction()
+        {
+            const int delta = 5;
+            IDeactivatingTransactionTestGrain grain = this.grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid());
+            int original = await grain.Get();
+            await grain.Add(delta);
+            await grain.Deactivate();
+            int expected = original + delta;
+            int actual = await grain.Get();
+            Assert.Equal(expected, actual);
+        }
+
+        [SkippableFact]
+        public async Task MultiGrainWriteTransaction_DeactivateAfterPerpare()
+        {
+            const int setval = 5;
+            const int addval = 7;
+            const int expected = setval + addval;
+            const int grainCount = TransactionTestConstants.MaxCoordinatedTransactions;
+
+            List<IDeactivatingTransactionTestGrain> grains =
+                Enumerable.Range(0, grainCount)
+                    .Select(i => this.grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid()))
+                    .ToList();
+
+            IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
+
+            await coordinator.MultiGrainSet(grains, setval);
+            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepare);
+
+            foreach (var grain in grains)
+            {
+                int actual = await grain.Get();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [SkippableFact]
+        public async Task MultiGrainWriteTransaction_DeactivateAfterPrepareAndCommit()
+        {
+            const int setval = 5;
+            const int addval = 7;
+            const int expected = setval + addval;
+            const int grainCount = TransactionTestConstants.MaxCoordinatedTransactions;
+
+            List<IDeactivatingTransactionTestGrain> grains =
+                Enumerable.Range(0, grainCount)
+                    .Select(i => this.grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid()))
+                    .ToList();
+
+            IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
+
+            await coordinator.MultiGrainSet(grains, setval);
+            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepareAndCommit);
+
+            foreach (var grain in grains)
+            {
+                int actual = await grain.Get();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [SkippableFact]
+        public async Task MultiGrainWriteTransaction_DeactivateAfterPrepared()
+        {
+            const int setval = 5;
+            const int addval = 7;
+            const int expected = setval + addval;
+            const int grainCount = TransactionTestConstants.MaxCoordinatedTransactions;
+
+            List<IDeactivatingTransactionTestGrain> grains =
+                Enumerable.Range(0, grainCount)
+                    .Select(i => this.grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid()))
+                    .ToList();
+
+            IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
+
+            await coordinator.MultiGrainSet(grains, setval);
+            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepared);
+
+            foreach (var grain in grains)
+            {
+                int actual = await grain.Get();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [SkippableFact]
+        public async Task MultiGrainWriteTransaction_DeactivateAfterCommit()
+        {
+            const int setval = 5;
+            const int addval = 7;
+            const int expected = setval + addval;
+            const int grainCount = TransactionTestConstants.MaxCoordinatedTransactions;
+
+            List<IDeactivatingTransactionTestGrain> grains =
+                Enumerable.Range(0, grainCount)
+                    .Select(i => this.grainFactory.GetGrain<IDeactivatingTransactionTestGrain>(Guid.NewGuid()))
+                    .ToList();
+
+            IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
+
+            await coordinator.MultiGrainSet(grains, setval);
+            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterConfirm);
+
+            foreach (var grain in grains)
+            {
+                int actual = await grain.Get();
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
@@ -70,7 +70,7 @@ namespace Orleans.Transactions.Tests
                 await coordinator.MultiGrainAddAndDeactivate(grains, addval);
             }
 
-            //if transactional state loaded correctly, then following should pass
+            //if transactional state loaded correctly after reactivation, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -104,7 +104,7 @@ namespace Orleans.Transactions.Tests
                 // activated again 
                 await coordinator.MultiGrainAddAndDeactivate(grains, addval);
             }
-            //if transactional state loaded correctly, then following should pass
+            //if transactional state loaded correctly after reactivation, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -138,7 +138,7 @@ namespace Orleans.Transactions.Tests
                 // activated again 
                 await coordinator.MultiGrainAddAndDeactivate(grains, addval);
             }
-            //if transactional state loaded correctly, then following should pass
+            //if transactional state loaded correctly after reactivation, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -172,7 +172,7 @@ namespace Orleans.Transactions.Tests
                 // activated again 
                 await coordinator.MultiGrainAddAndDeactivate(grains, addval);
             }
-            //if transactional state loaded correctly, then following should pass
+            //if transactional state loaded correctly after reactivation, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/DeactivationTransactionTestRunner.cs
@@ -59,8 +59,18 @@ namespace Orleans.Transactions.Tests
             IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
 
             await coordinator.MultiGrainSet(grains, setval);
-            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepare);
+            try
+            {
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepare);
+            }
+            catch (OrleansTransactionException)
+            {
+                //if failed due to timeout or other legitimate transaction exception, try again. This should succeed since the deactivated grains should be 
+                // activated again 
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval);
+            }
 
+            //if transactional state loaded correctly, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -84,8 +94,17 @@ namespace Orleans.Transactions.Tests
             IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
 
             await coordinator.MultiGrainSet(grains, setval);
-            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepareAndCommit);
-
+            try
+            {
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepareAndCommit);
+            }
+            catch (OrleansTransactionException)
+            {
+                //if failed due to timeout or other legitimate transaction exception, try again. This should succeed since the deactivated grains should be 
+                // activated again 
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval);
+            }
+            //if transactional state loaded correctly, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -109,8 +128,17 @@ namespace Orleans.Transactions.Tests
             IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
 
             await coordinator.MultiGrainSet(grains, setval);
-            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepared);
-
+            try
+            {
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterPrepared);
+            }
+            catch (OrleansTransactionException)
+            {
+                //if failed due to timeout or other legitimate transaction exception, try again. This should succeed since the deactivated grains should be 
+                // activated again 
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval);
+            }
+            //if transactional state loaded correctly, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
@@ -134,8 +162,17 @@ namespace Orleans.Transactions.Tests
             IDeactivatingTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IDeactivatingTransactionCoordinatorGrain>(Guid.NewGuid());
 
             await coordinator.MultiGrainSet(grains, setval);
-            await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterConfirm);
-
+            try
+            {
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval, TransactionDeactivationPhase.AfterConfirm);
+            }
+            catch (OrleansTransactionException)
+            {
+                //if failed due to timeout or other legitimate transaction exception, try again. This should succeed since the deactivated grains should be 
+                // activated again 
+                await coordinator.MultiGrainAddAndDeactivate(grains, addval);
+            }
+            //if transactional state loaded correctly, then following should pass
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();


### PR DESCRIPTION
- implemented DeactivationTransactionalState facet which can inject deactivation command into different phase of a transaction
- implemented DeactivationTransactionTestRunner and AzureDeactivationTransactionTests which uses the runner. This runner contains a minimum scenario which can happen during our recovery tests

The goal of this test runner is to break down transaction recovery tests into more granular test cases. Our current recovery test is a end to end test, we shutdown a silo (non)gracefully during the test, and see if transaction recovered. It is failing now, and it is very hard to debug since test may fail due to a different reason each time, and there's a broad range of possibilities to explore. This test runner introduced a list of possible scenarios which can happen in current recovery tests. We can add more possible scenarios later after this pr. 

Besides the value of fixing recovery tests, this test suit also should exist to ensure certain scenario works. 


The AzureDeactivationTransactionTests aren't all succeeding. Hence the todo list: 

TODO: 

- fix current failing AzureDeactivationTransactionTests. 
- adding more failure scenarios 
- change the grain to accept multiple state, add that as a param to the tests so grain with multiple state is tested too. 