### PR TITLE
Remove 'Who's using Orleans" file from table of contents.

### DIFF
--- a/src/Documentation/toc.yml
+++ b/src/Documentation/toc.yml
@@ -8,8 +8,6 @@
     href: frequently_asked_questions.md
   - name: What's new in Orleans
     href: whats_new_in_orleans.md
-  - name: Who's using Orleans
-    href: who_is_using_orleans.md
 - name: Core Concepts
   href: core_concepts/toc.yml
 - name: Grains


### PR DESCRIPTION
File is not needed.