### PR TITLE
Create GrainReferenceKeyInfo

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -293,7 +293,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Return this GrainId ina  standard components form, suitable for later use with the <see cref="FromKeyInfo"/> method.
+        /// Return this GrainId in a standard components form, suitable for later use with the <see cref="FromKeyInfo"/> method.
         /// </summary>
         /// <returns>GrainId in a standard components form.</returns>
         internal (ulong, ulong, ulong, string) ToKeyInfo()

--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -293,6 +293,15 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Return this GrainId ina  standard components form, suitable for later use with the <see cref="FromKeyInfo"/> method.
+        /// </summary>
+        /// <returns>GrainId in a standard components form.</returns>
+        internal (ulong, ulong, ulong, string) ToKeyInfo()
+        {
+            return (Key.N0, Key.N1, Key.TypeCodeData, Key.KeyExt);
+        }
+
+        /// <summary>
         /// Create a new GrainId object by parsing string in a standard form returned from <c>ToParsableString</c> method.
         /// </summary>
         /// <param name="grainId">String containing the GrainId info to be parsed.</param>
@@ -312,6 +321,20 @@ namespace Orleans.Runtime
             // NOTE: This function must be the "inverse" of ToParsableString, and data must round-trip reliably.
 
             var key = UniqueKey.Parse(grainId);
+            return FindOrCreateGrainId(key);
+        }
+
+        /// <summary>
+        /// Create a new GrainId object by parsing components returned form <see cref="ToKeyInfo"/>.
+        /// </summary>
+        /// <param name="grainId">Components containing the GrainId to be parsed.</param>
+        /// <returns>New GrainId object created from the input data.</returns>
+        internal static GrainId FromKeyInfo((ulong, ulong, ulong, string) grainId)
+        {
+            // NOTE: This function must be the "inverse" of ToKeyInfo, and data must round-trip reliably.
+
+            var (n0, n1, typeCodeData, keyExt) = grainId;
+            var key = UniqueKey.NewKey(n0, n1, typeCodeData, keyExt);
             return FindOrCreateGrainId(key);
         }
     }

--- a/src/Orleans.Core.Abstractions/IDs/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/UniqueKey.cs
@@ -372,7 +372,7 @@ namespace Orleans.Runtime
             }
         }
 
-        private static Category GetCategory(UInt64 typeCodeData)
+        internal static Category GetCategory(UInt64 typeCodeData)
         {
             return (Category)((typeCodeData >> 56) & 0xFF);
         }

