### PR TITLE
[WIP] Remove base class from [Client,Silo]MessagingOptions

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
@@ -49,11 +49,15 @@ namespace Orleans.Configuration
             // Translate legacy configuration to new Options
             services.Configure<ClientMessagingOptions>(options =>
             {
-                CopyCommonMessagingOptions(configuration, options);
-                options.PropagateActivityId = configuration.PropagateActivityId;
                 options.ClientSenderBuckets = configuration.ClientSenderBuckets;
                 options.PreferredFamily = configuration.PreferredFamily;
                 options.NetworkInterfaceName = configuration.NetInterface;
+            });
+
+            services.Configure<MessagingOptions>(options =>
+            {
+                CopyCommonMessagingOptions(configuration, options);
+                options.PropagateActivityId = configuration.PropagateActivityId;
             });
 
 

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -5,7 +5,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Specifies global messaging options that are client related.
     /// </summary>
-    public class ClientMessagingOptions : MessagingOptions
+    public class ClientMessagingOptions
     {
         /// <summary>
         ///  The ClientSenderBuckets attribute specifies the total number of grain buckets used by the client in client-to-gateway communication

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -7,7 +7,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Specifies global messaging options that are common to client and silo.
     /// </summary>
-    public abstract class MessagingOptions
+    public class MessagingOptions
     {
         /// <summary>
         /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -37,14 +37,14 @@ namespace Orleans
         /// </summary>
         /// <param name="runtimeClient">The runtime client.</param>
         /// <param name="loggerFactory">Logger factory used to create loggers</param>
-        /// <param name="clientMessagingOptions">Messaging parameters</param>
-        public ClusterClient(IRuntimeClient runtimeClient, ILoggerFactory loggerFactory, IOptions<ClientMessagingOptions> clientMessagingOptions)
+        /// <param name="messagingOptions">Messaging parameters</param>
+        public ClusterClient(IRuntimeClient runtimeClient, ILoggerFactory loggerFactory, IOptions<MessagingOptions> messagingOptions)
         {
             this.runtimeClient = runtimeClient;
             this.clusterClientLifecycle = new ClusterClientLifecycle(loggerFactory.CreateLogger<LifecycleSubject>());
 
-            //set PropagateActivityId flag from node cofnig
-            RequestContext.PropagateActivityId = clientMessagingOptions.Value.PropagateActivityId;
+            //set PropagateActivityId flag from node config
+            RequestContext.PropagateActivityId = messagingOptions.Value.PropagateActivityId;
 
             // register all lifecycle participants
             IEnumerable<ILifecycleParticipant<IClusterClientLifecycle>> lifecycleParticipants = this.ServiceProvider.GetServices<ILifecycleParticipant<IClusterClientLifecycle>>();

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -55,7 +55,7 @@ namespace Orleans
 
             // Serialization
             services.TryAddSingleton<SerializationManager>(sp => ActivatorUtilities.CreateInstance<SerializationManager>(sp,
-                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.LargeMessageWarningThreshold));
+                sp.GetRequiredService<IOptions<MessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -182,7 +182,6 @@ namespace Orleans.Hosting
             services.AddOptions<SiloMessagingOptions>()
                 .Configure<GlobalConfiguration>((options, config) =>
                 {
-                    LegacyConfigurationExtensions.CopyCommonMessagingOptions(config, options);
                     options.SiloSenderQueues = config.SiloSenderQueues;
                     options.GatewaySenderQueues = config.GatewaySenderQueues;
                     options.MaxForwardCount = config.MaxForwardCount;
@@ -193,13 +192,22 @@ namespace Orleans.Hosting
                 })
                 .Configure<NodeConfiguration>((options, config) =>
                 {
-                    options.PropagateActivityId = config.PropagateActivityId;
                     LimitValue requestLimit = config.LimitManager.GetLimit(LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS);
                     options.MaxEnqueuedRequestsSoftLimit = requestLimit.SoftLimitThreshold;
                     options.MaxEnqueuedRequestsHardLimit = requestLimit.HardLimitThreshold;
                     LimitValue statelessWorkerRequestLimit = config.LimitManager.GetLimit(LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER);
                     options.MaxEnqueuedRequestsSoftLimit_StatelessWorker = statelessWorkerRequestLimit.SoftLimitThreshold;
                     options.MaxEnqueuedRequestsHardLimit_StatelessWorker = statelessWorkerRequestLimit.HardLimitThreshold;
+                });
+
+            services.AddOptions<MessagingOptions>()
+                .Configure<GlobalConfiguration>((options, config) =>
+                {
+                    LegacyConfigurationExtensions.CopyCommonMessagingOptions(config, options);
+                })
+                .Configure<NodeConfiguration>((options, config) =>
+                {
+                    options.PropagateActivityId = config.PropagateActivityId;
                 });
 
             services.Configure<NetworkingOptions>(options => LegacyConfigurationExtensions.CopyNetworkingOptions(configuration.Globals, options));

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -8,7 +8,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Specifies global messaging options that are silo related.
     /// </summary>
-    public class SiloMessagingOptions : MessagingOptions
+    public class SiloMessagingOptions
     {
         /// <summary>
         /// The SiloSenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo to send outbound

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -23,7 +23,8 @@ namespace Orleans.Runtime
         private readonly OrleansTaskScheduler scheduler;
         private readonly Catalog catalog;
         private readonly ILogger logger;
-        private readonly SiloMessagingOptions messagingOptions;
+        private readonly MessagingOptions messagingOptions;
+        private readonly SiloMessagingOptions siloMessagingOptions;
         private readonly PlacementDirectorsManager placementDirectorsManager;
         private readonly ILocalGrainDirectory localGrainDirectory;
         private readonly ActivationCollector activationCollector;
@@ -36,7 +37,8 @@ namespace Orleans.Runtime
             OrleansTaskScheduler scheduler, 
             ISiloMessageCenter transport, 
             Catalog catalog,
-            IOptions<SiloMessagingOptions> messagingOptions,
+            IOptions<MessagingOptions> messagingOptions,
+            IOptions<SiloMessagingOptions> siloMessagingOptions,
             PlacementDirectorsManager placementDirectorsManager,
             ILocalGrainDirectory localGrainDirectory,
             ActivationCollector activationCollector,
@@ -50,6 +52,7 @@ namespace Orleans.Runtime
             this.catalog = catalog;
             Transport = transport;
             this.messagingOptions = messagingOptions.Value;
+            this.siloMessagingOptions = siloMessagingOptions.Value;
             this.invokeWorkItemLogger = loggerFactory.CreateLogger<InvokeWorkItem>();
             this.placementDirectorsManager = placementDirectorsManager;
             this.localGrainDirectory = localGrainDirectory;
@@ -613,7 +616,7 @@ namespace Orleans.Runtime
 
         internal bool TryForwardMessage(Message message, ActivationAddress forwardingAddress)
         {
-            if (!MayForward(message, this.messagingOptions)) return false;
+            if (!MayForward(message, this.siloMessagingOptions)) return false;
 
             message.ForwardCount = message.ForwardCount + 1;
             MessagingProcessingStatisticsGroup.OnIgcMessageForwared(message);

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime
         private readonly ILogger logger;
         private readonly ILogger invokeExceptionLogger;
         private readonly ILoggerFactory loggerFactory;
-        private readonly SiloMessagingOptions messagingOptions;
+        private readonly MessagingOptions messagingOptions;
         private readonly List<IDisposable> disposables;
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
         private SharedCallbackData sharedCallbackData;
@@ -62,7 +62,7 @@ namespace Orleans.Runtime
             MessageFactory messageFactory,
             ITransactionAgent transactionAgent,
             ILoggerFactory loggerFactory,
-            IOptions<SiloMessagingOptions> messagingOptions,
+            IOptions<MessagingOptions> messagingOptions,
             IGrainCancellationTokenRuntime cancellationTokenRuntime,
             IOptions<SchedulingOptions> schedulerOptions,
             ApplicationRequestsStatisticsGroup appRequestStatistics)

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -226,7 +226,7 @@ namespace Orleans.Hosting
 
             // Serialization
             services.TryAddSingleton<SerializationManager>(sp=>ActivatorUtilities.CreateInstance<SerializationManager>(sp,
-                sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value.LargeMessageWarningThreshold));
+                sp.GetRequiredService<IOptions<MessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -146,7 +146,7 @@ namespace Orleans.Runtime
             this.Services = services;
             this.Services.InitializeSiloUnobservedExceptionsHandler();
             //set PropagateActivityId flag from node config
-            IOptions<SiloMessagingOptions> messagingOptions = services.GetRequiredService<IOptions<SiloMessagingOptions>>();
+            var messagingOptions = this.Services.GetRequiredService<IOptions<MessagingOptions>>();
             RequestContext.PropagateActivityId = messagingOptions.Value.PropagateActivityId;
             this.loggerFactory = this.Services.GetRequiredService<ILoggerFactory>();
             logger = this.loggerFactory.CreateLogger<Silo>();
@@ -162,8 +162,7 @@ namespace Orleans.Runtime
                 this.siloDetails.DnsHostName, Environment.MachineName, localEndpoint, this.siloDetails.SiloAddress.Generation);
             logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0}", name);
 
-            var siloMessagingOptions = this.Services.GetRequiredService<IOptions<SiloMessagingOptions>>();
-            BufferPool.InitGlobalBufferPool(siloMessagingOptions.Value);
+            BufferPool.InitGlobalBufferPool(messagingOptions.Value);
 
             try
             {

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -75,7 +75,7 @@ namespace Orleans.TestingHost
                 if (Debugger.IsAttached)
                 {
                     // Test is running inside debugger - Make timeout ~= infinite
-                    services.Configure<SiloMessagingOptions>(op => op.ResponseTimeout = TimeSpan.FromMilliseconds(1000000));
+                    services.Configure<MessagingOptions>(op => op.ResponseTimeout = TimeSpan.FromMilliseconds(1000000));
                 }
             });
 

--- a/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -39,7 +39,7 @@ namespace Tester.AzureUtils.Streaming
             this.output = output;
             this.fixture = fixture;
             this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
-            BufferPool.InitGlobalBufferPool(new SiloMessagingOptions());
+            BufferPool.InitGlobalBufferPool(new MessagingOptions());
         }
         
         public void Dispose()

