### PR TITLE
Cherry-pick #5473 for 2.3.5

### DIFF
--- a/test/Grains/TestGrainInterfaces/RecursiveType.cs
+++ b/test/Grains/TestGrainInterfaces/RecursiveType.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IReferenceRecursiveTypeGrain : IGrainWithGuidKey
+    {
+        Task<RecursiveType> Echo(RecursiveType arg);
+    }
+
+    /// <summary>
+    /// These classes form a repro for https://github.com/dotnet/orleans/issues/5473, which resulted in a
+    /// StackOverflowException during code generation.
+    /// </summary>
+    [Serializable]
+    public class RecursiveType : SelfTyped<RecursiveType>
+    {
+    }
+
+    public abstract class SelfTyped<T> where T : SelfTyped<T>
+    {
+    }
+}


### PR DESCRIPTION
Fix #5473 - codegen fails on recursively defined types (#5688)