### PR TITLE
Revert Microsoft.ServiceFabric.Services version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,7 @@
     <MicrosoftAzureEventHubsVersion>1.0.3</MicrosoftAzureEventHubsVersion>
     <MicrosoftDataSQLiteVersion>2.0.0</MicrosoftDataSQLiteVersion>
     <MicrosoftPowerShell5ReferenceAssembliesVersion>1.1.0</MicrosoftPowerShell5ReferenceAssembliesVersion>
-    <MicrosoftServiceFabricServicesVersion>3.0.472</MicrosoftServiceFabricServicesVersion>
+    <MicrosoftServiceFabricServicesVersion>3.0.456</MicrosoftServiceFabricServicesVersion>
     <WindowsAzureStorageVersion>8.2.1</WindowsAzureStorageVersion>
 
     <FSharpCoreVersion>4.2.3</FSharpCoreVersion>


### PR DESCRIPTION
Upgrading even the patch version of the `Microsoft.ServiceFabric.Services` is a breaking change, and requires the user to upgrade their SF cluster. Please consider to revert this back to 3.0.456.