### PR TITLE
Fix RequestContext.PropagateActivityId value in Hosted Client scenario

### DIFF
--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -44,7 +44,7 @@ namespace Orleans
             this.clusterClientLifecycle = new ClusterClientLifecycle(loggerFactory.CreateLogger<LifecycleSubject>());
 
             //set PropagateActivityId flag from node cofnig
-            RequestContext.PropagateActivityId = clientMessagingOptions.Value.PropagateActivityId;
+            RequestContext.PropagateActivityId |= clientMessagingOptions.Value.PropagateActivityId;
 
             // register all lifecycle participants
             IEnumerable<ILifecycleParticipant<IClusterClientLifecycle>> lifecycleParticipants = this.ServiceProvider.GetServices<ILifecycleParticipant<IClusterClientLifecycle>>();


### PR DESCRIPTION
When hosted client is enabled (default in 2.3.0+), the value of `SiloMessagingOptions.PropagateActivityId` is being overridden by `ClientMessagingOptions.PropagateActivityId` in the `ClusterClient` constructor.

This workaround ensures that the `SiloMessagingOptions` value takes precedence. It's not perfect - a user could set conflicting values on both classes.

See long-term fix in #5574