### PR TITLE
Add Microsoft.Orleans.Streaming.AzureStorage as a dependency to AzureUtils

### DIFF
--- a/src/Azure/OrleansAzureUtils/Directory.Build.props
+++ b/src/Azure/OrleansAzureUtils/Directory.Build.props
@@ -61,4 +61,17 @@
     </Otherwise>
   </Choose>
 
+  <Choose>
+    <When Condition="$(OrleansAzureStreamingVersion) == $(VersionPrefix) AND $(OrleansAzureMetapackageVersion) == $(OrleansAzureStreamingVersion)">
+      <ItemGroup>
+        <ProjectReference Include="..\Orleans.Streaming.AzureStorage\Orleans.Streaming.AzureStorage.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="$(OrleansAzureStreamingVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
 </Project>


### PR DESCRIPTION
Fixes #4800.

Add `Microsoft.Orleans.Streaming.AzureStorage` as a dependency to `Microsoft.Orleans.OrleansAzureUtils`.