### PR TITLE
Add GSI cache maintentance and tests

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IClusterGrainDirectory.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IClusterGrainDirectory.cs
@@ -95,5 +95,9 @@ namespace Orleans.SystemTargetInterfaces
         /// <param name="grainId"></param>
         Task ProcessDeletion(GrainId grainId);
 
+        /// <summary>
+        /// Called on remote clusters to ping availability of a silo and determine cluster id.
+        /// </summary>
+        Task<string> Ping();
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -136,7 +136,7 @@ namespace Orleans.Runtime.GrainDirectory
                     grainFactory, 
                     executorService,
                     loggerFactory);
-            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, grainFactory, multiClusterOracle, executorService, siloDetails, multiClusterOptions, loggerFactory);
+            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, grainFactory, multiClusterOracle, executorService, siloDetails, multiClusterOptions, loggerFactory, registrarManager);
 
             var primarySiloEndPoint = developmentClusterMembershipOptions.Value.PrimarySiloEndpoint;
             if (primarySiloEndPoint != null)

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/ClusterGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/ClusterGrainDirectory.cs
@@ -206,7 +206,12 @@ namespace Orleans.Runtime.GrainDirectory
             return router.DeleteGrainAsync(grainId, 0);
         }
 
-
-
+        /// <summary>
+        /// Called on remote clusters to ping availability of a silo and determine cluster id.
+        /// </summary>
+        public Task<string> Ping()
+        {
+            return Task.FromResult(clusterId);
+        }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -25,6 +25,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IMultiClusterOracle multiClusterOracle;
         private readonly ILocalSiloDetails siloDetails;
         private readonly MultiClusterOptions multiClusterOptions;
+        private readonly RegistrarManager registrarManager;
 
         // scanning the entire directory for doubtful activations is too slow.
         // therefore, we maintain a list of potentially doubtful activations on the side.
@@ -42,7 +43,8 @@ namespace Orleans.Runtime.GrainDirectory
             ExecutorService executorService,
             ILocalSiloDetails siloDetails,
             IOptions<MultiClusterOptions> multiClusterOptions,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            RegistrarManager registrarManager)
             : base(executorService, loggerFactory)
         {
             this.router = router;
@@ -52,6 +54,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.siloDetails = siloDetails;
             this.multiClusterOptions = multiClusterOptions.Value;
             this.period = multiClusterOptions.Value.GlobalSingleInstanceRetryInterval;
+            this.registrarManager = registrarManager;
             multiClusterOracle.SubscribeToMultiClusterConfigurationEvents(this);
             logger.Debug("GSIP:M GlobalSingleInstanceActivationMaintainer Started, Period = {0}", period);
         }
@@ -141,6 +144,12 @@ namespace Orleans.Runtime.GrainDirectory
                             .Select(id => new KeyValuePair<string, SiloAddress>(id, this.multiClusterOracle.GetRandomClusterGateway(id)))
                             .ToList();
 
+                        // validate entries that point to remote clusters
+                        router.Scheduler.QueueTask(
+                                  () => RunBatchedValidation(),
+                                  router.CacheValidator.SchedulingContext
+                              ).Wait();
+
                         if (!remoteClusters.Any(kvp => kvp.Value == null))
                         {
                             // all clusters have at least one gateway reporting.
@@ -179,6 +188,66 @@ namespace Orleans.Runtime.GrainDirectory
 
             return Task.CompletedTask;
         }
