### PR TITLE
Invalidate activation cache entries from old epochs

### DIFF
--- a/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
@@ -585,6 +585,10 @@ namespace Orleans.Runtime.Messaging
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Transient,
                     string.Format("The target silo is no longer active: target was {0}, but this silo is {1}. The rejected message is {2}.",
                         msg.TargetSilo.ToLongString(), MessageCenter.MyAddress.ToLongString(), msg));
+
+                // Invalidate the remote caller's activation cache entry.
+                if (msg.TargetAddress != null) rejection.AddToCacheInvalidationHeader(msg.TargetAddress);
+
                 MessageCenter.OutboundQueue.SendMessage(rejection);
                 if (Log.IsEnabled(LogLevel.Debug)) Log.Debug("Rejecting an obsolete request; target was {0}, but this silo is {1}. The rejected message is {2}.",
                     msg.TargetSilo.ToLongString(), MessageCenter.MyAddress.ToLongString(), msg);


### PR DESCRIPTION
When rejecting a message which was addressed to an older generation of this silo, add the target activation to the cache invalidation headers.