### PR TITLE
Add LargeMessageWarningThreshold back to Silo(Client)MessagingOptions

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
@@ -114,7 +114,6 @@ namespace Orleans.Runtime.Configuration
         ///  Whether Trace.CorrelationManager.ActivityId settings should be propagated into grain calls.
         /// </summary>
         public bool PropagateActivityId { get; set; }
-
         /// <summary>
         /// </summary>
         public AddressFamily PreferredFamily { get; set; }

--- a/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
@@ -114,6 +114,7 @@ namespace Orleans.Configuration
             options.BufferPoolBufferSize = configuration.BufferPoolBufferSize;
             options.BufferPoolMaxSize = configuration.BufferPoolMaxSize;
             options.BufferPoolPreallocationSize = configuration.BufferPoolPreallocationSize;
+            options.LargeMessageWarningThreshold = configuration.LargeMessageWarningThreshold;
         }
 
         internal static void CopyNetworkingOptions(IMessagingConfiguration configuration, NetworkingOptions options)

--- a/src/Orleans.Core/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans.Core/Configuration/MessagingConfiguration.cs
@@ -89,6 +89,11 @@ namespace Orleans.Runtime.Configuration
         /// Gets the fallback serializer, used as a last resort when no other serializer is able to serialize an object.
         /// </summary>
         TypeInfo FallbackSerializationProvider { get; set; }
+
+        /// <summary>
+        /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
+        /// </summary>
+        int LargeMessageWarningThreshold { get; set; }
     }
 
     /// <summary>
@@ -120,6 +125,11 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public int MaxForwardCount { get; set; }
 
+        /// <summary>
+        /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
+        /// </summary>
+        public int LargeMessageWarningThreshold { get; set; }
+
         public List<TypeInfo> SerializationProviders { get; private set; }
         public TypeInfo FallbackSerializationProvider { get; set; }
 
@@ -149,6 +159,7 @@ namespace Orleans.Runtime.Configuration
             BufferPoolBufferSize = MessagingOptions.DEFAULT_BUFFER_POOL_BUFFER_SIZE;
             BufferPoolMaxSize = MessagingOptions.DEFAULT_BUFFER_POOL_MAX_SIZE;
             BufferPoolPreallocationSize = MessagingOptions.DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE;
+            LargeMessageWarningThreshold = MessagingOptions.DEFAULT_LARGE_MESSAGE_WARNING_THRESHOLD;
 
             if (isSiloConfig)
             {
@@ -202,6 +213,12 @@ namespace Orleans.Runtime.Configuration
                                       ? ConfigUtilities.ParseTimeSpan(child.GetAttribute("ResponseTimeout"),
                                                                  "Invalid ResponseTimeout")
                                       : MessagingOptions.DEFAULT_RESPONSE_TIMEOUT;
+
+            if (child.HasAttribute("LargeMessageWarningThreshold"))
+            {
+                LargeMessageWarningThreshold = ConfigUtilities.ParseInt(child.GetAttribute("LargeMessageWarningThreshold"),
+                    "Invalid boolean value for LargeMessageWarningThresholdattribute");
+            }
 
             if (child.HasAttribute("MaxResendCount"))
             {

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -69,5 +70,11 @@ namespace Orleans.Configuration
         /// </summary>
         public bool PropagateActivityId { get; set; } = DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
         public const bool DEFAULT_PROPAGATE_E2E_ACTIVITY_ID = false;
+
+        /// <summary>
+        /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
+        /// </summary>
+        public int LargeMessageWarningThreshold { get; set; } = DEFAULT_LARGE_MESSAGE_WARNING_THRESHOLD;
+        public const int DEFAULT_LARGE_MESSAGE_WARNING_THRESHOLD = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
     }
 }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Orleans.ApplicationParts;
 using Orleans.Configuration;
 using Orleans.Configuration.Validators;
@@ -53,7 +54,8 @@ namespace Orleans
             services.TryAddFromExisting<IClusterClient, IInternalClusterClient>();
 
             // Serialization
-            services.TryAddSingleton<SerializationManager>();
+            services.TryAddSingleton<SerializationManager>(sp => ActivatorUtilities.CreateInstance<SerializationManager>(sp,
+                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -84,9 +84,10 @@ namespace Orleans.Serialization
             IOptions<SerializationProviderOptions> serializationProviderOptions,
             ILoggerFactory loggerFactory,
             ITypeResolver typeResolver,
-            SerializationStatisticsGroup serializationStatistics)
+            SerializationStatisticsGroup serializationStatistics,
+            int LargetMessageWarningThreshold)
         {
-            this.LargeObjectSizeThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
+            this.LargeObjectSizeThreshold = LargetMessageWarningThreshold;
             this.serializationContext = new ThreadLocal<SerializationContext>(() => new SerializationContext(this));
             this.deserializationContext = new ThreadLocal<DeserializationContext>(() => new DeserializationContext(this));
 

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -85,9 +85,9 @@ namespace Orleans.Serialization
             ILoggerFactory loggerFactory,
             ITypeResolver typeResolver,
             SerializationStatisticsGroup serializationStatistics,
-            int LargetMessageWarningThreshold)
+            int largeMessageWarningThreshold)
         {
-            this.LargeObjectSizeThreshold = LargetMessageWarningThreshold;
+            this.LargeObjectSizeThreshold = largeMessageWarningThreshold;
             this.serializationContext = new ThreadLocal<SerializationContext>(() => new SerializationContext(this));
             this.deserializationContext = new ThreadLocal<DeserializationContext>(() => new DeserializationContext(this));
 

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -224,7 +224,8 @@ namespace Orleans.Hosting
             services.TryAddSingleton(typeof(IKeyedServiceCollection<,>), typeof(KeyedServiceCollection<,>));
 
             // Serialization
-            services.TryAddSingleton<SerializationManager>();
+            services.TryAddSingleton<SerializationManager>(sp=>ActivatorUtilities.CreateInstance<SerializationManager>(sp, 
+                sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();

--- a/test/TestInfrastructure/Orleans.TestingHost.Legacy/LegacyTestClusterConfiguration.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Legacy/LegacyTestClusterConfiguration.cs
@@ -150,7 +150,8 @@ namespace Orleans.TestingHost
                 Options.Create(new SerializationProviderOptions()),
                 new NullLoggerFactory(),
                 new CachedTypeResolver(),
-                new SerializationStatisticsGroup(Options.Create(new StatisticsOptions {CollectionLevel = StatisticsLevel.Info})));
+                new SerializationStatisticsGroup(Options.Create(new StatisticsOptions {CollectionLevel = StatisticsLevel.Info})),
+                MessagingOptions.DEFAULT_LARGE_MESSAGE_WARNING_THRESHOLD);
             serializationManager.RegisterSerializers(applicationPartManager);
             return serializationManager;
         }


### PR DESCRIPTION
Add LargeMessageWarningThreshold back to Silo(Client)MessagingOptions and also legacy configuration objects