### PR TITLE
Typo and spellcheck XML doc and strings. N to R. #Hacktoberfest

### DIFF
--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -89,11 +89,11 @@ namespace Orleans.Reminders.DynamoDB
 
         /// <summary>
         /// Reads a reminder for a grain reference by reminder name.
-        /// Read a row from the remider table
+        /// Read a row from the reminder table
         /// </summary>
         /// <param name="grainRef"> grain ref to locate the row </param>
-        /// <param name="reminderName"> remider name to locate the row </param>
-        /// <returns> Return the RemiderTableData if the rows were read successfully </returns>
+        /// <param name="reminderName"> reminder name to locate the row </param>
+        /// <returns> Return the ReminderTableData if the rows were read successfully </returns>
         public async Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
         {
             var reminderId = ConstructReminderId(this.serviceId, grainRef, reminderName);
@@ -117,10 +117,10 @@ namespace Orleans.Reminders.DynamoDB
         }
 
         /// <summary>
-        /// Read one row from the remider table
+        /// Read one row from the reminder table
         /// </summary>
         /// <param name="grainRef">grain ref to locate the row </param>
-        /// <returns> Return the RemiderTableData if the rows were read successfully </returns>
+        /// <returns> Return the ReminderTableData if the rows were read successfully </returns>
         public async Task<ReminderTableData> ReadRows(GrainReference grainRef)
         {
             var expressionValues = new Dictionary<string, AttributeValue>
@@ -199,7 +199,7 @@ namespace Orleans.Reminders.DynamoDB
         /// Remove one row from the reminder table 
         /// </summary>
         /// <param name="grainRef"> specific grain ref to locate the row </param>
-        /// <param name="reminderName"> remider name to locate the row </param>
+        /// <param name="reminderName"> reminder name to locate the row </param>
         /// <param name="eTag"> e tag </param>
         /// <returns> Return true if the row was removed </returns>
         public async Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -270,7 +270,7 @@ namespace Orleans.Reminders.DynamoDB
         }
 
         /// <summary>
