### PR TITLE
Terminate ConfirmationWorker loop on deactivation

### DIFF
--- a/src/Orleans.Transactions.TestkitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
+++ b/src/Orleans.Transactions.TestkitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
@@ -37,17 +37,14 @@ namespace Orleans.Transactions.TestKit
     public class FaultInjectionTransactionalStateFactory : IFaultInjectionTransactionalStateFactory
     {
         private IGrainActivationContext context;
-        private JsonSerializerSettings serializerSettings;
-        public FaultInjectionTransactionalStateFactory(IGrainActivationContext context, ITypeResolver typeResolver, IGrainFactory grainFactory)
+        public FaultInjectionTransactionalStateFactory(IGrainActivationContext context)
         {
             this.context = context;
-            this.serializerSettings =
-                TransactionalStateFactory.GetJsonSerializerSettings(typeResolver, grainFactory);
         }
 
         public IFaultInjectionTransactionalState<TState> Create<TState>(IFaultInjectionTransactionalStateConfiguration config) where TState : class, new()
         {
-            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, new TransactionalStateConfiguration(config), this.serializerSettings, this.context);
+            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, new TransactionalStateConfiguration(config), this.context);
             FaultInjectionTransactionalState<TState> deactivationTransactionalState = ActivatorUtilities.CreateInstance<FaultInjectionTransactionalState<TState>>(this.context.ActivationServices, transactionalState, this.context);
             deactivationTransactionalState.Participate(context.ObservableLifecycle);
             return deactivationTransactionalState;

--- a/src/Orleans.Transactions/State/ActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/ActivationLifetime.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.Transactions.State
+{
+    internal class ActivationLifetime : IActivationLifetime, ILifecycleObserver
+    {
+        private readonly CancellationTokenSource onDeactivating = new CancellationTokenSource();
+
+        private int pendingDeactivationLocks;
+
+        public ActivationLifetime(IGrainActivationContext activationContext)
+        {
+            activationContext.ObservableLifecycle.Subscribe(GrainLifecycleStage.Activate, this);
+        }
+
+        public CancellationToken OnDeactivating => this.onDeactivating.Token;
+
+        public Task OnStart(CancellationToken ct) => Task.CompletedTask;
+
+        public Task OnStop(CancellationToken ct)
+        {
+            this.onDeactivating.Cancel(throwOnFirstException: false);
+
+            if (!ct.IsCancellationRequested && pendingDeactivationLocks > 0)
+            {
+                return OnStopAsync(ct);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task OnStopAsync(CancellationToken ct)
+        {
+            var startTime = DateTime.UtcNow;
+            var maxTime = TimeSpan.FromSeconds(5);
+            while (!ct.IsCancellationRequested && pendingDeactivationLocks > 0 && DateTime.UtcNow - startTime < maxTime)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            }
+        }
+
+        public IDisposable BlockDeactivation() => new BlockDeactivationDisposable(this);
+
+        private class BlockDeactivationDisposable : IDisposable
+        {
+            private readonly ActivationLifetime owner;
+
+            public BlockDeactivationDisposable(ActivationLifetime owner)
+            {
+                this.owner = owner;
+                Interlocked.Increment(ref owner.pendingDeactivationLocks);
+            }
+
+            public void Dispose()
+            {
+                Interlocked.Decrement(ref owner.pendingDeactivationLocks);
+            }
+        }
+    }
+}

--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -21,9 +21,17 @@ namespace Orleans.Transactions.State
         private readonly Func<StorageBatch<TState>> getStorageBatch;
         private readonly ILogger logger;
         private readonly ITimerManager timerManager;
+        private readonly IActivationLifetime activationLifetime;
         private readonly HashSet<Guid> pending;
 
-        public ConfirmationWorker(IOptions<TransactionalStateOptions> options, ParticipantId me, BatchWorker storageWorker, Func<StorageBatch<TState>> getStorageBatch, ILogger logger, ITimerManager timerManager)
+        public ConfirmationWorker(
+            IOptions<TransactionalStateOptions> options,
+            ParticipantId me,
+            BatchWorker storageWorker,
+            Func<StorageBatch<TState>> getStorageBatch,
+            ILogger logger,
+            ITimerManager timerManager,
+            IActivationLifetime activationLifetime)
         {
             this.options = options.Value;
             this.me = me;
@@ -31,12 +39,13 @@ namespace Orleans.Transactions.State
             this.getStorageBatch = getStorageBatch;
             this.logger = logger;
             this.timerManager = timerManager;
+            this.activationLifetime = activationLifetime;
             this.pending = new HashSet<Guid>();
         }
 
         public void Add(Guid transactionId, DateTime timestamp, List<ParticipantId> participants)
         {
-            if(!IsConfirmed(transactionId))
+            if (!IsConfirmed(transactionId))
             {
                 this.pending.Add(transactionId);
                 SendConfirmation(transactionId, timestamp, participants).Ignore();
@@ -67,18 +76,36 @@ namespace Orleans.Transactions.State
                         this.logger))
                     .ToList();
 
+            if (confirmations.Count == 0) return;
+
             // attempts to confirm all, will retry every ConfirmationRetryDelay until all succeed
-            while ((await Task.WhenAll(confirmations.Select(c => c.Confirmed()))).Any(b => !b))
+            var ct = this.activationLifetime.OnDeactivating;
+            while (!ct.IsCancellationRequested && await HasPendingConfirmations(confirmations))
             {
-               await this.timerManager.Delay(this.options.ConfirmationRetryDelay);
+                await this.timerManager.Delay(this.options.ConfirmationRetryDelay);
+            }
+
+            async Task<bool> HasPendingConfirmations(List<Confirmation> values)
+            {
+                using (this.activationLifetime.BlockDeactivation())
+                {
+                    var results = await Task.WhenAll(confirmations.Select(c => c.Confirmed()));
+                    return results.Any(b => !b);
+                }
             }
         }
 
         // retries collect until it succeeds
         private async Task Collect(Guid transactionId)
         {
-            while (!await TryCollect(transactionId))
+            var ct = this.activationLifetime.OnDeactivating;
+            while (!ct.IsCancellationRequested)
             {
+                using (this.activationLifetime.BlockDeactivation())
+                {
+                    if (await TryCollect(transactionId)) break;
+                }
+
                 await this.timerManager.Delay(this.options.ConfirmationRetryDelay);
             }
         }
