### PR TITLE
Fix #5398: AmbiguousMatchException in code generator

### DIFF
--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -153,9 +153,8 @@ namespace Orleans.CodeGenerator
         /// </returns>
         public string GenerateSourceForAssembly(Assembly input)
         {
-            if (input.GetCustomAttribute<GeneratedCodeAttribute>() != null
-                || input.GetCustomAttribute<OrleansCodeGenerationTargetAttribute>() != null
-                || input.GetCustomAttribute<SkipCodeGenerationAttribute>() != null)
+            if (input.GetCustomAttributes<OrleansCodeGenerationTargetAttribute>().Any()
+                || input.GetCustomAttributes<SkipCodeGenerationAttribute>().Any())
             {
                 return string.Empty;
             }
@@ -652,9 +651,8 @@ namespace Orleans.CodeGenerator
         {
             return !assembly.IsDynamic
                    && TypeUtils.IsOrleansOrReferencesOrleans(assembly)
-                   && assembly.GetCustomAttribute<GeneratedCodeAttribute>() == null
-                   && assembly.GetCustomAttribute<OrleansCodeGenerationTargetAttribute>() == null
-                   && assembly.GetCustomAttribute<SkipCodeGenerationAttribute>() == null;
+                   && !assembly.GetCustomAttributes<OrleansCodeGenerationTargetAttribute>().Any()
+                   && !assembly.GetCustomAttributes<SkipCodeGenerationAttribute>().Any();
         }
 
         private bool IsOrleansGeneratedCode(MemberInfo type) =>


### PR DESCRIPTION
Fixes #5398

The cut over to the new code generator which occurred in 2.2.4 meant that we are now potentially emitting multiple OrleansGeneratedCodeAttributes and this is causing issues with the old code generator

Also dropped superfluous `GeneratedCodeAttribute` - it's not our attribute and we don't care about it.