### PR TITLE
Improve cleanup of activations on dead silos

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -274,6 +274,11 @@ namespace Orleans.Runtime
             return IsSameEndpoint(other) && this.Generation > other.Generation;
         }
 
+        public bool IsPredecessorOf(SiloAddress other)
+        {
+            return IsSameEndpoint(other) && this.Generation < other.Generation;
+        }
+
         // non-generic version of CompareTo is needed by some contexts. Just calls generic version.
         public int CompareTo(object obj)
         {

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -271,12 +271,12 @@ namespace Orleans.Runtime
 
         public bool IsSuccessorOf(SiloAddress other)
         {
-            return IsSameEndpoint(other) && this.Generation > other.Generation;
+            return IsSameEndpoint(other) && this.Generation != 0 && other.Generation != 0 && this.Generation > other.Generation;
         }
 
         public bool IsPredecessorOf(SiloAddress other)
         {
-            return IsSameEndpoint(other) && this.Generation < other.Generation;
+            return IsSameEndpoint(other) && this.Generation != 0 && other.Generation != 0 && this.Generation < other.Generation;
         }
 
         // non-generic version of CompareTo is needed by some contexts. Just calls generic version.

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -264,6 +264,15 @@ namespace Orleans.Runtime
                 ((Generation == other.Generation));
         }
 
+        internal bool IsSameEndpoint(SiloAddress other)
+        {
+            return other != null && this.Endpoint.Address.Equals(other.Endpoint.Address) && this.Endpoint.Port == other.Endpoint.Port;
+        }
+
+        public bool IsSuccessorOf(SiloAddress other)
+        {
+            return IsSameEndpoint(other) && this.Generation > other.Generation;
+        }
 
         // non-generic version of CompareTo is needed by some contexts. Just calls generic version.
         public int CompareTo(object obj)


### PR DESCRIPTION
3 targeted commits:

1: Consider any silo for which we have seen a successor (same endpoint, higher generation) to be `Dead`.
2 & 3: when adding/removing a silo, consider any predecessor to be dead.

Previously, only seeing a silo as dead would result in cleanup, but it has been extended to the on-add case