### PR TITLE
Sort out LocalGrainDirectory shutdown sequence

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -1414,7 +1414,7 @@ namespace Orleans.Runtime
                         {
                             var activationData = activation.Value;
                             if (!activationData.IsUsingGrainDirectory) continue;
-                            if (!directory.GetPrimaryForGrain(activationData.Grain).Equals(updatedSilo)) continue;
+                            if (!updatedSilo.Equals(directory.GetPrimaryForGrain(activationData.Grain))) continue;
 
                             lock (activationData)
                             {

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.GrainDirectory
                     GrainId grain = pair.Key;
                     var entry = pair.Value;
 
-                    SiloAddress owner = router.CalculateTargetSilo(grain);
+                    SiloAddress owner = router.CalculateGrainDirectoryPartition(grain);
                     if (owner == null) // Null means there's no other silo and we're shutting down, so skip this entry
                     {
                         continue;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -184,7 +184,6 @@ namespace Orleans.Runtime.GrainDirectory
             Dictionary<GrainId, IGrainInfo> batchUpdate = localDirectory.DirectoryPartition.GetItems();
 
             await HandoffMyPartitionUponStop(batchUpdate, silosHoldingMyPartitionCopy, true);
-            localDirectory.DirectoryPartition.Clear();
         }
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
@@ -157,12 +158,12 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        internal void ProcessSiloStoppingEvent()
+        internal Task ProcessSiloStoppingEvent()
         {
-            ProcessSiloStoppingEvent_Impl();
+            return ProcessSiloStoppingEvent_Impl();
         }
 
-        private async void ProcessSiloStoppingEvent_Impl()
+        private async Task ProcessSiloStoppingEvent_Impl()
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo stopping event");
 
@@ -181,15 +182,9 @@ namespace Orleans.Runtime.GrainDirectory
             }
             // take a copy of the current directory partition
             Dictionary<GrainId, IGrainInfo> batchUpdate = localDirectory.DirectoryPartition.GetItems();
-            try
-            {
-                await HandoffMyPartitionUponStop(batchUpdate, silosHoldingMyPartitionCopy, true);
-                localDirectory.MarkStopPreparationCompleted();
-            }
-            catch (Exception exc)
-            {
-                localDirectory.MarkStopPreparationFailed(exc);
-            }
+
+            await HandoffMyPartitionUponStop(batchUpdate, silosHoldingMyPartitionCopy, true);
+            localDirectory.DirectoryPartition.Clear();
         }
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)
@@ -215,7 +210,7 @@ namespace Orleans.Runtime.GrainDirectory
                     GrainDirectoryPartition splitPart = localDirectory.DirectoryPartition.Split(
                         grain =>
                         {
-                            var s = localDirectory.CalculateTargetSilo(grain);
+                            var s = localDirectory.CalculateGrainDirectoryPartition(grain);
                             return (s != null) && !localDirectory.MyAddress.Equals(s);
                         }, false);
                     List<ActivationAddress> splitPartListSingle = splitPart.ToListOfActivations(true);
@@ -261,7 +256,7 @@ namespace Orleans.Runtime.GrainDirectory
                             grain =>
                             {
                                 // Need to review the 2nd line condition.
-                                var s = localDirectory.CalculateTargetSilo(grain);
+                                var s = localDirectory.CalculateGrainDirectoryPartition(grain);
                                 return (s != null) && !predecessorOfNewSilo.Equals(s);
                             }, true);
                         directoryPartitionsMap[addedSilo] = splitPart;

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -21,7 +21,6 @@ namespace Orleans.Runtime.GrainDirectory
         RemoteGrainDirectory RemoteGrainDirectory { get; }
         RemoteGrainDirectory CacheValidator { get; }
         ClusterGrainDirectory RemoteClusterGrainDirectory { get; }
