### PR TITLE
Enable "cleaning" of all dead entries in the membership table

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -359,7 +359,7 @@ namespace Orleans.Clustering.DynamoDB
             };
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -357,6 +357,11 @@ namespace Orleans.Clustering.DynamoDB
                 IAmAliveTime = LogFormatter.PrintDate(memEntry.IAmAliveTime),
                 SiloIdentity = SiloInstanceRecord.ConstructSiloIdentity(memEntry.SiloAddress)
             };
+        }
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -359,7 +359,7 @@ namespace Orleans.Clustering.DynamoDB
             };
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -191,7 +191,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -191,7 +191,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -190,5 +190,10 @@ namespace Orleans.Runtime.MembershipService
                 throw;
             }
         }
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -59,9 +59,9 @@ namespace Orleans.Runtime.MembershipService
             return tableManager.DeleteTableEntries(clusterId);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
-            return tableManager.DeleteDeadMembershipTableEntries(beforeDate);
+            return tableManager.CleanupDefunctSiloEntries(beforeDate);
         }
 
         public async Task<MembershipTableData> ReadRow(SiloAddress key)

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -59,6 +59,11 @@ namespace Orleans.Runtime.MembershipService
             return tableManager.DeleteTableEntries(clusterId);
         }
 
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            return tableManager.DeleteDeadMembershipTableEntries(beforeDate);
+        }
+
         public async Task<MembershipTableData> ReadRow(SiloAddress key)
         {
             try
@@ -328,11 +333,6 @@ namespace Orleans.Runtime.MembershipService
                 PartitionKey = deploymentId,
                 RowKey = SiloInstanceTableEntry.ConstructRowKey(memEntry.SiloAddress)
             };
-        }
-
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -59,7 +59,7 @@ namespace Orleans.Runtime.MembershipService
             return tableManager.DeleteTableEntries(clusterId);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             return tableManager.DeleteDeadMembershipTableEntries(beforeDate);
         }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -329,5 +329,10 @@ namespace Orleans.Runtime.MembershipService
                 RowKey = SiloInstanceTableEntry.ConstructRowKey(memEntry.SiloAddress)
             };
         }
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -196,7 +196,7 @@ namespace Orleans.AzureUtils
             return entriesList.Count();
         }
 
-        public async Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public async Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             var entriesList = (await FindAllSiloEntries())
                 .Where(entry => entry.Item1.Status == INSTANCE_STATUS_DEAD && entry.Item1.Timestamp < beforeDate)

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -190,19 +190,36 @@ namespace Orleans.AzureUtils
 
             var entries = await storage.ReadAllTableEntriesForPartitionAsync(clusterId);
             var entriesList = new List<Tuple<SiloInstanceTableEntry, string>>(entries);
+
+            await DeleteEntriesBatch(entriesList);
+
+            return entriesList.Count();
+        }
+
+        public async Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            var entriesList = (await FindAllSiloEntries())
+                .Where(entry => entry.Item1.Status == INSTANCE_STATUS_DEAD && entry.Item1.Timestamp < beforeDate)
+                .ToList();
+
+            await DeleteEntriesBatch(entriesList);
+        }
+
+        private async Task DeleteEntriesBatch(List<Tuple<SiloInstanceTableEntry, string>> entriesList)
+        {
             if (entriesList.Count <= AzureTableDefaultPolicies.MAX_BULK_UPDATE_ROWS)
             {
                 await storage.DeleteTableEntriesAsync(entriesList);
-            }else
+            }
+            else
             {
-                List<Task> tasks = new List<Task>();
+                var tasks = new List<Task>();
                 foreach (var batch in entriesList.BatchIEnumerable(AzureTableDefaultPolicies.MAX_BULK_UPDATE_ROWS))
                 {
                     tasks.Add(storage.DeleteTableEntriesAsync(batch));
                 }
                 await Task.WhenAll(tasks);
             }
-            return entriesList.Count();
         }
 
         internal async Task<List<Tuple<SiloInstanceTableEntry, string>>> FindSiloEntryAndTableVersionRow(SiloAddress siloAddress)

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -196,7 +196,7 @@ namespace Orleans.AzureUtils
             return entriesList.Count();
         }
 