+
+        private Task RunBatchedValidation()
+        {
+            // organize remote references by silo
+            var allEntries = router.DirectoryPartition.GetItems();
+            var cachedEntries = FilterByMultiClusterStatus(allEntries, GrainDirectoryEntryStatus.Cached).ToList();
+            var entriesBySilo = new Dictionary<SiloAddress, List<KeyValuePair<GrainId, IGrainInfo>>>();
+
+            logger.Debug("GSIP:M validating {count} cache entries", cachedEntries.Count);
+
+            foreach (var entry in cachedEntries)
+            {
+                var silo = entry.Value.Instances.FirstOrDefault().Value.SiloAddress;
+                if (!entriesBySilo.TryGetValue(silo, out var list))
+                {
+                    list = entriesBySilo[silo] = new List<KeyValuePair<GrainId, IGrainInfo>>();
+                }
+                list.Add(entry);
+            }
+
+            // process by silo
+            var tasks = new List<Task>();
+            foreach (var kvp in entriesBySilo)
+            {
+                tasks.Add(RunBatchedValidation(kvp.Key, kvp.Value));
+            }
+            return Task.WhenAll(tasks);
+        }
+
+        private async Task RunBatchedValidation(SiloAddress silo, List<KeyValuePair<GrainId, IGrainInfo>> list)
+        {
+            var multiClusterConfig = this.multiClusterOracle.GetMultiClusterConfiguration();
+            string clusterId = null;
+
+            // if we are still in a multi-cluster try to find out which cluster the silo belongs to
+            if (multiClusterConfig != null)
+            {
+                try
+                {
+                    var validator = this.grainFactory.GetSystemTarget<IClusterGrainDirectory>(Constants.ClusterDirectoryServiceId, silo);
+                    clusterId = await validator.Ping();
+                }
+                catch { }
+            }
+
+            // if the silo could not be contacted or is not part of the multicluster, unregister
+            if (clusterId == null
+                || ! multiClusterConfig.Clusters.Contains(clusterId))
+            {
+                logger.Debug("GSIP:M removing {count} cache entries pointing to {silo}", list.Count, silo);
+
+                var registrar = registrarManager.GetRegistrar(GlobalSingleInstanceRegistration.Singleton);
+
+                foreach (var kvp in list)
+                {
+                    registrar.InvalidateCache(ActivationAddress.GetAddress(silo, kvp.Key, kvp.Value.Instances.FirstOrDefault().Key));
+                }
+            }
+        }
+
 
         private async Task RunBatchedActivationRequests(List<KeyValuePair<string, SiloAddress>> remoteClusters, List<GrainId> grains)
         {

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.GrainDirectory
             return this.GetRegistrar(strategy);
         }
 
-        private IGrainRegistrar GetRegistrar(IMultiClusterRegistrationStrategy strategy)
+        public IGrainRegistrar GetRegistrar(IMultiClusterRegistrationStrategy strategy)
         {
             IGrainRegistrar result;
             var strategyType = strategy.GetType();

--- a/src/Orleans.TestingHost/SiloHandle.cs
+++ b/src/Orleans.TestingHost/SiloHandle.cs
@@ -61,5 +61,10 @@ namespace Orleans.TestingHost
         {
             Dispose(false);
         }
+
+        public override string ToString()
+        {
+            return SiloAddress.ToString();
+        }
     }
 }

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -74,9 +74,9 @@ namespace Tests.GeoClusterTests
                 return toWait.GetResult();
             }
 
-            public void InjectMultiClusterConf(params string[] args)
+            public void InjectMultiClusterConf(string[] clusters, string comment = "", bool checkForLaggingSilos = true)
             {
-                systemManagement.InjectMultiClusterConfiguration(args).GetResult();
+                systemManagement.InjectMultiClusterConfiguration(clusters, comment, checkForLaggingSilos).GetResult();
             }
 
             IManagementGrain systemManagement;
@@ -130,7 +130,7 @@ namespace Tests.GeoClusterTests
                 await WaitForLivenessToStabilizeAsync();
 
                 // Configure multicluster
-                clients[0].InjectMultiClusterConf(cluster0, cluster1);
+                clients[0].InjectMultiClusterConf(new string[] { cluster0, cluster1 });
                 await WaitForMultiClusterGossipToStabilizeAsync(false);
             });
         }

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -496,7 +496,7 @@ namespace UnitTests.GeoClusterTests
             });
         }
 
