### PR TITLE
Allow default(ImmutableArray<T>) to be serialized

### DIFF
--- a/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using TestExtensions;
 using Xunit;
@@ -37,6 +37,14 @@ namespace UnitTests.Serialization
         {
             var original = ImmutableArray.Create("1","2","3");
             RoundTripCollectionSerializationTest(original);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        public void SerializationTests_ImmutableCollections_ArrayDefault()
+        {
+            var input = default(ImmutableArray<int>);
+            var output = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
+            Assert.Equal(input, output);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]


### PR DESCRIPTION
`ImmutableArray<T>` is a value type and the default value will throw `NullReferenceException` when the `Length` property is read. The serializer will read this property to determine how many elements in the array should be written to the stream making it impossible to serialize `default(ImmutableArray<T>)`.

This change ensures that `default(ImmutableArray<T>)` can be serialized without throwing a `NullReferenceException`. The value `default(ImmutableArray<T>)` is indicated by writing `-1` as the length of the array to the stream. Note that `ImmutableArray<T>.Empty` has a length of `0` so the code is able to distinguish between the two values.

The deserializer will make a call to `context.RecordObject`. I do not quite understand the purpose of this call and if it is meaningful to do with a value type but I included it in the added code because it was already in the existing code.

I have added a test that verifies that `default(ImmutableArray<T>)` can round-trip when serialized.