### PR TITLE
Add TimerManager as Task.Delay replacement

### DIFF
--- a/src/Orleans.Core/Async/BatchWorker.cs
+++ b/src/Orleans.Core/Async/BatchWorker.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
+using Orleans.Timers.Internal;
 
 namespace Orleans
 {
@@ -81,7 +82,7 @@ namespace Orleans
 
         private async Task ScheduleNotify(DateTime time, DateTime now)
         {
-            await Task.Delay(time - now);
+            await TimerManager.Delay(time - now);
 
             if (scheduledNotify == time)
             {

--- a/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
+++ b/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
@@ -1,0 +1,54 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Orleans.Threading
+{
+    /// <summary>
+    /// Lightweight recursive lock.
+    /// </summary>
+    internal sealed class RecursiveInterlockedExchangeLock
+    {
+        private const int Unlocked = -1;
+        private int lockState = Unlocked;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGet()
+        {
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+            var previousValue = Interlocked.CompareExchange(ref this.lockState, threadId, Unlocked);
+            return previousValue == Unlocked || previousValue == threadId;
+        }
+        
+        /// <summary>
+        /// Acquire the lock, blocking the thread if necessary.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Get()
+        {
+            if (this.TryGet())
+            {
+                return;
+            }
+
+            Spin();
+
+            void Spin()
+            {
+                var spinWait = new SpinWait();
+                while (!this.TryGet())
+                {
+                    spinWait.SpinOnce();
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Release() => Interlocked.Exchange(ref this.lockState, Unlocked);
+
+        public override string ToString()
+        {
+            var state = Volatile.Read(ref this.lockState);
+            return state == Unlocked ? "Unlocked" : $"Locked by Thread {state}";
+        }
+    }
+}

--- a/src/Orleans.Core/Timers/TimerManager.cs
+++ b/src/Orleans.Core/Timers/TimerManager.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Threading;
+
+namespace Orleans.Timers
+{
+    public static class TimerManager
+    {
+        public static Task Delay(TimeSpan timeout) => DelayUntil(DateTime.UtcNow + timeout);
+
+        public static Task DelayUntil(DateTime dueTime)
+        {
+            var result = new DelayTimer(dueTime);
+            TimerManager<DelayTimer>.Register(result);
+            return result.Completion;
+        }
+
+        private sealed class DelayTimer : ITimerCallback, ILinkedListElement<DelayTimer>
+        {
+            private readonly TaskCompletionSource<int> completion =
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public DelayTimer(DateTime dueTime)
+            {
+                this.DueTime = dueTime;
+            }
+
+            public Task Completion => this.completion.Task;
+
+            public DateTime DueTime { get; }
+
+            public bool IsCanceled => false;
+
+            public void OnTimeout() => this.completion.TrySetResult(0);
+
+            DelayTimer ILinkedListElement<DelayTimer>.Next { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Manages timers of a specified type, firing them after they expire.
+    /// </summary>
+    /// <typeparam name="T">The timer type.</typeparam>
+    internal static class TimerManager<T> where T : class, ITimerCallback, ILinkedListElement<T>
+    {
+        /// <summary>
+        /// The maximum number of times a queue can be denied servicing before servicing is mandatory.
+        /// </summary>
+        private const int MaxStarvation = 2;
+
+        /// <summary>
+        /// The number of milliseconds between timer servicing ticks.
+        /// </summary>
+        private const int TimerTickMilliseconds = 50;
+
+        /// <summary>
+        /// Lock protecting <see cref="allQueues"/>.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly object AllQueuesLock = new object();
+
+        // ReSharper disable once StaticMemberInGenericType
+        // ReSharper disable once NotAccessedField.Local
+        private static readonly Timer QueueChecker;
+
+        /// <summary>
+        /// Collection of all thread-local timer queues.
+        /// </summary>
+        private static ThreadLocalQueue[] allQueues = new ThreadLocalQueue[16];
+
+        /// <summary>
+        /// The queue for the current thread.
+        /// </summary>
+        [ThreadStatic]
+        private static ThreadLocalQueue threadLocalQueue;
+
+        static TimerManager()
+        {
+            var timerPeriod = TimeSpan.FromMilliseconds(TimerTickMilliseconds);
+            QueueChecker = new Timer(_ => CheckQueues(), null, timerPeriod, timerPeriod);
+        }
+
+        /// <summary>
+        /// Registers a timer.
+        /// </summary>
+        public static void Register(T timer)
+        {
+            ExpiredTimers expired = null;
+            var queue = EnsureCurrentThreadHasQueue();
+            queue.Lock.Get();
+
+            try
+            {
+                queue.AddTail(timer);
+
+                if (queue.StarvationCount >= MaxStarvation)
+                {
+                    // If the queue is too starved, service it now.
+                    expired = new ExpiredTimers();
+                    CheckQueueInLock(queue, DateTime.UtcNow, expired);
+                    Interlocked.Exchange(ref queue.StarvationCount, 0);
+                }
+            }
+            finally
+            {
+                queue.Lock.Release();
+
+                // Fire expired timers outside of lock.
+                expired?.FireTimers();
+            }
+        }
+        
+        private static void CheckQueues()
+        {
+            var expired = new ExpiredTimers();
+            var now = DateTime.UtcNow;
+            try
+            {
+                foreach (var queue in allQueues)
+                {
+                    if (queue == null)
+                    {
+                        continue;
+                    }
+
+                    if (!queue.Lock.TryGet())
+                    {
+                        // Check for starvation.
+                        if (Interlocked.Increment(ref queue.StarvationCount) > MaxStarvation)
+                        {
+                            // If the queue starved, block until the lock can be acquired.
+                            queue.Lock.Get();
+                            Interlocked.Exchange(ref queue.StarvationCount, 0);
+                        }
+                        else
+                        {
+                            // Move on to the next queue.
+                            continue;
+                        }
+                    }
+
+                    try
+                    {
+                        CheckQueueInLock(queue, now, expired);
+                    }
+                    finally
+                    {
+                        queue.Lock.Release();
+                    }
+                }
+            }
+            finally
+            {
+                // Expire timers outside of the loop and outside of any lock.
+                expired.FireTimers();
+            }
+        }
+
+        private static void CheckQueueInLock(ThreadLocalQueue queue, DateTime now, ExpiredTimers expired)
+        {
+            var previous = default(T);
+
+            for (var current = queue.Head; current != null; current = current.Next)
+            {
+                if (current.IsCanceled)
+                {
+                    // Dequeue and discard.
+                    queue.Remove(previous, current);
+                }
+                else if (current.DueTime < now)
+                {
+                    // Dequeue and add to expired list for later execution.
+                    queue.Remove(previous, current);
+                    expired.AddTail(current);
+                }
+                else
+                {
+                    // If the current item wasn't removed, update previous.
+                    previous = current;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the queue for the current thread, creating and registering one if it does not yet exist.
+        /// </summary>
+        /// <returns>The current thread's <see cref="ThreadLocalQueue"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ThreadLocalQueue EnsureCurrentThreadHasQueue()
+        {
+            return threadLocalQueue ?? (threadLocalQueue = InitializeThreadLocalQueue());
+
+            ThreadLocalQueue InitializeThreadLocalQueue()
+            {
+                var threadLocals = new ThreadLocalQueue();
+                while (true)
+                {
+                    lock (AllQueuesLock)
+                    {
+                        var queues = Volatile.Read(ref allQueues);
+
+                        // Find a spot in the existing array to register this thread.
+                        for (var i = 0; i < queues.Length; i++)
+                        {
+                            if (Volatile.Read(ref queues[i]) == null)
+                            {
+                                Volatile.Write(ref queues[i], threadLocals);
+                                return threadLocals;
+                            }
+                        }
+
+                        // The existing array is full, so copy all values to a new, larger array and register this thread.
+                        var newQueues = new ThreadLocalQueue[queues.Length * 2];
+                        Array.Copy(queues, newQueues, queues.Length);
+                        newQueues[queues.Length] = threadLocals;
+                        Volatile.Write(ref allQueues, newQueues);
+                        return threadLocals;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Holds per-thread timer data.
+        /// </summary>
+        private sealed class ThreadLocalQueue : ILinkedList<T>
+        {
+            public readonly RecursiveInterlockedExchangeLock Lock = new RecursiveInterlockedExchangeLock();
+
+            /// <summary>
+            /// The number of times that this queue has been starved since it was last serviced.
+            /// </summary>
+            public int StarvationCount;
+
+            public T Head { get; set; }
+
+            public T Tail { get; set; }
+        }
+
+        /// <summary>
+        /// Holds timers that have expired and should be fired.
+        /// </summary>
+        private sealed class ExpiredTimers : ILinkedList<T>
+        {
+            public T Head { get; set; }
+
+            public T Tail { get; set; }
+
+            public void FireTimers()
+            {
+                var current = this.Head;
+                while (current != null)
+                {
+                    try
+                    {
+                        current.OnTimeout();
+                    }
+                    catch
+                    {
+                        // Ignore any exceptions during firing.
+                    }
+
+                    current = current.Next;
+                }
+            }
+        }
+    }
+
+    internal interface ITimerCallback
+    {
+        /// <summary>
+        /// The UTC time when this timer is due.
+        /// </summary>
+        DateTime DueTime { get; }
+
+        bool IsCanceled { get; }
+
+        void OnTimeout();
+    }
+
+    /// <summary>
+    /// Represents a linked list.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    internal interface ILinkedList<T> where T : ILinkedListElement<T>
+    {
+        /// <summary>
+        /// Gets or sets the first element in the list.
+        /// This value must never be accessed or modified by user code.
+        /// </summary>
+        T Head { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last element in the list.
+        /// This value must never be accessed or modified by user code.
+        /// </summary>
+        T Tail { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an element in a linked list.
+    /// </summary>
+    /// <typeparam name="TSelf">Self-type. The type implementing this interface.</typeparam>
+    internal interface ILinkedListElement<TSelf> where TSelf : ILinkedListElement<TSelf>
+    {
+        /// <summary>
+        /// The next element in the list.
+        /// This value must never be accessed or modified by user code.
+        /// </summary>
+        TSelf Next { get; set; }
+    }
+
+    internal static class LinkedList
+    {
+        /// <summary>
+        /// Appends an item to the tail of a linked list.
+        /// </summary>
+        /// <param name="list">The linked list.</param>
+        /// <param name="element">The element to append.</param>
+        public static void AddTail<TList, TElement>(this TList list, TElement element)
+            where TList : class, ILinkedList<TElement> where TElement : class, ILinkedListElement<TElement>
+        {
+            // If this is the first element, update the head.
+            if (list.Head is null) list.Head = element;
+
+            // If this is not the first element, update the current tail.
+            var prevTail = list.Tail;
+            if (!(prevTail is null)) prevTail.Next = element;
+
+            // Update the tail.
+            list.Tail = element;
+        }
+
+        /// <summary>
+        /// Removes an item from a linked list.
+        /// </summary>
+        /// <param name="list">The linked list.</param>
+        /// <param name="previous">The element before <paramref name="current"/>.</param>
+        /// <param name="current">The element to remove.</param>
+        public static void Remove<TList, TElement>(this TList list, TElement previous, TElement current)
+            where TList : class, ILinkedList<TElement> where TElement : class, ILinkedListElement<TElement>
+        {
+            var next = current.Next;
+
+            // If not removing the first element, point the previous element at the next element.
+            if (!(previous is null)) previous.Next = next;
+
+            // If removing the first element, point the tail at the next element.
+            if (ReferenceEquals(list.Head, current))
+            {
+                list.Head = next ?? previous;
+            }
+
+            // If removing the last element, point the tail at the previous element.
+            if (ReferenceEquals(list.Tail, current))
+            {
+                list.Tail = previous;
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Timers/TimerManager.cs
+++ b/src/Orleans.Core/Timers/TimerManager.cs
@@ -4,11 +4,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Threading;
 
-namespace Orleans.Timers
+namespace Orleans.Timers.Internal
 {
-    public static class TimerManager
+    public interface ITimerManager
     {
-        public static Task Delay(TimeSpan timeout) => DelayUntil(DateTime.UtcNow + timeout);
+        Task Delay(TimeSpan timeSpan);
+    }
+
+    internal class TimerManagerImpl : ITimerManager
+    {
+        public Task Delay(TimeSpan timeSpan) => TimerManager.Delay(timeSpan);
+    }
+
+    internal static class TimerManager
+    {
+        public static Task Delay(TimeSpan timeSpan) => DelayUntil(DateTime.UtcNow + timeSpan);
 
         public static Task DelayUntil(DateTime dueTime)
         {

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -38,6 +38,7 @@ using System;
 using System.Reflection;
 using System.Linq;
 using Microsoft.Extensions.Options;
+using Orleans.Timers.Internal;
 
 namespace Orleans.Hosting
 {
@@ -297,6 +298,8 @@ namespace Orleans.Hosting
 
             // Validate all CollectionAgeLimit values for the right configuration.
             services.AddTransient<IConfigurationValidator, CollectionAgeLimitValidator>();
+
+            services.TryAddSingleton<ITimerManager, TimerManagerImpl>();
         }
     }
 }

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -9,6 +9,7 @@ using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using Orleans.Storage;
 using Orleans.Configuration;
+using Orleans.Timers.Internal;
 
 namespace Orleans.Transactions.State
 {
@@ -53,7 +54,8 @@ namespace Orleans.Transactions.State
             ITransactionalStateStorage<TState> storage,
             JsonSerializerSettings serializerSettings,
             IClock clock,
-            ILogger logger)
+            ILogger logger,
+            ITimerManager timerManager)
         {
             this.options = options.Value;
             this.resource = resource;
@@ -63,7 +65,7 @@ namespace Orleans.Transactions.State
             this.logger = logger;
             this.storageWorker = new BatchWorkerFromDelegate(StorageWork);
             this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger);
-            this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger);
+            this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager);
             this.unprocessedPreparedMessages = new Dictionary<DateTime, PreparedMessages>();
             this.commitQueue = new CommitQueue<TState>();
             this.readyTask = Task.CompletedTask;

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -11,6 +11,7 @@ using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.State;
 using Orleans.Configuration;
+using Orleans.Timers.Internal;
 
 namespace Orleans.Transactions
 {
@@ -219,7 +220,8 @@ namespace Orleans.Transactions
             Action deactivate = () => grainRuntime.DeactivateOnIdle(context.GrainInstance);
             var options = this.context.ActivationServices.GetRequiredService<IOptions<TransactionalStateOptions>>();
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
-            this.queue = new TransactionQueue<TState>(options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger);
+            var timerManager = this.context.ActivationServices.GetRequiredService<ITimerManager>();
+            this.queue = new TransactionQueue<TState>(options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger, timerManager);
 
             setupResourceFactory(this.context, this.config.StateName, queue);
 

--- a/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
+++ b/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Orleans.Configuration;
+using Orleans.Timers.Internal;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.State;
 
@@ -21,8 +22,9 @@ namespace Orleans.Transactions.TOC
             ITransactionalStateStorage<TransactionCommitter<TService>.OperationState> storage,
             JsonSerializerSettings serializerSettings,
             IClock clock,
-            ILogger logger)
-            : base(options, resource, deactivate, storage, serializerSettings, clock, logger)
+            ILogger logger,
+            ITimerManager timerManager)
+            : base(options, resource, deactivate, storage, serializerSettings, clock, logger, timerManager)
         {
             this.service = service;
         }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -9,6 +9,7 @@ using Orleans.CodeGeneration;
 using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Timers.Internal;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.State;
 using Orleans.Transactions.TOC;
@@ -146,7 +147,8 @@ namespace Orleans.Transactions
             var options = this.context.ActivationServices.GetRequiredService<IOptions<TransactionalStateOptions>>();
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
             TService service = this.context.ActivationServices.GetRequiredServiceByName<TService>(this.config.ServiceName);
-            this.queue = new TocTransactionQueue<TService>(service, options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger);
+            var timerManager = this.context.ActivationServices.GetRequiredService<ITimerManager>();
+            this.queue = new TocTransactionQueue<TService>(service, options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger, timerManager);
 
             // Add transaction manager factory to the grain context
             this.context.RegisterResourceFactory<ITransactionManager>(this.config.ServiceName, () => new TransactionManager<OperationState>(this.queue));


### PR DESCRIPTION
This is an alternative timer implementation for use in Transactions to reduce the lock contention on the `Timer` queue caused by `Task.Delay` inside transaction management code.

How it works:

* Each thread which registers a timer does so by adding a `DelayTimer` node to a linked list of `DelayTimer` instances. That list is stored in a thread local structure, `ThreadLocalQueue`.
* `TimerManager` maintains an array of all threads' `ThreadLocalQueue` instances in `allQueues`.
* Every 50 milliseconds, a .NET `Timer` (`QueueChecker`) fires to service all queues via `CheckQueues()`. The timer enumerates all thread-local queues in `allQueues`. For each queue:
  * Try to obtain a lock on the queue (using `queue.Lock`)
  * If the lock fails, increment `queue.Starvation` and if the queue is starved then spin until a lock can be obtained.
  * Enumerate all timers in the queue and move the expired timers into a new list (`ExpiredTimers`).
* Once all queues have been checked, enumerate the `ExpiredTimers` list and fire each one
* Discard the list of fired timers (all timers are one-shot)

This code is based on earlier work by @dVakulen in #2060