### PR TITLE
Improve type resolution in code generator

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
@@ -84,8 +84,17 @@ namespace Orleans.CodeGenerator.MSBuild
                 ? ProjectId.CreateFromSerialized(projectIdGuid)
                 : ProjectId.CreateNewId();
 
+            this.Log.LogDebug($"AssemblyName: {this.AssemblyName}");
             this.Log.LogDebug($"ProjectGuid: {ProjectGuid}");
             this.Log.LogDebug($"ProjectID: {projectId}");
+            this.Log.LogDebug($"ProjectName: {projectName}");
+            this.Log.LogDebug($"CodeGenOutputFile: {this.CodeGenOutputFile}");
+            this.Log.LogDebug($"ProjectPath: {this.ProjectPath}");
+            this.Log.LogDebug($"OutputType: {this.OutputType}");
+            this.Log.LogDebug($"TargetPath: {this.TargetPath}");
+            this.Log.LogDebug($"DefineConstants ({this.DefineConstants.Count}): {string.Join(", ", this.DefineConstants)}");
+            this.Log.LogDebug($"Sources ({this.Compile.Count}): {string.Join(", ", this.Compile)}");
+            this.Log.LogDebug($"References ({this.Reference.Count}): {string.Join(", ", this.Reference)}");
 
             var languageName = GetLanguageName(ProjectPath);
 

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -103,16 +103,36 @@ namespace Orleans.CodeGenerator
 
             INamedTypeSymbol Type(string type)
             {
-                var result = compilation.GetTypeByMetadataName(type);
-                if (result == null) throw new InvalidOperationException($"Unable to find type with metadata name \"{type}\".");
+                var result = ResolveType(type);
+                if (result == null)
+                {
+                    throw new InvalidOperationException($"Unable to find type with metadata name \"{type}\".");
+                }
                 return result;
             }
 
             OptionalType OptionalType(string type)
             {
-                var result = compilation.GetTypeByMetadataName(type);
+                var result = ResolveType(type);
                 if (result == null) return None.Instance;
                 return new Some(result);
+            }
+
+            INamedTypeSymbol ResolveType(string type)
+            {
+                var result = compilation.GetTypeByMetadataName(type);
+                if (result == null)
+                {
+                    foreach (var reference in compilation.References)
+                    {
+                        var asm = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
+                        if (asm == null) continue;
+                        result = asm.GetTypeByMetadataName(type);
+                        if (result != null) break;
+                    }
+                }
+
+                return result;
             }
         }
 


### PR DESCRIPTION
Fixes #5017

When there is an ambiguity resolving a type by metadata name, iterate over each assembly and return the first type which matches the specified metadata name.