### PR TITLE
Fix codegen warnings in source tree

### DIFF
--- a/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
@@ -508,7 +508,12 @@ namespace Orleans.CodeGenerator.Generators
                        !baseType.Equals(wellKnownTypes.Object) &&
                        !baseType.Equals(wellKnownTypes.Attribute))
                 {
-                    if (!hasUnsupportedRefAsmBase && baseType.ContainingAssembly.HasAttribute("ReferenceAssemblyAttribute") && !IsSupportedRefAsmType(baseType)) hasUnsupportedRefAsmBase = true;
+                    if (!hasUnsupportedRefAsmBase
+                        && baseType.ContainingAssembly.HasAttribute("ReferenceAssemblyAttribute")
+                        && !IsSupportedRefAsmType(baseType))
+                    {
+                        hasUnsupportedRefAsmBase = true;
+                    }
                     foreach (var field in baseType.GetDeclaredMembers<IFieldSymbol>())
                     {
                         if (hasUnsupportedRefAsmBase) referenceAssemblyHasFields = true;
@@ -531,19 +536,32 @@ namespace Orleans.CodeGenerator.Generators
                         if (location.IsInSource)
                         {
                             var pos = location.GetLineSpan();
-                            fileLocation = $"{pos.Path}({pos.StartLinePosition.Line + 1},{pos.StartLinePosition.Character + 1},{pos.EndLinePosition.Line + 1},{pos.EndLinePosition.Character + 1}): ";
+                            fileLocation = string.Format(
+                                "{0}({1},{2},{3},{4}): ",
+                                pos.Path,
+                                pos.StartLinePosition.Line + 1,
+                                pos.StartLinePosition.Character + 1,
+                                pos.EndLinePosition.Line + 1,
+                                pos.EndLinePosition.Character + 1);
                         }
                     }
 
                     logger.LogWarning(
-                        $"{fileLocation}warning ORL1001: Type {type} has a base type which belongs to a reference assembly. Serializer generation for this type may not include important base type fields.");
+                        $"{fileLocation}warning ORL1001: Type {type} has a base type which belongs to a reference assembly."
+                        + " Serializer generation for this type may not include important base type fields.");
                 }
 
                 bool IsSupportedRefAsmType(INamedTypeSymbol t)
                 {
                     INamedTypeSymbol baseDefinition;
-                    if (t.IsGenericType && !t.IsUnboundGenericType) baseDefinition = t.ConstructUnboundGenericType().OriginalDefinition;
-                    else baseDefinition = t.OriginalDefinition;
+                    if (t.IsGenericType && !t.IsUnboundGenericType)
+                    {
+                        baseDefinition = t.ConstructUnboundGenericType().OriginalDefinition;
+                    }
+                    else
+                    {
+                        baseDefinition = t.OriginalDefinition;
+                    }
 
                     foreach (var refAsmType in wellKnownTypes.SupportedRefAsmBaseTypes)
                     {

--- a/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
@@ -495,46 +495,63 @@ namespace Orleans.CodeGenerator.Generators
                 }
             }
 
