### PR TITLE
Use netcoreapp2.0 for msbuild target dll if using dotnet core msbuild but targeting full .net

### DIFF
--- a/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -18,6 +18,8 @@
 
     <CoreAssembly Condition="$(TargetFramework.Equals('netcoreapp2.0')) or $(TargetFramework.Equals('netstandard2.0'))">$(CoreAssembly20)</CoreAssembly>
     <CoreAssembly Condition="$(TargetFramework.Equals('netcoreapp2.1')) or $(TargetFramework.Equals('netstandard2.1'))">$(CoreAssembly21)</CoreAssembly>
+    <!-- Fallback to 2.0 assembly if needed -->
+    <CoreAssembly Condition="$(CoreAssembly) == ''">$(CoreAssembly20)</CoreAssembly>
 
     <!-- Specify the assembly containing the MSBuild tasks. -->
     <MSBuildIsCore Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(OS)' != 'Windows_NT'">true</MSBuildIsCore>


### PR DESCRIPTION
(Cherry-pick of #4689)

#4673 introduced a regression: when using the command `dotnet build` to build project that target the full .NET framework, the variable for `CoreAssembly` is not set, and the variable `TaskAssembly` depends on it.

The easiest workaround here is to always fallback to 2.0 dll

Maybe we could instead removing this task dependency, and rely on the fact that we should find the `dotnet` command in the path @ReubenBond ?