### PR TITLE
IMessageCenter.WaitMessage support cancellation

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -330,13 +330,7 @@ namespace Orleans.Messaging
         {
             try
             {
-                if (ct.IsCancellationRequested)
-                {
-                    return null;
-                }
-
-                // Don't pass CancellationToken to Take. It causes too much spinning.
-                return PendingInboundMessages.Take();
+                return PendingInboundMessages.Take(ct);
             }
             catch (ThreadAbortException exc)
             {

--- a/src/Orleans.Runtime/Messaging/IInboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/IInboundMessageQueue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -10,6 +11,6 @@ namespace Orleans.Runtime.Messaging
 
         void PostMessage(Message message);
 
-        Message WaitMessage(Message.Categories type);
+        Message WaitMessage(Message.Categories type, CancellationToken cancellationToken);
     }
 }

--- a/src/Orleans.Runtime/Messaging/InboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/InboundMessageQueue.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -89,11 +90,15 @@ namespace Orleans.Runtime.Messaging
         }
 
         /// <inheritdoc />
-        public Message WaitMessage(Message.Categories type)
+        public Message WaitMessage(Message.Categories type, CancellationToken cancellationToken)
         {
             try
             {
-                return this.messageQueues[(int)type].Take();
+                return this.messageQueues[(int)type].Take(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
             }
             catch (InvalidOperationException)
             {

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -241,7 +241,7 @@ namespace Orleans.Runtime.Messaging
 
         public Message WaitMessage(Message.Categories type, CancellationToken ct)
         {
-            return InboundQueue.WaitMessage(type);
+            return InboundQueue.WaitMessage(type, ct);
         }
 
         public void RegisterLocalMessageHandler(Message.Categories category, Action<Message> handler)


### PR DESCRIPTION
In the shutdown procedure, the message center thread is blocked for waiting for
new inbound messages. Meanwhile, the shutdown procedure also dispose 
the in-used objects (BlockingCollection), which cause unexpected throw
(ArgumentNullException) in message center thread.

The original decision that avoiding passing cancellation to
`BlockingCollection.Take` was in consideration of performance.
But I can't see any regression in my benchmark program.

see also:
https://github.com/dotnet/corefx/issues/14320#issuecomment-266128170

fix #4965