### PR TITLE
Revert "Stop packing *.symbols.nupkg packages"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <RepositoryUrl>https://github.com/dotnet/Orleans</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <IncludeSymbols>false</IncludeSymbols>
-    <IncludeSource>false</IncludeSource>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Reverts dotnet/orleans#5441

For some reason it seems to break our code signing infra...