-        public async Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             var entriesList = (await FindAllSiloEntries())
                 .Where(entry => entry.Item1.Status == INSTANCE_STATUS_DEAD && entry.Item1.Timestamp < beforeDate)

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -173,7 +173,7 @@ namespace Orleans.Runtime.Membership
             return new MembershipTableData(membershipEntries, _tableVersion);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Consul;
@@ -171,6 +171,11 @@ namespace Orleans.Runtime.Membership
                 .ToList();
 
             return new MembershipTableData(membershipEntries, _tableVersion);
+        }
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -173,7 +173,7 @@ namespace Orleans.Runtime.Membership
             return new MembershipTableData(membershipEntries, _tableVersion);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -337,7 +337,7 @@ namespace Orleans.Runtime.Membership
             return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data), MembershipSerializerSettings.Instance);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -337,7 +337,7 @@ namespace Orleans.Runtime.Membership
             return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data), MembershipSerializerSettings.Instance);
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -337,6 +337,10 @@ namespace Orleans.Runtime.Membership
             return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data), MembershipSerializerSettings.Instance);
         }
 
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     /// <summary>

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -92,17 +92,17 @@ namespace Orleans.Configuration
         public const int DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION = 2;
 
         /// <summary>
-        /// To be used with <see cref="CleanupDeadEntriesTimeout"/>
+        /// To be used with <see cref="DefunctSiloCleanupPeriod"/>
         /// </summary>
-        public TimeSpan DeleteEntriesOlderThan { get; set; } = DEFAULT_DELETE_ENTRIES_OLDER_THAN;
-        public static readonly TimeSpan DEFAULT_DELETE_ENTRIES_OLDER_THAN = TimeSpan.FromDays(7);
+        public TimeSpan DefunctSiloExpiration { get; set; } = DEFAULT_DEFUNCT_SILO_EXPIRATION;
+        public static readonly TimeSpan DEFAULT_DEFUNCT_SILO_EXPIRATION = TimeSpan.FromDays(7);
 
         /// <summary>
-        /// If set, will check if there are older entries than <see cref="DeleteEntriesOlderThan"/> in the membership table,
-        /// and will delete them
+        /// The duration between membership table cleanup operations. When this period elapses, all defunct silo
+        /// entries older than <see cref="DefunctSiloExpiration" /> are removed. This value is per-silo.
         /// </summary>
-        public TimeSpan? CleanupDeadEntriesTimeout { get; set; } = DEFAULT_DELETE_ENTRIES_OLDER_THAN;
-        public static readonly TimeSpan? DEFAULT_CLEANUP_DEAD_ENTRIES_TIMEOUT = null;
+        public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD;
+        public static readonly TimeSpan? DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD = null;
 
         /// <summary>
         /// TEST ONLY - Do not modify in production environments

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -92,7 +92,8 @@ namespace Orleans.Configuration
         public const int DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION = 2;
 
         /// <summary>
-        /// To be used with <see cref="DefunctSiloCleanupPeriod"/>
+        /// The period of time after which membership entries for defunct silos are eligible for removal.
+        /// Valid only if <see cref="DefunctSiloCleanupPeriod"/> is not <see langword="null" />.
         /// </summary>
         public TimeSpan DefunctSiloExpiration { get; set; } = DEFAULT_DEFUNCT_SILO_EXPIRATION;
         public static readonly TimeSpan DEFAULT_DEFUNCT_SILO_EXPIRATION = TimeSpan.FromDays(7);

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -92,6 +92,19 @@ namespace Orleans.Configuration
         public const int DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION = 2;
 
         /// <summary>
+        /// To be used with <see cref="CleanupDeadEntriesTimeout"/>
+        /// </summary>
+        public TimeSpan DeleteEntriesOlderThan { get; set; } = DEFAULT_DELETE_ENTRIES_OLDER_THAN;
+        public static readonly TimeSpan DEFAULT_DELETE_ENTRIES_OLDER_THAN = TimeSpan.FromDays(7);
+
+        /// <summary>
+        /// If set, will check if there are older entries than <see cref="DeleteEntriesOlderThan"/> in the membership table,
+        /// and will delete them
+        /// </summary>
+        public TimeSpan? CleanupDeadEntriesTimeout { get; set; } = DEFAULT_DELETE_ENTRIES_OLDER_THAN;
+        public static readonly TimeSpan? DEFAULT_CLEANUP_DEAD_ENTRIES_TIMEOUT = null;
+
+        /// <summary>
         /// TEST ONLY - Do not modify in production environments
         /// </summary>
         public bool IsRunningAsUnitTest { get; set; } = false;

