### PR TITLE
Fixed function persistence tests

### DIFF
--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
@@ -43,7 +43,7 @@ namespace Tester.AzureUtils.Persistence
             }
         }
 
-        public PersistenceStateTests_AzureBlobStore(ITestOutputHelper output, Fixture fixture) : base(output, fixture, "UnitTests.Grains.PersistentState")
+        public PersistenceStateTests_AzureBlobStore(ITestOutputHelper output, Fixture fixture) : base(output, fixture, "UnitTests.PersistentState.Grains")
         {
             fixture.EnsurePreconditionsMet();
         }

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureTableGrainStorage.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureTableGrainStorage.cs
@@ -41,7 +41,7 @@ namespace Tester.AzureUtils.Persistence
         }
 
         public PersistenceStateTests_AzureTableGrainStorage(ITestOutputHelper output, Fixture fixture) :
-            base(output, fixture, "UnitTests.Grains.PersistentState")
+            base(output, fixture, "UnitTests.PersistentState.Grains")
         {
             fixture.EnsurePreconditionsMet();
         }

--- a/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
@@ -2,8 +2,9 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
 
-namespace UnitTests.Grains.PersistentState
+namespace UnitTests.PersistentState.Grains
 {
     public class GrainStorageTestGrain : Grain,
         IGrainStorageTestGrain, IGrainStorageTestGrain_LongKey


### PR DESCRIPTION
Fixed function persistence tests broken when IPersistentState facet was introduced.