### PR TITLE
Allow placement strategies to specify deterministic activation ids

### DIFF
--- a/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
+++ b/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
@@ -10,5 +10,11 @@ namespace Orleans.Runtime
         /// the grain directory.
         /// </summary>
         public virtual bool IsUsingGrainDirectory => true;
+
+        /// <summary>
+        /// Returns a value indicating whether or not activations using this strategy must have deterministic activation ids.
+        /// If true then activations have activation ids equal to their grain id, otherwise activations are given unique ids.
+        /// </summary>
+        internal virtual bool IsDeterministicActivationId => false;
     }
 }

--- a/src/Orleans.Core/Placement/PlacementResult.cs
+++ b/src/Orleans.Core/Placement/PlacementResult.cs
@@ -6,9 +6,12 @@ namespace Orleans.Runtime
     internal class PlacementResult
     {
         public PlacementStrategy PlacementStrategy { get; private set; }
-        public bool IsNewPlacement { get { return PlacementStrategy != null; } }
+
+        public bool IsNewPlacement => PlacementStrategy != null;
+
         public ActivationId Activation { get; private set; }
         public SiloAddress Silo { get; private set; }
+
         /// <summary>
         /// Some storage providers need to know the grain type in order to read the state.
         /// The PlacementResult is generated based on the target grain type's policy, so the type
@@ -17,39 +20,40 @@ namespace Orleans.Runtime
         public string GrainType { get; private set; }
 
         private PlacementResult()
-        { }
+        {
+        }
 
         public static PlacementResult IdentifySelection(ActivationAddress address)
         {
-            return
-                new PlacementResult
-                    {
-                        Activation = address.Activation,
-                        Silo = address.Silo
-                    };
+            return new PlacementResult
+            {
+                Activation = address.Activation,
+                Silo = address.Silo
+            };
         }
 
-        public static PlacementResult
-            SpecifyCreation(
-                SiloAddress silo,
-                PlacementStrategy placement,
-                string grainType)
+        public static PlacementResult SpecifyCreation(
+            SiloAddress silo,
+            ActivationId activationId,
+            PlacementStrategy placement,
+            string grainType)
         {
             if (silo == null)
-                throw new ArgumentNullException("silo");
+                throw new ArgumentNullException(nameof(silo));
+            if (activationId == null)
+                throw new ArgumentNullException(nameof(activationId));
             if (placement == null)
-                throw new ArgumentNullException("placement");
+                throw new ArgumentNullException(nameof(placement));
             if (string.IsNullOrWhiteSpace(grainType))
-                throw new ArgumentException("'grainType' must contain a valid typename.");
+                throw new ArgumentException("'grainType' must contain a valid type name.", nameof(grainType));
 
-            return
-                new PlacementResult
-                    {
-                        Activation = ActivationId.NewId(),
-                        Silo = silo,
-                        PlacementStrategy = placement,
-                        GrainType = grainType
-                    };
+            return new PlacementResult
+            {
+                Activation = activationId,
+                Silo = silo,
+                PlacementStrategy = placement,
+                GrainType = grainType
+            };
         }
 
         public ActivationAddress ToAddress(GrainId grainId)
@@ -60,8 +64,7 @@ namespace Orleans.Runtime
         public override string ToString()
         {
             var placementStr = IsNewPlacement ? PlacementStrategy.ToString() : "*not-new*";
-            return String.Format("PlacementResult({0}, {1}, {2}, {3})",
-                Silo, Activation, placementStr, GrainType);
+            return $"PlacementResult({this.Silo}, {this.Activation}, {placementStr}, {this.GrainType})";
         }
     }
 }

--- a/src/Orleans.Runtime/Placement/PlacementDirectorsManager.cs
+++ b/src/Orleans.Runtime/Placement/PlacementDirectorsManager.cs
@@ -109,10 +109,25 @@ namespace Orleans.Runtime.Placement
                 throw new InvalidOperationException("Client grains are not activated using the placement subsystem.");
 
             var director = ResolveDirector(strategy);
+            var siloAddress = await director.OnAddActivation(strategy, target, context);
+            var grainTypeName = context.GetGrainTypeName(target.GrainIdentity.TypeCode);
+
+            ActivationId activationId;
+            if (strategy.IsDeterministicActivationId)
+            {
+                // Use the grain id as the activation id.
+                activationId = ActivationId.GetActivationId(((GrainId)target.GrainIdentity).Key);
+            }
+            else
+            {
+                activationId = ActivationId.NewId();
+            }
+
             return PlacementResult.SpecifyCreation(
-                await director.OnAddActivation(strategy, target, context), 
-                strategy, 
-                context.GetGrainTypeName(target.GrainIdentity.TypeCode));
+                siloAddress,
+                activationId,
+                strategy,
+                grainTypeName);
         }
 
         private void ResolveBuiltInStrategies()


### PR DESCRIPTION
When grains are placed using the (upcoming) Service Fabric Stateful Service strategy, there is no grain directory involvement and hence we need a mechanism to determine which activation id to use when routing messages.

This PR enables that functionality but keeps it *`internal`* so that it will only be exposed to the SF library for now. The reasoning here is that it's unlikely anyone else will need it and if someone stumbles upon this they may opt-in to it for their placement strategy without understanding the consequences.

If `PlacementStrategy.IsDeterministicActivationId` is `true`, then all activations for a particular grain will have an `ActivationId` whose `Key` is equal to the grain's `GrainId.Key`. If `false`, then no behavior changes and `ActivationId` is randomly generated.

Without this PR, initial calls to already-activated grains placed using `StatefulServicePlacement` will round-trip to the target silo using the incorrect generated `ActivationId` and the silo will need to forward those calls to the correct activation. The response message will invalidate the caller's routing cache, but will not specify the activation's new address, so the caller will continue to call using incorrect `ActivationId`s. This is *benign* but unpleasant and inefficient. Users would almost certainly complain about warnings and other garbage in their logs. It is also slower. This PR enables the first and subsequent call to succeed without any round-trips for routing info.

See #5073 under part 4:
> Changes to support activations which have a deterministic `ActivationId` (related to the above) so that a grain which is placed using `StatefulServicePlacement` has a fixed `ActivationId` which can be computed from its `GrainId` (i.e, 1:1 relationship). It's possible that this will be contentious, since previously an `ActivationId` was ephemeral. This change is important, though, because it lets us route calls without needing to learn the `ActivationId` from another source (the grain directory). This is implemented by adding an `IsDeterministicActivationId` property to `PlacementStrategy`, which is then used in `PlacementDirectorsManager.AddActivation`. (PR #5082)