### PR TITLE
fixed HostedClient method name in exception text

### DIFF
--- a/src/Orleans.Runtime/Core/IHostedClient.cs
+++ b/src/Orleans.Runtime/Core/IHostedClient.cs
@@ -40,6 +40,6 @@ namespace Orleans.Runtime
 
         private static T ThrowDisabledException<T>() =>
             throw new InvalidOperationException(
-                "Support for accessing the Orleans runtime from a non-Orleans context is not enabled. Enable support using the ISiloHostBuilder.EnableExternalContextCalls() method.");
+                $"Support for accessing the Orleans runtime from a non-Orleans context is not enabled. Enable support using the ISiloHostBuilder.{nameof(Hosting.CoreHostingExtensions.EnableDirectClient)}() method.");
     }
 }


### PR DESCRIPTION
Looks like that method were renamed during development, but exception text remained unchanged, what results in pretty confusing error text :)