### PR TITLE
Use typed loggers so it is easier to enable debug transaction logging

### DIFF
--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -23,7 +23,7 @@ namespace Orleans.Transactions.State
         private readonly ITimerManager timerManager;
         private readonly HashSet<Guid> pending;
 
-        public ConfirmationWorker(IOptions<TransactionalStateOptions> options, ParticipantId me, BatchWorker storageWorker, Func<StorageBatch<TState>> getStorageBatch, ILogger logger, ITimerManager timerManager)
+        public ConfirmationWorker(IOptions<TransactionalStateOptions> options, ParticipantId me, BatchWorker storageWorker, Func<StorageBatch<TState>> getStorageBatch, ILogger<ConfirmationWorker<TState>> logger, ITimerManager timerManager)
         {
             this.options = options.Value;
             this.me = me;
@@ -126,7 +126,7 @@ namespace Orleans.Transactions.State
             private Task pending;
             private bool complete;
 
-            public Confirmation(ParticipantId paricipant, Guid transactionId, DateTime timestamp, Func<Task> call, ILogger logger)
+            public Confirmation(ParticipantId paricipant, Guid transactionId, DateTime timestamp, Func<Task> call, ILogger<ConfirmationWorker<TState>> logger)
             {
                 this.paricipant = paricipant;
                 this.transactionId = transactionId;

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -51,7 +51,7 @@ namespace Orleans.Transactions.State
             IOptions<TransactionalStateOptions> options,
             TransactionQueue<TState> queue,
             BatchWorker storageWorker,
-            ILogger logger)
+            ILogger<ReadWriteLock<TState>> logger)
         {
             this.options = options.Value;
             this.queue = queue;

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -53,7 +53,7 @@ namespace Orleans.Transactions.State
             Action deactivate,
             ITransactionalStateStorage<TState> storage,
             IClock clock,
-            ILogger logger,
+            ILogger<TransactionQueue<TState>> logger,
             ITimerManager timerManager)
         {
             this.options = options.Value;

--- a/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
+++ b/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
@@ -22,7 +22,7 @@ namespace Orleans.Transactions.TOC
             ITransactionalStateStorage<TransactionCommitter<TService>.OperationState> storage,
             JsonSerializerSettings serializerSettings,
             IClock clock,
-            ILogger logger,
+            ILogger<TocTransactionQueue<TService>> logger,
             ITimerManager timerManager)
             : base(options, resource, deactivate, storage, clock, logger, timerManager)
         {


### PR DESCRIPTION
It took longer than expected to enable debug transaction logging without enabling all debug logging since most of it isn't using typed loggers. This change should allow just using `Orleans.Transactions` as a source filter.