### PR TITLE
Improve codegen's .NET Core 3 compatibility

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/runtimeconfig.template.json
+++ b/src/Orleans.CodeGenerator.MSBuild/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Fixes #5793 using @ReubenBond 's instructions.

Successfully compiles a minimal netstandard2.0 project on Linux .NET Core 2.2, 3.0 Preview 7 and a combination of the 2.
Previously this would fail on the 3.0 variant.