### PR TITLE
Avoid emitting assembly-level GeneratedCodeAttribute

### DIFF
--- a/src/Orleans.CodeGeneration/CodeGeneratorCommon.cs
+++ b/src/Orleans.CodeGeneration/CodeGeneratorCommon.cs
@@ -45,15 +45,7 @@ namespace Orleans.CodeGenerator
                                 .AddArgumentListArguments(
                                     SF.AttributeArgument(asm.GetName().FullName.GetLiteralExpression()))).ToArray())
                     .WithTarget(SF.AttributeTargetSpecifier(SF.Token(SyntaxKind.AssemblyKeyword)));
-            var generatedCodeAttribute =
-                SF.AttributeList()
-                    .AddAttributes(
-                        SF.Attribute(typeof(GeneratedCodeAttribute).GetNameSyntax())
-                            .AddArgumentListArguments(
-                                SF.AttributeArgument(ToolName.GetLiteralExpression()),
-                                SF.AttributeArgument(RuntimeVersion.FileVersion.GetLiteralExpression())))
-                    .WithTarget(SF.AttributeTargetSpecifier(SF.Token(SyntaxKind.AssemblyKeyword)));
-            return generatedSyntax.Syntax.AddAttributeLists(generatedCodeAttribute, codeGenTargetAttributes);
+            return generatedSyntax.Syntax.AddAttributeLists(codeGenTargetAttributes);
         }
 
         internal static AttributeSyntax GetGeneratedCodeAttributeSyntax()

--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -154,6 +154,7 @@ namespace Orleans.CodeGenerator
         public string GenerateSourceForAssembly(Assembly input)
         {
             if (input.GetCustomAttribute<GeneratedCodeAttribute>() != null
+                || input.GetCustomAttribute<OrleansCodeGenerationTargetAttribute>() != null
                 || input.GetCustomAttribute<SkipCodeGenerationAttribute>() != null)
             {
                 return string.Empty;
@@ -652,6 +653,7 @@ namespace Orleans.CodeGenerator
             return !assembly.IsDynamic
                    && TypeUtils.IsOrleansOrReferencesOrleans(assembly)
                    && assembly.GetCustomAttribute<GeneratedCodeAttribute>() == null
+                   && assembly.GetCustomAttribute<OrleansCodeGenerationTargetAttribute>() == null
                    && assembly.GetCustomAttribute<SkipCodeGenerationAttribute>() == null;
         }
 


### PR DESCRIPTION
Fixes #5265

This is a change for the reflection-based code generator to not add GeneratedCodeAttribute at the assembly level. It's unneeded and semantically incorrect - the assembly is (probably) not just generated code.