### PR TITLE
Don't throw SiloUnavailableException when a gateway stops

### DIFF
--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -72,7 +72,6 @@ namespace Orleans.Messaging
             IsLive = false;
             receiver.Stop();
             base.Stop();
-            MsgCenter.RuntimeClient.BreakOutstandingMessagesToDeadSilo(Silo);
             Socket s;
             lock (Lockable)
             {

--- a/test/Tester/MembershipTests/SilosStopTests.cs
+++ b/test/Tester/MembershipTests/SilosStopTests.cs
@@ -60,19 +60,6 @@ namespace UnitTests.MembershipTests
             await Assert.ThrowsAsync<SiloUnavailableException>(() => promise);
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Liveness")]
-        public async Task SiloUngracefulShutdown_ClientOutstandingRequestsBreak()
-        {
-            var grain = GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
-            var task = grain.LongRunningTask(true, TimeSpan.FromSeconds(7));
-            await Task.Delay(500);
-
-            await HostedCluster.KillSiloAsync(HostedCluster.SecondarySilos[0]);
-            await HostedCluster.KillSiloAsync(HostedCluster.Primary);
-
-            await Assert.ThrowsAsync<SiloUnavailableException>(() => task);
-        }
-
         private async Task<ILongRunningTaskGrain<bool>> GetGrainOnTargetSilo(SiloHandle siloHandle)
         {
             const int maxRetry = 10;


### PR DESCRIPTION
`GatewayConnection` is supposed to reroute not-yet-sent message to another Gateway, and messages already sent should be forwarded by the silos that is shutting down.

Calling `MsgCenter.RuntimeClient.BreakOutstandingMessagesToDeadSilo` cause to throw `SiloUnavailbleException` to ALL pending messages.

We shouldn't do this. Not doing it may cause some timeouts, but I think it's better to gice a chance to pending request to complete instead of throwing an exception for all of them.