-        Task StopPreparationCompletion { get; }  // Will be resolved when this directory is prepared to stop
 
         /// <summary>
         /// Removes the record for an non-existing activation from the directory service.

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// Stops the local portion of the directory service.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Stop")]
-        void Stop(bool doOnStopHandoff);
+        Task Stop(bool doOnStopHandoff);
 
         RemoteGrainDirectory RemoteGrainDirectory { get; }
         RemoteGrainDirectory CacheValidator { get; }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -237,22 +238,16 @@ namespace Orleans.Runtime.GrainDirectory
         // The alternative would be to allow the silo to process requests after it has handed off its partition, in which case those changes 
         // would receive successful responses but would not be reflected in the eventual state of the directory. 
         // It's easy to change this, if we think the trade-off is better the other way.
-        public void Stop(bool doOnStopHandoff)
+        public async Task Stop(bool doOnStopHandoff)
         {
             // This will cause remote write requests to be forwarded to the silo that will become the new owner.
             // Requests might bounce back and forth for a while as membership stabilizes, but they will either be served by the
             // new owner of the grain, or will wind up failing. In either case, we avoid requests succeeding at this silo after we've
             // begun stopping, which could cause them to not get handed off to the new owner.
+
+            //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
 
-            if (doOnStopHandoff)
-            {
-                HandoffManager.ProcessSiloStoppingEvent();
-            }
-            else
-            {
-                MarkStopPreparationCompleted();
-            }
             if (maintainer != null)
             {
                 maintainer.Stop();
@@ -261,7 +256,20 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 GsiActivationMaintainer.Stop();
             }
+
+            if (doOnStopHandoff)
+            {
+                try
+                {
+                    await HandoffManager.ProcessSiloStoppingEvent();
+                }catch (Exception exc)
+                {
+                    MarkStopPreparationFailed(exc);
+                }
+
+            }
             DirectoryCache.Clear();
+            MarkStopPreparationCompleted();
         }
 
         internal void MarkStopPreparationCompleted()
