### PR TITLE
Introduce support for network protocol versioning

### DIFF
--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,29 +14,33 @@ namespace Orleans.Runtime.Messaging
         private readonly MessageFactory messageFactory;
         private readonly ClientMessageCenter messageCenter;
         private readonly GatewayManager gatewayManager;
+        private readonly ConnectionManager connectionManager;
+        private readonly ConnectionOptions connectionOptions;
 
         public ClientOutboundConnection(
+            SiloAddress remoteSiloAddress,
             ConnectionContext connection,
             ConnectionDelegate middleware,
             MessageFactory messageFactory,
             IServiceProvider serviceProvider,
             ClientMessageCenter messageCenter,
             GatewayManager gatewayManager,
-            INetworkingTrace trace)
+            INetworkingTrace trace,
+            ConnectionManager connectionManager,
+            ConnectionOptions connectionOptions)
             : base(connection, middleware, serviceProvider, trace)
         {
             this.messageFactory = messageFactory;
             this.messageCenter = messageCenter;
             this.gatewayManager = gatewayManager;
-            if (connection.RemoteEndPoint is IPEndPoint ipEndpoint)
-            {
-                this.TargetSilo = SiloAddress.New(ipEndpoint, 0);
-            }
+            this.connectionManager = connectionManager;
+            this.connectionOptions = connectionOptions;
+            this.RemoteSiloAddress = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));
         }
 
         protected override IMessageCenter MessageCenter => this.messageCenter;
-
-        private SiloAddress TargetSilo { get; }
+        
+        public SiloAddress RemoteSiloAddress { get; }
 
         protected override void OnReceivedMessage(Message message)
         {
@@ -70,12 +73,27 @@ namespace Orleans.Runtime.Messaging
             {
                 this.messageCenter.OnGatewayConnectionOpen();
 
-                await ConnectionPreamble.Write(this.Context, this.messageCenter.ClientId, siloAddress: null);
+                await ConnectionPreamble.Write(
+                    this.Context,
+                    this.messageCenter.ClientId,
+                    this.connectionOptions.ProtocolVersion,
+                    siloAddress: null);
+
+                if (this.connectionOptions.ProtocolVersion >= NetworkProtocolVersion.Version2)
+                {
+                    var (_, protocolVersion, siloAddress) = await ConnectionPreamble.Read(this.Context);
+                    this.Log.LogInformation(
+                        "Established connection to {Silo} with protocol version {ProtocolVersion}",
+                        siloAddress,
+                        protocolVersion.ToString());
+                }
+
                 await base.RunInternal();
             }
             finally
             {
-                if (this.TargetSilo != null) this.gatewayManager.MarkAsDead(this.TargetSilo);
+                this.gatewayManager.MarkAsDead(this.RemoteSiloAddress);
+                this.connectionManager.OnConnectionTerminated(this.RemoteSiloAddress, this);
                 this.messageCenter.OnGatewayConnectionClosed();
             }
         }
@@ -94,7 +112,7 @@ namespace Orleans.Runtime.Messaging
 
             if (msg.TargetSilo != null) return true;
 
-            msg.TargetSilo = this.TargetSilo;
+            msg.TargetSilo = this.RemoteSiloAddress;
             if (msg.TargetGrain.IsSystemTarget)
                 msg.TargetActivation = ActivationId.GetSystemActivation(msg.TargetGrain, msg.TargetSilo);
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -215,7 +215,7 @@ namespace Orleans.Runtime.Messaging
                         address);
                 }
 
-                var connection = await this.connectionFactory.ConnectAsync(address.Endpoint, this.cancellation.Token);
+                var connection = await this.connectionFactory.ConnectAsync(address, this.cancellation.Token);
 
                 _ = Task.Run(async () =>
                 {
@@ -244,7 +244,7 @@ namespace Orleans.Runtime.Messaging
                     else
                     {
                         this.trace.LogInformation(
-                            "Connection to endpoint {EndPoint} closed.",
+                            "Connection to endpoint {EndPoint} closed",
                             address);
                     }
                 });

