### PR TITLE
Reject failed activations and fix possible race condition

### DIFF
--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -440,6 +440,7 @@ namespace Orleans
         Catalog_FinishGrainDeactivateAndCleanupStreams_Exception = CatalogBase + 44,
         Catalog_DeactivateAllActivations                = CatalogBase + 45,
         Catalog_ActivationCollector_BadState_3          = CatalogBase + 46,
+        Catalog_UnregisterAsync                         = CatalogBase + 47,
 
         MembershipBase                         = Runtime + 600,
         MembershipCantWriteLivenessDisabled    = Runtime_Error_100225, // Backward compatability

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -400,6 +400,7 @@ namespace Orleans.Runtime
             Success,
             ErrorInvalidActivation,
             ErrorStuckActivation,
+            ErrorActivateFailed,
         }
 
         /// <summary>
@@ -415,6 +416,12 @@ namespace Orleans.Runtime
                     logger.Warn(ErrorCode.Dispatcher_InvalidActivation,
                         "Cannot enqueue message to invalid activation {0} : {1}", this.ToDetailedString(), message);
                     return EnqueueMessageResult.ErrorInvalidActivation;
+                }
+                if (State == ActivationState.FailedToActivate)
+                {
+                    logger.Warn(ErrorCode.Dispatcher_InvalidActivation,
+                        "Cannot enqueue message to activation that failed in OnActivate {0} : {1}", this.ToDetailedString(), message);
+                    return EnqueueMessageResult.ErrorActivateFailed;
                 }
                 if (State == ActivationState.Deactivating)
                 {

--- a/src/Orleans.Runtime/Catalog/ActivationState.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationState.cs
@@ -6,24 +6,29 @@ namespace Orleans.Runtime
         /// Activation is being created
         /// </summary>
         Create,
+        
         ///// <summary>
         ///// Activation is in the middle of activation process.
         ///// </summary>
         Activating,
+        
         /// <summary>
         /// Activation was successfully activated and ready to process requests.
         /// </summary>
         Valid,
+        
         ///// <summary>
         ///// Activation is in the middle of deactivation process.
         ///// </summary>
         Deactivating,
+        
         /// <summary>
-        /// Tombstone for activation that is not registered in the Directory
+        /// Tombstone for an activation which has terminated.
         /// </summary>
         Invalid,
+        
         /// <summary>
-        /// Tombstone for activation that threw an exception in OnActivateAsync
+        /// Tombstone for an activation that threw an exception during activation.
         /// </summary>
         FailedToActivate,
     }

--- a/src/Orleans.Runtime/Catalog/ActivationState.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationState.cs
@@ -1,4 +1,4 @@
-﻿namespace Orleans.Runtime
+namespace Orleans.Runtime
 {
     internal enum ActivationState
     {
@@ -19,8 +19,12 @@
         ///// </summary>
         Deactivating,
         /// <summary>
-        /// Tombstone for activation that was unable to be properly created
+        /// Tombstone for activation that is not registered in the Directory
         /// </summary>
         Invalid,
+        /// <summary>
+        /// Tombstone for activation that threw an exception in OnActivateAsync
+        /// </summary>
+        FailedToActivate,
     }
 }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -548,8 +548,6 @@ namespace Orleans.Runtime
                     return;
                 }
 
-                initStage = ActivationInitializationStage.SetupState;
-
                 initStage = ActivationInitializationStage.InvokeActivate;
                 await InvokeActivate(activation, requestContextData);
 
@@ -640,21 +638,6 @@ namespace Orleans.Runtime
                             RerouteAllQueuedMessages(activation, null,
                                 "Failed RegisterActivationInGrainDirectory", exception);
                         }
