### PR TITLE
transaction consistency tests and error injection

### DIFF
--- a/src/Orleans.TestingHost/TestStorageProviders/RandomlyInjectedStorageException.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/RandomlyInjectedStorageException.cs
@@ -1,0 +1,30 @@
+﻿using Orleans.Storage;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Orleans.TestingHost
+{
+    [Serializable]
+    public class RandomlyInjectedStorageException : Exception
+    {
+        public RandomlyInjectedStorageException() : base("injected fault") { }
+
+        protected RandomlyInjectedStorageException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class RandomlyInjectedInconsistentStateException : InconsistentStateException
+    {
+        public RandomlyInjectedInconsistentStateException() : base("injected fault") { }
+
+        protected RandomlyInjectedInconsistentStateException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Orleans.Transactions/Abstractions/ITransactionalFaultInjector.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalFaultInjector.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Orleans.Transactions
+{
+    public interface ITransactionalFaultInjector
+    {
+        void BeforeStore();
+        void AfterStore();
+
+    }
+
+
+}

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -207,7 +207,8 @@ namespace Orleans.Transactions
             Action deactivate = () => grainRuntime.DeactivateOnIdle(context.GrainInstance);
             var options = this.context.ActivationServices.GetRequiredService<IOptions<TransactionalStateOptions>>();
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
-            this.queue = new TransactionQueue<TState>(options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger);
+            var errorInjector = this.context.ActivationServices.GetService<ITransactionalFaultInjector>();
+            this.queue = new TransactionQueue<TState>(options, this.participantId, deactivate, storage, this.serializerSettings, clock, errorInjector, logger);
 
             // Add resources factory to the grain context
             this.context.RegisterResourceFactory<ITransactionalResource>(this.config.StateName, () => new TransactionalResource<TState>(this.queue));

--- a/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjectionConsistencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjectionConsistencyTests.cs
@@ -1,0 +1,134 @@
+﻿using Orleans.TestingHost;
+using Orleans.Transactions.Tests;
+using Orleans.Transactions.Tests.Consistency;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.AzureStorage.Tests
+{
+    [TestCategory("BVT"), TestCategory("Transactions")]
+    public class FaultInjectionConsistencyTests: TransactionTestRunnerBase, IClassFixture<FaultInjectedTestFixture>
+    {
+        public FaultInjectionConsistencyTests(FaultInjectedTestFixture fixture, ITestOutputHelper output)
+            : base(fixture.GrainFactory, output)
+        { }
+
+        [SkippableTheory]
+        // high congestion
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // medium congestion
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // low congestion
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerAccess)]
+
+        public virtual async Task RandomizedConsistency(int numGrains, int scale, bool avoidDeadlocks, bool avoidTimeouts, ReadWriteDetermination readwrite)
+        {
+            var random = new Random(scale + numGrains * 1000 + (avoidDeadlocks ? 666 : 333) + ((int)readwrite) * 123976);
+
+            var harness = new ConsistencyTestHarness(grainFactory, numGrains, random.Next(), avoidDeadlocks, avoidTimeouts, readwrite, true);
+
+            // first, run the random work load to generate history events
+            output.WriteLine($"start at {DateTime.UtcNow}");
+            int numThreads = scale;
+            int numTxsPerThread = scale * scale;
+
+            // start the threads that run transactions
+            var tasks = new Task[numThreads];
+            for (int i = 0; i < numThreads; i++)
+            {
+                tasks[i] = harness.RunRandomTransactionSequence(i, numTxsPerThread, grainFactory, this.output);
+            }
+
+            // wait for the test to finish
+            await Task.WhenAll(tasks);
+            output.WriteLine($"end at {DateTime.UtcNow}");
+
+            // then, analyze the history results
+            harness.CheckConsistency(tolerateGenericTimeouts: true, tolerateUnknownExceptions: true);
+        }  
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Azure.Test/GoldenPathTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/GoldenPathTests.cs
@@ -12,5 +12,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
         {
             fixture.EnsurePreconditionsMet();
         }
+
+        protected override bool StorageAdaptorHasLimitedCommitSpace => true;
     }
 }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/SkewedClockGoldenPathTransactionTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/SkewedClockGoldenPathTransactionTests.cs
@@ -12,5 +12,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
         {
             fixture.EnsurePreconditionsMet();
         }
+
+        protected override bool StorageAdaptorHasLimitedCommitSpace => true;
     }
 }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -44,4 +44,15 @@ namespace Orleans.Transactions.AzureStorage.Tests
             base.ConfigureTestCluster(builder);
         }
     }