--- a/src/Orleans.Core/Networking/ConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/ConnectionOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Orleans.Networking.Shared;
+using Orleans.Runtime.Messaging;
 
 namespace Orleans.Configuration
 {
@@ -9,7 +10,12 @@ namespace Orleans.Configuration
         private readonly ConnectionBuilderDelegates connectionBuilder = new ConnectionBuilderDelegates();
 
         /// <summary>
-        /// The number of outbound connections to maintain for each endpoint.
+        /// The network protocol version to negotiate with.
+        /// </summary>
+        public NetworkProtocolVersion ProtocolVersion { get; set; } = NetworkProtocolVersion.Version1;
+
+        /// <summary>
+        /// The number of connections to maintain for each endpoint.
         /// </summary>
         public int ConnectionsPerEndpoint { get; set; } = 1;
 

--- a/src/Orleans.Core/Networking/NetworkProtocolVersion.cs
+++ b/src/Orleans.Core/Networking/NetworkProtocolVersion.cs
@@ -1,0 +1,11 @@
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// Identifies a network protocol version.
+    /// </summary>
+    public enum NetworkProtocolVersion : byte
+    {
+        Version1 = 1,
+        Version2 = 2,
+    }
+}

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -14,7 +14,6 @@ namespace Orleans.Runtime.Messaging
     internal abstract class ConnectionListener
     {
         private readonly IConnectionListenerFactory listenerFactory;
-        private readonly ConnectionOptions connectionOptions;
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
         private readonly ConcurrentDictionary<Connection, Task> connections = new ConcurrentDictionary<Connection, Task>(ReferenceEqualsComparer.Instance);
         private readonly INetworkingTrace trace;
@@ -30,7 +29,7 @@ namespace Orleans.Runtime.Messaging
         {
             this.ServiceProvider = serviceProvider;
             this.listenerFactory = listenerFactory;
-            this.connectionOptions = connectionOptions.Value;
+            this.ConnectionOptions = connectionOptions.Value;
             this.trace = trace;
         }
 
@@ -39,6 +38,8 @@ namespace Orleans.Runtime.Messaging
         protected IServiceProvider ServiceProvider { get; }
 
         public int ConnectionCount => this.connections.Count;
+
+        protected ConnectionOptions ConnectionOptions { get; }
 
         protected abstract Connection CreateConnection(ConnectionContext context);
 
@@ -54,7 +55,7 @@ namespace Orleans.Runtime.Messaging
 
                     // Configure the connection builder using the user-defined options.
                     var connectionBuilder = new ConnectionBuilder(this.ServiceProvider);
-                    this.connectionOptions.ConfigureConnectionBuilder(connectionBuilder);
+                    this.ConnectionOptions.ConfigureConnectionBuilder(connectionBuilder);
                     Connection.ConfigureBuilder(connectionBuilder);
                     return this.connectionDelegate = connectionBuilder.Build();
                 }

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -61,6 +61,7 @@ namespace Orleans.Runtime.Messaging
                 this.trace,
                 this.localSiloDetails,
                 this.multiClusterOptions,
+                this.ConnectionOptions,
                 this.messageCenter,
                 this.localSiloDetails,
                 this.siloStatusOracle);

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -174,7 +174,7 @@ namespace Orleans.Runtime.Messaging
                         // Inbound connection
                         var protocolVersion = await ReadPreamble();
 
