### PR TITLE
Optimize memory allocation with custom EqualityComparer

### DIFF
--- a/src/Orleans.Core/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans.Core/Serialization/BinaryTokenStreamWriter.cs
@@ -91,7 +91,7 @@ namespace Orleans.Serialization
 
         static BinaryTokenStreamWriter()
         {
-            typeTokens = new Dictionary<RuntimeTypeHandle, SerializationTokenType>();
+            typeTokens = new Dictionary<RuntimeTypeHandle, SerializationTokenType>(RuntimeTypeHandlerEqualityComparer.Instance);
             typeTokens[typeof(bool).TypeHandle] = SerializationTokenType.Boolean;
             typeTokens[typeof(int).TypeHandle] = SerializationTokenType.Int;
             typeTokens[typeof(uint).TypeHandle] = SerializationTokenType.Uint;
@@ -137,7 +137,7 @@ namespace Orleans.Serialization
             typeTokens[typeof(Tuple<,,,,,>).TypeHandle] = SerializationTokenType.Tuple + 6;
             typeTokens[typeof(Tuple<,,,,,,>).TypeHandle] = SerializationTokenType.Tuple + 7;
 
-            writers = new Dictionary<RuntimeTypeHandle, Action<BinaryTokenStreamWriter, object>>();
+            writers = new Dictionary<RuntimeTypeHandle, Action<BinaryTokenStreamWriter, object>>(RuntimeTypeHandlerEqualityComparer.Instance);
             writers[typeof(bool).TypeHandle] = (stream, obj) => stream.Write((bool) obj);
             writers[typeof(int).TypeHandle] = (stream, obj) => { stream.Write(SerializationTokenType.Int); stream.Write((int) obj); };
             writers[typeof(uint).TypeHandle] = (stream, obj) => { stream.Write(SerializationTokenType.Uint); stream.Write((uint) obj); };

--- a/src/Orleans.Core/Utils/RuntimeTypeHandlerEqualityComparer.cs
+++ b/src/Orleans.Core/Utils/RuntimeTypeHandlerEqualityComparer.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Runtime
+{
+    internal class RuntimeTypeHandlerEqualityComparer : IEqualityComparer<RuntimeTypeHandle>
+    {
+        public static RuntimeTypeHandlerEqualityComparer Instance { get; } = new RuntimeTypeHandlerEqualityComparer();
+
+
+        RuntimeTypeHandlerEqualityComparer() { }
+
+        public int GetHashCode(RuntimeTypeHandle handle) => handle.GetHashCode();
+
+        public bool Equals(RuntimeTypeHandle first, RuntimeTypeHandle second) => first.Equals(second);
+    }
+}


### PR DESCRIPTION
The `BinaryTokenStreamWriter` uses dictionaries with `RuntimeTypeHandle` keys to lookup appropriate `SerializationTokenType` and serialization action for every field in an object graph. 
Since `RuntimeTypeHandle` does not implement IEquatable interface (even though it has `Equals(RuntimeTypeHandle)` method) dictionaries are using `ObjectEqualityComparer` which in turn uses `Equals(object)` and that causes a boxing allocation to occur at every lookup of a dictionary.
In this PR I'm proposing a usage of a custom `RuntimeTypeHandlerEqualityComparer` to eliminate allocation.