@@ -145,7 +172,8 @@ namespace Orleans.Transactions.State
                 {
                     await this.pending;
                     this.complete = true;
-                } catch(Exception ex)
+                }
+                catch (Exception ex)
                 {
                     this.pending = null;
                     logger.LogWarning(ex, "Confirmation of transaction {TransactionId} with timestamp {Timestamp} to participant {Participant} failed.  Retrying", this.transactionId, this.timestamp, this.participant);

--- a/src/Orleans.Transactions/State/IActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/IActivationLifetime.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+
+namespace Orleans.Transactions.State
+{
+    internal interface IActivationLifetime
+    {
+        CancellationToken OnDeactivating { get; }
+
+        IDisposable BlockDeactivation();
+    }
+}

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using Orleans.Storage;
@@ -54,7 +53,8 @@ namespace Orleans.Transactions.State
             ITransactionalStateStorage<TState> storage,
             IClock clock,
             ILogger logger,
-            ITimerManager timerManager)
+            ITimerManager timerManager,
+            IActivationLifetime activationLifetime)
         {
             this.options = options.Value;
             this.resource = resource;
@@ -64,7 +64,7 @@ namespace Orleans.Transactions.State
             this.logger = logger;
             this.storageWorker = new BatchWorkerFromDelegate(StorageWork);
             this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger);
-            this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager);
+            this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager, activationLifetime);
             this.unprocessedPreparedMessages = new Dictionary<DateTime, PreparedMessages>();
             this.commitQueue = new CommitQueue<TState>();
             this.readyTask = Task.CompletedTask;

--- a/src/Orleans.Transactions/State/TransactionalStateFactory.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateFactory.cs
@@ -9,16 +9,14 @@ namespace Orleans.Transactions
     public class TransactionalStateFactory : ITransactionalStateFactory
     {
         private IGrainActivationContext context;
-        private JsonSerializerSettings serializerSettings;
-        public TransactionalStateFactory(IGrainActivationContext context, ITypeResolver typeResolver, IGrainFactory grainFactory)
+        public TransactionalStateFactory(IGrainActivationContext context)
         {
             this.context = context;
-            this.serializerSettings = GetJsonSerializerSettings(typeResolver, grainFactory);
         }
 
         public ITransactionalState<TState> Create<TState>(TransactionalStateConfiguration config) where TState : class, new()
         {
-            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, config, this.serializerSettings, this.context);
+            TransactionalState<TState> transactionalState = ActivatorUtilities.CreateInstance<TransactionalState<TState>>(this.context.ActivationServices, config, this.context);
             transactionalState.Participate(context.ObservableLifecycle);
             return transactionalState;
         }

--- a/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
+++ b/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Orleans.Configuration;
 using Orleans.Timers.Internal;
 using Orleans.Transactions.Abstractions;
