### PR TITLE
Fix OnCompleteAsync & OnErrorAsync in StreamImpl

### DIFF
--- a/src/Orleans.Core/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamImpl.cs
@@ -102,17 +102,13 @@ namespace Orleans.Streams
         public Task OnCompletedAsync()
         {
             IInternalAsyncBatchObserver<T> producerInterface = GetProducerInterface();
-            var observer = producerInterface as IAsyncObserver<T>;
-            var batchObserver = producerInterface as IAsyncBatchObserver<T>;
-            return Task.WhenAll(observer.OnCompletedAsync(), batchObserver.OnCompletedAsync());
+            return producerInterface.OnCompletedAsync();
         }
 
         public Task OnErrorAsync(Exception ex)
         {
             IInternalAsyncBatchObserver<T> producerInterface = GetProducerInterface();
-            var observer = producerInterface as IAsyncObserver<T>;
-            var batchObserver = producerInterface as IAsyncBatchObserver<T>;
-            return Task.WhenAll(observer.OnErrorAsync(ex), batchObserver.OnErrorAsync(ex));
+            return producerInterface.OnErrorAsync(ex);
         }
 
         internal Task<StreamSubscriptionHandle<T>> ResumeAsync(


### PR DESCRIPTION
Fixes #5697.
Fix NullRreferenceException thrown in OnCompletedAsync & OnErrorAsync.