--- a/src/Orleans.Core.Abstractions/Serialization/GrainReferenceKeyInfo.cs
+++ b/src/Orleans.Core.Abstractions/Serialization/GrainReferenceKeyInfo.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Net;
+using Orleans.Runtime;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// type is a low level representation of graui reference keys to enable
+    /// space-efficient serialization of grain references.
+    /// </summary>
+    /// <remarks>
+    /// This type is not intended for general use. It's a highly specialized type
+    /// for serializing and deserializing grain references, and as such is not
+    /// generally something you should pass around in your application.
+    /// </remarks>
+    public readonly struct GrainReferenceKeyInfo
+    {
+        /// <summary>
+        /// Observer id. Only applicable if <see cref="HasObserverId"/> is true.
+        /// </summary>
+        /// <remarks>In most cases, is Guid.Empty.</remarks>
+        public Guid ObserverId { get; }
+
+        /// <summary>
+        /// Target silo. Only applicable if <see cref="HasTargetSilo"/> is true.
+        /// </summary>
+        /// <remarks>In most cases, is <c>(null, 0)</c>.</remarks>
+        public (IPEndPoint endpoint, int generation) TargetSilo { get; }
+
+        /// <summary>
+        /// Generic argument. Only applicable if <see cref="HasGenericArgument"/> is true.
+        /// </summary>
+        /// <remarks>In most cases, is <c>null</c>.</remarks>
+        public string GenericArgument { get; }
+
+        /// <summary>
+        /// Grain key. For more specialized views, see <c>KeyAs*</c> methods and <c>KeyFrom*</c>.
+        /// </summary>
+        public (ulong, ulong, ulong, string) Key { get; }
+
+        /// <summary>
+        /// Whether or not key info has observer id.
+        /// </summary>
+        public bool HasObserverId => ObserverId != Guid.Empty;
+
+        /// <summary>
+        /// Whether or not key info has silo endpoint.
+        /// </summary>
+        public bool HasTargetSilo => TargetSilo.endpoint != null;
+
+        /// <summary>
+        /// Whether or not key info has generic argument.
+        /// </summary>
+        public bool HasGenericArgument => GenericArgument != null;
+
+        /// <summary>
+        /// Whether or not key info has a long key.
+        /// </summary>
+        public bool IsLongKey => Key.Item1 == 0;
+
+        /// <summary>
+        /// Whether or not key info has key extension.
+        /// </summary>
+        public bool HasKeyExt
+        {
+            get
+            {
+                var category = UniqueKey.GetCategory(Key.Item3);
+                return category == UniqueKey.Category.KeyExtGrain
+                    || category == UniqueKey.Category.GeoClient; // geo clients use the KeyExt string to specify the cluster id
+            }
+        }
+
+        public (Guid key, ulong typeCode) KeyAsGuid()
+        {
+            if (HasKeyExt)
+            {
+                throw new InvalidOperationException("Key has string extension");
+            }
+
+            return (ToGuid(Key), Key.Item3);
+        }
+
+        public static (ulong, ulong, ulong, string) KeyFromGuid(Guid key, ulong typeCode)
+        {
+            var (n0, n1) = FromGuid(key);
+            return (n0, n1, typeCode, null);
+        }
+
+        public (Guid key, string ext, ulong typeCode) KeyAsGuidWithExt()
+        {
+            return (ToGuid(Key), Key.Item4, Key.Item3);
+        }
+
+        public static (ulong, ulong, ulong, string) KeyFromGuidWithExt(Guid key, string ext, ulong typeCode)
+        {
+            var (n0, n1) = FromGuid(key);
+            return (n0, n1, typeCode, ext);
+        }
+
+        public (long key, ulong typeCode) KeyAsLong()
+        {
+            if (HasKeyExt)
+            {
+                throw new InvalidOperationException("Key has string extension");
+            }
+
+            if (!IsLongKey)
+            {
+                throw new InvalidOperationException("Key is not a long key");
+            }
+
+            return (unchecked((long)Key.Item2), Key.Item3);
+        }
+
+        public static (ulong, ulong, ulong, string) KeyFromLong(long key, ulong typeCode)
+        {
+            var n1 = unchecked((ulong)key);
+            return (0, n1, typeCode, null);
+        }
+
+        public (long key, string ext, ulong typeCode) KeyAsLongWithExt()
+        {
+            if (!IsLongKey)
+            {
+                throw new InvalidOperationException("Key is not a long key");
+            }
+
+            return (unchecked((long)Key.Item2), Key.Item4, Key.Item3);
+        }
+
+        public static (ulong, ulong, ulong, string) KeyFromLongWithExt(long key, string ext, ulong typeCode)
+        {
+            var n1 = unchecked((ulong)key);
+            return (0, n1, typeCode, ext);
+        }
+
+        public (string key, ulong typeCode) KeyAsString()
+        {
+            if (Key.Item1 != 0 || Key.Item2 != 0)
+            {
+                throw new InvalidOperationException("Key is not a string key");
+            }
+
+            if (!HasKeyExt)
+            {
+                throw new InvalidOperationException("Key has no string extension");
+            }
+
+            return (Key.Item4, Key.Item3);
+        }
+
+        public static (ulong, ulong, ulong, string) KeyFromString(string key, ulong typeCode)
+        {
+            return KeyFromLongWithExt(0L, key, typeCode);
+        }
+
+        public GrainReferenceKeyInfo((ulong, ulong, ulong, string) key)
+        {
+            Key = key;
+            ObserverId = Guid.Empty;
+            TargetSilo = (null, 0);
+            GenericArgument = null;
+        }
+
+        public GrainReferenceKeyInfo((ulong, ulong, ulong, string) key, Guid observerId)
+        {
+            Key = key;
+            ObserverId = observerId;
+            TargetSilo = (null, 0);
+            GenericArgument = null;
+        }
+
+        public GrainReferenceKeyInfo((ulong, ulong, ulong, string) key, (IPEndPoint endpoint, int generation) targetSilo)
+        {
+            Key = key;
+            ObserverId = Guid.Empty;
+            TargetSilo = targetSilo;
+            GenericArgument = null;
+        }
+
+        public GrainReferenceKeyInfo((ulong, ulong, ulong, string) key, string genericArgument)
+        {
+            Key = key;
+            ObserverId = Guid.Empty;
+            TargetSilo = (null, 0);
+            GenericArgument = genericArgument;
+        }
+
+        private static Guid ToGuid((ulong n0, ulong n1, ulong, string) key) =>
+            new Guid(
+                (uint)(key.n0 & 0xffffffff),
+                (ushort)(key.n0 >> 32),
+                (ushort)(key.n0 >> 48),
+                (byte)key.n1,
+                (byte)(key.n1 >> 8),
+                (byte)(key.n1 >> 16),
+                (byte)(key.n1 >> 24),
+                (byte)(key.n1 >> 32),
+                (byte)(key.n1 >> 40),
+                (byte)(key.n1 >> 48),
+                (byte)(key.n1 >> 56));
+
+        private static (ulong, ulong) FromGuid(Guid guid)
+        {
+            var guidBytes = guid.ToByteArray();
+            var n0 = BitConverter.ToUInt64(guidBytes, 0);
+            var n1 = BitConverter.ToUInt64(guidBytes, 8);
+            return (n0, n1);
+        }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Serialization/GrainReferenceKeyInfo.cs
+++ b/src/Orleans.Core.Abstractions/Serialization/GrainReferenceKeyInfo.cs
@@ -5,7 +5,7 @@ using Orleans.Runtime;
 namespace Orleans.Serialization
 {
     /// <summary>
-    /// type is a low level representation of graui reference keys to enable
+    /// Type is a low level representation of grain reference keys to enable
     /// space-efficient serialization of grain references.
     /// </summary>
     /// <remarks>

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans
 {
@@ -119,6 +120,9 @@ namespace Orleans
 
         /// <inheritdoc />
         public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key, this.GrainReferenceRuntime);
+
+        /// <inheritdoc />
+        public GrainReference GetGrainFromKeyInfo(GrainReferenceKeyInfo keyInfo) => GrainReference.FromKeyInfo(keyInfo, this.GrainReferenceRuntime);
 
         /// <inheritdoc />
         public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)

--- a/src/Orleans.Core/Runtime/IGrainReferenceConverter.cs
+++ b/src/Orleans.Core/Runtime/IGrainReferenceConverter.cs
@@ -1,3 +1,5 @@
+using Orleans.Serialization;
+
 namespace Orleans.Runtime
 {
     public interface IGrainReferenceConverter
@@ -8,5 +10,12 @@ namespace Orleans.Runtime
         /// <param name="key">The key string.</param>
         /// <returns>The newly created grain reference.</returns>
         GrainReference GetGrainFromKeyString(string key);
+
+        /// <summary>
+        /// Creates a grain reference from a storage key info struct.
+        /// </summary>
+        /// <param name="keyInfo">The key info.</param>
+        /// <returns>The newly created grain reference.</returns>
+        GrainReference GetGrainFromKeyInfo(GrainReferenceKeyInfo keyInfo);
     }
 }


### PR DESCRIPTION
Create new type GrainReferenceKeyInfo and methods for getting key info from a GrainReference, and getting a GrainReference form the key info. This enables serializers not part of orleans to serialize/deserialize GrainReferences into more space compact representations than the GetKeyString() format.

Resolves #3810.