### PR TITLE
Fix OneWay cache invalidation

### DIFF
--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -96,6 +96,7 @@ namespace Orleans.Runtime
             DuplicateRequest,
             Unrecoverable,
             GatewayTooBusy,
+            CacheInvalidation
         }
 
         internal HeadersContainer Headers { get; set; } = new HeadersContainer();
@@ -331,6 +332,8 @@ namespace Orleans.Runtime
             get { return Headers.CacheInvalidationHeader; }
             set { Headers.CacheInvalidationHeader = value; }
         }
+
+        public bool HasCacheInvalidationHeader => this.CacheInvalidationHeader != null && this.CacheInvalidationHeader.Count > 0;
         
         internal void AddToCacheInvalidationHeader(ActivationAddress address)
         {

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -333,7 +333,8 @@ namespace Orleans.Runtime
             set { Headers.CacheInvalidationHeader = value; }
         }
 
-        public bool HasCacheInvalidationHeader => this.CacheInvalidationHeader != null && this.CacheInvalidationHeader.Count > 0;
+        public bool HasCacheInvalidationHeader => this.CacheInvalidationHeader != null
+                                                  && this.CacheInvalidationHeader.Count > 0;
         
         internal void AddToCacheInvalidationHeader(ActivationAddress address)
         {

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -454,9 +454,13 @@ namespace Orleans
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Received {0}", response);
 
             // ignore duplicate requests
-            if (response.Result == Message.ResponseTypes.Rejection && response.RejectionType == Message.RejectionTypes.DuplicateRequest)
+            if (response.Result == Message.ResponseTypes.Rejection
+                && (response.RejectionType == Message.RejectionTypes.DuplicateRequest
+                 || response.RejectionType == Message.RejectionTypes.CacheInvalidation))
+            {
                 return;
-
+            }
+            
             CallbackData callbackData;
             var found = callbacks.TryGetValue(response.Id, out callbackData);
             if (found)

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -204,7 +204,8 @@ namespace Orleans.Runtime
             Exception exc, 
             string rejectInfo = null)
         {
-            if (message.Direction == Message.Directions.Request || (message.Direction == Message.Directions.OneWay && message.HasCacheInvalidationHeader))
+            if (message.Direction == Message.Directions.Request
+                || (message.Direction == Message.Directions.OneWay && message.HasCacheInvalidationHeader))
             {
                 var str = String.Format("{0} {1}", rejectInfo ?? "", exc == null ? "" : exc.ToString());
                 MessagingStatisticsGroup.OnRejectedMessage(message);
@@ -573,7 +574,11 @@ namespace Orleans.Runtime
                 // If the message was a one-way message, send a cache invalidation response even if the message was successfully forwarded.
                 if (message.Direction == Message.Directions.OneWay)
                 {
-                    this.RejectMessage(message, Message.RejectionTypes.CacheInvalidation, exc, "OneWay message sent to invalid activation");
+                    this.RejectMessage(
+                        message,
+                        Message.RejectionTypes.CacheInvalidation,
+                        exc,
+                        "OneWay message sent to invalid activation");
                     sentRejection = true;
                 }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -618,6 +618,9 @@ namespace Orleans.Runtime
                         }
                         break;
 
+                    case Message.RejectionTypes.CacheInvalidation when message.HasCacheInvalidationHeader:
+                        // The message targeted an invalid (eg, defunct) activation and this response serves only to invalidate this silo's activation cache.
+                        return;
                     default:
                         logger.Error(ErrorCode.Dispatcher_InvalidEnum_RejectionType,
                             "Missing enum in switch: " + message.RejectionType);

--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
+using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -58,7 +59,19 @@ namespace UnitTests.GrainInterfaces
 
         Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain, ISimpleGrainObserver observer);
 
+        Task<IOneWayGrain> GetOtherGrain();
+
+        Task NotifyOtherGrain();
+
         Task<int> GetCount();
+
+        Task Deactivate();
+
+        Task<SiloAddress> GetSiloAddress();
+
+        Task<SiloAddress> GetPrimaryForGrain();
+
+        Task<string> GetActivationAddress(IGrain grain);
     }
 
     public interface ICanBeOneWayGrain : IGrainWithGuidKey

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -221,7 +221,9 @@ namespace UnitTests.Grains
                     var directorySilo = await candidate.GetPrimaryForGrain();
                     var thisSilo = await this.GetSiloAddress();
                     var candidateSilo = await candidate.GetSiloAddress();
-                    if (!directorySilo.Equals(candidateSilo) && !directorySilo.Equals(thisSilo) && !candidateSilo.Equals(thisSilo))
+                    if (!directorySilo.Equals(candidateSilo)
+                        && !directorySilo.Equals(thisSilo)
+                        && !candidateSilo.Equals(thisSilo))
                     {
                         return candidate;
                     }

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -171,9 +173,20 @@ namespace UnitTests.Grains
         }
     }
 
