### PR TITLE
Cleaned up StreamId code

### DIFF
--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -35,7 +35,7 @@ namespace Orleans.Streams
         private StreamId((Guid Guid, string ProviderName, string Namespace) key)
         {
             Key = key;
-            UniformHashCode = new Lazy<uint>(() => CalculateUniformHashCode(key));
+            UniformHashCode = new Lazy<uint>(() => CalculateUniformHashCode(Key));
         }
 
         internal static StreamId GetStreamId(Guid guid, string providerName, string streamNamespace)
@@ -50,6 +50,9 @@ namespace Orleans.Streams
 
         public bool Equals(StreamId other)
             => Key.Equals(other?.Key);
+
+        public override bool Equals(object other)
+            => Equals(other as StreamId);
 
         public uint GetUniformHashCode()
             => UniformHashCode.Value;

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -49,7 +49,7 @@ namespace Orleans.Streams
         }
 
         public bool Equals(StreamId other)
-            => Key.Equals(other.Key);
+            => Key.Equals(other?.Key);
 
         public uint GetUniformHashCode()
             => UniformHashCode.Value;

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -35,18 +35,14 @@ namespace Orleans.Streams
         private StreamId((Guid Guid, string ProviderName, string Namespace) key)
         {
             Key = key;
-            UniformHashCode = new Lazy<uint>(() => CalculateUniformHashCode(Key));
+            UniformHashCode = new Lazy<uint>(CalculateUniformHashCode);
         }
 
         internal static StreamId GetStreamId(Guid guid, string providerName, string streamNamespace)
-        {
-            return FindOrCreateStreamId((guid, providerName, streamNamespace));
-        }
+            => FindOrCreateStreamId((guid, providerName, streamNamespace));
 
         private static StreamId FindOrCreateStreamId((Guid Guid, string ProviderName, string Namespace) key)
-        {
-            return streamIdInternCache.Value.FindOrCreate(key, k => new StreamId(k));
-        }
+            => streamIdInternCache.Value.FindOrCreate(key, k => new StreamId(k));
 
         public bool Equals(StreamId other)
             => Key.Equals(other?.Key);
@@ -81,13 +77,12 @@ namespace Orleans.Streams
             }
             return result;
         }
