### PR TITLE
Add configurable timeout to wait for queued messages being forwarded

### DIFF
--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -76,5 +76,13 @@ namespace Orleans.Configuration
         /// For test only - Do not use in production
         /// </summary>
         public bool AssumeHomogenousSilosForTesting { get; set; } = false;
+
+        public static TimeSpan DEFAULT_REROUTE_QUEUED_MESSAFES_On_SILO_SHUTDOWN_TIMEOUT { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// How long the silo will wait for rerouting queued mesages, before it continues shutting down. 
+        /// </summary>
+        public TimeSpan RerouteQueuedMessagesOnSiloShutdownTimeout { get; set; } =
+            DEFAULT_REROUTE_QUEUED_MESSAFES_On_SILO_SHUTDOWN_TIMEOUT;
     }
 }

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -77,12 +77,12 @@ namespace Orleans.Configuration
         /// </summary>
         public bool AssumeHomogenousSilosForTesting { get; set; } = false;
 
-        public static TimeSpan DEFAULT_REROUTE_QUEUED_MESSAFES_On_SILO_SHUTDOWN_TIMEOUT { get; set; } = TimeSpan.FromSeconds(10);
+        public static TimeSpan DEFAULT_SHUTDOWN_REROUTE_TIMEOUT { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// How long the silo will wait for rerouting queued mesages, before it continues shutting down. 
         /// </summary>
-        public TimeSpan RerouteQueuedMessagesOnSiloShutdownTimeout { get; set; } =
-            DEFAULT_REROUTE_QUEUED_MESSAFES_On_SILO_SHUTDOWN_TIMEOUT;
+        public TimeSpan ShutdownRerouteTimeout { get; set; } =
+            DEFAULT_SHUTDOWN_REROUTE_TIMEOUT;
     }
 }

--- a/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
@@ -22,11 +22,11 @@ namespace Orleans.Runtime.Messaging
         /// <summary>
         /// Current queue length
         /// </summary>
-        int Count { get; }
+        int GetCount();
 
         /// <summary>
         /// Application level message queue length
         /// </summary>
-        int ApplicationMessageCount { get; }
+        int GetApplicationMessageCount();
     }
 }

--- a/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/IOutboundMessageQueue.cs
@@ -23,5 +23,10 @@ namespace Orleans.Runtime.Messaging
         /// Current queue length
         /// </summary>
         int Count { get; }
+
+        /// <summary>
+        /// Application level message queue length
+        /// </summary>
+        int ApplicationMessageCount { get; }
     }
 }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -124,7 +124,7 @@ namespace Orleans.Runtime.Messaging
             DateTime maxWaitTime = DateTime.UtcNow + this.messagingOptions.ShutdownRerouteTimeout;
             while (DateTime.UtcNow < maxWaitTime)
             {
-                var applicationMessageQueueLength = this.OutboundQueue.ApplicationMessageCount;
+                var applicationMessageQueueLength = this.OutboundQueue.GetApplicationMessageCount();
                 if (applicationMessageQueueLength == 0)
                     break;
                 Thread.Sleep(100);
@@ -279,7 +279,7 @@ namespace Orleans.Runtime.Messaging
             GC.SuppressFinalize(this);
         }
 
-        public int SendQueueLength { get { return OutboundQueue.Count; } }
+        public int SendQueueLength { get { return OutboundQueue.GetCount(); } }
 
         public int ReceiveQueueLength { get { return InboundQueue.Count; } }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -121,13 +121,13 @@ namespace Orleans.Runtime.Messaging
 
         private void WaitToRerouteAllQueuedMessages()
         {
-            DateTime maxWaitTime = DateTime.UtcNow + this.messagingOptions.RerouteQueuedMessagesOnSiloShutdownTimeout;
+            DateTime maxWaitTime = DateTime.UtcNow + this.messagingOptions.ShutdownRerouteTimeout;
             while (DateTime.UtcNow < maxWaitTime)
             {
                 var applicationMessageQueueLength = this.OutboundQueue.ApplicationMessageCount;
                 if (applicationMessageQueueLength == 0)
                     break;
-                Task.Delay(TimeSpan.FromSeconds(1)).Wait();
+                Thread.Sleep(100);
             }
             
         }

