### PR TITLE
two transaction fixes (table storage, TM selection)

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.AzureStorage
             return $"{RK_PREFIX}{sequenceId.ToString("x16")}";
         }
 
-        public long SequenceId => long.Parse(RowKey.Substring(RK_PREFIX.Length));
+        public long SequenceId => long.Parse(RowKey.Substring(RK_PREFIX.Length), System.Globalization.NumberStyles.AllowHexSpecifier);
 
         // row keys range from s0000000000000001 to s7fffffffffffffff
         public const string RK_PREFIX = "s_";


### PR DESCRIPTION
Discovered two bugs yesterday and today.

- the table storage does not correctly read state back because the long.Parse does not expect hex format. D'oh. A bit surprising that we didn't notice this earlier.

- (as discussed in meeting on 8/23) fix bug introduced by #4831: only write-participants are eligible for TM selection. 