### PR TITLE
CodeGen: Reduce duplication for assembly metadata generation

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
@@ -84,14 +84,14 @@ namespace Orleans.CodeGenerator.MSBuild
                 ? ProjectId.CreateFromSerialized(projectIdGuid)
                 : ProjectId.CreateNewId();
 
-            this.Log.LogDebug($"ProjectGuid: {ProjectGuid}");
+            if (!string.IsNullOrWhiteSpace(this.ProjectGuid)) this.Log.LogDebug($"ProjectGuid: {this.ProjectGuid}");
             this.Log.LogDebug($"ProjectID: {projectId}");
 
             var languageName = GetLanguageName(ProjectPath);
 
             var projectInfo = ProjectInfo.Create(
                 projectId,
-                VersionStamp.Create(),
+                VersionStamp.Default,
                 projectName,
                 AssemblyName,
                 languageName,
@@ -102,18 +102,16 @@ namespace Orleans.CodeGenerator.MSBuild
                 metadataReferences: GetMetadataReferences(Reference),
                 parseOptions: new CSharpParseOptions(preprocessorSymbols: this.DefineConstants)
             );
-
-            this.Log.LogDebug($"Project: {projectInfo}");
-
+            
             var workspace = new AdhocWorkspace();
             workspace.AddProject(projectInfo);
 
             var project = workspace.CurrentSolution.Projects.Single();
-            this.Log.LogInformation($"Workspace creation completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"Workspace creation completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();
 
             var compilation = await project.GetCompilationAsync(cancellationToken);
-            this.Log.LogInformation($"GetCompilation completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"GetCompilation completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();
 
             if (compilation.ReferencedAssemblyNames.All(name => name.Name != AbstractionsAssemblyShortName))
@@ -124,11 +122,11 @@ namespace Orleans.CodeGenerator.MSBuild
 
             var generator = new CodeGenerator(compilation, this.Log);
             var syntax = generator.GenerateCode(cancellationToken);
-            this.Log.LogInformation($"GenerateCode completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"GenerateCode completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();
 
             var normalized = syntax.NormalizeWhitespace();
-            this.Log.LogInformation($"NormalizeWhitespace completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"NormalizeWhitespace completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();
             
             var sourceBuilder = new StringBuilder();
@@ -140,7 +138,7 @@ namespace Orleans.CodeGenerator.MSBuild
             sourceBuilder.AppendLine("#endif");
             var source = sourceBuilder.ToString();
 
-            this.Log.LogInformation($"Generate source from syntax completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"Generate source from syntax completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();
 
             if (File.Exists(this.CodeGenOutputFile))
@@ -150,7 +148,7 @@ namespace Orleans.CodeGenerator.MSBuild
                     var existing = await reader.ReadToEndAsync();
                     if (string.Equals(source, existing, StringComparison.Ordinal))
                     {
-                        this.Log.LogInformation("Generated code matches existing code.");
+                        this.Log.LogDebug("Generated code matches existing code.");
                         return true;
                     }
                 }
@@ -161,7 +159,7 @@ namespace Orleans.CodeGenerator.MSBuild
                 await sourceWriter.WriteAsync(source);
             }
 
-            this.Log.LogInformation($"Write source to disk completed in {stopwatch.ElapsedMilliseconds}ms.");
+            this.Log.LogDebug($"Write source to disk completed in {stopwatch.ElapsedMilliseconds}ms.");
 
             return true;
         }

--- a/src/Orleans.CodeGenerator/Model/SerializationTypeDescriptions.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializationTypeDescriptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Orleans.CodeGenerator.Compatibility;
 
 namespace Orleans.CodeGenerator.Model
 {
@@ -47,6 +48,17 @@ namespace Orleans.CodeGenerator.Model
 
     public class KnownTypeDescription
     {
+        public KnownTypeDescription(INamedTypeSymbol type)
+        {
+            this.Type = type.OriginalDefinition.ConstructedFrom;
+        }
+
+        public static IEqualityComparer<KnownTypeDescription> Comparer { get; } = new TypeTypeKeyEqualityComparer();
+
+        public INamedTypeSymbol Type { get; }
+
+        public string TypeKey => this.Type.OrleansTypeKeyString();
+
         private sealed class TypeTypeKeyEqualityComparer : IEqualityComparer<KnownTypeDescription>
         {
             public bool Equals(KnownTypeDescription x, KnownTypeDescription y)
@@ -55,28 +67,16 @@ namespace Orleans.CodeGenerator.Model
                 if (ReferenceEquals(x, null)) return false;
                 if (ReferenceEquals(y, null)) return false;
                 if (x.GetType() != y.GetType()) return false;
-                return Equals(x.type, y.type) && string.Equals(x.TypeKey, y.TypeKey);
+                return Equals(x.Type, y.Type);
             }
 
             public int GetHashCode(KnownTypeDescription obj)
             {
                 unchecked
                 {
-                    return ((obj.type != null ? obj.type.GetHashCode() : 0) * 397) ^ (obj.TypeKey != null ? obj.TypeKey.GetHashCode() : 0);
+                    return ((obj.Type != null ? obj.Type.GetHashCode() : 0) * 397);
                 }
             }
         }
-
-        public static IEqualityComparer<KnownTypeDescription> Comparer { get; } = new TypeTypeKeyEqualityComparer();
-
-        private INamedTypeSymbol type;
-
-        public INamedTypeSymbol Type
-        {
-            get => type;
-            set => type = value?.OriginalDefinition?.ConstructedFrom;
-        }
-
-        public string TypeKey { get; set; }
     }
 }

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -99,6 +99,7 @@ namespace Orleans.CodeGenerator
                 KnownAssemblyAttribute = Type("Orleans.CodeGeneration.KnownAssemblyAttribute"),
                 KnownBaseTypeAttribute = Type("Orleans.CodeGeneration.KnownBaseTypeAttribute"),
                 ConsiderForCodeGenerationAttribute = Type("Orleans.CodeGeneration.ConsiderForCodeGenerationAttribute"),
+                OrleansCodeGenerationTargetAttribute = Type("Orleans.CodeGeneration.OrleansCodeGenerationTargetAttribute"),
             };
 
             INamedTypeSymbol Type(string type)
