### PR TITLE
Mark key legacy types/methods as [Obsolete]

### DIFF
--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureClient.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureClient.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.Host
     /// <summary>
     /// Utility class for initializing an Orleans client running inside Azure.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use ClientBuilder to create an instance of IClusterClient instead.")]
     public static class AzureClient
     {
         private static readonly IServiceRuntimeWrapper serviceRuntimeWrapper = new ServiceRuntimeWrapper(AzureSilo.CreateDefaultLoggerFactory("AzureClient.log"));

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureSilo.cs
@@ -19,6 +19,7 @@ namespace Orleans.Runtime.Host
     /// <summary>
     /// Wrapper class for an Orleans silo running in the current host process.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use SiloHostBuilder to create an instance of ISiloHost instead.")]
     public class AzureSilo
     {
         /// <summary>

--- a/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
@@ -15,6 +15,7 @@ namespace Orleans.Runtime.Configuration
     /// <summary>
     /// Orleans client configuration parameters.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use configuration methods on ClientBuilder to configure specific types.")]
     [Serializable]
     public class ClientConfiguration : MessagingConfiguration, IStatisticsConfiguration
     {

--- a/src/Orleans.Core.Legacy/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClusterConfiguration.cs
@@ -15,6 +15,7 @@ namespace Orleans.Runtime.Configuration
     /// <summary>
     /// Data object holding Silo configuration parameters.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use configuration methods on ISiloHostBuilder to configure specific types.")]
     [Serializable]
     public class ClusterConfiguration
     {

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -33,6 +33,7 @@ namespace Orleans.Runtime.Configuration
     /// <summary>
     /// Data object holding Silo global configuration parameters.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use configuration methods on ISiloHostBuilder to configure specific types.")]
     [Serializable]
     public class GlobalConfiguration : MessagingConfiguration
     {

--- a/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
@@ -14,6 +14,7 @@ namespace Orleans.Runtime.Configuration
     /// <summary>
     /// Individual node-specific silo configuration parameters.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use configuration methods on ISiloHostBuilder to configure specific types.")]
     [Serializable]
     public class NodeConfiguration :IStatisticsConfiguration
     {

--- a/src/Orleans.Core.Legacy/Core/GrainClient.cs
+++ b/src/Orleans.Core.Legacy/Core/GrainClient.cs
@@ -14,7 +14,7 @@ namespace Orleans
     /// <summary>
     /// Client runtime for connecting to Orleans system
     /// </summary>
-    /// TODO: Make this class non-static and inject it where it is needed.
+    [Obsolete("This type is obsolete and may be removed in a future release. Use ClientBuilder to create an instance of IClusterClient instead.")]
     public static class GrainClient
     {
         /// <summary>

--- a/src/Orleans.Core.Legacy/Orleans.Core.Legacy.csproj
+++ b/src/Orleans.Core.Legacy/Orleans.Core.Legacy.csproj
@@ -19,4 +19,9 @@
     </None>
   </ItemGroup>
 
+  <PropertyGroup>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);612,618</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);FS2003,612,618</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/src/Orleans.PowerShell/StartGrainClient.cs
+++ b/src/Orleans.PowerShell/StartGrainClient.cs
@@ -1,9 +1,10 @@
-﻿using Orleans;
+using Orleans;
 using Orleans.Runtime.Configuration;
 using System;
 using System.IO;
 using System.Management.Automation;
 using System.Net;
+#pragma warning disable 618
 
 namespace OrleansPSUtils
 {

--- a/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
+++ b/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
@@ -17,6 +17,7 @@ namespace Orleans.Runtime.Host
     /// <summary>
     /// Allows programmatically hosting an Orleans silo in the current app domain.
     /// </summary>
+    [Obsolete("This type is obsolete and may be removed in a future release. Use SiloHostBuilder to create an instance of ISiloHost instead.")]
     public class SiloHost :
         MarshalByRefObject,
         IDisposable

--- a/src/Orleans.Runtime.Legacy/Orleans.Runtime.Legacy.csproj
+++ b/src/Orleans.Runtime.Legacy/Orleans.Runtime.Legacy.csproj
@@ -11,4 +11,9 @@
     <RootNamespace>Orleans.Runtime.Legacy</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);612,618</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);FS2003,612,618</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -118,6 +118,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="siloDetails">The silo initialization parameters</param>
         /// <param name="services">Dependency Injection container</param>
+        [Obsolete("This constructor is obsolete and may be removed in a future release. Use SiloHostBuilder to create an instance of ISiloHost instead.")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "Should not Dispose of messageCenter in this method because it continues to run / exist after this point.")]
         public Silo(ILocalSiloDetails siloDetails, IServiceProvider services)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,7 +6,8 @@
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);FS2003</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);612,618</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);FS2003,612,618</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #5221

I disabled legacy type warnings for the `test` subtree, maybe that's questionable. The alternative is to either:

1. Port all tests away from `[Obsolete]` types
2. Individually mark every file with the right `#pragma` incantation
3. Individually surround every usage with the right `#pragma`

I figured:

* 1 is too much work for now (especially between rc and final)
* 2 offers little benefit over the chosen approach with more cost
* 3 would make code ugly since it requires many changes which will eventually need to be undone before (presumably) 3.0.