@@ -377,7 +385,7 @@ namespace Orleans.Runtime.GrainDirectory
             foreach (Tuple<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>, int> tuple in DirectoryCache.KeyValues)
             {
                 // 2) remove entries now owned by me (they should be retrieved from my directory partition)
-                if (MyAddress.Equals(CalculateTargetSilo(tuple.Item1)))
+                if (MyAddress.Equals(CalculateGrainDirectoryPartition(tuple.Item1)))
                 {
                     DirectoryCache.Remove(tuple.Item1);
                 }
@@ -434,20 +442,7 @@ namespace Orleans.Runtime.GrainDirectory
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
             // This silo's status has changed
-            if (Equals(updatedSilo, MyAddress))
-            {
-                if (status == SiloStatus.Stopping || status == SiloStatus.ShuttingDown)
-                {
-                    // QueueAction up the "Stop" to run on a system turn
-                    Scheduler.QueueAction(() => Stop(true), CacheValidator.SchedulingContext).Ignore();
-                }
-                else if (status == SiloStatus.Dead)
-                {
-                    // QueueAction up the "Stop" to run on a system turn
-                    Scheduler.QueueAction(() => Stop(false), CacheValidator.SchedulingContext).Ignore();
-                }
-            }
-            else // Status change for some other silo
+            if (!Equals(updatedSilo, MyAddress)) // Status change for some other silo
             {
                 if (status.IsTerminating())
                 {
@@ -469,13 +464,11 @@ namespace Orleans.Runtime.GrainDirectory
 
         /// <summary>
         /// Finds the silo that owns the directory information for the given grain ID.
-        /// This routine will always return a non-null silo address unless the excludeThisSiloIfStopping parameter is true,
-        /// this is the only silo known, and this silo is stopping.
+        /// This method will only be null when I'm the only silo in the cluster and I'm shutting down
         /// </summary>
         /// <param name="grainId"></param>
-        /// <param name="excludeThisSiloIfStopping"></param>
         /// <returns></returns>
-        public SiloAddress CalculateTargetSilo(GrainId grainId, bool excludeThisSiloIfStopping = true)
+        public SiloAddress CalculateGrainDirectoryPartition(GrainId grainId)
         {
             // give a special treatment for special grains
             if (grainId.IsSystemTarget)
@@ -501,14 +494,16 @@ namespace Orleans.Runtime.GrainDirectory
             int hash = unchecked((int)grainId.GetUniformHashCode());
 
             // excludeMySelf from being a TargetSilo if we're not running and the excludeThisSIloIfStopping flag is true. see the comment in the Stop method.
-            bool excludeMySelf = !Running && excludeThisSiloIfStopping;
+            // excludeThisSIloIfStopping flag was removed because we believe that flag complicates things unnecessarily. We can add it back if it turns out that flag 
+            // is doing something valuable. 
+            bool excludeMySelf = !Running;
 
             lock (membershipCache)
             {
                 if (membershipRingList.Count == 0)
                 {
                     // If the membership ring is empty, then we're the owner by default unless we're stopping.
-                    return excludeThisSiloIfStopping && !Running ? null : MyAddress;
+                    return !Running ? null : MyAddress;
                 }
 
                 // need to implement a binary search, but for now simply traverse the list of silos sorted by their hashes
@@ -540,7 +535,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public SiloAddress CheckIfShouldForward(GrainId grainId, int hopCount, string operationDescription)
         {
-            SiloAddress owner = CalculateTargetSilo(grainId);
+            SiloAddress owner = CalculateGrainDirectoryPartition(grainId);
 
             if (owner == null)
             {
@@ -792,10 +787,18 @@ namespace Orleans.Runtime.GrainDirectory
         {
             localLookups.Increment();
 
-            SiloAddress silo = CalculateTargetSilo(grain, false);
-            // No need to check that silo != null since we're passing excludeThisSiloIfStopping = false
+            SiloAddress silo = CalculateGrainDirectoryPartition(grain);
 
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("Silo {0} tries to lookup for {1}-->{2} ({3}-->{4})", MyAddress, grain, silo, grain.GetUniformHashCode(), silo.GetConsistentHashCode());
+
+            if (log.IsEnabled(LogLevel.Debug)) log.Debug("Silo {0} tries to lookup for {1}-->{2} ({3}-->{4})", MyAddress, grain, silo, grain.GetUniformHashCode(), silo?.GetConsistentHashCode());
+
+            //this will only happen if I'm the only silo in the cluster and I'm shutting down
+            if (silo == null)
+            {
+                if (log.IsEnabled(LogLevel.Trace)) log.Trace("LocalLookup mine {0}=null", grain);
+                result = new AddressesAndTag();
+                return false;
+            }
 
             // check if we own the grain
             if (silo.Equals(MyAddress))
@@ -972,7 +975,7 @@ namespace Orleans.Runtime.GrainDirectory
             // for multi-cluster registration, the local directory may cache remote activations
             // and we need to remove them here, on the fast path, to avoid forwarding the message
             // to the wrong destination again
-            if (invalidateDirectoryAlso && CalculateTargetSilo(grainId).Equals(MyAddress))
+            if (invalidateDirectoryAlso && CalculateGrainDirectoryPartition(grainId).Equals(MyAddress))
             {
                 var registrar = this.registrarManager.GetRegistrarForGrain(grainId);
                 registrar.InvalidateCache(activationAddress);
@@ -988,7 +991,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns></returns>
         public SiloAddress GetPrimaryForGrain(GrainId grain)
         {
-            return CalculateTargetSilo(grain);
+            return CalculateGrainDirectoryPartition(grain);
         }
 
         /// <summary>
@@ -1000,7 +1003,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns></returns>
         public List<SiloAddress> GetSilosHoldingDirectoryInformationForGrain(GrainId grain)
         {
-            var primary = CalculateTargetSilo(grain);
+            var primary = CalculateGrainDirectoryPartition(grain);
             return FindPredecessors(primary, 1);
         }
 
@@ -1014,7 +1017,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns></returns>
         public List<ActivationAddress> GetLocalDataForGrain(GrainId grain, out bool isPrimary)
         {
-            var primary = CalculateTargetSilo(grain);
+            var primary = CalculateGrainDirectoryPartition(grain);
             List<ActivationAddress> backupData = HandoffManager.GetHandedOffInfo(grain);
             if (MyAddress.Equals(primary))
             {

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -975,7 +975,7 @@ namespace Orleans.Runtime.GrainDirectory
             // for multi-cluster registration, the local directory may cache remote activations
             // and we need to remove them here, on the fast path, to avoid forwarding the message
             // to the wrong destination again
-            if (invalidateDirectoryAlso && CalculateGrainDirectoryPartition(grainId).Equals(MyAddress))
+            if (invalidateDirectoryAlso && MyAddress.Equals(CalculateGrainDirectoryPartition(grainId)))
             {
                 var registrar = this.registrarManager.GetRegistrarForGrain(grainId);
                 registrar.InvalidateCache(activationAddress);

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -399,7 +399,14 @@ namespace Orleans.Runtime.MembershipService
                     membershipOracleData.UpdateMyStatusLocal(status);
                     if (status == SiloStatus.Stopping || status == SiloStatus.ShuttingDown || status == SiloStatus.Dead)
                     {
-                        GossipMyStatus().Wait(shutdownGossipTimeout);
+                        try
+                        {
+                            await GossipMyStatus().WithTimeout(shutdownGossipTimeout);
+                        }
+                        catch (Exception e)
+                        {
+                            this.logger.LogWarning($"GossipMyStatus failed when silo {status}, due to exception {e}");
+                        }
                     }
                     else
                     {

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -705,10 +705,6 @@ namespace Orleans.Runtime
             // Stop scheduling/executing application turns
             SafeExecute(scheduler.StopApplicationTurns);
 
-            // Directory: Speed up directory handoff
-            // will be started automatically when directory receives SiloStatusChangeNotification(Stopping)
-            SafeExecute(() => LocalGrainDirectory.StopPreparationCompletion.WithCancellation(ct));
-
             return Task.CompletedTask;
         }
 

--- a/test/Tester/Forwarding/ShutdownSiloTests.cs
+++ b/test/Tester/Forwarding/ShutdownSiloTests.cs
@@ -40,7 +40,7 @@ namespace Tester.Forwarding
             });
         }
 
-        [Fact, TestCategory("Forward"), TestCategory("Functional")]
+        [Fact, TestCategory("Forward")]
         public async Task SiloGracefulShutdown_ForwardPendingRequest()
         {
             var grain = await GetLongRunningTaskGrainOnSecondary<bool>();

--- a/test/Tester/Forwarding/ShutdownSiloTests.cs
+++ b/test/Tester/Forwarding/ShutdownSiloTests.cs
@@ -40,7 +40,7 @@ namespace Tester.Forwarding
             });
         }
 
-        [Fact, TestCategory("Forward")]
+        [Fact, TestCategory("Forward"), TestCategory("Functional")]
         public async Task SiloGracefulShutdown_ForwardPendingRequest()
         {
             var grain = await GetLongRunningTaskGrainOnSecondary<bool>();


### PR DESCRIPTION
- move LocalGrainDirectory stop to `silo.OnBecomeActiveStop` after `MembershipOracle.shutdown`, instead being trigged by MembershipOracleShutdown -> Sent notification to its SiloStatatusListeners about its shuttingdown -> LocalGrainDirectory.Stop(). and not awaiting the call. 

- sort out its shutdown sequence to be : 

1. exclude itself from GrainDirectoryPartition calculation, since it is shutting down and cannot serve as as GrainDirectoryPartition anymore
2. Stop Mantainers
3. GrainPartition handoff and we are awaiting this call 
4. Clear local activation cache
5. MarkStopPreparationCompleted

