### PR TITLE
Fix incorrectly configured listening ports in tests

### DIFF
--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -154,7 +154,7 @@ namespace Orleans.TestingHost
                 basePort = basePort - (basePort % consecutivePortsToCheck);
                 int endPort = basePort + consecutivePortsToCheck;
 
-                // make sure non of the ports in the sub range are in use
+                // make sure none of the ports in the sub range are in use
                 if (tcpConnInfoArray.All(endpoint => endpoint.Port < basePort || endpoint.Port >= endPort))
                     return basePort;
             }

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -138,6 +138,11 @@ namespace Orleans.TestingHost
                 options.AdvertisedIPAddress = IPAddress.Loopback;
                 options.SiloPort = siloPort;
                 options.GatewayPort = gatewayPort;
+                options.SiloListeningEndpoint = new IPEndPoint(IPAddress.Loopback, siloPort);
+                if (gatewayPort != 0)
+                {
+                    options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Loopback, gatewayPort);
+                }
             });
         }
 


### PR DESCRIPTION
Legacy configuration support messes with how port configuration works