### PR TITLE
[1.5.5] Propagate message serialization errors to callers

### DIFF
--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -246,28 +246,48 @@ namespace Orleans.Messaging
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         protected override void OnMessageSerializationFailure(Message msg, Exception exc)
         {
-            // we only get here if we failed to serialise the msg (or any other catastrophic failure).
-            // Request msg fails to serialise on the sending silo, so we just enqueue a rejection msg.
-            Log.Warn(ErrorCode.ProxyClient_SerializationError, String.Format("Unexpected error serializing message to gateway {0}.", Address), exc);
-            FailMessage(msg, String.Format("Unexpected error serializing message to gateway {0}. {1}", Address, exc));
-            if (msg.Direction == Message.Directions.Request || msg.Direction == Message.Directions.OneWay)
+            // we only get here if we failed to serialize the msg (or any other catastrophic failure).
+            // Request msg fails to serialize on the sender, so we just enqueue a rejection msg.
+            // Response msg fails to serialize on the responding silo, so we try to send an error response back.
+            if (this.Log.IsWarning)
             {
-                return;
+                this.Log.Warn(
+                    ErrorCode.ProxyClient_SerializationError,
+                    "Unexpected error serializing message {0}: {1}",
+                    msg,
+                    exc);
             }
 
-            // Response msg fails to serialize on the responding silo, so we try to send an error response back.
-            // if we failed sending an original response, turn the response body into an error and reply with it.
-            msg.Result = Message.ResponseTypes.Error;
-            msg.BodyObject = Response.ExceptionResponse(exc);
-            try
+            msg.ReleaseBodyAndHeaderBuffers();
+            MessagingStatisticsGroup.OnFailedSentMessage(msg);
+
+            var retryCount = msg.RetryCount ?? 0;
+
+            if (msg.Direction == Message.Directions.Request)
             {
-                MsgCenter.SendMessage(msg);
+                this.MsgCenter.RejectMessage(msg, $"Unable to serialize message. Encountered exception: {exc?.GetType()}: {exc?.Message}", exc);
             }
-            catch (Exception ex)
+            else if (msg.Direction == Message.Directions.Response && retryCount < 1)
             {
-                // If we still can't serialize, drop the message on the floor
-                Log.Warn(ErrorCode.ProxyClient_DroppingMsg, "Unable to serialize message - DROPPING " + msg, ex);
-                msg.ReleaseBodyAndHeaderBuffers();
+                // if we failed sending an original response, turn the response body into an error and reply with it.
+                // unless we have already tried sending the response multiple times.
+                msg.Result = Message.ResponseTypes.Error;
+                msg.BodyObject = Response.ExceptionResponse(exc);
+                msg.RetryCount = retryCount + 1;
+                this.MsgCenter.SendMessage(msg);
+            }
+            else
+            {
+                if (this.Log.IsWarning)
+                {
+                    this.Log.Warn(
+                        ErrorCode.ProxyClient_DroppingMsg,
+                        "Gateway client is dropping message which failed during serialization: {0}. Exception = {1}",
+                        msg,
+                        exc);
+                }
+
+                MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }
 

--- a/src/Orleans/Messaging/MessageFactory.cs
+++ b/src/Orleans/Messaging/MessageFactory.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
             return response;
         }
 
-        public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, OrleansException ex = null)
+        public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, Exception ex = null)
         {
             var response = this.CreateResponseMessage(request);
             response.Result = Message.ResponseTypes.Rejection;

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -371,11 +371,10 @@ namespace Orleans.Messaging
             PendingInboundMessages.Add(msg);
         }
 
-        private void RejectMessage(Message msg, string reasonFormat, params object[] reasonParams)
+        public void RejectMessage(Message msg, string reason, Exception exc = null)
         {
             if (!Running) return;
-
-            var reason = String.Format(reasonFormat, reasonParams);
+            
             if (msg.Direction != Message.Directions.Request)
             {
                 if (logger.IsVerbose) logger.Verbose(ErrorCode.ProxyClient_DroppingMsg, "Dropping message: {0}. Reason = {1}", msg, reason);
@@ -384,7 +383,7 @@ namespace Orleans.Messaging
             {
                 if (logger.IsVerbose) logger.Verbose(ErrorCode.ProxyClient_RejectingMsg, "Rejecting message: {0}. Reason = {1}", msg, reason);
                 MessagingStatisticsGroup.OnRejectedMessage(msg);
-                Message error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason);
+                Message error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 QueueIncomingMessage(error);
             }
         }

