### PR TITLE
Add Kubernetes support to Docker sample

### DIFF
--- a/Samples/2.0/docker-aspnet-core/API/API.csproj
+++ b/Samples/2.0/docker-aspnet-core/API/API.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+    <ServerGarbageCollection>false</ServerGarbageCollection> <!-- https://blog.markvincze.com/troubleshooting-high-memory-usage-with-asp-net-core-on-kubernetes/ -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/2.0/docker-aspnet-core/Makefile
+++ b/Samples/2.0/docker-aspnet-core/Makefile
@@ -1,0 +1,47 @@
+# a Makefile to test this sample on Kubernetes
+# you can test it locally (e.g. using Docker for Windows/Mac) or remotely, on your cloud provider of choice
+# do not forget to set Azure Storage connection string on Silo/Program.cs and API/Startup.cs
+
+# your Docker registry (we suppose you have logged in and have push access)
+REGISTRY ?= docker.io/dgkanatsios
+# the context of your local Kubernetes cluster
+LOCAL_K8S_CLUSTER=docker-for-desktop
+# the contect of your remote Kubernetes cluster
+REMOTE_K8S_CLUSTER=aks
+# version/tag of the images that will be pushed to Docker Hub
+VERSION=0.0.8
+
+API_PROJECT_NAME=orleans-api
+SILO_PROJECT_NAME=orleans-silo
+
+# tag of the images that will be pushed for local development
+TAG?=$(shell git rev-list HEAD --max-count=1 --abbrev-commit)
+
+buildlocal: 
+		docker build -f ./Silo/Dockerfile -t $(SILO_PROJECT_NAME):$(TAG) .
+		docker build -f ./API/Dockerfile -t $(API_PROJECT_NAME):$(TAG) .
+		docker system prune -f
+deploylocal: uselocalcontext
+		kubectl config use-context $(LOCAL_K8S_CLUSTER)
+		sed -e 's/orleans-silo-image/$(SILO_PROJECT_NAME):$(TAG)/' -e 's/orleans-api-image/$(API_PROJECT_NAME):$(TAG)/' deploy.yaml | kubectl apply -f -
+cleandeploylocal: uselocalcontext clean
+uselocalcontext:
+		kubectl config use-context $(LOCAL_K8S_CLUSTER)
+
+buildremote: 
+		docker build -f ./Silo/Dockerfile -t $(REGISTRY)/$(SILO_PROJECT_NAME):$(VERSION) .
+		docker build -f ./API/Dockerfile -t $(REGISTRY)/$(API_PROJECT_NAME):$(VERSION) .
+		docker system prune -f
+pushremote:
+		docker push $(REGISTRY)/$(SILO_PROJECT_NAME):$(VERSION)
+		docker push $(REGISTRY)/$(API_PROJECT_NAME):$(VERSION)
+deployremote: useremotecontext
+		sed -e 's,orleans-silo-image,$(REGISTRY)/$(SILO_PROJECT_NAME):$(VERSION),' -e 's,orleans-api-image,$(REGISTRY)/$(API_PROJECT_NAME):$(VERSION),' deploy.yaml | kubectl apply -f -
+		# after a few minutes, you can do a `kubectl get service` to get the Public IP endpoint
+cleandeployremote: useremotecontext clean
+useremotecontext:	
+		kubectl config use-context $(REMOTE_K8S_CLUSTER)
+
+clean:
+		kubectl delete deployment $(SILO_PROJECT_NAME) $(API_PROJECT_NAME)
+		kubectl delete service $(API_PROJECT_NAME)	

--- a/Samples/2.0/docker-aspnet-core/Makefile
+++ b/Samples/2.0/docker-aspnet-core/Makefile
@@ -7,9 +7,9 @@ REGISTRY ?= docker.io/dgkanatsios
 # the context of your local Kubernetes cluster
 LOCAL_K8S_CLUSTER=docker-for-desktop
 # the contect of your remote Kubernetes cluster
-REMOTE_K8S_CLUSTER=aks
+REMOTE_K8S_CLUSTER=aksorleans
 # version/tag of the images that will be pushed to Docker Hub
-VERSION=0.0.8
+VERSION=0.0.14
 
 API_PROJECT_NAME=orleans-api
 SILO_PROJECT_NAME=orleans-silo