@@ -204,6 +205,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol KnownAssemblyAttribute { get; private set; }
         public INamedTypeSymbol KnownBaseTypeAttribute { get; private set; }
         public INamedTypeSymbol ConsiderForCodeGenerationAttribute { get; private set; }
+        public INamedTypeSymbol OrleansCodeGenerationTargetAttribute { get; private set; }
         public class OptionalType { }
 
         public class None : OptionalType

--- a/src/Orleans.Core.Abstractions/CodeGeneration/OrleansCodeGenerationTargetAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/OrleansCodeGenerationTargetAttribute.cs
@@ -6,7 +6,7 @@ namespace Orleans.CodeGeneration
     /// The attribute which informs the code generator which assemblies an assembly contains generated code for.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-    public class OrleansCodeGenerationTargetAttribute : Attribute
+    public sealed class OrleansCodeGenerationTargetAttribute : Attribute
     {
         /// <summary>Initializes a new instance of <see cref="OrleansCodeGenerationTargetAttribute"/>.</summary>
         /// <param name="assemblyName">The target assembly name.</param>
@@ -15,9 +15,23 @@ namespace Orleans.CodeGeneration
             this.AssemblyName = assemblyName;
         }
 
+        /// <summary>Initializes a new instance of <see cref="OrleansCodeGenerationTargetAttribute"/>.</summary>
+        /// <param name="assemblyName">The target assembly name.</param>
+        /// <param name="metadataOnly">Whether or not only metadata was generated for the target assembly</param>
+        public OrleansCodeGenerationTargetAttribute(string assemblyName, bool metadataOnly)
+        {
+            this.AssemblyName = assemblyName;
+            this.MetadataOnly = metadataOnly;
+        }
+
         /// <summary>
         /// The target assembly name that the generated code is for.
         /// </summary>
-        public string AssemblyName { get; set; }
+        public string AssemblyName { get; }
+
+        /// <summary>
+        /// Whether or not only metadata was generated for the target assembly.
+        /// </summary>
+        public bool MetadataOnly { get; }
     }
 }


### PR DESCRIPTION
Fixes #5021 

Tells the code generator to track assemblies which have already had code/metadata generated for them so that duplicate metadata is not generated.