--- a/src/OrleansRuntime/Messaging/SiloMessageSender.cs
+++ b/src/OrleansRuntime/Messaging/SiloMessageSender.cs
@@ -109,24 +109,45 @@ namespace Orleans.Runtime.Messaging
             // we only get here if we failed to serialize the msg (or any other catastrophic failure).
             // Request msg fails to serialize on the sending silo, so we just enqueue a rejection msg.
             // Response msg fails to serialize on the responding silo, so we try to send an error response back.
-            Log.Warn(ErrorCode.MessagingUnexpectedSendError, String.Format("Unexpected error sending message {0}", msg.ToString()), exc);
-            
+            if (this.Log.IsWarning)
+            {
+                this.Log.Warn(
+                    ErrorCode.MessagingUnexpectedSendError,
+                    "Unexpected error serializing message {0}: {1}",
+                    msg,
+                    exc);
+            }
+
             msg.ReleaseBodyAndHeaderBuffers();
             MessagingStatisticsGroup.OnFailedSentMessage(msg);
+
+            var retryCount = msg.RetryCount ?? 0;
+
             if (msg.Direction == Message.Directions.Request)
             {
                 messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, exc.ToString());
             }
-            else if (msg.Direction == Message.Directions.Response && msg.Result != Message.ResponseTypes.Error)
+            else if (msg.Direction == Message.Directions.Response && retryCount < 1)
             {
                 // if we failed sending an original response, turn the response body into an error and reply with it.
-                // unless the response was already an error response (so we don't loop forever).
+                // unless we have already tried sending the response multiple times.
                 msg.Result = Message.ResponseTypes.Error;
                 msg.BodyObject = Response.ExceptionResponse(exc);
-                messageCenter.SendMessage(msg);
+                msg.RetryCount = retryCount + 1;
+                this.messageCenter.SendMessage(msg);
             }
             else
             {
+                if (this.Log.IsWarning)
+                {
+                    this.Log.Warn(
+                        ErrorCode.Messaging_OutgoingMS_DroppingMessage,
+                        "Silo {0} is dropping message which failed during serialization: {1}. Exception = {2}",
+                        this.messageCenter.MyAddress,
+                        msg,
+                        exc);
+                }
+
                 MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }

--- a/test/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/TestGrainInterfaces/IExceptionGrain.cs
@@ -1,3 +1,8 @@
+using System;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+
 namespace UnitTests.GrainInterfaces
 {
     using System.Threading.Tasks;
@@ -31,10 +36,76 @@ namespace UnitTests.GrainInterfaces
 
     public interface IMessageSerializationGrain : IGrainWithIntegerKey
     {
-        Task<object> EchoObject(object input);
+        Task Send(UndeserializableType input);
+        Task<UnserializableType> Get();
 
-        Task GetUnserializableObjectChained();
+        Task SendToOtherSilo();
+        Task GetFromOtheSilo();
+
+        Task SendToClient(IMessageSerializationClientObject obj);
+        Task GetFromClient(IMessageSerializationClientObject obj);
 
         Task<string> GetSiloIdentity();
+    }
+
+    public interface IMessageSerializationClientObject : IAddressable
+    {
+        Task Send(UndeserializableType input);
+        Task<UnserializableType> Get();
+    }
+
+    [Serializable]
+    public struct UndeserializableType
+    {
+        public const string FailureMessage = "Can't do it, sorry.";
+
+        public UndeserializableType(int num)
+        {
+            this.Number = num;
+        }
+
+        public int Number { get; }
+
+        [CopierMethod]
+        public static object DeepCopy(object original, ICopyContext context)
+        {
+            var typed = (UndeserializableType) original;
+            return new UndeserializableType(typed.Number);
+        }
+
+        [SerializerMethod]
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
+        {
+            var typed = (UndeserializableType) untypedInput;
+            context.StreamWriter.Write(typed.Number);
+        }
+
+        [DeserializerMethod]
+        public static object Deserialize(Type expected, IDeserializationContext context)
+        {
+            throw new NotSupportedException(FailureMessage);
+        }
+    }
+
+    [Serializable]
+    public class UnserializableType
+    {
+        [CopierMethod]
+        public static object DeepCopy(object original, ICopyContext context)
+        {
+            return original;
+        }
+
+        [SerializerMethod]
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
+        {
+            throw new NotSupportedException(UndeserializableType.FailureMessage);
+        }
+
+        [DeserializerMethod]
+        public static object Deserialize(Type expected, IDeserializationContext context)
+        {
+            return null;
+        }
     }
 }

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -1,19 +1,41 @@
-﻿namespace UnitTests.Grains
+﻿using Orleans.CodeGeneration;
+
+namespace UnitTests.Grains
 {
     using System;
     using System.Threading.Tasks;
 
     using Orleans;
-    using Orleans.Runtime;
     using Orleans.Serialization;
 
     using UnitTests.GrainInterfaces;
     
     public class MessageSerializationGrain : Grain, IMessageSerializationGrain
     {
-        public Task<object> EchoObject(object input) => Task.FromResult(input);
+        public Task Send(UndeserializableType input) => Task.FromResult(input);
+        public Task<UnserializableType> Get() => Task.FromResult(new UnserializableType());
 
-        public async Task GetUnserializableObjectChained()
+        public async Task SendToOtherSilo()
+        {
+            var otherGrain = await GetGrainOnOtherSilo();
+
+            // Message that grain in a way which should fail.
+            await otherGrain.Send(new UndeserializableType(35));
+        }
+
+        public async Task GetFromOtheSilo()
+        {
+            var otherGrain = await GetGrainOnOtherSilo();
+
+            // Message that grain in a way which should fail.
+            await otherGrain.Get();
+        }
+
+        public Task SendToClient(IMessageSerializationClientObject obj) => obj.Send(new UndeserializableType(35));
+
+        public Task GetFromClient(IMessageSerializationClientObject obj) => obj.Get();
+
+        private async Task<IMessageSerializationGrain> GetGrainOnOtherSilo()
         {
             // Find a grain on another silo.
             IMessageSerializationGrain otherGrain;
@@ -23,14 +45,13 @@
             {
                 otherGrain = this.GrainFactory.GetGrain<IMessageSerializationGrain>(++id);
                 var otherIdentity = await otherGrain.GetSiloIdentity();
-                if (!string.Equals(otherIdentity, currentSiloIdentity))
+                if (!String.Equals(otherIdentity, currentSiloIdentity))
                 {
                     break;
                 }
             }
 
-            // Message that grain in a way which should fail.
-            await otherGrain.EchoObject(new SimpleType(35));
+            return otherGrain;
         }
 
         public Task<string> GetSiloIdentity()
@@ -38,46 +59,8 @@
             return Task.FromResult(this.RuntimeIdentity);
         }
     }
-
-    [Serializable]
-    public struct SimpleType
-    {
-        public SimpleType(int num)
-        {
-            this.Number = num;
-        }
-
-        public int Number { get; }
-    }
-
-    /// <summary>
-    /// Serializer which can serialize <see cref="SimpleType"/> but cannot deserialize it.
-    /// </summary>
-    [Serializable]
-    public class OneWaySerializer : IExternalSerializer
-    {
-        public const string FailureMessage = "Can't do it, sorry.";
-
         public void Initialize(Logger logger)
         {
         }
 
-        public bool IsSupportedType(Type itemType) => itemType == typeof(SimpleType);
-
-        public object DeepCopy(object source, ICopyContext context)
-        {
-            return source;
-        }
-
-        public void Serialize(object item, ISerializationContext context, Type expectedType)
-        {
-            var typed = (SimpleType)item;
-            context.StreamWriter.Write(typed.Number);
-        }
-
-        public object Deserialize(Type expectedType, IDeserializationContext context)
-        {
-            throw new NotSupportedException(FailureMessage);
-        }
-    }
 }


### PR DESCRIPTION
This is a port of #4907 to the 1.5.x branch