### PR TITLE
Fix defensive check in LogConsistentGrain

### DIFF
--- a/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
+++ b/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
@@ -107,7 +107,7 @@ namespace Orleans.LogConsistency
                 : this.ServiceProvider.GetService<ILogViewAdaptorFactory>();
             if (attr != null && defaultFactory == null)
             {
-                var errMsg = $"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}"
+                var errMsg = $"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}";
                 throw new BadGrainStorageConfigException(errMsg);
             }
 

--- a/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
+++ b/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
@@ -107,9 +107,7 @@ namespace Orleans.LogConsistency
                 : this.ServiceProvider.GetService<ILogViewAdaptorFactory>();
             if (attr != null && defaultFactory == null)
             {
-                var errMsg = attr != null
-                    ? $"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}"
-                    : $"No consistency provider manager found loading grain type {this.GetType().FullName}";
+                var errMsg = $"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}"
                 throw new BadGrainStorageConfigException(errMsg);
             }
 


### PR DESCRIPTION
Found this low hanging fruit around the Orleans.Core project.

The original intent of this code is to have two possible error messages:

1.  `$"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}"`
2.  `$"No consistency provider manager found loading grain type {this.GetType().FullName}";`

However, the wrapping `if`statement above that says:

`if (attr != null && defaultFactory == null)`

...makes the expression below to always fall into the first error message because it evaluates always to `true`, thus, making impossible for the error message to be the second one.

Furthermore, there is another safety check below that ultimately ensures `defaultFactory` is not null and throws an exception if so.
 
