### PR TITLE
Support ProxyGatewayEndpoint from legacy configuration

### DIFF
--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -167,6 +167,13 @@ namespace Orleans.Hosting
                         options.AdvertisedIPAddress = nodeConfig.Endpoint.Address;
                         options.SiloPort = nodeConfig.Endpoint.Port;
                     }
+
+                    var gatewayEndpoint = nodeConfig.ProxyGatewayEndpoint;
+                    if (gatewayEndpoint != null)
+                    {
+                        options.GatewayPort = gatewayEndpoint.Port;
+                        options.GatewayListeningEndpoint = gatewayEndpoint;
+                    }
                 });
 
             services.Configure<SerializationProviderOptions>(options =>

--- a/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Sockets;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -87,8 +87,12 @@ namespace Orleans.Hosting
 
         internal static IPEndPoint GetPublicProxyEndpoint(this EndpointOptions options)
         {
-            return options.GatewayPort != 0 
-                ? new IPEndPoint(options.AdvertisedIPAddress, options.GatewayPort)
+            var gatewayPort = options.GatewayPort != 0
+                ? options.GatewayPort
+                : options.GatewayListeningEndpoint?.Port ?? 0;
+
+            return gatewayPort != 0
+                ? new IPEndPoint(options.AdvertisedIPAddress, gatewayPort)
                 : null;
         }
 
@@ -99,9 +103,6 @@ namespace Orleans.Hosting
 
         internal static IPEndPoint GetListeningProxyEndpoint(this EndpointOptions options)
         {
-            if (options.GatewayPort == 0)
-                return null;
-
             return options.GatewayListeningEndpoint ?? options.GetPublicProxyEndpoint();
         }
     }

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -22,7 +22,13 @@ namespace Orleans.Runtime
 
             var endpointOptions = siloEndpointOptions.Value;
             this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.GetPublicSiloEndpoint(), SiloAddress.AllocateNewGeneration()));
-            this.gatewayAddressLazy = new Lazy<SiloAddress>(() => endpointOptions.GatewayPort != 0 ? SiloAddress.New(endpointOptions.GetPublicProxyEndpoint(), 0) : null);
+            this.gatewayAddressLazy = new Lazy<SiloAddress>(() =>
+            {
+                var publicProxyEndpoint = endpointOptions.GetPublicProxyEndpoint();
+                return publicProxyEndpoint != null
+                        ? SiloAddress.New(publicProxyEndpoint, 0)
+                        : null;
+            });
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Propagates the `ProxyGatewayEndpoint` setting from legacy `NodeConfiguration` to `EndpointOptions`. The silo-to-silo endpoint options are being propagated correctly and don't need to change.

~~`GatewayPort` is redundant and should not be used if `GatewayEndpoint` is set, but it shouldn't hurt to explicitly set it anyway.~~ EDIT: setting gateway port here `GatewayPort` wasn't redundant: it was being used to determine whether or not to start a gateway, etc. I added changes to fix that.