### PR TITLE
Updating Blazor Sample

### DIFF
--- a/Samples/2.3/Blazor/Sample.ClientSide/App.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/App.razor
@@ -1,1 +1,5 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" />
+<Router AppAssembly="typeof(Program).Assembly">
+    <NotFoundContent>
+        <p>Sorry, there's nothing at this address.</p>
+    </NotFoundContent>
+</Router>

--- a/Samples/2.3/Blazor/Sample.ClientSide/Models/TodoItem.cs
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Models/TodoItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Sample.ClientSide.Models
 {
@@ -18,7 +18,9 @@ namespace Sample.ClientSide.Models
                 && OwnerKey == other.OwnerKey;
         }
 
+        /*
         public override int GetHashCode() =>
             HashCode.Combine(Key, Title, IsDone, OwnerKey);
+        */
     }
 }

--- a/Samples/2.3/Blazor/Sample.ClientSide/Pages/Counter.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Pages/Counter.razor
@@ -1,12 +1,12 @@
-﻿@page "/counter"
+@page "/counter"
 
 <h1>Counter</h1>
 
 <p>Current count: @currentCount</p>
 
-<button class="btn btn-primary" onclick="@IncrementCount">Click me</button>
+<button class="btn btn-primary" @onclick="@IncrementCount">Click me</button>
 
