### PR TITLE
Reduce default liveness probe timeout from 10 seconds to 5

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -29,7 +29,7 @@ namespace Orleans.Configuration
         /// The number of seconds to periodically probe other silos for their liveness or for the silo to send "I am alive" heartbeat  messages about itself.
         /// </summary>
         public TimeSpan ProbeTimeout { get; set; } = DEFAULT_LIVENESS_PROBE_TIMEOUT;
-        public static readonly TimeSpan DEFAULT_LIVENESS_PROBE_TIMEOUT = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan DEFAULT_LIVENESS_PROBE_TIMEOUT = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// The number of seconds to periodically fetch updates from the membership table.


### PR DESCRIPTION
The default timeout (and interval) setting for cluster membership pings of 10 seconds is very conservative and hasn't changed since early versions of Orleans. It adds up to the default detection time for a dead silo of 30 seconds. This puts a lower limits on node failure recovery time because recovery cannot start before a failure is detected.

We believe in today's cloud environments we can half the default detection time by lowering this setting to 5 seconds, and this will lead to a better experience for most Orleans users. If somebody isn't comfortable with the new default, they can explicitly set it to the old value.