+
+
+    public class FaultInjectedTestFixture : TestFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<ErrorInjectorConfigurator>();
+            base.ConfigureTestCluster(builder);
+        }
+    }
+
 }

--- a/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestGrain.cs
@@ -1,0 +1,173 @@
+﻿using Microsoft.Extensions.Logging;
+using Orleans.Concurrency;
+using Orleans.Transactions.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Transactions.Tests.Consistency
+{
+    [Reentrant]
+    public class ConsistencyTestGrain : Grain, IConsistencyTestGrain
+    {
+        private Random random;
+        private readonly ILogger logger;
+
+        [Serializable]
+        public class State
+        {
+            public string WriterTx = ConsistencyTestHarness.InitialTx; // last writer
+            public int SeqNo;   // 0, 1, 2,...
+        }
+
+        protected ITransactionalState<State> data;
+
+        public ConsistencyTestGrain(
+            [TransactionalState("data", TransactionTestConstants.TransactionStore)]
+            ITransactionalState<State> data,
+            ILoggerFactory loggerFactory
+            )
+        {
+            this.data = data;
+            this.logger = loggerFactory.CreateLogger(nameof(ConsistencyTestGrain) + ".graincall");
+        }
+
+        private int MyNumber => (int)(this.GetPrimaryKeyLong() % ConsistencyTestOptions.MaxGrains);
+
+        public const double recursionProbability = .1 - .9 * (1 / (10 * 40 - 1));
+
+        public async Task<Observation[]> Run(ConsistencyTestOptions options, int depth, string stack, int maxgrain, DateTime stopAfter)
+        {
+            if (random == null)
+                random = new Random(options.RandomSeed* options.NumGrains + MyNumber);
+
+            if (depth < options.MaxDepth && random.NextDouble() < recursionProbability)
+            {
+                switch (random.Next(2))
+                {
+                    case 0:
+                        return await Recurse(options, depth, stack, random, 10, ! options.AvoidDeadlocks, maxgrain, stopAfter);
+                    case 1:
+                        return await Recurse(options, depth, stack, random, 10, false, maxgrain, stopAfter);
+                    case 2:
+                        return await Recurse(options, depth, stack, random, 3, false, maxgrain, stopAfter);
+                }
+            }
+
+            //if (random.Next(20 + 6 * depth) == 0)
+            //{
+            //    logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {partition}.{iteration} L{depth} UserAbort");
+            //    throw new UserAbort();
+            //}
+
+            var txhash = stack.Substring(0, stack.IndexOf(')')).GetHashCode();
+
+            var whethertoreadorwrite =
+                  (options.ReadWrite == ReadWriteDetermination.PerTransaction) ? new Random(options.RandomSeed + txhash)
+                : (options.ReadWrite == ReadWriteDetermination.PerGrain) ? new Random(options.RandomSeed + txhash * 10000 + MyNumber)
+                : random;
+
+            try
+            {
+                switch (whethertoreadorwrite.Next(4))
+                {
+                    case 0:
+                        logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {stack} Write");
+                        return await Write();
+                    default:
+                        logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {stack} Read");
+                        return await Read();
+                }
+            } catch(Exception e)
+            {
+                logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {stack} --> {e.GetType().Name}");
+                throw;
+            }
+        }
+
+        private Task<Observation[]> Read()
+        {
+            var txid = data.CurrentTransactionId;
+            return data.PerformRead((state) =>
+            {
+                return new Observation[] {
+                    new Observation()
+                    {
+                        ExecutingTx = txid,
+                        WriterTx = state.WriterTx,
+                        Grain = MyNumber,
+                        SeqNo = state.SeqNo
+                    }
+                };
+            });
+        }
+
+        private Task<Observation[]> Write()
+        { 
+            var txid = data.CurrentTransactionId;
+            return data.PerformUpdate((state) =>
+            {
+                var observe = new Observation[2];
+                observe[0] = new Observation()
+                {
+                    ExecutingTx = txid,
+                    WriterTx = state.WriterTx,
+                    Grain = MyNumber,
+                    SeqNo = state.SeqNo
+                };
+                state.WriterTx = txid;
+                state.SeqNo++;
+                observe[1] = new Observation()
+                {
+                    ExecutingTx = txid,
+                    WriterTx = state.WriterTx,
+                    Grain = MyNumber,
+                    SeqNo = state.SeqNo
+                };
+                return observe;
+            });
+        }
+
+        private async Task<Observation[]> Recurse(ConsistencyTestOptions options, int depth, string stack, Random random, int count, bool parallel, int maxgrain, DateTime stopAfter)
+        {
+            logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {stack} Recurse {count} {(parallel ? "par" : "seq")}");
+            try
+            {
+                int min = options.AvoidDeadlocks ? MyNumber : 0;
+                int max = options.AvoidDeadlocks ? maxgrain : options.NumGrains;
+                var tasks = new List<Task<Observation[]>>();
+                int[] targets = new int[count];
+                for (int i = 0; i < count; i++)
+                    targets[i] = random.Next(min, max);
+                if (options.AvoidDeadlocks)
+                    Array.Sort(targets);
+                for (int i = 0; i < count; i++)
+                {
+                    var randomTarget = GrainFactory.GetGrain<IConsistencyTestGrain>(options.GrainOffset + targets[i]);
+                    var maxgrainfornested = (i < count - 1) ? targets[i + 1] : max;
+                    var task = randomTarget.Run(options, depth + 1, $"{stack}.{(parallel ? 'P' : 'S')}{i}", maxgrainfornested, stopAfter);
+                    tasks.Add(task);
+                    if (!parallel)
+                        await task;
+                    if (DateTime.UtcNow > stopAfter)
+                        break;
+                }
+                await Task.WhenAll(tasks);
+                var result = new HashSet<Observation>();
+                for (int i = 0; i < count; i++)
+                {
+                    foreach (var x in tasks[i].Result)
+                        result.Add(x);
+                }
+                return result.ToArray();
+            }
+            catch (Exception e)
+            {
+                logger.LogTrace($"g{MyNumber} {data.CurrentTransactionId} {stack} --> {e.GetType().Name}");
+                throw;
+            }
+        }
+    } 
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestHarness.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestHarness.cs
@@ -1,0 +1,275 @@
+﻿using Orleans.Runtime;
+using Orleans.Storage;
+using Orleans.TestingHost;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests.Consistency
+{
+    public class ConsistencyTestHarness
+    {
+        private readonly ConsistencyTestOptions options;
+        private ITestOutputHelper output;
+
+        private readonly Dictionary<int,       // Grain
+                          SortedDictionary<int, // SeqNo
+                          Dictionary<string,    // WriterTx
+                          HashSet<string>>>>    // ReaderTx
+            tuples;
+
+        private readonly HashSet<string> succeeded;
+        private readonly HashSet<string> aborted;
+        private readonly Dictionary<string, string> indoubt;
+        private bool timeoutsOccurred;
+        private bool tolerateUnknownExceptions;
+        private readonly IGrainFactory grainFactory;
+
+        private readonly Dictionary<string, HashSet<string>> orderEdges = new Dictionary<string, HashSet<string>>();
+        private readonly Dictionary<string, bool> marks = new Dictionary<string, bool>();
+
+
+        public ConsistencyTestHarness(
+            IGrainFactory grainFactory,
+            int numGrains,
+            int seed,
+            bool avoidDeadlocks,
+            bool avoidTimeouts,
+            ReadWriteDetermination readWrite,
+            bool errorInjectionActive)
+        {
+            this.grainFactory = grainFactory;
+
+            Assert.True(numGrains < ConsistencyTestOptions.MaxGrains);
+            this.options = new ConsistencyTestOptions()
+            {
+                AvoidDeadlocks = avoidDeadlocks,
+                ReadWrite = readWrite,
+                MaxDepth = 5,
+                NumGrains = numGrains,
+                RandomSeed = seed,
+                AvoidTimeouts = avoidTimeouts,
+                GrainOffset = (DateTime.UtcNow.Ticks & 0xFFFFFFFF) * ConsistencyTestOptions.MaxGrains,
+            };
+
+            this.tuples = new Dictionary<int, SortedDictionary<int, Dictionary<string, HashSet<string>>>>();
+            this.succeeded = new HashSet<string>();
+            this.aborted = new HashSet<string>();
+            this.indoubt = new Dictionary<string, string>();
+
+            // determine what to check for in the end
+            this.tolerateUnknownExceptions = errorInjectionActive;
+        }
+
+        public const string InitialTx = "initial";
+
+        public int NumAborted => aborted.Count;
+
+        public async Task RunRandomTransactionSequence(int partition, int count, IGrainFactory grainFactory, ITestOutputHelper output)
+        {
+            this.output = output;
+            var localRandom = new Random(options.RandomSeed + partition);
+
+            for (int i = 0; i < count; i++)
+            {
+                string id = null;
+                var target = localRandom.Next(options.NumGrains);
+                output.WriteLine($"({partition},{i}) g{target}");
+
+                try
+                {
+                    var targetgrain = grainFactory.GetGrain<IConsistencyTestGrain>(options.GrainOffset + target);
+                    var stopAfter = options.AvoidTimeouts ? DateTime.UtcNow + TimeSpan.FromSeconds(22) : DateTime.MaxValue;
+                    var result = await targetgrain.Run(options, 0, $"({partition},{i})", options.NumGrains, stopAfter);
+
+                    if (result.Length > 0)
+                    {
+                        id = result[0].ExecutingTx;
+
+                        lock (succeeded)
+                            succeeded.Add(id);                           
+
+                        output.WriteLine($"{partition}.{i} g{target} -> {result.Length} tuples");
+
+                        foreach (var tuple in result)
+                        {
+                            Assert.Equal(tuple.ExecutingTx, id); // all effects of this transaction must have same id
+                            lock (tuples)
+                            {
+                                if (!tuples.TryGetValue(tuple.Grain, out var versions))
+                                {
+                                    tuples.Add(tuple.Grain, versions = new SortedDictionary<int, Dictionary<string, HashSet<string>>>());
+                                }
+                                if (!versions.TryGetValue(tuple.SeqNo, out var writers))
+                                {
+                                    versions.Add(tuple.SeqNo, writers = new Dictionary<string, HashSet<string>>());
+                                }
+                                if (!writers.TryGetValue(tuple.WriterTx, out var readers))
+                                {
+                                    writers.Add(tuple.WriterTx, readers = new HashSet<string>());
+                                }
+                                readers.Add(tuple.ExecutingTx);
+                            }
+                        }
+                    }
+
+                }
+                catch (OrleansTransactionAbortedException e)
+                {
+                    output.WriteLine($"{partition}.{i} g{target} -> aborted {e.GetType().Name} {e.InnerException} {e.TransactionId}");
+                    lock (aborted)
+                        aborted.Add(e.TransactionId);
+                }
+                catch (OrleansTransactionInDoubtException f)
+                {
+                    output.WriteLine($"{partition}.{i} g{target} -> in doubt {f.TransactionId}");
+                    lock (indoubt)
+                        indoubt.Add(f.TransactionId, f.Message);
+                }
+                catch (System.TimeoutException)
+                {
+                    output.WriteLine($"{partition}.{i} g{target} -> timeout");
+                    timeoutsOccurred = true;
+                }
+                catch (OrleansException o)
+                {
+                    if (o.InnerException is RandomlyInjectedStorageException)
+                        output.WriteLine($"{partition}.{i} g{target} -> injected fault");
+                    else
+                        throw;
+                }
+            }
+        }
+
+        public void CheckConsistency(bool tolerateGenericTimeouts = false, bool tolerateUnknownExceptions = false)
+        {
+            foreach (var grainKvp in tuples)
+            {
+                var pos = 0;
+                Action<string> fail = (msg) =>
+                {
+                    foreach (var kvp1 in grainKvp.Value)
+                        foreach (var kvp2 in kvp1.Value)
+                            foreach (var r in kvp2.Value)
+                                output.WriteLine($"g{grainKvp.Key} v{kvp1.Key} w:{kvp2.Key} a:{r}");
+                    Assert.False(true, msg);
+                };
+
+                HashSet<string> readersOfPreviousVersion = new HashSet<string>();
+                
+                foreach (var seqnoKvp in grainKvp.Value)
+                {
+                    var seqno = seqnoKvp.Key;
+
+                    if (pos++ != seqno && indoubt.Count == 0 && !timeoutsOccurred)
+                        fail($"g{grainKvp.Key} is missing version v{pos - 1}, found v{seqno} instead");
+
+                    var writers = seqnoKvp.Value;
+                    if (writers.Count != 1)
+                        fail($"g{grainKvp.Key} v{seqno} has multiple writers {string.Join(",", writers.Keys)}");
+
+                    var writer = writers.First().Key;
+                    var readers = writers.First().Value;
+ 
+                    if (seqno == 0)
+                    {
+                        if (writer != InitialTx)
+                            fail($"g{grainKvp.Key} v{seqno} not written by {InitialTx}");
+                    }
+                    else
+                    {
+                        if (aborted.Contains(writer))
+                            fail($"g{grainKvp.Key} v{seqno} written by aborted transaction {writer}");
+                        if (!timeoutsOccurred && !(succeeded.Contains(writer) || indoubt.ContainsKey(writer)))
+                            fail($"g{grainKvp.Key} v{seqno} written by unknown transaction {writer}");
+                        if (indoubt.Count == 0 && !timeoutsOccurred && !readers.Contains(writer))
+                            fail($"g{grainKvp.Key} v{seqno} writer {writer} missing");
+                    }
+
+                    // add edges from previous readers to this write
+                    foreach (var r in readersOfPreviousVersion)
+                        if (r != writer)
+                        {
+                            if (!orderEdges.TryGetValue(r, out var readedges))
+                                orderEdges[r] = readedges = new HashSet<string>();
+                            readedges.Add(writer);
+                        }
+
+                    if (!orderEdges.TryGetValue(writer, out var writeedges))
+                        orderEdges[writer] = writeedges = new HashSet<string>();
+
+                    foreach (var r in readers)
+                        if (r != writer)
+                        {
+                            if (!succeeded.Contains(r))
+                                fail($"g{grainKvp.Key} v{seqno} read by aborted transaction {r}");
+                            writeedges.Add(r);
+                        }
+
+                    readersOfPreviousVersion = readers;
+                }
+            }
+
+            // due a DFS to find cycles in the ordered-before graph (= violation of serializability)
+            DFS();             
+
+            // report unknown exceptions
+            if (!tolerateUnknownExceptions)
+            foreach (var kvp in indoubt)
+                if (kvp.Value.Contains("failure during transaction commit"))
+                    Assert.False(true, $"exception during commit {kvp.Key} {kvp.Value}");
+
+            // report timeout exceptions          
+            if (!tolerateGenericTimeouts && timeoutsOccurred)
+                Assert.False(true, $"generic timeout exception caught");
+        }
+
+
+        private void DFS()
+        {
+            foreach (var kvp in orderEdges)
+                if (!marks.ContainsKey(kvp.Key))
+                {
+                    var cycleFound = Visit(kvp.Key, kvp.Value);
+                    Assert.False(cycleFound, $"found serializability violation");
+                }
+        }
+
+        private bool Visit(string node, HashSet<string> edges)
+        {
+            if (marks.TryGetValue(node, out var mark))
+            {
+                if (mark)
+                {
+                    return false;
+                }
+                else
+                {
+                    output.WriteLine($"!!! CYCLE FOUND:");
+                    output.WriteLine($"{node}");
+                    return true;
+                }
+            }
+            else
+            {
+                marks[node] = false;
+                foreach (var n in edges)
+                    if (orderEdges.TryGetValue(n, out var edges2))
+                    {
+                        if (Visit(n, edges2))
+                        {
+                            output.WriteLine($"{node}");
+                            return true;
+                        }
+                    }
+                marks[node] = true;
+                return false;
+            }
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestOptions.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Consistency/ConsistencyTestOptions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Transactions.Tests.Consistency
+{
+    [Serializable]
+    public class ConsistencyTestOptions
+    {
+        public int RandomSeed { get; set; } = 0;
+        public int NumGrains { get; set; } = 50;
+        public int MaxDepth { get; set; } = 5;
+        public bool AvoidDeadlocks { get; set; } = true;
+        public bool AvoidTimeouts { get; set; } = true;
+        public ReadWriteDetermination ReadWrite { get; set; } = ReadWriteDetermination.PerGrain;
+        public long GrainOffset { get; set; }
+
+        public const int MaxGrains = 100000;
+    }
+
+    public enum ReadWriteDetermination
+    {
+        PerTransaction, PerGrain, PerAccess
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Consistency/IConsistencyTestGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Consistency/IConsistencyTestGrain.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Transactions.Tests.Consistency
+{
+    public interface IConsistencyTestGrain : IGrainWithIntegerKey
+    {
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task<Observation[]> Run(ConsistencyTestOptions options, int depth, string stack, int max, DateTime stopAfter);
+    }
+
+
+    [Serializable]
+    public class UserAbort : Exception
+    {
+        public UserAbort() : base("User aborted transaction") { }
+
+        protected UserAbort(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Consistency/Observation.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Consistency/Observation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Transactions.Tests.Consistency
+{
+    [Serializable]
+    public struct Observation
+    {
+        public int Grain { get; set; }
+        public int SeqNo { get; set; }
+        public string WriterTx { get; set; }
+        public string ExecutingTx { get; set; }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/FaultInjectionConsistencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/FaultInjectionConsistencyTests.cs
@@ -1,0 +1,133 @@
+﻿using Orleans.TestingHost;
+using Orleans.Transactions.Tests.Consistency;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests.Memory
+{
+    [TestCategory("BVT"), TestCategory("Transactions")]
+    public class FaultInjectionConsistencyTests: TransactionTestRunnerBase, IClassFixture<FaultInjectedMemoryTransactionsFixture>
+    {
+        public FaultInjectionConsistencyTests(FaultInjectedMemoryTransactionsFixture fixture, ITestOutputHelper output)
+            : base(fixture.GrainFactory, output)
+        { }
+
+        [SkippableTheory]
+        // high congestion
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // medium congestion
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // low congestion
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerAccess)]
+
+        public virtual async Task RandomizedConsistency(int numGrains, int scale, bool avoidDeadlocks, bool avoidTimeouts, ReadWriteDetermination readwrite)
+        {
+            var random = new Random(scale + numGrains * 1000 + (avoidDeadlocks ? 666 : 333) + ((int)readwrite) * 123976);
+
+            var harness = new ConsistencyTestHarness(grainFactory, numGrains, random.Next(), avoidDeadlocks, avoidTimeouts, readwrite, true);
+
+            // first, run the random work load to generate history events
+            output.WriteLine($"start at {DateTime.UtcNow}");
+            int numThreads = scale;
+            int numTxsPerThread = scale * scale;
+
+            // start the threads that run transactions
+            var tasks = new Task[numThreads];
+            for (int i = 0; i < numThreads; i++)
+            {
+                tasks[i] = harness.RunRandomTransactionSequence(i, numTxsPerThread, grainFactory, this.output);
+            }
+
+            // wait for the test to finish
+            await Task.WhenAll(tasks);
+            output.WriteLine($"end at {DateTime.UtcNow}");
+
+            // then, analyze the history results
+            harness.CheckConsistency(tolerateGenericTimeouts: true, tolerateUnknownExceptions: true);
+        }  
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
@@ -31,4 +31,13 @@ namespace Orleans.Transactions.Tests
             base.ConfigureTestCluster(builder);
         }
     }
+
+    public class FaultInjectedMemoryTransactionsFixture : MemoryTransactionsFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<ErrorInjectorConfigurator>();
+            base.ConfigureTestCluster(builder);
+        }
+    }
 }

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/ErrorInjector.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/ErrorInjector.cs
@@ -1,0 +1,67 @@
+﻿using Orleans.Storage;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Orleans.Transactions.Tests
+{
+    internal class ErrorInjector : ITransactionalFaultInjector
+    {
+        private readonly double conflictProbability;
+        private readonly double beforeProbability;
+        private readonly double afterProbability;
+
+        private readonly Random random;
+
+        public ErrorInjector(double injectionProbability)
+        {
+            conflictProbability = injectionProbability / 5;
+            beforeProbability = 2 * injectionProbability / 5;
+            afterProbability = 2 * injectionProbability / 5;
+            random = new Random();
+        }
+
+        public void BeforeStore()
+        {
+            if (random.NextDouble() < conflictProbability)
+            {
+                throw new RandomlyInjectedInconsistentStateException();
+            }
+            if (random.NextDouble() < beforeProbability)
+            {
+                throw new RandomlyInjectedStorageException();
+            }
+        }
+
+        public void AfterStore()
+        {
+            if (random.NextDouble() < afterProbability)
+            {
+                throw new RandomlyInjectedStorageException();
+            }
+        }
+
+        [Serializable]
+        public class RandomlyInjectedStorageException : Exception
+        {
+            public RandomlyInjectedStorageException() : base("injected fault") { }
+
+            protected RandomlyInjectedStorageException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
+            }
+        }
+
+        [Serializable]
+        public class RandomlyInjectedInconsistentStateException : InconsistentStateException
+        {
+            public RandomlyInjectedInconsistentStateException() : base("injected fault") { }
+
+            protected RandomlyInjectedInconsistentStateException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
+            }
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/ErrorInjectorConfigurator.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/ErrorInjectorConfigurator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+
+namespace Orleans.Transactions.Tests
+{
+    public class ErrorInjectorConfigurator : ISiloBuilderConfigurator
+    {
+        private static readonly double probability = 0.05;
+
+        public void Configure(ISiloHostBuilder hostBuilder)
+        {
+            hostBuilder
+                .ConfigureServices(services => services.AddSingleton<ITransactionalFaultInjector>(sp => new ErrorInjector(probability)));
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/GoldenPathTransactionTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/GoldenPathTransactionTestRunner.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using Orleans.Transactions.Tests.Consistency;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,6 +13,13 @@ namespace Orleans.Transactions.Tests
     {
         protected GoldenPathTransactionTestRunner(IGrainFactory grainFactory, ITestOutputHelper output)
         : base(grainFactory, output) { }
+
+
+        // settings that are configuration dependent can be overridden by runner subclasses
+        // this allows tests to adapt their logic, or be skipped, for specific contexts
+        protected virtual bool StorageAdaptorHasLimitedCommitSpace => false;
+
+
 
         [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
@@ -160,6 +169,120 @@ namespace Orleans.Transactions.Tests
             {
                 Assert.Equal(expected, actual);
             }
+        }
+
+        [SkippableTheory]
+        // high congestion
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(2, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(2, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // medium congestion
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(30, 2, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, true, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(30, 5, false, false, ReadWriteDetermination.PerAccess)]
+        // low congestion
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, true, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerGrain)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerTransaction)]
+        [InlineData(1000, 2, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 3, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 4, false, false, ReadWriteDetermination.PerAccess)]
+        [InlineData(1000, 5, false, false, ReadWriteDetermination.PerAccess)]
+
+        public virtual async Task RandomizedConsistency(int numGrains, int scale, bool avoidDeadlocks, bool avoidTimeouts, ReadWriteDetermination readwrite)
+        {
+            var random = new Random(scale + numGrains * 1000 + (avoidDeadlocks ? 666 : 333) + ((int)readwrite) * 123976);
+
+            var harness = new ConsistencyTestHarness(grainFactory, numGrains, random.Next(), avoidDeadlocks, avoidTimeouts, readwrite, false);
+
+            // first, run the random work load to generate history events
+            output.WriteLine($"start at {DateTime.UtcNow}");
+            int numThreads = scale;
+            int numTxsPerThread = scale * scale;
+            var tasks = new Task[numThreads];
+            for (int i = 0; i < numThreads; i++)
+            {
+                tasks[i] = harness.RunRandomTransactionSequence(i, numTxsPerThread, grainFactory, this.output);
+            }
+            await Task.WhenAll(tasks);
+            output.WriteLine($"end at {DateTime.UtcNow}");
+
+            // all transactions are expected to pass when avoiding deadlocks and lock upgrades
+            if (avoidDeadlocks && (readwrite == ReadWriteDetermination.PerGrain || readwrite == ReadWriteDetermination.PerTransaction))
+            {
+                Assert.Equal(0, harness.NumAborted);
+            }
+
+            // then, analyze the history results
+            harness.CheckConsistency(tolerateGenericTimeouts: scale > 4, tolerateUnknownExceptions: StorageAdaptorHasLimitedCommitSpace);
         }
     }
 }


### PR DESCRIPTION
the consistency tests I have been using for testing the transaction implementation.

- includes a test runner that runs randomized transaction tests using various scale and randomization settings.  Running all of those takes a long time (because of the large number of tests, and the volume of the tests) but this is sort of intentional for this type of test (random testing is quite good at discovering subtle race conditions if run with enough volume).

- each consistency test records a lot of data while executing the random transactions (state version numbers read & written by each transaction for each grain)  that is checked for serializability in the end. Also, I check if any exceptions encountered are expected for the type of test being run. For example, there should not be any transient exceptions under low congestion and when avoiding deadlocks, and there should not be any unknown exceptions when storage injection is off.

- These tests can run with or without fault injection. 

- The fault injector randomly injects three kinds of exceptions:
    - an uninterpreted exception before or after writing to storage
    - an InconsistentStateException before writing to storage