### PR TITLE
Ensure AsyncAgent restarts on fault

### DIFF
--- a/test/Grains/TestInternalGrainInterfaces/IAgentTestGrain.cs
+++ b/test/Grains/TestInternalGrainInterfaces/IAgentTestGrain.cs
@@ -1,0 +1,10 @@
+﻿using Orleans;
+using System.Threading.Tasks;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IAgentTestGrain : IGrainWithIntegerKey
+    {
+        Task<int> GetFailureCount();
+    }
+}

--- a/test/Grains/TestInternalGrains/AgentTestGrain.cs
+++ b/test/Grains/TestInternalGrains/AgentTestGrain.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    public class AgentTestGrain : Grain, IAgentTestGrain
+    {
+        private readonly TestDedicatedAsynchAgent testAgent;
+
+        public AgentTestGrain(IServiceProvider services)
+        {
+            this.testAgent = services.GetService(typeof(TestDedicatedAsynchAgent)) as TestDedicatedAsynchAgent;
+        }
+
+        public Task<int> GetFailureCount()
+        {
+            return Task.FromResult(this.testAgent.FailureCount);
+        }
+    }
+
+    internal class TestDedicatedAsynchAgent : DedicatedAsynchAgent, ILifecycleParticipant<ISiloLifecycle>
+    {
+        private readonly ILogger logger;
+
+        public int FailureCount { get; private set; }
+
+        public TestDedicatedAsynchAgent(ExecutorService executorService, ILoggerFactory loggerFactory) : base(executorService, loggerFactory)
+        {
+            OnFault = FaultBehavior.RestartOnFault;
+            this.logger = loggerFactory.CreateLogger<TestDedicatedAsynchAgent>();
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe<TestDedicatedAsynchAgent>(ServiceLifecycleStage.Active, OnStart);
+        }
+
+        protected override void Run()
+        {
+            RunAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task RunAsync()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            this.logger.LogInformation("Failure");
+            this.FailureCount++;
+            throw new ApplicationException();
+        }
+
+        private Task OnStart(CancellationToken ct)
+        {
+            this.logger.LogInformation("Starting");
+            this.Start();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/TesterInternal/AgentTests.cs
+++ b/test/TesterInternal/AgentTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+
+namespace UnitTests
+{
+    public class AgentTests : OrleansTestingBase, IClassFixture<AgentTests.Fixture>
+    {
+        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
+        private readonly Fixture fixture;
+
+        public AgentTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<Configurator>();
+            }
+
+            private class Configurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.ConfigureServices(services => services.TryAddSingleton<TestDedicatedAsynchAgent>());
+                    hostBuilder.ConfigureServices(services => services.TryAddSingleton(sp => sp.GetService(typeof(TestDedicatedAsynchAgent)) as ILifecycleParticipant<ISiloLifecycle>));
+                }
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DedicatedAsynchAgentRestartsTest()
+        {
+            IAgentTestGrain grain = this.fixture.GrainFactory.GetGrain<IAgentTestGrain>(GetRandomGrainId());
+            await TestingUtils.WaitUntilAsync(lastTry => CheckForFailures(grain, lastTry), timeout);
+        }
+
+        private async Task<bool> CheckForFailures(IAgentTestGrain grain, bool assertIsTrue)
+        {
+            int result = await grain.GetFailureCount();
+            if (assertIsTrue)
+            {
+                Assert.True(result > 1);
+                return true;
+            }
+            else
+            {
+                return result > 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
AsyncAgents were not restarting on fault when configured to do so.
- Added test to repro
- Fixed in AsyncAgent
