### PR TITLE
Fix breakage in Microsoft.Extensions.Hosting.Abstractions

### DIFF
--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -27,9 +27,7 @@ namespace Orleans.Hosting
                 {
                     services.PostConfigure<SiloOptions>(
                         options => options.SiloName =
-                            options.SiloName
-                            ?? context.HostingEnvironment.ApplicationName
-                            ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
+                            options.SiloName ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
 
                     services.TryAddSingleton<Silo>();
                     DefaultSiloServices.AddDefaultServices(context.GetApplicationPartManager(), services);
@@ -155,9 +153,7 @@ namespace Orleans.Hosting
                 {
                     services.PostConfigure<SiloOptions>(
                         options => options.SiloName =
-                            options.SiloName
-                            ?? context.HostingEnvironment.ApplicationName
-                            ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
+                            options.SiloName ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
 
                     services.TryAddSingleton<Silo>();
                     DefaultSiloServices.AddDefaultServices(context.GetApplicationPartManager(), services);


### PR DESCRIPTION
A [recent change](https://github.com/aspnet/Extensions/pull/1100) in `Microsoft.Extensions.Hosting.Abstractions` caused our Generic Host support to [fail during startup](https://github.com/dotnet/orleans/issues/5431) with a `MissingMethodException`, requiring a [workaround](https://gist.github.com/ReubenBond/ce04b0c662e622f29382cd620210bf7d) to remove the code which referenced the changed method.

This PR removes the code which relied on that method, resolving the breakage.