### PR TITLE
[WIP] Simplified BatchWorker

### DIFF
--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -17,13 +17,13 @@ namespace Orleans.Transactions.State
     {
         private readonly TransactionalStateOptions options;
         private readonly ParticipantId me;
-        private readonly BatchWorker storageWorker;
+        private readonly SimpleBatchWorkerFromDelegate storageWorker;
         private readonly Func<StorageBatch<TState>> getStorageBatch;
         private readonly ILogger logger;
         private readonly ITimerManager timerManager;
         private readonly HashSet<Guid> pending;
 
-        public ConfirmationWorker(IOptions<TransactionalStateOptions> options, ParticipantId me, BatchWorker storageWorker, Func<StorageBatch<TState>> getStorageBatch, ILogger logger, ITimerManager timerManager)
+        public ConfirmationWorker(IOptions<TransactionalStateOptions> options, ParticipantId me, SimpleBatchWorkerFromDelegate storageWorker, Func<StorageBatch<TState>> getStorageBatch, ILogger logger, ITimerManager timerManager)
         {
             this.options = options.Value;
             this.me = me;

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -15,8 +15,8 @@ namespace Orleans.Transactions.State
     {
         private readonly TransactionalStateOptions options;
         private readonly TransactionQueue<TState> queue;
-        private BatchWorker lockWorker;
-        private BatchWorker storageWorker;
+        private SimpleBatchWorkerFromDelegate lockWorker;
+        private SimpleBatchWorkerFromDelegate storageWorker;
         private readonly ILogger logger;
 
         // the linked list of lock groups
@@ -47,14 +47,14 @@ namespace Orleans.Transactions.State
         public ReadWriteLock(
             IOptions<TransactionalStateOptions> options,
             TransactionQueue<TState> queue,
-            BatchWorker storageWorker,
+            SimpleBatchWorkerFromDelegate storageWorker,
             ILogger logger)
         {
             this.options = options.Value;
             this.queue = queue;
             this.storageWorker = storageWorker;
             this.logger = logger;
-            this.lockWorker = new BatchWorkerFromDelegate(LockWork);
+            this.lockWorker = new SimpleBatchWorkerFromDelegate(LockWork);
         }
 
         public async Task<TResult> EnterLock<TResult>(Guid transactionId, DateTime priority,

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -20,7 +20,7 @@ namespace Orleans.Transactions.State
         private readonly ParticipantId resource;
         private readonly Action deactivate;
         private readonly ITransactionalStateStorage<TState> storage;
-        private readonly BatchWorker storageWorker;
+        private readonly SimpleBatchWorkerFromDelegate storageWorker;
         protected readonly ILogger logger;
         private readonly ConfirmationWorker<TState> confirmationWorker;
         private CommitQueue<TState> commitQueue;
@@ -63,7 +63,7 @@ namespace Orleans.Transactions.State
             this.storage = storage;
             this.Clock = new CausalClock(clock);
             this.logger = logger;
-            this.storageWorker = new BatchWorkerFromDelegate(StorageWork);
+            this.storageWorker = new SimpleBatchWorkerFromDelegate(StorageWork);
             this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger);
             this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager);
             this.unprocessedPreparedMessages = new Dictionary<DateTime, PreparedMessages>();


### PR DESCRIPTION
This implements a simpler/cheaper alternative to `BatchWorker` used in Transactions, Event Sourcing, and Multi-clustering.

The implementation sits alongside the existing implementation and only Transactions code is modified to use it (other consumers will still use the original `BatchWorker`).

The purpose of the batch worker is to deduplicate requests to process some backlog of work. It does this through its `Notify()` and `Notify(DateTime dueTime)` interface.

* `Notify()` schedules work immediately and if the worker is currently processing requests then it ensures that the worker will loop at least one more time to process the most recent request.
* `Notify(DateTime dueTime)` calls `Notify()` at the specified time.