### PR TITLE
Remove response callback using a single operation

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -86,8 +86,6 @@ namespace Orleans.Runtime
                 {
                     this.stopwatch.Stop();
                 }
-
-                this.shared.Unregister(this.Message);
             }
 
             if (requestStatistics.CollectApplicationRequestsStats)

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -458,7 +458,7 @@ namespace Orleans
                 return;
 
             CallbackData callbackData;
-            var found = callbacks.TryGetValue(response.Id, out callbackData);
+            var found = callbacks.TryRemove(response.Id, out callbackData);
             if (found)
             {
                 // We need to import the RequestContext here as well.

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -626,7 +626,7 @@ namespace Orleans.Runtime
             }
 
             CallbackData callbackData;
-            bool found = callbacks.TryGetValue(message.Id, out callbackData);
+            bool found = callbacks.TryRemove(message.Id, out callbackData);
             if (found)
             {
                 if (message.TransactionInfo != null)


### PR DESCRIPTION
Removes response callbacks using a single operation instead of TryGet + TryRemove. I don't expect the impact to be significant unless perhaps the system is under very high concurrent load.