### PR TITLE
Stop background transaction processing when a grain deactivates

### DIFF
--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -21,6 +21,7 @@ namespace Orleans.Transactions.State
         private BatchWorker lockWorker;
         private BatchWorker storageWorker;
         private readonly ILogger logger;
+        private readonly IActivationLifetime activationLifetime;
 
         // the linked list of lock groups
         // the head is the group that is currently holding the lock
@@ -50,12 +51,14 @@ namespace Orleans.Transactions.State
             IOptions<TransactionalStateOptions> options,
             TransactionQueue<TState> queue,
             BatchWorker storageWorker,
-            ILogger logger)
+            ILogger logger,
+            IActivationLifetime activationLifetime)
         {
             this.options = options.Value;
             this.queue = queue;
             this.storageWorker = storageWorker;
             this.logger = logger;
+            this.activationLifetime = activationLifetime;
             this.lockWorker = new BatchWorkerFromDelegate(LockWork);
         }
 
@@ -274,108 +277,114 @@ namespace Orleans.Transactions.State
 
         private async Task LockWork()
         {
-            var now = DateTime.UtcNow;
-
-            if (currentGroup != null)
+            // Stop pumping lock work if this activation is stopping/stopped.
+            if (this.activationLifetime.OnDeactivating.IsCancellationRequested) return;
+            using (this.activationLifetime.BlockDeactivation())
             {
-                // check if there are any group members that are ready to exit the lock
-                if (currentGroup.Count > 0)
+                var now = DateTime.UtcNow;
+
+                if (currentGroup != null)
                 {
-                    if (LockExits(out var single, out var multiple))
+                    // check if there are any group members that are ready to exit the lock
+                    if (currentGroup.Count > 0)
                     {
-                        if (single != null)
+                        if (LockExits(out var single, out var multiple))
                         {
-                            await this.queue.EnqueueCommit(single);
-                        }
-                        else if (multiple != null)
-                        {
-                            foreach (var r in multiple)
+                            if (single != null)
                             {
-                                await this.queue.EnqueueCommit(r);
+                                await this.queue.EnqueueCommit(single);
                             }
+                            else if (multiple != null)
+                            {
+                                foreach (var r in multiple)
+                                {
+                                    await this.queue.EnqueueCommit(r);
+                                }
+                            }
+
+                            lockWorker.Notify();
+                            storageWorker.Notify();
                         }
 
-                        lockWorker.Notify();
-                        storageWorker.Notify();
-                    }
-
-                    else if (currentGroup.Deadline.HasValue)
-                    {
-                        if (currentGroup.Deadline.Value < now)
+                        else if (currentGroup.Deadline.HasValue)
                         {
-                            // the lock group has timed out.
-                            string txlist = string.Join(",", currentGroup.Keys.Select(g => g.ToString()));
-                            TimeSpan late = now - currentGroup.Deadline.Value;
-                            logger.LogWarning("Break-lock timeout for transactions {TransactionIds}. {Late}ms late", txlist, Math.Floor(late.TotalMilliseconds));
-                            await AbortExecutingTransactions();
-                            lockWorker.Notify();
+                            if (currentGroup.Deadline.Value < now)
+                            {
+                                // the lock group has timed out.
+                                string txlist = string.Join(",", currentGroup.Keys.Select(g => g.ToString()));
+                                TimeSpan late = now - currentGroup.Deadline.Value;
+                                logger.LogWarning("Break-lock timeout for transactions {TransactionIds}. {Late}ms late", txlist, Math.Floor(late.TotalMilliseconds));
+                                await AbortExecutingTransactions();
+                                lockWorker.Notify();
+                            }
+                            else
+                            {
+                                if (logger.IsEnabled(LogLevel.Trace))
+                                    logger.Trace("recheck lock expiration at {Deadline}", currentGroup.Deadline.Value.ToString("o"));
+
+                                // check again when the group expires
+                                lockWorker.Notify(currentGroup.Deadline.Value);
+                            }
                         }
                         else
                         {
-                            if (logger.IsEnabled(LogLevel.Trace))
-                                logger.Trace("recheck lock expiration at {Deadline}", currentGroup.Deadline.Value.ToString("o"));
-
-                            // check again when the group expires
-                            lockWorker.Notify(currentGroup.Deadline.Value);
+                            string txlist = string.Join(",", currentGroup.Keys.Select(g => g.ToString()));
+                            logger.LogWarning("Deadline not set for transactions {TransactionIds}", txlist);
                         }
-                    } else
-                    {
-                        string txlist = string.Join(",", currentGroup.Keys.Select(g => g.ToString()));
-                        logger.LogWarning("Deadline not set for transactions {TransactionIds}", txlist);
                     }
-                }
 
-                else
-                {
-                    // the lock is empty, a new group can enter
-                    currentGroup = currentGroup.Next;
-
-                    if (currentGroup != null)
+                    else
                     {
-                        currentGroup.Deadline = now + this.options.LockTimeout;
+                        // the lock is empty, a new group can enter
+                        currentGroup = currentGroup.Next;
 
-                        // discard expired waiters that have no chance to succeed
-                        // because they have been waiting for the lock for a longer timespan than the 
-                        // total transaction timeout
-                        List<Guid> expiredWaiters = null;
-                        foreach (var kvp in currentGroup)
+                        if (currentGroup != null)
                         {
-                            if (now > kvp.Value.Deadline)
-                            {
-                                if (expiredWaiters == null)
-                                    expiredWaiters = new List<Guid>();
-                                expiredWaiters.Add(kvp.Key);
+                            currentGroup.Deadline = now + this.options.LockTimeout;
 
-                                if (logger.IsEnabled(LogLevel.Trace))
-                                    logger.Trace($"expire-lock-waiter {kvp.Key}");
-                            }
-                        }
-
-                        if (expiredWaiters != null)
-                        {
-                            foreach (var guid in expiredWaiters)
-                            {
-                                currentGroup.Remove(guid);
-                            }
-                        }
-
-                        if (logger.IsEnabled(LogLevel.Trace))
-                        {
-                            logger.Trace($"lock groupsize={currentGroup.Count} deadline={currentGroup.Deadline:o}");
+                            // discard expired waiters that have no chance to succeed
+                            // because they have been waiting for the lock for a longer timespan than the 
+                            // total transaction timeout
+                            List<Guid> expiredWaiters = null;
                             foreach (var kvp in currentGroup)
-                                logger.Trace($"enter-lock {kvp.Key}");
-                        }
-
-                        // execute all the read and update tasks
-                        if (currentGroup.Tasks != null)
-                        {
-                            foreach (var t in currentGroup.Tasks)
                             {
-                                t();
-                            }
-                        }
+                                if (now > kvp.Value.Deadline)
+                                {
+                                    if (expiredWaiters == null)
+                                        expiredWaiters = new List<Guid>();
+                                    expiredWaiters.Add(kvp.Key);
 
-                        lockWorker.Notify();
+                                    if (logger.IsEnabled(LogLevel.Trace))
+                                        logger.Trace($"expire-lock-waiter {kvp.Key}");
+                                }
+                            }
+
+                            if (expiredWaiters != null)
+                            {
+                                foreach (var guid in expiredWaiters)
+                                {
+                                    currentGroup.Remove(guid);
+                                }
+                            }
+
+                            if (logger.IsEnabled(LogLevel.Trace))
+                            {
+                                logger.Trace($"lock groupsize={currentGroup.Count} deadline={currentGroup.Deadline:o}");
+                                foreach (var kvp in currentGroup)
+                                    logger.Trace($"enter-lock {kvp.Key}");
+                            }
+
+                            // execute all the read and update tasks
+                            if (currentGroup.Tasks != null)
+                            {
+                                foreach (var t in currentGroup.Tasks)
+                                {
+                                    t();
+                                }
+                            }
+
+                            lockWorker.Notify();
+                        }
                     }
                 }
             }

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -21,6 +21,7 @@ namespace Orleans.Transactions.State
         private readonly ITransactionalStateStorage<TState> storage;
         private readonly BatchWorker storageWorker;
         protected readonly ILogger logger;
