### PR TITLE
Cherry-pick #5570 and #5575 for 2.3.2

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -143,7 +143,7 @@ namespace Orleans.Storage
             if (record != null)
             {
                 var loadedState = ConvertFromStorageFormat(record);
-                grainState.State = loadedState ?? Activator.CreateInstance(grainState.State.GetType());
+                grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
                 grainState.ETag = record.ETag.ToString();
             }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -38,7 +38,7 @@ namespace Orleans.Storage
 
         private GrainStateTableDataManager tableDataManager;
         private JsonSerializerSettings JsonSettings;
-        
+
         // each property can hold 64KB of data and each entity can take 1MB in total, so 15 full properties take
         // 15 * 64 = 960 KB leaving room for the primary key, timestamp etc
         private const int MAX_DATA_CHUNK_SIZE = 64 * 1024;
@@ -50,7 +50,7 @@ namespace Orleans.Storage
         private string name;
 
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, IOptions<ClusterOptions> clusterOptions, SerializationManager serializationManager, 
+        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, IOptions<ClusterOptions> clusterOptions, SerializationManager serializationManager,
             IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
         {
             this.options = options;
@@ -80,9 +80,8 @@ namespace Orleans.Storage
                 var entity = record.Entity;
                 if (entity != null)
                 {
-                    var stateType = grainState.State.GetType();
-                    var loadedState = ConvertFromStorageFormat(entity, stateType);
-                    grainState.State = loadedState ?? Activator.CreateInstance(grainState.State.GetType());
+                    var loadedState = ConvertFromStorageFormat(entity, grainState.Type);
+                    grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
                     grainState.ETag = record.ETag;
                 }
             }

--- a/src/Orleans.Core/CodeGeneration/IGrainState.cs
+++ b/src/Orleans.Core/CodeGeneration/IGrainState.cs
@@ -8,6 +8,9 @@ namespace Orleans
         /// <summary>The application level payload that is the actual state.</summary>
         object State { get; set; }
 
+        /// <summary>Type of the grain state</summary>
+        Type Type { get; }
+
         /// <summary>An e-tag that allows optimistic concurrency checks at the storage provider level.</summary>
         string ETag { get; set; }
     }
@@ -26,13 +29,16 @@ namespace Orleans
             get
             {
                 return State;
-                
+
             }
             set
             {
                 State = (T)value;
             }
         }
+
+        /// <inheritdoc />
+        public Type Type => typeof(T);
 
         /// <inheritdoc />
         public string ETag { get; set; }

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -44,7 +44,7 @@ namespace Orleans
             this.clusterClientLifecycle = new ClusterClientLifecycle(loggerFactory.CreateLogger<LifecycleSubject>());
 
             //set PropagateActivityId flag from node cofnig
-            RequestContext.PropagateActivityId = clientMessagingOptions.Value.PropagateActivityId;
+            RequestContext.PropagateActivityId |= clientMessagingOptions.Value.PropagateActivityId;
 
             // register all lifecycle participants
             IEnumerable<ILifecycleParticipant<IClusterClientLifecycle>> lifecycleParticipants = this.ServiceProvider.GetServices<ILifecycleParticipant<IClusterClientLifecycle>>();

--- a/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
@@ -19,11 +19,16 @@ namespace Orleans.EventSourcing.LogStorage
         /// Gets and Sets StateAndMetaData
         /// </summary>
         public LogStateWithMetaData<TEntry> StateAndMetaData { get; set; }
-       
+
         /// <summary>
         /// Gets and Sets Etag
         /// </summary>
         public string ETag { get; set; }
+
+        /// <summary>
+        /// Gets Type
+        /// </summary>
+        public Type Type => typeof(LogStateWithMetaData<TEntry>);
 
         object IGrainState.State
         {
@@ -80,7 +85,7 @@ namespace Orleans.EventSourcing.LogStorage
         /// But this map is represented compactly as a simple string to reduce serialization/deserialization overhead
         /// Bits are read by <see cref="GetBit"/> and flipped by  <see cref="FlipBit"/>.
         /// Bits are toggled when writing, so that the retry logic can avoid appending an entry twice
-        /// when retrying a failed append. 
+        /// when retrying a failed append.
         /// </summary>
         public string WriteVector { get; set; }
 

--- a/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -19,11 +19,16 @@ namespace Orleans.EventSourcing.StateStorage
         /// Gets and Sets StateAndMetaData
         /// </summary>
         public GrainStateWithMetaData<TView> StateAndMetaData { get; set; }
-       
+
         /// <summary>
         /// Gets and Sets Etag
         /// </summary>
         public string ETag { get; set; }
+
+        /// <summary>
+        /// Gets Type
+        /// </summary>
+        public Type Type => typeof(GrainStateWithMetaData<TView>);
 
         object IGrainState.State
         {
@@ -88,7 +93,7 @@ namespace Orleans.EventSourcing.StateStorage
         /// But this map is represented compactly as a simple string to reduce serialization/deserialization overhead
         /// Bits are read by <see cref="GetBit"/> and flipped by  <see cref="FlipBit"/>.
         /// Bits are toggled when writing, so that the retry logic can avoid appending an entry twice
-        /// when retrying a failed append. 
+        /// when retrying a failed append.
         /// </summary>
         public string WriteVector { get; set; }
 

--- a/src/OrleansProviders/Storage/MemoryStorageGrain.cs
+++ b/src/OrleansProviders/Storage/MemoryStorageGrain.cs
@@ -41,7 +41,7 @@ namespace Orleans.Storage
             var grainState = storage.GetGrainState(grainStoreKey);
             return Task.FromResult(grainState);
         }
-        
+
         public Task<string> WriteStateAsync(string stateStore, string grainStoreKey, IGrainState grainState)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("WriteStateAsync for {0} grain: {1} eTag: {2}", stateStore, grainStoreKey, grainState.ETag);
@@ -151,6 +151,7 @@ namespace Orleans.Storage
                     ETag = string.Empty;
                 }
                 public object State { get; set; }
+                public Type Type => typeof(object);
                 public string ETag { get; set; }
             }
             private static readonly IGrainState Deleted = new DeletedState();

--- a/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
+++ b/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
@@ -133,6 +133,7 @@ namespace DefaultCluster.Tests.StorageTests
             }
 
             public object State { get; set; }
+            public Type Type => typeof(int);
             public string ETag { get; set; }
         }
     }


### PR DESCRIPTION
Prevent NullReferenceException with some storage providers when state is Nullable<T> (#5570)
Accommodate existing RequestContext.PropagateActivityId value in ClusterClient (#5575)