### PR TITLE
Execute tasks scheduled against defunct activations

### DIFF
--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -654,7 +654,7 @@ namespace Orleans
         SchedulerTurnTooLong2                   = SchedulerBase + 14,
         SchedulerTurnTooLong3                   = SchedulerBase + 15,
         SchedulerWorkGroupShuttingDown          = SchedulerBase + 16,
-        SchedulerNotEnqueuWorkWhenShutdown      = SchedulerBase + 17,
+        SchedulerEnqueueWorkWhenShutdown        = SchedulerBase + 17,
         SchedulerNotExecuteWhenShutdown         = SchedulerBase + 18,
         SchedulerAppTurnsStopped_1              = SchedulerBase + 19,
         SchedulerWorkGroupStopping              = SchedulerBase + 20,

--- a/src/Orleans.Core/Timers/ValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/ValueStopwatch.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
         /// Starts a new instance.
         /// </summary>
         /// <returns>A new, running stopwatch.</returns>
-        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+        public static ValueStopwatch StartNew() => new ValueStopwatch(GetTimestamp());
         
         private ValueStopwatch(long timestamp)
         {
@@ -62,6 +62,20 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Gets the number of ticks in the timer mechanism.
+        /// </summary>
+        /// <returns>The number of ticks in the timer mechanism</returns>
+        public static long GetTimestamp() => Stopwatch.GetTimestamp();
+
+        /// <summary>
+        /// Returns a new, stopped <see cref="ValueStopwatch"/> with the provided start and end timestamps.
+        /// </summary>
+        /// <param name="start">The start timestamp.</param>
+        /// <param name="end">The end timestamp.</param>
+        /// <returns>A new, stopped <see cref="ValueStopwatch"/> with the provided start and end timestamps.</returns>
+        public static ValueStopwatch FromTimestamp(long start, long end) => new ValueStopwatch(-(end - start));
+
+        /// <summary>
         /// Gets the raw counter value for this instance.
         /// </summary>
         /// <remarks> 
@@ -83,7 +97,7 @@ namespace Orleans.Runtime
 
             // Stopwatch is stopped, therefore value is zero or negative.
             // Add the negative value to the current timestamp to start the stopwatch again.
-            var newValue = Stopwatch.GetTimestamp() + timestamp;
+            var newValue = GetTimestamp() + timestamp;
             if (newValue == 0) newValue = 1;
             this.value = newValue;
         }
@@ -91,7 +105,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Restarts this stopwatch, beginning from zero time elapsed.
         /// </summary>
-        public void Restart() => this.value = Stopwatch.GetTimestamp();
+        public void Restart() => this.value = GetTimestamp();
 
         /// <summary>
         /// Stops this stopwatch.
@@ -103,7 +117,7 @@ namespace Orleans.Runtime
             // If already stopped, do nothing.
             if (!this.IsRunning) return;
 
-            var end = Stopwatch.GetTimestamp();
+            var end = GetTimestamp();
             var delta = end - timestamp;
 
             this.value = -delta;

--- a/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
@@ -59,6 +59,12 @@ namespace Orleans.Configuration
         /// For test use only.  Do not alter from default in production services
         /// </summary>
         public bool EnableWorkerThreadInjection { get; set; } = DEFAULT_ENABLE_WORKER_THREAD_INJECTION;
+
+        /// <summary>
+        /// The period of time after which to log errors for tasks scheduled to stopped activations.
+        /// </summary>
+        public TimeSpan StoppedActivationWarningInterval { get; set; } = TimeSpan.FromMinutes(1);
+
         public const bool DEFAULT_ENABLE_WORKER_THREAD_INJECTION = false;
     }
 }

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -107,6 +107,7 @@ namespace Orleans.Runtime
 
             if (context == null)
             {
+                // Move exceptions into local functions to help inlining this method.
                 ThrowMissingContext();
                 void ThrowMissingContext() => throw new InvalidOperationException("Activation access violation. A non-activation thread attempted to access activation services.");
             }