--- a/Samples/2.0/docker-aspnet-core/README.md
+++ b/Samples/2.0/docker-aspnet-core/README.md
@@ -1,0 +1,84 @@
+# Docker - Kubernetes - ASP.NET Core
+
+## Description
+
+This sample creates two Docker containers, one that creates the Silo that hosts `ValueGrain` instances (you can find it in the `Grains/ValueGrain.cs` file) and a ASP.NET Core app (which acts like a client to this Silo) called `API` and resides in the `API` folder. User can access the API app and create/update `ValueGrain` instances. 
+These two containers can be tested using [Docker Compose](https://docs.docker.com/compose/) or in a [Kubernetes](https://www.kubernetes.io) cluster. 
+
+## Before running the sample
+
+Before running the sample, you should
+
+- Edit `API/startup.cs` and `Silo/Program.cs` and add your Azure Storage Connection string. However, bear in mind that in production environments the recommended way to set configuration information is via environment variables
+- Edit `Makefile` and modify the `REGISTRY`, `LOCAL_K8S_CLUSTER` and `REMOTE_K8S_CLUSTER` with the appropriate values for your setup
+
+## Docker compose
+
+To build and run the sample using [Docker Compose](https://docs.docker.com/compose/) run:
+
+```bash
+docker-compose up
+```
+
+Then, on another command prompt, you can do `docker ps` to find out the port the the API service is listening.
+
+```
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                   NAMES
+9af86b6a00fa        api                 "dotnet API.dll"    31 seconds ago      Up 26 seconds       0.0.0.0:32771->80/tcp   docker-aspnet-core_api_1
+3e71db40b80e        silo                "dotnet Silo.dll"   31 seconds ago      Up 27 seconds                               docker-aspnet-core_silo_1
+```
+
+As you can see, API is listening to port *32771* (your port will be different, of course). Now, you can use your browser and navigate to `http://localhost:32771` to test the app.
+
+To stop the sample you can use `Ctrl-C`, whereas to delete resources you should run:
+
+```bash
+docker-compose down
+```
+
+## Kubernetes
+
+We've added a `Makefile` as well as a `deploy.yaml` file with the necessary commands to run the solution on a Kubernetes cluster.
+
+### Local Kubernetes cluster
+
+You can run the sample on your local Kubernetes cluster. We have tested this with [Docker for Windows](https://docs.docker.com/docker-for-windows/) but it should also work with [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Minikube](https://kubernetes.io/docs/setup/minikube/) as well. To run it on local cluster, use a Linux shell or [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) on Windows and run:
+
+```bash
+make buildlocal
+make deploylocal
+```
+
+Use your browser and navigate to `http://localhost:8888` to test the app.
+
+If you want to remove resources, use:
+
+```bash
+make cleandeploylocal
+```
+
+### Remote Kubernetes cluster
+
+To run the sample on your remote Kubernetes cluster, use:
+
+```bash
+make buildremote
+make pushremote
+make deployremote
+# if you want to do it in one step, you can use make buildremote pushremote deployremote
+```
+
+You can use `kubectl get svc` to get the Public IP for the API [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/), so you can connect via web browser. Alternatively, you can do `kubectl port-forward service/orleans-api 8888:8888` to create a tunnel between your machine and the remote Service. This way, you can access it via web browser at `http://localhost:8888`.
+
+If you want to remove remote resources, use:
+
+```bash
+make cleandeployremote
+```
+
+### Additional stuff
+
+- If you have issues with Silos not being able to get activated when you re-deploy/update your Deployments, try deleting all rows from the Azure Table Storage membership table.
+- We're using `imagePullPolicy: Always` so you would not need to increment the `VERSION` variable on the Makefile, but be aware that you may have to, just in case. Oh, and don't use `latest` in Production ([source](https://kubernetes.io/docs/concepts/configuration/overview/#container-images)).
+- We're using `hostNetwork` for the Silo Pods on the `deploy.yaml` file. Silo Pods register their Port/ProxyPort to the Membership table. So, in order to communicate, they lookup this table to find other Silos' Port/ProxyPort. If we did not use `hostNetwork`, Silos would need to be aware of the Hpst port Kubernetes would map for their container Port. By using `hostNetwork` in combination with random port usage on `Silo/Program.cs`, we guarantee that the ports listed on the Membership table are the ones that should be used.
+- If you would like to use Kubernetes to store Membership information (via Custom Resource Definitions), check out [this](https://github.com/OrleansContrib/Orleans.Clustering.Kubernetes) project.

--- a/Samples/2.0/docker-aspnet-core/Silo/Program.cs
+++ b/Samples/2.0/docker-aspnet-core/Silo/Program.cs
@@ -26,7 +26,7 @@ namespace Silo
                     options.ServiceId = "AspNetSampleApp";
                 })
                 .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
-                .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+                .ConfigureEndpoints(new Random(Guid.NewGuid().GetHashCode()).Next(30001, 30100), new Random(Guid.NewGuid().GetHashCode()).Next(20001, 20100), listenOnAnyHostAddress: true)
                 .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
                 .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
                 .Build();

--- a/Samples/2.0/docker-aspnet-core/Silo/Program.cs
+++ b/Samples/2.0/docker-aspnet-core/Silo/Program.cs
@@ -26,7 +26,7 @@ namespace Silo
                     options.ServiceId = "AspNetSampleApp";
                 })
                 .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
-                .ConfigureEndpoints(new Random(Guid.NewGuid().GetHashCode()).Next(30001, 30100), new Random(Guid.NewGuid().GetHashCode()).Next(20001, 20100), listenOnAnyHostAddress: true)
+                .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
                 .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
                 .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
                 .Build();

--- a/Samples/2.0/docker-aspnet-core/Silo/Silo.csproj
+++ b/Samples/2.0/docker-aspnet-core/Silo/Silo.csproj
@@ -5,6 +5,7 @@
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <ServerGarbageCollection>false</ServerGarbageCollection> <!-- https://blog.markvincze.com/troubleshooting-high-memory-usage-with-asp-net-core-on-kubernetes/ -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/2.0/docker-aspnet-core/deploy.yaml
+++ b/Samples/2.0/docker-aspnet-core/deploy.yaml
@@ -21,6 +21,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 80
+        resources:
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
 ---
 apiVersion: v1
 kind: Service
@@ -58,8 +62,14 @@ spec:
       labels:
         run: orleans-silo
     spec:
-      hostNetwork: true
       containers:
       - image: orleans-silo-image # image name updated by Makefile
         name: orleans-silo
         imagePullPolicy: Always
+        ports:
+        - containerPort: 11111
+        - containerPort: 30000
+        resources:
+          limits:
+            memory: "256Mi"
+            cpu: "250m"

--- a/Samples/2.0/docker-aspnet-core/deploy.yaml
+++ b/Samples/2.0/docker-aspnet-core/deploy.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: orleans-api
+  name: orleans-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: orleans-api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        run: orleans-api
+    spec:
+      containers:
+      - image: orleans-api-image # image name updated by Makefile
+        name: orleans-api
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: orleans-api
+  name: orleans-api
+spec:
+  ports:
+  - port: 8888
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: orleans-api
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: orleans-silo
+  name: orleans-silo
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  replicas: 2
+  selector:
+    matchLabels:
+      run: orleans-silo
+  template:
+    metadata:
+      labels:
+        run: orleans-silo
+    spec:
+      hostNetwork: true
+      containers:
+      - image: orleans-silo-image # image name updated by Makefile
+        name: orleans-silo
+        imagePullPolicy: Always


### PR DESCRIPTION
This is a WIP PR to add support for Kubernetes on the Docker sample. I played with the sample myself, wrote a simple Makefile to test and I thought of PR'ing it to get some feedback whether you want something like that. E.g. want the Kubernetes sample combined with the Docker one or maybe we should create a separate Kubernetes sample? I'm open to suggestions :)

Btw, whereas deployment works (tested locally with Docker for Windows and remotely using Azure Kubernetes Service), I'm getting an Exception after some time and the silo dies. Any hints?

```
orleans-silo-6988656b9-jh5wz orleans-silo Silo started
orleans-silo-6988656b9-jh5wz orleans-silo warn: Orleans.Runtime.MembershipService.MembershipOracleData[100618]
orleans-silo-6988656b9-jh5wz orleans-silo       I should be Dead according to membership table (in CleanupTableEntries): entry = SiloAddress=S10.244.0.62:11111:291805778 SiloName=Silo_98c6d Status=Dead.
orleans-silo-6988656b9-jh5wz orleans-silo fail: Orleans.Runtime.MembershipService.MembershipOracleData[100627]
orleans-silo-6988656b9-jh5wz orleans-silo       I have been told I am dead, so this silo will stop! I should be Dead according to membership table (in CleanupTableEntries): entry = SiloAddress=S10.244.0.62:11111:291805778 SiloName=Silo_98c6d Status=Dead.
orleans-silo-6988656b9-jh5wz orleans-silo fail: Orleans.Runtime.MembershipService.MembershipOracleData[100627]
orleans-silo-6988656b9-jh5wz orleans-silo       INTERNAL FAILURE! About to crash! Fail message is: I have been told I am dead, so this silo will stop! I should be Dead according to membership table (in CleanupTableEntries): entry = SiloAddress=S10.244.0.62:11111:291805778 SiloName=Silo_98c6d Status=Dead.
```

Btw, I'm pretty new to Orleans so apologies in advance if I missed something.