--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -504,6 +504,7 @@ namespace Orleans
         MembershipUpdateIAmAliveFailure        = MembershipBase + 59,
         MembershipStartingIAmAliveTimer        = MembershipBase + 60,
         MembershipJoiningPreconditionFailure   = MembershipBase + 61,
+        MembershipCleanDeadEntriesFailure      = MembershipBase + 62,
 
         NSMembershipStarting                   = MembershipBase + 70,
         NSMembershipBecomeActive               = MembershipBase + 71,

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -24,7 +24,10 @@ namespace Orleans
         /// </summary>
         Task DeleteMembershipTableEntries(string clusterId);
 
-        Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate);
+        /// <summary>
+        /// Delete all dead silo entries older than <paramref name="beforeDate"/>
+        /// </summary>
+        Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate);
 
         /// <summary>
         /// Atomically reads the Membership Table information about a given silo.

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -24,7 +24,7 @@ namespace Orleans
         /// </summary>
         Task DeleteMembershipTableEntries(string clusterId);
 
-        Task DeleteDeadMembershipTableEntries(DateTime beforeDate);
+        Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate);
 
         /// <summary>
         /// Atomically reads the Membership Table information about a given silo.

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -24,6 +24,8 @@ namespace Orleans
         /// </summary>
         Task DeleteMembershipTableEntries(string clusterId);
 
+        Task DeleteDeadMembershipTableEntries(DateTime beforeDate);
+
         /// <summary>
         /// Atomically reads the Membership Table information about a given silo.
         /// The returned MembershipTableData includes one MembershipEntry entry for a given silo and the 

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -224,7 +224,7 @@ namespace Orleans.Runtime.MembershipService
         private void StartCleanupEntriesTimer()
         {
             // If timeout value not set, cleanup disabled
-            if (this.clusterMembershipOptions.CleanupDeadEntriesTimeout == default(TimeSpan))
+            if (this.clusterMembershipOptions.DefunctSiloCleanupPeriod == default(TimeSpan))
                 return;
 
             logger.Info(ErrorCode.MembershipStartingIAmAliveTimer, "Starting StartCleanupEntriesTimer.");
@@ -237,8 +237,8 @@ namespace Orleans.Runtime.MembershipService
                 this.timerLogger,
                 OnCleanupEntriesTimer,
                 null,
-                this.clusterMembershipOptions.CleanupDeadEntriesTimeout.Value,
-                this.clusterMembershipOptions.CleanupDeadEntriesTimeout.Value,
+                this.clusterMembershipOptions.DefunctSiloCleanupPeriod.Value,
+                this.clusterMembershipOptions.DefunctSiloCleanupPeriod.Value,
                 "Membership.OnCleanupEntriesTimer");
 
             this.timerCleanupEntries.Start();
@@ -926,7 +926,7 @@ namespace Orleans.Runtime.MembershipService
 
         private void OnCleanupEntriesTimer(object data)
         {
-            var dateLimit = DateTime.UtcNow - this.clusterMembershipOptions.DeleteEntriesOlderThan;
+            var dateLimit = DateTime.UtcNow - this.clusterMembershipOptions.DefunctSiloExpiration;
 
             try
             {
@@ -939,7 +939,7 @@ namespace Orleans.Runtime.MembershipService
                             return true;
                         }).Ignore();
             }
