### PR TITLE
Propagate message serialization exceptions to callers

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -376,11 +376,10 @@ namespace Orleans.Messaging
             PendingInboundMessages.Add(msg);
         }
 
-        private void RejectMessage(Message msg, string reasonFormat, params object[] reasonParams)
+        public void RejectMessage(Message msg, string reason, Exception exc = null)
         {
             if (!Running) return;
-
-            var reason = String.Format(reasonFormat, reasonParams);
+            
             if (msg.Direction != Message.Directions.Request)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.ProxyClient_DroppingMsg, "Dropping message: {0}. Reason = {1}", msg, reason);
@@ -389,7 +388,7 @@ namespace Orleans.Messaging
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.ProxyClient_RejectingMsg, "Rejecting message: {0}. Reason = {1}", msg, reason);
                 MessagingStatisticsGroup.OnRejectedMessage(msg);
-                Message error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason);
+                Message error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 QueueIncomingMessage(error);
             }
         }

--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -250,28 +250,42 @@ namespace Orleans.Messaging
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         protected override void OnMessageSerializationFailure(Message msg, Exception exc)
         {
-            // we only get here if we failed to serialise the msg (or any other catastrophic failure).
-            // Request msg fails to serialise on the sending silo, so we just enqueue a rejection msg.
-            Log.Warn(ErrorCode.ProxyClient_SerializationError, $"Unexpected error serializing message to gateway {Address}.", exc);
-            FailMessage(msg, $"Unexpected error serializing message to gateway {Address}. {exc}");
-            if (msg.Direction == Message.Directions.Request || msg.Direction == Message.Directions.OneWay)
-            {
-                return;
-            }
-
+            // we only get here if we failed to serialize the msg (or any other catastrophic failure).
+            // Request msg fails to serialize on the sender, so we just enqueue a rejection msg.
             // Response msg fails to serialize on the responding silo, so we try to send an error response back.
-            // if we failed sending an original response, turn the response body into an error and reply with it.
-            msg.Result = Message.ResponseTypes.Error;
-            msg.BodyObject = Response.ExceptionResponse(exc);
-            try
+            this.Log.LogWarning(
+                (int) ErrorCode.ProxyClient_SerializationError,
+                "Unexpected error serializing message {Message}: {Exception}",
+                msg,
+                exc);
+
+            msg.ReleaseBodyAndHeaderBuffers();
+            MessagingStatisticsGroup.OnFailedSentMessage(msg);
+
+            var retryCount = msg.RetryCount ?? 0;
+
+            if (msg.Direction == Message.Directions.Request)
             {
-                MsgCenter.SendMessage(msg);
+                this.MsgCenter.RejectMessage(msg, $"Unable to serialize message. Encountered exception: {exc?.GetType()}: {exc?.Message}", exc);
             }
-            catch (Exception ex)
+            else if (msg.Direction == Message.Directions.Response && retryCount < 1)
             {
-                // If we still can't serialize, drop the message on the floor
-                Log.Warn(ErrorCode.ProxyClient_DroppingMsg, "Unable to serialize message - DROPPING " + msg, ex);
-                msg.ReleaseBodyAndHeaderBuffers();
+                // if we failed sending an original response, turn the response body into an error and reply with it.
+                // unless we have already tried sending the response multiple times.
+                msg.Result = Message.ResponseTypes.Error;
+                msg.BodyObject = Response.ExceptionResponse(exc);
+                msg.RetryCount = retryCount + 1;
+                this.MsgCenter.SendMessage(msg);
+            }
+            else
+            {
+                this.Log.LogWarning(
+                    (int)ErrorCode.ProxyClient_DroppingMsg,
+                    "Gateway client is dropping message which failed during serialization: {Message}. Exception = {Exception}",
+                    msg,
+                    exc);
+
+                MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }
 

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -588,10 +588,41 @@ namespace Orleans.Runtime.Messaging
                 // we only get here if we failed to serialize the msg (or any other catastrophic failure).
                 // Request msg fails to serialize on the sending silo, so we just enqueue a rejection msg.
                 // Response msg fails to serialize on the responding silo, so we try to send an error response back.
-                Log.Warn(ErrorCode.Messaging_Gateway_SerializationError, String.Format("Unexpected error serializing message {0} on the gateway", msg.ToString()), exc);
+                this.Log.LogWarning(
+                    (int)ErrorCode.Messaging_Gateway_SerializationError,
+                    "Unexpected error serializing message {Message}: {Exception}",
+                    msg,
+                    exc);
+
                 msg.ReleaseBodyAndHeaderBuffers();
                 MessagingStatisticsGroup.OnFailedSentMessage(msg);
-                MessagingStatisticsGroup.OnDroppedSentMessage(msg);
+
+                var retryCount = msg.RetryCount ?? 0;
+
+                if (msg.Direction == Message.Directions.Request)
+                {
+                    this.gateway.messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, exc.ToString());
+                }
+                else if (msg.Direction == Message.Directions.Response && retryCount < 1)
+                {
+                    // if we failed sending an original response, turn the response body into an error and reply with it.
+                    // unless we have already tried sending the response multiple times.
+                    msg.Result = Message.ResponseTypes.Error;
+                    msg.BodyObject = Response.ExceptionResponse(exc);
+                    msg.RetryCount = retryCount + 1;
+                    this.gateway.messageCenter.SendMessage(msg);
+                }
+                else
+                {
+                    this.Log.LogWarning(
+                        (int)ErrorCode.Messaging_OutgoingMS_DroppingMessage,
+                        "Gateway {GatewayAddress} is dropping message which failed during serialization: {Message}. Exception = {Exception}",
+                        this.gateway.gatewayAddress,
+                        msg,
+                        exc);
+
+                    MessagingStatisticsGroup.OnDroppedSentMessage(msg);
+                }
             }
         }
     }

