### PR TITLE
ClusterClient: only call IRuntimeClient.Reset for OutsideRuntimeClient

### DIFF
--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -161,7 +161,7 @@ namespace Orleans
                         Utils.SafeExecute(() => (this.runtimeClient as OutsideRuntimeClient)?.Disconnect());
                     }
 
-                    Utils.SafeExecute(() => this.runtimeClient.Reset(gracefully));
+                    Utils.SafeExecute(() => (this.runtimeClient as OutsideRuntimeClient)?.Reset(gracefully));
                     this.Dispose(true);
                 }
                 finally


### PR DESCRIPTION
Fixes some benign exceptions during shutdown now that ClusterClient is also used on silos