### PR TITLE
Revert "Don't enforce reentrancy for one way requests" #4382

### DIFF
--- a/src/Orleans.Core/Messaging/CorrelationId.cs
+++ b/src/Orleans.Core/Messaging/CorrelationId.cs
@@ -78,7 +78,7 @@ namespace Orleans.Runtime
 
         public static bool operator !=(CorrelationId lhs, CorrelationId rhs)
         {
-            return (rhs?.id != lhs?.id);
+            return (rhs.id != lhs.id);
         }
 
         public int CompareTo(CorrelationId other)

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -244,12 +244,6 @@ namespace Orleans.Runtime
             }
         }
 
-        public CorrelationId CallChainId
-        {
-            get { return Headers.CallChainId; }
-            set { Headers.CallChainId = value; }
-        }
-
         public ActivationAddress SendingAddress
         {
             get { return sendingAddress ?? (sendingAddress = ActivationAddress.GetAddress(SendingSilo, SendingGrain, SendingActivation)); }
@@ -576,7 +570,6 @@ namespace Orleans.Runtime
             AppendIfExists(HeadersContainer.Headers.TARGET_ACTIVATION, sb, (m) => m.TargetActivation);
             AppendIfExists(HeadersContainer.Headers.TARGET_GRAIN, sb, (m) => m.TargetGrain);
             AppendIfExists(HeadersContainer.Headers.TARGET_OBSERVER, sb, (m) => m.TargetObserverId);
-            AppendIfExists(HeadersContainer.Headers.CALL_CHAIN_ID, sb, (m) => m.CallChainId);
             AppendIfExists(HeadersContainer.Headers.TARGET_SILO, sb, (m) => m.TargetSilo);
 
             return sb.ToString();
@@ -760,7 +753,6 @@ namespace Orleans.Runtime
                 TRANSACTION_INFO = 1 << 27,
                 IS_TRANSACTION_REQUIRED = 1 << 28,
 
-                CALL_CHAIN_ID = 1 << 29,
                 // Do not add over int.MaxValue of these.
             }
 
@@ -793,7 +785,6 @@ namespace Orleans.Runtime
             private RejectionTypes _rejectionType;
             private string _rejectionInfo;
             private Dictionary<string, object> _requestContextData;
-            private CorrelationId _callChainId;
             private readonly DateTime _localCreationTime;
 
             public HeadersContainer()
@@ -1073,15 +1064,6 @@ namespace Orleans.Runtime
                 }
             }
 
-            public CorrelationId CallChainId
-            {
-                get { return _callChainId; }
-                set
-                {
-                    _callChainId = value;
-                }
-            }
-
             internal Headers GetHeadersMask()
             {
                 Headers headers = Headers.NONE;
@@ -1122,7 +1104,6 @@ namespace Orleans.Runtime
                 headers = _rejectionType == default(RejectionTypes) ? headers & ~Headers.REJECTION_TYPE : headers | Headers.REJECTION_TYPE;
                 headers = string.IsNullOrEmpty(_rejectionInfo) ? headers & ~Headers.REJECTION_INFO : headers | Headers.REJECTION_INFO;
                 headers = _requestContextData == null || _requestContextData.Count == 0 ? headers & ~Headers.REQUEST_CONTEXT : headers | Headers.REQUEST_CONTEXT;
-                headers = _callChainId == null ? headers & ~Headers.CALL_CHAIN_ID : headers | Headers.CALL_CHAIN_ID;
                 headers = IsTransactionRequired ? headers | Headers.IS_TRANSACTION_REQUIRED : headers & ~Headers.IS_TRANSACTION_REQUIRED;
                 headers = _transactionInfo == null ? headers & ~Headers.TRANSACTION_INFO : headers | Headers.TRANSACTION_INFO;
                 return headers;
@@ -1249,11 +1230,6 @@ namespace Orleans.Runtime
                     WriteObj(context, typeof(GuidId), input.TargetObserverId);
                 }
 
-                if ((headers & Headers.CALL_CHAIN_ID) != Headers.NONE)
-                {
-                    writer.Write(input.CallChainId);
-                }
-
                 if ((headers & Headers.TARGET_SILO) != Headers.NONE)
                 {
                     writer.Write(input.TargetSilo);
@@ -1366,9 +1342,6 @@ namespace Orleans.Runtime
 
                 if ((headers & Headers.TARGET_OBSERVER) != Headers.NONE)
                     result.TargetObserverId = (Orleans.Runtime.GuidId)ReadObj(typeof(Orleans.Runtime.GuidId), context);
-
-                if ((headers & Headers.CALL_CHAIN_ID) != Headers.NONE)
-                    result.CallChainId = reader.ReadCorrelationId();
 
                 if ((headers & Headers.TARGET_SILO) != Headers.NONE)
                     result.TargetSilo = reader.ReadSiloAddress();

--- a/test/Grains/TestGrainInterfaces/IReentrancyGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IReentrancyGrain.cs
@@ -21,23 +21,6 @@ namespace UnitTests.GrainInterfaces
         Task<string> Two();
 
         Task SetSelf(INonReentrantGrain self);
-
-        Task<int> GetCounter();
-
-        Task IncrementCounter();
-
-        Task<int> GetCounterAndScheduleIncrement();
-
-        Task<int> Ping(int t);
-
-        Task<int> PingOther(INonReentrantGrain target, int t);
-
-        [AlwaysInterleave]
-        Task<int> PingSelfThroughOtherInterleaving(INonReentrantGrain target, int t);
-
-        Task ScheduleDelayedIncrement(INonReentrantGrain target, TimeSpan delay);
-
-        Task DoAsyncWork(TimeSpan waitTime, GrainCancellationToken gct);
     }
 
     public interface IMayInterleavePredicateGrain : IGrainWithIntegerKey

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.CodeGeneration;
@@ -40,8 +39,6 @@ namespace UnitTests.Grains
 
         private Logger logger;
 