-            // Some reference assemblies are compiled without private fields.
-            // Warn the user if they are inheriting from a type in one of these assemblies using a heuristic:
-            // If the type inherits from a type in a reference assembly and there are no fields declared on those
-            // base types, emit a warning.
-            var hasReferenceAssemblyBase = false;
-            var referenceAssemblyHasFields = false;
-            var baseType = type.BaseType;
-            while (baseType != null &&
-                   !baseType.Equals(wellKnownTypes.Object) &&
-                   !baseType.Equals(wellKnownTypes.Attribute))
+            if (type.TypeKind == TypeKind.Class)
             {
-                if (!hasReferenceAssemblyBase && baseType.ContainingAssembly.HasAttribute("ReferenceAssemblyAttribute")) hasReferenceAssemblyBase = true;
-                foreach (var field in baseType.GetDeclaredMembers<IFieldSymbol>())
+                // Some reference assemblies are compiled without private fields.
+                // Warn the user if they are inheriting from a type in one of these assemblies using a heuristic:
+                // If the type inherits from a type in a reference assembly and there are no fields declared on those
+                // base types, emit a warning.
+                var hasUnsupportedRefAsmBase = false;
+                var referenceAssemblyHasFields = false;
+                var baseType = type.BaseType;
+                while (baseType != null &&
+                       !baseType.Equals(wellKnownTypes.Object) &&
+                       !baseType.Equals(wellKnownTypes.Attribute))
                 {
-                    if (hasReferenceAssemblyBase) referenceAssemblyHasFields = true;
-                    if (ShouldSerializeField(wellKnownTypes, field))
+                    if (!hasUnsupportedRefAsmBase && baseType.ContainingAssembly.HasAttribute("ReferenceAssemblyAttribute") && !IsSupportedRefAsmType(baseType)) hasUnsupportedRefAsmBase = true;
+                    foreach (var field in baseType.GetDeclaredMembers<IFieldSymbol>())
                     {
-                        result.Add(new FieldInfoMember(wellKnownTypes, model, type, field, result.Count));
+                        if (hasUnsupportedRefAsmBase) referenceAssemblyHasFields = true;
+                        if (ShouldSerializeField(wellKnownTypes, field))
+                        {
+                            result.Add(new FieldInfoMember(wellKnownTypes, model, type, field, result.Count));
+                        }
                     }
+
+                    baseType = baseType.BaseType;
                 }
 
-                baseType = baseType.BaseType;
-            }
-
-            if (type.TypeKind == TypeKind.Class && hasReferenceAssemblyBase && !referenceAssemblyHasFields)
-            {
-                var fileLocation = string.Empty;
-                var declaration = type.DeclaringSyntaxReferences.FirstOrDefault();
-                if (declaration != null)
+                if (hasUnsupportedRefAsmBase && !referenceAssemblyHasFields)
                 {
-                    var location = declaration.SyntaxTree.GetLocation(declaration.Span);
-                    if (location.IsInSource)
+                    var fileLocation = string.Empty;
+                    var declaration = type.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as ClassDeclarationSyntax;
+                    if (declaration != null)
                     {
-                        var pos = location.GetMappedLineSpan();
-                        fileLocation = $"{pos.Path}({pos.Span.Start.Line},{pos.Span.Start.Character}): ";
+                        var location = declaration.Identifier.GetLocation();
+                        if (location.IsInSource)
+                        {
+                            var pos = location.GetLineSpan();
+                            fileLocation = $"{pos.Path}({pos.StartLinePosition.Line + 1},{pos.StartLinePosition.Character + 1},{pos.EndLinePosition.Line + 1},{pos.EndLinePosition.Character + 1}): ";
+                        }
                     }
+
+                    logger.LogWarning(
+                        $"{fileLocation}warning ORL1001: Type {type} has a base type which belongs to a reference assembly. Serializer generation for this type may not include important base type fields.");
                 }
 
-                logger.LogWarning(
-                    $"{fileLocation}Warning: Type {type} has a base type which belongs to a reference assembly. Serializer generation for this type may not include important base type fields.");
+                bool IsSupportedRefAsmType(INamedTypeSymbol t)
+                {
+                    INamedTypeSymbol baseDefinition;
+                    if (t.IsGenericType && !t.IsUnboundGenericType) baseDefinition = t.ConstructUnboundGenericType().OriginalDefinition;
+                    else baseDefinition = t.OriginalDefinition;
+
+                    foreach (var refAsmType in wellKnownTypes.SupportedRefAsmBaseTypes)
+                    {
+                        if (baseDefinition.Equals(refAsmType)) return true;
+                    }
+
+                    return false;
+                }
             }
 
             result.Sort(FieldInfoMember.Comparer.Instance);

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
@@ -101,6 +102,11 @@ namespace Orleans.CodeGenerator
                 KnownBaseTypeAttribute = Type("Orleans.CodeGeneration.KnownBaseTypeAttribute"),
                 ConsiderForCodeGenerationAttribute = Type("Orleans.CodeGeneration.ConsiderForCodeGenerationAttribute"),
                 OrleansCodeGenerationTargetAttribute = Type("Orleans.CodeGeneration.OrleansCodeGenerationTargetAttribute"),
+                SupportedRefAsmBaseTypes =
+                {
+                    Type("System.Collections.Generic.EqualityComparer`1"),
+                    Type("System.Collections.Generic.Comparer`1")
+                }
             };
 
             INamedTypeSymbol Type(string type)
@@ -138,6 +144,7 @@ namespace Orleans.CodeGenerator
             }
         }
 
+        public List<INamedTypeSymbol> SupportedRefAsmBaseTypes { get; } = new List<INamedTypeSymbol>();
         public IAssemblySymbol AbstractionsAssembly { get; private set; }
         public INamedTypeSymbol Attribute { get; private set; }
         public INamedTypeSymbol TimeSpan { get; private set; }

--- a/test/Grains/TestGrainInterfaces/SerializerExclusions.cs
+++ b/test/Grains/TestGrainInterfaces/SerializerExclusions.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Orleans.UnitTest.GrainInterfaces
 {
-    public class SubDictionary : Dictionary<int, ulong>
-    {
-    }
-
     public class MyTypeWithAPrivateTypeField
     {
         private MyPrivateDependency _dependency;
@@ -43,13 +38,6 @@ namespace Orleans.UnitTest.GrainInterfaces
     public interface IPrivateReturnType : IGrainWithIntegerKey
     {
         Task<MyTypeWithAPrivateTypeField> Foo();
-    }
-
-    // Verify that we do not try to generate a custom serializer for SubDictionary because Dictionary contains fileds of private types.
-    // If we do, compilation will fail. 
-    public interface ISubDictionaryReturnType : IGrainWithIntegerKey
-    {
-        Task<SubDictionary> Foo();
     }
 
     // Verify that we do generate a custom serializer for MyTypeWithAnInternalTypeField because it is visible within the assembly.


### PR DESCRIPTION
Fixes #5255

Also fixes the source line when the warning is emitted so that it will show correctly in VS/tooling