### PR TITLE
Replace Environment.FailFast with Environment.Exit

### DIFF
--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -275,7 +275,9 @@ namespace Orleans.Runtime
             {
                 logger.Error(ErrorCode.Logger_ProcessCrashing, "INTERNAL FAILURE! Process crashing!");
 
-                Environment.FailFast("Unrecoverable failure: " + message);
+                // Environment.FailFast triggers a popup on some machine "xxx has stopped working"
+                // Environment.FailFast("Unrecoverable failure: " + message);
+                Environment.Exit(128);
             }
         }
     }

--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -276,7 +276,6 @@ namespace Orleans.Runtime
                 logger.Error(ErrorCode.Logger_ProcessCrashing, "INTERNAL FAILURE! Process crashing!");
 
                 // Environment.FailFast triggers a popup on some machine "xxx has stopped working"
-                // Environment.FailFast("Unrecoverable failure: " + message);
                 Environment.Exit(128);
             }
         }


### PR DESCRIPTION
On some machine,  `Environment.FailFast` triggers a popup "xxx has stopped working". We believe it can stalls some deployments when they encounter this error.

