### PR TITLE
Implement IApplicationLifetime for ClientBuilder/SiloHostBuilder

### DIFF
--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -5,6 +5,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
 using Orleans.ApplicationParts;
 using Orleans.Serialization;
+using Microsoft.Extensions.Hosting;
+using IHostingEnvironment = Orleans.Hosting.IHostingEnvironment;
+using HostBuilderContext = Orleans.Hosting.HostBuilderContext;
+using HostDefaults = Orleans.Hosting.HostDefaults;
+using EnvironmentName = Orleans.Hosting.EnvironmentName;
 
 namespace Orleans
 {
@@ -46,6 +51,7 @@ namespace Orleans
                     services.AddSingleton(this.hostingEnvironment);
                     services.AddSingleton(this.hostBuilderContext);
                     services.AddSingleton(this.appConfiguration);
+                    services.AddSingleton<IApplicationLifetime, ClientApplicationLifetime>();
                     services.AddOptions();
                     services.AddLogging();
                 });

--- a/src/Orleans.Core/Hosting/ApplicationLifetime.cs
+++ b/src/Orleans.Core/Hosting/ApplicationLifetime.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Allows consumers to perform cleanup during a graceful shutdown.
+    /// </summary>
+    internal abstract class ApplicationLifetime : IApplicationLifetime
+    {
+        private readonly CancellationTokenSource startedSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource stoppingSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource stoppedSource = new CancellationTokenSource();
+        private readonly ILogger<ApplicationLifetime> logger;
+
+        public ApplicationLifetime(ILogger<ApplicationLifetime> logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Triggered when the application host has fully started and is about to wait
+        /// for a graceful shutdown.
+        /// </summary>
+        public CancellationToken ApplicationStarted => this.startedSource.Token;
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// Request may still be in flight. Shutdown will block until this event completes.
+        /// </summary>
+        public CancellationToken ApplicationStopping => this.stoppingSource.Token;
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// All requests should be complete at this point. Shutdown will block
+        /// until this event completes.
+        /// </summary>
+        public CancellationToken ApplicationStopped => this.stoppedSource.Token;
+
+        /// <summary>
+        /// Signals the ApplicationStopping event and blocks until it completes.
+        /// </summary>
+        public void StopApplication()
+        {
+            // Lock on CTS to synchronize multiple calls to StopApplication. This guarantees that the first call 
+            // to StopApplication and its callbacks run to completion before subsequent calls to StopApplication, 
+            // which will no-op since the first call already requested cancellation, get a chance to execute.
+            lock (this.stoppingSource)
+            {
+                try
+                {
+                    this.ExecuteHandlers(this.stoppingSource);
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogError("An error occurred stopping the application", ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Signals the ApplicationStarted event and blocks until it completes.
+        /// </summary>
+        public void NotifyStarted()
+        {
+            try
+            {
+                this.ExecuteHandlers(this.startedSource);
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError("An error occurred starting the application", ex);
+            }
+        }
+
+        /// <summary>
+        /// Signals the ApplicationStopped event and blocks until it completes.
+        /// </summary>
+        public void NotifyStopped()
+        {
+            try
+            {
+                this.ExecuteHandlers(this.stoppedSource);
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError("An error occurred stopping the application", ex);
+            }
+        }
+
+        private void ExecuteHandlers(CancellationTokenSource cancel)
+        {
+            // Noop if this is already cancelled
+            if (cancel.IsCancellationRequested)
+            {
+                return;
+            }
+
+            // Run the cancellation token callbacks
+            cancel.Cancel(throwOnFirstException: false);
+        }
+    }
+
+    internal sealed class ClientApplicationLifetime : ApplicationLifetime
+    {
+        public ClientApplicationLifetime(ILogger<ApplicationLifetime> logger) : base(logger)
+        {
+        }
+    }
+
+    internal sealed class SiloApplicationLifetime : ApplicationLifetime
+    {
+        public SiloApplicationLifetime(ILogger<ApplicationLifetime> logger) : base(logger)
+        {
+        }
+    }
+}

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Orleans.ApplicationParts;
 
 namespace Orleans.Hosting
@@ -146,6 +147,7 @@ namespace Orleans.Hosting
                     services.AddSingleton(this.hostingEnvironment);
                     services.AddSingleton(this.hostBuilderContext);
                     services.AddSingleton(this.appConfiguration);
+                    services.AddSingleton<IApplicationLifetime, SiloApplicationLifetime>();
                     services.AddOptions();
                     services.AddLogging();
                 });

--- a/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Orleans.Runtime;
 
 namespace Orleans.Hosting
@@ -8,6 +10,7 @@ namespace Orleans.Hosting
     internal class SiloWrapper : ISiloHost
     {
         private readonly Silo silo;
+        private readonly SiloApplicationLifetime applicationLifetime;
         private bool isDisposing;
 
         public SiloWrapper(Silo silo, IServiceProvider services)
@@ -15,6 +18,9 @@ namespace Orleans.Hosting
             this.Services = services;
             this.silo = silo;
             this.Stopped = silo.SiloTerminated;
+
+            // It is fine for this field to be null in the case that the client is not the host.
+            this.applicationLifetime = services.GetService<IApplicationLifetime>() as SiloApplicationLifetime;
         }
 
         /// <inheritdoc />
@@ -24,16 +30,25 @@ namespace Orleans.Hosting
         public Task Stopped { get; }
 
         /// <inheritdoc />
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
-            return this.silo.StartAsync(cancellationToken);
+            await this.silo.StartAsync(cancellationToken).ConfigureAwait(false);
+            this.applicationLifetime?.NotifyStarted();
         }
 
         /// <inheritdoc />
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            await silo.StopAsync(cancellationToken);
-            await this.Stopped;
+            try
+            {
+                this.applicationLifetime?.StopApplication();
+                await silo.StopAsync(cancellationToken);
+                await this.Stopped;
+            }
+            finally
+            {
+                this.applicationLifetime?.NotifyStopped();
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This is a pre-requisite for #5436, which uses `IApplicationLifetime` (from shared Hosting package) to ensure all connections are closed during shutdown.

This aligns `ClusterClient` and `SiloHostBuilder` more closely with the generic `HostBuilder` from `Microsoft.Extensions.Hosting`.