### PR TITLE
Fix inconsistencies between docs and examples

### DIFF
--- a/src/Documentation/clusters_and_clients/configuration_guide/server_configuration.md
+++ b/src/Documentation/clusters_and_clients/configuration_guide/server_configuration.md
@@ -26,7 +26,7 @@ var silo = new SiloHostBuilder()
     .Configure<ClusterOptions>(options =>
     {
         options.ClusterId = "my-first-cluster";
-        options.ServiceId = "MyAwesomeOrleansService";
+        options.ServiceId = "AspNetSampleApp";
     })
     // Clustering provider
     .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
@@ -47,7 +47,7 @@ Let's breakdown the steps used in this sample:
     // Clustering information
     .Configure<ClusterOptions>(options =>
     {
-        options.ClusterId = "orleans-docker";
+        options.ClusterId = "my-first-cluster";
         options.ServiceId = "AspNetSampleApp";
     })
     [...]


### PR DESCRIPTION
In the source version of this document under the header Orleans Clustering Information the documentation described the ClusterId as being set to "my-first-cluster", but the example code above this documentation was setting ClusterId to "orleans-docker". The example code has been updated to set the ClusterId to "my-first-cluster" in line with the documentation. 

In the same section ServiceId was being described as set to "AspNetSampleApp", but in the Server Configuration section the example code was setting ServiceId to "MyAwesomeOrleansService". This example code has been updated to set the ServiceId to "AspNetSampleApp" in line with the documentation.