-                        break;
-
-                    case ActivationInitializationStage.SetupState: // failed to setup persistent state
-
-                        logger.Warn(ErrorCode.Catalog_Failed_SetupActivationState,
-                            string.Format("Failed to SetupActivationState for {0}.", activation), exception);
-                        // Need to undo the registration we just did earlier
-                        if (activation.IsUsingGrainDirectory)
-                        {
-                            scheduler.RunOrQueueTask(
-                                () => directory.UnregisterAsync(address, UnregistrationCause.Force),
-                                SchedulingContext).Ignore();
-                        }
-
-                        RerouteAllQueuedMessages(activation, null, "Failed SetupActivationState", exception);
                         break;
 
                     case ActivationInitializationStage.InvokeActivate: // failed to InvokeActivate

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -74,6 +74,8 @@ namespace Orleans.Runtime
         internal ISiloStatusOracle SiloStatusOracle { get; set; }
         private readonly ActivationCollector activationCollector;
 
+        private static readonly TimeSpan UnregisterTimeout = TimeSpan.FromSeconds(1);
+
         private readonly ILocalGrainDirectory directory;
         private readonly OrleansTaskScheduler scheduler;
         private readonly ActivationDirectory activations;
@@ -97,6 +99,7 @@ namespace Orleans.Runtime
         private readonly ILoggerFactory loggerFactory;
         private readonly IOptions<GrainCollectionOptions> collectionOptions;
         private readonly IOptions<SiloMessagingOptions> messagingOptions;
+
         public Catalog(
             ILocalSiloDetails localSiloDetails,
             ILocalGrainDirectory grainDirectory,
@@ -544,7 +547,7 @@ namespace Orleans.Runtime
                 if (!registrationResult.IsSuccess)
                 {
                     // If registration failed, recover and bail out.
-                    RecoverFailedInitActivation(activation, initStage, registrationResult);
+                    await RecoverFailedInitActivation(activation, initStage, registrationResult);
                     return;
                 }
 
@@ -559,7 +562,7 @@ namespace Orleans.Runtime
             }
             catch (Exception ex)
             {
-                RecoverFailedInitActivation(activation, initStage, exception: ex);
+                await RecoverFailedInitActivation(activation, initStage, exception: ex);
                 throw;
             }
         }
@@ -571,91 +574,87 @@ namespace Orleans.Runtime
         /// <param name="initStage">The initialization stage at which initialization failed.</param>
         /// <param name="registrationResult">The result of registering the activation with the grain directory.</param>
         /// <param name="exception">The exception, if present, for logging purposes.</param>
