### PR TITLE
Increase package versions to 2.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,7 +107,7 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.1.1</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.2.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->
@@ -122,35 +122,35 @@
 
   <!-- Inner dependency versions -->
   <PropertyGroup Condition="$(FullBuild) != 'true'">
-    <OrleansCoreAbstractionsVersion>2.1.0</OrleansCoreAbstractionsVersion>
-    <OrleansRuntimeAbstractionsVersion>2.1.0</OrleansRuntimeAbstractionsVersion>
-    <OrleansCoreVersion>2.1.0</OrleansCoreVersion>
-    <OrleansRuntimeVersion>2.1.0</OrleansRuntimeVersion>
-    <OrleansCoreLegacyVersion>2.1.0</OrleansCoreLegacyVersion>
-    <OrleansRuntimeLegacyVersion>2.1.0</OrleansRuntimeLegacyVersion>
-    <OrleansProvidersVersion>2.1.0</OrleansProvidersVersion>
-    <OrleansExtensionsVersion>2.1.1</OrleansExtensionsVersion>
-    <OrleansEventSourcingVersion>2.1.0</OrleansEventSourcingVersion>
-    <OrleansAdoNetVersion>2.1.0</OrleansAdoNetVersion>
-    <OrleansAWSVersion>2.1.0</OrleansAWSVersion>
-    <OrleansAzureClusteringVersion>2.1.0</OrleansAzureClusteringVersion>
-    <OrleansAzureStreamingVersion>2.1.0</OrleansAzureStreamingVersion>
-    <OrleansAzureEventHubsVersion>2.1.0</OrleansAzureEventHubsVersion>
-    <OrleansAzurePersistenceVersion>2.1.0</OrleansAzurePersistenceVersion>
-    <OrleansAzureRemindersVersion>2.1.0</OrleansAzureRemindersVersion>
-    <OrleansAzureMetapackageVersion>2.1.0</OrleansAzureMetapackageVersion>
-    <OrleansGoogleCloudProviderVersion>2.1.0</OrleansGoogleCloudProviderVersion>
-    <OrleansAzureCloudServicesVersion>2.1.0</OrleansAzureCloudServicesVersion>
-    <OrleansTestingHostVersion>2.1.0</OrleansTestingHostVersion>
-    <OrleansTransactionsVersion>2.1.0</OrleansTransactionsVersion>
-    <OrleansServiceFabricVersion>2.1.0</OrleansServiceFabricVersion>
-    <OrleansSerializersVersion>2.1.0</OrleansSerializersVersion>
-    <OrleansToolsVersion>2.1.0</OrleansToolsVersion>
-    <OrleansClientVersion>2.1.0</OrleansClientVersion>
-    <OrleansServerVersion>2.1.0</OrleansServerVersion>
-    <OrleansCodegenVersion>2.1.0</OrleansCodegenVersion>
-    <OrleansEventHubProviderVersion>2.1.0</OrleansEventHubProviderVersion>
-    <OrleansTelemetryConsumersVersion>2.1.0</OrleansTelemetryConsumersVersion>
+    <OrleansCoreAbstractionsVersion>2.2.0</OrleansCoreAbstractionsVersion>
+    <OrleansRuntimeAbstractionsVersion>2.2.0</OrleansRuntimeAbstractionsVersion>
+    <OrleansCoreVersion>2.2.0</OrleansCoreVersion>
+    <OrleansRuntimeVersion>2.2.0</OrleansRuntimeVersion>
+    <OrleansCoreLegacyVersion>2.2.0</OrleansCoreLegacyVersion>
+    <OrleansRuntimeLegacyVersion>2.2.0</OrleansRuntimeLegacyVersion>
+    <OrleansProvidersVersion>2.2.0</OrleansProvidersVersion>
+    <OrleansExtensionsVersion>2.2.0</OrleansExtensionsVersion>
+    <OrleansEventSourcingVersion>2.2.0</OrleansEventSourcingVersion>
+    <OrleansAdoNetVersion>2.2.0</OrleansAdoNetVersion>
+    <OrleansAWSVersion>2.2.0</OrleansAWSVersion>
+    <OrleansAzureClusteringVersion>2.2.0</OrleansAzureClusteringVersion>
+    <OrleansAzureStreamingVersion>2.2.0</OrleansAzureStreamingVersion>
+    <OrleansAzureEventHubsVersion>2.2.0</OrleansAzureEventHubsVersion>
+    <OrleansAzurePersistenceVersion>2.2.0</OrleansAzurePersistenceVersion>
+    <OrleansAzureRemindersVersion>2.2.0</OrleansAzureRemindersVersion>
+    <OrleansAzureMetapackageVersion>2.2.0</OrleansAzureMetapackageVersion>
+    <OrleansGoogleCloudProviderVersion>2.2.0</OrleansGoogleCloudProviderVersion>
+    <OrleansAzureCloudServicesVersion>2.2.0</OrleansAzureCloudServicesVersion>
+    <OrleansTestingHostVersion>2.2.0</OrleansTestingHostVersion>
+    <OrleansTransactionsVersion>2.2.0</OrleansTransactionsVersion>
+    <OrleansServiceFabricVersion>2.2.0</OrleansServiceFabricVersion>
+    <OrleansSerializersVersion>2.2.0</OrleansSerializersVersion>
+    <OrleansToolsVersion>2.2.0</OrleansToolsVersion>
+    <OrleansClientVersion>2.2.0</OrleansClientVersion>
+    <OrleansServerVersion>2.2.0</OrleansServerVersion>
+    <OrleansCodegenVersion>2.2.0</OrleansCodegenVersion>
+    <OrleansEventHubProviderVersion>2.2.0</OrleansEventHubProviderVersion>
+    <OrleansTelemetryConsumersVersion>2.2.0</OrleansTelemetryConsumersVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(FullBuild) == 'true'">

--- a/src/Azure/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
+++ b/src/Azure/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
@@ -9,6 +9,10 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(OrleansServiceFabricVersion)!=$(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Hosting.ServiceFabric\Orleans.Hosting.ServiceFabric.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Increase package versions to 2.2.0, so that we don't need to update it for every patch release.
Also add a missing nuget packaging condition for Service Fabric meta-package.