@@ -20,11 +19,11 @@ namespace Orleans.Transactions.TOC
             ParticipantId resource,
             Action deactivate,
             ITransactionalStateStorage<TransactionCommitter<TService>.OperationState> storage,
-            JsonSerializerSettings serializerSettings,
             IClock clock,
             ILogger logger,
-            ITimerManager timerManager)
-            : base(options, resource, deactivate, storage, clock, logger, timerManager)
+            ITimerManager timerManager,
+            IActivationLifetime activationLifetime)
+            : base(options, resource, deactivate, storage, clock, logger, timerManager, activationLifetime)
         {
             this.service = service;
         }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -4,10 +4,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Orleans.CodeGeneration;
 using Orleans.Configuration;
-using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Timers.Internal;
 using Orleans.Transactions.Abstractions;
@@ -24,11 +22,9 @@ namespace Orleans.Transactions
         private readonly ITransactionCommitterConfiguration config;
         private readonly IGrainActivationContext context;
         private readonly ITransactionDataCopier<OperationState> copier;
-        private readonly IProviderRuntime runtime;
         private readonly IGrainRuntime grainRuntime;
         private readonly ILoggerFactory loggerFactory;
-        private readonly JsonSerializerSettings serializerSettings;
-
+        private readonly ActivationLifetime activationLifetime;
         private ILogger logger;
         private ParticipantId participantId;
         private TransactionQueue<OperationState> queue;
@@ -39,19 +35,15 @@ namespace Orleans.Transactions
             ITransactionCommitterConfiguration config,
             IGrainActivationContext context,
             ITransactionDataCopier<OperationState> copier,
-            IProviderRuntime runtime,
             IGrainRuntime grainRuntime,
-            ILoggerFactory loggerFactory,
-            JsonSerializerSettings serializerSettings
-            )
+            ILoggerFactory loggerFactory)
         {
             this.config = config;
             this.context = context;
             this.copier = copier;
-            this.runtime = runtime;
             this.grainRuntime = grainRuntime;
             this.loggerFactory = loggerFactory;
-            this.serializerSettings = serializerSettings;
+            this.activationLifetime = new ActivationLifetime(this.context);
         }
 
         /// <inheritdoc/>
@@ -148,7 +140,7 @@ namespace Orleans.Transactions
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
             TService service = this.context.ActivationServices.GetRequiredServiceByName<TService>(this.config.ServiceName);
             var timerManager = this.context.ActivationServices.GetRequiredService<ITimerManager>();
-            this.queue = new TocTransactionQueue<TService>(service, options, this.participantId, deactivate, storage, this.serializerSettings, clock, logger, timerManager);
+            this.queue = new TocTransactionQueue<TService>(service, options, this.participantId, deactivate, storage, clock, logger, timerManager, this.activationLifetime);
 
             // Add transaction manager factory to the grain context
             this.context.RegisterResourceFactory<ITransactionManager>(this.config.ServiceName, () => new TransactionManager<OperationState>(this.queue));

--- a/src/Orleans.Transactions/TOC/TransactionCommitterFactory.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitterFactory.cs
@@ -1,6 +1,5 @@
-﻿
+
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 
@@ -9,16 +8,15 @@ namespace Orleans.Transactions
     public class TransactionCommitterFactory : ITransactionCommitterFactory
     {
         private IGrainActivationContext context;
-        private JsonSerializerSettings serializerSettings;
-        public TransactionCommitterFactory(IGrainActivationContext context, ITypeResolver typeResolver, IGrainFactory grainFactory)
+
+        public TransactionCommitterFactory(IGrainActivationContext context)
         {
             this.context = context;
-            this.serializerSettings = TransactionalStateFactory.GetJsonSerializerSettings(typeResolver, grainFactory);
         }
 
         public ITransactionCommitter<TService> Create<TService>(ITransactionCommitterConfiguration config) where TService : class
         {
-            TransactionCommitter<TService> transactionalState = ActivatorUtilities.CreateInstance<TransactionCommitter<TService>>(this.context.ActivationServices, config, this.serializerSettings, this.context);
+            TransactionCommitter<TService> transactionalState = ActivatorUtilities.CreateInstance<TransactionCommitter<TService>>(this.context.ActivationServices, config, this.context);
             transactionalState.Participate(context.ObservableLifecycle);
             return transactionalState;
         }


### PR DESCRIPTION
An implicit assumption in the ConfirmationWorker (part of Transactions) was that async tasks would stop executing when a grain was deactivated. However, since #5588 we are continuing to execute Tasks scheduled against deactivated grains.

This resulted in tasks continually being scheduled against a deactivated grain, causing a significant amount of log noise.