### PR TITLE
Add warm up to transaction recovery tests and reduce grain logging

### DIFF
--- a/test/Transactions/Orleans.Transactions.Tests/Grains/ITransactionalBitArrayGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Grains/ITransactionalBitArrayGrain.cs
@@ -7,6 +7,11 @@ namespace Orleans.Transactions.Tests.Correctness
     public interface ITransactionalBitArrayGrain : IGrainWithGuidKey
     {
         /// <summary>
+        /// Ping 
+        /// </summary>
+        /// <returns></returns>
+        Task Ping();
+        /// <summary>
         /// apply set operation to every transaction state
         /// </summary>
         /// <param name="newValue"></param>

--- a/test/Transactions/Orleans.Transactions.Tests/Grains/MultiStateTransactionalBitArrayGrain.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Grains/MultiStateTransactionalBitArrayGrain.cs
@@ -211,13 +211,18 @@ namespace Orleans.Transactions.Tests.Correctness
             this.dataArray = dataArray;
             this.loggerFactory = loggerFactory;
         }
-
+        
         public override Task OnActivateAsync()
         {
             this.logger = this.loggerFactory.CreateLogger(this.GetGrainIdentity().ToString());
-            this.logger.LogInformation($"GrainId : {this.GetPrimaryKey()}.");
+            this.logger.LogTrace($"GrainId : {this.GetPrimaryKey()}.");
 
             return base.OnActivateAsync();
+        }
+
+        public Task Ping()
+        {
+            return Task.CompletedTask;
         }
 
         public Task SetBit(int index)
@@ -225,9 +230,9 @@ namespace Orleans.Transactions.Tests.Correctness
             return Task.WhenAll(this.dataArray
                 .Select(data => data.PerformUpdate(state =>
                 {
-                    this.logger.LogInformation($"Setting bit {index} in state {state}. Transaction {TransactionContext.CurrentTransactionId}");
+                    this.logger.LogTrace($"Setting bit {index} in state {state}. Transaction {TransactionContext.CurrentTransactionId}");
                     state.Set(index, true);
-                    this.logger.LogInformation($"Set bit {index} in state {state}.");
+                    this.logger.LogTrace($"Set bit {index} in state {state}.");
                 })));
         }
 
@@ -236,7 +241,7 @@ namespace Orleans.Transactions.Tests.Correctness
             return (await Task.WhenAll(this.dataArray
                 .Select(state => state.PerformRead(s =>
                 {
-                    this.logger.LogInformation($"Get state {s}.");
+                    this.logger.LogTrace($"Get state {s}.");
                     return s;
                 })))).ToList();
         }


### PR DESCRIPTION
TransactionWillRecoverAfterRandomSiloFailure test failed on the first assert, where we send transaction request to grains for the first time, before we shutdown or kill silo. Failure are prepareTimeout and break lock. So I suspect it is because grains are taking too long to activate or grains logging are too verbose. So in order to make TransactionWillRecoverAfterRandomSiloFailure passing more consistent,  added a ping method to the grain interface and call Ping() to activate grains before transaction calls, and reduce grain logging level.