### PR TITLE
Prereqs information for `LoadSheddingOptions`

### DIFF
--- a/src/Documentation/clusters_and_clients/configuration_guide/list_of_options_classes.md
+++ b/src/Documentation/clusters_and_clients/configuration_guide/list_of_options_classes.md
@@ -33,7 +33,7 @@ All Options classes used to configure Orleans should be in the `Orleans.Configur
 | `EndpointOptions` | Setting the Silo endpoint options |
 | `GrainCollectionOptions` | Options for grain garbage collection |
 | `GrainVersioningOptions` |  Governs grain implementation selection in heterogeneous deployments |
-| `LoadSheddingOptions` | Settings for load shedding configuration |
+| `LoadSheddingOptions` | Settings for load shedding configuration. Must have a registered implementation of `IHostEnvironmentStatistics` such as through `builder.UsePerfCounterEnvironmentStatistics()` (Windows only) for `LoadShedding` to function. |
 | `MultiClusterOptions` | Options for configuring multi-cluster support |
 | `PerformanceTuningOptions` | Performance tuning options (networking, number of threads) |
 | `ProcessExitHandlingOptions` | Configure silo behavior on process exit |


### PR DESCRIPTION
I'm not sure if this really belongs here, but didn't see much otherwise regarding `LoadShedding` in the docs.  `LoadShedding` appears to only be functional once a `IHostEnvironmentStatistics` implementation has been registered - calling that out in the "Used for" column.