@@ -115,6 +116,7 @@ namespace Orleans.Runtime
                 && schedulingContext.Activation is ActivationData activation
                 && activation.State == ActivationState.Invalid)
             {
+                // Move exceptions into local functions to help inlining this method.
                 ThrowInvalidActivation(activation);
                 void ThrowInvalidActivation(ActivationData activationData) => throw new InvalidOperationException($"Attempt to access an invalid activation: {activationData}");
             }

--- a/src/Orleans.Runtime/Scheduler/OrleansSchedulerAsynchAgent.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansSchedulerAsynchAgent.cs
@@ -9,8 +9,6 @@ namespace Orleans.Runtime.Scheduler
 {
     internal class OrleansSchedulerAsynchAgent : AsynchQueueAgent<IWorkItem>
     {
-        private readonly TaskScheduler scheduler;
-
         private readonly ThreadPoolExecutorOptions.BuilderConfigurator configureExecutorOptionsBuilder;
         
         public OrleansSchedulerAsynchAgent(
@@ -19,11 +17,9 @@ namespace Orleans.Runtime.Scheduler
             int maxDegreeOfParalelism, 
             TimeSpan delayWarningThreshold, 
             TimeSpan turnWarningLengthThreshold,
-            TaskScheduler scheduler,
             bool drainAfterCancel,
             ILoggerFactory loggerFactory) : base(name, executorService, loggerFactory)
         {
-            this.scheduler = scheduler;
             configureExecutorOptionsBuilder = builder => builder
                 .WithDegreeOfParallelism(maxDegreeOfParalelism)
                 .WithDrainAfterCancel(drainAfterCancel)
@@ -49,11 +45,6 @@ namespace Orleans.Runtime.Scheduler
             {
                 RuntimeContext.ResetExecutionContext();
             }
-        }
-
-        protected override void OnEnqueue(IWorkItem request)
-        {
-            base.OnEnqueue(request);
         }
         
         protected override ThreadPoolExecutorOptions.Builder ExecutorOptionsBuilder => configureExecutorOptionsBuilder(base.ExecutorOptionsBuilder);

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -54,6 +54,7 @@ namespace Orleans.Runtime.Scheduler
             applicationTurnsStopped = false;
             TurnWarningLengthThreshold = options.Value.TurnWarningLengthThreshold;
             this.MaxPendingItemsSoftLimit = options.Value.MaxPendingWorkItemsSoftLimit;
+            this.StoppedWorkItemGroupWarningInterval = options.Value.StoppedActivationWarningInterval;
             workgroupDirectory = new ConcurrentDictionary<ISchedulingContext, WorkItemGroup>();
 
             const int maxSystemThreads = 2;
@@ -68,7 +69,6 @@ namespace Orleans.Runtime.Scheduler
                     degreeOfParallelism,
                     options.Value.DelayWarningThreshold,
                     options.Value.TurnWarningLengthThreshold,
-                    this,
                     drainAfterCancel,
                     loggerFactory);
             }
@@ -92,6 +92,8 @@ namespace Orleans.Runtime.Scheduler
         }
 
         public int WorkItemGroupCount => workgroupDirectory.Count;
+
+        public TimeSpan StoppedWorkItemGroupWarningInterval { get; }
 
         private float AverageRunQueueLengthLevelTwo
         {
@@ -316,15 +318,6 @@ namespace Orleans.Runtime.Scheduler
                      + "which will be the case if you create it inside Task.Run.");
             }
             GetWorkItemGroup(context); // GetWorkItemGroup throws for Invalid context
-        }
-
-        public TaskScheduler GetTaskScheduler(ISchedulingContext context)
-        {
-            if (context == null)
-                return this;
-            
-            WorkItemGroup workGroup;
-            return workgroupDirectory.TryGetValue(context, out workGroup) ? (TaskScheduler) workGroup.TaskRunner : this;
         }
 
         public override int MaximumConcurrencyLevel => maximumConcurrencyLevel;

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.Scheduler
             this.statisticsOptions = statisticsOptions;
             this.logger = loggerFactory.CreateLogger<OrleansTaskScheduler>();
             cancellationTokenSource = new CancellationTokenSource();
