### PR TITLE
Minor client/silo teardown tweaks

### DIFF
--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -273,11 +273,9 @@ namespace Orleans
         {
             if (disposing)
             {
-                Utils.SafeExecute(() => (this.runtimeClient as IDisposable)?.Dispose());
+                Utils.SafeExecute(() => (this.runtimeClient as OutsideRuntimeClient)?.Dispose());
                 this.state = LifecycleState.Disposed;
             }
-
-            GC.SuppressFinalize(this);
         }
 
         private void ThrowIfDisposedOrNotInitialized()

--- a/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
@@ -43,7 +43,6 @@ namespace Orleans.Hosting
             {
                 this.applicationLifetime?.StopApplication();
                 await silo.StopAsync(cancellationToken);
-                await this.Stopped;
             }
             finally
             {


### PR DESCRIPTION
* Check for `OutsideRuntimeClient` in `ClusterClient` before calling Dispose (which arguably should be removed anyway...)
* Pulse `incomingMessages` queue to give `HostedClient` to gracefully terminate
* Avoid Dispose in `Silo` (it exists in `SiloWrapper`)
* Capture a weal reference to `Silo` in `AppDomain.CurrentDomain.ProcessExit` to fix memory leak (apparent during long test runs)
* Don't await Terminated/Stopped tasks during shutdown (doing so could cause deadlocks)
