### PR TITLE
Add TableName to Azure Storage clustering and reminders config

### DIFF
--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.MembershipService
             LogFormatter.SetExceptionDecoder(typeof(StorageException), AzureStorageUtils.PrintStorageException);
 
             tableManager = await OrleansSiloInstanceManager.GetManager(
-                this.clusterId, options.ConnectionString, this.loggerFactory);
+                this.clusterId, options.ConnectionString, options.TableName, this.loggerFactory);
 
             // even if I am not the one who created the table, 
             // try to insert an initial table version if it is not already there,

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -26,7 +26,8 @@ namespace Orleans.AzureUtils
 
         public async Task InitializeGatewayListProvider()
         {
-            siloInstanceManager = await OrleansSiloInstanceManager.GetManager(this.clusterId, this.options.ConnectionString, this.loggerFactory);
+            siloInstanceManager = await OrleansSiloInstanceManager.GetManager(
+                this.clusterId, this.options.ConnectionString, this.options.TableName, this.loggerFactory);
         }
         // no caching
         public Task<IList<Uri>> GetGateways()

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
@@ -14,5 +14,11 @@
         /// </summary>
         [RedactConnectionString]
         public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Table name for Azure Storage
+        /// </summary>
+        public string TableName { get; set; } = DEFAULT_TABLE_NAME;
+        public const string DEFAULT_TABLE_NAME = "OrleansSiloInstances";
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
@@ -7,5 +7,10 @@
         /// </summary>
         [RedactConnectionString]
         public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Table name for Azure Storage
