### PR TITLE
(docs) fix links to presentations

### DIFF
--- a/src/Documentation/resources/Presentations/index.md
+++ b/src/Documentation/resources/Presentations/index.md
@@ -10,24 +10,24 @@ title: Orleans Presentations
 
 * [Orleans Presentation from the 15th International Workshop on High Performance Transaction Systems (HPTS 2013)](http://www.hpts.ws/papers/2013/Bykov.pdf)
 
-* [Balancing Techniques in Orleans](http://dotnet.github.io/orleans/Presentations/Balancing Techniques in Orleans.pptx)
+* [Balancing Techniques in Orleans](http://dotnet.github.io/orleans/Presentations/Balancing%20Techniques%20in%20Orleans.pptx)
 
-* [Uniform API is 42 - Virtual Meetup #3](http://dotnet.github.io/orleans/Presentations/(VM03) Uniform Api is 42.pptx)
+* [Uniform API is 42 - Virtual Meetup #3](http://dotnet.github.io/orleans/Presentations/(VM03)%20Uniform%20Api%20is%2042.pptx)
 
-* [Orleans at FreeBay - Virtual Meetup #4](http://dotnet.github.io/orleans/Presentations/VM-4 - Using Orleans at FreeBay.pptx)
+* [Orleans at FreeBay - Virtual Meetup #4](http://dotnet.github.io/orleans/Presentations/VM-4%20-%20Using%20Orleans%20at%20FreeBay.pptx)
 
-* [Orleans Streaming - Virtual Meetup #5 - May 2015](http://dotnet.github.io/orleans/Presentations/Orleans Streaming - Virtual meetup - 5-22-2015.pptx)
+* [Orleans Streaming - Virtual Meetup #5 - May 2015](http://dotnet.github.io/orleans/Presentations/Orleans%20Streaming%20-%20Virtual%20meetup%20-%205-22-2015.pptx)
 
-* [Geo Distributed Orleans - Virtual Meetup #6 - October 2015](http://dotnet.github.io/orleans/Presentations/VM-6 - Orleans-Geo-Replication.pptx)
+* [Geo Distributed Orleans - Virtual Meetup #6 - October 2015](http://dotnet.github.io/orleans/Presentations/VM-6%20-%20Orleans-Geo-Replication.pptx)
 
-* [Orleankka Functional API for Orleans - Virtual Meetup #7](http://dotnet.github.io/orleans/Presentations/(VM07) Orleankka Functional API for Orleans.pptx)
+* [Orleankka Functional API for Orleans - Virtual Meetup #7](http://dotnet.github.io/orleans/Presentations/(VM07)%20Orleankka%20Functional%20API%20for%20Orleans.pptx)
 
-* [Orleans Roadmap - Virtual Meetup #8 - January 2016](http://dotnet.github.io/orleans/Presentations/Orleans Roadmap 1-21-2016.pptx)
+* [Orleans Roadmap - Virtual Meetup #8 - January 2016](http://dotnet.github.io/orleans/Presentations/Orleans%20Roadmap%201-21-2016.pptx)
 
-* [Orleans Networking discussion- Virtual Meetup #8.5 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-8.5 - Orleans Networking.pptx)
+* [Orleans Networking discussion- Virtual Meetup #8.5 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-8.5%20-%20Orleans%20Networking.pptx)
 
-* [Orleans on Service Fabric - Virtual Meetup #9 Part 1 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-9 - Part.1 Orleans-on-Service-Fabric.pptx)
+* [Orleans on Service Fabric - Virtual Meetup #9 Part 1 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-9%20-%20Part.1%20Orleans-on-Service-Fabric.pptx)
 
-* [Orleans with YAMS - Virtual Meetup #9 Part 2 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-9 - Part.2 Orleans-with-YAMS.pptx)
+* [Orleans with YAMS - Virtual Meetup #9 Part 2 - February 2016](http://dotnet.github.io/orleans/Presentations/VM-9%20-%20Part.2%20Orleans-with-YAMS.pptx)
 
-* [Walk In Distributed Systems Park With Orleans](http://dotnet.github.io/orleans/Presentations/(FWDAYSKIEV2016) Walk.In.Distributed.Systems.Park.With.Orleans.pptx)
+* [Walk In Distributed Systems Park With Orleans](http://dotnet.github.io/orleans/Presentations/(FWDAYSKIEV2016)%20Walk.In.Distributed.Systems.Park.With.Orleans.pptx)


### PR DESCRIPTION
GH-pages does not support links with spaces so I've escaped them.