-            WorkItemGroup.ActivationSchedulingQuantum = options.Value.ActivationSchedulingQuantum;
+            this.SchedulingOptions = options.Value;
             applicationTurnsStopped = false;
             TurnWarningLengthThreshold = options.Value.TurnWarningLengthThreshold;
             this.MaxPendingItemsSoftLimit = options.Value.MaxPendingWorkItemsSoftLimit;
@@ -94,6 +94,8 @@ namespace Orleans.Runtime.Scheduler
         public int WorkItemGroupCount => workgroupDirectory.Count;
 
         public TimeSpan StoppedWorkItemGroupWarningInterval { get; }
+
+        public SchedulingOptions SchedulingOptions { get; }
 
         private float AverageRunQueueLengthLevelTwo
         {
@@ -263,7 +265,7 @@ namespace Orleans.Runtime.Scheduler
             }
             else
             {
-                t.Start(workItemGroup.TaskRunner);
+                t.Start(workItemGroup.TaskScheduler);
             }
         }
 

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -21,13 +21,13 @@ namespace Orleans.Core
         {
             get
             {
-                CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext();
                 return grainState.State;
             }
 
             set
             {
-                CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext();
                 grainState.State = value;
             }
         }
@@ -61,7 +61,7 @@ namespace Orleans.Core
             Stopwatch sw = Stopwatch.StartNew();
             try
             {
-                CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext();
 
                 await store.ReadStateAsync(name, grainRef, grainState);
 
@@ -93,7 +93,7 @@ namespace Orleans.Core
             const string what = "WriteState";
             try
             {
-                CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext();
 
                 Stopwatch sw = Stopwatch.StartNew();
                 await store.WriteStateAsync(name, grainRef, grainState);
@@ -122,7 +122,7 @@ namespace Orleans.Core
             const string what = "ClearState";
             try
             {
-                CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext();
 
                 Stopwatch sw = Stopwatch.StartNew();
                 // Clear (most likely Delete) state from external storage
@@ -159,14 +159,6 @@ namespace Orleans.Core
 
             return string.Format("Error from storage provider {0} during {1} for grain Type={2} Pk={3} Id={4} Error={5}" + Environment.NewLine + " {6}",
                 $"{this.store.GetType().Name}.{this.name}", what, name, grainRef.GrainId.ToDetailedString(), grainRef, errorCode, LogFormatter.PrintException(exc));
-        }
-
-        private static void CheckRuntimeContext()
-        {
-            if (RuntimeContext.Current == null)
-            {
-                throw new InvalidOperationException("Activation access violation. A non-activation thread attempted to access activation state.");
-            }
         }
     }
 }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -31,13 +31,11 @@ namespace UnitTests.SchedulerTests
 
         private static readonly int WaitFactor = Debugger.IsAttached ? 100 : 1;
         private readonly ILoggerFactory loggerFactory;
-        private readonly TestHooksHostEnvironmentStatistics performanceMetrics;
 
         public OrleansTaskSchedulerAdvancedTests(ITestOutputHelper output)
         {
             this.output = output;
             this.loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
-            this.performanceMetrics = new TestHooksHostEnvironmentStatistics();
         }
 
         public void Dispose()