--- a/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests.OrleansRuntime
         public ExceptionsTests(TestEnvironmentFixture fixture)
         {
             this.fixture = fixture;
-            BufferPool.InitGlobalBufferPool(new ClientMessagingOptions());
+            BufferPool.InitGlobalBufferPool(new MessagingOptions());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/TestInfrastructure/Orleans.TestingHost.Legacy/LegacyTestClusterConfiguration.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Legacy/LegacyTestClusterConfiguration.cs
@@ -158,7 +158,7 @@ namespace Orleans.TestingHost
 
         internal static string Serialize(SerializationManager serializationManager, object config)
         {
-            BufferPool.InitGlobalBufferPool(new SiloMessagingOptions());
+            BufferPool.InitGlobalBufferPool(new MessagingOptions());
             var writer = new BinaryTokenStreamWriter();
             serializationManager.Serialize(config, writer);
             string serialized = Convert.ToBase64String(writer.ToByteArray());

--- a/test/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/test/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.StreamingTests
                         op.CollectionAge = CollectionAge;
                         op.ClassSpecificCollectionAge.Add(typeof(MultipleSubscriptionConsumerGrain).FullName, TimeSpan.FromHours(2));
                     })
-                    .Configure<SiloMessagingOptions>(op=>op.ResponseTimeout = TimeSpan.FromMinutes(30));
+                    .Configure<MessagingOptions>(op=>op.ResponseTimeout = TimeSpan.FromMinutes(30));
             }
         }
         public class ClientConfiguretor : IClientBuilderConfigurator

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.LivenessTests
         {
             public Fixture()
             {
-                BufferPool.InitGlobalBufferPool(new SiloMessagingOptions());
+                BufferPool.InitGlobalBufferPool(new MessagingOptions());
             }
         }
 

--- a/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
+++ b/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests.StorageTests
         {
             public Fixture()
             {
-                BufferPool.InitGlobalBufferPool(new SiloMessagingOptions());
+                BufferPool.InitGlobalBufferPool(new MessagingOptions());
                 ClientConfiguration cfg = ClientConfiguration.LoadFromFile("ClientConfigurationForTesting.xml");
             }
         }


### PR DESCRIPTION
This separates the `MessagingOptions` base class from `ClientMessagingOptions` and `SiloMessagingOptions`.

This is a breaking change: users may have to fix some code so that their application continues to compile.

Effectively subsumes #4753.