### PR TITLE
Typo and spelling check XML doc and strings. A to E. #Hacktoberfest

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -295,7 +295,7 @@ namespace Orleans.Clustering.DynamoDB
             }
 
             if (suspectingSilos.Count != suspectingTimes.Count)
-                throw new OrleansException(String.Format("SuspectingSilos.Length of {0} as read from Azure table is not eqaul to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
+                throw new OrleansException(String.Format("SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
 
             for (int i = 0; i < suspectingSilos.Count; i++)
                 parse.AddSuspector(suspectingSilos[i], suspectingTimes[i]);

--- a/src/AdoNet/Shared/Storage/IRelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/IRelationalStorage.cs
@@ -105,7 +105,7 @@ namespace Orleans.Tests.SqlUtils
         string InvariantName { get; }
 
         /// <summary>
-        /// The connection string used to connecto the database.
+        /// The connection string used to connect to the database.
         /// </summary>
         string ConnectionString { get; }
     }

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -66,7 +66,7 @@ namespace Orleans.Tests.SqlUtils
 
 
         /// <summary>
-        /// The connection string used to connecto the database.
+        /// The connection string used to connect to the database.
         /// </summary>
         public string ConnectionString
         {

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -21,7 +21,7 @@ namespace Orleans.Tests.SqlUtils
 #endif
 {
     /// <summary>
-    /// Convenienience functions to work with objects of type <see cref="IRelationalStorage"/>.
+    /// Convenience functions to work with objects of type <see cref="IRelationalStorage"/>.
     /// </summary>
     internal static class RelationalStorageExtensions
     {
@@ -253,7 +253,7 @@ namespace Orleans.Tests.SqlUtils
 
         /// <summary>
         /// Returns a native implementation of <see cref="DbDataReader.GetStream(int)"/> for those providers
-        /// which support it. Otherwise returns a chuncked read using <see cref="DbDataReader.GetBytes(int, long, byte[], int, int)"/>.
+        /// which support it. Otherwise returns a chunked read using <see cref="DbDataReader.GetBytes(int, long, byte[], int, int)"/>.
         /// </summary>
         /// <param name="reader">The reader from which to return the stream.</param>
         /// <param name="ordinal">The ordinal column for which to return the stream.</param>

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -258,7 +258,7 @@ namespace Orleans.Runtime.MembershipService
             }
 
             if (suspectingSilos.Count != suspectingTimes.Count)
-                throw new OrleansException(String.Format("SuspectingSilos.Length of {0} as read from Azure table is not eqaul to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
+                throw new OrleansException(String.Format("SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
 
             for (int i = 0; i < suspectingSilos.Count; i++)
                 parse.AddSuspector(suspectingSilos[i], suspectingTimes[i]);

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureConfigUtils.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureConfigUtils.cs
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.Host
         /// </summary>
         /// <param name="cfgFileName">Name of the file to be found.</param>
         /// <param name="what">Short description of the file to be found.</param>
-        /// <returns>Location if the file, if found, otherwise FileNotFound exeception will be thrown.</returns>
+        /// <returns>Location if the file, if found, otherwise FileNotFound exception will be thrown.</returns>
         /// <exception cref="FileNotFoundException">If the specified config file cannot be located</exception>
         internal static FileInfo FindConfigFile(string cfgFileName, string what)
         {
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.Host
         /// <summary>
         /// Return the expected possible base locations for the Azure app directory we are being run from
         /// </summary>
-        /// <returns>Enererable list of app directory locations</returns>
+        /// <returns>Enumerable list of app directory locations</returns>
         public static DirectoryInfo[] AppDirectoryLocations
         {
             get { return appDirectoryLocations ?? (appDirectoryLocations = FindAppDirectoryLocations().ToArray()); }
@@ -82,7 +82,7 @@ namespace Orleans.Runtime.Host
         /// <summary>
         /// Return the expected possible base locations for the Azure app directory we are being run from
         /// </summary>
-        /// <returns>Enererable list of app directory locations</returns>
+        /// <returns>Enumerable list of app directory locations</returns>
         private static IEnumerable<DirectoryInfo> FindAppDirectoryLocations()
         {
             // App directory locations:

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/QueueBalancers/AzureDeploymentQueueBalancer.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/QueueBalancers/AzureDeploymentQueueBalancer.cs
@@ -33,7 +33,7 @@ namespace Orleans.Streams
         /// Requires silo running in Azure.
         /// This Balancer uses both the information about the full set of silos as reported by Azure role code but 
         /// does NOT use the information from Membership oracle about currently alive silos. 
-        /// That is, it does not rebalance queues based on dymanic changes in the cluster Membership.
+        /// That is, it does not rebalance queues based on dynamic changes in the cluster Membership.
         /// </summary>
         public static ISiloPersistentStreamConfigurator UseStaticAzureDeploymentBalancer(this ISiloPersistentStreamConfigurator configurator,
            TimeSpan? siloMaturityPeriod = null)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -25,7 +25,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     }
 
     /// <summary>
-    /// Original data adapter.  Here to maintain backwards compatablity, but does not support json and other custom serializers
+    /// Original data adapter.  Here to maintain backwards compatibility, but does not support json and other custom serializers
     /// </summary>
     public class AzureQueueDataAdapterV1 : IAzureQueueDataAdapter, IOnDeserialized
     {

--- a/src/Azure/Orleans.Streaming.EventHubs/OrleansServiceBusErrorCode.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/OrleansServiceBusErrorCode.cs
@@ -10,7 +10,7 @@ namespace Orleans.ServiceBus
     internal enum OrleansServiceBusErrorCode
     {
         /// <summary>
-        /// Start of orlean servicebus errocodes
+        /// Start of orlean servicebus error codes
         /// </summary>
         ServiceBus = 1<<16,
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
@@ -35,7 +35,7 @@ namespace Orleans.ServiceBus.Providers
         { }
 
         /// <summary>
-        /// Contructor
+        /// Constructor
         /// </summary>
         /// <param name="flowControlThreshold"></param>
         /// <param name="logger"></param>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -186,7 +186,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Aquire delivery failure handler for a queue
+        /// Acquire delivery failure handler for a queue
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -55,7 +55,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Batch container that deliveres events from cached EventHub data associated with an orleans stream
+        /// Batch container that delivers events from cached EventHub data associated with an orleans stream
         /// </summary>
         /// <param name="eventHubMessage"></param>
         /// <param name="serializationManager"></param>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -46,7 +46,7 @@ namespace Orleans.ServiceBus.Providers
     public class EventHubMessage
     {
         /// <summary>
-        /// Contructor
+        /// Constructor
         /// </summary>
         /// <param name="streamIdentity">Stream Identity</param>
         /// <param name="partitionKey">EventHub partition key for message</param>
@@ -122,7 +122,7 @@ namespace Orleans.ServiceBus.Providers
     }
 
     /// <summary>
-    /// Default eventhub data comparer.  Implements comparisions against CachedEventHubMessage
+    /// Default eventhub data comparer.  Implements comparisons against CachedEventHubMessage
     /// </summary>
     public class EventHubDataComparer : ICacheDataComparer<CachedEventHubMessage>
     {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -28,7 +28,7 @@ namespace Orleans.ServiceBus.Providers
     ///   The SequenceNumber is required for uniqueness and ordering of EventHub messages within a partition.
     /// event Index - Since each EventHub message may contain more than one application layer event, this value
     ///   indicates which application layer event this token is for, within an EventHub message.  It is required for uniqueness
-    ///   and ordering of aplication layer events within an EventHub message.
+    ///   and ordering of application layer events within an EventHub message.
     /// </summary>
     [Serializable]
     public class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
@@ -69,7 +69,7 @@ namespace Orleans.Configuration
         /// </summary>
         public int? PrefetchCount { get; set; }
         /// <summary>
-        /// In cases where no checkpoint is found, this indicates if service should read from the most recent data, or from the begining of a partition.
+        /// In cases where no checkpoint is found, this indicates if service should read from the most recent data, or from the beginning of a partition.
         /// </summary>
         public bool StartFromNow { get; set; } = DEFAULT_START_FROM_NOW;
         public const bool DEFAULT_START_FROM_NOW = true;

--- a/src/Azure/Shared/Storage/AzureStorageUtils.cs
+++ b/src/Azure/Shared/Storage/AzureStorageUtils.cs
@@ -52,7 +52,7 @@ namespace Orleans.Transactions.AzureStorage
     /// General utility functions related to Azure storage.
     /// </summary>
     /// <remarks>
-    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constrants this class needs to have public visibility.
+    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constraints this class needs to have public visibility.
     /// </remarks>
     public static class AzureStorageUtils
     {
@@ -105,7 +105,7 @@ namespace Orleans.Transactions.AzureStorage
         /// <summary>
         /// Examine a storage exception, and if applicable extracts the HTTP status code, and REST error code if <c>getRESTErrors=true</c>.
         /// </summary>
-        /// <param name="e">Exeption to be examined.</param>
+        /// <param name="e">Exception to be examined.</param>
         /// <param name="httpStatusCode">Output HTTP status code if applicable, otherwise HttpStatusCode.Unused (306)</param>
         /// <param name="restStatus">When <c>getRESTErrors=true</c>, will output REST error code if applicable, otherwise <c>null</c></param>
         /// <param name="getRESTErrors">Whether REST error code should also be examined / extracted.</param>

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -35,7 +35,7 @@ namespace Orleans.Transactions.AzureStorage
     /// Utility class to encapsulate row-based access to Azure table storage.
     /// </summary>
     /// <remarks>
-    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constrants this class needs to have public visibility.
+    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constraints this class needs to have public visibility.
     /// </remarks>
     /// <typeparam name="T">Table data entry used by this table / manager.</typeparam>
     public class AzureTableDataManager<T> where T : class, ITableEntity, new()

--- a/src/Azure/Shared/Storage/AzureTableDefaultPolicies.cs
+++ b/src/Azure/Shared/Storage/AzureTableDefaultPolicies.cs
@@ -31,7 +31,7 @@ namespace Orleans.Transactions.AzureStorage
     /// Utility class for default retry / timeout settings for Azure storage.
     /// </summary>
     /// <remarks>
-    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constrants this class needs to have public visibility.
+    /// These functions are mostly intended for internal usage by Orleans runtime, but due to certain assembly packaging constraints this class needs to have public visibility.
     /// </remarks>
     internal static class AzureTableDefaultPolicies
     {

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -226,7 +226,7 @@ namespace Orleans.Runtime.Membership
 
         /// <summary>
         /// Updates the IAmAlive part (column) of the MembershipEntry for this silo.
-        /// This operation should only update the IAmAlive collumn and not change other columns.
+        /// This operation should only update the IAmAlive column and not change other columns.
         /// This operation is a "dirty write" or "in place update" and is performed without etag validation. 
         /// With regards to eTags update:
         /// This operation may automatically update the eTag associated with the given silo row, but it does not have to. It can also leave the etag not changed ("dirty write").

--- a/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
+++ b/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
@@ -19,7 +19,7 @@ namespace Orleans.CodeGeneration
     internal class AssemblyResolver
     {
         /// <summary>
-        /// Needs to be public so can be serialized accross the the app domain.
+        /// Needs to be public so can be serialized across the app domain.
         /// </summary>
         public Dictionary<string, string> ReferenceAssemblyPaths { get; } = new Dictionary<string, string>();
 

--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -171,7 +171,7 @@ namespace Orleans.CodeGenerator
         /// <summary>
         /// Generates a syntax tree for the provided assemblies.
         /// </summary>
-        /// <param name="targetAssembly">The assemblies used for accessiblity checks, or <see langword="null"/> during runtime code generation.</param>
+        /// <param name="targetAssembly">The assemblies used for accessibility checks, or <see langword="null"/> during runtime code generation.</param>
         /// <param name="assemblies">The assemblies to generate code for.</param>
         /// <returns>The generated syntax tree.</returns>
         private GeneratedSyntax GenerateCode(Assembly targetAssembly, List<Assembly> assemblies)

--- a/src/Orleans.Core.Abstractions/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/GrainFactoryBase.cs
@@ -12,7 +12,7 @@ namespace Orleans.CodeGeneration
     public static class GrainFactoryBase
     {
         /// <summary>
-        /// Check that a grain observer parameter is of the correct underlying concrent type -- either extending from <c>GrainRefereence</c> or <c>Grain</c>
+        /// Check that a grain observer parameter is of the correct underlying concurrent type -- either extending from <c>GrainRefereence</c> or <c>Grain</c>
         /// </summary>
         /// <param name="grainObserver">Grain observer parameter to be checked.</param>
         /// <exception cref="ArgumentNullException">If grainObserver is <c>null</c></exception>

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -223,7 +223,7 @@ namespace Orleans
         }
 
         /// <summary>
-        /// This method is called at the begining of the process of deactivating a grain.
+        /// This method is called at the beginning of the process of deactivating a grain.
         /// </summary>
         public virtual Task OnDeactivateAsync()
         {

--- a/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
@@ -136,7 +136,7 @@ namespace Orleans
         /// Returns the long representation of a grain primary key.
         /// </summary>
         /// <param name="grain">The grain to find the primary key for.</param>
-        /// <param name="keyExt">The output paramater to return the extended key part of the grain primary key, if extened primary key was provided for that grain.</param>
+        /// <param name="keyExt">The output parameter to return the extended key part of the grain primary key, if extended primary key was provided for that grain.</param>
         /// <returns>A long representing the primary key for this grain.</returns>
         public static long GetPrimaryKeyLong(this IAddressable grain, out string keyExt)
         {
@@ -157,7 +157,7 @@ namespace Orleans
         /// Returns the Guid representation of a grain primary key.
         /// </summary>
         /// <param name="grain">The grain to find the primary key for.</param>
-        /// <param name="keyExt">The output paramater to return the extended key part of the grain primary key, if extened primary key was provided for that grain.</param>
+        /// <param name="keyExt">The output parameter to return the extended key part of the grain primary key, if extended primary key was provided for that grain.</param>
         /// <returns>A Guid representing the primary key for this grain.</returns>
         public static Guid GetPrimaryKey(this IAddressable grain, out string keyExt)
         {

--- a/src/Orleans.Core.Abstractions/Internal/Interner.cs
+++ b/src/Orleans.Core.Abstractions/Internal/Interner.cs
@@ -44,8 +44,8 @@ namespace Orleans.Core.Abstractions.Internal
     /// Interner is used to optimise garbage collection.
     /// We use it to store objects that are allocated frequently and may have long timelife. 
     /// This means those object may quickly fill gen 2 and cause frequent costly full heap collections.
-    /// Specificaly, a message that arrives to a silo and all the headers and ids inside it may stay alive long enough to reach gen 2.
-    /// Therefore, we store all ids in interner to re-use their memory accros different messages.
+    /// Specifically, a message that arrives to a silo and all the headers and ids inside it may stay alive long enough to reach gen 2.
+    /// Therefore, we store all ids in interner to re-use their memory across different messages.
     /// </summary>
     /// <typeparam name="K">Type of objects to be used for intern keys</typeparam>
     /// <typeparam name="T">Type of objects to be interned / cached</typeparam>

--- a/src/Orleans.Core.Abstractions/Lifecycle/ILifecycleObservable.cs
+++ b/src/Orleans.Core.Abstractions/Lifecycle/ILifecycleObservable.cs
@@ -6,7 +6,7 @@ namespace Orleans
     /// Observable lifecycle.
     /// Each stage of lifecycle is observable.  All observers will be notified 
     ///   when the stage is reached when starting, and stopping.
-    /// Stages are started in ascending order, and stopped in decending order.
+    /// Stages are started in ascending order, and stopped in descending order.
     /// </summary>
     public interface ILifecycleObservable
     {

--- a/src/Orleans.Core.Abstractions/Streams/Extensions/AsyncObservableExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Extensions/AsyncObservableExtensions.cs
@@ -15,12 +15,12 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.</returns>
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.</returns>
         public static Task<StreamSubscriptionHandle<T>> SubscribeAsync<T>(this IAsyncObservable<T> obs,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
                                                                            Func<Exception, Task> onErrorAsync,
@@ -37,11 +37,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.</returns>
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.</returns>
         public static Task<StreamSubscriptionHandle<T>> SubscribeAsync<T>(this IAsyncObservable<T> obs,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
                                                                            Func<Exception, Task> onErrorAsync)
@@ -56,11 +56,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.</returns>
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.</returns>
         public static Task<StreamSubscriptionHandle<T>> SubscribeAsync<T>(this IAsyncObservable<T> obs,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
                                                                            Func<Task> onCompletedAsync)
@@ -75,10 +75,10 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.</returns>
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.</returns>
         public static Task<StreamSubscriptionHandle<T>> SubscribeAsync<T>(this IAsyncObservable<T> obs,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync)
         {
@@ -93,16 +93,16 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <param name="filterFunc">Filter to be applied for this subscription</param>
         /// <param name="filterData">Data object that will be passed in to the filterFunc.
-        /// This will usually contain any paramaters required by the filterFunc to make it's filtering decision.</param>
+        /// This will usually contain any parameters required by the filterFunc to make it's filtering decision.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if the supplied stream filter function is not suitable. 
         /// Usually this is because it is not a static method. </exception>
@@ -125,15 +125,15 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <param name="filterFunc">Filter to be applied for this subscription</param>
         /// <param name="filterData">Data object that will be passed in to the filterFunc.
-        /// This will usually contain any paramaters required by the filterFunc to make it's filtering decision.</param>
+        /// This will usually contain any parameters required by the filterFunc to make it's filtering decision.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if the supplied stream filter function is not suitable. 
         /// Usually this is because it is not a static method. </exception>
@@ -154,15 +154,15 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <param name="filterFunc">Filter to be applied for this subscription</param>
         /// <param name="filterData">Data object that will be passed in to the filterFunc.
-        /// This will usually contain any paramaters required by the filterFunc to make it's filtering decision.</param>
+        /// This will usually contain any parameters required by the filterFunc to make it's filtering decision.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if the supplied stream filter function is not suitable. 
         /// Usually this is because it is not a static method. </exception>
@@ -183,14 +183,14 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="obs">The Observable object.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <param name="filterFunc">Filter to be applied for this subscription</param>
         /// <param name="filterData">Data object that will be passed in to the filterFunc.
-        /// This will usually contain any paramaters required by the filterFunc to make it's filtering decision.</param>
+        /// This will usually contain any parameters required by the filterFunc to make it's filtering decision.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if the supplied stream filter function is not suitable. 
         /// Usually this is because it is not a static method. </exception>

--- a/src/Orleans.Core.Abstractions/Streams/Extensions/StreamSubscriptionHandleExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Extensions/StreamSubscriptionHandleExtensions.cs
@@ -15,13 +15,13 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="handle">The subscription handle.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         public static Task<StreamSubscriptionHandle<T>> ResumeAsync<T>(this StreamSubscriptionHandle<T> handle,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
@@ -40,12 +40,12 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="handle">The subscription handle.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onErrorAsync">Delegte that is called for IAsyncObserver.OnErrorAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onErrorAsync">Delegate that is called for IAsyncObserver.OnErrorAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         public static Task<StreamSubscriptionHandle<T>> ResumeAsync<T>(this StreamSubscriptionHandle<T> handle,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
@@ -62,12 +62,12 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="handle">The subscription handle.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
-        /// <param name="onCompletedAsync">Delegte that is called for IAsyncObserver.OnCompletedAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onCompletedAsync">Delegate that is called for IAsyncObserver.OnCompletedAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         public static Task<StreamSubscriptionHandle<T>> ResumeAsync<T>(this StreamSubscriptionHandle<T> handle,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,
@@ -83,11 +83,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The type of object produced by the observable.</typeparam>
         /// <param name="handle">The subscription handle.</param>
-        /// <param name="onNextAsync">Delegte that is called for IAsyncObserver.OnNextAsync.</param>
+        /// <param name="onNextAsync">Delegate that is called for IAsyncObserver.OnNextAsync.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
-        /// The subscription remains active for as long as it is not explicitely unsubscribed.
+        /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
         public static Task<StreamSubscriptionHandle<T>> ResumeAsync<T>(this StreamSubscriptionHandle<T> handle,
                                                                            Func<T, StreamSequenceToken, Task> onNextAsync,

--- a/src/Orleans.Core.Abstractions/SystemTargetInterfaces/ISystemTarget.cs
+++ b/src/Orleans.Core.Abstractions/SystemTargetInterfaces/ISystemTarget.cs
@@ -4,8 +4,8 @@ namespace Orleans
 {
     /// <summary>
     /// This is a markup interface for system targets.
-    /// System target are internal runtime objects that share some behaivior with grains, but also impose certain restrictions. In particular:
-    /// System target are asynchronusly addressable actors.
+    /// System target are internal runtime objects that share some behavior with grains, but also impose certain restrictions. In particular:
+    /// System target are asynchronously addressable actors.
     /// Proxy class is being generated for ISystemTarget, just like for IGrain
     /// System target are scheduled by the runtime scheduler and follow turn based concurrency.
     /// </summary> 

--- a/src/Orleans.Core.Legacy/Configuration/ApplicationConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ApplicationConfiguration.cs
@@ -59,7 +59,7 @@ namespace Orleans.Runtime.Configuration
         public IEnumerable<GrainTypeConfiguration> ClassSpecific { get { return this.classSpecific.Values; } }
 
         /// <summary>
-        /// Load this configuratin from xml element.
+        /// Load this configuration from xml element.
         /// </summary>
         /// <param name="xmlElement"></param>
         public void Load(XmlElement xmlElement)
@@ -248,7 +248,7 @@ namespace Orleans.Runtime.Configuration
         public string FullTypeName { get; private set; }
 
         /// <summary>
-        /// Whether this is a defualt configuration that applies to all grain types.
+        /// Whether this is a default configuration that applies to all grain types.
         /// </summary>
         public bool AreDefaults { get { return this.FullTypeName == null; } }
 

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -165,7 +165,7 @@ namespace Orleans.Runtime.Configuration
         /// If a silo is suspected to be dead, but this attribute is set to "false", the suspicions will not propagated to the system and enforced,
         /// This parameter is intended for use only for testing and troubleshooting.
         /// In production, liveness should always be enabled.
-        /// Default is true (eanabled)
+        /// Default is true (enabled)
         /// </summary>
         public bool LivenessEnabled { get; set; }
         /// <summary>

--- a/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
@@ -6,7 +6,7 @@ using Orleans.Runtime;
 namespace Orleans
 {
     /// <summary>
-    /// This class a convinent utiliity class to execute a certain asyncronous function with retires,
+    /// This class a convenient utility class to execute a certain asynchronous function with retires,
     /// allowing to specify custom retry filters and policies.
     /// </summary>
     internal static class AsyncExecutorWithRetries

--- a/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
@@ -6,7 +6,7 @@ using Orleans.Runtime;
 namespace Orleans
 {
     /// <summary>
-    /// This class is a convenient utility class to execute a certain asynchronous function with retires,
+    /// This class is a convenient utility class to execute a certain asynchronous function with retries,
     /// allowing to specify custom retry filters and policies.
     /// </summary>
     internal static class AsyncExecutorWithRetries

--- a/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
@@ -6,7 +6,7 @@ using Orleans.Runtime;
 namespace Orleans
 {
     /// <summary>
-    /// This class a convenient utility class to execute a certain asynchronous function with retires,
+    /// This class is a convenient utility class to execute a certain asynchronous function with retires,
     /// allowing to specify custom retry filters and policies.
     /// </summary>
     internal static class AsyncExecutorWithRetries

--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -17,7 +17,7 @@ namespace Orleans
     /// </list>
     ///
     /// It is still useful, at times, to provide exclusive access to a critical section of code. AsyncLock provides semantics
-    /// that correspond to that of a (non-recursive) mutex, while maintining compatibility with the tenets of async programming.
+    /// that correspond to that of a (non-recursive) mutex, while maintaining compatibility with the tenets of async programming.
     /// </remarks>
     /// <example>
     /// The following example implements some work that needs to be done under lock:
@@ -36,14 +36,14 @@ namespace Orleans
     /// </code>
     /// </example>
     ///
-    /// We decided to keep the implemention simple and mimic the semantics of a regular mutex as much as possible.
-    /// 1) AsyncLock is NOT IDisposable, since we don't want to give the developer an option to erraneously manualy dispose the lock
+    /// We decided to keep the implementation simple and mimic the semantics of a regular mutex as much as possible.
+    /// 1) AsyncLock is NOT IDisposable, since we don't want to give the developer an option to erroneously manually dispose the lock
     /// while there may be some unreleased LockReleasers.
     /// 2) AsyncLock does NOT have to implement the Finalizer function. The underlying resource of SemaphoreSlim will be eventually released by the .NET,
     /// when SemaphoreSlim is finalized. Having finalizer for AsyncLock will not speed it up.
     /// 3) LockReleaser is IDisposable to implement the "using" pattern.
-    /// 4) LockReleaser does NOT have to implement the Finalizer function. If users forget to Dispose the LockReleaser (analagous to forgetting to release a mutex)
-    /// the AsyncLock wil remain locked, which may potentialy cause deadlock. This is OK, since these are the exact regular mutex semantics - if one forgets to unlock the mutex, it stays locked.
+    /// 4) LockReleaser does NOT have to implement the Finalizer function. If users forget to Dispose the LockReleaser (analogous to forgetting to release a mutex)
+    /// the AsyncLock will remain locked, which may potentially cause deadlock. This is OK, since these are the exact regular mutex semantics - if one forgets to unlock the mutex, it stays locked.
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
     internal class AsyncLock
     {

--- a/src/Orleans.Core/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans.Core/Configuration/MessagingConfiguration.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         int MaxResendCount { get; set; }
         /// <summary>
-        /// The ResendOnTimeout attribute specifies whether the message should be automaticaly resend by the runtime when it times out on the sender.
+        /// The ResendOnTimeout attribute specifies whether the message should be automatically resend by the runtime when it times out on the sender.
         /// Default is false.
         /// </summary>
         bool ResendOnTimeout { get; set; }

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -20,7 +20,7 @@ namespace Orleans.Configuration
         /// If a silo is suspected to be dead, but this attribute is set to "false", the suspicions will not propagated to the system and enforced,
         /// This parameter is intended for use only for testing and troubleshooting.
         /// In production, liveness should always be enabled.
-        /// Default is true (eanabled)
+        /// Default is true (enabled)
         /// </summary>
         public bool LivenessEnabled { get; set; } = DEFAULT_LIVENESS_ENABLED;
         public const bool DEFAULT_LIVENESS_ENABLED = true;

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -34,7 +34,7 @@ namespace Orleans.Configuration
         public int MaxResendCount { get; set; }
 
         /// <summary>
-        /// The ResendOnTimeout attribute specifies whether the message should be automaticaly resend by the runtime when it times out on the sender.
+        /// The ResendOnTimeout attribute specifies whether the message should be automatically resend by the runtime when it times out on the sender.
         /// Default is false.
         /// </summary>
         public bool ResendOnTimeout { get; set; }

--- a/src/Orleans.Core/Configuration/ProviderConfiguration.cs
+++ b/src/Orleans.Core/Configuration/ProviderConfiguration.cs
@@ -151,7 +151,7 @@ namespace Orleans.Runtime.Configuration
     }
 
     /// <summary>
-    /// Provider categoty configuration.
+    /// Provider category configuration.
     /// </summary>
     [Serializable]
     public class ProviderCategoryConfiguration

--- a/src/Orleans.Core/IDs/Interner.cs
+++ b/src/Orleans.Core/IDs/Interner.cs
@@ -46,8 +46,8 @@ namespace Orleans
     /// Interner is used to optimise garbage collection.
     /// We use it to store objects that are allocated frequently and may have long timelife. 
     /// This means those object may quickly fill gen 2 and cause frequent costly full heap collections.
-    /// Specificaly, a message that arrives to a silo and all the headers and ids inside it may stay alive long enough to reach gen 2.
-    /// Therefore, we store all ids in interner to re-use their memory accros different messages.
+    /// Specifically, a message that arrives to a silo and all the headers and ids inside it may stay alive long enough to reach gen 2.
+    /// Therefore, we store all ids in interner to re-use their memory across different messages.
     /// </summary>
     /// <typeparam name="K">Type of objects to be used for intern keys</typeparam>
     /// <typeparam name="T">Type of objects to be interned / cached</typeparam>

--- a/src/Orleans.Core/Logging/FileLoggerProvider.cs
+++ b/src/Orleans.Core/Logging/FileLoggerProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace Orleans.Logging
 {
     /// <summary>
-    /// FileLoggerProvider implemets ILoggerProvider, creates <see cref="FileLogger"/>
+    /// FileLoggerProvider implements ILoggerProvider, creates <see cref="FileLogger"/>
     /// </summary>
     public class FileLoggerProvider : ILoggerProvider
     {
@@ -28,7 +28,7 @@ namespace Orleans.Logging
     }
 
     /// <summary>
-    /// Exentions methods to configure ILoggingBuilder with FileLoggerProvider
+    /// Extension methods to configure ILoggingBuilder with FileLoggerProvider
     /// </summary>
     public static class FileLoggerProviderExtensions
     {

--- a/src/Orleans.Core/Messaging/ILegacyGatewayListProviderConfigurator.cs
+++ b/src/Orleans.Core/Messaging/ILegacyGatewayListProviderConfigurator.cs
@@ -13,7 +13,7 @@ namespace Orleans.Messaging
     }
 
     /// <summary>
-    /// Wrapper for legacy client config.  Should not be used for any new developent, only adapting legacy systems.
+    /// Wrapper for legacy client config.  Should not be used for any new development, only adapting legacy systems.
     /// </summary>
     public class ClientConfigurationReader
     {

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -40,9 +40,9 @@ namespace Orleans.Storage
     public interface IRestExceptionDecoder
     {
         /// <summary>
-        /// Decode details of the exceprion
+        /// Decode details of the exception
         /// </summary>
-        /// <param name="e">Excption to decode</param>
+        /// <param name="e">Exception to decode</param>
         /// <param name="httpStatusCode">HTTP status code for the error</param>
         /// <param name="restStatus">REST status for the error</param>
         /// <param name="getExtendedErrors">Whether or not to extract REST error code</param>

--- a/src/Orleans.Core/Providers/ILeaseProvider.cs
+++ b/src/Orleans.Core/Providers/ILeaseProvider.cs
@@ -18,11 +18,11 @@ namespace Orleans.LeaseProviders
         /// </summary>
         public string ResourceKey { get; }
         /// <summary>
-        /// Duration of the aquired lease
+        /// Duration of the acquired lease
         /// </summary>
         public TimeSpan Duration { get; }
         /// <summary>
-        /// Lease token, whcih will be null if acquiring or renewing the lease failed
+        /// Lease token, which will be null if acquiring or renewing the lease failed
         /// </summary>
         public string Token { get; }
         /// <summary>
@@ -31,7 +31,7 @@ namespace Orleans.LeaseProviders
         public DateTime StartTimeUtc { get; }
 
         /// <summary>
-        /// Consructor
+        /// Constructor
         /// </summary>
         /// <param name="resourceKey"></param>
         /// <param name="duration"></param>
@@ -46,7 +46,7 @@ namespace Orleans.LeaseProviders
         }
 
         /// <summary>
-        /// Consructor
+        /// Constructor
         /// </summary>
         /// <param name="resourceKey"></param>
         public AcquiredLease(string resourceKey)

--- a/src/Orleans.Core/Runtime/GrainReferenceCache.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceCache.cs
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
 
         /// <summary>
         /// Get a grain reference for the specified cache-key.
-        /// The grain reference will either be taken from cahce, or a new one will be created by calling the <c>FetchValueDelegate</c>
+        /// The grain reference will either be taken from cache, or a new one will be created by calling the <c>FetchValueDelegate</c>
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1495,7 +1495,7 @@ namespace Orleans.Serialization
         }
 
         /// <summary>
-        /// Deserialize data from the specified byte[] and rehydrate backi into objects.
+        /// Deserialize data from the specified byte[] and rehydrate back into objects.
         /// </summary>
         /// <typeparam name="T">Type of data to be returned.</typeparam>
         /// <param name="data">Input data.</param>

--- a/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
@@ -21,11 +21,11 @@ namespace Orleans.Streams
     }
 
     /// <summary>
-    /// The extesion multiplexes all stream related messages to this grain between different streams and their stream observers.
+    /// The extension multiplexes all stream related messages to this grain between different streams and their stream observers.
     /// 
-    /// On the silo, we have one extension object per activation and this extesion multiplexes all streams on this activation 
+    /// On the silo, we have one extension object per activation and this extension multiplexes all streams on this activation 
     ///     (streams of all types and ids: different stream ids and different stream providers).
-    /// On the client, we have one extension per stream (we bind an extesion for every StreamConsumer, therefore every stream has its own extension).
+    /// On the client, we have one extension per stream (we bind an extension for every StreamConsumer, therefore every stream has its own extension).
     /// </summary>
     [Serializable]
     internal class StreamConsumerExtension : IStreamConsumerExtension

--- a/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapterFactory.cs
+++ b/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapterFactory.cs
@@ -28,7 +28,7 @@ namespace Orleans.Streams
         IStreamQueueMapper GetStreamQueueMapper();
 
         /// <summary>
-        /// Aquire delivery failure handler for a queue
+        /// Acquire delivery failure handler for a queue
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -10,11 +10,11 @@ using Microsoft.Extensions.Logging;
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
     /// <summary>
-    /// Multiplexes messages to mutiple different producers in the same grain over one grain-extension interface.
+    /// Multiplexes messages to multiple different producers in the same grain over one grain-extension interface.
     /// 
-    /// On the silo, we have one extension per activation and this extesion multiplexes all streams on this activation 
+    /// On the silo, we have one extension per activation and this extension multiplexes all streams on this activation 
     ///     (different stream ids and different stream providers).
-    /// On the client, we have one extension per stream (we bind an extesion for every StreamProducer, therefore every stream has its own extension).
+    /// On the client, we have one extension per stream (we bind an extension for every StreamProducer, therefore every stream has its own extension).
     /// </summary>
     [Serializable]
     internal class SimpleMessageStreamProducerExtension : IStreamProducerExtension

--- a/src/Orleans.Core/SystemTargetInterfaces/IManagementGrain.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IManagementGrain.cs
@@ -56,20 +56,20 @@ namespace Orleans.Runtime
         Task<SiloRuntimeStatistics[]> GetRuntimeStatistics(SiloAddress[] hostsIds);
 
         /// <summary>
-        /// Return the most recent grain statistics information, amalgomated across silos.
+        /// Return the most recent grain statistics information, amalgamated across silos.
         /// </summary>
         /// <param name="hostsIds">List of silos this command is to be sent to.</param>
         /// <returns>Completion promise for this operation.</returns>
         Task<SimpleGrainStatistic[]> GetSimpleGrainStatistics(SiloAddress[] hostsIds);
 
         /// <summary>
-        /// Return the most recent grain statistics information, amalgomated across all silos.
+        /// Return the most recent grain statistics information, amalgamated across all silos.
         /// </summary>
         /// <returns>Completion promise for this operation.</returns>
         Task<SimpleGrainStatistic[]> GetSimpleGrainStatistics();
 
         /// <summary>
-        /// Returns the most recent detailed grain statistics information, amalgomated across silos for the specified types.
+        /// Returns the most recent detailed grain statistics information, amalgamated across silos for the specified types.
         /// </summary>
         /// <param name="hostsIds">List of silos this command is to be sent to.</param>
         /// <param name="types">Array of grain types to filter the results with</param>

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -81,7 +81,7 @@ namespace Orleans
 
         /// <summary>
         /// Updates the IAmAlive part (column) of the MembershipEntry for this silo.
-        /// This operation should only update the IAmAlive collumn and not change other columns.
+        /// This operation should only update the IAmAlive column and not change other columns.
         /// This operation is a "dirty write" or "in place update" and is performed without etag validation. 
         /// With regards to eTags update:
         /// This operation may automatically update the eTag associated with the given silo row, but it does not have to. It can also leave the etag not changed ("dirty write").

--- a/src/Orleans.Core/Timers/ValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/ValueStopwatch.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Restarts this stopwatch, begining from zero time elapsed.
+        /// Restarts this stopwatch, beginning from zero time elapsed.
         /// </summary>
         public void Restart() => this.value = Stopwatch.GetTimestamp();
 

--- a/src/Orleans.EventSourcing/CustomStorage/LogConsistencyProvider.cs
+++ b/src/Orleans.EventSourcing/CustomStorage/LogConsistencyProvider.cs
@@ -22,7 +22,7 @@ namespace Orleans.EventSourcing.CustomStorage
 
         /// <summary>
         /// Specifies a clusterid of the primary cluster from which to access storage exclusively, null if
-        /// storage should be accessed direcly from all clusters.
+        /// storage should be accessed directly from all clusters.
         /// </summary>
         public string PrimaryCluster => options.PrimaryCluster;
 

--- a/src/Orleans.Runtime.Abstractions/MembershipService/ILegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Abstractions/MembershipService/ILegacyMembershipConfigurator.cs
@@ -34,7 +34,7 @@ namespace Orleans.Runtime.MembershipService
     }
 
     /// <summary>
-    /// Wrapper for legacy config.  Should not be used for any new developent, only adapting legacy systems.
+    /// Wrapper for legacy config.  Should not be used for any new development, only adapting legacy systems.
     /// </summary>
     public class GlobalConfigurationReader
     {

--- a/src/Orleans.Runtime/Development/DevelopmentSiloBuilderExtensions.cs
+++ b/src/Orleans.Runtime/Development/DevelopmentSiloBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime.Development
     public static class DevelopmentSiloBuilderExtensions
     {
         /// <summary>
-        /// Configure silo with test/developement features.
+        /// Configure silo with test/development features.
         /// NOT FOR PRODUCTION USE - dev/test only
         /// </summary>
         public static ISiloHostBuilder UseInMemoryLeaseProvider(this ISiloHostBuilder builder)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -364,7 +364,7 @@ namespace Orleans.Runtime.GrainDirectory
 
    
         /// <summary>
-        /// Removes the grain (and, effectively, all its activations) from the diretcory
+        /// Removes the grain (and, effectively, all its activations) from the directory
         /// </summary>
         /// <param name="grain"></param>
         internal void RemoveGrain(GrainId grain)

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -61,10 +61,10 @@ namespace Orleans.Runtime.GrainDirectory
         /// Invalidates cache entry for the given activation address.
         /// This method is intended to be called whenever a directory client tries to access 
         /// an activation returned from the previous directory lookup and gets a reject from the target silo 
-        /// notifiying him that the activation does not exist.
+        /// notifying him that the activation does not exist.
         /// </summary>
         /// <param name="activation">The address of the activation that needs to be invalidated in the directory cache for the given grain.</param>
-        /// <param name="invalidateDirectoryAlso">If true, on owner, invalidates directory entry that point to activatiosn in remote clusters as well</param>
+        /// <param name="invalidateDirectoryAlso">If true, on owner, invalidates directory entry that point to activations in remote clusters as well</param>
         void InvalidateCacheEntry(ActivationAddress activation, bool invalidateDirectoryAlso = false);
 
         /// <summary>
@@ -104,8 +104,8 @@ namespace Orleans.Runtime.GrainDirectory
         AddressesAndTag GetLocalDirectoryData(GrainId grain);
 
         /// <summary>
-        /// For testing and troubleshhoting purposes only.
-        /// Returns the directory information held in a local directory cacche for the provided grain ID.
+        /// For testing and troubleshooting purposes only.
+        /// Returns the directory information held in a local directory cache for the provided grain ID.
         /// The result will be null if no information is held.
         /// </summary>
         /// <param name="grain"></param>

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -348,7 +348,7 @@ namespace Orleans.Runtime.GrainDirectory
         }
 
         /// <summary>
-        /// Adjust local directory following the removal of a silo by droping all activations located on the removed silo
+        /// Adjust local directory following the removal of a silo by dropping all activations located on the removed silo
         /// </summary>
         /// <param name="removedSilo"></param>
         protected void AdjustLocalDirectory(SiloAddress removedSilo)
@@ -363,7 +363,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        /// Adjust local cache following the removal of a silo by droping:
+        /// Adjust local cache following the removal of a silo by dropping:
         /// 1) entries that point to activations located on the removed silo 
         /// 2) entries for grains that are now owned by this silo (me)
         /// 3) entries for grains that were owned by this removed silo - we currently do NOT do that.

--- a/src/Orleans.Runtime/MembershipService/ISiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/ISiloStatusOracle.cs
@@ -53,7 +53,7 @@ namespace Orleans.Runtime
         /// Get the status of a given silo. 
         /// This method returns an approximate view on the status of a given silo. 
         /// In particular, this oracle may think the given silo is alive, while it may already have failed.
-        /// If this oracle thinks the given silo is dead, it has been authoratively told so by ISiloDirectory.
+        /// If this oracle thinks the given silo is dead, it has been authoritatively told so by ISiloDirectory.
         /// </summary>
         /// <param name="siloAddress">A silo whose status we are interested in.</param>
         /// <returns>The status of a given silo.</returns>
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
         bool TryGetSiloName(SiloAddress siloAddress, out string siloName);
 
         /// <summary>
-        /// Determine if the current silo is valid for creating new activations on or for directoy lookups.
+        /// Determine if the current silo is valid for creating new activations on or for directory lookups.
         /// </summary>
         /// <returns>The silo so ask about.</returns>
         bool IsFunctionalDirectory(SiloAddress siloAddress);

--- a/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
@@ -3,7 +3,7 @@ using System;
 namespace Orleans.Runtime.Messaging
 {
     /// <summary>
-    /// Used for controlling message delverye
+    /// Used for controlling message delivery
     /// </summary>
     internal interface IOutboundMessageQueue : IDisposable
     {

--- a/src/Orleans.Runtime/MultiClusterNetwork/IMultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/IMultiClusterOracle.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
         /// <summary>
         /// Inject a multicluster configuration. For this to have any effect, the timestamp must be newer 
-        /// than the latest configuation stored in the multicluster network.
+        /// than the latest configuration stored in the multicluster network.
         /// </summary>
         /// <returns>A task that completes once information has propagated to the multicluster channels</returns>
         Task InjectMultiClusterConfiguration(MultiClusterConfiguration configuration);

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -108,7 +108,7 @@ namespace Orleans.Runtime
             scheduler.QueueTask(() => OnRangeChange(oldRange, newRange, increased), this.SchedulingContext).Ignore();
         }
 
-        /// <summary>Invoked when the ring range owned by the service instance changes because of a change in the clsuter state</summary>
+        /// <summary>Invoked when the ring range owned by the service instance changes because of a change in the cluster state</summary>
         public virtual Task OnRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
         {
             Logger.Info(ErrorCode.RS_RangeChanged, "My range changed from {0} to {1} increased = {2}", oldRange, newRange, increased);

--- a/src/Orleans.Runtime/Streams/QueueBalancer/BestFitBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/BestFitBalancer.cs
@@ -40,7 +40,7 @@ namespace Orleans.Streams
         /// Constructor.
         /// Initializes an ideal distribution to be used to aid in resource to bucket affinity.
         /// </summary>
-        /// <param name="buckets">Buckets among which to destribute resources.</param>
+        /// <param name="buckets">Buckets among which to distribute resources.</param>
         /// <param name="resources">Resources to be distributed.</param>
         public BestFitBalancer(IEnumerable<TBucket> buckets, IEnumerable<TResource> resources)
         {
@@ -123,9 +123,9 @@ namespace Orleans.Streams
 
         /// <summary>
         /// Distribute resources evenly among buckets in a deterministic way.
-        /// - Must distribute resources evenly regardles off order of inputs.
+        /// - Must distribute resources evenly regardless off order of inputs.
         /// </summary>
-        /// <param name="buckets">Buckets among which to destribute resources.</param>
+        /// <param name="buckets">Buckets among which to distribute resources.</param>
         /// <param name="resources">Resources to be distributed.</param>
         /// <returns>Dictionary of resources evenly distributed among the buckets</returns>
         private static Dictionary<TBucket, List<TResource>> BuildIdealDistribution(IEnumerable<TBucket> buckets, IEnumerable<TResource> resources)

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -14,7 +14,7 @@ using Orleans.Timers;
 namespace Orleans.Streams
 {
     /// <summary>
-    /// IResourceSelector selects a centain amount of resource from a resource list
+    /// IResourceSelector selects a certain amount of resource from a resource list
     /// </summary>
     /// <typeparam name="T"></typeparam>
     internal interface IResourceSelector<T>

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -33,7 +33,7 @@ namespace Orleans.TestingHost
         private readonly FaultInjectionGrainStorageOptions options;
         
         /// <summary>
-        /// Default conststructor which creates the decorated storage provider
+        /// Default constructor which creates the decorated storage provider
         /// </summary>
         public FaultInjectionGrainStorage(IGrainStorage realStorageProvider, string name, ILoggerFactory loggerFactory, 
             IGrainFactory grainFactory, FaultInjectionGrainStorageOptions faultInjectionOptions)

--- a/src/Orleans.Transactions/Utilities/CommitQueue.cs
+++ b/src/Orleans.Transactions/Utilities/CommitQueue.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Orleans.Transactions
 {
     /// <summary>
-    /// A deque data structure that stores transaction records in a circular buffer, sorted by timestamps.
+    /// A queue data structure that stores transaction records in a circular buffer, sorted by timestamps.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     internal struct CommitQueue<T>

--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -89,7 +89,7 @@ namespace Orleans.Providers.Streams.Common
     }
 
     /// <summary>
-    /// Cache data comparer exstension functions that switch argument order
+    /// Cache data comparer extension functions that switch argument order
     /// </summary>
     public static class CacheDataComparerExtensions
     {

--- a/src/OrleansProviders/Streams/Common/PooledCache/TimePurgePredicate.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/TimePurgePredicate.cs
@@ -12,7 +12,7 @@ namespace Orleans.Providers.Streams.Common
         private readonly TimeSpan maxRelativeMessageAge;
 
         /// <summary>
-        /// Contructor
+        /// Constructor
         /// </summary>
         /// <param name="minTimeInCache">minimum time data should be keept in cache, unless purged due to data size.</param>
         /// <param name="maxRelativeMessageAge">maximum age of data to keep in the cache</param>

--- a/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
+++ b/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
@@ -13,7 +13,7 @@ namespace Orleans.Configuration
         /// </summary>
         public TimeSpan DataMinTimeInCache { get; set; } = DefaultDataMinTimeInCache;
         /// <summary>
-        /// Drfault DataMinTimeInCache
+        /// Default DataMinTimeInCache
         /// </summary>
         public static readonly TimeSpan DefaultDataMinTimeInCache = TimeSpan.FromMinutes(5);
 

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -225,7 +225,7 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Aquires the next message in the cache at the provided cursor
+        /// Acquires the next message in the cache at the provided cursor
         /// </summary>
         /// <param name="cursor"></param>
         /// <param name="batch"></param>

--- a/src/OrleansProviders/Streams/Generator/IStreamGenerator.cs
+++ b/src/OrleansProviders/Streams/Generator/IStreamGenerator.cs
@@ -12,7 +12,7 @@ namespace Orleans.Providers.Streams.Generator
     public interface IStreamGenerator
     {
         /// <summary>
-        /// Tries to get an evente, if the generator is configured to generate any at this time
+        /// Tries to get an event, if the generator is configured to generate any at this time
         /// </summary>
         /// <param name="utcNow"></param>
         /// <param name="events"></param>

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -910,7 +910,7 @@ namespace UnitTests.Streaming.Reliability
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
 
-            when = "After starting additonal silo " + newSilo;
+            when = "After starting additional silo " + newSilo;
             output.WriteLine(when);
             CheckSilosRunning(when, numExpectedSilos + 1);
 

--- a/test/Grains/TestGrains/AsyncSimpleGrain.cs
+++ b/test/Grains/TestGrains/AsyncSimpleGrain.cs
@@ -5,7 +5,7 @@ using UnitTests.GrainInterfaces;
 namespace UnitTests.Grains
 {
     /// <summary>
-    /// A simple grain that allows to set two agruments and then multiply them.
+    /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
     public class AsyncSimpleGrain : SimpleGrain, ISimpleGrainWithAsyncMethods
     {

--- a/test/Grains/TestGrains/ChainedGrain.cs
+++ b/test/Grains/TestGrains/ChainedGrain.cs
@@ -18,7 +18,7 @@ namespace UnitTests.Grains
     }
 
     /// <summary>
-    /// A simple grain that allows to set two agruments and then multiply them.
+    /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
     [StorageProvider(ProviderName = "MemoryStore")]
     public class ChainedGrain : Grain<ChainedGrainState>, IChainedGrain

--- a/test/Grains/TestGrains/PromiseForwardGrain.cs
+++ b/test/Grains/TestGrains/PromiseForwardGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains
     }
 
     /// <summary>
-    /// A simple grain that allows to set two agruments and then multiply them.
+    /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
     [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
     public class PromiseForwardGrain : Grain<SimpleGrainState>, IPromiseForwardGrain

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -195,7 +195,7 @@ namespace UnitTests.Grains
             // only SimpleMessageStreamProducer implements IDisposable and a means to verify it was cleaned up.
             if (null == observerAsSMSProducer)
             {
-                _logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuted.");
+                _logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
                 _observerDisposedYet = true;
             }
             else
@@ -222,7 +222,7 @@ namespace UnitTests.Grains
             // only SimpleMessageStreamProducer implements IDisposable and a means to verify it was cleaned up.
             if (null == observerAsSMSProducer)
             {
-                //_logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuted.");
+                //_logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
                 _observerDisposedYet = true;
             }
             else

--- a/test/TestInfrastructure/TestExtensions/TestCategory.cs
+++ b/test/TestInfrastructure/TestExtensions/TestCategory.cs
@@ -10,8 +10,8 @@ using Xunit.Sdk;
 /// If we replace the MSTest [TestCategoryAttribute] for the [Trait("Category", "BVT")], we will surely fall at some time in cases 
 /// where people will typo on the "Category" key part of the Trait. 
 /// On order to achieve the same behaviour as on MSTest, a custom [TestCategory] was created 
-/// to mimic the MSTest one and avoid replace it on every exitent test. 
-/// The tests can be filtered by xunit runners by usage of "-trait" on the command line with the expresion like
+/// to mimic the MSTest one and avoid replace it on every existing test. 
+/// The tests can be filtered by xunit runners by usage of "-trait" on the command line with the expression like
 /// <code>-trait "Category=BVT"</code> for example that will only run the tests with [TestCategory("BVT")] on it.
 /// More on Trait extensibility <see href="https://github.com/xunit/samples.xunit/tree/master/TraitExtensibility" />
 /// </summary>

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
@@ -56,7 +56,7 @@ namespace Tester.StreamingTests
                     return Task.FromResult(lease.Key);
                 }
             }
-            throw new KeyNotFoundException("No more lease to aquire");
+            throw new KeyNotFoundException("No more lease to acquire");
         }
 
         public Task<bool> Renew(QueueId leaseNumber)

--- a/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionConcurrencyTestRunner.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Runners/TransactionConcurrencyTestRunner.cs
@@ -91,7 +91,7 @@ namespace Orleans.Transactions.Tests
         }
 
         /// <summary>
-        /// Single transaction containing two grains is dependant on two other transaction, one from each grain
+        /// Single transaction containing two grains is dependent on two other transaction, one from each grain
         /// </summary>
         /// <param name="grainStates"></param>
         /// <returns></returns>


### PR DESCRIPTION
:dog2: *Much error.* :dog2: 
:dog: *Very typo.* :dog: 
:heavy_check_mark: *Many spell check.* :heavy_check_mark: 

I had to break this up into multiple PRs. This PR only contains **A to E** corrections. Mostly focused on XML doc comments. I tried to ignore `//` source comments. Also, corrected some hard-coded strings in `Exception` messages that had spelling errors.

Let me know if you'd like me to continue checking.

Also, happy #Hacktoberfest ! :smiley_cat: :fearful: :skull_and_crossbones: :moon: :bat: 

Thanks,
Brian

:crystal_ball: :dolls: ***["Magic and technology. Voodoo dolls and chants. Electricity. Were makin weird science..."](https://www.youtube.com/watch?v=Jm-upHSP9KU)***