-        private int counter;
-
         public override Task OnActivateAsync()
         {
             logger = this.GetLogger();
@@ -66,63 +63,10 @@ namespace UnitTests.Grains
             return result;
         }
 
-        public Task<int> GetCounter()
-        {
-            return Task.FromResult(counter);
-        }
-
-        public async Task<int> GetCounterAndScheduleIncrement()
-        {
-            Self.InvokeOneWay(grain => grain.IncrementCounter());
-            await Task.Delay(300);
-            return counter;
-        }
-
-        public Task IncrementCounter()
-        {
-            counter++;
-            return Task.CompletedTask;
-        }
-
         public Task SetSelf(INonReentrantGrain self)
         {
             logger.Info("SetSelf {0}", self);
             Self = self;
-            return Task.CompletedTask;
-        }
-
-        [AlwaysInterleave]
-        public Task<int> Ping(int t)
-        {
-            return Task.FromResult(t);
-        }
-
-        [AlwaysInterleave]
-        public Task<int> PingOther(INonReentrantGrain target, int t)
-        {
-            return target.Ping(t);
-        }
-
-        [AlwaysInterleave]
-        public Task<int> PingSelfThroughOtherInterleaving(INonReentrantGrain target, int t)
-        {
-            return target.PingOther(this, t);
-        }
-
-        public async Task DoAsyncWork(TimeSpan waitTime, GrainCancellationToken gct)
-        {
-            await Task.Delay(waitTime, gct.CancellationToken);
-        }
-
-        public Task ScheduleDelayedIncrement(INonReentrantGrain target, TimeSpan delay)
-        {
-            RegisterTimer(async o =>
-                {
-                    await target.IncrementCounter();
-                },
-                null,
-                delay,
-                TimeSpan.FromMilliseconds(-1));
             return Task.CompletedTask;
         }
     }

--- a/test/TesterInternal/ReentrancyTests.cs
+++ b/test/TesterInternal/ReentrancyTests.cs
@@ -127,41 +127,6 @@ namespace UnitTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
-        public async Task Callchain_Reentrancy_OneWayMessage_Disabled_2()
-        {
-            var grain = this.fixture.GrainFactory.GetGrain<INonReentrantGrain>(1);
-            await grain.SetSelf(grain);
-            var initialCounter = await grain.GetCounter();
-            var counter = await grain.GetCounterAndScheduleIncrement();
-            Assert.Equal(initialCounter, counter);
-            this.fixture.Logger.Info("Callchain_Reentrancy_OneWayMessage_Disabled_2 OK - no reentrancy.");
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
-        public async Task Callchain_Reentrancy_InterleavingSecondCall_Enabled()
-        {
-            var grain = fixture.GrainFactory.GetGrain<INonReentrantGrain>(0);
-            var target = fixture.GrainFactory.GetGrain<INonReentrantGrain>(1);
-            var gcts = new GrainCancellationTokenSource();
-            grain.DoAsyncWork(TimeSpan.FromHours(1), gcts.Token).Ignore();
-            var i = 1;
-            var pingResult = await grain.PingSelfThroughOtherInterleaving(target, i);
-            Assert.Equal(i, pingResult);
-            await gcts.Cancel();
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
-        public async Task Callchain_Reentrancy_TimerOrigin_Enabled()
-        {
-            var grain = fixture.GrainFactory.GetGrain<INonReentrantGrain>(0);
-            await grain.ScheduleDelayedIncrement(grain, TimeSpan.FromMilliseconds(1));
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
-            var counter = await grain.GetCounter();
-            var expected = 1;
-            Assert.Equal(expected, counter);
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public void Reentrancy_Deadlock_1()
         {
             List<Task> done = new List<Task>();


### PR DESCRIPTION
It seems that #4382 introduced some regressions (see #5080, #5059, maybe other weird behavior).

I propose we revert it, to be able to quickly publish a new 2.1 version. We can then work to bring it back in 2.2.0 once the issue is fixed.