### PR TITLE
Change Client IP Address selection logic to use routing tables

### DIFF
--- a/src/Orleans.Core/Messaging/IGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/IGatewayListProvider.cs
@@ -51,4 +51,18 @@ namespace Orleans.Messaging
 
         bool UnSubscribeFromGatewayNotificationEvents(IGatewayListListener listener);
     }
+
+    /// <summary>
+    /// An optional interface that GatewayListProvider may implement in order to provide routing information when selecting an IP address.
+    /// By default GatewayListProvider should work only after InitializeGatewayListProvider is called.
+    /// IGatewayListRoute functions are called before that.
+    /// This is optional and not required.
+    /// </summary>
+    public interface IGatewayListRoute
+    {
+        /// <summary>
+        /// A  (likely invalid) address of a gateway. This is used to compute the proper local address to use.
+        /// </summary>
+        Uri SampleGatewayAddress { get; }
+    }
 }

--- a/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
@@ -6,7 +6,7 @@ using Orleans.Configuration;
 
 namespace Orleans.Messaging
 {
-    public class StaticGatewayListProvider : IGatewayListProvider
+    public class StaticGatewayListProvider : IGatewayListProvider, IGatewayListRoute
     {
         private readonly StaticGatewayListProviderOptions options;
         private readonly TimeSpan maxStaleness;
@@ -17,7 +17,7 @@ namespace Orleans.Messaging
         }
 
         public Task InitializeGatewayListProvider() => Task.CompletedTask;
-        
+
 
         public Task<IList<Uri>> GetGateways() => Task.FromResult<IList<Uri>>(this.options.Gateways);
 
@@ -29,6 +29,11 @@ namespace Orleans.Messaging
         public bool IsUpdatable
         {
             get => true;
+        }
+
+        public Uri SampleGatewayAddress
+        {
+            get => this.options.Gateways[0];
         }
     }
 }

--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -51,7 +51,7 @@ namespace Tester.ClientConnectionTests
             Assert.Single(exceptions);
         }
 
-        public class MockGatewayListProvider : IGatewayListProvider
+        public class MockGatewayListProvider : IGatewayListProvider, IGatewayListRoute
         {
             public ReadOnlyCollection<Uri> Gateways { get; set; } = new ReadOnlyCollection<Uri>(new List<Uri>());
 
@@ -62,6 +62,8 @@ namespace Tester.ClientConnectionTests
             public TimeSpan MaxStaleness => TimeSpan.FromSeconds(30);
 
             public bool IsUpdatable => true;
+
+            public Uri SampleGatewayAddress => this.Gateways[0];
         }
     }
 }

--- a/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
@@ -18,13 +18,15 @@ using Orleans.Configuration;
 
 namespace Tester
 {
-    public class TestGatewayManager : IGatewayListProvider
+    public class TestGatewayManager : IGatewayListProvider, IGatewayListRoute
     {
         public TimeSpan MaxStaleness => TimeSpan.FromSeconds(1);
 
         public bool IsUpdatable => true;
 
         public IList<Uri> Gateways { get; }
+
+        public Uri SampleGatewayAddress => this.Gateways[0];
 
         public TestGatewayManager()
         {

--- a/test/TesterInternal/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GatewaySelectionTest.cs
@@ -122,7 +122,7 @@ namespace UnitTests.MessageCenterTests
             Assert.True((low <= counts[3]) && (counts[3] <= up), "Gateway selection is incorrectly skewed. " + counts[3]);
         }
 
-        private class TestListProvider : IGatewayListProvider
+        private class TestListProvider : IGatewayListProvider, IGatewayListRoute
         {
             private readonly IList<Uri> list;
 
@@ -145,6 +145,12 @@ namespace UnitTests.MessageCenterTests
             {
                 get { return false; }
             }
+
+            public Uri SampleGatewayAddress
+            {
+                get { return list[0]; }
+            }
+
             public Task InitializeGatewayListProvider()
             {
                 return Task.CompletedTask;


### PR DESCRIPTION
Addresses #5568.

Haven't tested the pull request, but at least it builds. If someone knows of an easy way to test a PR to Orleans under Linux, I would be glad to hear.

Based on code from [this StackOverflow question](https://stackoverflow.com/questions/15086863/c-sharp-know-with-which-ip-we-use-to-communicate-with-another-ip).

This PR is mostly a proof-of-concept for now.