### PR TITLE
Reduce delay localdirectory when cluster membership is not stable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -112,7 +112,7 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.3.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.4.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -11,6 +11,7 @@ using Orleans.Hosting;
 using Orleans.Runtime.Scheduler;
 using Orleans.Runtime.MultiClusterNetwork;
 using Orleans.Configuration;
+using System.ComponentModel;
 
 namespace Orleans.Runtime.GrainDirectory
 {
@@ -34,8 +35,8 @@ namespace Orleans.Runtime.GrainDirectory
         private Action<SiloAddress, SiloStatus> catalogOnSiloRemoved;
 
         // Consider: move these constants into an apropriate place
-        internal const int HOP_LIMIT = 6; // forward a remote request no more than 4 times
-        public static readonly TimeSpan RETRY_DELAY = TimeSpan.FromMilliseconds(200); // Pause 5 seconds between forwards to let the membership directory settle down
+        internal const int HOP_LIMIT = 6; // forward a remote request no more than 5 times
+        public static readonly TimeSpan RETRY_DELAY = TimeSpan.FromMilliseconds(200); // Pause 200ms between forwards to let the membership directory settle down
 
         protected SiloAddress Seed { get { return seed; } }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime.MembershipService
 {
     internal class MembershipOracle : SystemTarget, IMembershipOracle, IMembershipService
     {
-        private readonly static TimeSpan shutdownGossipTimeout = TimeSpan.FromMilliseconds(30);
+        private readonly static TimeSpan shutdownGossipTimeout = TimeSpan.FromSeconds(10);
         private readonly IInternalGrainFactory grainFactory;
         private IMembershipTable membershipTableProvider;
         private readonly MembershipOracleData membershipOracleData;

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime.MembershipService
 {
     internal class MembershipOracle : SystemTarget, IMembershipOracle, IMembershipService
     {
-        private readonly static TimeSpan shutdownGossipTimeout = TimeSpan.FromSeconds(10);
+        private readonly static TimeSpan shutdownGossipTimeout = TimeSpan.FromSeconds(3);
         private readonly IInternalGrainFactory grainFactory;
         private IMembershipTable membershipTableProvider;
         private readonly MembershipOracleData membershipOracleData;


### PR DESCRIPTION
When the `LocalGrainDirectory` receives a register/unregister request that needs to be forwarded (it can happen when all silos doesn't have the same view of the cluster membership), it currently wait 5 seconds before forwarding, to allow some time for the membership changes to propagate.

200ms seems to be a better value since with gossip the membership change should propagate quickly.