### PR TITLE
Fix fault injection tests and enable them 

### DIFF
--- a/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/ControlledInjection/TransactionFaultInjectionTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/ControlledInjection/TransactionFaultInjectionTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Orleans.Transactions.Azure.Tests
 {
-    [TestCategory("Azure"), TestCategory("Transactions")]
+    [TestCategory("Azure"), TestCategory("Transactions"), TestCategory("Functional")]
     public class TransactionFaultInjectionTests : ControlledFaultInjectionTransactionTestRunner, IClassFixture<ControlledFaultInjectionTestFixture>
     {
         public TransactionFaultInjectionTests(ControlledFaultInjectionTestFixture fixture, ITestOutputHelper output)

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
@@ -17,6 +17,12 @@ namespace Orleans.Transactions.Tests.DeactivatingInjection
     {
         public TransactionFaultInjectPhase FaultInjectionPhase = TransactionFaultInjectPhase.None;
         public FaultInjectionType FaultInjectionType = FaultInjectionType.None;
+
+        public void Reset()
+        {
+            this.FaultInjectionType = FaultInjectionType.None;
+            this.FaultInjectionPhase = TransactionFaultInjectPhase.None;
+        }
     }
 
     public enum TransactionFaultInjectPhase

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjection/ControlledInjection/SingleStateDeactivatingTransactionalGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjection/ControlledInjection/SingleStateDeactivatingTransactionalGrain.cs
@@ -41,14 +41,11 @@ namespace Orleans.Transactions.Tests.DeactivationTransaction
 
         public Task Add(int numberToAdd, FaultInjectionControl faultInjectionControl = null)
         {
+            //reset in case control from last tx isn't cleared for some reason
+            faultInjectionControl.Reset();
             //dont replace it with this.data.FaultInjectionControl = faultInjectionControl, 
             //this.data.FaultInjectionControl must remain the same reference
-            if (faultInjectionControl == null)
-            {
-                this.data.FaultInjectionControl.FaultInjectionPhase = TransactionFaultInjectPhase.None;
-                this.data.FaultInjectionControl.FaultInjectionType = FaultInjectionType.None;
-            }
-            else
+            if (faultInjectionControl != null)
             {
                 this.data.FaultInjectionControl.FaultInjectionPhase = faultInjectionControl.FaultInjectionPhase;
                 this.data.FaultInjectionControl.FaultInjectionType = faultInjectionControl.FaultInjectionType;

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -75,6 +75,7 @@ namespace Orleans.Transactions.Tests
             }
             catch (OrleansTransactionException)
             {
+                await Task.Delay(TimeSpan.FromSeconds(2));
                 //if failed due to timeout or other legitimate transaction exception, try again. This should succeed 
                 await coordinator.MultiGrainAddAndFaultInjection(grains, addval);
             }


### PR DESCRIPTION
I didn't know confirm would be retried on storage error, so I didn't reset fault injection control after confirmed once, which cause some of the tests failing. 