### PR TITLE
Fix the test trace file name on Unix systems

### DIFF
--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -41,7 +41,7 @@ namespace Orleans.TestingHost.Utils
                 Directory.CreateDirectory(traceFileFolder);
             }
 
-            var traceFileName = $"{traceFileFolder}\\{clusterId}_{nodeName}.log";
+            var traceFileName = Path.Combine(traceFileFolder, $"{clusterId}_{nodeName}.log");
 
             return traceFileName;
         }


### PR DESCRIPTION
Use the correct path separator on Unix systems, otherwise it creates files with names like 'logs\testcluster-2019-06-25t15-34-58-179_MainClient.log'