### PR TITLE
Directory: perform early handoff & forward to successor

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -946,6 +946,8 @@ namespace Orleans.Runtime
         // Reroute pending
         private Task DestroyActivations(List<ActivationData> list)
         {
+            if (list.Count == 0) return Task.CompletedTask;
+
             var tcs = new MultiTaskCompletionSource(list.Count);
             StartDestroyActivations(list, tcs);
             return tcs.Task;

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Text;
@@ -33,6 +32,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 if (member.Value.Status == SiloStatus.Active)
                 {
+                    ++this.ActiveMemberCount;
                     var silo = member.Value.SiloAddress;
                     activeMembers.Add(silo);
                 }
@@ -61,6 +61,11 @@ namespace Orleans.Runtime.GrainDirectory
         /// The monotonically increasing membership version associated with this snapshot.
         /// </summary>
         public ClusterMembershipSnapshot ClusterMembership { get; }
+
+        /// <summary>
+        /// The number of active silos.
+        /// </summary>
+        public int ActiveMemberCount { get; }
 
         /// <summary>
         /// Returns the <see cref="SiloAddress"/> which owns the directory partition of the provided grain.
@@ -100,7 +105,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
             }
 
-            if (siloAddress == null)
+            if (siloAddress is null)
             {
                 // If not found in the traversal, last silo will do (we are on a ring).
                 // We checked above to make sure that the list isn't empty, so this should always be safe.

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -107,7 +107,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task RemoveHandoffPartition(SiloAddress source)
         {
-            localGrainDirectory.HandoffManager.RemoveHandoffPartition(source);
+            // No-op
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
This PR tweaks the behavior of the grain directory during membership change (startup, shutdown):

* During startup, wait until the local silo has received a "split partition" before allowing the local directory to serve requests
* During shutdown, perform handoff before any membership change has occurred
* During shutdown, after handoff has completed, forward all requests which should be served by the local silo (according to membership) to the would-be successor of the local silo (i.e, the silo which the local silo handed-off its directory partition to).
* Allow serving requests which should be served by a different silo (according to membership) if that silo has handed off its partition into this silo (i.e, indicating that it is in the process of shutting down).