### PR TITLE
Fix ReadLineStartingWithAsync for LinuxEnvironmentStatistics

### DIFF
--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
@@ -255,9 +255,10 @@ namespace Orleans.Statistics
             using (var r = new StreamReader(fs, Encoding.ASCII))
             {
                 string line;
-                while ((line = await r.ReadLineAsync()) != null && line.StartsWith(lineStartsWith))
+                while ((line = await r.ReadLineAsync()) != null)
                 {
-                    return line;
+                    if (line.StartsWith(lineStartsWith))
+                        return line;
                 }
             }
 


### PR DESCRIPTION
Don't know how I missed this (been using a different implementation internally).
Has coincidentally worked for `MemTotal` since it's at the top of the file but doesnt work for `MemAvailable`.

Sorry about this