### PR TITLE
Remove concurrency cap for Xunit

### DIFF
--- a/test/Analyzers.Tests/AssemblyInfo.cs
+++ b/test/Analyzers.Tests/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/CodeGeneration/CodeGenerator.Tests/Properties/AssemblyInfo.cs
+++ b/test/CodeGeneration/CodeGenerator.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/DefaultCluster.Tests/Properties/AssemblyInfo.cs
+++ b/test/DefaultCluster.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/DependencyInjection.Tests/Properties/AssemblyInfo.cs
+++ b/test/DependencyInjection.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/AWSUtils.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/AWSUtils.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/Consul.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/Consul.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/PSUtils.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/PSUtils.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/Serializers/BondUtils.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/Serializers/BondUtils.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/ServiceBus.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/ServiceBus.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/TestServiceFabric/Properties/AssemblyInfo.cs
+++ b/test/Extensions/TestServiceFabric/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/TesterAdoNet/Properties/AssemblyInfo.cs
+++ b/test/Extensions/TesterAdoNet/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/TesterAzureUtils/Properties/AssemblyInfo.cs
+++ b/test/Extensions/TesterAzureUtils/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Extensions/TesterZooKeeperUtils/Properties/AssemblyInfo.cs
+++ b/test/Extensions/TesterZooKeeperUtils/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/NetCore.Tests/Properties/AssemblyInfo.cs
+++ b/test/NetCore.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/RuntimeCodeGen.Tests/Properties/AssemblyInfo.cs
+++ b/test/RuntimeCodeGen.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Tester/Properties/AssemblyInfo.cs
+++ b/test/Tester/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/TesterInternal/Properties/AssemblyInfo.cs
+++ b/test/TesterInternal/Properties/AssemblyInfo.cs
@@ -1,5 +1,8 @@
 using System.Runtime.CompilerServices;
 
+// Disable XUnit concurrency limit
+[assembly: Xunit.CollectionBehavior(MaxParallelThreads = -1)]
+
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
 [assembly: InternalsVisibleTo("Tester.AdoNet")]
 [assembly: InternalsVisibleTo("AWSUtils.Tests")]

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AssemblyInfo.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/Transactions/Orleans.Transactions.Tests/AssemblyInfo.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-using System.Runtime.CompilerServices;
 using Xunit;
 
 // Disable XUnit concurrency limit
 [assembly: CollectionBehavior(MaxParallelThreads = -1)]
-
-[assembly: InternalsVisibleTo("TesterInternal")]


### PR DESCRIPTION
I noticed in some stack traces that Xunit was running tests under a `MaxConcurrencySynchronizationContext`.

Tests may behave differently (eg, potentially hitting a deadlock), so this PR removes the limit by setting it to -1 for all test assemblies