-
-
-        static uint CalculateUniformHashCode((Guid Guid, string ProviderName, string Namespace) key)
+        
+        uint CalculateUniformHashCode()
         {
-            var guidBytes = key.Guid.ToByteArray();
-            var providerBytes = GetBytes(key.ProviderName);
-            var namespaceBytes = GetBytes(key.Namespace);
+            var guidBytes = Guid.ToByteArray();
+            var providerBytes = GetBytes(ProviderName);
+            var namespaceBytes = GetBytes(Namespace);
             var allBytes = new byte[guidBytes.Length + providerBytes.Length + namespaceBytes.Length];
             Buffer.BlockCopy(guidBytes, 0, allBytes, 0, guidBytes.Length);
             Buffer.BlockCopy(providerBytes, 0, allBytes, guidBytes.Length, providerBytes.Length);

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -4,7 +4,8 @@ using System.Text;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 
-namespace Orleans.Streams {
+namespace Orleans.Streams
+{
 
     // TODO: Use this record type instead of the value tuple when c# language releases the feature.
     //struct StreamIdKey(Guid Guid, string ProviderName, string Namespace);
@@ -13,7 +14,8 @@ namespace Orleans.Streams {
     /// Identifier of an Orleans virtual stream.
     /// </summary>
     [Serializable, Immutable]
-    internal class StreamId : IStreamIdentity, IRingIdentifier<StreamId>, IEquatable<StreamId>, IComparable<StreamId> {
+    internal class StreamId : IStreamIdentity, IRingIdentifier<StreamId>, IEquatable<StreamId>, IComparable<StreamId>
+    {
 
         // TODO: Integrate with Orleans serializer to get interning working even better.
 
@@ -29,16 +31,19 @@ namespace Orleans.Streams {
         public string Namespace => Key.Namespace;
         public string ProviderName => Key.ProviderName;
 
-        private StreamId((Guid Guid, string ProviderName, string Namespace) key) {
+        private StreamId((Guid Guid, string ProviderName, string Namespace) key)
+        {
             Key = key;
             UniformHashCode = new Lazy<uint>(() => CalculateUniformHashCode(key));
         }
 
-        internal static StreamId GetStreamId(Guid guid, string providerName, string streamNamespace) {
+        internal static StreamId GetStreamId(Guid guid, string providerName, string streamNamespace)
+        {
             return FindOrCreateStreamId((guid, providerName, streamNamespace));
         }
 
-        private static StreamId FindOrCreateStreamId((Guid Guid, string ProviderName, string Namespace) key) {
+        private static StreamId FindOrCreateStreamId((Guid Guid, string ProviderName, string Namespace) key)
+        {
             return streamIdInternCache.FindOrCreate(key, k => new StreamId(k));
         }
 
@@ -48,7 +53,8 @@ namespace Orleans.Streams {
         public uint GetUniformHashCode()
             => UniformHashCode.Value;
 
-        public int CompareTo(StreamId other) {
+        public int CompareTo(StreamId other)
+        {
             if (null == other) return 1;
             var result = Guid.CompareTo(other.Guid);
             if (result != 0) return result;
@@ -62,16 +68,19 @@ namespace Orleans.Streams {
                 ^ (ProviderName?.GetHashCode() ?? 0)
                 ^ (Namespace?.GetHashCode() ?? 0);
 
-        public override string ToString() {
+        public override string ToString()
+        {
             var result = $"{Guid}-{ProviderName}";
-            if (null != Namespace) {
+            if (null != Namespace)
+            {
                 result = $"{Namespace}-" + result;
             }
             return result;
         }
 
 
-        static uint CalculateUniformHashCode((Guid Guid, string ProviderName, string Namespace) key) {
+        static uint CalculateUniformHashCode((Guid Guid, string ProviderName, string Namespace) key)
+        {
             var guidBytes = key.Guid.ToByteArray();
             var providerBytes = GetBytes(key.ProviderName);
             var namespaceBytes = GetBytes(key.Namespace);
@@ -81,7 +90,8 @@ namespace Orleans.Streams {
             Buffer.BlockCopy(namespaceBytes, 0, allBytes, guidBytes.Length + providerBytes.Length, namespaceBytes.Length);
             return JenkinsHash.ComputeHash(allBytes);
 
-            byte[] GetBytes(string value) {
+            byte[] GetBytes(string value)
+            {
                 if (null == value) return new byte[0];
                 return Encoding.UTF8.GetBytes(value);
             }

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -63,6 +63,13 @@ namespace Orleans.Streams
             return string.Compare(Namespace, other.Namespace, StringComparison.Ordinal);
         }
 
+        /// <remarks>
+        /// We could consider replacing the body of this method with <code>=> Key.GetHashCode()</code>.
+        /// Doing so would result in returning a different value of the hash code than was returned by the original 
+        /// implementation, so for now, pending feedback, I decided to use an implementation that returned
+        /// exactly the same value as previous implementations, instead of opting for a simpler (and better) implementation,
+        /// keeping in mind that someone somewhere might be depending on an unchanged hash code implementation.
+        /// </remarks>
         public override int GetHashCode()
             => Guid.GetHashCode()
                 ^ (ProviderName?.GetHashCode() ?? 0)

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -20,7 +20,8 @@ namespace Orleans.Streams
         // TODO: Integrate with Orleans serializer to get interning working even better.
 
         [NonSerialized]
-        private static readonly Interner<(Guid Guid, string ProviderName, string Namespace), StreamId> streamIdInternCache = new Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>();
+        private static readonly Lazy<Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>> streamIdInternCache = new Lazy<Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>>(
+            () => new Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>());
 
         private readonly (Guid Guid, string ProviderName, string Namespace) Key;
 
@@ -44,7 +45,7 @@ namespace Orleans.Streams
 
         private static StreamId FindOrCreateStreamId((Guid Guid, string ProviderName, string Namespace) key)
         {
-            return streamIdInternCache.FindOrCreate(key, k => new StreamId(k));
+            return streamIdInternCache.Value.FindOrCreate(key, k => new StreamId(k));
         }
 
         public bool Equals(StreamId other)

--- a/src/Orleans.Core/IDs/StreamId.cs
+++ b/src/Orleans.Core/IDs/StreamId.cs
@@ -21,7 +21,7 @@ namespace Orleans.Streams
 
         [NonSerialized]
         private static readonly Lazy<Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>> streamIdInternCache = new Lazy<Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>>(
-            () => new Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>());
+            () => new Interner<(Guid Guid, string ProviderName, string Namespace), StreamId>(InternerConstants.SIZE_LARGE, InternerConstants.DefaultCacheCleanupFreq));
 
         private readonly (Guid Guid, string ProviderName, string Namespace) Key;
 

--- a/test/Grains/TestInternalGrainInterfaces/IStreamIdTestGrain.cs
+++ b/test/Grains/TestInternalGrainInterfaces/IStreamIdTestGrain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace UnitTests.GrainInterfaces
+{
+    internal interface IStreamIdTestGrain : IGrainWithIntegerKey
+    {
+        Task<StreamId> GetStreamId(Guid guid, string streamNamespace, string providerName);
+    }
+}

--- a/test/Grains/TestInternalGrains/StreamIdTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamIdTestGrain.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+using Orleans.Runtime.Configuration;
+using Orleans.Streams;
+
+namespace UnitTests.Grains
+{
+    internal class StreamIdTestGrain : Grain, IStreamIdTestGrain
+    {
+        public Task<StreamId> GetStreamId(Guid guid, string streamNamespace, string providerName)
+        {
+            return Task.FromResult(StreamId.GetStreamId(guid, providerName, streamNamespace));
+        }
+    }
+}

--- a/test/TesterInternal/OrleansRuntime/Streams/StreamIdTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/StreamIdTests.cs
@@ -1,0 +1,39 @@
+﻿using Orleans.Serialization;
+using Orleans.Streams;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams
+{
+
+
+    public class StreamIdTests
+    {
+
+        private readonly ISiloHost silo;
+        public StreamIdTests()
+        {
+
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void StreamIdSerializationTests()
+        {
+            var guid = new Guid("{71C5C809-CA45-44C6-9006-BA759F1BAC06}");
+            var streamNameSpace = "testNameSpace";
+            var providerName = "testProviderName";
+            var streamId = StreamId.GetStreamId(guid, providerName, streamNameSpace);
+            var uniformHash = streamId.GetUniformHashCode();
+
+            var deserializedStreamId = streamId;
+            Assert.Equal(guid, deserializedStreamId.Guid);
+            Assert.Equal(streamNameSpace, deserializedStreamId.Namespace);
+            Assert.Equal(providerName, deserializedStreamId.ProviderName);
+            Assert.Equal(uniformHash, deserializedStreamId.GetUniformHashCode());
+        }
+    }
+}


### PR DESCRIPTION
The ValueTuple type allowed a lovely cleanup of the StreamId class. 
When the Record types becomes a c# feature, another cleanup can be made.