-    public class OneWayGrain : Grain, IOneWayGrain
+    internal class OneWayGrain : Grain, IOneWayGrain, ISimpleGrainObserver
     {
         private int count;
+        private TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+        private IOneWayGrain other;
+        private Catalog catalog;
+
+        public OneWayGrain(Catalog catalog)
+        {
+            this.catalog = catalog;
+        }
+
+        private ILocalGrainDirectory LocalGrainDirectory => this.ServiceProvider.GetRequiredService<ILocalGrainDirectory>();
+        private ILocalSiloDetails LocalSiloDetails => this.ServiceProvider.GetRequiredService<ILocalSiloDetails>();
 
         public Task Notify()
         {
@@ -196,11 +209,67 @@ namespace UnitTests.Grains
             return completedSynchronously;
         }
 
+        public async Task<IOneWayGrain> GetOtherGrain()
+        {
+            return this.other ?? (this.other = await GetGrainOnOtherSilo());
+
+            async Task<IOneWayGrain> GetGrainOnOtherSilo()
+            {
+                while (true)
+                {
+                    var candidate = this.GrainFactory.GetGrain<IOneWayGrain>(Guid.NewGuid());
+                    var directorySilo = await candidate.GetPrimaryForGrain();
+                    var thisSilo = await this.GetSiloAddress();
+                    var candidateSilo = await candidate.GetSiloAddress();
+                    if (!directorySilo.Equals(candidateSilo) && !directorySilo.Equals(thisSilo) && !candidateSilo.Equals(thisSilo))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+        }
+
+        public Task<string> GetActivationAddress(IGrain grain)
+        {
+            var grainId = ((GrainReference)grain).GrainId;
+            if (this.catalog.FastLookup(grainId, out var addresses))
+            {
+                return Task.FromResult(addresses.Addresses.Single().ToString());
+            }
+
+            return Task.FromResult<string>(null);
+        }
+
+        public Task NotifyOtherGrain() => this.other.Notify(this.AsReference<ISimpleGrainObserver>());
+
         public Task<int> GetCount() => Task.FromResult(this.count);
+
+        public Task Deactivate()
+        {
+            this.DeactivateOnIdle();
+            return Task.CompletedTask;
+        }
 
         public Task ThrowsOneWay()
         {
             throw new Exception("GET OUT!");
+        }
+
+        public Task<SiloAddress> GetSiloAddress()
+        {
+            return Task.FromResult(this.LocalSiloDetails.SiloAddress);
+        }
+
+        public Task<SiloAddress> GetPrimaryForGrain()
+        {
+            var grainId = (GrainId)this.Identity;
+            var primaryForGrain = this.LocalGrainDirectory.GetPrimaryForGrain(grainId);
+            return Task.FromResult(primaryForGrain);
+        }
+
+        public void StateChanged(int a, int b)
+        {
+            this.tcs.TrySetResult(0);
         }
     }
 

--- a/test/Tester/OneWayDeactivationTests.cs
+++ b/test/Tester/OneWayDeactivationTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.General
+{
+    [TestCategory("BVT"), TestCategory("OneWay")]
+    public class OneWayDeactivationTests : OrleansTestingBase, IClassFixture<OneWayDeactivationTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.Options.InitialSilosCount = 3;
+            }
+        }
+
+        public OneWayDeactivationTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        /// <summary>
+        /// Tests that calling [OneWay] methods on an activation which no longer exists triggers a cache invalidation.
+        /// Subsequent calls should reactivate the grain.
+        /// </summary>
+        [Fact]
+        public async Task OneWay_Deactivation_CacheInvalidated()
+        {
+            IOneWayGrain grainToCallFrom;
+            while (true)
+            {
+                grainToCallFrom = this.fixture.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+                var grainHost = await grainToCallFrom.GetSiloAddress();
+                if (grainHost.Equals(this.fixture.HostedCluster.Primary.SiloAddress))
+                {
+                    break;
+                }
+            }
+
+            // Activate the grain & record its address.
+            var grainToDeactivate = await grainToCallFrom.GetOtherGrain();
+            var initialActivationAddress = await grainToCallFrom.GetActivationAddress(grainToDeactivate);
+
+            // Deactivate the grain.
+            await grainToDeactivate.Deactivate();
+
+            // We expect cache invalidation to propagate quickly, but will wait a few seconds just in case.
+            var remainingAttempts = 50;
+            bool cacheUpdated;
+            do
+            {
+                // Have the first grain make a one-way call to the grain which was deactivated.
+                // The purpose of this is to trigger a cache invalidation rejection response.
+                _ = grainToCallFrom.NotifyOtherGrain();
+
+                // Ask the first grain for its cached value of the second grain's activation address.
+                // This value should eventually be updated to a new activation because of the cache invalidation.
+                var activationAddress = await grainToCallFrom.GetActivationAddress(grainToDeactivate);
+
+                Assert.True(--remainingAttempts > 0);
+
+                cacheUpdated = !string.Equals(activationAddress, initialActivationAddress);
+                if (!cacheUpdated) await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+            } while (!cacheUpdated);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4896

When a OneWay message is destined for a defunct activation, send a rejection response for the purpose of cache invalidation. This rejection is sent even though the message may be forwarded on to a new activation simultaneously. The rejection is ignored by the receiver after the cache invalidation headers have been inspected.