### PR TITLE
Allow placement strategies to skip directory registration

### DIFF
--- a/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
+++ b/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
@@ -5,5 +5,10 @@ namespace Orleans.Runtime
     [Serializable]
     public abstract class PlacementStrategy
     {
+        /// <summary>
+        /// Returns a value indicating whether or not this placement strategy requires activations to be registered in
+        /// the grain directory.
+        /// </summary>
+        public virtual bool IsUsingGrainDirectory => true;
     }
 }

--- a/src/Orleans.Core.Abstractions/Placement/StatelessWorkerPlacement.cs
+++ b/src/Orleans.Core.Abstractions/Placement/StatelessWorkerPlacement.cs
@@ -7,6 +7,11 @@ namespace Orleans.Runtime
     {
         private static readonly int DefaultMaxStatelessWorkers = Environment.ProcessorCount;
 
+        /// <summary>
+        /// Stateless workers are not registered in the grain directory.
+        /// </summary>
+        public override bool IsUsingGrainDirectory => false;
+
         public int MaxLocal { get; private set; }
 
         internal StatelessWorkerPlacement(int maxLocal = -1)

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -446,10 +446,13 @@ namespace Orleans.Runtime
         public IMultiClusterRegistrationStrategy RegistrationStrategy { get; private set; }
 
         // Currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
-        internal bool IsStatelessWorker { get { return PlacedUsing is StatelessWorkerPlacement; } }
-
-        // Currently, the only grain type that is not registered in the Grain Directory is StatelessWorker. 
-        internal bool IsUsingGrainDirectory { get { return !IsStatelessWorker; } }
+        internal bool IsStatelessWorker => this.PlacedUsing is StatelessWorkerPlacement;
+        
+        /// <summary>
+        /// Returns a value indicating whether or not this placement strategy requires activations to be registered in
+        /// the grain directory.
+        /// </summary>
+        internal bool IsUsingGrainDirectory => this.PlacedUsing.IsUsingGrainDirectory;
 
         public Message Running { get; private set; }
 

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -1263,6 +1263,7 @@ namespace Orleans.Runtime
         private async Task<ActivationRegistrationResult> RegisterActivationInGrainDirectoryAndValidate(ActivationData activation)
         {
             ActivationAddress address = activation.Address;
+
             // Currently, the only grain type that is not registered in the Grain Directory is StatelessWorker. 
             // Among those that are registered in the directory, we currently do not have any multi activations.
             if (activation.IsUsingGrainDirectory)
@@ -1272,9 +1273,9 @@ namespace Orleans.Runtime
                
                 return new ActivationRegistrationResult(existingActivationAddress: result.Address);
             }
-            else
+            else if (activation.PlacedUsing is StatelessWorkerPlacement stPlacement)
             {
-                StatelessWorkerPlacement stPlacement = activation.PlacedUsing as StatelessWorkerPlacement;
+                // Stateless workers are not registered in the directory and can have multiple local activations.
                 int maxNumLocalActivations = stPlacement.MaxLocal;
                 lock (activations)
                 {
@@ -1286,6 +1287,21 @@ namespace Orleans.Runtime
                     return new ActivationRegistrationResult(existingActivationAddress: id);
                 }
             }
+            else
+            {
+                // Some other non-directory, single-activation placement.
+                lock (activations)
+                {
+                    var exists = LocalLookup(address.Grain, out var local);
+                    if (exists && local.Count == 1 && local[0].ActivationId.Equals(activation.ActivationId))
+                    {
+                        return ActivationRegistrationResult.Success;
+                    }
+
+                    return new ActivationRegistrationResult(existingActivationAddress: local[0].Address);
+                }
+            }
+
             // We currently don't have any other case for multiple activations except for StatelessWorker. 
         }
 


### PR DESCRIPTION
Changes to support placement directors which do not use the grain directory. In short, adds an `IsUsingGrainDirectory` prop to `PlacementStrategy` and removes some existing special-casing around `StatelessWorkerPlacement` being the only placement strategy which can bypass the directory.

This is a supporting PR for Service Fabric Stateful Service hosting #5073