### PR TITLE
Avoid wrapping exceptions thrown during lifecycle

### DIFF
--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
@@ -60,7 +60,7 @@ namespace Orleans
             {
                 string error = $"Lifecycle start canceled due to errors at stage {this.highStage}";
                 this.logger?.Error(ErrorCode.LifecycleStartFailure, error, ex);
-                throw new OrleansLifecycleCanceledException(error, ex);
+                throw;
             }
         }
 

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -142,7 +142,7 @@ namespace Tester
             // run lifecycle
             if (failOnStart.HasValue)
             {
-                await Assert.ThrowsAsync<OrleansLifecycleCanceledException>(() => lifecycle.OnStart());
+                await Assert.ThrowsAsync<Exception>(() => lifecycle.OnStart());
             }
             else
             {


### PR DESCRIPTION
These exceptions significantly detract from the debugging experience