--- a/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
@@ -1,3 +1,8 @@
+using System;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+
 namespace UnitTests.GrainInterfaces
 {
     using System.Threading.Tasks;
@@ -33,10 +38,76 @@ namespace UnitTests.GrainInterfaces
 
     public interface IMessageSerializationGrain : IGrainWithIntegerKey
     {
-        Task<object> EchoObject(object input);
+        Task Send(UndeserializableType input);
+        Task<UnserializableType> Get();
 
-        Task GetUnserializableObjectChained();
+        Task SendToOtherSilo();
+        Task GetFromOtheSilo();
+
+        Task SendToClient(IMessageSerializationClientObject obj);
+        Task GetFromClient(IMessageSerializationClientObject obj);
 
         Task<string> GetSiloIdentity();
+    }
+
+    public interface IMessageSerializationClientObject : IAddressable
+    {
+        Task Send(UndeserializableType input);
+        Task<UnserializableType> Get();
+    }
+
+    [Serializable]
+    public struct UndeserializableType
+    {
+        public const string FailureMessage = "Can't do it, sorry.";
+
+        public UndeserializableType(int num)
+        {
+            this.Number = num;
+        }
+
+        public int Number { get; }
+
+        [CopierMethod]
+        public static object DeepCopy(object original, ICopyContext context)
+        {
+            var typed = (UndeserializableType) original;
+            return new UndeserializableType(typed.Number);
+        }
+
+        [SerializerMethod]
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
+        {
+            var typed = (UndeserializableType) untypedInput;
+            context.StreamWriter.Write(typed.Number);
+        }
+
+        [DeserializerMethod]
+        public static object Deserialize(Type expected, IDeserializationContext context)
+        {
+            throw new NotSupportedException(FailureMessage);
+        }
+    }
+
+    [Serializable]
+    public class UnserializableType
+    {
+        [CopierMethod]
+        public static object DeepCopy(object original, ICopyContext context)
+        {
+            return original;
+        }
+
+        [SerializerMethod]
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
+        {
+            throw new NotSupportedException(UndeserializableType.FailureMessage);
+        }
+
+        [DeserializerMethod]
+        public static object Deserialize(Type expected, IDeserializationContext context)
+        {
+            return null;
+        }
     }
 }