@@ -55,7 +53,7 @@ namespace UnitTests.SchedulerTests
             int n = 0;
             bool insideTask = false;
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
 
             this.output.WriteLine("Running Main in Context=" + RuntimeContext.Current);
             this.orleansTaskScheduler.QueueWorkItem(new ClosureWorkItem(() =>
@@ -91,7 +89,7 @@ namespace UnitTests.SchedulerTests
             int n = 0;
             bool insideTask = false;
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
 
             var result = new TaskCompletionSource<bool>();
 
@@ -141,7 +139,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public void Sched_AC_MainTurnWait_Test()
         {
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(new UnitTestSchedulingContext(), this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(new UnitTestSchedulingContext(), this.loggerFactory);
             var promise = Task.Factory.StartNew(() =>
             {
                 Thread.Sleep(1000);
@@ -172,7 +170,7 @@ namespace UnitTests.SchedulerTests
             // You test that no CW/StartNew runs until the main turn is fully done. And run in stress.
 
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
 
             var result1 = new TaskCompletionSource<bool>();
             var result2 = new TaskCompletionSource<bool>();
@@ -208,6 +206,33 @@ namespace UnitTests.SchedulerTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
+        public async Task Sched_Stopped_WorkItemGroup()
+        {
+            var context = new UnitTestSchedulingContext();
+            var scheduler = this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
+            WorkItemGroup workItemGroup = this.orleansTaskScheduler.GetWorkItemGroup(context);
+
+            Task ScheduleTask() => Task.Factory.StartNew(_ => { }, "some state", CancellationToken.None, TaskCreationOptions.DenyChildAttach, workItemGroup.TaskRunner);
+
+            // Check that the WorkItemGroup is functioning.
+            await ScheduleTask();
+
+            workItemGroup.Stop();
+
+            var taskAfterStopped = ScheduleTask();
+            var resultTask = await Task.WhenAny(taskAfterStopped, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(taskAfterStopped, resultTask);
+
+            // Wait for the WorkItemGroup to upgrade the warning to an error and try again.
+            // This delay is based upon SchedulingOptions.StoppedActivationWarningInterval.
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+            taskAfterStopped = ScheduleTask();
+            resultTask = await Task.WhenAny(taskAfterStopped, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(taskAfterStopped, resultTask);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public void Sched_Task_Turn_Execution_Order()
         {
             // A unit test that checks that any turn is indeed run till completion before any other turn? 
@@ -215,7 +240,7 @@ namespace UnitTests.SchedulerTests
             // You test that no CW/StartNew runs until the main turn is fully done. And run in stress.
 
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            OrleansTaskScheduler masterScheduler = this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            OrleansTaskScheduler masterScheduler = this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
             WorkItemGroup workItemGroup = this.orleansTaskScheduler.GetWorkItemGroup(context);
             ActivationTaskScheduler activationScheduler = workItemGroup.TaskRunner;
 
@@ -352,7 +377,7 @@ namespace UnitTests.SchedulerTests
         public void Sched_AC_Current_TaskScheduler()
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            OrleansTaskScheduler orleansTaskScheduler = orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            OrleansTaskScheduler orleansTaskScheduler = orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
             ActivationTaskScheduler activationScheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
 
             // RuntimeContext.InitializeThread(masterScheduler);
@@ -450,7 +475,7 @@ namespace UnitTests.SchedulerTests
         public void Sched_AC_ContinueWith_1_Test()
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
 
             var result = new TaskCompletionSource<bool>();
             int n = 0;
@@ -481,7 +506,7 @@ namespace UnitTests.SchedulerTests
             stopwatch.Start();
 
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
 
             // ReSharper disable AccessToModifiedClosure
             this.orleansTaskScheduler.QueueWorkItem(new ClosureWorkItem(() =>
@@ -524,7 +549,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public void Sched_AC_ContinueWith_2_OrleansSched()
         {
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(new UnitTestSchedulingContext(), this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(new UnitTestSchedulingContext(), this.loggerFactory);
 
             var result1 = new TaskCompletionSource<bool>();
             var result2 = new TaskCompletionSource<bool>();
@@ -567,7 +592,7 @@ namespace UnitTests.SchedulerTests
         public void Sched_Task_SchedulingContext()
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            this.orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
             ActivationTaskScheduler scheduler = this.orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
 
             var result = new TaskCompletionSource<bool>();

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -50,7 +50,7 @@ namespace UnitTests.SchedulerTests
         {
             // This is not a great test because there's a 50/50 shot that it will work even if the scheduling
             // is completely and thoroughly broken and both closures are executed "simultaneously"
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             int n = 0;
             // ReSharper disable AccessToModifiedClosure
@@ -72,7 +72,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public void ActivationSched_NewTask_ContinueWith_Wrapped()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             Task<Task> wrapped = new Task<Task>(() =>
             {
@@ -104,7 +104,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public void ActivationSched_SubTaskExecutionSequencing()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             LogContext("Main-task " + Task.CurrentId);
 
@@ -156,7 +156,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_ContinueWith_1_Test()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             var result = new TaskCompletionSource<bool>();
             int n = 0;
@@ -194,7 +194,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_WhenAny()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             ManualResetEvent pause1 = new ManualResetEvent(false);
             ManualResetEvent pause2 = new ManualResetEvent(false);
@@ -250,7 +250,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_WhenAny_Timeout()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             ManualResetEvent pause1 = new ManualResetEvent(false);
             ManualResetEvent pause2 = new ManualResetEvent(false);
@@ -309,7 +309,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_WhenAny_Busy_Timeout()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             var pause1 = new TaskCompletionSource<bool>();
             var pause2 = new TaskCompletionSource<bool>();
@@ -373,7 +373,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Task_Run()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             ManualResetEvent pause1 = new ManualResetEvent(false);
             ManualResetEvent pause2 = new ManualResetEvent(false);
@@ -434,7 +434,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Task_Run_Delay()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             ManualResetEvent pause1 = new ManualResetEvent(false);
             ManualResetEvent pause2 = new ManualResetEvent(false);
@@ -499,7 +499,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Task_Delay()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             Task wrapper = new Task(async () =>
             {
@@ -531,7 +531,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Turn_Execution_Order_Loop()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             const int NumChains = 100;
             const int ChainLength = 3;
@@ -645,7 +645,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Test1()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             await Run_ActivationSched_Test1(scheduler, false);
         }
@@ -653,7 +653,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Test1_Bounce()
         {
-            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskRunner;
+            TaskScheduler scheduler = this.masterScheduler.GetWorkItemGroup(this.context).TaskScheduler;
 
             await Run_ActivationSched_Test1(scheduler, true);
         }
@@ -663,7 +663,7 @@ namespace UnitTests.SchedulerTests
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
             OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
-            ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
+            ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskScheduler;
 
             await Run_ActivationSched_Test1(scheduler, false);
         }
@@ -672,7 +672,7 @@ namespace UnitTests.SchedulerTests
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
             OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
-            ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
+            ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskScheduler;
 
             await Run_ActivationSched_Test1(scheduler, true);
         }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -36,7 +36,7 @@ namespace UnitTests.SchedulerTests
             this.loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
             this.context = new UnitTestSchedulingContext();
             this.performanceMetrics = new TestHooksHostEnvironmentStatistics();
-            this.masterScheduler = TestInternalHelper.InitializeSchedulerForTesting(this.context, this.performanceMetrics, this.loggerFactory);
+            this.masterScheduler = TestInternalHelper.InitializeSchedulerForTesting(this.context, this.loggerFactory);
         }
         
         public void Dispose()
@@ -662,7 +662,7 @@ namespace UnitTests.SchedulerTests
         public async Task OrleansSched_Test1()
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
             ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
 
             await Run_ActivationSched_Test1(scheduler, false);
@@ -671,7 +671,7 @@ namespace UnitTests.SchedulerTests
         public async Task OrleansSched_Test1_Bounce()
         {
             UnitTestSchedulingContext context = new UnitTestSchedulingContext();
-            OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, this.loggerFactory);
+            OrleansTaskScheduler orleansTaskScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.loggerFactory);
             ActivationTaskScheduler scheduler = orleansTaskScheduler.GetWorkItemGroup(context).TaskRunner;
 
             await Run_ActivationSched_Test1(scheduler, true);

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -45,7 +45,6 @@ namespace UnitTests.SchedulerTests
     {
         private readonly ITestOutputHelper output;
         private static readonly object Lockable = new object();
-        private readonly IHostEnvironmentStatistics performanceMetrics;
         private readonly UnitTestSchedulingContext rootContext;
         private readonly OrleansTaskScheduler scheduler;
         private readonly ILoggerFactory loggerFactory;
@@ -54,9 +53,8 @@ namespace UnitTests.SchedulerTests
             this.output = output;
             SynchronizationContext.SetSynchronizationContext(null);
             this.loggerFactory = InitSchedulerLogging();
-            this.performanceMetrics = new TestHooksHostEnvironmentStatistics();
             this.rootContext = new UnitTestSchedulingContext();
-            this.scheduler = TestInternalHelper.InitializeSchedulerForTesting(this.rootContext, this.performanceMetrics, this.loggerFactory);
+            this.scheduler = TestInternalHelper.InitializeSchedulerForTesting(this.rootContext, this.loggerFactory);
         }
         
         public void Dispose()

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -81,7 +81,7 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("AsynchronyPrimitives")]
         public void Async_Task_Start_ActivationTaskScheduler()
         {
-            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskRunner;
+            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskScheduler;
 
             int expected = 2;
             bool done = false;
@@ -100,7 +100,7 @@ namespace UnitTests.SchedulerTests
         {
             // This is not a great test because there's a 50/50 shot that it will work even if the scheduling
             // is completely and thoroughly broken and both closures are executed "simultaneously"
-            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskRunner;
+            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskScheduler;
 
             int n = 0;
             // ReSharper disable AccessToModifiedClosure
@@ -124,7 +124,7 @@ namespace UnitTests.SchedulerTests
         {
             // This is not a great test because there's a 50/50 shot that it will work even if the scheduling
             // is completely and thoroughly broken and both closures are executed "simultaneously"
-            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskRunner;
+            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskScheduler;
 
             int n = 0;
 
@@ -326,7 +326,7 @@ namespace UnitTests.SchedulerTests
         [Fact]
         public async Task Sched_Task_TaskWorkItem_CurrentScheduler()
         {
-            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskRunner;
+            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskScheduler;
 
             var result0 = new TaskCompletionSource<bool>();
             var result1 = new TaskCompletionSource<bool>();
@@ -374,7 +374,7 @@ namespace UnitTests.SchedulerTests
         [Fact]
         public async Task Sched_Task_ClosureWorkItem_SpecificScheduler()
         {
-            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskRunner;
+            ActivationTaskScheduler activationScheduler = this.scheduler.GetWorkItemGroup(this.rootContext).TaskScheduler;
 
             var result0 = new TaskCompletionSource<bool>();
             var result1 = new TaskCompletionSource<bool>();

--- a/test/NonSilo.Tests/TestInternalHelper.cs
+++ b/test/NonSilo.Tests/TestInternalHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -14,7 +14,6 @@ namespace UnitTests.TesterInternal
     {
         internal static OrleansTaskScheduler InitializeSchedulerForTesting(
             ISchedulingContext context,
-            IHostEnvironmentStatistics hostStatistics,
             ILoggerFactory loggerFactory)
         {
             var services = new ServiceCollection();
@@ -30,6 +29,7 @@ namespace UnitTests.TesterInternal
                 options.DelayWarningThreshold = TimeSpan.FromMilliseconds(100);
                 options.ActivationSchedulingQuantum = TimeSpan.FromMilliseconds(100);
                 options.TurnWarningLengthThreshold = TimeSpan.FromMilliseconds(100);
+                options.StoppedActivationWarningInterval = TimeSpan.FromMilliseconds(200);
             });
 
             var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Currently, `Task`s which are scheduled against an activation's `TaskScheduler` will be ignored if that activation has become defunct. This is generally not a problem and ignoring these tasks is fine (eg, it could be a non-awaited task from a grain method call). However, there are some cases where not executing these tasks can lead to larger issues. For example, we have encountered a library which captures an activation's `TaskScheduler` and use it for servicing a work queue.

This PR changes the behavior of `WorkItemGroup` so that `Task`s scheduled after an activation has terminated are still executed.

A warning will still be emitted and that warning will be upgraded to an error after 1 minute (configurable via `SchedulingOptions.StoppedWorkItemGroupWarningInterval`). The error will then be logged at most once per minute per activation.

This allows systems to continue functioning when a library misbehaves and gives the application developer more tools to find the misbehaving code.

Since this allows grain code to continue executing after being deactivated (eg, due to an end-user programming error), this PR also adds additional runtime checks so that invalid activations cannot access runtime services as easily.