### PR TITLE
Changed link to documentation to use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then either restart VS, or go to the task manager and kill the processes that st
 Documentation
 =============
 
-Documentation is located [here](http://dotnet.github.io/orleans/)
+Documentation is located [here](https://dotnet.github.io/orleans/)
 
 Code Examples
 =============


### PR DESCRIPTION
When I access the documentation using http://dotnet.github.io/orleans/Documentation/Introduction.html I am missing the navigation bar. The https version works fine. 