### PR TITLE
Implement full-duplex silo-to-silo connections

### DIFF
--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime.Messaging
             {
                 this.messageCenter.OnGatewayConnectionOpen();
 
-                await ConnectionPreamble.Write(this.Context, this.messageCenter.ClientId);
+                await ConnectionPreamble.Write(this.Context, this.messageCenter.ClientId, siloAddress: null);
                 await base.RunInternal();
             }
             finally

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -128,11 +128,11 @@ namespace Orleans.Runtime.Messaging
 
         protected override async Task RunInternal()
         {
-            var grainId = await ConnectionPreamble.Read(this.Context);
+            var (grainId, siloAddress) = await ConnectionPreamble.Read(this.Context);
 
             if (grainId.Equals(Constants.SiloDirectConnectionId))
             {
-                throw new InvalidOperationException("Unexpected direct silo connection on proxy endpoint.");
+                throw new InvalidOperationException($"Unexpected direct silo connection on proxy endpoint from {siloAddress?.ToString() ?? "unknown silo"}");
             }
 
             // refuse clients that are connecting to the wrong cluster

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -12,7 +12,9 @@ namespace Orleans.Runtime.Messaging
         private readonly MessageCenter messageCenter;
         private readonly MessageFactory messageFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly ConnectionManager connectionManager;
         private readonly SiloAddress myAddress;
+        private SiloAddress remoteSiloAddress;
 
         public SiloConnection(
             ConnectionContext connection,
@@ -22,12 +24,14 @@ namespace Orleans.Runtime.Messaging
             MessageCenter messageCenter,
             MessageFactory messageFactory,
             ILocalSiloDetails localSiloDetails,
-            ISiloStatusOracle siloStatusOracle)
+            ISiloStatusOracle siloStatusOracle,
+            ConnectionManager connectionManager)
             : base(connection, middleware, serviceProvider, trace)
         {
             this.messageCenter = messageCenter;
             this.messageFactory = messageFactory;
             this.siloStatusOracle = siloStatusOracle;
+            this.connectionManager = connectionManager;
             this.myAddress = localSiloDetails.SiloAddress;
         }
 
@@ -151,19 +155,32 @@ namespace Orleans.Runtime.Messaging
 
         protected override async Task RunInternal()
         {
-            await Task.WhenAll(ReadPreamble(), WritePreamble());
+            try
+            {
+                await Task.WhenAll(ReadPreamble(), WritePreamble());
 
-            await base.RunInternal();
+                await base.RunInternal();
+            }
+            finally
+            {
+                if (!(this.remoteSiloAddress is null)) this.connectionManager.OnConnectionTerminated(this.remoteSiloAddress, this);
+            }
 
-            Task WritePreamble() => ConnectionPreamble.Write(this.Context, Constants.SiloDirectConnectionId);
+            Task WritePreamble() => ConnectionPreamble.Write(this.Context, Constants.SiloDirectConnectionId, this.myAddress);
 
             async Task ReadPreamble()
             {
-                var grainId = await ConnectionPreamble.Read(this.Context);
+                var (grainId, siloAddress) = await ConnectionPreamble.Read(this.Context);
 
                 if (!grainId.Equals(Constants.SiloDirectConnectionId))
                 {
                     throw new InvalidOperationException("Unexpected non-proxied connection on silo endpoint.");
+                }
+
+                if (siloAddress != null)
+                {
+                    this.remoteSiloAddress = siloAddress;
+                    this.connectionManager.OnConnected(siloAddress, this);
                 }
             }
         }

--- a/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IServiceProvider serviceProvider;
         private readonly MessageFactory messageFactory;
+        private ConnectionManager connectionManager;
         private MessageCenter messageCenter;
 
         public SiloConnectionFactory(
@@ -35,6 +36,7 @@ namespace Orleans.Runtime.Messaging
         protected override Connection CreateConnection(ConnectionContext context)
         {
             if (this.messageCenter is null) this.messageCenter = this.serviceProvider.GetRequiredService<MessageCenter>();
+            if (this.connectionManager is null) this.connectionManager = this.serviceProvider.GetRequiredService<ConnectionManager>();
 
             return new SiloConnection(
                 context,
@@ -44,7 +46,8 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter,
                 this.messageFactory,
                 this.localSiloDetails,
-                this.siloStatusOracle);
+                this.siloStatusOracle,
+                this.connectionManager);
         }
     }
 }

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -17,6 +17,7 @@ namespace Orleans.Runtime.Messaging
         private readonly MessageCenter messageCenter;
         private readonly MessageFactory messageFactory;
         private readonly EndpointOptions endpointOptions;
+        private readonly ConnectionManager connectionManager;
 
         public SiloConnectionListener(
             IServiceProvider serviceProvider,
@@ -27,7 +28,8 @@ namespace Orleans.Runtime.Messaging
             INetworkingTrace trace,
             IOptions<EndpointOptions> endpointOptions,
             ILocalSiloDetails localSiloDetails,
-            ISiloStatusOracle siloStatusOracle)
+            ISiloStatusOracle siloStatusOracle,
+            ConnectionManager connectionManager)
             : base(serviceProvider, listenerFactory, connectionOptions, trace)
         {
             this.messageCenter = messageCenter;
@@ -35,6 +37,7 @@ namespace Orleans.Runtime.Messaging
             this.trace = trace;
             this.localSiloDetails = localSiloDetails;
             this.siloStatusOracle = siloStatusOracle;
+            this.connectionManager = connectionManager;
             this.endpointOptions = endpointOptions.Value;
         }
 
@@ -50,7 +53,8 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter,
                 this.messageFactory,
                 this.localSiloDetails,
-                this.siloStatusOracle);
+                this.siloStatusOracle,
+                this.connectionManager);
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)


### PR DESCRIPTION
This PR upgrades the networking protocol in a backwards-compatible manner to add support for full-duplex silo-to-silo connections.

Currently silos establish outgoing connections to each other in order to send messages. This results in each silo pair having two connections between them, where each connection is used for traffic in a single direction.

By sending a `SiloAddress` along with the connection preamble, we can support full-duplex connections & save on connections.