--- a/test/Grains/TestGrains/MessageSerializationGrain.cs
+++ b/test/Grains/TestGrains/MessageSerializationGrain.cs
@@ -1,19 +1,41 @@
-﻿namespace UnitTests.Grains
+﻿using Orleans.CodeGeneration;
+
+namespace UnitTests.Grains
 {
     using System;
     using System.Threading.Tasks;
 
     using Orleans;
-    using Orleans.Runtime;
     using Orleans.Serialization;
 
     using UnitTests.GrainInterfaces;
     
     public class MessageSerializationGrain : Grain, IMessageSerializationGrain
     {
-        public Task<object> EchoObject(object input) => Task.FromResult(input);
+        public Task Send(UndeserializableType input) => Task.FromResult(input);
+        public Task<UnserializableType> Get() => Task.FromResult(new UnserializableType());
 
-        public async Task GetUnserializableObjectChained()
+        public async Task SendToOtherSilo()
+        {
+            var otherGrain = await GetGrainOnOtherSilo();
+
+            // Message that grain in a way which should fail.
+            await otherGrain.Send(new UndeserializableType(35));
+        }
+
+        public async Task GetFromOtheSilo()
+        {
+            var otherGrain = await GetGrainOnOtherSilo();
+
+            // Message that grain in a way which should fail.
+            await otherGrain.Get();
+        }
+
+        public Task SendToClient(IMessageSerializationClientObject obj) => obj.Send(new UndeserializableType(35));
+
+        public Task GetFromClient(IMessageSerializationClientObject obj) => obj.Get();
+
+        private async Task<IMessageSerializationGrain> GetGrainOnOtherSilo()
         {
             // Find a grain on another silo.
             IMessageSerializationGrain otherGrain;
@@ -23,57 +45,18 @@
             {
                 otherGrain = this.GrainFactory.GetGrain<IMessageSerializationGrain>(++id);
                 var otherIdentity = await otherGrain.GetSiloIdentity();
-                if (!string.Equals(otherIdentity, currentSiloIdentity))
+                if (!String.Equals(otherIdentity, currentSiloIdentity))
                 {
                     break;
                 }
             }
 
-            // Message that grain in a way which should fail.
-            await otherGrain.EchoObject(new SimpleType(35));
+            return otherGrain;
         }
 
         public Task<string> GetSiloIdentity()
         {
             return Task.FromResult(this.RuntimeIdentity);
-        }
-    }
-
-    [Serializable]
-    public struct SimpleType
-    {
-        public SimpleType(int num)
-        {
-            this.Number = num;
-        }
-
-        public int Number { get; }
-    }
-
-    /// <summary>
-    /// Serializer which can serialize <see cref="SimpleType"/> but cannot deserialize it.
-    /// </summary>
-    [Serializable]
-    public class OneWaySerializer : IExternalSerializer
-    {
-        public const string FailureMessage = "Can't do it, sorry.";
-
-        public bool IsSupportedType(Type itemType) => itemType == typeof(SimpleType);
-
-        public object DeepCopy(object source, ICopyContext context)
-        {
-            return source;
-        }
-
-        public void Serialize(object item, ISerializationContext context, Type expectedType)
-        {
-            var typed = (SimpleType)item;
-            context.StreamWriter.Write(typed.Number);
-        }
-
-        public object Deserialize(Type expectedType, IDeserializationContext context)
-        {
-            throw new NotSupportedException(FailureMessage);
         }
     }
 }

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -3,11 +3,7 @@ using Orleans;
 namespace UnitTests.General
 {
     using System;
-    using System.Reflection;
     using System.Threading.Tasks;
-    
-    using Orleans.TestingHost;
-    
     using TestExtensions;
 
     using UnitTests.GrainInterfaces;
@@ -32,15 +28,6 @@ namespace UnitTests.General
 
         public class Fixture : BaseTestClusterFixture
         {
-            protected override void ConfigureTestCluster(TestClusterBuilder builder)
-            {
-                builder.ConfigureLegacyConfiguration(legacy =>
-                {
-                    legacy.ClientConfiguration.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
-                    legacy.ClusterConfiguration.Globals.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
-                    legacy.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(200);
-                });
-            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
@@ -206,35 +193,89 @@ namespace UnitTests.General
             var secondEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[1]);
             Assert.Equal("Test exception 2", secondEx.Message);
         }
-        
+
         /// <summary>
-        /// Tests that when the body of a message sent between a client and a grain cannot be deserialized, an exception
-        /// is immediately propagated back to the caller.
+        /// Tests that when a grain cannot deserialize a request from a client, an exception is promptly propagated from the grain to the caller.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Messaging"), TestCategory("Serialization")]
-        public async Task ExceptionPropagationMessageBodyDeserializationFailure()
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_GrainToClient_DeserializationFailure()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
-
-            // A serializer is used on the client & silo which can serialize but not deserialize the type being used.
-            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.EchoObject(new SimpleType(2)));
-            Assert.Contains(OneWaySerializer.FailureMessage, exception.Message);
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.Send(new UndeserializableType(2)));
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
         }
 
         /// <summary>
