### PR TITLE
Persistent state facet

### DIFF
--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
@@ -1,0 +1,9 @@
+using Orleans.Core;
+
+namespace Orleans.Runtime
+{
+    public interface IPersistentState<TState> : IStorage<TState>
+        where TState : new()
+    {
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateConfiguration.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateConfiguration.cs
@@ -1,0 +1,9 @@
+
+namespace Orleans.Runtime
+{
+    public interface IPersistentStateConfiguration
+    {
+        string StateName { get; }
+        string StorageName { get; }
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
@@ -1,0 +1,8 @@
+
+namespace Orleans.Runtime
+{
+    public interface IPersistentStateFactory
+    {
+        IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration config) where TState : new();
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/PersistentStateAttribute.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/PersistentStateAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Orleans.Runtime
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class PersistentStateAttribute : Attribute, IFacetMetadata, IPersistentStateConfiguration
+    {
+        public string StateName { get; }
+        public string StorageName { get; }
+
+        public PersistentStateAttribute(string stateName, string storageName = null)
+        {
+            this.StateName = stateName;
+            this.StorageName = storageName;
+        }
+    }
+}

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateAttributeMapper.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateAttributeMapper.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    public class PersistentStateAttributeMapper : IAttributeToFactoryMapper<PersistentStateAttribute>
+    {
+        private static readonly MethodInfo create = typeof(IPersistentStateFactory).GetMethod("Create");
+
+        public Factory<IGrainActivationContext, object> GetFactory(ParameterInfo parameter, PersistentStateAttribute attribute)
+        {
+            IPersistentStateConfiguration config = attribute;
+            // set state name to parameter name, if not already specified
+            if (string.IsNullOrEmpty(config.StateName))
+            {
+                config = new PersistentStateConfiguration() { StateName = parameter.Name, StorageName = attribute.StorageName };
+            }
+            // use generic type args to define collection type.
+            MethodInfo genericCreate = create.MakeGenericMethod(parameter.ParameterType.GetGenericArguments());
+            return context => Create(context, genericCreate, config);
+        }
+
+        private object Create(IGrainActivationContext context, MethodInfo genericCreate, IPersistentStateConfiguration config)
+        {
+            IPersistentStateFactory factory = context.ActivationServices.GetRequiredService<IPersistentStateFactory>();
+            object[] args = new object[] { context, config };
+            return genericCreate.Invoke(factory, args);
+        }
+
+        private class PersistentStateConfiguration : IPersistentStateConfiguration
+        {
+            public string StateName { get; set; }
+
+            public string StorageName { get; set; }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Storage;
+using Orleans.Utilities;
 
 namespace Orleans.Runtime
 {
@@ -28,7 +28,7 @@ namespace Orleans.Runtime
 
         protected virtual string GetFullStateName(IGrainActivationContext context, IPersistentStateConfiguration cfg)
         {
-            return $"{context.GrainType.FullName}.{cfg.StateName}";
+            return $"{RuntimeTypeNameFormatter.Format(context.GrainType)}.{cfg.StateName}";
         }
 
         private static void ThrowMissingProviderException(IGrainActivationContext context, IPersistentStateConfiguration cfg)

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Core;
+using Orleans.Storage;
+
+namespace Orleans.Runtime
+{
+    public class PersistentStateFactory : IPersistentStateFactory
+    {
+        public IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration cfg)
+            where TState : new()
+        {
+            IGrainStorage storageProvider = !string.IsNullOrWhiteSpace(cfg.StorageName)
+                ? context.ActivationServices.GetServiceByName<IGrainStorage>(cfg.StorageName)
+                : context.ActivationServices.GetService<IGrainStorage>();
+            if (storageProvider == null)
+            {
+                ThrowMissingProviderException(context, cfg);
+            }
+            string fullStateName = GetFullStateName(context, cfg);
+            var bridge = new PersistentStateBridge<TState>(fullStateName, context, storageProvider);
+            bridge.Participate(context.ObservableLifecycle);
+            return bridge;
+        }
+
+        protected virtual string GetFullStateName(IGrainActivationContext context, IPersistentStateConfiguration cfg)
+        {
+            return $"{context.GrainType.FullName}.{cfg.StateName}";
+        }
+
+        private static void ThrowMissingProviderException(IGrainActivationContext context, IPersistentStateConfiguration cfg)
+        {
+            string errMsg;
+            var grainTypeName = context.GrainType.GetParseableName(TypeFormattingOptions.LogFormat);
+            if (string.IsNullOrEmpty(cfg.StorageName))
+            {
+                errMsg = $"No default storage provider found loading grain type {grainTypeName}.";
+            }
+            else
+            {
+                errMsg = $"No storage provider named \"{cfg.StorageName}\" found loading grain type {grainTypeName}.";
+            }
+
+            throw new BadGrainStorageConfigException(errMsg);
+        }
+
+        private class PersistentStateBridge<TState> : IPersistentState<TState>, ILifecycleParticipant<IGrainLifecycle>
+            where TState : new()
+        {
+            private readonly string fullStateName;
+            private readonly IGrainActivationContext context;
+            private readonly IGrainStorage storageProvider;
+            private IStorage<TState> storage;
+
+            public PersistentStateBridge(string fullStateName, IGrainActivationContext context, IGrainStorage storageProvider)
+            {
+                this.fullStateName = fullStateName;
+                this.context = context;
+                this.storageProvider = storageProvider;
+            }
+
+            public TState State
+            {
+                get { return this.storage.State; }
+                set { this.storage.State = value; }
+            }
+
+            public string Etag => this.storage.Etag;
+
+            public Task ClearStateAsync()
+            {
+                return this.storage.ClearStateAsync();
+            }
+
+            public Task ReadStateAsync()
+            {
+                return this.storage.ReadStateAsync();
+            }
+
+            public Task WriteStateAsync()
+            {
+                return this.storage.WriteStateAsync();
+            }
+
+            public void Participate(IGrainLifecycle lifecycle)
+            {
+                lifecycle.Subscribe(this.GetType().FullName, GrainLifecycleStage.SetupState, OnSetupState);
+            }
+
+            private Task OnSetupState(CancellationToken ct)
+            {
+                if (ct.IsCancellationRequested)
+                    return Task.CompletedTask;
+                this.storage = new StateStorageBridge<TState>(this.fullStateName, context.GrainInstance.GrainReference, this.storageProvider, context.ActivationServices.GetService<ILoggerFactory>());
+                return this.ReadStateAsync();
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -299,6 +299,10 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, GrainCollectionOptionsValidator>();
 
             services.TryAddSingleton<ITimerManager, TimerManagerImpl>();
+
+            // persistent state facet support
+            services.TryAddSingleton<IPersistentStateFactory, PersistentStateFactory>();
+            services.TryAddSingleton(typeof(IAttributeToFactoryMapper<PersistentStateAttribute>), typeof(PersistentStateAttributeMapper));
         }
     }
 }

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -68,14 +68,14 @@ namespace Tester.AzureUtils.Persistence
             return providerConfig.First();
         }
 
-        public Base_PersistenceGrainTests_AzureStore(ITestOutputHelper output, BaseTestClusterFixture fixture)
+        public Base_PersistenceGrainTests_AzureStore(ITestOutputHelper output, BaseTestClusterFixture fixture, string grainNamespace = "UnitTests.Grains")
         {
             this.output = output;
             this.logger = fixture.Logger;
             HostedCluster = fixture.HostedCluster;
             GrainFactory = fixture.GrainFactory;
             timingFactor = TestUtils.CalibrateTimings();
-            this.basicPersistenceTestsRunner = new GrainPersistenceTestsRunner(output, fixture);
+            this.basicPersistenceTestsRunner = new GrainPersistenceTestsRunner(output, fixture, grainNamespace);
         }
 
         public IGrainFactory GrainFactory { get; }

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
@@ -1,0 +1,97 @@
+//#define REREAD_STATE_AFTER_WRITE_FAILED
+
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans.TestingHost;
+using TestExtensions;
+using Orleans.Hosting;
+using Orleans.Configuration;
+
+// ReSharper disable RedundantAssignment
+// ReSharper disable UnusedVariable
+// ReSharper disable InconsistentNaming
+
+namespace Tester.AzureUtils.Persistence
+{
+    /// <summary>
+    /// PersistenceStateTests using AzureStore - Requires access to external Azure blob storage
+    /// </summary>
+    [TestCategory("Persistence"), TestCategory("Azure")]
+    public class PersistenceStateTests_AzureBlobStore : Base_PersistenceGrainTests_AzureStore, IClassFixture<PersistenceStateTests_AzureBlobStore.Fixture>
+    {
+        public class Fixture : BaseAzureTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.Options.InitialSilosCount = 4;
+                builder.Options.UseTestClusterMembership = false;
+                builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
+                builder.AddSiloBuilderConfigurator<StorageSiloBuilderConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientBuilderConfigurator>();
+            }
+
+            private class StorageSiloBuilderConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddAzureBlobGrainStorage("GrainStorageForTest", (AzureBlobStorageOptions options) =>
+                    {
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                    });
+                }
+            }
+        }
+
+        public PersistenceStateTests_AzureBlobStore(ITestOutputHelper output, Fixture fixture) : base(output, fixture, "UnitTests.Grains.PersistentState")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureBlobStore_Delete()
+        {
+            await base.Grain_AzureStore_Delete();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureBlobStore_Read()
+        {
+            await base.Grain_AzureStore_Read();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_GuidKey_AzureBlobStore_Read_Write()
+        {
+            await base.Grain_GuidKey_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_LongKey_AzureBlobStore_Read_Write()
+        {
+            await base.Grain_LongKey_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_LongKeyExtended_AzureBlobStore_Read_Write()
+        {
+            await base.Grain_LongKeyExtended_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_GuidKeyExtended_AzureBlobStore_Read_Write()
+        {
+            await base.Grain_GuidKeyExtended_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureBlobStore_SiloRestart()
+        {
+            await base.Grain_AzureStore_SiloRestart();
+        }
+    }
+}
+
+// ReSharper restore RedundantAssignment
+// ReSharper restore UnusedVariable
+// ReSharper restore InconsistentNaming

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureTableGrainStorage.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureTableGrainStorage.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using TestExtensions;
+
+namespace Tester.AzureUtils.Persistence
+{
+    /// <summary>
+    /// PersistenceStateTests using AzureGrainStorage - Requires access to external Azure table storage
+    /// </summary>
+    [TestCategory("Persistence"), TestCategory("Azure")]
+    public class PersistenceStateTests_AzureTableGrainStorage : Base_PersistenceGrainTests_AzureStore, IClassFixture<PersistenceStateTests_AzureTableGrainStorage.Fixture>
+    {
+        public class Fixture : BaseAzureTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.Options.InitialSilosCount = 4;
+                builder.Options.UseTestClusterMembership = false;
+                builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
+                builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientBuilderConfigurator>();
+            }
+
+            private class MySiloBuilderConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder
+                        .AddAzureTableGrainStorage("GrainStorageForTest", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
+                        {
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.DeleteStateOnClear = true;
+                        }));
+                }
+            }
+        }
+
+        public PersistenceStateTests_AzureTableGrainStorage(ITestOutputHelper output, Fixture fixture) :
+            base(output, fixture, "UnitTests.Grains.PersistentState")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureTableGrainStorage_Delete()
+        {
+            await base.Grain_AzureStore_Delete();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureTableGrainStorage_Read()
+        {
+            await base.Grain_AzureStore_Read();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_GuidKey_AzureTableGrainStorage_Read_Write()
+        {
+            await base.Grain_GuidKey_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_LongKey_AzureTableGrainStorage_Read_Write()
+        {
+            await base.Grain_LongKey_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_LongKeyExtended_AzureTableGrainStorage_Read_Write()
+        {
+            await base.Grain_LongKeyExtended_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_GuidKeyExtended_AzureTableGrainStorage_Read_Write()
+        {
+            await base.Grain_GuidKeyExtended_AzureStore_Read_Write();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Grain_AzureTableGrainStorage_SiloRestart()
+        {
+            await base.Grain_AzureStore_SiloRestart();
+        }
+    }
+}

--- a/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
@@ -1,0 +1,85 @@
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains.PersistentState
+{
+    public class GrainStorageTestGrain : Grain,
+        IGrainStorageTestGrain, IGrainStorageTestGrain_LongKey
+    {
+        private readonly IPersistentState<PersistenceTestGrainState> persistentState;
+
+        public GrainStorageTestGrain(
+            [PersistentState("state", "GrainStorageForTest")]
+            IPersistentState<PersistenceTestGrainState> persistentState)
+        {
+            this.persistentState = persistentState;
+        }
+
+        public Task<int> GetValue()
+        {
+            return Task.FromResult(this.persistentState.State.Field1);
+        }
+
+        public Task DoWrite(int val)
+        {
+            this.persistentState.State.Field1 = val;
+            return this.persistentState.WriteStateAsync();
+        }
+
+        public async Task<int> DoRead()
+        {
+            await this.persistentState.ReadStateAsync(); // Re-read state from store
+            return this.persistentState.State.Field1;
+        }
+
+        public Task DoDelete()
+        {
+            return this.persistentState.ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle 
+        }
+    }
+
+    [Orleans.Providers.StorageProvider(ProviderName = "GrainStorageForTest")]
+    public class GrainStorageTestGrainExtendedKey : Grain,
+        IGrainStorageTestGrain_GuidExtendedKey, IGrainStorageTestGrain_LongExtendedKey
+    {
+        private readonly IPersistentState<PersistenceTestGrainState> persistentState;
+
+        public GrainStorageTestGrainExtendedKey(
+            [PersistentState("state", "GrainStorageForTest")]
+            IPersistentState<PersistenceTestGrainState> persistentState)
+        {
+            this.persistentState = persistentState;
+        }
+
+        public Task<int> GetValue()
+        {
+            return Task.FromResult(this.persistentState.State.Field1);
+        }
+
+        public Task<string> GetExtendedKeyValue()
+        {
+            string extKey;
+            var pk = this.GetPrimaryKey(out extKey);
+            return Task.FromResult(extKey);
+        }
+
+        public Task DoWrite(int val)
+        {
+            this.persistentState.State.Field1 = val;
+            return this.persistentState.WriteStateAsync();
+        }
+
+        public async Task<int> DoRead()
+        {
+            await this.persistentState.ReadStateAsync(); // Re-read state from store
+            return this.persistentState.State.Field1;
+        }
+
+        public Task DoDelete()
+        {
+            return this.persistentState.ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle 
+        }
+    }
+}

--- a/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs
+++ b/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs
@@ -18,14 +18,16 @@ namespace TestExtensions.Runners
     public class GrainPersistenceTestsRunner : OrleansTestingBase
     {
         private readonly ITestOutputHelper output;
+        private readonly string grainNamespace;
         private readonly BaseTestClusterFixture fixture;
         protected readonly ILogger logger;
         protected TestCluster HostedCluster { get; private set; }
 
-        public GrainPersistenceTestsRunner(ITestOutputHelper output, BaseTestClusterFixture fixture)
+        public GrainPersistenceTestsRunner(ITestOutputHelper output, BaseTestClusterFixture fixture, string grainNamespace = "UnitTests.Grains")
         {
             this.output = output;
             this.fixture = fixture;
+            this.grainNamespace = grainNamespace;
             this.logger = fixture.Logger;
             HostedCluster = fixture.HostedCluster;
             GrainFactory = fixture.GrainFactory;
@@ -37,7 +39,7 @@ namespace TestExtensions.Runners
         public async Task Grain_GrainStorage_Delete()
         {
             Guid id = Guid.NewGuid();
-            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id);
+            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id, this.grainNamespace);
 
             await grain.DoWrite(1);
 
@@ -56,7 +58,7 @@ namespace TestExtensions.Runners
         public async Task Grain_GrainStorage_Read()
         {
             Guid id = Guid.NewGuid();
-            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id);
+            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -67,7 +69,7 @@ namespace TestExtensions.Runners
         public async Task Grain_GuidKey_GrainStorage_Read_Write()
         {
             Guid id = Guid.NewGuid();
-            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id);
+            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -90,7 +92,7 @@ namespace TestExtensions.Runners
         public async Task Grain_LongKey_GrainStorage_Read_Write()
         {
             long id = random.Next();
-            IGrainStorageTestGrain_LongKey grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_LongKey>(id);
+            IGrainStorageTestGrain_LongKey grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_LongKey>(id, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -116,7 +118,7 @@ namespace TestExtensions.Runners
             string extKey = random.Next().ToString(CultureInfo.InvariantCulture);
 
             IGrainStorageTestGrain_LongExtendedKey
-                grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_LongExtendedKey>(id, extKey, null);
+                grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_LongExtendedKey>(id, extKey, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -147,7 +149,7 @@ namespace TestExtensions.Runners
             string extKey = random.Next().ToString(CultureInfo.InvariantCulture);
 
             IGrainStorageTestGrain_GuidExtendedKey
-                grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_GuidExtendedKey>(id, extKey, null);
+                grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain_GuidExtendedKey>(id, extKey, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -176,7 +178,7 @@ namespace TestExtensions.Runners
         {
             long id = random.Next();
 
-            IGrainStorageGenericGrain<int> grain = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<int>>(id);
+            IGrainStorageGenericGrain<int> grain = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<int>>(id, this.grainNamespace);
 
             int val = await grain.GetValue();
 
@@ -200,7 +202,7 @@ namespace TestExtensions.Runners
         {
             long id = random.Next();
 
-            IGrainStorageGenericGrain<List<int>> grain = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<List<int>>>(id);
+            IGrainStorageGenericGrain<List<int>> grain = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<List<int>>>(id, this.grainNamespace);
 
             var val = await grain.GetValue();
 
@@ -226,11 +228,11 @@ namespace TestExtensions.Runners
             long id2 = id1;
             long id3 = id1;
 
-            IGrainStorageGenericGrain<int> grain1 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<int>>(id1);
+            IGrainStorageGenericGrain<int> grain1 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<int>>(id1, this.grainNamespace);
 
-            IGrainStorageGenericGrain<string> grain2 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<string>>(id2);
+            IGrainStorageGenericGrain<string> grain2 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<string>>(id2, this.grainNamespace);
 
-            IGrainStorageGenericGrain<double> grain3 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<double>>(id3);
+            IGrainStorageGenericGrain<double> grain3 = this.GrainFactory.GetGrain<IGrainStorageGenericGrain<double>>(id3, this.grainNamespace);
 
             int val1 = await grain1.GetValue();
             Assert.Equal(0, val1);  // "Initial value - 1"
@@ -292,7 +294,7 @@ namespace TestExtensions.Runners
             output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, initialServiceId);
 
             Guid id = Guid.NewGuid();
-            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id);
+            IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id, this.grainNamespace);
 
             int val = await grain.GetValue();
 


### PR DESCRIPTION
This change Introduces a storage facet IPersistentState<T> which allows grains to define state which can be stored in using the existing IGrainStorage implementations.