### PR TITLE
Fix a code typo in migration guide

### DIFF
--- a/src/Documentation/resources/Migration/MigrationAzure2.0.md
+++ b/src/Documentation/resources/Migration/MigrationAzure2.0.md
@@ -123,7 +123,7 @@ Orleans 2.0 provides a more flexible and modular API for configuring and hosting
             // Build silo host, so that any errors will restart the role instance
             this.host = this.builder.Build();
 
-            base.OnStart();
+            return base.OnStart();
         }
 
         public override void OnStop()


### PR DESCRIPTION
Trying to fill some gaps that I found trying to follow migration guides and pages.