### PR TITLE
[Docs] Add unit-testing guide to the menu

### DIFF
--- a/src/Documentation/implementation/toc.yml
+++ b/src/Documentation/implementation/toc.yml
@@ -8,3 +8,5 @@
   href: streams_implementation.md
 - name: Load Balancing
   href: load_balancing.md
+- name: Unit Testing
+  href: testing.md

--- a/src/Documentation/toc.yml
+++ b/src/Documentation/toc.yml
@@ -37,5 +37,3 @@
   href: implementation/toc.yml
 - name: Resources
   href: resources/toc.yml
-
-  


### PR DESCRIPTION
PR contains the following changes:
+ unit-testing guide for v2 version has been added to the menu;
+ trailing whitespaces have been removed from the testing document;
+ the example with mocks has been fixed to reflect worker grain mock + fixed typo in `verify` method;