--- a/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
@@ -28,6 +28,15 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
+        public int ApplicationMessageCount
+        {
+            get
+            {
+                int n = senders.Where(sender => sender.IsValueCreated).Sum(sender => sender.Value.Count);
+                return n;
+            }
+        }
+
         internal const string QUEUED_TIME_METADATA = "QueuedTime";
 
         internal OutboundMessageQueue(MessageCenter mc, IOptions<SiloMessagingOptions> options, SerializationManager serializationManager, ExecutorService executorService, ILoggerFactory loggerFactory)

--- a/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
@@ -18,23 +18,17 @@ namespace Orleans.Runtime.Messaging
         private readonly ILogger logger;
         private bool stopped;
 
-        public int Count
+        public int GetCount()
         {
-            get
-            {
-                int n = senders.Where(sender => sender.IsValueCreated).Sum(sender => sender.Value.Count);
-                n += systemSender.Count + pingSender.Count;
-                return n;
-            }
+            int n = GetApplicationMessageCount();
+            n += systemSender.Count + pingSender.Count;
+            return n;
         }
 
-        public int ApplicationMessageCount
+        public int GetApplicationMessageCount()
         {
-            get
-            {
-                int n = senders.Where(sender => sender.IsValueCreated).Sum(sender => sender.Value.Count);
-                return n;
-            }
+            int n = senders.Where(sender => sender.IsValueCreated).Sum(sender => sender.Value.Count);
+            return n;
         }
 
         internal const string QUEUED_TIME_METADATA = "QueuedTime";

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -761,6 +761,8 @@ namespace Orleans.Runtime
                         .WithCancellation(ct, "MembershipOracle Shutting down failed because the task was cancelled");
                     // Deactivate all grains
                     SafeExecute(() => catalog.DeactivateAllActivations().Wait(ct));
+                    //wait for all queued message sent to OutboundMessageQueue before MessageCenter stop and OutboundMessageQueue stop. 
+                    await Task.Delay(TimeSpan.FromSeconds(2));
                 }
                 else
                 {

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -38,7 +38,7 @@ namespace Orleans.Runtime
     {
         /// <summary> Standard name for Primary silo. </summary>
         public const string PrimarySiloName = "Primary";
-
+        private static TimeSpan WaitForMessageToBeQueuedForOutbound = TimeSpan.FromSeconds(2);
         /// <summary> Silo Types. </summary>
         public enum SiloType
         {
@@ -762,7 +762,7 @@ namespace Orleans.Runtime
                     // Deactivate all grains
                     SafeExecute(() => catalog.DeactivateAllActivations().Wait(ct));
                     //wait for all queued message sent to OutboundMessageQueue before MessageCenter stop and OutboundMessageQueue stop. 
-                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    await Task.Delay(WaitForMessageToBeQueuedForOutbound);
                 }
                 else
                 {

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -195,6 +195,8 @@ namespace UnitTests.GrainInterfaces
     public interface ILongRunningTaskGrain<T> : IGrainWithGuidKey
     {
         Task<string> GetRuntimeInstanceId();
+        Task<string> GetRuntimeInstanceIdWithDelay(TimeSpan delay);
+
         Task LongWait(GrainCancellationToken tc, TimeSpan delay);
         Task<T> LongRunningTask(T t, TimeSpan delay);
         Task<T> CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay);

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -673,6 +673,12 @@ namespace UnitTests.Grains
         {
             return Task.FromResult(RuntimeIdentity);
         }
+
+        public async Task<string> GetRuntimeInstanceIdWithDelay(TimeSpan delay)
+        {
+            await Task.Delay(delay);
+            return RuntimeIdentity;
+        }
     }
 
     public class GenericGrainWithContraints<A, B, C>: Grain, IGenericGrainWithConstraints<A, B, C>


### PR DESCRIPTION
On my local test for "forwarding messages during silo graceful shutdown", one of the reasons for message forwarding failure is 

- OutboundMessageQueue stopped before queued message being forwarded to other silo. 

The causes can be
- application messages weren't queued into OutboundMessageQueue before OutboundMessageQueue  stopped
- messages queued into OutboundMessageQueue didn't finish forwarding before it stopped

This PR tries to address the two causeses by 
- adding a 2 sec delay after `catalog.DeactivateAllActivations()`, this hopefully give enough time for the messages (queued messages for deactivated activations) to be queued into OutboundMessageQueue 
- adding a RerouteQueuedMessagesOnSiloShutdownTimeout as the max wait time for OutboundMessageQueue to finish forwarding before stopping. 