-            catch (MissingMethodException)
+            catch (Exception ex) when (ex is NotImplementedException || ex is NotImplementedException)
             {
                 this.logger.Error(
                     ErrorCode.MembershipCleanDeadEntriesFailure,

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -224,7 +224,7 @@ namespace Orleans.Runtime.MembershipService
         private void StartCleanupEntriesTimer()
         {
             // If timeout value not set, cleanup disabled
-            if (this.clusterMembershipOptions.DefunctSiloCleanupPeriod == default(TimeSpan))
+            if (this.clusterMembershipOptions.DefunctSiloCleanupPeriod == default)
                 return;
 
             logger.Info(ErrorCode.MembershipStartingIAmAliveTimer, "Starting StartCleanupEntriesTimer.");

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -40,7 +40,13 @@ namespace Orleans.Runtime.MembershipService
         private TimeSpan AllowedIAmAliveMissPeriod { get { return this.clusterMembershipOptions.IAmAliveTablePublishTimeout.Multiply(this.clusterMembershipOptions.NumMissedTableIAmAliveLimit); } }
         private readonly ILoggerFactory loggerFactory;
 
-        public MembershipOracle(ILocalSiloDetails siloDetails, IOptions<ClusterMembershipOptions> clusterMembershipOptions, IMembershipTable membershipTable, IInternalGrainFactory grainFactory, IOptions<MultiClusterOptions> multiClusterOptions, ILoggerFactory loggerFactory)
+        public MembershipOracle(
+            ILocalSiloDetails siloDetails,
+            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
+            IMembershipTable membershipTable,
+            IInternalGrainFactory grainFactory,
+            IOptions<MultiClusterOptions> multiClusterOptions,
+            ILoggerFactory loggerFactory)
             : base(Constants.MembershipOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -227,7 +227,7 @@ namespace Orleans.Runtime.MembershipService
             if (this.clusterMembershipOptions.DefunctSiloCleanupPeriod == default)
                 return;
 
-            logger.Info(ErrorCode.MembershipStartingIAmAliveTimer, "Starting StartCleanupEntriesTimer.");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.MembershipStartingIAmAliveTimer, "Starting StartCleanupEntriesTimer.");
 
             if (this.timerCleanupEntries != null)
                 this.timerCleanupEntries.Dispose();

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -931,7 +931,7 @@ namespace Orleans.Runtime.MembershipService
             try
             {
                 this.membershipTableProvider
-                        .DeleteDeadMembershipTableEntries(dateLimit)
+                        .CleanupDefunctSiloEntries(dateLimit)
                         .ContinueWith(task =>
                         {
                             if (task.IsFaulted)

--- a/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task UpdateIAmAlive(MembershipEntry entry) => this.grain.UpdateIAmAlive(entry);
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }
@@ -182,7 +182,7 @@ namespace Orleans.Runtime.MembershipService
             return Task.CompletedTask;
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task UpdateIAmAlive(MembershipEntry entry) => this.grain.UpdateIAmAlive(entry);
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }
@@ -182,7 +182,7 @@ namespace Orleans.Runtime.MembershipService
             return Task.CompletedTask;
         }
 
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             throw new NotImplementedException();
         }

--- a/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
@@ -102,6 +102,11 @@ namespace Orleans.Runtime.MembershipService
         public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion) => this.grain.UpdateRow(entry, etag, tableVersion);
 
         public Task UpdateIAmAlive(MembershipEntry entry) => this.grain.UpdateIAmAlive(entry);
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     [Reentrant]
@@ -175,6 +180,11 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("UpdateIAmAlive entry = {0}", entry.ToFullString());
             table.UpdateIAmAlive(entry);
             return Task.CompletedTask;
+        }
+
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -115,7 +115,7 @@ namespace Tester.AzureUtils
 
             await Task.Delay(TimeSpan.FromSeconds(3));
 
-            await manager.DeleteDeadMembershipTableEntries(DateTime.Now - TimeSpan.FromSeconds(1));
+            await manager.CleanupDefunctSiloEntries(DateTime.Now - TimeSpan.FromSeconds(1));
 
             var entries = await manager.FindAllSiloEntries();
             Assert.Equal(5, entries.Count);

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -18,7 +18,7 @@ namespace NonSilo.Tests
 {
     public class NoOpMembershipTable : IMembershipTable
     {
-        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
         {
             return Task.CompletedTask;
         }

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -18,7 +18,7 @@ namespace NonSilo.Tests
 {
     public class NoOpMembershipTable : IMembershipTable
     {
-        public Task DeleteDeadMembershipTableEntries(DateTimeOffset beforeDate)
+        public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             return Task.CompletedTask;
         }

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -18,6 +18,11 @@ namespace NonSilo.Tests
 {
     public class NoOpMembershipTable : IMembershipTable
     {
+        public Task DeleteDeadMembershipTableEntries(DateTime beforeDate)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task DeleteMembershipTableEntries(string clusterId)
         {
             return Task.CompletedTask;


### PR DESCRIPTION
Right now, we don't delete old entries in the membership table, and that can be an issue since it will grow forever. 

This PR enable deleting old silo entries, and implement it in the azure membership provider. Other providers still need to implement this logic.