### PR TITLE
Log warning when ClusterMembershipOptions.ValidateInitialConnectivity=true

### DIFF
--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -473,7 +473,7 @@ namespace Orleans.Runtime.MembershipService
                 else
                     logger.Warn(
                         ErrorCode.MembershipSendingPreJoinPing,
-                        $"${nameof(ClusterMembershipOptions.ValidateInitialConnectivity)} is set to false. This is NOT a supported value for production environment.");
+                        $"${nameof(ClusterMembershipOptions.ValidateInitialConnectivity)} is set to false. This is NOT recommended for a production environment.");
             }
             
             TableVersion next = table.Version.Next();

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -466,8 +466,15 @@ namespace Orleans.Runtime.MembershipService
             myEntry.Status = newStatus;
             myEntry.IAmAliveTime = now;
 
-            if (newStatus == SiloStatus.Active && this.clusterMembershipOptions.ValidateInitialConnectivity)
-                await GetJoiningPreconditionPromise(table);
+            if (newStatus == SiloStatus.Active)
+            {
+                if (this.clusterMembershipOptions.ValidateInitialConnectivity)
+                    await GetJoiningPreconditionPromise(table);
+                else
+                    logger.Warn(
+                        ErrorCode.MembershipSendingPreJoinPing,
+                        $"${nameof(ClusterMembershipOptions.ValidateInitialConnectivity)} is set to false. This is NOT a supported value for production environment.");
+            }
             
             TableVersion next = table.Version.Next();
             if (myEtag != null) // no previous etag for my entry -> its the first write to this entry, so insert instead of update.


### PR DESCRIPTION
While it can be fine to run with this setting set to true in test environment, it's generally a very bad idea to use it in production.

This PR just add a warning when a silo tries to join a cluster with this setting enabled.