+        /// </summary>
+        public string TableName { get; set; } = AzureStorageClusteringOptions.DEFAULT_TABLE_NAME;
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -15,9 +15,7 @@ namespace Orleans.AzureUtils
 {
     internal class OrleansSiloInstanceManager
     {
-        public string TableName { get { return INSTANCE_TABLE_NAME; } }
-
-        private const string INSTANCE_TABLE_NAME = "OrleansSiloInstances";
+        public string TableName { get; }
 
         private readonly string INSTANCE_STATUS_CREATED = SiloStatus.Created.ToString();  //"Created";
         private readonly string INSTANCE_STATUS_ACTIVE = SiloStatus.Active.ToString();    //"Active";
@@ -30,17 +28,18 @@ namespace Orleans.AzureUtils
 
         public string DeploymentId { get; private set; }
 
-        private OrleansSiloInstanceManager(string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
+        private OrleansSiloInstanceManager(string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)
         {
             DeploymentId = clusterId;
+            TableName = tableName;
             logger = loggerFactory.CreateLogger<OrleansSiloInstanceManager>();
             storage = new AzureTableDataManager<SiloInstanceTableEntry>(
-                INSTANCE_TABLE_NAME, storageConnectionString, loggerFactory);
+                tableName, storageConnectionString, loggerFactory);
         }
 
-        public static async Task<OrleansSiloInstanceManager> GetManager(string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
+        public static async Task<OrleansSiloInstanceManager> GetManager(string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)
         {
-            var instance = new OrleansSiloInstanceManager(clusterId, storageConnectionString, loggerFactory);
+            var instance = new OrleansSiloInstanceManager(clusterId, storageConnectionString, tableName, loggerFactory);
             try
             {
                 await instance.storage.InitTableAsync()

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Logging;
 using Orleans.AzureUtils.Utilities;
+using Orleans.Configuration;
 using Orleans.Hosting.AzureCloudServices;
 using Orleans.Hosting;
 
@@ -110,7 +111,7 @@ namespace Orleans.Runtime.Host
 
                 try
                 {
-                    var manager = siloInstanceManager ?? await OrleansSiloInstanceManager.GetManager(clusterId, connectionString, loggerFactory);
+                    var manager = siloInstanceManager ?? await OrleansSiloInstanceManager.GetManager(clusterId, connectionString, AzureStorageClusteringOptions.DEFAULT_TABLE_NAME, loggerFactory);
                     var instances = await manager.DumpSiloInstanceTable();
                     logger.Debug(instances);
                 }
@@ -256,7 +257,7 @@ namespace Orleans.Runtime.Host
             try
             {
                 siloInstanceManager = OrleansSiloInstanceManager.GetManager(
-                    clusterId, connectionString, this.loggerFactory).WithTimeout(AzureTableDefaultPolicies.TableCreationTimeout).Result;
+                    clusterId, connectionString, AzureStorageClusteringOptions.DEFAULT_TABLE_NAME, this.loggerFactory).WithTimeout(AzureTableDefaultPolicies.TableCreationTimeout).Result;
             }
             catch (Exception exc)
             {

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -32,7 +32,8 @@ namespace Orleans.Runtime.ReminderService
 
         public async Task Init()
         {
-            this.remTableManager = await RemindersTableManager.GetManager(this.clusterOptions.ServiceId, this.clusterOptions.ClusterId, this.storageOptions.ConnectionString, this.loggerFactory);
+            this.remTableManager = await RemindersTableManager.GetManager(
+                this.clusterOptions.ServiceId, this.clusterOptions.ClusterId, this.storageOptions.ConnectionString, this.storageOptions.TableName, this.loggerFactory);
         }
 
         private ReminderTableData ConvertFromTableEntryList(IEnumerable<Tuple<ReminderTableEntry, string>> entries)

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureTableReminderStorageOptions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureTableReminderStorageOptions.cs
@@ -8,5 +8,11 @@ namespace Orleans.Configuration
         /// </summary>
         [RedactConnectionString]
         public string ConnectionString { get; set; }
+        
+        /// <summary>
+        /// Table name for Azure Storage
+        /// </summary>
+        public string TableName { get; set; } = DEFAULT_TABLE_NAME;
+        public const string DEFAULT_TABLE_NAME = "OrleansReminders";
     }
 }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -70,16 +70,14 @@ namespace Orleans.Runtime.ReminderService
     
     internal class RemindersTableManager : AzureTableDataManager<ReminderTableEntry>
     {
-        private const string REMINDERS_TABLE_NAME = "OrleansReminders";
-
         public string ServiceId { get; private set; }
         public string ClusterId { get; private set; }
 
         private static readonly TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
 
-        public static async Task<RemindersTableManager> GetManager(string serviceId, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
+        public static async Task<RemindersTableManager> GetManager(string serviceId, string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)
         {
-            var singleton = new RemindersTableManager(serviceId, clusterId, storageConnectionString, loggerFactory);
+            var singleton = new RemindersTableManager(serviceId, clusterId, storageConnectionString, tableName, loggerFactory);
             try
             {
                 singleton.Logger.Info("Creating RemindersTableManager for service id {0} and clusterId {1}.", serviceId, clusterId);
@@ -101,8 +99,8 @@ namespace Orleans.Runtime.ReminderService
             return singleton;
         }
 
-        private RemindersTableManager(string serviceId, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
-            : base(REMINDERS_TABLE_NAME, storageConnectionString, loggerFactory)
+        private RemindersTableManager(string serviceId, string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)
+            : base(tableName, storageConnectionString, loggerFactory)
         {
             ClusterId = clusterId;
             ServiceId = serviceId;

--- a/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -14,6 +14,7 @@ using UnitTests.MembershipTests;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.Clustering.AzureStorage;
+using Orleans.Configuration;
 
 namespace Tester.AzureUtils
 {
@@ -52,7 +53,7 @@ namespace Tester.AzureUtils
             output.WriteLine("ClusterId={0} Generation={1}", this.clusterId, generation);
 
             output.WriteLine("Initializing SiloInstanceManager");
-            manager = OrleansSiloInstanceManager.GetManager(this.clusterId, TestDefaultConfiguration.DataConnectionString, fixture.LoggerFactory)
+            manager = OrleansSiloInstanceManager.GetManager(this.clusterId, TestDefaultConfiguration.DataConnectionString, AzureStorageClusteringOptions.DEFAULT_TABLE_NAME, fixture.LoggerFactory)
                 .WaitForResultWithThrow(SiloInstanceTableTestConstants.Timeout);
         }
 


### PR DESCRIPTION
This resolves: https://github.com/dotnet/orleans/issues/4971
As it is implemented here, it solves our needs.

As far as I could see there are no validators for these options, but I can whip some up in a separate PR.

One open question: Should this also be made configurable for AzureSilo and the tests?