-        private void RecoverFailedInitActivation(
+        private async Task RecoverFailedInitActivation(
             ActivationData activation,
             ActivationInitializationStage initStage,
             ActivationRegistrationResult registrationResult = default(ActivationRegistrationResult),
             Exception exception = null)
         {
             ActivationAddress address = activation.Address;
-            lock (activation)
+
+            if (initStage == ActivationInitializationStage.Register && registrationResult.ExistingActivationAddress != null)
             {
-                activation.SetState(ActivationState.Invalid);
-                try
+                // Another activation is registered in the directory: let's forward everything
+                lock (activation)
                 {
-                    UnregisterMessageTarget(activation);
-                }
-                catch (Exception exc)
-                {
-                    logger.Warn(ErrorCode.Catalog_UnregisterMessageTarget4, $"UnregisterMessageTarget failed on {activation}.", exc);
-                }
-
-                switch (initStage)
-                {
-                    case ActivationInitializationStage.Register: // failed to RegisterActivationInGrainDirectory
-
-                        // Failure!! Could it be that this grain uses single activation placement, and there already was an activation?
-                        // If the registration result is not set, the forwarding address will be null.
-                        activation.ForwardingAddress = registrationResult.ExistingActivationAddress;
-                        if (activation.ForwardingAddress != null)
+                    activation.SetState(ActivationState.Invalid);
+                    activation.ForwardingAddress = registrationResult.ExistingActivationAddress;
+                    if (activation.ForwardingAddress != null)
+                    {
+                        CounterStatistic
+                            .FindOrCreate(StatisticNames.CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS)
+                            .Increment();
+                        var primary = directory.GetPrimaryForGrain(activation.ForwardingAddress.Grain);
+                        if (logger.IsEnabled(LogLevel.Information))
                         {
-                            CounterStatistic
-                                .FindOrCreate(StatisticNames.CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS)
-                                .Increment();
-                            var primary = directory.GetPrimaryForGrain(activation.ForwardingAddress.Grain);
-                            if (logger.IsEnabled(LogLevel.Information))
-                            {
-                                // If this was a duplicate, it's not an error, just a race.
-                                // Forward on all of the pending messages, and then forget about this activation.
-                                var logMsg =
-                                    $"Tried to create a duplicate activation {address}, but we'll use {activation.ForwardingAddress} instead. " +
-                                    $"GrainInstanceType is {activation.GrainInstanceType}. " +
-                                    $"{(primary != null ? "Primary Directory partition for this grain is " + primary + ". " : string.Empty)}" +
-                                    $"Full activation address is {address.ToFullString()}. We have {activation.WaitingCount} messages to forward.";
-                                if (activation.IsUsingGrainDirectory)
-                                {
-                                    logger.Info(ErrorCode.Catalog_DuplicateActivation, logMsg);
-                                }
-                                else
-                                {
-                                    logger.Debug(ErrorCode.Catalog_DuplicateActivation, logMsg);
-                                }
-                            }
-
-                            RerouteAllQueuedMessages(activation, activation.ForwardingAddress, "Duplicate activation", exception);
-                        }
-                        else
-                        {
-                            logger.Warn(ErrorCode.Runtime_Error_100064,
-                                $"Failed to RegisterActivationInGrainDirectory for {activation}.", exception);
-                            // Need to undo the registration we just did earlier
+                            // If this was a duplicate, it's not an error, just a race.
+                            // Forward on all of the pending messages, and then forget about this activation.
+                            var logMsg =
+                                $"Tried to create a duplicate activation {address}, but we'll use {activation.ForwardingAddress} instead. " +
+                                $"GrainInstanceType is {activation.GrainInstanceType}. " +
+                                $"{(primary != null ? "Primary Directory partition for this grain is " + primary + ". " : string.Empty)}" +
+                                $"Full activation address is {address.ToFullString()}. We have {activation.WaitingCount} messages to forward.";
                             if (activation.IsUsingGrainDirectory)
                             {
-                                scheduler.RunOrQueueTask(
-                                    () => directory.UnregisterAsync(address, UnregistrationCause.Force),
-                                    SchedulingContext).Ignore();
+                                logger.Info(ErrorCode.Catalog_DuplicateActivation, logMsg);
                             }
-                            RerouteAllQueuedMessages(activation, null,
-                                "Failed RegisterActivationInGrainDirectory", exception);
-                        }
-                        break;
-
-                    case ActivationInitializationStage.InvokeActivate: // failed to InvokeActivate
-
-                        logger.Warn(ErrorCode.Catalog_Failed_InvokeActivate,
-                            string.Format("Failed to InvokeActivate for {0}.", activation), exception);
-                        // Need to undo the registration we just did earlier
-                        if (activation.IsUsingGrainDirectory)
-                        {
-                            scheduler.RunOrQueueTask(
-                                () => directory.UnregisterAsync(address, UnregistrationCause.Force),
-                                SchedulingContext).Ignore();
+                            else
+                            {
+                                logger.Debug(ErrorCode.Catalog_DuplicateActivation, logMsg);
+                            }
                         }
 
+                        UnregisterMessageTarget(activation);
+                        RerouteAllQueuedMessages(activation, activation.ForwardingAddress, "Duplicate activation", exception);
+                    }
+                }
+            }
+            else
+            {
+                // Before anything let's unregister the activation from the directory, so other silo don't keep sending message to it
+                if (activation.IsUsingGrainDirectory)
+                {
+                    try
+                    {
+                        await this.scheduler.RunOrQueueTask(
+                                    () => directory.UnregisterAsync(address, UnregistrationCause.Force),
+                                    SchedulingContext).WithTimeout(UnregisterTimeout);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Warn(
+                            ErrorCode.Catalog_UnregisterAsync,
+                            $"Failed to unregister activation {activation} after {initStage} stage failed",
+                            ex);
+                    }
+                }
+                lock (activation)
+                {
+                    UnregisterMessageTarget(activation);
+                    if (initStage == ActivationInitializationStage.InvokeActivate)
+                    {
+                        activation.SetState(ActivationState.FailedToActivate);
+                        logger.Warn(ErrorCode.Catalog_Failed_InvokeActivate, string.Format("Failed to InvokeActivate for {0}.", activation), exception);
                         // Reject all of the messages queued for this activation.
                         var activationFailedMsg = nameof(Grain.OnActivateAsync) + " failed";
                         RejectAllQueuedMessages(activation, activationFailedMsg, exception);
-                        break;
+                    }
+                    else
+                    {
+                        activation.SetState(ActivationState.Invalid);
+                        logger.Warn(ErrorCode.Runtime_Error_100064, $"Failed to RegisterActivationInGrainDirectory for {activation}.", exception);
+                        RerouteAllQueuedMessages(activation, null, "Failed RegisterActivationInGrainDirectory", exception);
+                    }
                 }
             }
         }
@@ -1139,8 +1138,6 @@ namespace Orleans.Runtime
             {
                 logger.Error(ErrorCode.Catalog_ErrorCallingActivate,
                     string.Format("Error calling grain's OnActivateAsync() method - Grain type = {1} Activation = {0}", activation, grainTypeName), exc);
-
-                activation.SetState(ActivationState.Invalid); // Mark this activation as unusable
 
                 activationsFailedToActivate.Increment();
 

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -262,15 +262,7 @@ namespace Orleans.Runtime
         {
             lock (targetActivation)
             {
-                if (targetActivation.State == ActivationState.Invalid)
-                {
-                    ProcessRequestToInvalidActivation(
-                        message,
-                        targetActivation.Address,
-                        targetActivation.ForwardingAddress,
-                        "ReceiveRequest");
-                }
-                else if (!ActivationMayAcceptRequest(targetActivation, message))
+                if (!ActivationMayAcceptRequest(targetActivation, message))
                 {
                     // Check for deadlock before Enqueueing.
                     if (schedulingOptions.PerformDeadlockDetection && !message.TargetGrain.IsSystemTarget)

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -416,7 +416,15 @@ namespace Orleans.Runtime
                     var compatibilityDirector = compatibilityDirectorManager.GetDirector(request.InterfaceId);
                     var currentVersion = catalog.GrainTypeManager.GetLocalSupportedVersion(request.InterfaceId);
                     if (!compatibilityDirector.IsCompatible(request.InterfaceVersion, currentVersion))
+                    {
                         catalog.DeactivateActivationOnIdle(targetActivation);
+                        ProcessRequestToInvalidActivation(
+                            message,
+                            targetActivation.Address,
+                            targetActivation.ForwardingAddress,
+                            "HandleIncomingRequest - Incompatible request");
+                        return;
+                    }
                 }
 
                 // Now we can actually scheduler processing of this request

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -399,6 +399,17 @@ namespace Orleans.Runtime
         {
             lock (targetActivation)
             {
+                if (targetActivation.State == ActivationState.Invalid || targetActivation.State == ActivationState.FailedToActivate)
+                {
+                    ProcessRequestToInvalidActivation(
+                        message,
+                        targetActivation.Address,
+                        targetActivation.ForwardingAddress,
+                        "HandleIncomingRequest",
+                        rejectMessages: targetActivation.State == ActivationState.FailedToActivate);
+                    return;
+                }
+
                 if (targetActivation.Grain.IsGrain && message.IsUsingInterfaceVersions)
                 {
                     var request = (InvokeMethodRequest)message.BodyObject;
@@ -406,12 +417,6 @@ namespace Orleans.Runtime
                     var currentVersion = catalog.GrainTypeManager.GetLocalSupportedVersion(request.InterfaceId);
                     if (!compatibilityDirector.IsCompatible(request.InterfaceVersion, currentVersion))
                         catalog.DeactivateActivationOnIdle(targetActivation);
-                }
-
-                if (targetActivation.State == ActivationState.Invalid || targetActivation.State == ActivationState.Deactivating)
-                {
-                    ProcessRequestToInvalidActivation(message, targetActivation.Address, targetActivation.ForwardingAddress, "HandleIncomingRequest");
-                    return;
                 }
 
                 // Now we can actually scheduler processing of this request
@@ -445,6 +450,9 @@ namespace Orleans.Runtime
                 case ActivationData.EnqueueMessageResult.ErrorInvalidActivation:
                     ProcessRequestToInvalidActivation(message, targetActivation.Address, targetActivation.ForwardingAddress, "EnqueueRequest");
                     break;
+                case ActivationData.EnqueueMessageResult.ErrorActivateFailed:
+                    ProcessRequestToInvalidActivation(message, targetActivation.Address, targetActivation.ForwardingAddress, "EnqueueRequest", rejectMessages: true);
+                    break;
                 case ActivationData.EnqueueMessageResult.ErrorStuckActivation:
                     // Avoid any new call to this activation
                     catalog.DeactivateStuckActivation(targetActivation);
@@ -468,8 +476,9 @@ namespace Orleans.Runtime
             Message message, 
             ActivationAddress oldAddress, 
             ActivationAddress forwardingAddress, 
-            string failedOperation, 
-            Exception exc = null)
+            string failedOperation,
+            Exception exc = null,
+            bool rejectMessages = false)
         {
             // Just use this opportunity to invalidate local Cache Entry as well. 
             if (oldAddress != null)
@@ -477,9 +486,18 @@ namespace Orleans.Runtime
                 this.localGrainDirectory.InvalidateCacheEntry(oldAddress);
             }
             // IMPORTANT: do not do anything on activation context anymore, since this activation is invalid already.
-            scheduler.QueueWorkItem(new ClosureWorkItem(
-                () => TryForwardRequest(message, oldAddress, forwardingAddress, failedOperation, exc)),
-                catalog.SchedulingContext);
+            if (rejectMessages)
+            {
+                scheduler.QueueWorkItem(new ClosureWorkItem(
+                    () => RejectMessage(message, Message.RejectionTypes.Transient, exc, failedOperation)),
+                    catalog.SchedulingContext);
+            }
+            else
+            {
+                scheduler.QueueWorkItem(new ClosureWorkItem(
+                    () => TryForwardRequest(message, oldAddress, forwardingAddress, failedOperation, exc)),
+                    catalog.SchedulingContext);
+            }
         }
 
         internal void ProcessRequestsToInvalidActivation(

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -240,8 +240,8 @@ namespace Orleans.Runtime
             {
                 if (targetActivation.State == ActivationState.Invalid || targetActivation.State == ActivationState.FailedToActivate)
                 {
-                    logger.Warn(ErrorCode.Dispatcher_Receive_InvalidActivation,
-                        "Response received for {state} activation {message}", targetActivation.State, message);
+                    logger.Warn((int)ErrorCode.Dispatcher_Receive_InvalidActivation,
+                        "Response received for {State} activation {Message}", targetActivation.State, message);
                     MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Invalid");
                     return;
                 }

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -238,10 +238,10 @@ namespace Orleans.Runtime
         {
             lock (targetActivation)
             {
-                if (targetActivation.State == ActivationState.Invalid)
+                if (targetActivation.State == ActivationState.Invalid || targetActivation.State == ActivationState.FailedToActivate)
                 {
                     logger.Warn(ErrorCode.Dispatcher_Receive_InvalidActivation,
-                        "Response received for invalid activation {0}", message);
+                        "Response received for {state} activation {message}", targetActivation.State, message);
                     MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Invalid");
                     return;
                 }

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -114,7 +114,7 @@ namespace Orleans.Runtime
 
             if (context.ActivationContext is SchedulingContext schedulingContext
                 && schedulingContext.Activation is ActivationData activation
-                && activation.State == ActivationState.Invalid)
+                && (activation.State == ActivationState.Invalid || activation.State == ActivationState.FailedToActivate))
             {
                 // Move exceptions into local functions to help inlining this method.
                 ThrowInvalidActivation(activation);


### PR DESCRIPTION
- Add another terminal state for activation to reject messages when `OnActivateAsync`failed
- Unregister failed activation from the directory before marking it as `Invalid` to avoid forwarding messages to the same activation
- Do not forward messages if the activation is in the `Deactivating` state. All pending messages will be forwarded after the activation has been unregistered from the directory