### PR TITLE
Change usages of TypeInfo back to Type

### DIFF
--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -300,7 +300,7 @@ namespace Orleans.Tests.SqlUtils
         {
             if (!EqualityComparer<T>.Default.Equals(parameters, default(T)))
             {
-                var properties = parameters.GetType().GetTypeInfo().GetProperties();
+                var properties = parameters.GetType().GetProperties();
                 for (int i = 0; i < properties.Length; ++i)
                 {
                     var property = properties[i];

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -77,7 +77,7 @@ namespace Orleans.Tests.SqlUtils
                 //The following assumes the property names will be retrieved in the same
                 //order as is the index iteration done.                                
                 var onlyOnceRow = new List<string>();
-                var properties = parameters.First().GetType().GetTypeInfo().GetProperties();
+                var properties = parameters.First().GetType().GetProperties();
                 columns = string.Join(",", nameMap == null ? properties.Select(pn => string.Format("{0}{1}{2}", startEscapeIndicator, pn.Name, endEscapeIndicator)) : properties.Select(pn => string.Format("{0}{1}{2}", startEscapeIndicator, (nameMap.ContainsKey(pn.Name) ? nameMap[pn.Name] : pn.Name), endEscapeIndicator)));
                 if(onlyOnceColumns != null && onlyOnceColumns.Any())
                 {

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureConfigUtils.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/AzureConfigUtils.cs
@@ -99,7 +99,7 @@ namespace Orleans.Runtime.Host
                 if (roleRootDir != null)
                 {
                     // Being called from Role startup code - either Azure WorkerRole or WebRole
-                    Assembly assy = typeof(AzureConfigUtils).GetTypeInfo().Assembly;
+                    Assembly assy = typeof(AzureConfigUtils).Assembly;
                     string appRootPath = Path.GetDirectoryName(assy.Location);
                     if (appRootPath != null)
                         locations.Add(new DirectoryInfo(appRootPath));
@@ -119,7 +119,7 @@ namespace Orleans.Runtime.Host
 
             Utils.SafeExecute(() =>
             {
-                Assembly assy = typeof(AzureConfigUtils).GetTypeInfo().Assembly;
+                Assembly assy = typeof(AzureConfigUtils).Assembly;
                 string appRootPath = Path.GetDirectoryName(new Uri(assy.CodeBase).LocalPath);
                 if (appRootPath != null)
                     locations.Add(new DirectoryInfo(appRootPath));

--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -102,7 +102,7 @@ namespace Orleans.CodeGeneration
             AppDomain appDomain = null;
             try
             {
-                var assembly = typeof(CodeGenerator).GetTypeInfo().Assembly;
+                var assembly = typeof(CodeGenerator).Assembly;
 
                 // Create AppDomain.
                 var thisAssemblyPath = new Uri(assembly.CodeBase).LocalPath;

--- a/src/Orleans.CodeGeneration.Build/Program.cs
+++ b/src/Orleans.CodeGeneration.Build/Program.cs
@@ -49,7 +49,20 @@ namespace Orleans.CodeGeneration
 
                     if (arg.StartsWith("/"))
                     {
-                        if (arg.StartsWith("/reference:") || arg.StartsWith("/r:"))
+                        if (arg.StartsWith("/waitForDebugger"))
+                        {
+                            var i = 0;
+                            while (!Debugger.IsAttached)
+                            {
+                                if (i++ % 50 == 0)
+                                {
+                                    Console.WriteLine("Waiting for debugger to attach.");
+                                }
+
+                                Thread.Sleep(100);
+                            }
+                        }
+                        else if (arg.StartsWith("/reference:") || arg.StartsWith("/r:"))
                         {
                             // list of references passed from from project file. separator =';'
                             string refstr = arg.Substring(arg.IndexOf(':') + 1);

--- a/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -63,6 +63,7 @@
       <Output TaskParameter="DotNetHost" PropertyName="DotNetHost" />
     </Orleans.CodeGeneration.GetDotNetHost>
     <ItemGroup>
+      <CodeGenArgs Include="/waitForDebugger" Condition="'$(OrleansCodeGenWaitForDebugger)' != ''" />
       <CodeGenArgs Include="/in:$(InputAssembly)"/>
       <CodeGenArgs Include="/out:$(OutputFileName)"/>
       <CodeGenArgs Include="/loglevel:$(OrleansCodeGenLogLevel)"/>

--- a/src/Orleans.CodeGeneration/GrainMethodInvokerGenerator.cs
+++ b/src/Orleans.CodeGeneration/GrainMethodInvokerGenerator.cs
@@ -43,8 +43,7 @@ namespace Orleans.CodeGenerator
         {
             var baseTypes = new List<BaseTypeSyntax> { SF.SimpleBaseType(typeof(IGrainMethodInvoker).GetTypeSyntax()) };
 
-            var grainTypeInfo = grainType.GetTypeInfo();
-            var genericTypes = grainTypeInfo.IsGenericTypeDefinition
+            var genericTypes = grainType.IsGenericTypeDefinition
                                    ? grainType.GetGenericArguments()
                                          .Select(_ => SF.TypeParameter(_.ToString()))
                                          .ToArray()
@@ -72,7 +71,7 @@ namespace Orleans.CodeGenerator
             };
 
             // If this is an IGrainExtension, make the generated class implement IGrainExtensionMethodInvoker.
-            if (typeof(IGrainExtension).GetTypeInfo().IsAssignableFrom(grainTypeInfo))
+            if (typeof(IGrainExtension).IsAssignableFrom(grainType))
             {
                 baseTypes.Add(SF.SimpleBaseType(typeof(IGrainExtensionMethodInvoker).GetTypeSyntax()));
                 members.Add(GenerateExtensionInvokeMethod(grainType));

--- a/src/Orleans.CodeGeneration/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGeneration/GrainReferenceGenerator.cs
@@ -52,9 +52,8 @@ namespace Orleans.CodeGenerator
         /// </returns>
         internal static TypeDeclarationSyntax GenerateClass(Type grainType, string generatedTypeName, Action<Type> onEncounteredType)
         {
-            var grainTypeInfo = grainType.GetTypeInfo();
-            var genericTypes = grainTypeInfo.IsGenericTypeDefinition
-                                   ? grainTypeInfo.GetGenericArguments()
+            var genericTypes = grainType.IsGenericTypeDefinition
+                                   ? grainType.GetGenericArguments()
                                          .Select(_ => SF.TypeParameter(_.ToString()))
                                          .ToArray()
                                    : new TypeParameterSyntax[0];
@@ -104,7 +103,7 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax[] GenerateConstructors(string className)
         {
             var baseConstructors =
-                typeof(GrainReference).GetTypeInfo().GetConstructors(
+                typeof(GrainReference).GetConstructors(
                     BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).Where(_ => !_.IsPrivate);
             var constructors = new List<MemberDeclarationSyntax>();
             foreach (var baseConstructor in baseConstructors)
@@ -150,7 +149,7 @@ namespace Orleans.CodeGenerator
                 foreach (var parameter in parameters)
                 {
                     onEncounteredType(parameter.ParameterType);
-                    if (typeof(IGrainObserver).GetTypeInfo().IsAssignableFrom(parameter.ParameterType))
+                    if (typeof(IGrainObserver).IsAssignableFrom(parameter.ParameterType))
                     {
                         body.Add(
                             SF.ExpressionStatement(
@@ -332,8 +331,8 @@ namespace Orleans.CodeGenerator
             var argIdentifier = arg.GetOrCreateName(argIndex).ToIdentifierName();
 
             // Addressable arguments must be converted to references before passing.
-            if (typeof(IAddressable).GetTypeInfo().IsAssignableFrom(arg.ParameterType)
-                && arg.ParameterType.GetTypeInfo().IsInterface)
+            if (typeof(IAddressable).IsAssignableFrom(arg.ParameterType)
+                && arg.ParameterType.IsInterface)
             {
                 return
                     SF.ConditionalExpression(

--- a/src/Orleans.CodeGeneration/SerializerGenerationManager.cs
+++ b/src/Orleans.CodeGeneration/SerializerGenerationManager.cs
@@ -56,12 +56,11 @@ namespace Orleans.CodeGenerator
         private bool HasSerializer(Type type)
         {
             if (this.typesToIgnore.Contains(type)) return true;
-            var typeInfo = type.GetTypeInfo();
-            if (typeInfo.IsOrleansPrimitive()) return true;
-            if (!typeInfo.IsGenericType) return false;
-            var genericTypeDefinition = typeInfo.GetGenericTypeDefinition();
+            if (type.IsOrleansPrimitive()) return true;
+            if (!type.IsGenericType) return false;
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
             return this.typesToIgnore.Contains(genericTypeDefinition) &&
-                   typeInfo.GetGenericArguments().All(arg => HasSerializer(arg));
+                   type.GetGenericArguments().All(arg => this.HasSerializer(arg));
         }
 
         internal bool IsTypeRecorded(Type type)
@@ -83,9 +82,9 @@ namespace Orleans.CodeGenerator
 
             if (t.IsGenericParameter || processedTypes.Contains(t) || typesToProcess.Contains(t)
                 || typesToIgnore.Contains(t)
-                || typeof (Exception).GetTypeInfo().IsAssignableFrom(t)
-                || typeof (Delegate).GetTypeInfo().IsAssignableFrom(t)
-                || typeof (Task<>).GetTypeInfo().IsAssignableFrom(t)) return false;
+                || typeof (Exception).IsAssignableFrom(t)
+                || typeof (Delegate).IsAssignableFrom(t)
+                || typeof (Task<>).IsAssignableFrom(t)) return false;
 
             if (t.IsArray)
             {
@@ -121,7 +120,7 @@ namespace Orleans.CodeGenerator
             }
 
             if (t.IsOrleansPrimitive() || this.HasSerializer(t) ||
-                typeof(IAddressable).GetTypeInfo().IsAssignableFrom(t)) return false;
+                typeof(IAddressable).IsAssignableFrom(t)) return false;
 
             if (t.Namespace != null && (t.Namespace.Equals("System") || t.Namespace.StartsWith("System.")))
             {

--- a/src/Orleans.CodeGeneration/SerializerGenerator.cs
+++ b/src/Orleans.CodeGeneration/SerializerGenerator.cs
@@ -87,9 +87,8 @@ namespace Orleans.CodeGenerator
         /// </returns>
         internal static TypeDeclarationSyntax GenerateClass(string className, Type type, Action<Type> onEncounteredType)
         {
-            var typeInfo = type;
-            var genericTypes = typeInfo.IsGenericTypeDefinition
-                                   ? typeInfo.GetGenericArguments().Select(_ => SF.TypeParameter(_.ToString())).ToArray()
+            var genericTypes = type.IsGenericTypeDefinition
+                                   ? type.GetGenericArguments().Select(_ => SF.TypeParameter(_.ToString())).ToArray()
                                    : new TypeParameterSyntax[0];
 
             var attributes = new List<AttributeSyntax>
@@ -137,7 +136,7 @@ namespace Orleans.CodeGenerator
         {
             var body = new List<StatementSyntax>();
 
-            Expression<Action<TypeInfo>> getField = _ => _.GetField(string.Empty, BindingFlags.Default);
+            Expression<Action<Type>> getField = _ => _.GetField(string.Empty, BindingFlags.Default);
             Expression<Action<IFieldUtils>> getGetter = _ => _.GetGetter(default(FieldInfo));
             Expression<Action<IFieldUtils>> getReferenceSetter = _ => _.GetReferenceSetter(default(FieldInfo));
             Expression<Action<IFieldUtils>> getValueSetter = _ => _.GetValueSetter(default(FieldInfo));
@@ -510,15 +509,15 @@ namespace Orleans.CodeGenerator
         }
 
         /// <summary>
-        /// Return a parameterless ctor if found. Since typeInfo.GetConstructor can throw BadImageFormatException, 
+        /// Return a parameterless ctor if found. Since type.GetConstructor can throw BadImageFormatException, 
         /// we have to do the manual filtering here.
         /// </summary>
-        /// <param name="typeInfo">The typeInfo</param>
+        /// <param name="type">The type</param>
         /// <returns>Given ctor or null if not found.</returns>
-        private static ConstructorInfo GetEmptyConstructor(Type typeInfo)
+        private static ConstructorInfo GetEmptyConstructor(Type type)
         {
             var result = default(ConstructorInfo);
-            var ctors = typeInfo.GetConstructors();
+            var ctors = type.GetConstructors();
 
             foreach (var ctor in ctors)
             {

--- a/src/Orleans.CodeGeneration/Utilities/SyntaxFactoryExtensions.cs
+++ b/src/Orleans.CodeGeneration/Utilities/SyntaxFactoryExtensions.cs
@@ -319,11 +319,10 @@ namespace Orleans.CodeGenerator.Utilities
         /// </returns>
         public static TypeParameterConstraintClauseSyntax[] GetTypeConstraintSyntax(this Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            if (typeInfo.IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 var constraints = new List<TypeParameterConstraintClauseSyntax>();
-                foreach (var genericParameter in typeInfo.GetGenericArguments())
+                foreach (var genericParameter in type.GetGenericArguments())
                 {
                     constraints.AddRange(GetTypeParameterConstraints(genericParameter));
                 }
@@ -338,7 +337,7 @@ namespace Orleans.CodeGenerator.Utilities
         {
             var results = new List<TypeParameterConstraintClauseSyntax>();
             var parameterConstraints = new List<TypeParameterConstraintSyntax>();
-            var attributes = genericParameter.GetTypeInfo().GenericParameterAttributes;
+            var attributes = genericParameter.GenericParameterAttributes;
 
             // The "class" or "struct" constraints must come first.
             if (attributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint))
@@ -351,7 +350,7 @@ namespace Orleans.CodeGenerator.Utilities
             }
 
             // Follow with the base class or interface constraints.
-            foreach (var genericType in genericParameter.GetTypeInfo().GetGenericParameterConstraints())
+            foreach (var genericType in genericParameter.GetGenericParameterConstraints())
             {
                 // If the "struct" constraint was specified, skip the corresponding "ValueType" constraint.
                 if (genericType == typeof(ValueType))

--- a/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
@@ -14,7 +14,7 @@ namespace Orleans.CodeGeneration
         /// The type itself is not relevant, and it's just a way to indirectly identify the assembly.</param>
         public KnownAssemblyAttribute(Type type)
         {
-            this.Assembly = type.GetTypeInfo().Assembly;
+            this.Assembly = type.Assembly;
         }
 
         /// <summary>

--- a/src/Orleans.Core.Legacy/Configuration/ApplicationConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ApplicationConfiguration.cs
@@ -365,7 +365,6 @@ namespace Orleans.Runtime.Configuration
                 logger.Error(ErrorCode.Loader_TypeLoadError_2, errStr);
                 throw new OrleansException(errStr);
             }
-            var typeInfo = type.GetTypeInfo();
             // postcondition: returned type must implement IGrain.
             if (!typeof(IGrain).IsAssignableFrom(type))
             {
@@ -375,7 +374,7 @@ namespace Orleans.Runtime.Configuration
             }
             // postcondition: returned type must either be an interface or a class.
             
-            if (!typeInfo.IsInterface && !typeInfo.IsClass)
+            if (!type.IsInterface && !type.IsClass)
             {
                 string errStr = string.Format("Type {0} must either be an interface or class used Application configuration context.",type.FullName);
                 logger.Error(ErrorCode.Loader_TypeLoadError_4, errStr);

--- a/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
@@ -360,13 +360,12 @@ namespace Orleans.Runtime.Configuration
         /// <param name="properties">Properties that will be passed to stream provider upon initialization</param>
         public void RegisterStreamProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : Orleans.Streams.IStreamProvider
         {
-            TypeInfo providerTypeInfo = typeof(T).GetTypeInfo();
-            if (providerTypeInfo.IsAbstract ||
-                providerTypeInfo.IsGenericType ||
-                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(typeof(T)))
+            if (typeof(T).IsAbstract ||
+                typeof(T).IsGenericType ||
+                !typeof(Streams.IStreamProvider).IsAssignableFrom(typeof(T)))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStreamProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(this.ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, typeof(T).FullName, providerName, properties);
         }
 
         /// <summary>

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -1016,10 +1016,9 @@ namespace Orleans.Runtime.Configuration
         public void RegisterStreamProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : Orleans.Streams.IStreamProvider
         {            
             Type providerType = typeof(T);
-            var providerTypeInfo = providerType.GetTypeInfo();
-            if (providerTypeInfo.IsAbstract ||
-                providerTypeInfo.IsGenericType ||
-                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(providerType))
+            if (providerType.IsAbstract ||
+                providerType.IsGenericType ||
+                !typeof(Streams.IStreamProvider).IsAssignableFrom(providerType))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStreamProvider interface", "typeof(T)");
 
             ProviderConfigurationUtility.RegisterProvider(this.ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
@@ -1045,13 +1044,12 @@ namespace Orleans.Runtime.Configuration
         public void RegisterStorageProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : IStorageProvider
         {
             Type providerType = typeof(T);
-            var providerTypeInfo = providerType.GetTypeInfo();
-            if (providerTypeInfo.IsAbstract ||
-                providerTypeInfo.IsGenericType ||
+            if (providerType.IsAbstract ||
+                providerType.IsGenericType ||
                 !typeof(IStorageProvider).IsAssignableFrom(providerType))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStorageProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(this.ProviderConfigurations, ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(this.ProviderConfigurations, ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
         }
 
         /// <summary>
@@ -1086,9 +1084,8 @@ namespace Orleans.Runtime.Configuration
         public void RegisterLogConsistencyProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : ILogConsistencyProvider
         {
             Type providerType = typeof(T);
-            var providerTypeInfo = providerType.GetTypeInfo();
-            if (providerTypeInfo.IsAbstract ||
-                providerTypeInfo.IsGenericType ||
+            if (providerType.IsAbstract ||
+                providerType.IsGenericType ||
                 !typeof(ILogConsistencyProvider).IsAssignableFrom(providerType))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements ILogConsistencyProvider interface", "typeof(T)");
 

--- a/src/Orleans.Core/AssemblyLoader/AssemblyLoaderReflectionCriterion.cs
+++ b/src/Orleans.Core/AssemblyLoader/AssemblyLoaderReflectionCriterion.cs
@@ -39,7 +39,7 @@ namespace Orleans.Runtime
             return NewCriterion(
                     (Assembly assembly, out IEnumerable<string> assemblyComplaints) =>
                     {
-                        TypeInfo[] types;
+                        Type[] types;
                         try
                         {
                             types = TypeUtils.GetDefinedTypes(assembly).ToArray();

--- a/src/Orleans.Core/AssemblyLoader/TypeMetadataCache.cs
+++ b/src/Orleans.Core/AssemblyLoader/TypeMetadataCache.cs
@@ -35,9 +35,8 @@ namespace Orleans.Runtime
 
         public Type GetGrainReferenceType(Type interfaceType)
         {
-            var typeInfo = interfaceType.GetTypeInfo();
             var genericInterfaceType = interfaceType.IsConstructedGenericType
-                                           ? typeInfo.GetGenericTypeDefinition()
+                                           ? interfaceType.GetGenericTypeDefinition()
                                            : interfaceType;
 
             if (!typeof(IAddressable).IsAssignableFrom(interfaceType))
@@ -56,7 +55,7 @@ namespace Orleans.Runtime
 
             if (interfaceType.IsConstructedGenericType)
             {
-                grainReferenceType = grainReferenceType.MakeGenericType(typeInfo.GenericTypeArguments);
+                grainReferenceType = grainReferenceType.MakeGenericType(interfaceType.GenericTypeArguments);
             }
 
             if (!typeof(IAddressable).IsAssignableFrom(grainReferenceType))
@@ -71,9 +70,8 @@ namespace Orleans.Runtime
 
         public Type GetGrainMethodInvokerType(Type interfaceType)
         {
-            var typeInfo = interfaceType.GetTypeInfo();
             var genericInterfaceType = interfaceType.IsConstructedGenericType
-                                           ? typeInfo.GetGenericTypeDefinition()
+                                           ? interfaceType.GetGenericTypeDefinition()
                                            : interfaceType;
 
             // Try to find the correct IGrainMethodInvoker type for this interface.
@@ -86,7 +84,7 @@ namespace Orleans.Runtime
 
             if (interfaceType.IsConstructedGenericType)
             {
-                invokerType = invokerType.MakeGenericType(typeInfo.GenericTypeArguments);
+                invokerType = invokerType.MakeGenericType(interfaceType.GenericTypeArguments);
             }
 
             return invokerType;

--- a/src/Orleans.Core/Configuration/ConfigUtilities.cs
+++ b/src/Orleans.Core/Configuration/ConfigUtilities.cs
@@ -215,7 +215,7 @@ namespace Orleans.Runtime.Configuration
             return returnValue;
         }
 
-        internal static void ValidateSerializationProvider(TypeInfo type)
+        internal static void ValidateSerializationProvider(Type type)
         {
             if (type.IsClass == false)
             {
@@ -232,7 +232,7 @@ namespace Orleans.Runtime.Configuration
                 throw new FormatException(string.Format("The serialization provider type {0} is not public", type.FullName));
             }
 
-            if (type.IsGenericType && type.IsConstructedGenericType() == false)
+            if (type.IsGenericType && type.IsConstructedGenericType == false)
             {
                 throw new FormatException(string.Format("The serialization provider type {0} is generic and has a missing type parameter specification", type.FullName));
             }
@@ -537,7 +537,7 @@ namespace Orleans.Runtime.Configuration
         public static string FindConfigFile(bool isSilo)
         {
             // Add directory containing Orleans binaries to the search locations for config files
-            defaultConfigDirs[0] = Path.GetDirectoryName(typeof(ConfigUtilities).GetTypeInfo().Assembly.Location);
+            defaultConfigDirs[0] = Path.GetDirectoryName(typeof(ConfigUtilities).Assembly.Location);
 
             var notFound = new List<string>();
             foreach (string dir in defaultConfigDirs)

--- a/src/Orleans.Core/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans.Core/Configuration/MessagingConfiguration.cs
@@ -83,12 +83,12 @@ namespace Orleans.Runtime.Configuration
         /// <summary>
         /// The list of serialization providers
         /// </summary>
-        List<TypeInfo> SerializationProviders { get; }
+        List<Type> SerializationProviders { get; }
 
         /// <summary>
         /// Gets the fallback serializer, used as a last resort when no other serializer is able to serialize an object.
         /// </summary>
-        TypeInfo FallbackSerializationProvider { get; set; }
+        Type FallbackSerializationProvider { get; set; }
 
         /// <summary>
         /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
@@ -130,8 +130,8 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public int LargeMessageWarningThreshold { get; set; }
 
-        public List<TypeInfo> SerializationProviders { get; private set; }
-        public TypeInfo FallbackSerializationProvider { get; set; }
+        public List<Type> SerializationProviders { get; private set; }
+        public Type FallbackSerializationProvider { get; set; }
 
         internal const int DEFAULT_MAX_FORWARD_COUNT = 2;
         private const bool DEFAULT_RESEND_ON_TIMEOUT = false;
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.Configuration
             {
                 MaxForwardCount = 0;
             }
-            SerializationProviders = new List<TypeInfo>();
+            SerializationProviders = new List<Type>();
         }
 
         public override string ToString()
@@ -311,11 +311,10 @@ namespace Orleans.Runtime.Configuration
                                 $"The type specification for the 'type' attribute of the Provider element could not be loaded. Type specification: '{t}'."));
                     foreach (var type in types)
                     {
-                        var typeinfo = type.GetTypeInfo();
-                        ConfigUtilities.ValidateSerializationProvider(typeinfo);
-                        if (SerializationProviders.Contains(typeinfo) == false)
+                        ConfigUtilities.ValidateSerializationProvider(type);
+                        if (this.SerializationProviders.Contains(type) == false)
                         {
-                            SerializationProviders.Add(typeinfo);
+                            this.SerializationProviders.Add((Type)type);
                         }
                     }
                 }
@@ -333,7 +332,7 @@ namespace Orleans.Runtime.Configuration
                     var type = ConfigUtilities.ParseFullyQualifiedType(
                         typeName,
                         $"The type specification for the 'type' attribute of the FallbackSerializationProvider element could not be loaded. Type specification: '{typeName}'.");
-                    this.FallbackSerializationProvider = type.GetTypeInfo();
+                    this.FallbackSerializationProvider = type;
                 }
             }
         }

--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using System.Reflection;
+using System;
 
 namespace Orleans.Configuration
 {
@@ -11,11 +11,11 @@ namespace Orleans.Configuration
         /// <summary>
         /// Externally registered serializers
         /// </summary>
-        public List<TypeInfo> SerializationProviders { get; set; } = new List<TypeInfo>();
+        public List<Type> SerializationProviders { get; set; } = new List<Type>();
 
         /// <summary>
         /// Serializer used if no serializer is found for a type.
         /// </summary>
-        public TypeInfo FallbackSerializationProvider { get; set; }
+        public Type FallbackSerializationProvider { get; set; }
     }
 }

--- a/src/Orleans.Core/Core/GrainCasterFactory.cs
+++ b/src/Orleans.Core/Core/GrainCasterFactory.cs
@@ -58,7 +58,7 @@ namespace Orleans
                 "caster_" + grainReferenceType.Name,
                 typeof(object),
                 new[] { typeof(IAddressable) },
-                typeof(GrainFactory).GetTypeInfo().Module,
+                typeof(GrainFactory).Module,
                 true);
             var il = method.GetILGenerator();
             var returnLabel = il.DefineLabel();

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -145,16 +145,15 @@ namespace Orleans
         private TGrainObserverInterface CreateObjectReferenceImpl<TGrainObserverInterface>(IAddressable obj) where TGrainObserverInterface : IAddressable
         {
             var interfaceType = typeof(TGrainObserverInterface);
-            var interfaceTypeInfo = interfaceType.GetTypeInfo();
-            if (!interfaceTypeInfo.IsInterface)
+            if (!interfaceType.IsInterface)
             {
                 throw new ArgumentException(
-                    $"The provided type parameter must be an interface. '{interfaceTypeInfo.FullName}' is not an interface.");
+                    $"The provided type parameter must be an interface. '{interfaceType.FullName}' is not an interface.");
             }
 
-            if (!interfaceTypeInfo.IsInstanceOfType(obj))
+            if (!interfaceType.IsInstanceOfType(obj))
             {
-                throw new ArgumentException($"The provided object must implement '{interfaceTypeInfo.FullName}'.", nameof(obj));
+                throw new ArgumentException($"The provided object must implement '{interfaceType.FullName}'.", nameof(obj));
             }
 
             IGrainMethodInvoker invoker;
@@ -169,11 +168,10 @@ namespace Orleans
 
         private IAddressable MakeGrainReferenceFromType(Type interfaceType, GrainId grainId)
         {
-            var typeInfo = interfaceType.GetTypeInfo();
             return GrainReference.FromGrainId(
                 grainId,
                 this.GrainReferenceRuntime,
-                typeInfo.IsGenericType ? TypeUtils.GenericTypeArgsString(typeInfo.UnderlyingSystemType.FullName) : null);
+                interfaceType.IsGenericType ? TypeUtils.GenericTypeArgsString(interfaceType.UnderlyingSystemType.FullName) : null);
         }
 
         private GrainClassData GetGrainClassData(Type interfaceType, string grainClassNamePrefix)

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -80,7 +80,6 @@ namespace Orleans
                     $"Type {implementationType} passed to {nameof(CreateMapForNonGeneric)} is a constructed generic type.");
             }
 
-            var implementationTypeInfo = implementationType.GetTypeInfo();
             var interfaces = implementationType.GetInterfaces();
 
             // Create an invoker for every interface on the provided type.
@@ -98,7 +97,7 @@ namespace Orleans
                     // get the mapping for the interface which it does belong to.
                     if (mapping.InterfaceType != method.DeclaringType)
                     {
-                        mapping = implementationTypeInfo.GetRuntimeInterfaceMap(method.DeclaringType);
+                        mapping = implementationType.GetTypeInfo().GetRuntimeInterfaceMap(method.DeclaringType);
                     }
 
                     // Find the index of the interface method and then get the implementation method at that position.
@@ -135,8 +134,6 @@ namespace Orleans
             }
 
             var genericClass = implementationType.GetGenericTypeDefinition();
-            var genericClassTypeInfo = genericClass.GetTypeInfo();
-            var implementationTypeInfo = implementationType.GetTypeInfo();
 
             var genericInterfaces = genericClass.GetInterfaces();
             var concreteInterfaces = implementationType.GetInterfaces();
@@ -161,8 +158,8 @@ namespace Orleans
                     var genericInterfaceMethod = genericMethods[j];
                     if (genericMap.InterfaceType != genericInterfaceMethod.DeclaringType)
                     {
-                        genericMap = genericClassTypeInfo.GetRuntimeInterfaceMap(genericInterfaceMethod.DeclaringType);
-                        concreteMap = implementationTypeInfo.GetRuntimeInterfaceMap(concreteInterfaceMethods[j].DeclaringType);
+                        genericMap = genericClass.GetTypeInfo().GetRuntimeInterfaceMap(genericInterfaceMethod.DeclaringType);
+                        concreteMap = implementationType.GetTypeInfo().GetRuntimeInterfaceMap(concreteInterfaceMethods[j].DeclaringType);
                     }
 
                     // Determine the position in the definition's map which the target method belongs to and take the implementation

--- a/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
+++ b/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
@@ -100,7 +100,7 @@ namespace Orleans.LogConsistency
 
         private ILogViewAdaptorFactory SetupLogConsistencyProvider(IGrainActivationContext activationContext)
         {
-            var attr = this.GetType().GetTypeInfo().GetCustomAttributes<LogConsistencyProviderAttribute>(true).FirstOrDefault();
+            var attr = this.GetType().GetCustomAttributes<LogConsistencyProviderAttribute>(true).FirstOrDefault();
 
             ILogViewAdaptorFactory defaultFactory = attr != null
                 ? this.ServiceProvider.GetServiceByName<ILogViewAdaptorFactory>(attr.ProviderName)

--- a/src/Orleans.Core/Providers/ProviderTypeLoader.cs
+++ b/src/Orleans.Core/Providers/ProviderTypeLoader.cs
@@ -81,13 +81,12 @@ namespace Orleans.Providers
             }
         }
 
-        internal void ProcessType(TypeInfo typeInfo)
+        internal void ProcessType(Type type)
         {
-            var type = typeInfo.AsType();
-            if (alreadyProcessed.Contains(type) || typeInfo.IsInterface || typeInfo.IsAbstract || !condition(type)) return;
+            if (this.alreadyProcessed.Contains(type) || type.IsInterface || type.IsAbstract || !this.condition(type)) return;
 
-            alreadyProcessed.Add(type);
-            callback(type);
+            this.alreadyProcessed.Add(type);
+            this.callback(type);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/Orleans.Core/Runtime/GrainClassData.cs
+++ b/src/Orleans.Core/Runtime/GrainClassData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -54,10 +54,9 @@ namespace Orleans.Runtime
 
         internal long GetTypeCode(Type interfaceType)
         {
-            var typeInfo = interfaceType.GetTypeInfo();
-            if (typeInfo.IsGenericType && this.IsGeneric)
+            if (interfaceType.IsGenericType && this.IsGeneric)
             {
-                string args = TypeUtils.GetGenericTypeArgs(typeInfo.GetGenericArguments(), t => true);
+                string args = TypeUtils.GetGenericTypeArgs(interfaceType.GetGenericArguments(), t => true);
                 int hash = Utils.CalculateIdHash(args);
                 return (((long)(hash & 0x00FFFFFF)) << 32) + GrainTypeCode;
             }

--- a/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
@@ -106,9 +106,8 @@ namespace Orleans.Runtime
         {
             lock (this)
             {
-                var grainTypeInfo = grain.GetTypeInfo();
-                var grainName = TypeUtils.GetFullName(grainTypeInfo);
-                var isGenericGrainClass = grainTypeInfo.ContainsGenericParameters;
+                var grainName = TypeUtils.GetFullName(grain);
+                var isGenericGrainClass = grain.ContainsGenericParameters;
                 var grainTypeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grain);
 
                 var grainInterfaceData = GetOrAddGrainInterfaceData(iface, isGenericGrainClass);
@@ -134,7 +133,7 @@ namespace Orleans.Runtime
 
                 if (localTestMode)
                 {
-                    var assembly = grainTypeInfo.Assembly.CodeBase;
+                    var assembly = grain.Assembly.CodeBase;
                     if (!loadedGrainAsemblies.Contains(assembly))
                         loadedGrainAsemblies.Add(assembly);
                 }
@@ -225,10 +224,9 @@ namespace Orleans.Runtime
 
         internal static string GetTypeKey(Type interfaceType, bool isGenericGrainClass)
         {
-            var typeInfo = interfaceType.GetTypeInfo();
-            if (isGenericGrainClass && typeInfo.IsGenericType)
+            if (isGenericGrainClass && interfaceType.IsGenericType)
             {
-                return typeInfo.GetGenericTypeDefinition().AssemblyQualifiedName;
+                return interfaceType.GetGenericTypeDefinition().AssemblyQualifiedName;
             }
             else 
             {

--- a/src/Orleans.Core/Runtime/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Runtime/GrainTypeResolver.cs
@@ -38,7 +38,6 @@ namespace Orleans.Runtime
         {
             implementation = null;
             GrainInterfaceData interfaceData;
-            var typeInfo = interfaceType.GetTypeInfo();
 
             // First, try to find a non-generic grain implementation:
             if (this.typeToInterfaceData.TryGetValue(GrainInterfaceMap.GetTypeKey(interfaceType, false), out interfaceData) &&
@@ -49,7 +48,7 @@ namespace Orleans.Runtime
 
             // If a concrete implementation was not found and the interface is generic, 
             // try to find a generic grain implementation:
-            if (typeInfo.IsGenericType &&
+            if (interfaceType.IsGenericType &&
                 this.typeToInterfaceData.TryGetValue(GrainInterfaceMap.GetTypeKey(interfaceType, true), out interfaceData) &&
                 TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix))
             {

--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                Assembly thisProg = typeof(RuntimeVersion).GetTypeInfo().Assembly;
+                Assembly thisProg = typeof(RuntimeVersion).Assembly;
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
                 bool isDebug = IsAssemblyDebugBuild(thisProg);
                 string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
@@ -29,7 +29,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                AssemblyName libraryInfo = typeof(RuntimeVersion).GetTypeInfo().Assembly.GetName();
+                AssemblyName libraryInfo = typeof(RuntimeVersion).Assembly.GetName();
                 return libraryInfo.Version.ToString();
             }
         }
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                Assembly thisProg = typeof(RuntimeVersion).GetTypeInfo().Assembly;
+                Assembly thisProg = typeof(RuntimeVersion).Assembly;
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
                 string fileVersion = progVersionInfo.FileVersion;
                 return string.IsNullOrEmpty(fileVersion) ? ApiVersion : fileVersion;
@@ -56,7 +56,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                Assembly thisProg = Assembly.GetEntryAssembly() ?? typeof(RuntimeVersion).GetTypeInfo().Assembly;
+                Assembly thisProg = Assembly.GetEntryAssembly() ?? typeof(RuntimeVersion).Assembly;
                 AssemblyName progInfo = thisProg.GetName();
                 return progInfo.Name;
             }

--- a/src/Orleans.Core/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterSerializer.cs
@@ -12,7 +12,7 @@ namespace Orleans.Serialization
     {
         public bool IsSupportedType(Type itemType)
         {
-            return itemType.GetTypeInfo().IsSerializable;
+            return itemType.IsSerializable;
         }
 
         public object DeepCopy(object source, ICopyContext context)

--- a/src/Orleans.Core/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans.Core/Serialization/BinaryTokenStreamWriter.cs
@@ -345,7 +345,7 @@ namespace Orleans.Serialization
                 return;
             }
 
-            if (t.GetTypeInfo().IsGenericType)
+            if (t.IsGenericType)
             {
                 if (typeTokens.TryGetValue(t.GetGenericTypeDefinition().TypeHandle, out token))
                 {

--- a/src/Orleans.Core/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans.Core/Serialization/ILBasedSerializer.cs
@@ -80,7 +80,7 @@
         /// <param name="t">The type of the item to be serialized</param>
         /// <returns>A value indicating whether the item can be serialized.</returns>
         public bool IsSupportedType(Type t)
-            => this.serializers.ContainsKey(t) || ILSerializerGenerator.IsSupportedType(t.GetTypeInfo());
+            => this.serializers.ContainsKey(t) || ILSerializerGenerator.IsSupportedType(t);
 
         /// <inheritdoc />
         public object DeepCopy(object source, ICopyContext context)
@@ -151,7 +151,7 @@
 
         private SerializerBundle GenerateSerializer(Type type)
         {
-            if (type.GetTypeInfo().IsGenericTypeDefinition) return this.thisSerializer;
+            if (type.IsGenericTypeDefinition) return this.thisSerializer;
 
             if (TypeType.IsAssignableFrom(type))
             {

--- a/src/Orleans.Core/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamDirectory.cs
@@ -25,7 +25,7 @@ namespace Orleans.Streams
             var streamOfT = stream as IAsyncStream<T>;
             if (streamOfT == null)
             {
-                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested ({typeof(T)}) does not match the previously requested type ({stream.GetType().GetTypeInfo().GetGenericArguments().FirstOrDefault()}).");
+                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested ({typeof(T)}) does not match the previously requested type ({stream.GetType().GetGenericArguments().FirstOrDefault()}).");
             }
 
             return streamOfT;

--- a/src/Orleans.Core/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Core/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -240,7 +240,7 @@ namespace Orleans.Streams
                 throw new ArgumentException($"{grainClass.FullName} is not a grain class.", nameof(grainClass));
             }
 
-            var attribs = grainClass.GetTypeInfo().GetCustomAttributes<ImplicitStreamSubscriptionAttribute>(true);
+            var attribs = grainClass.GetCustomAttributes<ImplicitStreamSubscriptionAttribute>(true);
 
             return attribs.Select(attrib => attrib.Predicate).ToList();
         }

--- a/src/Orleans.Runtime.Legacy/Configuration/BootstrapProviderConfiguration.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/BootstrapProviderConfiguration.cs
@@ -19,13 +19,12 @@ namespace Orleans.Runtime.Configuration
         public static void RegisterBootstrapProvider<T>(this GlobalConfiguration config, string providerName, IDictionary<string, string> properties = null) where T : IBootstrapProvider
         {
             Type providerType = typeof(T);
-            var providerTypeInfo = providerType.GetTypeInfo();
-            if (providerTypeInfo.IsAbstract ||
-                providerTypeInfo.IsGenericType ||
+            if (providerType.IsAbstract ||
+                providerType.IsGenericType ||
                 !typeof(IBootstrapProvider).IsAssignableFrom(providerType))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IBootstrapProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(config.ProviderConfigurations, BOOTSTRAP_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(config.ProviderConfigurations, BOOTSTRAP_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -523,7 +523,7 @@ namespace Orleans.Runtime
                 "PrepForRemoting",
                 typeof(Exception),
                 new[] { typeof(Exception) },
-                typeof(SerializationManager).GetTypeInfo().Module,
+                typeof(SerializationManager).Module,
                 true);
             var il = method.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
@@ -26,7 +26,7 @@ namespace Orleans.GrainDirectory
 
         internal MultiClusterRegistrationStrategy GetMultiClusterRegistrationStrategy(Type grainClass)
         {
-            var attribs = grainClass.GetTypeInfo().GetCustomAttributes<RegistrationAttribute>(inherit: true).ToArray();
+            var attribs = grainClass.GetCustomAttributes<RegistrationAttribute>(inherit: true).ToArray();
 
             switch (attribs.Length)
             {

--- a/src/Orleans.Runtime/GrainTypeManager/GenericGrainTypeData.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/GenericGrainTypeData.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime
         public GenericGrainTypeData(Type activationType) :
             base(activationType)
         {
-            if (!activationType.GetTypeInfo().IsGenericTypeDefinition)
+            if (!activationType.IsGenericTypeDefinition)
                 throw new ArgumentException("Activation type is not generic: " + activationType.Name);
 
             this.activationType = activationType;

--- a/src/Orleans.Runtime/GrainTypeManager/GrainTypeData.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/GrainTypeData.cs
@@ -25,14 +25,13 @@ namespace Orleans.Runtime
    
         public GrainTypeData(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
             Type = type;
-            IsReentrant = typeInfo.GetCustomAttributes(typeof (ReentrantAttribute), true).Any();
+            this.IsReentrant = type.GetCustomAttributes(typeof (ReentrantAttribute), true).Any();
             // TODO: shouldn't this use GrainInterfaceUtils.IsStatelessWorker?
-            IsStatelessWorker = typeInfo.GetCustomAttributes(typeof(StatelessWorkerAttribute), true).Any();
-            GrainClass = TypeUtils.GetFullName(typeInfo);
+            this.IsStatelessWorker = type.GetCustomAttributes(typeof(StatelessWorkerAttribute), true).Any();
+            this.GrainClass = TypeUtils.GetFullName(type);
             RemoteInterfaceTypes = GetRemoteInterfaces(type);
-            MayInterleave = GetMayInterleavePredicate(typeInfo) ?? (_ => false);
+            this.MayInterleave = GetMayInterleavePredicate(type) ?? (_ => false);
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ namespace Orleans.Runtime
                 }
 
                 // Traverse the class hierarchy
-                grainType = grainType.GetTypeInfo().BaseType;
+                grainType = grainType.BaseType;
             }
 
             return interfaceTypes;
@@ -65,7 +64,7 @@ namespace Orleans.Runtime
             Type grainInterface, Func<T, PlacementStrategy> extract, out PlacementStrategy placement)
                 where T : Attribute
         {
-            var attribs = grainInterface.GetTypeInfo().GetCustomAttributes<T>(inherit: true).ToArray();
+            var attribs = grainInterface.GetCustomAttributes<T>(inherit: true).ToArray();
             switch (attribs.Length)
             {
                 case 0:
@@ -106,7 +105,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="grainType">Grain class.</param>
         /// <returns></returns>
-        private static Func<InvokeMethodRequest, bool> GetMayInterleavePredicate(TypeInfo grainType)
+        private static Func<InvokeMethodRequest, bool> GetMayInterleavePredicate(Type grainType)
         {
             if (!grainType.GetCustomAttributes<MayInterleaveAttribute>().Any())
                 return null;

--- a/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
@@ -139,7 +139,7 @@ namespace Orleans.Runtime
         internal void GetTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)
         {
             if (!ClusterGrainInterfaceMap.TryGetTypeInfo(typeCode, out grainClass, out placement, out activationStrategy, genericArguments))
-                throw new OrleansException(String.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
+                throw new OrleansException(string.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
         }
 
         internal void SetInterfaceMapsBySilo(Dictionary<SiloAddress, GrainInterfaceMap> value)
@@ -328,7 +328,7 @@ namespace Orleans.Runtime
 
                 if (excluded != null && excluded.Contains(className)) continue;
 
-                var typeData = grainType.GetTypeInfo().IsGenericTypeDefinition ?
+                var typeData = grainType.IsGenericTypeDefinition ?
                     new GenericGrainTypeData(grainType) :
                     new GrainTypeData(grainType);
                 result[className] = typeData;
@@ -345,7 +345,7 @@ namespace Orleans.Runtime
             foreach (var grainType in grainTypeData.Values.OrderBy(gtd => gtd.Type.FullName))
             {
                 // Skip system targets and Orleans grains
-                var assemblyName = grainType.Type.GetTypeInfo().Assembly.FullName.Split(',')[0];
+                var assemblyName = grainType.Type.Assembly.FullName.Split(',')[0];
                 if (!typeof(ISystemTarget).IsAssignableFrom(grainType.Type))
                 {
                     int grainClassTypeCode = CodeGeneration.GrainInterfaceUtils.GetGrainClassTypeCode(grainType.Type);
@@ -389,7 +389,7 @@ namespace Orleans.Runtime
             public InvokerData(Type invokerType)
             {
                 baseInvokerType = invokerType;
-                this.isGeneric = invokerType.GetTypeInfo().IsGenericType;
+                this.isGeneric = invokerType.IsGenericType;
                 if (this.isGeneric)
                 {
                     cachedGenericInvokers = new CachedReadConcurrentDictionary<string, IGrainMethodInvoker>();

--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -190,7 +190,7 @@ namespace Orleans.Runtime.MembershipService
 
         private static MembershipEntry CreateNewMembershipEntry(string siloName, SiloAddress myAddress, int proxyPort, string myHostname, SiloStatus myStatus, DateTime startTime)
         {
-            var assy = Assembly.GetEntryAssembly() ?? typeof(MembershipOracleData).GetTypeInfo().Assembly;
+            var assy = Assembly.GetEntryAssembly() ?? typeof(MembershipOracleData).Assembly;
             var roleName = assy.GetName().Name;
 
             var entry = new MembershipEntry

--- a/src/OrleansCounterControl/CounterControl.cs
+++ b/src/OrleansCounterControl/CounterControl.cs
@@ -51,7 +51,7 @@ namespace Orleans.Counter.Control
         {
             using (var usageStr = new StringWriter())
             {
-                usageStr.WriteLine(typeof(CounterControl).GetTypeInfo().Assembly.GetName().Name + ".exe {command}");
+                usageStr.WriteLine(typeof(CounterControl).Assembly.GetName().Name + ".exe {command}");
                 usageStr.WriteLine("Where commands are:");
                 usageStr.WriteLine(" /? or /help       = Display usage info");
                 usageStr.WriteLine(" /r or /register   = Register Windows performance counters for Orleans [default]");
@@ -138,7 +138,7 @@ namespace Orleans.Counter.Control
             }
             catch (Exception exc)
             {
-                ConsoleText.WriteError("Error running " + typeof(CounterControl).GetTypeInfo().Assembly.GetName().Name + ".exe", exc);
+                ConsoleText.WriteError("Error running " + typeof(CounterControl).Assembly.GetName().Name + ".exe", exc);
 
                 if (!BruteForce) return 2;
 

--- a/src/OrleansCounterControl/Program.cs
+++ b/src/OrleansCounterControl/Program.cs
@@ -12,7 +12,7 @@ namespace Orleans.Counter.Control
             var prog = new CounterControl(CounterControl.InitDefaultLogging());
 
             // Program ident
-            AssemblyName thisProgram = typeof(Program).GetTypeInfo().Assembly.GetName();
+            AssemblyName thisProgram = typeof(Program).Assembly.GetName();
             var progTitle = string.Format("{0} v{1}", thisProgram.Name, thisProgram.Version.ToString());
             ConsoleText.WriteStatus(progTitle);
             Console.Title = progTitle;

--- a/src/Serializers/Orleans.Serialization.Bond/BondSerializer.cs
+++ b/src/Serializers/Orleans.Serialization.Bond/BondSerializer.cs
@@ -49,13 +49,12 @@ namespace Orleans.Serialization
                 return true;
             }
 
-            var typeInfo = itemType.GetTypeInfo();
-            if (typeInfo.IsGenericType && itemType.IsConstructedGenericType == false)
+            if (itemType.IsGenericType && itemType.IsConstructedGenericType == false)
             {
                 return false;
             }
 
-            if (typeInfo.GetCustomAttribute<SchemaAttribute>() == null)
+            if (itemType.GetCustomAttribute<SchemaAttribute>() == null)
             {
                 return false;
             }

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Benchmarks</RootNamespace>
     <AssemblyName>Benchmarks</AssemblyName>

--- a/test/Benchmarks/Serialization/SerializationBenchmarks.cs
+++ b/test/Benchmarks/Serialization/SerializationBenchmarks.cs
@@ -25,19 +25,19 @@ namespace Benchmarks.Serialization
     {
         private void InitializeSerializer(SerializerToUse serializerToUse)
         {
-            TypeInfo fallback = null;
+            Type fallback = null;
             switch (serializerToUse)
             {
                 case SerializerToUse.Default:
                     break;
                 case SerializerToUse.IlBasedFallbackSerializer:
-                    fallback = typeof(ILBasedSerializer).GetTypeInfo();
+                    fallback = typeof(ILBasedSerializer);
                     break;
                 case SerializerToUse.BinaryFormatterFallbackSerializer:
-                    fallback = typeof(BinaryFormatterSerializer).GetTypeInfo();
+                    fallback = typeof(BinaryFormatterSerializer);
                     break;
                 case SerializerToUse.ProtoBufNet:
-                    fallback = typeof(ProtobufNetSerializer).GetTypeInfo();
+                    fallback = typeof(ProtobufNetSerializer);
                     break;
                 default:
                     throw new InvalidOperationException("Invalid Serializer was selected");

--- a/test/Extensions/Serializers/BondUtils.Tests/Serialization/BondSerializationTests.cs
+++ b/test/Extensions/Serializers/BondUtils.Tests/Serialization/BondSerializationTests.cs
@@ -19,7 +19,7 @@ namespace BondUtils.Tests.Serialization
                 {
                     SerializationProviders =
                     {
-                        typeof(BondSerializer).GetTypeInfo()
+                        typeof(BondSerializer)
                     }
                 });
         }

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/GoogleProtoBufSerializationTests.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/GoogleProtoBufSerializationTests.cs
@@ -20,7 +20,7 @@ namespace ProtoBuf.Serialization.Tests
             {
                 SerializationProviders =
                 {
-                    typeof(ProtobufSerializer).GetTypeInfo()
+                    typeof(ProtobufSerializer)
                 }
             }))
         {

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/ProtobufNetSerializationTests.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/ProtobufNetSerializationTests.cs
@@ -20,7 +20,7 @@ namespace ProtoBuf.Serialization.Tests
             {
                 SerializationProviders =
                 {
-                    typeof(ProtobufNetSerializer).GetTypeInfo()
+                    typeof(ProtobufNetSerializer)
                 }
             }))
         {

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -799,11 +799,11 @@ namespace UnitTests.Grains
 
 
             Type GetImmediateSubclass(Type subject) {
-                if(subject.GetTypeInfo().BaseType == typeof(BasicGrain)) {
+                if(subject.BaseType == typeof(BasicGrain)) {
                     return subject;
                 }
 
-                return GetImmediateSubclass(subject.GetTypeInfo().BaseType);
+                return GetImmediateSubclass(subject.BaseType);
             }
         }
 

--- a/test/NonSilo.Tests/General/InterfaceRules.cs
+++ b/test/NonSilo.Tests/General/InterfaceRules.cs
@@ -143,7 +143,7 @@ namespace UnitTests.General
             Type grainBase = typeof(Grain);
             Assert.True(grainMarker.IsAssignableFrom(grainClass), $"{grainClass} is {grainMarker}");
             Assert.True(grainBase.IsAssignableFrom(grainClass), $"{grainClass} is {grainBase}");
-            Assert.True(grainBase.GetTypeInfo().IsAssignableFrom(grainClass), $"{grainClass} is {grainBase}");
+            Assert.True(grainBase.IsAssignableFrom(grainClass), $"{grainClass} is {grainBase}");
 
             Assert.True(isConcreteGrainClass, $"IsConcreteGrainClass {grainClass}");
         }

--- a/test/NonSilo.Tests/General/InternalSerializationTests.cs
+++ b/test/NonSilo.Tests/General/InternalSerializationTests.cs
@@ -107,28 +107,27 @@ namespace UnitTests.Serialization
         public GrainReference GetGrainReference<TGrainInterface>()
         {
             var grainType = typeof(TGrainInterface);
-            var typeInfo = grainType.GetTypeInfo();
 
-            if (typeInfo.IsGenericTypeDefinition)
+            if (grainType.IsGenericTypeDefinition)
             {
                 throw new ArgumentException("Cannot create grain reference for non-concrete grain type");
             }
 
-            if (typeInfo.IsConstructedGenericType)
+            if (grainType.IsConstructedGenericType)
             {
-                grainType = typeInfo.GetGenericTypeDefinition();
+                grainType = grainType.GetGenericTypeDefinition();
             }
 
-            var type = typeInfo.Assembly.DefinedTypes.First(
+            var type = grainType.Assembly.DefinedTypes.First(
                 _ =>
                 {
                     var attr = _.GetCustomAttribute<GrainReferenceAttribute>();
                     return attr != null && attr.TargetType == grainType;
                 }).AsType();
 
-            if (typeInfo.IsConstructedGenericType)
+            if (grainType.IsConstructedGenericType)
             {
-                type = type.MakeGenericType(typeInfo.GetGenericArguments());
+                type = type.MakeGenericType(grainType.GetGenericArguments());
             }
 
             var regularGrainId = GrainId.GetGrainIdForTesting(Guid.NewGuid());

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -71,17 +71,17 @@ namespace UnitTests.Serialization
                 serializerToUse,
                 _ =>
                 {
-                    TypeInfo fallback;
+                    Type fallback;
                     switch (serializerToUse)
                     {
                         case SerializerToUse.IlBasedFallbackSerializer:
-                            fallback = typeof(ILBasedSerializer).GetTypeInfo();
+                            fallback = typeof(ILBasedSerializer);
                             break;
                         case SerializerToUse.BinaryFormatterFallbackSerializer:
-                            fallback = typeof(BinaryFormatterSerializer).GetTypeInfo();
+                            fallback = typeof(BinaryFormatterSerializer);
                             break;
                         case SerializerToUse.NoFallback:
-                            fallback = typeof(SupportsNothingSerializer).GetTypeInfo();
+                            fallback = typeof(SupportsNothingSerializer);
                             break;
                         default:
                             throw new InvalidOperationException("Invalid Serializer was selected");

--- a/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
+++ b/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Serialization
             {
                 SerializationProviders =
                 {
-                    typeof(FakeSerializer).GetTypeInfo()
+                    typeof(FakeSerializer)
                 }
             };
             this.environment = SerializationTestEnvironment.InitializeWithDefaults(config);

--- a/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Serialization
 
         public ILBasedExceptionSerializerTests()
         {
-            this.environment = SerializationTestEnvironment.Initialize(null, typeof(ILBasedSerializer).GetTypeInfo());
+            this.environment = SerializationTestEnvironment.Initialize(null, typeof(ILBasedSerializer));
         }
 
         /// <summary>

--- a/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Serialization
 
         public OrleansJsonSerializerTests()
         {
-            var config = new ClientConfiguration { SerializationProviders = { typeof(OrleansJsonSerializer).GetTypeInfo() } };
+            var config = new ClientConfiguration { SerializationProviders = { typeof(OrleansJsonSerializer) } };
             this.environment = SerializationTestEnvironment.InitializeWithDefaults(config);
         }
 
@@ -39,7 +39,7 @@ namespace UnitTests.Serialization
                 .Configure<ClusterOptions>(o => o.ClusterId = o.ServiceId = "s")
                 .UseLocalhostClustering()
                 .Configure<SerializationProviderOptions>(o =>
-                    o.SerializationProviders.Add(typeof(OrleansJsonSerializer).GetTypeInfo()))
+                    o.SerializationProviders.Add(typeof(OrleansJsonSerializer)))
                 .Build();
             var serializationManager = silo.Services.GetRequiredService<SerializationManager>();
             TestSerializationRoundTrip(serializationManager);

--- a/test/NonSilo.Tests/Serialization/SerializationOrderTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationOrderTests.cs
@@ -19,8 +19,8 @@ namespace UnitTests.Serialization
             {
                 SerializationProviders =
                 {
-                    typeof(FakeSerializer1).GetTypeInfo(),
-                    typeof(FakeSerializer2).GetTypeInfo()
+                    typeof(FakeSerializer1),
+                    typeof(FakeSerializer2)
                 }
             };
 

--- a/test/TestInfrastructure/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestInfrastructure/TestExtensions/SerializationTestEnvironment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,6 +62,11 @@ namespace TestExtensions
         }
 
         public static SerializationTestEnvironment Initialize(List<TypeInfo> serializationProviders = null, TypeInfo fallbackProvider = null)
+        {
+            return Initialize(serializationProviders?.Select(t => t.AsType()).ToList(), fallbackProvider?.AsType());
+        }
+
+        public static SerializationTestEnvironment Initialize(List<Type> serializationProviders = null, Type fallbackProvider = null)
         {
             var config = new ClientConfiguration {FallbackSerializationProvider = fallbackProvider};
             if (serializationProviders != null) config.SerializationProviders.AddRange(serializationProviders);


### PR DESCRIPTION
Back when we were preparing the codebase for .NET Standard 1.0 (IIRC), we had to convert most instances of `Type` to instances of `TypeInfo` where `Type` did not support the required functionality (generally type metadata/reflection).

Now that we're firmly on .NET Standard 2.0 it's time to undo this change. Conversion between the two is not free and shows up during serialization benchmarks (around 2.7% inclusive time on serialization benchmarks)