-        [SkippableFact, TestCategory("Functional")
+        [SkippableFact, TestCategory("Functional")]
         public async Task CacheCleanup()
         {
             await RunWithTimeout("Start Clusters and Clients", 180 * 1000, () =>

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -217,9 +217,9 @@ namespace UnitTests.GeoClusterTests
             }
             StreamSubscriptionHandle<int> handle;
 
-            public void InjectClusterConfiguration(params string[] clusters)
+            public void InjectClusterConfiguration(string[] clusters, string comment = "", bool checkForLaggingSilos = true)
             {
-                systemManagement.InjectMultiClusterConfiguration(clusters).Wait();
+                systemManagement.InjectMultiClusterConfiguration(clusters, comment, checkForLaggingSilos).Wait();
             }
             IManagementGrain systemManagement;
             public string GetGrainRef(int i)
@@ -268,8 +268,15 @@ namespace UnitTests.GeoClusterTests
             lock (random)
                 return random.Next();
         }
+        private int[] Next(int count)
+        {
+            var result = new int[count];
+            lock (random)
+                for (int i = 0; i < count; i++)
+                    result[i] = random.Next();
+            return result;
+        }
 
-      
         private async Task SequentialCalls()
         {
             await Task.Yield();
@@ -448,7 +455,7 @@ namespace UnitTests.GeoClusterTests
             {
                 Action<ClusterConfiguration> c =
                   (cc) => { cc.Globals.DirectoryLazyDeregistrationDelay = TimeSpan.FromSeconds(5); };
-                return StartClustersAndClients(c, null, 1, 1);
+                return StartClustersAndClients(c, null, 2, 2);
             });
 
             await RunWithTimeout("BlockedDeact", 10 * 1000, async () =>
@@ -481,7 +488,128 @@ namespace UnitTests.GeoClusterTests
                 AssertEqual(1, val, gref);
                 var newid = Clients[1][0].GetRuntimeId(x);
                 WriteLog("{2} sees Grain {0} at {1}", gref, newid, ClusterNames[1]);
-                Assert.True(Clusters[ClusterNames[1]].Silos.First().SiloAddress.ToString() == newid);
+                Assert.Contains(newid, Clusters[ClusterNames[1]].Silos.Select(s => s.SiloAddress.ToString()));
+
+                // connect from cluster A
+                val = Clients[0][0].CallGrain(x);
+                AssertEqual(2, val, gref);
+            });
+        }
+
+        [SkippableFact, TestCategory("Functional")
+        public async Task CacheCleanup()
+        {
+            await RunWithTimeout("Start Clusters and Clients", 180 * 1000, () =>
+            {
+                Action<ClusterConfiguration> c =
+                  (cc) => {
+                  };
+                return StartClustersAndClients(c, null, 1, 1);
+            });
+
+            await RunWithTimeout("CacheCleanup", 1000000, async () =>
+            {
+                var x = Next();
+                var gref = Clients[0][0].GetGrainRef(x);
+
+                // put grain into cluster A 
+                var id = Clients[0][0].GetRuntimeId(x);
+
+                WriteLog("Grain {0} at {1}", gref, id);
+                Assert.Contains(Clusters[ClusterNames[0]].Silos, silo => silo.SiloAddress.ToString() == id);
+
+                // access the grain from B, causing
+                // causing entry to be installed in B's directory and/or B's directory caches
+                var id2 = Clients[1][0].GetRuntimeId(x);
+                AssertEqual(id2, id, gref);
+
+                // block communication from A to B
+                BlockAllClusterCommunication(ClusterNames[0], ClusterNames[1]);
+
+                // change multi-cluster configuration to be only { B }, i.e. exclude A
+                WriteLog($"Removing A from multi-cluster");
+                Clients[1][0].InjectClusterConfiguration(new string[] { ClusterNames[1] }, "exclude A", false);
+                WaitForMultiClusterGossipToStabilizeAsync(false).WaitWithThrow(TimeSpan.FromMinutes(System.Diagnostics.Debugger.IsAttached ? 60 : 1));
+
+                // give the cache cleanup process time to remove all cached references in B
+                await Task.Delay(40000);
+
+                // now try to access the grain from cluster B
+                // if everything works correctly this should succeed, creating a new instances on B locally
+                // (if invalid caches were not removed this times out)
+                WriteLog("Grain {0} doubly-activating.", gref);
+                var val = Clients[1][0].CallGrain(x);
+                AssertEqual(1, val, gref);
+                var newid = Clients[1][0].GetRuntimeId(x);
+                WriteLog("{2} sees Grain {0} at {1}", gref, newid, ClusterNames[1]);
+                Assert.Contains(newid, Clusters[ClusterNames[1]].Silos.Select(s => s.SiloAddress.ToString()));
+            });
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task CacheCleanupMultiple()
+        {
+            await RunWithTimeout("Start Clusters and Clients", 180 * 1000, () =>
+            {
+                Action<ClusterConfiguration> c =
+                  (cc) => {
+                  };
+                return StartClustersAndClients(c, null, 3, 3);
+            });
+
+            await RunWithTimeout("CacheCleanupMultiple", 1000000, async () =>
+            {
+                int count = 100;
+
+                var grains = Next(count);
+                var grefs = grains.Select((x) => Clients[0][0].GetGrainRef(x)).ToList();
+
+                // put grains into cluster A 
+                var ids = grains.Select((x,i) => Clients[0][i % 3].GetRuntimeId(x)).ToList();
+                WriteLog($"{count} Grains activated on A");
+                for (int i = 0; i < count; i++ )
+                   Assert.Contains(Clusters[ClusterNames[0]].Silos, silo => silo.SiloAddress.ToString() == ids[i]);
+
+                // access all the grains living in A from all the clients of B
+                // causing  entries to be installed in B's directory and in B's directory caches
+                for (int j = 0; j < 3; j++)
+                {
+                    var ids2 = grains.Select((x) => Clients[1][j].GetRuntimeId(x)).ToList();
+                    for (int i = 0; i < count; i++)
+                        AssertEqual(ids2[i], ids[i], grefs[i]);
+                }
+                WriteLog($"{count} Grain references cached in B");
+
+                // block communication from A to B
+                BlockAllClusterCommunication(ClusterNames[0], ClusterNames[1]);
+
+                // change multi-cluster configuration to be only { B }, i.e. exclude A
+                WriteLog($"Removing A from multi-cluster");
+                Clients[1][0].InjectClusterConfiguration(new string[] { ClusterNames[1] }, "exclude A", false);
+                WaitForMultiClusterGossipToStabilizeAsync(false).WaitWithThrow(TimeSpan.FromMinutes(System.Diagnostics.Debugger.IsAttached ? 60 : 1));
+
+                // give the cache cleanup process time to remove all cached references in B
+                await Task.Delay(50000);
+
+                // call the grains from random clients of B
+                // if everything works correctly this should succeed, creating new instances on B locally
+                // (if invalid caches were not removed this times out)
+                var vals = grains.Select((x) => Clients[1][Math.Abs(x) % 3].CallGrain(x)).ToList();
+                for (int i = 0; i < count; i++)
+                    AssertEqual(1, vals[i], grefs[i]);
+
+                // check the placement of the new grains, from client 0
+                var newids = grains.Select((x) => Clients[1][0].GetRuntimeId(x)).ToList();
+                for (int i = 0; i < count; i++)
+                    Assert.Contains(newids[i], Clusters[ClusterNames[1]].Silos.Select(s => s.SiloAddress.ToString()));
+
+                // check the placement of these same grains, from other clients
+                for (int j = 1; j < 3; j++)
+                {
+                    var ids2 = grains.Select((x) => Clients[1][j].GetRuntimeId(x)).ToList();
+                    for (int i = 0; i < count; i++)
+                        AssertEqual(ids2[i], newids[i], grefs[i]);
+                }
             });
         }
     }


### PR DESCRIPTION
Fixes the problem where a global-single-instance grain becomes permanently unavailable on a cluster because its directory entry points to a remote cluster that is no longer responsive, even if that cluster has been removed from the multi-cluster.

I added tests to expose the problem behavior, and code that implements a fix.

**Tests:**

The tests use two clusters A and B, create a grain in A, then access it from B (which means cluster B now caches the reference to the grain in A). Then I block communication from A to B (to simulate cluster A going down), and change the multi-cluster configuration to remove A from the multi-cluster (to simulate an admin responding to the outage). Then I try to access the grain from B. Without the fix, this times out trying to contact a non-responding silo in cluster A. With the fix (and if I wait long enough for the cache cleanup to complete before trying to access the grain) this succeeds because the dangling cached reference was removed.

The difference between the two tests is scale (number of grains, silos, clients).

**Fix:**

I added code that validates GSI remote references stored in the grain directory. It is triggered both periodically (30s default), and also immediately after a multi-cluster configuration change.

The validation logic is pretty simple: To check if a reference to a remote cluster should be kept, it pings the silo, and the silo responds with its cluster ID (this is not a throughput hazard… the whole validation happens at a low period, there is only one ping per remote silo, and the ping is a tiny message).

If the response indicates the cluster is not part of the configuration, OR if the response times out, we remove the GSI remote reference from the grain directory. 

This is always safe from a correctness perspective (the reference is logically just a cache), and from a performance perspective, I believe it is ok also: if things are in flux or we timed out for random reasons, it just means the cache may be removed sooner than necessary, but still not “extremely too soon” since this whole validation triggers at a modest period (30s default). 

