### PR TITLE
Make transaction log group max size configurable

### DIFF
--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -25,7 +25,6 @@ namespace Orleans.Transactions.State
         // the linked list of lock groups
         // the head is the group that is currently holding the lock
         private LockGroup currentGroup = null;
-        private const int maxGroupSize = 20;
 
         // cache the last known minimum so we don't have to recompute it as much
         private DateTime cachedMin = DateTime.MaxValue;
@@ -405,7 +404,7 @@ namespace Orleans.Transactions.State
 
                     // if we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
                     if (group == null
-                        && pos.FillCount < maxGroupSize
+                        && pos.FillCount < this.options.MaxLockGroupSize
                         && !HasConflict(isRead, DateTime.MaxValue, guid, pos, out var resolvable))
                     {
                         group = pos;

--- a/src/Orleans.Transactions/State/TransactionalStateOptions.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateOptions.cs
@@ -25,5 +25,8 @@ namespace Orleans.Configuration
         public static int ConfirmationRetryLimit { get; set; } = DefaultConfirmationRetryLimit;
         public const int DefaultConfirmationRetryLimit = 3;
 
+        public int MaxLockGroupSize { get; set; } = DefaultMaxLockGroupSize;
+        public const int DefaultMaxLockGroupSize = 20;
+
     }
 }


### PR DESCRIPTION
When trying to determine cause of broken lock exceptions this was useful.
I can also see it being used to adapt to different storage latencies.