-        /// Tests that when the body of a message sent between two grains cannot be deserialized, an exception is immediately
-        /// propagated back to the caller.
+        /// Tests that when a grain cannot serialize a response to a client, an exception is promptly propagated from the grain to the caller.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Messaging"), TestCategory("Serialization")]
-        public async Task ExceptionPropagationGrainToGrainMessageBodyDeserializationFailure()
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_GrainToClient_SerializationFailure()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.Get());
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
+        }
 
-            // A serializer is used on the client & silo which can serialize but not deserialize the type being used.
-            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.GetUnserializableObjectChained());
-            Assert.Contains(OneWaySerializer.FailureMessage, exception.Message);
+        /// <summary>
+        /// Tests that when a grain cannot deserialize a request from another silo, an exception is promptly propagated from the grain to the caller.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_GrainToGrain_DeserializationFailure()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.SendToOtherSilo());
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
+        }
+
+        /// <summary>
+        /// Tests that when a grain cannot serialize a response to another silo, an exception is promptly propagated from the grain to the caller.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_GrainToGrain_SerializationFailure()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.GetFromOtheSilo());
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
+        }
+
+        /// <summary>
+        /// Tests that when a client cannot deserialize a request from a grain, an exception is promptly propagated from the client to the caller.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_ClientToGrain_DeserializationFailure()
+        {
+            var obj = new MessageSerializationClientObject();
+            var grainFactory = (IInternalGrainFactory)this.fixture.GrainFactory;
+            var objRef = grainFactory.CreateObjectReference<IMessageSerializationClientObject>(obj);
+            var grain = this.fixture.GrainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.SendToClient(objRef));
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
+        }
+        
+        /// <summary>
+        /// Tests that when a client cannot serialize a response to a grain, an exception is promptly propagated from the client to the caller.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Messaging"), TestCategory("Serialization")]
+        public async Task ExceptionPropagation_ClientToGrain_SerializationFailure()
+        {
+            var obj = new MessageSerializationClientObject();
+            var grainFactory = (IInternalGrainFactory)this.fixture.GrainFactory;
+            var objRef = grainFactory.CreateObjectReference<IMessageSerializationClientObject>(obj);
+            var grain = grainFactory.GetGrain<IMessageSerializationGrain>(GetRandomGrainId());
+            
+            var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(() => grain.GetFromClient(objRef));
+            Assert.Contains(UndeserializableType.FailureMessage, exception.Message);
+        }
+
+        private class MessageSerializationClientObject : IMessageSerializationClientObject
+        {
+            public Task Send(UndeserializableType input) => Task.FromResult(input);
+            public Task<UnserializableType> Get() => Task.FromResult(new UnserializableType());
         }
     }
 }


### PR DESCRIPTION
Fixes #4793 

There are 6 scenarios being tested, which can be summed up as `{Serialization, Deserialization} exception sending to a {client, grain} from a {client, grain}` except I didn't add tests for the client-to-client cases (they go via silo anyway).

In the end, there's similar logic for handling these exceptions in:
* `GatewayConnection.OnMessageSerializationFailure` - client to gateway (request)
* `InvokableObjectManager.LocalObjectMessagePumpAsync` - client to gateway (response)
* `Gateway.GatewaySender.OnMessageSerializationFailure` - gateway to client
* `SiloMessageSender.OnMessageSerializationFailure` - silo to silo

The client-to-gateway response scenarios are a little contrived, since client objects are not supposed to be able to return `Task` or `Task<T>`, only `void`. The code generator blocks `Task`/`Task<T>` for external users. Nevertheless, it's worth adding tests for the scenario just in case, and it helped to uncover some issues and places we could improve logging.