### PR TITLE
Remove RequestInvocationHistorySummary to fix backward compatibility

### DIFF
--- a/src/Orleans.Core/Messaging/RequestInvocationHistory.cs
+++ b/src/Orleans.Core/Messaging/RequestInvocationHistory.cs
@@ -2,38 +2,24 @@ using System;
 
 namespace Orleans.Runtime
 {
-    // used for tracking request invocation history for deadlock detection.
+    // used for tracking request invocation history for deadlock detection and call chain reentrancy
     [Serializable]
-    internal sealed class RequestInvocationHistory : RequestInvocationHistorySummary
+    internal sealed class RequestInvocationHistory
     {
         public GrainId GrainId { get; private set; }
+        public ActivationId ActivationId { get; private set; }
         public string DebugContext { get; private set; }
 
-        public RequestInvocationHistory(GrainId grainId, ActivationId activationId, string debugContext) : base(activationId)
+        public RequestInvocationHistory(GrainId grainId, ActivationId activationId, string debugContext)
         {
             this.GrainId = grainId;
-            DebugContext = debugContext;
+            this.ActivationId = activationId;
+            this.DebugContext = debugContext;
         }
 
         public override string ToString()
         {
             return $"RequestInvocationHistory {GrainId}:{ActivationId}:{DebugContext}";
-        }
-    }
-    // used for tracking request invocation history for call chain reentrancy
-    [Serializable]
-    internal class RequestInvocationHistorySummary
-    {
-        public ActivationId ActivationId { get; private set; }
-
-        public RequestInvocationHistorySummary(ActivationId activationId)
-        {
-            this.ActivationId = activationId;
-        }
-
-        public override string ToString()
-        {
-            return $"RequestInvocationHistorySummary {ActivationId}";
         }
     }
 }

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -369,7 +369,7 @@ namespace Orleans.Runtime
             // check if the target activation already appears in the call chain.
             foreach (object invocationObj in prevChain)
             {
-                var prevId = ((RequestInvocationHistorySummary)invocationObj).ActivationId;
+                var prevId = ((RequestInvocationHistory)invocationObj).ActivationId;
                 if (prevId.Equals(nextActivationId))
                 {
                     return true;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -292,17 +292,11 @@ namespace Orleans.Runtime
 
                 if (!message.TargetGrain.IsSystemTarget)
                 {
-                    if (schedulingOptions.PerformDeadlockDetection)
+                    if (schedulingOptions.PerformDeadlockDetection || schedulingOptions.AllowCallChainReentrancy)
                     {
                         UpdateInvocationHistoryInRequestContext(
                             new RequestInvocationHistory(message.TargetGrain, message.TargetActivation, message.DebugContext));
                     }
-                    else if (schedulingOptions.AllowCallChainReentrancy)
-                    {
-                        UpdateInvocationHistoryInRequestContext(
-                            new RequestInvocationHistorySummary(message.TargetActivation));
-                    }
-
                     // RequestContext is automatically saved in the msg upon send and propagated to the next hop
                     // in RuntimeClient.CreateMessage -> RequestContextExtensions.ExportToMessage(message);
                 }
@@ -579,17 +573,17 @@ namespace Orleans.Runtime
         }
 
         // assumes deadlock information was already loaded into RequestContext from the message
-        private static void UpdateInvocationHistoryInRequestContext(RequestInvocationHistorySummary thisInvocation)
+        private static void UpdateInvocationHistoryInRequestContext(RequestInvocationHistory thisInvocation)
         {
-            IList<RequestInvocationHistorySummary> prevChain;
+            IList<RequestInvocationHistory> prevChain;
 
-            if (RequestContext.Get(RequestContext.CALL_CHAIN_REQUEST_CONTEXT_HEADER) is IList<RequestInvocationHistorySummary> obj)
+            if (RequestContext.Get(RequestContext.CALL_CHAIN_REQUEST_CONTEXT_HEADER) is IList<RequestInvocationHistory> obj)
             {
                 prevChain = obj;
             }
             else
             {
-                prevChain = new List<RequestInvocationHistorySummary>();
+                prevChain = new List<RequestInvocationHistory>();
                 RequestContext.Set(RequestContext.CALL_CHAIN_REQUEST_CONTEXT_HEADER, prevChain);
             }
 


### PR DESCRIPTION
#5145 was a breaking change (my bad)

Removing the added type `RequestInvocationHistorySummary` and using the previous `RequestInvocationHistory` implementation fix the bc issue while keeping the fix from #5145 