-        /// Async method to put an entry into the remider table
+        /// Async method to put an entry into the reminder table
         /// </summary>
         /// <param name="entry"> The entry to put </param>
         /// <returns> Return the entry ETag if entry was upsert successfully </returns>

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
@@ -12,7 +12,7 @@ using SQSMessage = Amazon.SQS.Model.Message;
 namespace OrleansAWSUtils.Streams
 {
     /// <summary>
-    /// Recieves batches of messages from a single partition of a message queue.  
+    /// Receives batches of messages from a single partition of a message queue.  
     /// </summary>
     internal class SQSAdapterReceiver : IQueueAdapterReceiver
     {

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSStreamProviderUtils.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSStreamProviderUtils.cs
@@ -14,7 +14,7 @@ namespace OrleansAWSUtils.Streams
     public class SQSStreamProviderUtils
     {
         /// <summary>
-        /// Async method to delete all used queques, for specific provider and clusterId
+        /// Async method to delete all used queues, for specific provider and clusterId
         /// </summary>
         /// <returns> Task object for this async method </returns>
         public static async Task DeleteAllUsedQueues(string providerName, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -37,13 +37,13 @@ namespace Orleans.Tests.SqlUtils
 
         /// <summary>
         /// If the ADO.NET provider of this storage supports cancellation or not. This
-        /// capability is queried and the the result is cached here.
+        /// capability is queried and the result is cached here.
         /// </summary>
         private readonly bool supportsCommandCancellation;
 
         /// <summary>
         /// If the underlying ADO.NET implementation is natively asynchronous
-        /// (the ADO.NET Db*.XXXAsync classes are overriden) or not.
+        /// (the ADO.NET Db*.XXXAsync classes are overridden) or not.
         /// </summary>
         private readonly bool isSynchronousAdoNetImplementation;
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -13,7 +13,7 @@ using Orleans.AzureUtils.Utilities;
 namespace Orleans.Providers.Streams.AzureQueue
 {
     /// <summary>
-    /// Recieves batches of messages from a single partition of a message queue.  
+    /// Receives batches of messages from a single partition of a message queue.  
     /// </summary>
     internal class AzureQueueAdapterReceiver: IQueueAdapterReceiver
     {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
@@ -11,7 +11,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
     public class StreamDeliveryFailureEntity : TableEntity
     {
         /// <summary>
-        /// Id of the subscription on which this delivery failure occured.
+        /// Id of the subscription on which this delivery failure occurred.
         /// </summary>
         public Guid SubscriptionId { get; set; }
 
@@ -21,12 +21,12 @@ namespace Orleans.Providers.Streams.PersistentStreams
         public string StreamProviderName { get; set; }
 
         /// <summary>
-        /// Guid Id of the stream on which the failure occured.
+        /// Guid Id of the stream on which the failure occurred.
         /// </summary>
         public Guid StreamGuid { get; set; }
 
         /// <summary>
-        /// Namespace of the stream on which the failure occured.
+        /// Namespace of the stream on which the failure occurred.
         /// </summary>
         public string StreamNamespace { get; set; }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamOptions.cs
@@ -8,7 +8,7 @@ namespace Orleans.Configuration
     {
         /// <summary>
         /// Configure eventhub partition count wanted. EventDataGeneratorStreamProvider would generate the same set of partitions based on the count, when initializing.
-        /// For example, if parition count set at 5, the generated partitions will be  partition-0, partition-1, partition-2, partition-3, partiton-4
+        /// For example, if partition count set at 5, the generated partitions will be  partition-0, partition-1, partition-2, partition-3, partition-4
         /// </summary>
         public int EventHubPartitionCount = DefaultEventHubPartitionCount;
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -72,7 +72,7 @@ namespace Orleans.ServiceBus.Providers
         protected Func<string, IStreamQueueCheckpointer<string>, ILoggerFactory, ITelemetryProducer, IEventHubQueueCache> CacheFactory { get; set; }
 
         /// <summary>
-        /// Creates a parition checkpointer.
+        /// Creates a partition checkpointer.
         /// </summary>
         private IStreamQueueCheckpointerFactory checkpointerFactory;
 
@@ -218,7 +218,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Creates a quere receiver for the specificed queueId
+        /// Creates a queue receiver for the specified queueId
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -103,7 +103,7 @@ namespace Orleans.ServiceBus.Providers
                 : Initialize();
         }
         /// <summary>
-        /// Initialization of EventHub receiver is performed at adapter reciever initialization, but if it fails,
+        /// Initialization of EventHub receiver is performed at adapter receiver initialization, but if it fails,
         ///  it will be retried when messages are requested
         /// </summary>
         /// <returns></returns>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -50,12 +50,12 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         /// <param name="streamIdentity">Stream Identity</param>
         /// <param name="partitionKey">EventHub partition key for message</param>
-        /// <param name="offset">Offset into the EventHub parition where this message was from</param>
-        /// <param name="sequenceNumber">Offset into the EventHub parition where this message was from</param>
+        /// <param name="offset">Offset into the EventHub partition where this message was from</param>
+        /// <param name="sequenceNumber">Offset into the EventHub partition where this message was from</param>
         /// <param name="enqueueTimeUtc">Time in UTC when this message was injected by EventHub</param>
         /// <param name="dequeueTimeUtc">Time in UTC when this message was read from EventHub into the current service</param>
         /// <param name="properties">User properties from EventData object</param>
-        /// <param name="payload">Binary data from EventData objbect</param>
+        /// <param name="payload">Binary data from EventData object</param>
         public EventHubMessage(IStreamIdentity streamIdentity, string partitionKey, string offset, long sequenceNumber,
             DateTime enqueueTimeUtc, DateTime dequeueTimeUtc, IDictionary<string, object> properties, byte[] payload)
         {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueMapper.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueMapper.cs
@@ -31,7 +31,7 @@ namespace Orleans.ServiceBus.Providers
             QueueId[] queues = GetAllQueues().ToArray();
             if (queues.Length != partitionIds.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(partitionIds), "partitons and Queues do not line up");
+                throw new ArgumentOutOfRangeException(nameof(partitionIds), "partitions and Queues do not line up");
             }
             for (int i = 0; i < queues.Length; i++)
             {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/MonitorAggregationDimentions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/MonitorAggregationDimentions.cs
@@ -90,7 +90,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Zero parametrers constructor
+        /// Zero parameters constructor
         /// </summary>
         public EventHubCacheMonitorDimensions()
         {

--- a/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
@@ -11,7 +11,7 @@ namespace Orleans.CodeGeneration
     {
         /// <summary>Initializes a new instance of <see cref="KnownAssemblyAttribute"/>.</summary>
         /// <param name="type">A type contained by the target assembly. 
-        /// The type itself is not relevant, and it's just a way to inrectly identify the assembly.</param>
+        /// The type itself is not relevant, and it's just a way to indirectly identify the assembly.</param>
         public KnownAssemblyAttribute(Type type)
         {
             this.Assembly = type.GetTypeInfo().Assembly;

--- a/src/Orleans.Core.Abstractions/Core/Immutable.cs
+++ b/src/Orleans.Core.Abstractions/Core/Immutable.cs
@@ -5,7 +5,7 @@ namespace Orleans.Concurrency
     /// </summary>
     /// <remarks>
     /// Objects that are known to be immutable are given special fast-path handling by the Orleans serializer 
-    /// -- which in a nutshell allows the DeepCopy step to be skipped during message sends where the sender and reveiving grain are in the same silo.
+    /// -- which in a nutshell allows the DeepCopy step to be skipped during message sends where the sender and receiver grain are in the same silo.
     /// 
     /// One very common usage pattern for Immutable is when passing byte[] parameters to a grain. 
     /// If a program knows it will not alter the contents of the byte[] (for example, if it contains bytes from a static image file read from disk)

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -128,7 +128,7 @@ namespace Orleans.Runtime
         /// <remarks>
         /// Note: This string value is not comparable with the <c>FromParsableString</c> method -- use the <c>ToParsableString</c> method for that purpose.
         /// </remarks>
-        /// <returns>String representaiton of this SiloAddress.</returns>
+        /// <returns>String representation of this SiloAddress.</returns>
         public string ToLongString()
         {
             return ToString();
@@ -140,7 +140,7 @@ namespace Orleans.Runtime
         /// <remarks>
         /// Note: This string value is not comparable with the <c>FromParsableString</c> method -- use the <c>ToParsableString</c> method for that purpose.
         /// </remarks>
-        /// <returns>String representaiton of this SiloAddress.</returns>
+        /// <returns>String representation of this SiloAddress.</returns>
         public string ToStringWithHashCode()
         {
             return String.Format("{0}/x{1, 8:X8}", ToString(), GetConsistentHashCode());

--- a/src/Orleans.Core.Abstractions/Streams/Core/IAsyncObserver.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Core/IAsyncObserver.cs
@@ -53,7 +53,7 @@ namespace Orleans.Streams
         /// The Task returned from this method should be completed when the consumer is done processing the stream closure.
         /// </para>
         /// </summary>
-        /// <param name="ex">An Exception that describes the error that occured on the stream.</param>
+        /// <param name="ex">An Exception that describes the error that occurred on the stream.</param>
         /// <returns>A Task that is completed when the close has been accepted.</returns>
         Task OnErrorAsync(Exception ex);
     }

--- a/src/Orleans.Core.Abstractions/Streams/Core/IAsyncStream.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Core/IAsyncStream.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Orleans.Streams
 {
     /// <summary>
-    /// This interface represents an object that serves as a distributed rendevous between producers and consumers.
+    /// This interface represents an object that serves as a distributed rendezvous between producers and consumers.
     /// It is similar to a Reactive Framework <code>Subject</code> and implements
     /// <code>IObserver</code> nor <code>IObservable</code> interfaces.
     /// </summary>

--- a/src/Orleans.Core.Abstractions/Timers/IRemindable.cs
+++ b/src/Orleans.Core.Abstractions/Timers/IRemindable.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Orleans
 {
     /// <summary>
-    /// Callback interface that grains must implement inorder to be able to register and receive Reminders.
+    /// Callback interface that grains must implement in order to be able to register and receive Reminders.
     /// </summary>
     public interface IRemindable : IGrain
     {

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -181,7 +181,7 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public TimeSpan DeathVoteExpirationTimeout { get; set; }
         /// <summary>
-        /// The number of seconds to periodically write in the membership table that this silo is alive. Used ony for diagnostics.
+        /// The number of seconds to periodically write in the membership table that this silo is alive. Used only for diagnostics.
         /// </summary>
         public TimeSpan IAmAliveTablePublishTimeout { get; set; }
         /// <summary>

--- a/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggerProvider.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggerProvider.cs
@@ -73,7 +73,7 @@ namespace Orleans.Logging.Legacy
     public class OrleansLoggerSeverityOverrides
     {
         /// <summary>
-        /// LoggerSeverityOverrides, which key being logger category name, value being its overrided severity
+        /// LoggerSeverityOverrides, which key being logger category name, value being its overridden severity
         /// </summary>
         public Dictionary<string, Severity> LoggerSeverityOverrides { get; set; } = new Dictionary<string, Severity>();
     }

--- a/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
@@ -397,7 +397,7 @@ namespace Orleans.Runtime
 
                         if (!isLoadable)
                         {
-                            complaints = new[] { $"The file {fileName} is not loadable into this process, either it is not an MSIL assembly or the compliled for a different processor architecture." };
+                            complaints = new[] { $"The file {fileName} is not loadable into this process, either it is not an MSIL assembly or the complied for a different processor architecture." };
                         }
 
                         return isLoadable;
@@ -423,7 +423,7 @@ namespace Orleans.Runtime
             }
             catch (MissingMethodException)
             {
-                complaints = new[] { "MissingMethodException occured. Please try to add a BindingRedirect for System.Collections.ImmutableCollections to the App.config file to correct this error." };
+                complaints = new[] { "MissingMethodException occurred. Please try to add a BindingRedirect for System.Collections.ImmutableCollections to the App.config file to correct this error." };
                 return false;
             }
             catch (Exception ex)

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -79,7 +79,7 @@ namespace Orleans
                 this.logger.LogInformation(stringBuiler.ToString());
             } catch(Exception ex)
             {
-                this.logger.LogError(ex, $"An error occured while logging options {formatter.Name}", formatter.Name);
+                this.logger.LogError(ex, $"An error occurred while logging options {formatter.Name}", formatter.Name);
                 throw;
             }
         }

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -44,7 +44,7 @@ namespace Orleans.Configuration
         public static readonly TimeSpan DEFAULT_LIVENESS_DEATH_VOTE_EXPIRATION_TIMEOUT = TimeSpan.FromSeconds(120);
 
         /// <summary>
-        /// The number of seconds to periodically write in the membership table that this silo is alive. Used ony for diagnostics.
+        /// The number of seconds to periodically write in the membership table that this silo is alive. Used only for diagnostics.
         /// </summary>
         public TimeSpan IAmAliveTablePublishTimeout { get; set; } = DEFAULT_LIVENESS_I_AM_ALIVE_TABLE_PUBLISH_TIMEOUT;
         public static readonly TimeSpan DEFAULT_LIVENESS_I_AM_ALIVE_TABLE_PUBLISH_TIMEOUT = TimeSpan.FromMinutes(5);

--- a/src/Orleans.Core/Configuration/Options/GatewayOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GatewayOptions.cs
@@ -14,12 +14,12 @@ namespace Orleans.Configuration
         public TimeSpan GatewayListRefreshPeriod { get; set; } = DEFAULT_GATEWAY_LIST_REFRESH_PERIOD;
 
         /// <summary>
-        /// Default preferred gateway index,. Value -1 means perfer no gateway
+        /// Default preferred gateway index,. Value -1 means prefer no gateway
         /// </summary>
         public const int DEFAULT_PREFERED_GATEWAY_INDEX = -1;
 
         /// <summary>
-        /// Prefered gateway index
+        /// Preferred gateway index
         /// </summary>
         public int PreferedGatewayIndex { get; set; } = DEFAULT_PREFERED_GATEWAY_INDEX;
     }

--- a/src/Orleans.Core/Configuration/OptionsOverrides.cs
+++ b/src/Orleans.Core/Configuration/OptionsOverrides.cs
@@ -27,7 +27,7 @@ namespace Orleans.Configuration.Overrides
         public static IClientBuilder AddProviderClusterOptions(this IClientBuilder builder, string providerName, Action<ClusterOptions> configureOptions) => builder.ConfigureServices(services => services.AddOptionsOverride<ClusterOptions>(providerName, ob => ob.Configure(configureOptions)));
 
         /// <summary>
-        /// Gets option that can be overriden by named service.
+        /// Gets option that can be overridden by named service.
         /// </summary>
         private static IOptions<TOptions> GetOverridableOption<TOptions>(this IServiceProvider services, string key)
             where TOptions : class, new()

--- a/src/Orleans.Core/Providers/GrainStorageExtensions.cs
+++ b/src/Orleans.Core/Providers/GrainStorageExtensions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Storage
     public static class GrainStorageExtensions
     {
         /// <summary>
-        /// Aquire the storage provider associated with the grain type.
+        /// Acquire the storage provider associated with the grain type.
         /// </summary>
         /// <returns></returns>
         public static IGrainStorage GetGrainStorage(this Grain grain, IServiceProvider services)

--- a/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
+++ b/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
@@ -135,7 +135,7 @@ namespace Orleans.Runtime
         public int GrainCount { get; set; }
 
         /// <summary>
-        /// Number of activation of a agrain of this type.
+        /// Number of activation of a grain of this type.
         /// </summary>
         public int ActivationCount { get; set; }
 
@@ -145,7 +145,7 @@ namespace Orleans.Runtime
         public int SiloCount { get; set; }
 
         /// <summary>
-        /// Returns the string representatio of this GrainStatistic.
+        /// Returns the string representation of this GrainStatistic.
         /// </summary>
         public override string ToString()
         {
@@ -175,7 +175,7 @@ namespace Orleans.Runtime
         public int ActivationCount { get; set; }
 
         /// <summary>
-        /// Returns the string representatio of this SimpleGrainStatistic.
+        /// Returns the string representation of this SimpleGrainStatistic.
         /// </summary>
         public override string ToString()
         {

--- a/src/Orleans.Core/Streams/Internal/IStreamControl.cs
+++ b/src/Orleans.Core/Streams/Internal/IStreamControl.cs
@@ -11,7 +11,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Perform cleanup functions for this stream.
         /// </summary>
-        /// <returns>Completion promise for the cleanup operstions for this stream.</returns>
+        /// <returns>Completion promise for the cleanup operations for this stream.</returns>
         Task Cleanup(bool cleanupProducers, bool cleanupConsumers);
     }
 }

--- a/src/Orleans.Core/Streams/PubSub/FaultedSubscriptionException.cs
+++ b/src/Orleans.Core/Streams/PubSub/FaultedSubscriptionException.cs
@@ -5,7 +5,7 @@ using Orleans.Runtime;
 namespace Orleans.Streams
 {
     /// <summary>
-    /// This exception indicates that an error has occured on a stream subscription that has placed the subscription into
+    /// This exception indicates that an error has occurred on a stream subscription that has placed the subscription into
     ///  a faulted state.  Work on faulted subscriptions should be abandoned.
     /// </summary>
     [Serializable]

--- a/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapter.cs
+++ b/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapter.cs
@@ -27,7 +27,7 @@ namespace Orleans.Streams
         Task QueueMessageBatchAsync<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext);
 
         /// <summary>
-        /// Creates a quere receiver for the specificed queueId
+        /// Creates a queue receiver for the specified queueId
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans.Core/Streams/QueueAdapters/IQueueAdapterReceiver.cs
@@ -22,7 +22,7 @@ namespace Orleans.Streams
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
 
         /// <summary>
-        /// Notifies the adapter receiver that the mesages were delivered to all consumers,
+        /// Notifies the adapter receiver that the messages were delivered to all consumers,
         /// so the receiver can take an appropriate action (e.g., delete the messages from a message queue).
         /// </summary>
         /// <returns></returns>

--- a/src/Orleans.Core/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Core/Streams/QueueAdapters/IQueueCache.cs
@@ -18,7 +18,7 @@ namespace Orleans.Streams
         bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems);
 
         /// <summary>
-        /// Acquire a stream message cursor.  This can be used to retreave messages from the
+        /// Acquire a stream message cursor.  This can be used to retrieve messages from the
         ///   cache starting at the location indicated by the provided token.
         /// </summary>
         /// <param name="streamIdentity"></param>

--- a/src/Orleans.Core/SystemTargetInterfaces/IClusterGrainDirectory.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IClusterGrainDirectory.cs
@@ -16,7 +16,7 @@ namespace Orleans.SystemTargetInterfaces
     }
 
     /// <summary>
-    /// Reponse message used by Global Single Instance Protocol
+    /// Response message used by Global Single Instance Protocol
     /// </summary>
     [Serializable]
     internal class RemoteClusterActivationResponse

--- a/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
+++ b/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
@@ -15,7 +15,7 @@ using Orleans.Runtime.Startup;
 namespace Orleans.Runtime.Host
 {
     /// <summary>
-    /// Allows programmatically hosting an Orleans silo in the curent app domain.
+    /// Allows programmatically hosting an Orleans silo in the current app domain.
     /// </summary>
     public class SiloHost :
         MarshalByRefObject,

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -514,10 +514,10 @@ namespace Orleans.Runtime
         /// <summary>Decrement the number of in-flight messages currently being processed.</summary>
         public void DecrementInFlightCount() { Interlocked.Decrement(ref inFlightCount); }
 
-        /// <summary>Increment the number of messages currently in the prcess of being received.</summary>
+        /// <summary>Increment the number of messages currently in the process of being received.</summary>
         public void IncrementEnqueuedOnDispatcherCount() { Interlocked.Increment(ref enqueuedOnDispatcherCount); }
 
-        /// <summary>Decrement the number of messages currently in the prcess of being received.</summary>
+        /// <summary>Decrement the number of messages currently in the process of being received.</summary>
         public void DecrementEnqueuedOnDispatcherCount() { Interlocked.Decrement(ref enqueuedOnDispatcherCount); }
        
         /// <summary>

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
             {
                 if (extensionMap == null || !extensionMap.ContainsKey(request.InterfaceId))
                     throw new InvalidOperationException(
-                        String.Format("Extension invoker invoked with an unknown inteface ID:{0}.", request.InterfaceId));
+                        String.Format("Extension invoker invoked with an unknown interface ID:{0}.", request.InterfaceId));
 
                 var invoker = extensionMap[request.InterfaceId].Item2;
                 var extension = extensionMap[request.InterfaceId].Item1;

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -1244,7 +1244,7 @@ namespace Orleans.Runtime
             }
             
             /// <summary>
-            /// Returns true if this instance represents a successful registration, false otheriwse.
+            /// Returns true if this instance represents a successful registration, false otherwise.
             /// </summary>
             public bool IsSuccess { get; private set; }
 

--- a/src/Orleans.Runtime/Configuration/Options/ConsistentRingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/ConsistentRingOptions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Configuration
     public class ConsistentRingOptions
     {
         /// <summary>
-        /// Determines the number of registerations a silo maintains in a consistent hash ring.  This affects the probabilistic
+        /// Determines the number of registrations a silo maintains in a consistent hash ring.  This affects the probabilistic
         ///   balancing of resource allocations across the cluster.  More virtual buckets increase the probability of evenly balancing
         ///   while minimally increasing management cost. 
         /// </summary>

--- a/src/Orleans.Runtime/ConsistentRing/IConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/IConsistentRingProvider.cs
@@ -5,7 +5,7 @@ namespace Orleans.Runtime.ConsistentRing
     internal interface IConsistentRingProvider
     {
         /// <summary>
-        /// Get the responsbility range of the current silo
+        /// Get the responsibility range of the current silo
         /// </summary>
         /// <returns></returns>
         IRingRange GetMyRange();

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -241,7 +241,7 @@ namespace Orleans.Runtime
                 {
                     logger.Warn(ErrorCode.Dispatcher_Receive_InvalidActivation,
                         "Response received for invalid activation {0}", message);
-                    MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Ivalid");
+                    MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Invalid");
                     return;
                 }
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedOk(message);

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -589,7 +589,7 @@ namespace Orleans.Runtime.GrainDirectory
         }
 
         /// <summary>
-        /// Sets the internal parition dictionary to the one given as input parameter.
+        /// Sets the internal partition dictionary to the one given as input parameter.
         /// This method is supposed to be used by handoff manager to update the old partition with a new partition.
         /// </summary>
         /// <param name="newPartitionData">new internal partition dictionary</param>

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
@@ -136,7 +136,7 @@ namespace Orleans.Runtime.GrainDirectory
             if (ownerResponses.Count > 0)
             {
                 if (ownerResponses.Count > 1)
-                    logger.Warn((int)ErrorCode.GlobalSingleInstance_MultipleOwners, "GSIP:Req {0} Unexpected error occured. Multiple Owner Replies.", grainId);
+                    logger.Warn((int)ErrorCode.GlobalSingleInstance_MultipleOwners, "GSIP:Req {0} Unexpected error occurred. Multiple Owner Replies.", grainId);
 
                 return new GlobalSingleInstanceResponseOutcome(OutcomeState.RemoteOwner, ownerResponses[0].ExistingActivationAddress, ownerResponses[0].ClusterId);
             }

--- a/src/Orleans.Runtime/MembershipService/ISiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/ISiloStatusOracle.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime
         /// Get the statuses of all silo. 
         /// This method returns an approximate view on the statuses of all silo.
         /// </summary>
-        /// <param name="onlyActive">Include only silo who are currently considered to be active. If false, inlude all.</param>
+        /// <param name="onlyActive">Include only silo who are currently considered to be active. If false, include all.</param>
         /// <returns>A list of silo statuses.</returns>
         Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false);
 

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
@@ -468,7 +468,7 @@ namespace Orleans.Runtime.Messaging
             // situation that shows when the remote host has finished sending data.
             if (e.BytesTransferred <= 0)
             {
-                if (Log.IsEnabled(LogLevel.Debug)) Log.Debug("Closing recieving socket: " + e.RemoteEndPoint);
+                if (Log.IsEnabled(LogLevel.Debug)) Log.Debug("Closing receiving socket: " + e.RemoteEndPoint);
                 rcc.IMA.SafeCloseSocket(rcc.Socket);
                 FreeSocketAsyncEventArgs(e);
                 return;

--- a/src/Orleans.Runtime/Messaging/ObjectPool.cs
+++ b/src/Orleans.Runtime/Messaging/ObjectPool.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
     }
 
     /// <summary>
-    /// Utility class to support pooled objects by allowing them to track the pook they came from and return to it when disposed
+    /// Utility class to support pooled objects by allowing them to track the pool they came from and return to it when disposed
     /// </summary>
     /// <typeparam name="T"></typeparam>
     internal abstract class PooledResource<T> : IDisposable

--- a/src/Orleans.Runtime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -177,7 +177,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Checks to see if deployment configuration has changed, by adding or removing silos.
         /// If so, it updates the list of all silo names and creates a new resource balancer.
-        /// This should occure rarely.
+        /// This should occur rarely.
         /// </summary>
         private BestFitBalancer<string, QueueId> GetBalancer()
         {

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -134,7 +134,7 @@ namespace Orleans.Runtime
             {
                 logger.Error( 
                     ErrorCode.Timer_GrainTimerCallbackError,
-                    string.Format( "Caught and ignored exception: {0} with mesagge: {1} thrown from timer callback {2}",
+                    string.Format( "Caught and ignored exception: {0} with message: {1} thrown from timer callback {2}",
                         exc.GetType(),
                         exc.Message,
                         GetFullName()),

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -108,7 +108,7 @@ namespace Orleans.TestingHost.Utils
             await task;
         }
 
-        /// <summary> Multipy a timeout by a value </summary>
+        /// <summary> Multiply a timeout by a value </summary>
         public static TimeSpan Multiply(TimeSpan time, double value)
         {
             double ticksD = checked(time.Ticks * value);

--- a/src/OrleansProviders/Streams/Common/Monitors/IBlockPoolMonitor.cs
+++ b/src/OrleansProviders/Streams/Common/Monitors/IBlockPoolMonitor.cs
@@ -18,7 +18,7 @@ namespace Orleans.Providers.Streams.Common
         void TrackMemoryAllocated(long allocatedMemoryInByte);
 
         /// <summary>
-        /// Track memory relased from cache
+        /// Track memory released from cache
         /// </summary>
         /// <param name="releasedMemoryInByte"></param>
         void TrackMemoryReleased(long releasedMemoryInByte);

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
@@ -119,7 +119,7 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Access the cached message at the provdied index.
+        /// Access the cached message at the provided index.
         /// </summary>
         /// <param name="index"></param>
         /// <returns></returns>

--- a/src/OrleansProviders/Streams/Common/PooledCache/IObjectPool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IObjectPool.cs
@@ -27,7 +27,7 @@ namespace Orleans.Providers.Streams.Common
     }
 
     /// <summary>
-    /// Utility class to support pooled objects by allowing them to track the pook they came from and return to it when disposed
+    /// Utility class to support pooled objects by allowing them to track the pool they came from and return to it when disposed
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public abstract class PooledResource<T> : IDisposable

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -150,7 +150,7 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Acquire a stream message cursor.  This can be used to retreave messages from the
+        /// Acquire a stream message cursor.  This can be used to retrieve messages from the
         ///   cache starting at the location indicated by the provided token.
         /// </summary>
         /// <param name="streamIdentity"></param>

--- a/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
@@ -181,7 +181,7 @@ namespace Orleans.Providers.Streams.Generator
         }
 
         /// <summary>
-        /// Creates a quere receiver for the specificed queueId
+        /// Creates a queue receiver for the specified queueId
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -251,7 +251,7 @@ namespace Orleans.Providers.Streams.Generator
         }
 
         /// <summary>
-        /// Acquire a stream message cursor.  This can be used to retreave messages from the
+        /// Acquire a stream message cursor.  This can be used to retrieve messages from the
         ///   cache starting at the location indicated by the provided token.
         /// </summary>
         /// <param name="streamIdentity"></param>

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -147,7 +147,7 @@ namespace Orleans.Providers
         }
 
         /// <summary>
-        /// Creates a quere receiver for the specificed queueId
+        /// Creates a queue receiver for the specified queueId
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>

--- a/test/TesterInternal/RetryHelper.cs
+++ b/test/TesterInternal/RetryHelper.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 namespace UnitTests
 {
     /// <summary>
-    /// Predeterimed retry operation, used with <see cref="RetryHelper"/>.
+    /// Predetermined retry operation, used with <see cref="RetryHelper"/>.
     /// </summary>
     /// <remarks>A very crude system for current tests.</remarks>
     public static class RetryOperation
     {
         /// <summary>
-        /// Procudes sigmoid shaped delay curve.
+        /// Produces sigmoid shaped delay curve.
         /// </summary>
         /// <param name="retryAttempt">The current retry attempt.</param>
         /// <returns>Delay for the next attempt to retry.</returns>

--- a/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
+++ b/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
@@ -136,7 +136,7 @@ namespace Samples.StorageProviders
         /// Constructs a grain state instance by deserializing a JSON document.
         /// </summary>
         /// <param name="grainState">Grain state to be populated for storage.</param>
-        /// <param name="entityData">JSON storage format representaiton of the grain state.</param>
+        /// <param name="entityData">JSON storage format representation of the grain state.</param>
         protected static void ConvertFromStorageFormat(IGrainState grainState, string entityData)
         {
             JavaScriptSerializer deserializer = new JavaScriptSerializer();


### PR DESCRIPTION
Bonjour,

Sorry for the delay. I had to help some of my customers. We're back to our regularly scheduled program. :clock1:  

Largely, **N to R** corrections (plus some I missed in the last PRs).

I did notice a spelling mistake in the public API while checking:
https://github.com/dotnet/orleans/blob/83d69190d39dea6ccad34c3dc68bece5f257385a/src/Orleans.Core/Configuration/Options/GatewayOptions.cs#L16-L24

`Prefered` is spelled `Preferred`?

Let me know what you'd like me to do about these spelling errors in public APIs.

Happy **#Hacktoberfest** :smiley_cat: :fearful: :skull_and_crossbones: :moon: :bat: 

Thanks,
Brian

:briefcase: :necktie: ***["Taking care of business every day... Taking care of business every way..."](https://www.youtube.com/watch?v=mmwic9kFx2c)***