### PR TITLE
Implementing Chirper Sample on v2.2

### DIFF
--- a/Samples/2.2/Chirper/Chirper.Client/Chirper.Client.csproj
+++ b/Samples/2.2/Chirper/Chirper.Client/Chirper.Client.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.2.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chirper.Grains.Interfaces\Chirper.Grains.Interfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.2/Chirper/Chirper.Client/ChirperConsoleViewer.cs
+++ b/Samples/2.2/Chirper/Chirper.Client/ChirperConsoleViewer.cs
@@ -1,0 +1,44 @@
+using System;
+using Chirper.Grains;
+using Chirper.Grains.Models;
+
+namespace Chirper.Client
+{
+    /// <summary>
+    /// Implements an <see cref="IChirperViewer"/> that outputs notifications to the console.
+    /// </summary>
+    public class ChirperConsoleViewer : IChirperViewer
+    {
+        /// <summary>
+        /// Creates a new <see cref="IChirperViewer"/> that outputs notifications to the console.
+        /// </summary>
+        /// <param name="userName">The user name of the account being observed.</param>
+        public ChirperConsoleViewer(string userName)
+        {
+            this.userName = userName ?? throw new ArgumentNullException(nameof(userName));
+        }
+
+        /// <summary>
+        /// The user name of the account being observed.
+        /// </summary>
+        private readonly string userName;
+
+        /// <inheritdoc />
+        public void NewChirp(ChirperMessage message)
+        {
+            Console.WriteLine($"Observed: Account {message.PublisherUserName} chirped '{message.Message}'");
+        }
+
+        /// <inheritdoc />
+        public void SubscriptionAdded(string username)
+        {
+            Console.WriteLine($"Observed: [{this.userName}] is now following [{username}]");
+        }
+
+        /// <inheritdoc />
+        public void SubscriptionRemoved(string username)
+        {
+            Console.WriteLine($"Observed: [{this.userName}] is no longer following [{username}]");
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Client/Program.cs
+++ b/Samples/2.2/Chirper/Chirper.Client/Program.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Hosting;
+
+namespace Chirper.Client
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.Title = nameof(Client);
+
+            var client = new ClientBuilder()
+                .UseLocalhostClustering()
+                .ConfigureLogging(_ =>
+                {
+                    _.AddDebug();
+                })
+                .Build();
+
+            var logger = client.ServiceProvider.GetService<ILoggerProvider>().CreateLogger(typeof(Program).FullName);
+
+            Console.WriteLine("Connecting...");
+
+            var retries = 100;
+            client.Connect(async error =>
+            {
+                if (--retries < 0)
+                {
+                    logger.LogError("Could not connect to the cluster: {@Message}", error.Message);
+                    return false;
+                }
+                else
+                {
+                    logger.LogWarning(error, "Error Connecting: {@Message}", error.Message);
+                }
+                await Task.Delay(1000);
+                return true;
+            }).Wait();
+
+            Console.WriteLine("Connected.");
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true;
+                client.Close().Wait();
+                Environment.Exit(0);
+            };
+
+            new Shell(client)
+                .RunAsync(client)
+                .Wait();
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Client/Shell.cs
+++ b/Samples/2.2/Chirper/Chirper.Client/Shell.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Chirper.Grains;
+using Orleans;
+
+namespace Chirper.Client
+{
+    public class Shell
+    {
+        public Shell(IClusterClient client)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        private readonly IClusterClient client;
+        private IChirperViewer viewer;
+        private IChirperAccount account;
+
+        public async Task RunAsync(IClusterClient client)
+        {
+            this.ShowHelp(true);
+
+            while (true)
+            {
+                var command = Console.ReadLine();
+                if (command == "/help")
+                {
+                    this.ShowHelp();
+                }
+                else if (command == "/quit")
+                {
+                    return;
+                }
+                else if (command.StartsWith("/user "))
+                {
+                    var match = Regex.Match(command, @"/user (?<username>\w{1,100})");
+                    if (match.Success)
+                    {
+                        await this.Unobserve();
+                        var username = match.Groups["username"].Value;
+                        this.account = client.GetGrain<IChirperAccount>(username);
+
+                        Console.WriteLine($"The current user is now [{username}]");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Invalid username. Try again or type /help for a list of commands.");
+                    }
+                }
+                else if (command.StartsWith("/follow "))
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        var match = Regex.Match(command, @"/follow (?<username>\w{1,100})");
+                        if (match.Success)
+                        {
+                            var targetName = match.Groups["username"].Value;
+                            await this.account.FollowUserIdAsync(targetName);
+
+                            Console.WriteLine($"[{this.account.GetPrimaryKeyString()}] is now following [{targetName}]");
+                        }
+                        else
+                        {
+                            Console.WriteLine("Invalid target username. Try again or type /help for a list of commands.");
+                        }
+                    }
+                }
+                else if (command == "/following")
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        (await this.account.GetFollowingListAsync())
+                            .ForEach(_ => Console.WriteLine(_));
+                    }
+                }
+                else if (command == "/followers")
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        (await this.account.GetFollowersListAsync())
+                            .ForEach(_ => Console.WriteLine(_));
+                    }
+                }
+                else if (command == "/observe")
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        if (this.viewer == null)
+                        {
+                            this.viewer = await client.CreateObjectReference<IChirperViewer>(new ChirperConsoleViewer(this.account.GetPrimaryKeyString()));
+                        }
+
+                        await this.account.SubscribeAsync(this.viewer);
+
+                        Console.WriteLine($"Now observing [{this.account.GetPrimaryKeyString()}]");
+                    }
+                }
+                else if (command == "/unobserve")
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        await this.Unobserve();
+                    }
+                }
+                else if (command.StartsWith("/unfollow "))
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        var match = Regex.Match(command, @"/unfollow (?<username>\w{1,100})");
+                        if (match.Success)
+                        {
+                            var targetName = match.Groups["username"].Value;
+                            await this.account.UnfollowUserIdAsync(targetName);
+
+                            Console.WriteLine($"[{this.account.GetPrimaryKeyString()}] is no longer following [{targetName}]");
+                        }
+                        else
+                        {
+                            Console.WriteLine("Invalid target username. Try again or type /help for a list of commands.");
+                        }
+                    }
+                }
+                else if (command.StartsWith("/chirp "))
+                {
+                    if (this.EnsureActiveAccount())
+                    {
+                        var match = Regex.Match(command, @"/chirp (?<message>.+)");
+                        if (match.Success)
+                        {
+                            var message = match.Groups["message"].Value;
+                            await this.account.PublishMessageAsync(message);
+                            Console.WriteLine("Published the new message!");
+                        }
+                        else
+                        {
+                            Console.WriteLine("Invalid chirp. Try again or type /help for a list of commands.");
+                        }
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Unknown command. Type /help for list of commands.");
+                }
+            }
+        }
+
+        private bool EnsureActiveAccount()
+        {
+            if (this.account == null)
+            {
+                Console.WriteLine("This command requires an active user. Try again or type /help for a list of commands.");
+                return false;
+            }
+            return true;
+        }
+
+        private async Task Unobserve()
+        {
+            if (this.viewer != null)
+            {
+                await this.account.UnsubscribeAsync(this.viewer);
+
+                this.viewer = null;
+
+                Console.WriteLine($"No longer observing [{this.account.GetPrimaryKeyString()}]");
+            }
+        }
+
+        private void ShowHelp(bool title = false)
+        {
+            if (title)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Welcome to the Chirper Sample!");
+                Console.WriteLine("These are the available commands:");
+            }
+
+            Console.WriteLine("/help: Shows this list.");
+            Console.WriteLine("/user <username>: Acts as the given account.");
+            Console.WriteLine("/chirp <message>: Publishes a message to the active account.");
+            Console.WriteLine("/follow <username>: Makes the active account follows the given account.");
+            Console.WriteLine("/unfollow <username>: Makes the active account unfollow the given accout.");
+            Console.WriteLine("/following: Lists the accounts that the active account is following.");
+            Console.WriteLine("/followers: Lists the accounts that follow the active account.");
+            Console.WriteLine("/observe: Start receiving real-time activity updates from the active account.");
+            Console.WriteLine("/unobserve: Stop receiving real-time activity updates from the active account.");
+            Console.WriteLine("/quit: Closes this client.");
+            Console.WriteLine();
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/Chirper.Grains.Interfaces.csproj
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/Chirper.Grains.Interfaces.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Chirper.Grains</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.2.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/EnumerableExtensions.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/EnumerableExtensions.cs
@@ -1,0 +1,22 @@
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Helper extensions for enumerables.
+    /// </summary>
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Short-hand fora regular foreach.
+        /// </summary>
+        /// <typeparam name="T">The type of the element.</typeparam>
+        /// <param name="enumerable">The enumerable to iterate.</param>
+        /// <param name="action">The action to apply for each element.</param>
+        public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> action)
+        {
+            foreach (var item in enumerable)
+            {
+                action(item);
+            }
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperAccount.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperAccount.cs
@@ -1,0 +1,56 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Chirper.Grains.Models;
+
+namespace Chirper.Grains
+{
+    /// <summary>
+    /// Orleans grain interface IChirperAccount -- This is the user-facing control grain for a particular user. 
+    /// A suitably authenticated external application can perform both publisher and subscriber functions on behalf of a user through this grain.
+    /// This grain mediates command and communications between the external application and that user's publisher & subscriber agent grains.
+    /// </summary>
+    public interface IChirperAccount : IChirperPublisher, IChirperSubscriber
+    {
+        /// <summary>Add a new follower subscription from this user to the specified publisher</summary>
+        /// <param name="userNameToFollow">The user name of the new publisher now being followed by this user</param>
+        /// <returns>Task status for this operation</returns>
+        Task FollowUserIdAsync(string userNameToFollow);
+
+        /// <summary>Remove a follower subscription from this user to the specified publisher</summary>
+        /// <param name="userNameToUnfollow">The user name of the publisher no longer being followed by this user</param>
+        /// <returns>AsyncCompletion status for this operation</returns>
+        Task UnfollowUserIdAsync(string userNameToUnfollow);
+
+        /// <summary>Get the list of publishers who this user is following</summary>
+        /// <returns>List of users being followed</returns>
+        Task<ImmutableList<string>> GetFollowingListAsync();
+
+        /// <summary>Get the list of subscribers who are following this user</summary>
+        /// <returns>List of users who are following this user</returns>
+        Task<ImmutableList<string>> GetFollowersListAsync();
+
+        /// <summary>Publish a new Chirp message</summary>
+        /// <param name="chirpMessage">The message text to be published as a new Chirp</param>
+        /// <returns>Completion status for the publish operation</returns>
+        Task PublishMessageAsync(string chirpMessage);
+
+        /// <summary>Request the most recent 'n' Chirp messages received by this subscriber, from the specified start position.</summary>
+        /// <param name="n">Number of Chirp messages requested. A value of -1 means all messages.</param>
+        /// <param name="start">The start position for returned messages. A value of 0 means start with most recent message. A positive value means skip past that many of the most recent messages</param>
+        /// <returns>List of Chirp messages received by this subscriber</returns>
+        /// <remarks>The subscriber might only return a partial record of historic events due to message retention policies.</remarks>
+        Task<ImmutableList<ChirperMessage>> GetReceivedMessagesAsync(int n = 10, int start = 0);
+
+        /// <summary>
+        /// Subscribes to real-time notifications from this grain.
+        /// </summary>
+        /// <param name="viewer">The observer to receive notifications.</param>
+        Task SubscribeAsync(IChirperViewer viewer);
+
+        /// <summary>
+        /// Unsubscribes the given viewer from real-time notifications from this grain.
+        /// </summary>
+        /// <param name="viewer"></param>
+        Task UnsubscribeAsync(IChirperViewer viewer);
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperPublisher.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperPublisher.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Chirper.Grains.Models;
+using Orleans;
+
+namespace Chirper.Grains
+{
+    /// <summary>
+    /// Orleans grain interface IChirperPublisher.
+    /// </summary>
+    public interface IChirperPublisher : IGrainWithStringKey
+    {
+        /// <summary>
+        /// Request a copy of the most recent 'n' Chirp messages posted by this publisher, from the specified start position.
+        /// </summary>
+        /// <param name="n">Number of Chirp messages requested. A value of -1 means all messages.</param>
+        /// <param name="start">The start position for returned messages. A value of 0 means start with most recent message. A positive value means skip past that many of the most recent messages</param>
+        /// <returns>Bulk list of Chirp messages posted by this publisher</returns>
+        /// <remarks>The publisher might only return a partial record of historic events due to message retention policies.</remarks>
+        Task<ImmutableList<ChirperMessage>> GetPublishedMessagesAsync(int n = 10, int start = 0);
+
+        /// <summary>
+        /// Subscribe from receiving notifications of new Chirps sent by this publisher.
+        /// </summary>
+        /// <param name="userName">The user name of the subscriber to add.</param>
+        /// <param name="subscriber">The subscriber to add.</param>
+        /// <returns>AsyncCompletion status for this operation</returns>
+        Task AddFollowerAsync(string userName, IChirperSubscriber subscriber);
+
+        /// <summary>
+        /// Unsubscribe from receiving notifications of new Chirps sent by this publisher.
+        /// </summary>
+        /// <param name="userName">The user name of the subscriber to remove.</param>
+        /// <returns>AsyncCompletion for this operation</returns>
+        Task RemoveFollowerAsync(string userName);
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperSubscriber.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperSubscriber.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Chirper.Grains.Models;
+using Orleans;
+
+namespace Chirper.Grains
+{
+    /// <summary>
+    /// Orleans observer interface IChirperSubscriber.
+    /// </summary>
+    public interface IChirperSubscriber : IGrainWithStringKey
+    {
+        /// <summary>
+        /// Notification that a new Chirp has been received.
+        /// </summary>
+        /// <param name="chirp">Chirp message entry.</param>
+        Task NewChirpAsync(ChirperMessage chirp);
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperViewer.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/IChirperViewer.cs
@@ -1,0 +1,27 @@
+using Chirper.Grains.Models;
+using Orleans;
+
+namespace Chirper.Grains
+{
+    /// <summary>
+    /// Interface of observers of an <see cref="IChirperAccount"/> instance.
+    /// </summary>
+    public interface IChirperViewer : IGrainObserver
+    {
+        /// <summary>
+        /// Notifies that an account has published the message.
+        /// This is either the observed account or a followed account.
+        /// </summary>
+        void NewChirp(ChirperMessage message);
+
+        /// <summary>
+        /// Notifies that the account has added a subscription.
+        /// </summary>
+        void SubscriptionAdded(string username);
+
+        /// <summary>
+        /// Notifies that the account has removed a subscription.
+        /// </summary>
+        void SubscriptionRemoved(string username);
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains.Interfaces/Models/ChirperMessage.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains.Interfaces/Models/ChirperMessage.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Chirper.Grains.Models
+{
+    /// <summary>
+    /// Data object representing one Chirp message entry
+    /// </summary>
+    public class ChirperMessage
+    {
+        /// <summary>
+        /// Creates a new message.
+        /// </summary>
+        public ChirperMessage(string message, DateTime timestamp, string publisherUserName)
+        {
+            this.MessageId = Guid.NewGuid();
+            this.Message = message;
+            this.Timestamp = timestamp;
+            this.PublisherUserName = publisherUserName;
+        }
+
+        /// <summary>
+        /// The unique id of this chirp message.
+        /// </summary>
+        public Guid MessageId { get; }
+
+        /// <summary>
+        /// The message content for this chirp message entry.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// The timestamp of when this chirp message entry was originally republished.
+        /// </summary>
+        public DateTime Timestamp { get; }
+
+        /// <summary>
+        /// The user name of the publisher of this chirp message.
+        /// </summary>
+        public string PublisherUserName { get; }
+
+        /// <summary>
+        /// Returns a string representation of this message.
+        /// </summary>
+        public override string ToString() => $"Chirp: '{this.Message}' from @{this.PublisherUserName} at {this.Timestamp}";
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains/Chirper.Grains.csproj
+++ b/Samples/2.2/Chirper/Chirper.Grains/Chirper.Grains.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.2.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chirper.Grains.Interfaces\Chirper.Grains.Interfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.2/Chirper/Chirper.Grains/ChirperAccount.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains/ChirperAccount.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Chirper.Grains.Models;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Concurrency;
+
+namespace Chirper.Grains
+{
+    public class ChirperAccountState
+    {
+        /// <summary>
+        /// The list of publishers who this user is following.
+        /// </summary>
+        public Dictionary<string, IChirperPublisher> Subscriptions { get; set; }
+
+        /// <summary>
+        /// The list of subscribers who are following this user.
+        /// </summary>
+        public Dictionary<string, IChirperSubscriber> Followers { get; set; }
+
+        /// <summary>
+        /// Chirp messages recently received by this user.
+        /// </summary>
+        public Queue<ChirperMessage> RecentReceivedMessages { get; set; }
+
+        /// <summary>
+        /// Chirp messages recently published by this user.
+        /// </summary>
+        public Queue<ChirperMessage> MyPublishedMessages { get; set; }
+    }
+
+    [Reentrant]
+    public class ChirperAccount : Grain<ChirperAccountState>, IChirperAccount
+    {
+        /// <summary>
+        /// Size for the recently received message cache.
+        /// </summary>
+        private const int ReceivedMessagesCacheSize = 100;
+
+        /// <summary>
+        /// Size for the published message cache.
+        /// </summary>
+        private const int PublishedMessagesCacheSize = 100;
+
+        /// <summary>
+        /// The category logger.
+        /// </summary>
+        private readonly ILogger<ChirperAccount> logger;
+
+        /// <summary>
+        /// Allows state writing to happen in the background.
+        /// </summary>
+        private Task outstandingWriteStateOperation;
+
+        /// <summary>
+        /// Max length of each chirp.
+        /// </summary>
+        private const int MAX_MESSAGE_LENGTH = 280;
+
+        /// <summary>
+        /// Holds the transient list of viewers.
+        /// This list is not part of state and will not survive grain deactivation.
+        /// </summary>
+        private readonly HashSet<IChirperViewer> viewers = new HashSet<IChirperViewer>();
+
+        public ChirperAccount(ILogger<ChirperAccount> logger)
+        {
+            this.logger = logger;
+        }
+
+        private string GrainType => nameof(ChirperAccount);
+        private string GrainKey => this.GetPrimaryKeyString();
+
+        #region Grain overrides
+
+        public override Task OnActivateAsync()
+        {
+            // initialize state as needed
+            if (this.State.RecentReceivedMessages == null) this.State.RecentReceivedMessages = new Queue<ChirperMessage>(ReceivedMessagesCacheSize);
+            if (this.State.MyPublishedMessages == null) this.State.MyPublishedMessages = new Queue<ChirperMessage>(PublishedMessagesCacheSize);
+            if (this.State.Followers == null) this.State.Followers = new Dictionary<string, IChirperSubscriber>();
+            if (this.State.Subscriptions == null) this.State.Subscriptions = new Dictionary<string, IChirperPublisher>();
+
+            this.logger.LogInformation("{@GrainType} {@GrainKey} activated.", this.GrainType, this.GrainKey);
+
+            return Task.CompletedTask;
+        }
+
+        #endregion
+
+        #region IChirperAccountGrain interface methods
+
+        public async Task PublishMessageAsync(string message)
+        {
+            var chirp = this.CreateNewChirpMessage(message);
+
+            this.logger.LogInformation("{@GrainType} {@GrainKey} publishing new chirp message '{@Chirp}'.",
+                this.GrainType, this.GrainKey, chirp);
+
+            this.State.MyPublishedMessages.Enqueue(chirp);
+
+            while (this.State.MyPublishedMessages.Count > PublishedMessagesCacheSize)
+            {
+                this.State.MyPublishedMessages.Dequeue();
+            }
+
+            await this.WriteStateAsync();
+
+            // notify viewers of new message
+            this.logger.LogInformation("{@GrainType} {@GrainKey} sending new chirp message to {@ViewerCount} viewers.",
+                this.GrainType, this.GrainKey, this.viewers.Count);
+
+            this.viewers.ForEach(_ => _.NewChirp(chirp));
+
+            // notify followers of a new message
+            this.logger.LogInformation("{@GrainType} {@GrainKey} sending new chirp message to {@FollowerCount} followers.",
+                this.GrainType, this.GrainKey, this.State.Followers.Count);
+
+            await Task.WhenAll(this.State.Followers.Values.Select(_ => _.NewChirpAsync(chirp)).ToArray());
+        }
+
+        public Task<ImmutableList<ChirperMessage>> GetReceivedMessagesAsync(int n, int start)
+        {
+            if (start < 0) start = 0;
+            if ((start + n) > this.State.RecentReceivedMessages.Count)
+            {
+                n = this.State.RecentReceivedMessages.Count - start;
+            }
+
+            return Task.FromResult(
+                this.State.RecentReceivedMessages.Skip(start).Take(n).ToImmutableList());
+        }
+
+        public async Task FollowUserIdAsync(string username)
+        {
+            this.logger.LogInformation("{@GrainType} {@UserName} > FollowUserName({@TargetUserName}).",
+                this.GrainType, this.GrainKey, username);
+
+            var userToFollow = this.GrainFactory.GetGrain<IChirperPublisher>(username);
+
+            await userToFollow.AddFollowerAsync(this.GrainKey, this.AsReference<IChirperSubscriber>());
+
+            this.State.Subscriptions[username] = userToFollow;
+
+            await this.WriteStateAsync();
+
+            // notify any viewers that a subscription has been added for this user
+            this.viewers.ForEach(_ => _.SubscriptionAdded(username));
+        }
+
+        public async Task UnfollowUserIdAsync(string username)
+        {
+            this.logger.LogInformation("{@GrainType} {@GrainKey} > UnfollowUserName({@TargetUserName}).",
+                this.GrainType, this.GrainKey, username);
+
+            // ask the publisher to remove this grain as a follower
+            await GrainFactory.GetGrain<IChirperPublisher>(username)
+                .RemoveFollowerAsync(this.GrainKey);
+
+            // remove this publisher from the subscriptions list
+            this.State.Subscriptions.Remove(username);
+
+            // save now
+            await this.WriteStateAsync();
+
+            // notify event subscribers
+            this.viewers.ForEach(_ => _.SubscriptionRemoved(username));
+        }
+
+        public Task<ImmutableList<string>> GetFollowingListAsync() => Task.FromResult(this.State.Subscriptions.Keys.ToImmutableList());
+
+        public Task<ImmutableList<string>> GetFollowersListAsync() => Task.FromResult(this.State.Followers.Keys.ToImmutableList());
+
+        public Task SubscribeAsync(IChirperViewer viewer)
+        {
+            this.viewers.Add(viewer);
+            return Task.CompletedTask;
+        }
+
+        public Task UnsubscribeAsync(IChirperViewer viewer)
+        {
+            this.viewers.Remove(viewer);
+            return Task.CompletedTask;
+        }
+
+        #endregion
+
+        #region IChirperPublisher interface methods
+
+        public Task<ImmutableList<ChirperMessage>> GetPublishedMessagesAsync(int n, int start)
+        {
+            if (start < 0) start = 0;
+            if ((start + n) > this.State.MyPublishedMessages.Count) n = this.State.MyPublishedMessages.Count - start;
+            return Task.FromResult(
+                this.State.MyPublishedMessages.Skip(start).Take(n).ToImmutableList());
+        }
+
+        public async Task AddFollowerAsync(string username, IChirperSubscriber follower)
+        {
+            this.State.Followers[username] = follower;
+            await this.WriteStateAsync();
+        }
+
+        public async Task RemoveFollowerAsync(string username)
+        {
+            this.State.Followers.Remove(username);
+            await this.WriteStateAsync();
+        }
+
+        #endregion
+
+        #region IChirperSubscriber notification callback interface
+
+        public async Task NewChirpAsync(ChirperMessage chirp)
+        {
+            this.logger.LogInformation("{@GrainType} {@GrainKey} received chirp message = {@Chirp}",
+                this.GrainType, this.GrainKey, chirp);
+
+            this.State.RecentReceivedMessages.Enqueue(chirp);
+
+            // only relevant when not using fixed queue
+            while (this.State.MyPublishedMessages.Count > PublishedMessagesCacheSize) // to keep not more than the max number of messages
+            {
+                this.State.MyPublishedMessages.Dequeue();
+            }
+
+            await this.WriteStateAsync();
+
+            // notify any viewers that a new chirp has been received
+            this.logger.LogInformation("{@GrainType} {@GrainKey} sending received chirp message to {@ViewerCount} viewers",
+                this.GrainType, this.GrainKey, this.viewers.Count);
+
+            this.viewers.ForEach(_ => _.NewChirp(chirp));
+        }
+
+        #endregion
+
+        private ChirperMessage CreateNewChirpMessage(string message) => new ChirperMessage(message, DateTime.Now, this.GrainKey);
+
+        // When reentrant grain is doing WriteStateAsync, etag violations are possible due to concurrent writes.
+        // The solution is to serialize and batch writes, and make sure only a single write is outstanding at any moment in time.
+        protected override async Task WriteStateAsync()
+        {
+            var currentWriteStateOperation = this.outstandingWriteStateOperation;
+            if (currentWriteStateOperation != null)
+            {
+                try
+                {
+                    // await the outstanding write, but ignore it since it doesn't include our changes
+                    await currentWriteStateOperation;
+                }
+                catch
+                {
+                    // Ignore all errors from this in-flight write operation, since the original caller(s) of it will observe it.
+                }
+                finally
+                {
+                    if (this.outstandingWriteStateOperation == currentWriteStateOperation)
+                    {
+                        // only null out the outstanding operation if it's the same one as the one we awaited, otherwise
+                        // another request might have already done so.
+                        this.outstandingWriteStateOperation = null;
+                    }
+                }
+            }
+
+            if (this.outstandingWriteStateOperation == null)
+            {
+                // If after the initial write is completed, no other request initiated a new write operation, do it now.
+                currentWriteStateOperation = base.WriteStateAsync();
+                this.outstandingWriteStateOperation = currentWriteStateOperation;
+            }
+            else
+            {
+                // If there were many requests enqueued to persist state, there is no reason to enqueue a new write 
+                // operation for each, since any write (after the initial one that we already awaited) will have cumulative
+                // changes including the one requested by our caller. Just await the new outstanding write.
+                currentWriteStateOperation = this.outstandingWriteStateOperation;
+            }
+
+            try
+            {
+                await currentWriteStateOperation;
+            }
+            finally
+            {
+                if (this.outstandingWriteStateOperation == currentWriteStateOperation)
+                {
+                    // only null out the outstanding operation if it's the same one as the one we awaited, otherwise
+                    // another request might have already done so.
+                    this.outstandingWriteStateOperation = null;
+                }
+            }
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Grains/StringExtensions.cs
+++ b/Samples/2.2/Chirper/Chirper.Grains/StringExtensions.cs
@@ -1,0 +1,61 @@
+namespace System
+{
+    /// <summary>
+    /// Helper extensions for handling strings.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// If the length of the string is greater than the given length, then returns a truncated string to the given length.
+        /// Otherwise returns the original string.
+        /// </summary>
+        /// <param name="str">The string to truncate.</param>
+        /// <param name="maxLength">The length upon which to truncate the string.</param>
+        public static string Truncate(this string str, int maxLength)
+        {
+            if (str == null) throw new ArgumentNullException(nameof(str));
+            if (maxLength < 0) throw new ArgumentOutOfRangeException(nameof(maxLength));
+
+            return str.Length > maxLength ? str.Substring(0, maxLength) : str;
+        }
+
+        /// <summary>
+        /// Short-hand for the regular String.IsNullOrEmpty().
+        /// </summary>
+        /// <param name="str">The string to test.</param>
+        public static bool IsNullOrEmpty(this string str)
+        {
+            return string.IsNullOrEmpty(str);
+        }
+
+        /// <summary>
+        /// Short-hand for the regular String.IsNullOrWhiteSpace().
+        /// </summary>
+        /// <param name="str">The string to test.</param>
+        public static bool IsNullOrWhiteSpace(this string str)
+        {
+            return string.IsNullOrWhiteSpace(str);
+        }
+
+        /// <summary>
+        /// Returns true if the given string is surrounded by at least one space on either side.
+        /// </summary>
+        /// <param name="str">The string to test.</param>
+        public static bool IsUntrimmed(this string str)
+        {
+            return
+                str.Length == 0 ||
+                str.Substring(0, 1).Trim().Length == 0 ||
+                str.Substring(str.Length - 1, 1).Trim().Length == 0;
+        }
+
+        /// <summary>
+        /// Returns true if the given string is null or white space or surrounded by at least one space on either side.
+        /// </summary>
+        /// <param name="str">The string to test.</param>
+        public static bool IsNullOrWhiteSpaceOrUntrimmed(this string str)
+        {
+            return str.IsNullOrWhiteSpace() || str.IsUntrimmed();
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.Silo/Chirper.Silo.csproj
+++ b/Samples/2.2/Chirper/Chirper.Silo/Chirper.Silo.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="2.2.4" />
+    <PackageReference Include="OrleansDashboard" Version="2.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chirper.Grains\Chirper.Grains.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.2/Chirper/Chirper.Silo/Program.cs
+++ b/Samples/2.2/Chirper/Chirper.Silo/Program.cs
@@ -1,0 +1,40 @@
+using System;
+using Chirper.Grains;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Hosting;
+
+namespace Chirper.Silo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.Title = nameof(Silo);
+
+            var host = new SiloHostBuilder()
+                .UseLocalhostClustering()
+                .ConfigureApplicationParts(_ => _.AddApplicationPart(typeof(ChirperAccount).Assembly).WithReferences())
+                .ConfigureLogging(_ =>
+                {
+                    _.AddFilter("Orleans.Runtime.Management.ManagementGrain", LogLevel.Warning);
+                    _.AddFilter("Orleans.Runtime.SiloControl", LogLevel.Warning);
+                    _.AddConsole();
+                })
+                .AddMemoryGrainStorageAsDefault()
+                .AddMemoryGrainStorage("PubSubStore")
+                .UseDashboard()
+                .Build();
+
+            host.StartAsync().Wait();
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true;
+                host.StopAsync().Wait();
+            };
+
+            host.Stopped.Wait();
+        }
+    }
+}

--- a/Samples/2.2/Chirper/Chirper.sln
+++ b/Samples/2.2/Chirper/Chirper.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.438
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chirper.Grains.Interfaces", "Chirper.Grains.Interfaces\Chirper.Grains.Interfaces.csproj", "{A6AFFAFA-0CF8-43FA-8B1E-24DC53A3F81C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chirper.Grains", "Chirper.Grains\Chirper.Grains.csproj", "{25C197AE-59F7-42F2-BE5D-D69A0F804EF7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chirper.Silo", "Chirper.Silo\Chirper.Silo.csproj", "{2C967379-D025-4EBB-96C0-1A4C6CBE4B4B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chirper.Client", "Chirper.Client\Chirper.Client.csproj", "{3BE53D35-938D-47D8-B135-501786B145DC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A6AFFAFA-0CF8-43FA-8B1E-24DC53A3F81C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6AFFAFA-0CF8-43FA-8B1E-24DC53A3F81C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6AFFAFA-0CF8-43FA-8B1E-24DC53A3F81C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6AFFAFA-0CF8-43FA-8B1E-24DC53A3F81C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25C197AE-59F7-42F2-BE5D-D69A0F804EF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25C197AE-59F7-42F2-BE5D-D69A0F804EF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25C197AE-59F7-42F2-BE5D-D69A0F804EF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25C197AE-59F7-42F2-BE5D-D69A0F804EF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C967379-D025-4EBB-96C0-1A4C6CBE4B4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C967379-D025-4EBB-96C0-1A4C6CBE4B4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C967379-D025-4EBB-96C0-1A4C6CBE4B4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C967379-D025-4EBB-96C0-1A4C6CBE4B4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BE53D35-938D-47D8-B135-501786B145DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BE53D35-938D-47D8-B135-501786B145DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BE53D35-938D-47D8-B135-501786B145DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BE53D35-938D-47D8-B135-501786B145DC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C89E84AE-23F3-4B37-97EB-BB71303D494F}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR implements the v1.x Chirper sample on Orleans v2.2.

- .NET Core 2.1.
- The newer host builder components are used but not the generic host integration yet.
- Command line client rebuilt for simplicity.
- ChirperAccount grain key changed to string (for username) for demo simplicity.
- Legacy ObserverManager replaced with an internal collection.
- Network load generators *not* migrated as they appear to depend on windows-only performance counters.

Legacy files from 1.x have not been touched. Only new files for v2.2 are added.

There's more improvements that could be done, e.g. removing aged-out observers, but not sure it is warranted on a sample. That said, happy to apply fixes or improvements as needed.