### PR TITLE
Move actor identity content from 1.5 tutorials to grains section

### DIFF
--- a/src/Documentation/Orleans-2.0.md
+++ b/src/Documentation/Orleans-2.0.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Orleans 2.0
+---
+
+# Orleans 2.0
+
+2.0 is a major release of Orleans with the main goal of making it .NET Standard 2.0 compatible and cross-platform (via .NET Core). As part of that effort, several modernizations of Orleans APIs were made to make it more aligned with how technologies like ASP.NET are configured and hosted today.
+
+Being compatible with .NET Standard 2.0, Orleans 2.0 can be used by applications targeting .NET Core or full .NET Framework. The emphasis of testing by the Core team for this release is on full .NET Framework to ensure that existing applications can easily migrate from 1.5 to 2.0, and with full backward compatibility.
+
+The open source community has been running pre-release version of 2.0 with .NET Core successfully on both Windows and Linux, but test coverage on those platforms at this moment is much less comprehensive than on full .NET Framework. We plan to expand testing on .NET Core after the 2.0 release.
+
+The most significant changes in 2.0 are as follows.
+
+* Completely move to programmatic config leveraging Dependency Injection with a fluid builder pattern API. Old API based on configuration objects and XML files is preserved for backward compatibility, but will not move forward, and will get deprecated in the future. See more details in the [Configuration](clusters_and_clients/configuration_guide/index.md) section.
+
+* Explicit programmatic specification of application assemblies that replaces automatic scanning of folders by the Orleans runtime upon silo or client initialization. 
+Orleans will still automatically find relevant types, such as grain interfaces and classes, serializers, etc. in the specified assemblies, but it will not anymore try to load every assembly it can find in the folder.
+An optional helper method for loading all assemblies in the folder is provided for backward compatibility. See [Configuration](clusters_and_clients/configuration_guide/index.md) and [Migration](resources/Migration/Migration1.5.md) sections for more details.
+
+* Overhaul of code generation. While mostly invisible for developer, code generation became much more robust in handling serialization of various possible types. Special handling is required for F# assemblies. See [Code generation](resources/Migration/Codegen.md) section for more details.
+
+* Created a `Microsoft.Orleans.Core.Abstractions` NuGet package and moved/refactored several types into it. Grain code would most likely need to reference only these abstractions, whereas the silo host and client will reference more of Orleans packages. We plan to update this package less frequently.
+
+* Add support for Scoped services. This means that each grain activation gets its own scoped service provider, and Orleans registers a contextual `IGrainActivationContext` object that can be injected into a *Transient* or *Scoped* service to get access to activation specific information and grain activation lifecycle events. This is similar to how ASP.NET Core 2.0 creates a scoped context for each Request, but in the case of Orleans it applies to the entire lifetime of a grain activation. See [Service Lifetimes and Registration Options](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection#service-lifetimes-and-registration-options) in the ASP.NET Core documentation for more information about service lifetimes.
+
+* Migrated the logging infrastructure to use `Microsoft.Extensions.Logging` (same abstractions as ASP.NET Core 2.0).
+
+* 2.0 includes a beta version of support for ACID distributed cross-grain transactions. The functionality will be ready for prototyping and development, and will graduate for production use sometime after 2.0 release. See [Transactions](grains/transactions.md) for more details.

--- a/src/Documentation/grains/actor_identity.md
+++ b/src/Documentation/grains/actor_identity.md
@@ -1,0 +1,126 @@
+---
+layout: page
+title: Actor Identity
+---
+
+# Actor Identity
+
+In object-oriented environments, the identity of an object is hard to distinguish from a reference to it.
+Thus, when an object is created using new, the reference you get back represents all aspects of its identity except those that map the object to some external entity that it represents.
+
+In distributed systems, object references cannot represent instance identity, since references are typically limited to a single address space.
+That is certainly the case for .NET references.
+Furthermore, a virtual actor must have an identity regardless of whether it is active, so that we can activate it on demand.
+Therefore grains have a primary key.
+The primary key can be either a GUID (A Globally Unique Identifier), a long integer, or a string.
+
+The primary key is scoped to the grain type.
+Therefore, the complete identity of a grain is formed from the actor type and its key.
+
+The caller of the grain decides a long, a GUID, or a string scheme should be used.
+In fact the underlying data is the same, so the schemes can be used interchangeably.
+When a long is used, a GUID is actually created, and padded with zeros.
+
+Situations that require a singleton grain instance, such as a dictionary or registry, benefit from using `0` (a valid GUID) as its key.
+This is merely a convention, but by adhering, it becomes clear at the call site that it is what is going on, as we saw in the first tutorial:
+
+## Using GUIDs
+
+GUIDs are useful when there are several processes that could request a grain, such as a number of web servers in a web farm.
+You don't need to coordinate the allocation of keys, which could introduce a single point of failure in the system, or a system-side lock on a resource which could present a bottleneck.
+There is a very low chance of GUIDs colliding, so they would probably be the default choice when architecting an Orleans system.
+
+Referencing a grain by GUID in client code:
+
+``` csharp
+var grain = GrainClient.GrainFactory.GetGrain<IExample>(Guid.NewGuid());
+```
+
+Retrieving the primary key from grain code:
+
+``` csharp
+public override Task OnActivateAsync()
+{
+    Guid primaryKey = this.GetPrimaryKey();
+    return base.OnActivateAsync();
+}
+```
+
+## Using Longs
+
+A long integer is also available, which would make sense if the grain is persisted to a relational database, where numerical indexes are preferred over GUIDs.
+
+Referencing a grain by long integer in client code:
+
+``` csharp
+var grain = GrainClient.GrainFactory.GetGrain<IExample>(1);
+```
+
+Retrieving the primary key form grain code:
+
+``` csharp
+public override Task OnActivateAsync()
+{
+    long primaryKey = this.GetPrimaryKeyLong();
+    return base.OnActivateAsync();
+}
+```
+
+## Using Strings
+
+A string is also available.
+
+Referencing a grain by String in client code:
+
+``` csharp
+var grain = GrainClient.GrainFactory.GetGrain<IExample>("myGrainKey");
+```
+
+Retrieving the primary key form grain code:
+
+``` csharp
+public override Task OnActivateAsync()
+{
+    string primaryKey = this.GetPrimaryKeyString();
+    return base.OnActivateAsync();
+}
+```
+
+The stock ticker example used in the [Interaction with Libraries and Services](Interaction-with-Libraries-and-Services.md) uses a string keys to activate grains representing different stock symbols.
+
+## Using Compound Primary Key
+
+If you have a system that doesn't fit well with either GUIDs or longs, you can opt for a compound primary key which allows you to use a combination of a GUID or long and a string to reference a grain.
+
+You can inherit your interface from 'IGrainWithGuidCompoundKey' or 'IGrainWithIntegerCompoundKey" interface like this:
+
+``` csharp
+public interface IExampleGrain : Orleans.IGrainWithIntegerCompoundKey
+{
+    Task Hello();
+}
+```
+
+In client code, this adds a second argument to the `GetGrain` method on the grain factory.
+
+``` csharp
+var grain = GrainClient.GrainFactory.GetGrain<IExample>(0, "a string!", null);
+```
+
+To access the compound key in the grain, we can call an overload on the `GetPrimaryKey` method:
+
+``` csharp
+public class ExampleGrain : Orleans.Grain, IExampleGrain
+{
+    public Task Hello()
+    {
+	string keyExtension;
+        long primaryKey = this.GetPrimaryKey(out keyExtension);
+        Console.WriteLine("Hello from " + keyExtension);
+        return TaskDone.Done;
+    }
+}
+```
+
+
+

--- a/src/Documentation/grains/actor_identity.md
+++ b/src/Documentation/grains/actor_identity.md
@@ -85,9 +85,6 @@ public override Task OnActivateAsync()
     return base.OnActivateAsync();
 }
 ```
-
-The stock ticker example used in the [Interaction with Libraries and Services](Interaction-with-Libraries-and-Services.md) uses a string keys to activate grains representing different stock symbols.
-
 ## Using Compound Primary Key
 
 If you have a system that doesn't fit well with either GUIDs or longs, you can opt for a compound primary key which allows you to use a combination of a GUID or long and a string to reference a grain.

--- a/src/Documentation/grains/toc.yml
+++ b/src/Documentation/grains/toc.yml
@@ -1,7 +1,7 @@
 - name: Developing a Grain
   href: index.md
-- name: Types of Grains
-  href: types_of_grains.md
+- name: Actor Identity
+  href: actor_identity.md
 - name: Timers and Reminders
   href: timers_and_reminders.md
 - name: Observers

--- a/src/Documentation/grains/types_of_grains.md
+++ b/src/Documentation/grains/types_of_grains.md
@@ -1,9 +1,0 @@
----
-layout: page
-title: Types of Grains
----
-#There are different types of grains
-
-///TODO find page about grain types - make sure it includes stateless workers and stateful/persistent grains
-
-


### PR DESCRIPTION
The content of the 1.5 tutorial "Actor Identity" contains information about grain IDs and no steps to accomplish a task. It should be put with other similar pages.

