### PR TITLE
Fix packaging warning in Orleans.CodeGenerator.MSBuild

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -87,7 +87,7 @@
       <PublishedFiles Include="$(PublishRoot)**/*" Exclude="$(PublishRoot)**/$(AssemblyName).*;$(PublishRoot)*/refs/**/*" />
       <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).Tasks.*" />
       <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).deps.json" />
-      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).*.config" />
+      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).*.config" Exclude="$(PublishRoot)**/$(AssemblyName).Tasks.*" />
       <_PackageFiles Include="@(PublishedFiles)">
         <PackagePath>tasks/$(RecursiveDir)</PackagePath>
         <Visible>false</Visible>


### PR DESCRIPTION
The `.Tasks.*` files are already included and including them multiple times causes a packaging warning