### PR TITLE
Fix intermittent failures of MultiClusterRegistrationTests.ThreeClusterBattery

### DIFF
--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -621,10 +621,13 @@ namespace Orleans.Runtime
         }
 
         // Forwarding is used by the receiver, usually when it cannot process the message and forwards it to another silo to perform the processing
-        // (got here due to outdated cache, silo is shutting down/overloaded, ...).
+        // (got here due to duplicate activation, outdated cache, silo is shutting down/overloaded, ...).
         private static bool MayForward(Message message, SiloMessagingOptions messagingOptions)
         {
-            return message.ForwardCount < messagingOptions.MaxForwardCount;
+            return message.ForwardCount < messagingOptions.MaxForwardCount
+                // allow one more forward hop for multi-cluster case
+                + (message.IsReturnedFromRemoteCluster ? 1 : 0)
+                ;
         }
 
         /// <summary>

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.GeoClusterTests
                 await t;
         }
 
-        [SkippableFact(Skip= "https://github.com/dotnet/orleans/issues/4265"), TestCategory("Functional")]
+        [SkippableFact(), TestCategory("Functional")]
         public async Task ThreeClusterBattery()
         {
 
@@ -369,7 +369,6 @@ namespace UnitTests.GeoClusterTests
             Clients[0][0].GetRuntimeId(x);
             WriteLog("{0} created grain", gref);
 
-            var listeners = new List<ClusterTestListener>();
             var promises = new List<Task<int>>();
 
             // create an observer on each client
@@ -384,8 +383,8 @@ namespace UnitTests.GeoClusterTests
                         WriteLog("{3} observedcall {2} on Client[{0}][{1}]", i, j, num, gref);
                         promise.TrySetResult(num);
                     });
-                    promises.Add(promise.Task);
-                    listeners.Add(listener);
+                    lock(promises)
+                        promises.Add(promise.Task);
                     Clients[i][j].Subscribe(x, listener);
                     WriteLog("{2} subscribed to Client[{0}][{1}]", i, j, gref);
                 }
@@ -410,7 +409,6 @@ namespace UnitTests.GeoClusterTests
             Clients[0][0].EnableStreamNotifications(x);
             WriteLog("{0} created grain", gref);
 
-            var listeners = new List<ClusterTestListener>();
             var promises = new List<Task<int>>();
 
             // create an observer on each client
@@ -425,8 +423,8 @@ namespace UnitTests.GeoClusterTests
                         WriteLog("{3} observedcall {2} on Client[{0}][{1}]", i, j, num, gref);
                         promise.TrySetResult(num);
                     });
-                    promises.Add(promise.Task);
-                    listeners.Add(listener);
+                    lock (promises)
+                        promises.Add(promise.Task);
                     Clients[i][j].SubscribeStream(x, listener);
                     WriteLog("{2} subscribed to Client[{0}][{1}]", i, j, gref);
                 }


### PR DESCRIPTION
Fixes issue #4265.

- adjust the forward limit on messages to properly account for GSI case.
- fix a race condition in the testcase that occasionally caused the test to fail.
- re-enable the test that was being skipped.






