### PR TITLE
Check that a silo is not known to be dead before attempting a connection

### DIFF
--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -261,7 +261,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        internal void Remove(SiloAddress siloAddress, Connection connection)
+        private void Remove(SiloAddress siloAddress, Connection connection)
         {
             if (connection is null) return;
 

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -15,7 +15,6 @@ namespace Orleans.Runtime.Messaging
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IOptions<MultiClusterOptions> multiClusterOptions;
         private readonly MessageCenter messageCenter;
-        private readonly ISiloStatusOracle siloStatusOracle;
         private readonly EndpointOptions endpointOptions;
         private readonly MessageFactory messageFactory;
         private readonly OverloadDetector overloadDetector;
@@ -32,8 +31,7 @@ namespace Orleans.Runtime.Messaging
             ILocalSiloDetails localSiloDetails,
             IOptions<MultiClusterOptions> multiClusterOptions,
             IOptions<EndpointOptions> endpointOptions,
-            MessageCenter messageCenter,
-            ISiloStatusOracle siloStatusOracle)
+            MessageCenter messageCenter)
             : base(serviceProvider, listenerFactory, connectionOptions, trace)
         {
             this.messageFactory = messageFactory;
@@ -43,7 +41,6 @@ namespace Orleans.Runtime.Messaging
             this.localSiloDetails = localSiloDetails;
             this.multiClusterOptions = multiClusterOptions;
             this.messageCenter = messageCenter;
-            this.siloStatusOracle = siloStatusOracle;
             this.endpointOptions = endpointOptions.Value;
         }
 
@@ -63,8 +60,7 @@ namespace Orleans.Runtime.Messaging
                 this.multiClusterOptions,
                 this.ConnectionOptions,
                 this.messageCenter,
-                this.localSiloDetails,
-                this.siloStatusOracle);
+                this.localSiloDetails);
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
@@ -10,7 +10,6 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
-        private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IServiceProvider serviceProvider;
         private readonly MessageFactory messageFactory;
         private readonly object initializationLock = new object();
@@ -24,15 +23,13 @@ namespace Orleans.Runtime.Messaging
             IConnectionFactory connectionFactory,
             MessageFactory messageFactory,
             INetworkingTrace trace,
-            ILocalSiloDetails localSiloDetails,
-            ISiloStatusOracle siloStatusOracle)
+            ILocalSiloDetails localSiloDetails)
             : base(connectionFactory, serviceProvider, connectionOptions)
         {
             this.serviceProvider = serviceProvider;
             this.messageFactory = messageFactory;
             this.trace = trace;
             this.localSiloDetails = localSiloDetails;
-            this.siloStatusOracle = siloStatusOracle;
         }
 
         protected override Connection CreateConnection(SiloAddress address, ConnectionContext context)
@@ -48,7 +45,6 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter,
                 this.messageFactory,
                 this.localSiloDetails,
-                this.siloStatusOracle,
                 this.connectionManager,
                 this.ConnectionOptions);
         }

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -13,7 +13,6 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
-        private readonly ISiloStatusOracle siloStatusOracle;
         private readonly MessageCenter messageCenter;
         private readonly MessageFactory messageFactory;
         private readonly EndpointOptions endpointOptions;
@@ -28,7 +27,6 @@ namespace Orleans.Runtime.Messaging
             INetworkingTrace trace,
             IOptions<EndpointOptions> endpointOptions,
             ILocalSiloDetails localSiloDetails,
-            ISiloStatusOracle siloStatusOracle,
             ConnectionManager connectionManager)
             : base(serviceProvider, listenerFactory, connectionOptions, trace)
         {
@@ -36,7 +34,6 @@ namespace Orleans.Runtime.Messaging
             this.messageFactory = messageFactory;
             this.trace = trace;
             this.localSiloDetails = localSiloDetails;
-            this.siloStatusOracle = siloStatusOracle;
             this.connectionManager = connectionManager;
             this.endpointOptions = endpointOptions.Value;
         }
@@ -54,7 +51,6 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter,
                 this.messageFactory,
                 this.localSiloDetails,
-                this.siloStatusOracle,
                 this.connectionManager,
                 this.ConnectionOptions);
         }


### PR DESCRIPTION
This also removes checks for dead silos from other locations, since those are not needed & can cause issues during shutdown in test scenarios (where SystemTargetBasedMembership is used)