-                        // To support graceful transition to higher protocol versions, send a preamble the remote endpoint supports it.
+                        // To support graceful transition to higher protocol versions, send a preamble if the remote endpoint supports it.
                         if (protocolVersion >= NetworkProtocolVersion.Version2)
                         {
                             await WritePreamble();
@@ -194,7 +194,7 @@ namespace Orleans.Runtime.Messaging
                         // Inbound connection
                         var protocolVersion = await ReadPreamble();
 
-                        // To support graceful transition from lower protocol versions, only send a preamble the remote endpoint supports it.
+                        // To support graceful transition from lower protocol versions, only send a preamble if the remote endpoint supports it.
                         if (protocolVersion >= NetworkProtocolVersion.Version2)
                         {
                             await WritePreamble();

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -14,10 +14,10 @@ namespace Orleans.Runtime.Messaging
         private readonly MessageFactory messageFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly ConnectionManager connectionManager;
-        private readonly SiloAddress myAddress;
-        private SiloAddress remoteSiloAddress;
+        private readonly ConnectionOptions connectionOptions;
 
         public SiloConnection(
+            SiloAddress remoteSiloAddress,
             ConnectionContext connection,
             ConnectionDelegate middleware,
             IServiceProvider serviceProvider,
@@ -26,17 +26,24 @@ namespace Orleans.Runtime.Messaging
             MessageFactory messageFactory,
             ILocalSiloDetails localSiloDetails,
             ISiloStatusOracle siloStatusOracle,
-            ConnectionManager connectionManager)
+            ConnectionManager connectionManager,
+            ConnectionOptions connectionOptions)
             : base(connection, middleware, serviceProvider, trace)
         {
             this.messageCenter = messageCenter;
             this.messageFactory = messageFactory;
             this.siloStatusOracle = siloStatusOracle;
             this.connectionManager = connectionManager;
-            this.myAddress = localSiloDetails.SiloAddress;
+            this.connectionOptions = connectionOptions;
+            this.LocalSiloAddress = localSiloDetails.SiloAddress;
+            this.RemoteSiloAddress = remoteSiloAddress;
         }
 
         protected override IMessageCenter MessageCenter => this.messageCenter;
+
+        public SiloAddress RemoteSiloAddress { get; private set; }
+
+        public SiloAddress LocalSiloAddress { get; }
 
         protected override void OnReceivedMessage(Message msg)
         {
@@ -158,23 +165,67 @@ namespace Orleans.Runtime.Messaging
         {
             try
             {
-                await Task.WhenAll(ReadPreamble(), WritePreamble());
+                if (this.connectionOptions.ProtocolVersion == NetworkProtocolVersion.Version1)
+                {
+                    // This version of the protocol does not support symmetric preamble, so either send or receive preamble depending on
+                    // Whether or not this is an inbound or outbound connection.
+                    if (this.RemoteSiloAddress is null)
+                    {
+                        // Inbound connection
+                        var protocolVersion = await ReadPreamble();
+
+                        // To support graceful transition to higher protocol versions, send a preamble the remote endpoint supports it.
+                        if (protocolVersion >= NetworkProtocolVersion.Version2)
+                        {
+                            await WritePreamble();
+                        }
+                    }
+                    else
+                    {
+                        // Outbound connection
+                        await WritePreamble();
+                    }
+                }
+                else
+                {
+                    // Later versions of the protocol send and receive preamble at both ends of the connection.
+                    if (this.RemoteSiloAddress is null)
+                    {
+                        // Inbound connection
+                        var protocolVersion = await ReadPreamble();
+
+                        // To support graceful transition from lower protocol versions, only send a preamble the remote endpoint supports it.
+                        if (protocolVersion >= NetworkProtocolVersion.Version2)
+                        {
+                            await WritePreamble();
+                        }
+                    }
+                    else
+                    {
+                        // Outbound connection
+                        await Task.WhenAll(ReadPreamble().AsTask(), WritePreamble());
+                    }
+                }
 
                 await base.RunInternal();
             }
             finally
             {
-                if (!(this.remoteSiloAddress is null)) this.connectionManager.OnConnectionTerminated(this.remoteSiloAddress, this);
+                if (!(this.RemoteSiloAddress is null)) this.connectionManager.OnConnectionTerminated(this.RemoteSiloAddress, this);
             }
 
             async Task WritePreamble()
             {
-                await ConnectionPreamble.Write(this.Context, Constants.SiloDirectConnectionId, this.myAddress);
+                await ConnectionPreamble.Write(
+                    this.Context,
+                    Constants.SiloDirectConnectionId,
+                    this.connectionOptions.ProtocolVersion,
+                    this.LocalSiloAddress);
             }
 
-            async Task ReadPreamble()
+            async ValueTask<NetworkProtocolVersion> ReadPreamble()
             {
-                var (grainId, siloAddress) = await ConnectionPreamble.Read(this.Context);
+                var (grainId, protocolVersion, siloAddress) = await ConnectionPreamble.Read(this.Context);
 
                 if (!grainId.Equals(Constants.SiloDirectConnectionId))
                 {
@@ -183,9 +234,11 @@ namespace Orleans.Runtime.Messaging
 
                 if (siloAddress != null)
                 {
-                    this.remoteSiloAddress = siloAddress;
+                    this.RemoteSiloAddress = siloAddress;
                     this.connectionManager.OnConnected(siloAddress, this);
                 }
+
+                return protocolVersion;
             }
         }
 
@@ -200,7 +253,7 @@ namespace Orleans.Runtime.Messaging
 
             // Fill in the outbound message with our silo address, if it's not already set
             if (msg.SendingSilo == null)
-                msg.SendingSilo = this.myAddress;
+                msg.SendingSilo = this.LocalSiloAddress;
 
             // If we know this silo is dead, don't bother
             if (msg.TargetSilo != null && this.siloStatusOracle.IsDeadSilo(msg.TargetSilo))
@@ -217,14 +270,14 @@ namespace Orleans.Runtime.Messaging
             MessagingStatisticsGroup.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
-                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug(ErrorCode.MessagingSendingRejection, "Silo {SiloAddress} is rejecting message: {Message}. Reason = {Reason}", this.myAddress, msg, reason);
+                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug(ErrorCode.MessagingSendingRejection, "Silo {SiloAddress} is rejecting message: {Message}. Reason = {Reason}", this.LocalSiloAddress, msg, reason);
 
                 // Done retrying, send back an error instead
-                this.messageCenter.SendRejection(msg, Message.RejectionTypes.Transient, $"Silo {this.myAddress} is rejecting message: {msg}. Reason = {reason}");
+                this.messageCenter.SendRejection(msg, Message.RejectionTypes.Transient, $"Silo {this.LocalSiloAddress} is rejecting message: {msg}. Reason = {reason}");
             }
             else
             {
-                this.Log.Info(ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Silo {SiloAddress} is dropping message: {Message}. Reason = {Reason}", this.myAddress, msg, reason);
+                this.Log.Info(ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Silo {SiloAddress} is dropping message: {Message}. Reason = {Reason}", this.LocalSiloAddress, msg, reason);
                 MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }
@@ -288,7 +341,7 @@ namespace Orleans.Runtime.Messaging
                 this.Log.LogWarning(
                     (int)ErrorCode.Messaging_OutgoingMS_DroppingMessage,
                     "Silo {SiloAddress} is dropping message which failed during serialization: {Message}. Exception = {Exception}",
-                    this.myAddress,
+                    this.LocalSiloAddress,
                     msg,
                     exc);
 

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -46,6 +46,7 @@ namespace Orleans.Runtime.Messaging
         protected override Connection CreateConnection(ConnectionContext context)
         {
             return new SiloConnection(
+                default(SiloAddress),
                 context,
                 this.ConnectionDelegate,
                 this.ServiceProvider,
@@ -54,7 +55,8 @@ namespace Orleans.Runtime.Messaging
                 this.messageFactory,
                 this.localSiloDetails,
                 this.siloStatusOracle,
-                this.connectionManager);
+                this.connectionManager,
+                this.ConnectionOptions);
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)


### PR DESCRIPTION
This PR modifies the connection preamble which is sent whenever a connection is established in order to support network protocol versioning in a forward- and backward-compatible manner.

For end-users, the protocol versions can only be incremented or decremented by one per deployment (i.e, no skipping ahead until all nodes are updated to at least version 1 on Orleans 3.0).

The current Orleans protocol does not send a preamble in both directions. Instead, the client/silo establishing the connection sends a preamble and the listening side receives it. This PR expands that behavior so that both sides send a preamble as long as the connecting node's protocol version is at least `Version2`.

This is a 3.0-only change and does not need to be back-ported to 2.x