### PR TITLE
Added better type serialization support to DynamoDB Storage Provider

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -143,7 +143,7 @@ namespace Orleans.Storage
 
             if (record != null)
             {
-                var loadedState = ConvertFromStorageFormat(record);
+                var loadedState = ConvertFromStorageFormat(record, grainState.Type);
                 grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
                 grainState.ETag = record.ETag.ToString();
             }
@@ -297,7 +297,7 @@ namespace Orleans.Storage
             return AWSUtils.ValidateDynamoDBPartitionKey(key);
         }
 
-        internal object ConvertFromStorageFormat(GrainStateRecord entity)
+        internal object ConvertFromStorageFormat(GrainStateRecord entity, Type stateType)
         {
             var binaryData = entity.BinaryState;
             var stringData = entity.StringState;
@@ -312,7 +312,7 @@ namespace Orleans.Storage
                 }
                 else if (!string.IsNullOrEmpty(stringData))
                 {
-                    dataValue = JsonConvert.DeserializeObject<object>(stringData, this.jsonSettings);
+                    dataValue = JsonConvert.DeserializeObject(stringData, stateType, this.jsonSettings);
                 }
 
                 // Else, no data found

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -157,7 +157,7 @@ namespace AWSUtils.Tests.StorageTests
 
             storage.ConvertToStorageFormat(initialState, entity);
 
-            var convertedState = (TestStoreGrainState)storage.ConvertFromStorageFormat(entity);
+            var convertedState = (TestStoreGrainState)storage.ConvertFromStorageFormat(entity, initialState.GetType());
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.A, convertedState.A);
             Assert.Equal(initialState.B, convertedState.B);
@@ -176,7 +176,7 @@ namespace AWSUtils.Tests.StorageTests
         private Task<DynamoDBGrainStorage> InitDynamoDBGrainStorage(bool useJson = false)
         {
             var options = new DynamoDBStorageOptions
-            {                
+            {
                 Service = AWSTestConstants.Service,
                 UseJson = useJson
             };

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -142,7 +142,7 @@ namespace AWSUtils.Tests.StorageTests
                 this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
             var convertedState = new GrainStateContainingGrainReferences();
-            convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity);
+            convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
             Assert.NotNull(convertedState); // Converted state
             Assert.Equal(initialState.Grain, convertedState.Grain);  // "Grain"
         }
@@ -168,7 +168,7 @@ namespace AWSUtils.Tests.StorageTests
                 await InitDynamoDBTableStorageProvider(
                     this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
-            var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity);
+            var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.GrainList.Count, convertedState.GrainList.Count);  // "GrainList size"
             Assert.Equal(initialState.GrainDict.Count, convertedState.GrainDict.Count);  // "GrainDict size"


### PR DESCRIPTION
The current DynamoDB storage provider assumes that type information is included in the json via the Json.NET `TypeNameHandling` option. This PR matches the behavior of other storage providers, allowing plain json objects to be stored and deserialized based on the state's type.