### PR TITLE
Provide separate options for worker & IO pool min thread counts

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
@@ -238,8 +238,6 @@ namespace Orleans.Runtime.Configuration
 
             this.LimitManager = new LimitManager();
 
-            this.MinDotNetThreadPoolSize = PerformanceTuningOptions.DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
-
             // .NET ServicePointManager settings / optimizations
             this.Expect100Continue = false;
             this.DefaultConnectionLimit = PerformanceTuningOptions.DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT;

--- a/src/Orleans.Core/Configuration/Options/PerformanceTuningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/PerformanceTuningOptions.cs
@@ -10,16 +10,20 @@ namespace Orleans.Configuration
         /// ServicePointManager related settings
         /// </summary>
         public int DefaultConnectionLimit { get; set; } = DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT;
-        public static readonly int DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT = DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
+        public static readonly int DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT = 200;
 
         public bool Expect100Continue { get; set; }
 
         public bool UseNagleAlgorithm { get; set; }
 
         /// <summary>
-        /// Minimum number of DotNet threads.
+        /// Minimum number of .NET worker threads.
         /// </summary>
-        public int MinDotNetThreadPoolSize { get; set; } = DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
-        public const int DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE = 200;
+        public int MinDotNetThreadPoolSize { get; set; }
+
+        /// <summary>
+        /// Minimum number of I/O completion port threads.
+        /// </summary>
+        public int MinIOThreadPoolSize { get; set; }
     }
 }

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -341,6 +341,7 @@ namespace Orleans.Hosting
                     options.Expect100Continue = config.Expect100Continue;
                     options.UseNagleAlgorithm = config.UseNagleAlgorithm;
                     options.MinDotNetThreadPoolSize = config.MinDotNetThreadPoolSize;
+                    options.MinIOThreadPoolSize = config.MinDotNetThreadPoolSize;
                 });
 
             services.AddOptions<TypeManagementOptions>()

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -578,17 +578,17 @@ namespace Orleans.Runtime
         private void ConfigureThreadPoolAndServicePointSettings()
         {
             PerformanceTuningOptions performanceTuningOptions = Services.GetRequiredService<IOptions<PerformanceTuningOptions>>().Value;
-            if (performanceTuningOptions.MinDotNetThreadPoolSize > 0)
+            if (performanceTuningOptions.MinDotNetThreadPoolSize > 0 || performanceTuningOptions.MinIOThreadPoolSize > 0)
             {
                 int workerThreads;
                 int completionPortThreads;
                 ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
                 if (performanceTuningOptions.MinDotNetThreadPoolSize > workerThreads ||
-                    performanceTuningOptions.MinDotNetThreadPoolSize > completionPortThreads)
+                    performanceTuningOptions.MinIOThreadPoolSize > completionPortThreads)
                 {
                     // if at least one of the new values is larger, set the new min values to be the larger of the prev. and new config value.
                     int newWorkerThreads = Math.Max(performanceTuningOptions.MinDotNetThreadPoolSize, workerThreads);
-                    int newCompletionPortThreads = Math.Max(performanceTuningOptions.MinDotNetThreadPoolSize, completionPortThreads);
+                    int newCompletionPortThreads = Math.Max(performanceTuningOptions.MinIOThreadPoolSize, completionPortThreads);
                     bool ok = ThreadPool.SetMinThreads(newWorkerThreads, newCompletionPortThreads);
                     if (ok)
                     {


### PR DESCRIPTION
Set defaults to 0 (no minimum set)

During development of #5436, the default value for these thread pools was found to be a detrimental to throughput.

It is better to avoid setting a minimum and instead allow users to follow general .NET guidance on setting thread pool limits.