### PR TITLE
Make MaxSockets in SocketManager configurable

### DIFF
--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -19,5 +19,12 @@ namespace Orleans.Configuration
         /// </summary>
         public TimeSpan MaxSocketAge { get; set; } = DEFAULT_MAX_SOCKET_AGE;
         public static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
+
+        /// <summary>
+        /// The MaxSockets attribute defines the muximum number of TCP sockets a silo would keep open at any point in time.
+        /// When the limit is reached, least recently used sockets will be closed to keep the number of open sockets below the limit.
+        /// </summary>
+        public int MaxSockets { get; set; } = DEFAULT_MAX_SOCKETS;
+        public static readonly int DEFAULT_MAX_SOCKETS = 500;
     }
 }

--- a/src/Orleans.Core/Messaging/SocketManager.cs
+++ b/src/Orleans.Core/Messaging/SocketManager.cs
@@ -16,13 +16,12 @@ namespace Orleans.Runtime
         private readonly LRU<IPEndPoint, Socket> cache;
         private readonly TimeSpan connectionTimeout;
         private readonly ILogger logger;
-        private const int MAX_SOCKETS = 200;
 
         internal SocketManager(IOptions<NetworkingOptions> options, ILoggerFactory loggerFactory)
         {
             var networkingOptions = options.Value;
             connectionTimeout = networkingOptions.OpenConnectionTimeout;
-            cache = new LRU<IPEndPoint, Socket>(MAX_SOCKETS, networkingOptions.MaxSocketAge, SendingSocketCreator);
+            cache = new LRU<IPEndPoint, Socket>(networkingOptions.MaxSockets, networkingOptions.MaxSocketAge, SendingSocketCreator);
             this.logger = loggerFactory.CreateLogger<SocketManager>();
             cache.RaiseFlushEvent += FlushHandler;
         }


### PR DESCRIPTION
Make MaxSockets in SocketManager configurable.
Raise the default from 200 to 500.

With clusters larger than 200 silos the hardcoded limit on the number of sockets causes massive churn of sockets that get constantly closed and reopened.