### PR TITLE
Fix exception in LatestVersionSelector when there are no deployed versions of a grain

### DIFF
--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -66,11 +66,13 @@ namespace Orleans.Runtime.Versions
 
         public async Task<CompatibilityStrategy> GetCompatibilityStrategy()
         {
+            ThrowIfNotEnabled();
             return await StoreGrain.GetCompatibilityStrategy();
         }
 
         public async Task<VersionSelectorStrategy> GetSelectorStrategy()
         {
+            ThrowIfNotEnabled();
             return await StoreGrain.GetSelectorStrategy();
         }
 

--- a/src/Orleans.Runtime/Versions/Selector/LatestVersionDirector.cs
+++ b/src/Orleans.Runtime/Versions/Selector/LatestVersionDirector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Orleans.Versions.Compatibility;
@@ -9,10 +10,18 @@ namespace Orleans.Runtime.Versions.Selector
     {
         public IReadOnlyList<ushort> GetSuitableVersion(ushort requestedVersion, IReadOnlyList<ushort> availableVersions, ICompatibilityDirector compatibilityDirector)
         {
-            return new[]
+            var max = int.MinValue;
+            foreach (var version in availableVersions)
             {
-                availableVersions.Where(v => compatibilityDirector.IsCompatible(requestedVersion, v)).Max()
-            };
+                if (compatibilityDirector.IsCompatible(requestedVersion, version) && version > max)
+                {
+                    max = version;
+                }
+            }
+
+            if (max < 0) return Array.Empty<ushort>();
+
+            return new[] { (ushort)max };
         }
     }
 }


### PR DESCRIPTION
Also throw in GrainVersionStore when versioning is not enabled.