-@functions {
+@code {
 
     [Parameter]
     public int IncrementAmount { get; set; } = 1;

--- a/Samples/2.3/Blazor/Sample.ClientSide/Pages/FetchData.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Pages/FetchData.razor
@@ -1,4 +1,4 @@
-﻿@page "/fetchdata"
+@page "/fetchdata"
 @inject ApiService ApiService
 
 <h1>Weather forecast</h1>
@@ -34,7 +34,7 @@ else
     </table>
 }
 
-@functions {
+@code {
 
     private WeatherInfo[] forecasts;
 

--- a/Samples/2.3/Blazor/Sample.ClientSide/Pages/Todo.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Pages/Todo.razor
@@ -1,4 +1,4 @@
-﻿@page "/todo"
+@page "/todo"
 @inject ApiService ApiService
 
 <h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
@@ -8,20 +8,20 @@
     <div class="input-group mb-3">
         <div class="input-group-prepend">
             <div class="input-group-text">
-                <input type="checkbox" checked="@todo.IsDone" onchange="@(async e => await HandleTodoDoneAsync(todo, (bool)e.Value))" />
+                <input type="checkbox" checked="@todo.IsDone" @onchange="@(async e => await HandleTodoDoneAsync(todo, (bool)e.Value))" />
             </div>
-            <button class="btn btn-outline-secondary" type="button" onclick="@(async e => await HandleDeleteTodoAsync(todo))">
+            <button class="btn btn-outline-secondary" type="button" @onclick="@(async e => await HandleDeleteTodoAsync(todo))">
                 <span class="oi oi-trash" aria-hidden="true"></span>
             </button>
         </div>
-        <input class="form-control" value="@todo.Title" onchange="@(async e => await HandleTodoTitleChangeAsync(todo, (string)e.Value))" />
+        <input class="form-control" value="@todo.Title" @onchange="@(async e => await HandleTodoTitleChangeAsync(todo, (string)e.Value))" />
     </div>
 }
 
-<input placeholder="Something todo" bind="@newTodo" />
-<button onclick="@AddTodoAsync">Add Todo</button>
+<input placeholder="Something todo" @bind="@newTodo" />
+<button @onclick="@AddTodoAsync">Add Todo</button>
 
-@functions {
+@code {
 
     private Guid ownerKey = Guid.Empty;
     private List<TodoItem> todos = new List<TodoItem>();

--- a/Samples/2.3/Blazor/Sample.ClientSide/Sample.ClientSide.csproj
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Sample.ClientSide.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview5-19227-01" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview5-19227-01" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview5-19227-01" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview7.19365.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0-preview7.19362.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0-preview7.19362.4" />
   </ItemGroup>
 
 </Project>

--- a/Samples/2.3/Blazor/Sample.ClientSide/Sample.ClientSide.csproj
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Sample.ClientSide.csproj
@@ -1,11 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RestoreAdditionalProjectSources>
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>

--- a/Samples/2.3/Blazor/Sample.ClientSide/Shared/NavMenu.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Shared/NavMenu.razor
@@ -1,11 +1,11 @@
-﻿<div class="top-row pl-4 navbar navbar-dark">
+<div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">Sample.ClientSide</a>
-    <button class="navbar-toggler" onclick="@ToggleNavMenu">
+    <button class="navbar-toggler" @onclick="@ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>
 </div>
 
-<div class="@NavMenuCssClass" onclick="@ToggleNavMenu">
+<div class="@NavMenuCssClass" @onclick="@ToggleNavMenu">
     <ul class="nav flex-column">
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
@@ -30,7 +30,7 @@
     </ul>
 </div>
 
-@functions {
+@code {
     bool collapseNavMenu = true;
 
     string NavMenuCssClass => collapseNavMenu ? "collapse" : null;

--- a/Samples/2.3/Blazor/Sample.ClientSide/Shared/SurveyPrompt.razor
+++ b/Samples/2.3/Blazor/Sample.ClientSide/Shared/SurveyPrompt.razor
@@ -1,4 +1,4 @@
-﻿<div class="alert alert-secondary mt-4" role="alert">
+<div class="alert alert-secondary mt-4" role="alert">
     <span class="oi oi-pencil mr-2" aria-hidden="true"></span>
     <strong>@Title</strong>
 
@@ -9,7 +9,7 @@
     and tell us what you think.
 </div>
 
-@functions {
+@code {
     // Demonstrates how a parent component can supply parameters
     [Parameter] string Title { get; set; }
 }

--- a/Samples/2.3/Blazor/Sample.ClientSide/libman.json
+++ b/Samples/2.3/Blazor/Sample.ClientSide/libman.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "defaultProvider": "cdnjs",
+  "libraries": []
+}

--- a/Samples/2.3/Blazor/Sample.Grains.Interfaces/Sample.Grains.Interfaces.csproj
+++ b/Samples/2.3/Blazor/Sample.Grains.Interfaces/Sample.Grains.Interfaces.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.5">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.6" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>

--- a/Samples/2.3/Blazor/Sample.Grains/Sample.Grains.csproj
+++ b/Samples/2.3/Blazor/Sample.Grains/Sample.Grains.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.5">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.5" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.6" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.3.6" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>

--- a/Samples/2.3/Blazor/Sample.Grains/Sample.Grains.csproj
+++ b/Samples/2.3/Blazor/Sample.Grains/Sample.Grains.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;IDE0009</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.6">
       <PrivateAssets>all</PrivateAssets>

--- a/Samples/2.3/Blazor/Sample.ServerSide/Pages/Counter.razor
+++ b/Samples/2.3/Blazor/Sample.ServerSide/Pages/Counter.razor
@@ -4,7 +4,7 @@
 
 <p>Current count: @currentCount</p>
 
-<button class="btn btn-primary" onclick="@IncrementCount">Click me</button>
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
 @functions {
     int currentCount = 0;

--- a/Samples/2.3/Blazor/Sample.ServerSide/Pages/FetchData.razor
+++ b/Samples/2.3/Blazor/Sample.ServerSide/Pages/FetchData.razor
@@ -34,7 +34,7 @@ else
     </table>
 }
 
-@functions {
+@code {
 
     ImmutableArray<WeatherInfo> forecasts;
 

--- a/Samples/2.3/Blazor/Sample.ServerSide/Pages/Todo.razor
+++ b/Samples/2.3/Blazor/Sample.ServerSide/Pages/Todo.razor
@@ -9,20 +9,20 @@
     <div class="input-group mb-3">
         <div class="input-group-prepend">
             <div class="input-group-text">
-                <input type="checkbox" checked="@todo.IsDone" onchange="@(async e => await HandleTodoDoneAsync(todo, (bool)e.Value))" />
+                <input type="checkbox" checked="@todo.IsDone" @onchange="@(async e => await HandleTodoDoneAsync(todo, (bool)e.Value))" />
             </div>
-            <button class="btn btn-outline-secondary" type="button" onclick="@(async e => await HandleDeleteTodoAsync(todo))">
+            <button class="btn btn-outline-secondary" type="button" @onclick="@(async e => await HandleDeleteTodoAsync(todo))">
                 <span class="oi oi-trash" aria-hidden="true"></span>
             </button>
         </div>
-        <input class="form-control" value="@todo.Title" onchange="@(async e => await HandleTodoTitleChangeAsync(todo, (string)e.Value))" />
+        <input class="form-control" value="@todo.Title" @onchange="@(async e => await HandleTodoTitleChangeAsync(todo, (string)e.Value))" />
     </div>
 }
 
-<input placeholder="Something todo" bind="@newTodo" />
-<button onclick="@AddTodoAsync">Add Todo</button>
+<input placeholder="Something todo" @bind="@newTodo" />
+<button @onclick="@AddTodoAsync">Add Todo</button>
 
-@functions {
+@code {
 
     private Guid ownerKey = Guid.Empty;
     private TodoKeyedCollection todos = new TodoKeyedCollection();

--- a/Samples/2.3/Blazor/Sample.ServerSide/Pages/Todo.razor
+++ b/Samples/2.3/Blazor/Sample.ServerSide/Pages/Todo.razor
@@ -1,4 +1,4 @@
-﻿@page "/todo"
+@page "/todo"
 @inject TodoService TodoService
 @implements IDisposable
 
@@ -20,7 +20,7 @@
 }
 
 <input placeholder="Something todo" @bind="@newTodo" />
-<button @onclick="@AddTodoAsync">Add Todo</button>
+<button @onclick="AddTodoAsync">Add Todo</button>
 
 @code {
 

--- a/Samples/2.3/Blazor/Sample.ServerSide/Sample.ServerSide.csproj
+++ b/Samples/2.3/Blazor/Sample.ServerSide/Sample.ServerSide.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.3.5" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.3.6" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/2.3/Blazor/Sample.Silo/Api/ApiService.cs
+++ b/Samples/2.3/Blazor/Sample.Silo/Api/ApiService.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Swashbuckle.AspNetCore.Swagger;
 using System.Threading;
@@ -15,10 +16,15 @@ namespace Sample.Silo.Api
     {
         private readonly IWebHost host;
 
-        public ApiService(IGrainFactory factory)
+        public ApiService(IGrainFactory factory, ILoggerProvider loggerProvider)
         {
             host = WebHost
                 .CreateDefaultBuilder()
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddProvider(loggerProvider);
+                })
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton(factory);

--- a/Samples/2.3/Blazor/Sample.Silo/Program.cs
+++ b/Samples/2.3/Blazor/Sample.Silo/Program.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Orleans;
 using Orleans.Hosting;
 using Sample.Grains;
 using Sample.Silo.Api;
-using System.Threading.Tasks;
+using Serilog;
+using Serilog.Events;
 
 namespace Sample.Silo
 {
@@ -22,9 +23,13 @@ namespace Sample.Silo
                 })
                 .ConfigureLogging(builder =>
                 {
-                    builder.AddConsole();
                     builder.AddFilter("Orleans.Runtime.Management.ManagementGrain", LogLevel.Warning);
                     builder.AddFilter("Orleans.Runtime.SiloControl", LogLevel.Warning);
+                    builder.AddSerilog(new LoggerConfiguration()
+                        .WriteTo.Console()
+                        .Filter.ByExcluding(e => e.Properties["SourceContext"].ToString() == @"""Orleans.Runtime.Management.ManagementGrain""" && e.Level < LogEventLevel.Warning)
+                        .Filter.ByExcluding(e => e.Properties["SourceContext"].ToString() == @"""Orleans.Runtime.SiloControl""" && e.Level < LogEventLevel.Warning)
+                        .CreateLogger());
                 })
                 .ConfigureServices(services =>
                 {

--- a/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
+++ b/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0-preview7.19362.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0-preview7.19362.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0-preview7.19362.4" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="2.3.6" />
     <PackageReference Include="OrleansDashboard" Version="2.3.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />

--- a/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
+++ b/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="2.3.5" />
-    <PackageReference Include="OrleansDashboard" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="2.3.6" />
+    <PackageReference Include="OrleansDashboard" Version="2.3.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
 

--- a/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
+++ b/Samples/2.3/Blazor/Sample.Silo/Sample.Silo.csproj
@@ -7,6 +7,10 @@
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;IDE0009</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
@@ -16,6 +20,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0-preview7.19362.4" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="2.3.6" />
     <PackageReference Include="OrleansDashboard" Version="2.3.6" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
 

--- a/Samples/2.3/Blazor/readme.md
+++ b/Samples/2.3/Blazor/readme.md
@@ -2,8 +2,8 @@
 
 Orleans ASP.NET Core Blazor Sample targetting:
 
-* .NET Core 3.0 Preview
-* Blazor 3.0 Preview
+* .NET Core 3.0 Preview 7
+* Blazor 3.0 Preview 7
 * Orleans 2.3.6
 
 This sample demonstrates how to integrate [ASP.NET Core Blazor](https://docs.microsoft.com/en-us/aspnet/core/blazor/?view=aspnetcore-3.0)
@@ -20,8 +20,8 @@ Note that at the time of building this sample, Blazor is still in preview, so ex
 ### Prerequisites
 
 * Visual Studio 2019 Preview
-* .NET Core 3.0 Preview SDK
-* Blazor 3.0 Preview Extensions 
+* .NET Core 3.0 Preview 7 SDK
+* Blazor 3.0 Preview Extensions
 
 ### How To Run
 

--- a/Samples/2.3/Blazor/readme.md
+++ b/Samples/2.3/Blazor/readme.md
@@ -4,7 +4,7 @@ Orleans ASP.NET Core Blazor Sample targetting:
 
 * .NET Core 3.0 Preview
 * Blazor 3.0 Preview
-* Orleans 2.3.5
+* Orleans 2.3.6
 
 This sample demonstrates how to integrate [ASP.NET Core Blazor](https://docs.microsoft.com/en-us/aspnet/core/blazor/?view=aspnetcore-3.0)
 with [Microsoft Orleans](https://dotnet.github.io/orleans/). This demonstrates both client-side and server-side Blazor hosting models.
@@ -15,7 +15,7 @@ The client-side sample application leverages ASP.NET Web API running alongside O
 
 Both applications are based on the [official tutorial](https://docs.microsoft.com/en-us/aspnet/core/tutorials/build-your-first-blazor-app?view=aspnetcore-3.0), adapted to showcase integration with Orleans.
 
-Note that at the time of building this sample, Blazor is still in preview, so expect things to change.
+Note that at the time of building this sample, Blazor is still in preview, so expect things to change and break.
 
 ### Prerequisites
 


### PR DESCRIPTION
This updates the Blazor sample to .NET 3.0 Preview 7 requirements, as per the chat on gitter and #5788.
I expect this to break again but for the time being it appears to function.