+        private readonly IActivationLifetime activationLifetime;
         private readonly ConfirmationWorker<TState> confirmationWorker;
         private CommitQueue<TState> commitQueue;
         private Task readyTask;
@@ -62,8 +63,9 @@ namespace Orleans.Transactions.State
             this.storage = storage;
             this.Clock = new CausalClock(clock);
             this.logger = logger;
+            this.activationLifetime = activationLifetime;
             this.storageWorker = new BatchWorkerFromDelegate(StorageWork);
-            this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger);
+            this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger, activationLifetime);
             this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager, activationLifetime);
             this.unprocessedPreparedMessages = new Dictionary<DateTime, PreparedMessages>();
             this.commitQueue = new CommitQueue<TState>();
@@ -496,94 +498,100 @@ namespace Orleans.Transactions.State
 
         private async Task StorageWork()
         {
-            try
+            // Stop if this activation is stopping/stopped.
+            if (this.activationLifetime.OnDeactivating.IsCancellationRequested) return;
+
+            using (this.activationLifetime.BlockDeactivation())
             {
-                // count committable entries at the bottom of the commit queue
-                int committableEntries = 0;
-                while (committableEntries < commitQueue.Count && commitQueue[committableEntries].ReadyToCommit)
+                try
                 {
-                    committableEntries++;
-                }
-
-                // process all committable entries, assembling a storage batch
-                if (committableEntries > 0)
-                {
-                    // process all committable entries, adding storage events to the storage batch
-                    CollectEventsForBatch(committableEntries);
-
-                    if (logger.IsEnabled(LogLevel.Debug))
+                    // count committable entries at the bottom of the commit queue
+                    int committableEntries = 0;
+                    while (committableEntries < commitQueue.Count && commitQueue[committableEntries].ReadyToCommit)
                     {
-                        var r = commitQueue.Count > committableEntries ? commitQueue[committableEntries].ToString() : "";
-                        logger.Debug($"batchcommit={committableEntries} leave={commitQueue.Count - committableEntries} {r}");
+                        committableEntries++;
                     }
-                }
-                else
-                {
-                    // send or re-send messages and detect timeouts
-                    await CheckProgressOfCommitQueue();
-                }
 
-                // store the current storage batch, if it is not empty
-                StorageBatch<TState> batchBeingSentToStorage = null;
-                if (this.storageBatch.BatchSize > 0)
-                {
-                    // get the next batch in place so it can be filled while we store the old one
-                    batchBeingSentToStorage = this.storageBatch;
-                    this.storageBatch = new StorageBatch<TState>(batchBeingSentToStorage);
-
-                    try
+                    // process all committable entries, assembling a storage batch
+                    if (committableEntries > 0)
                     {
-                        if (await batchBeingSentToStorage.CheckStorePreConditions())
+                        // process all committable entries, adding storage events to the storage batch
+                        CollectEventsForBatch(committableEntries);
+
+                        if (logger.IsEnabled(LogLevel.Debug))
                         {
-                            // perform the actual store, and record the e-tag
-                            this.storageBatch.ETag = await batchBeingSentToStorage.Store(storage);
-                            failCounter = 0;
+                            var r = commitQueue.Count > committableEntries ? commitQueue[committableEntries].ToString() : "";
+                            logger.Debug($"batchcommit={committableEntries} leave={commitQueue.Count - committableEntries} {r}");
                         }
-                        else
+                    }
+                    else
+                    {
+                        // send or re-send messages and detect timeouts
+                        await CheckProgressOfCommitQueue();
+                    }
+
+                    // store the current storage batch, if it is not empty
+                    StorageBatch<TState> batchBeingSentToStorage = null;
+                    if (this.storageBatch.BatchSize > 0)
+                    {
+                        // get the next batch in place so it can be filled while we store the old one
+                        batchBeingSentToStorage = this.storageBatch;
+                        this.storageBatch = new StorageBatch<TState>(batchBeingSentToStorage);
+
+                        try
                         {
-                            logger.LogWarning("Store pre conditions not met.");
-                            await AbortAndRestore(TransactionalStatus.CommitFailure);
+                            if (await batchBeingSentToStorage.CheckStorePreConditions())
+                            {
+                                // perform the actual store, and record the e-tag
+                                this.storageBatch.ETag = await batchBeingSentToStorage.Store(storage);
+                                failCounter = 0;
+                            }
+                            else
+                            {
+                                logger.LogWarning("Store pre conditions not met.");
+                                await AbortAndRestore(TransactionalStatus.CommitFailure);
+                                return;
+                            }
+                        }
+                        catch (InconsistentStateException e)
+                        {
+                            logger.LogWarning(888, e, "Reload from storage triggered by e-tag mismatch.");
+                            await AbortAndRestore(TransactionalStatus.StorageConflict, true);
+                            return;
+                        }
+                        catch (Exception e)
+                        {
+                            logger.Warn(888, $"Storage exception in storageWorker.", e);
+                            await AbortAndRestore(TransactionalStatus.UnknownException);
                             return;
                         }
                     }
-                    catch (InconsistentStateException e)
+
+                    if (committableEntries > 0)
                     {
-                        logger.LogWarning(888, e, "Reload from storage triggered by e-tag mismatch.");
-                        await AbortAndRestore(TransactionalStatus.StorageConflict, true);
-                        return;
+                        // update stable state
+                        var lastCommittedEntry = commitQueue[committableEntries - 1];
+                        this.stableState = lastCommittedEntry.State;
+                        this.stableSequenceNumber = lastCommittedEntry.SequenceNumber;
+                        if (logger.IsEnabled(LogLevel.Trace))
+                            logger.Trace($"Stable state version: {this.stableSequenceNumber}");
+
+                        // remove committed entries from commit queue
+                        commitQueue.RemoveFromFront(committableEntries);
+                        storageWorker.Notify();  // we have to re-check for work
                     }
-                    catch (Exception e)
+
+                    if (batchBeingSentToStorage != null)
                     {
-                        logger.Warn(888, $"Storage exception in storageWorker.", e);
-                        await AbortAndRestore(TransactionalStatus.UnknownException);
-                        return;
+                        batchBeingSentToStorage.RunFollowUpActions();
+                        storageWorker.Notify();  // we have to re-check for work
                     }
                 }
-
-                if (committableEntries > 0)
+                catch (Exception e)
                 {
-                    // update stable state
-                    var lastCommittedEntry = commitQueue[committableEntries - 1];
-                    this.stableState = lastCommittedEntry.State;
-                    this.stableSequenceNumber = lastCommittedEntry.SequenceNumber;
-                    if (logger.IsEnabled(LogLevel.Trace))
-                        logger.Trace($"Stable state version: {this.stableSequenceNumber}");
-
-                    // remove committed entries from commit queue
-                    commitQueue.RemoveFromFront(committableEntries);
-                    storageWorker.Notify();  // we have to re-check for work
+                    logger.LogWarning(888, e, "Exception in storageWorker.  Retry {FailCounter}", failCounter);
+                    await AbortAndRestore(TransactionalStatus.UnknownException);
                 }
-
-                if (batchBeingSentToStorage != null)
-                { 
-                    batchBeingSentToStorage.RunFollowUpActions();
-                    storageWorker.Notify();  // we have to re-check for work
-                }
-            }
-            catch (Exception e)
-            {
-                logger.LogWarning(888, e, "Exception in storageWorker.  Retry {FailCounter}", failCounter);
-                await AbortAndRestore(TransactionalStatus.UnknownException);
             }
         }
 


### PR DESCRIPTION
Several parts of the transaction processing system rely on background workers for transaction servicing. For example, there is a storage worker, a lock worker, and a confirmation worker.

When an activation terminates, these workers must be made aware so that they can also gracefully terminate.

This PR is a follow-up to #5821, extending the termination to the storage worker & lock worker