### PR TITLE
Remove new() requirement from persistent state facet and Grain<T>

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -248,7 +248,7 @@ namespace Orleans
     /// Base class for a Grain with declared persistent state.
     /// </summary>
     /// <typeparam name="TGrainState">The class of the persistent state object</typeparam>
-    public class Grain<TGrainState> : Grain where TGrainState : new()
+    public class Grain<TGrainState> : Grain
     {
         private IStorage<TGrainState> storage;
 

--- a/src/Orleans.Core.Abstractions/Core/IStorage.cs
+++ b/src/Orleans.Core.Abstractions/Core/IStorage.cs
@@ -1,9 +1,8 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Orleans.Core
 {
     public interface IStorage<TState>
-        where TState : new()
     {
         TState State { get; set; }
 

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Orleans.Core;
 using Orleans.Streams;
 using Orleans.Timers;
@@ -38,6 +38,6 @@ namespace Orleans.Runtime
 
         void DelayDeactivation(Grain grain, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new();
+        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain);
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
@@ -3,7 +3,6 @@ using Orleans.Core;
 namespace Orleans.Runtime
 {
     public interface IPersistentState<TState> : IStorage<TState>
-        where TState : new()
     {
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
@@ -3,6 +3,6 @@ namespace Orleans.Runtime
 {
     public interface IPersistentStateFactory
     {
-        IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration config) where TState : new();
+        IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration config);
     }
 }

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -5,6 +5,7 @@ using Orleans.Configuration;
 using Orleans.Core;
 using Orleans.Timers;
 using Orleans.Storage;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Runtime
 {
@@ -92,11 +93,12 @@ namespace Orleans.Runtime
             grain.Data.DelayDeactivation(timeSpan);
         }
 
-        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new()
+        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain)
         {
             IGrainStorage grainStorage = grain.GetGrainStorage(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;
-            return new StateStorageBridge<TGrainState>(grainTypeName, grain.GrainReference, grainStorage, this.loggerFactory);
+            Factory< TGrainState> stateFactory = () => ActivatorUtilities.CreateInstance<TGrainState>(this.ServiceProvider);
+            return new StateStorageBridge<TGrainState>(grainTypeName, stateFactory, grain.GrainReference, grainStorage, this.loggerFactory);
         }
 
         private static void CheckRuntimeContext()

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -97,7 +97,7 @@ namespace Orleans.Runtime
         {
             IGrainStorage grainStorage = grain.GetGrainStorage(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;
-            Factory< TGrainState> stateFactory = () => ActivatorUtilities.CreateInstance<TGrainState>(this.ServiceProvider);
+            Factory< TGrainState> stateFactory = () => Activator.CreateInstance<TGrainState>();
             return new StateStorageBridge<TGrainState>(grainTypeName, stateFactory, grain.GrainReference, grainStorage, this.loggerFactory);
         }
 

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -11,7 +11,6 @@ namespace Orleans.Runtime
     public class PersistentStateFactory : IPersistentStateFactory
     {
         public IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration cfg)
-            where TState : new()
         {
             IGrainStorage storageProvider = !string.IsNullOrWhiteSpace(cfg.StorageName)
                 ? context.ActivationServices.GetServiceByName<IGrainStorage>(cfg.StorageName)
@@ -48,7 +47,6 @@ namespace Orleans.Runtime
         }
 
         private class PersistentStateBridge<TState> : IPersistentState<TState>, ILifecycleParticipant<IGrainLifecycle>
-            where TState : new()
         {
             private readonly string fullStateName;
             private readonly IGrainActivationContext context;
@@ -94,7 +92,8 @@ namespace Orleans.Runtime
             {
                 if (ct.IsCancellationRequested)
                     return Task.CompletedTask;
-                this.storage = new StateStorageBridge<TState>(this.fullStateName, context.GrainInstance.GrainReference, this.storageProvider, context.ActivationServices.GetService<ILoggerFactory>());
+                Factory<TState> stateFactory = () => ActivatorUtilities.CreateInstance<TState>(this.context.ActivationServices);
+                this.storage = new StateStorageBridge<TState>(this.fullStateName, stateFactory, this.context.GrainInstance.GrainReference, this.storageProvider, context.ActivationServices.GetService<ILoggerFactory>());
                 return this.ReadStateAsync();
             }
         }

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -8,6 +8,7 @@ using Orleans.Storage;
 using Orleans.Utilities;
 using Orleans.Transactions.Abstractions;
 using Orleans.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
 
 [assembly: GenerateSerializer(typeof(Orleans.Transactions.TransactionalStateRecord<>))]
 
@@ -103,7 +104,8 @@ namespace Orleans.Transactions
         {
             string formattedTypeName = RuntimeTypeNameFormatter.Format(this.context.GrainInstance.GetType());
             string fullStateName = $"{formattedTypeName}-{this.stateName}";
-            return new StateStorageBridge<TransactionalStateRecord<TState>>(fullStateName, this.context.GrainInstance.GrainReference, grainStorage, this.loggerFactory);
+            Factory<TransactionalStateRecord<TState>> stateFactory = () => ActivatorUtilities.CreateInstance<TransactionalStateRecord<TState>>(this.context.ActivationServices);
+            return new StateStorageBridge<TransactionalStateRecord<TState>>(fullStateName, stateFactory, this.context.GrainInstance.GrainReference, grainStorage, this.loggerFactory);
         }
     }
 


### PR DESCRIPTION
Note: This change introduced interface changes in core.abstractions.  We may not want to do this at this time.