### PR TITLE
Add back .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,202 @@
+# http://EditorConfig.org
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset                  = utf-8
+end_of_line              = crlf
+indent_style             = space
+indent_size              = 4
+insert_final_newline     = false
+trim_trailing_whitespace = true
+
+# Solution Files
+[*.sln]
+indent_style = tab
+
+# XML Project Files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Configuration Files
+[*.{json,xml,yml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,ts,css,scss,less}]
+indent_size          = 2
+insert_final_newline = true
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+# Dotnet Code Style Settings
+# See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+# See http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
+[*.{cs,csx,cake,vb}]
+dotnet_sort_system_directives_first                                          = true
+dotnet_style_coalesce_expression                                             = true : suggestion
+dotnet_style_collection_initializer                                          = true : suggestion
+dotnet_style_explicit_tuple_names                                            = true : suggestion
+dotnet_style_null_propagation                                                = true : suggestion
+dotnet_style_object_initializer                                              = true : suggestion
+dotnet_style_predefined_type_for_locals_parameters_members                   = true : suggestion
+dotnet_style_predefined_type_for_member_access                               = true : suggestion
+# TODO: change dotnet_style_qualification to suggestion after correct style is agreed and existing code-base has been consistently styled
+dotnet_style_qualification_for_event                                         = true : none
+dotnet_style_qualification_for_field                                         = true : none
+dotnet_style_qualification_for_method                                        = true : none
+dotnet_style_qualification_for_property                                      = true : none
+
+# Naming Symbols
+# constant_fields - Define constant fields
+dotnet_naming_symbols.constant_fields.applicable_kinds                       = field
+dotnet_naming_symbols.constant_fields.required_modifiers                     = const
+# non_private_readonly_fields - Define public, internal and protected readonly fields
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, internal, protected
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds           = field
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers         = readonly
+# static_readonly_fields - Define static and readonly fields
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds                = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers              = static, readonly
+# private_readonly_fields - Define private readonly fields
+dotnet_naming_symbols.private_readonly_fields.applicable_accessibilities     = private
+dotnet_naming_symbols.private_readonly_fields.applicable_kinds               = field
+dotnet_naming_symbols.private_readonly_fields.required_modifiers             = readonly
+# public_internal_fields - Define public and internal fields
+dotnet_naming_symbols.public_internal_fields.applicable_accessibilities      = public, internal
+dotnet_naming_symbols.public_internal_fields.applicable_kinds                = field
+# private_protected_fields - Define private and protected fields
+dotnet_naming_symbols.private_protected_fields.applicable_accessibilities    = private, protected
+dotnet_naming_symbols.private_protected_fields.applicable_kinds              = field
+# public_symbols - Define any public symbol
+dotnet_naming_symbols.public_symbols.applicable_accessibilities              = public, internal, protected, protected_internal
+dotnet_naming_symbols.public_symbols.applicable_kinds                        = method, property, event, delegate
+# parameters - Defines any parameter
+dotnet_naming_symbols.parameters.applicable_kinds                            = parameter
+# non_interface_types - Defines class, struct, enum and delegate types
+dotnet_naming_symbols.non_interface_types.applicable_kinds                   = class, struct, enum, delegate
+# interface_types - Defines interfaces
+dotnet_naming_symbols.interface_types.applicable_kinds                       = interface
+
+# Naming Styles
+# camel_case - Define the camelCase style
+dotnet_naming_style.camel_case.capitalization                                = camel_case
+# pascal_case - Define the Pascal_case style
+dotnet_naming_style.pascal_case.capitalization                               = pascal_case
+# first_upper - The first character must start with an upper-case character
+dotnet_naming_style.first_upper.capitalization                               = first_word_upper
+# prefix_interface_interface_with_i - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_interface_with_i.capitalization         = pascal_case
+dotnet_naming_style.prefix_interface_interface_with_i.required_prefix        = I
+
+# Naming Rules
+# Constant fields must be PascalCase
+dotnet_naming_rule.constant_fields_must_be_pascal_case.severity              = suggestion
+dotnet_naming_rule.constant_fields_must_be_pascal_case.symbols               = constant_fields
+dotnet_naming_rule.constant_fields_must_be_pascal_case.style                 = pascal_case
+# Public, internal and protected readonly fields must be PascalCase
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.severity  = suggestion
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.symbols   = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.style     = pascal_case
+# Static readonly fields must be PascalCase
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.severity       = suggestion
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.symbols        = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.style          = pascal_case
+# Private readonly fields must be camelCase
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.severity       = suggestion
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.symbols        = private_readonly_fields
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.style          = camel_case
+# Public and internal fields must be PascalCase
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.severity       = suggestion
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.symbols        = public_internal_fields
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.style          = pascal_case
+# Private and protected fields must be camelCase
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.severity      = suggestion
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.symbols       = private_protected_fields
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.style         = camel_case
+# Public members must be capitalized
+dotnet_naming_rule.public_members_must_be_capitalized.severity               = suggestion
+dotnet_naming_rule.public_members_must_be_capitalized.symbols                = public_symbols
+dotnet_naming_rule.public_members_must_be_capitalized.style                  = first_upper
+# Parameters must be camelCase
+dotnet_naming_rule.parameters_must_be_camel_case.severity                    = suggestion
+dotnet_naming_rule.parameters_must_be_camel_case.symbols                     = parameters
+dotnet_naming_rule.parameters_must_be_camel_case.style                       = camel_case
+# Class, struct, enum and delegates must be PascalCase
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.severity          = suggestion
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.symbols           = non_interface_types
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.style             = pascal_case
+# Interfaces must be PascalCase and start with an 'I'
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.severity          = suggestion
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.symbols           = interface_types
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style             = prefix_interface_interface_with_i
+
+# C# Code Style Settings
+# See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+# See http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
+[*.{cs,csx,cake}]
+# Indentation Options
+csharp_indent_block_contents                                             = true
+csharp_indent_braces                                                     = false
+csharp_indent_case_contents                                              = true
+csharp_indent_labels                                                     = no_change
+csharp_indent_switch_labels                                              = true
+# Style Options
+csharp_style_conditional_delegate_call                                   = true : suggestion
+# TODO: change csharp_style_expression_bodied_accessors to suggestion after existing code-base has been has been consistently styled
+csharp_style_expression_bodied_accessors                                 = true : none
+csharp_style_expression_bodied_constructors                              = true : none
+csharp_style_expression_bodied_indexers                                  = true : suggestion
+csharp_style_expression_bodied_methods                                   = true : none
+csharp_style_expression_bodied_operators                                 = true : suggestion
+csharp_style_expression_bodied_properties                                = true : none
+# TODO: change csharp_style_inlined_variable_declaration to suggestion after existing code-base has been has been consistently styled
+csharp_style_inlined_variable_declaration                                = true : none
+csharp_style_pattern_matching_over_as_with_null_check                    = true : suggestion
+csharp_style_pattern_matching_over_is_with_cast_check                    = true : suggestion
+csharp_style_throw_expression                                            = true : suggestion
+csharp_style_var_elsewhere                                               = true : suggestion
+csharp_style_var_for_built_in_types                                      = true : none
+csharp_style_var_when_type_is_apparent                                   = true : suggestion
+# New Line Options
+csharp_new_line_before_catch                                             = true
+csharp_new_line_before_else                                              = true
+csharp_new_line_before_finally                                           = true
+csharp_new_line_before_members_in_anonymous_types                        = true
+csharp_new_line_before_members_in_object_initializers                    = true
+csharp_new_line_before_open_brace                                        = all
+csharp_new_line_between_query_expression_clauses                         = true
+# Spacing Options
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+# Wrapping Options
+csharp_preserve_single_line_blocks                                       = true
+csharp_preserve_single_line_statements                                   = true


### PR DESCRIPTION
This adds back the .editorconfig file from #3872 that was removed by #3963.
I fixed some bugs in the file (removed severity from formatting rules that don't support it) and changed all warnings to suggestions or even to "none" for some rules.
Changed some of the rules to better match the existing codebase, but it's not always consistent, so suggestions for style changes are welcome.