### PR TITLE
Cleanup types in transaction state storage interface

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
@@ -37,7 +37,7 @@ namespace Orleans.Transactions.AzureStorage
                 RowKey = MakeRowKey(pendingState.SequenceId),
                 TransactionId = pendingState.TransactionId,
                 TransactionTimestamp = pendingState.TimeStamp,
-                TransactionManager = pendingState.TransactionManager,
+                TransactionManager = JsonConvert.SerializeObject(pendingState.TransactionManager, JsonSettings),
                 StateJson = JsonConvert.SerializeObject(pendingState.State, JsonSettings)
             };
         }

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -39,7 +39,7 @@ namespace Orleans.Transactions
             return new TransactionalStorageLoadResponse<TState>(stateStorage.Etag, stateStorage.State.CommittedState, stateStorage.State.CommittedSequenceId, stateStorage.State.Metadata, stateStorage.State.PendingStates);
         }
 
-        public async Task<string> Store(string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
+        public async Task<string> Store(string expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TState>> statesToPrepare, long? commitUpTo, long? abortAfter)
         {
             if (this.StateStorage.Etag != expectedETag)
                 throw new ArgumentException(nameof(expectedETag), "Etag does not match");
@@ -115,7 +115,7 @@ namespace Orleans.Transactions
 
         public long CommittedSequenceId { get; set; }
 
-        public string Metadata { get; set; }
+        public TransactionalStateMetaData Metadata { get; set; } = new TransactionalStateMetaData();
 
         public List<PendingTransactionState<TState>> PendingStates { get; set; } = new List<PendingTransactionState<TState>>();
     }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/FaultInjectionAzureTableTransactionStateStorage.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/FaultInjectionAzureTableTransactionStateStorage.cs
@@ -33,7 +33,7 @@ namespace Orleans.Transactions.Azure.Tests.FaultInjection
         public async Task<string> Store(
 
             string expectedETag,
-            string metadata,
+            TransactionalStateMetaData metadata,
 
             // a list of transactions to prepare.
             List<PendingTransactionState<TState>> statesToPrepare,

--- a/test/Transactions/Orleans.Transactions.Azure.Test/GoldenPathTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/GoldenPathTests.cs
@@ -12,6 +12,5 @@ namespace Orleans.Transactions.AzureStorage.Tests
         {
             fixture.EnsurePreconditionsMet();
         }
-
     }
 }

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/SerializationTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Xunit;
 using Orleans.Runtime;
 using Xunit.Abstractions;
+using Orleans.Transactions.Abstractions;
 
 namespace Orleans.Transactions.Tests.Memory
 {
@@ -23,9 +24,8 @@ namespace Orleans.Transactions.Tests.Memory
         {
             ITransactionTestGrain testGrain = this.RandomTestGrain(TransactionTestConstants.SingleStateTransactionalGrain);
             GrainReference reference = (GrainReference)testGrain;
-            var metaData = new MetaData();
+            var metaData = new TransactionalStateMetaData();
             metaData.TimeStamp = DateTime.UtcNow;
-            metaData.CommitRecords = new Dictionary<Guid, CommitRecord>();
             metaData.CommitRecords.Add(Guid.NewGuid(), new CommitRecord()
             {
                 Timestamp = DateTime.UtcNow,
@@ -37,7 +37,7 @@ namespace Orleans.Transactions.Tests.Memory
             //should be able to serialize it
             string jsonMetaData = JsonConvert.SerializeObject(metaData, serializerSettings);
 
-            MetaData deseriliazedMetaData = JsonConvert.DeserializeObject<MetaData>(jsonMetaData, serializerSettings);
+            TransactionalStateMetaData deseriliazedMetaData = JsonConvert.DeserializeObject<TransactionalStateMetaData>(jsonMetaData, serializerSettings);
             Assert.Equal(metaData.TimeStamp, deseriliazedMetaData.TimeStamp);
         }
     }


### PR DESCRIPTION
Participated of transaction manager and metadata are now passed to storage by structure, not string values.