### PR TITLE
Avoid modification of interned SiloAddresses in Consul and ZooKeeper providers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,7 +107,7 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.1.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.1.1</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->
@@ -129,7 +129,7 @@
     <OrleansCoreLegacyVersion>2.1.0</OrleansCoreLegacyVersion>
     <OrleansRuntimeLegacyVersion>2.1.0</OrleansRuntimeLegacyVersion>
     <OrleansProvidersVersion>2.1.0</OrleansProvidersVersion>
-    <OrleansExtensionsVersion>2.1.0</OrleansExtensionsVersion>
+    <OrleansExtensionsVersion>2.1.1</OrleansExtensionsVersion>
     <OrleansEventSourcingVersion>2.1.0</OrleansEventSourcingVersion>
     <OrleansAdoNetVersion>2.1.0</OrleansAdoNetVersion>
     <OrleansAWSVersion>2.1.0</OrleansAWSVersion>

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Consul;
 using Orleans.Messaging;
@@ -63,8 +64,9 @@ namespace Orleans.Runtime.Membership
                 Where(m => m.Status == SiloStatus.Active && m.ProxyPort != 0).
                 Select(m =>
                 {
-                    m.SiloAddress.Endpoint.Port = m.ProxyPort;
-                    return m.SiloAddress.ToGatewayUri();
+                    var endpoint = new IPEndPoint(m.SiloAddress.Endpoint.Address, m.ProxyPort);
+                    var gatewayAddress = SiloAddress.New(endpoint, m.SiloAddress.Generation);
+                    return gatewayAddress.ToGatewayUri();
                 }).ToList();
         }
     }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Orleans.Messaging;
 using Orleans.Runtime.Configuration;
@@ -55,8 +56,9 @@ namespace Orleans.Runtime.Membership
                 Where(m => m.Status == SiloStatus.Active && m.ProxyPort != 0).
                 Select(m =>
                 {
-                    m.SiloAddress.Endpoint.Port = m.ProxyPort;
-                    return m.SiloAddress.ToGatewayUri();
+                    var endpoint = new IPEndPoint(m.SiloAddress.Endpoint.Address, m.ProxyPort);
+                    var gatewayAddress = SiloAddress.New(endpoint, m.SiloAddress.Generation);
+                    return gatewayAddress.ToGatewayUri();
                 }).ToList();
         }
 


### PR DESCRIPTION
Fixes #5025 

Ideally, `System.Net.IPEndpoint` should be immutable.

Also bumped version to 2.1.1 for Consul/ZK packages