### PR TITLE
Fix potential deadlock between Catalog and LocalGrainDirectory

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -5,7 +5,7 @@ using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    interface ILocalGrainDirectory : IGrainDirectory
+    internal interface ILocalGrainDirectory : IGrainDirectory
     {
         /// <summary>
         /// Starts the local portion of the directory service.
@@ -76,25 +76,6 @@ namespace Orleans.Runtime.GrainDirectory
         SiloAddress GetPrimaryForGrain(GrainId grain);
 
         /// <summary>
-        /// For testing purposes only.
-        /// Returns the silos that this silo thinks hold copied directory information for
-        /// the provided grain ID.
-        /// </summary>
-        /// <param name="grain"></param>
-        /// <returns></returns>
-        List<SiloAddress> GetSilosHoldingDirectoryInformationForGrain(GrainId grain);
-
-        /// <summary>
-        /// For testing purposes only.
-        /// Returns the directory information held by another silo for the provided grain ID.
-        /// The result will be null if no information is held.
-        /// </summary>
-        /// <param name="grain"></param>
-        /// <param name="isPrimary"></param>
-        /// <returns></returns>
-        List<ActivationAddress> GetLocalDataForGrain(GrainId grain, out bool isPrimary);
-
-        /// <summary>
         /// Returns the directory information held in a local directory partition for the provided grain ID.
         /// The result will be null if no information is held.
         /// </summary>
@@ -117,11 +98,6 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="silo">the address of the silo</param>
         /// <returns>true if the silo is known to be part of this cluster</returns>
         bool IsSiloInCluster(SiloAddress silo);
-
-        /// <summary>
-        /// The id of this cluster
-        /// </summary>
-        string ClusterId { get; }
 
         /// <summary>
         /// Sets the callback to <see cref="Catalog"/> which is called when a silo is removed from membership.

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -12,6 +12,7 @@ using Orleans.Runtime.Scheduler;
 using Orleans.Runtime.MultiClusterNetwork;
 using Orleans.Configuration;
 using System.ComponentModel;
+using System.Collections.Immutable;
 
 namespace Orleans.Runtime.GrainDirectory
 {
@@ -22,9 +23,26 @@ namespace Orleans.Runtime.GrainDirectory
         /// <summary>
         /// list of silo members sorted by the hash value of their address
         /// </summary>
-        private readonly List<SiloAddress> membershipRingList;
-        
-        private readonly HashSet<SiloAddress> membershipCache;
+        private readonly List<SiloAddress> mutableMembershipRingList = new List<SiloAddress>();
+        private readonly HashSet<SiloAddress> mutableMembershipCache = new HashSet<SiloAddress>();
+        private readonly object writeLock = new object();
+
+        private DirectoryMembership directoryMembership = DirectoryMembership.Default;
+
+        private class DirectoryMembership
+        {
+            public DirectoryMembership(ImmutableList<SiloAddress> membershipRingList, ImmutableHashSet<SiloAddress> membershipCache)
+            {
+                this.MembershipRingList = membershipRingList;
+                this.MembershipCache = membershipCache;
+            }
+
+            public static DirectoryMembership Default { get; }  = new DirectoryMembership(ImmutableList<SiloAddress>.Empty, ImmutableHashSet<SiloAddress>.Empty);
+
+            public ImmutableList<SiloAddress> MembershipRingList { get; }
+            public ImmutableHashSet<SiloAddress> MembershipCache { get; }
+        }        
+
         private readonly DedicatedAsynchAgent maintainer;
         private readonly ILogger log;
         private readonly SiloAddress seed;
@@ -113,8 +131,6 @@ namespace Orleans.Runtime.GrainDirectory
             this.siloStatusOracle = siloStatusOracle;
             this.multiClusterOracle = multiClusterOracle;
             this.grainFactory = grainFactory;
-            membershipRingList = new List<SiloAddress>();
-            membershipCache = new HashSet<SiloAddress>();
             ClusterId = clusterId;
 
             DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(grainDirectoryOptions.Value);
@@ -199,15 +215,17 @@ namespace Orleans.Runtime.GrainDirectory
             directoryPartitionCount = IntValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_PARTITION_SIZE, () => DirectoryPartition.Count);
             IntValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_MYPORTION_RINGDISTANCE, () => RingDistanceToSuccessor());
             FloatValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_MYPORTION_RINGPERCENTAGE, () => (((float)this.RingDistanceToSuccessor()) / ((float)(int.MaxValue * 2L))) * 100);
-            FloatValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_MYPORTION_AVERAGERINGPERCENTAGE, () => this.membershipRingList.Count == 0 ? 0 : ((float)100 / (float)this.membershipRingList.Count));
-            IntValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_RINGSIZE, () => this.membershipRingList.Count);
+            FloatValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_MYPORTION_AVERAGERINGPERCENTAGE, () =>
+            {
+                var ring = this.directoryMembership.MembershipRingList;
+                return ring.Count == 0 ? 0 : ((float)100 / (float)ring.Count);
+            });
+            IntValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_RINGSIZE, () => this.directoryMembership.MembershipRingList.Count);
             StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING, () =>
-                {
-                    lock (this.membershipCache)
-                    {
-                        return Utils.EnumerableToString(this.membershipRingList, siloAddressPrint);
-                    }
-                });
+            {
+                var ring = this.directoryMembership.MembershipRingList;
+                return Utils.EnumerableToString(ring, siloAddressPrint);
+            });
             StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_PREDECESSORS, () => Utils.EnumerableToString(this.FindPredecessors(this.MyAddress, 1), siloAddressPrint));
             StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_SUCCESSORS, () => Utils.EnumerableToString(this.FindSuccessors(this.MyAddress, 1), siloAddressPrint));
 
@@ -272,7 +290,7 @@ namespace Orleans.Runtime.GrainDirectory
         public void SetSiloRemovedCatalogCallback(Action<SiloAddress, SiloStatus> callback)
         {
             if (callback == null) throw new ArgumentNullException(nameof(callback));
-            lock (membershipCache)
+            lock (this.writeLock)
             {
                 this.catalogOnSiloRemoved = callback;
             }
@@ -280,15 +298,14 @@ namespace Orleans.Runtime.GrainDirectory
 
         protected void AddServer(SiloAddress silo)
         {
-            lock (membershipCache)
+            lock (this.writeLock)
             {
-                if (membershipCache.Contains(silo))
+                var existing = this.directoryMembership;
+                if (existing.MembershipCache.Contains(silo))
                 {
                     // we have already cached this silo
                     return;
                 }
-
-                membershipCache.Add(silo);
 
                 // insert new silo in the sorted order
                 long hash = silo.GetConsistentHashCode();
@@ -296,8 +313,11 @@ namespace Orleans.Runtime.GrainDirectory
                 // Find the last silo with hash smaller than the new silo, and insert the latter after (this is why we have +1 here) the former.
                 // Notice that FindLastIndex might return -1 if this should be the first silo in the list, but then
                 // 'index' will get 0, as needed.
-                int index = membershipRingList.FindLastIndex(siloAddr => siloAddr.GetConsistentHashCode() < hash) + 1;
-                membershipRingList.Insert(index, silo);
+                int index = existing.MembershipRingList.FindLastIndex(siloAddr => siloAddr.GetConsistentHashCode() < hash) + 1;
+
+                this.directoryMembership = new DirectoryMembership(
+                    existing.MembershipRingList.Insert(index, silo),
+                    existing.MembershipCache.Add(silo));
 
                 HandoffManager.ProcessSiloAddEvent(silo);
 
@@ -310,9 +330,10 @@ namespace Orleans.Runtime.GrainDirectory
 
         protected void RemoveServer(SiloAddress silo, SiloStatus status)
         {
-            lock (membershipCache)
+            lock (this.writeLock)
             {
-                if (!membershipCache.Contains(silo))
+                var existing = this.directoryMembership;
+                if (!existing.MembershipCache.Contains(silo))
                 {
                     // we have already removed this silo
                     return;
@@ -334,8 +355,10 @@ namespace Orleans.Runtime.GrainDirectory
 
                 // the call order is important
                 HandoffManager.ProcessSiloRemoveEvent(silo);
-                membershipCache.Remove(silo);
-                membershipRingList.Remove(silo);
+
+                this.directoryMembership = new DirectoryMembership(
+                    existing.MembershipRingList.Remove(silo),
+                    existing.MembershipCache.Remove(silo));
 
                 AdjustLocalDirectory(silo, dead: true);
                 AdjustLocalCache(silo, dead: true);
@@ -407,46 +430,42 @@ namespace Orleans.Runtime.GrainDirectory
 
         internal List<SiloAddress> FindPredecessors(SiloAddress silo, int count)
         {
-            lock (membershipCache)
+            var existing = this.directoryMembership;
+            int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
+            if (index == -1)
             {
-                int index = membershipRingList.FindIndex(elem => elem.Equals(silo));
-                if (index == -1)
-                {
-                    log.Warn(ErrorCode.Runtime_Error_100201, "Got request to find predecessors of silo " + silo + ", which is not in the list of members");
-                    return null;
-                }
-
-                var result = new List<SiloAddress>();
-                int numMembers = membershipRingList.Count;
-                for (int i = index - 1; ((i + numMembers) % numMembers) != index && result.Count < count; i--)
-                {
-                    result.Add(membershipRingList[(i + numMembers) % numMembers]);
-                }
-
-                return result;
+                log.Warn(ErrorCode.Runtime_Error_100201, "Got request to find predecessors of silo " + silo + ", which is not in the list of members");
+                return null;
             }
+
+            var result = new List<SiloAddress>();
+            int numMembers = existing.MembershipRingList.Count;
+            for (int i = index - 1; ((i + numMembers) % numMembers) != index && result.Count < count; i--)
+            {
+                result.Add(existing.MembershipRingList[(i + numMembers) % numMembers]);
+            }
+
+            return result;
         }
 
         internal List<SiloAddress> FindSuccessors(SiloAddress silo, int count)
         {
-            lock (membershipCache)
+            var existing = this.directoryMembership;
+            int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
+            if (index == -1)
             {
-                int index = membershipRingList.FindIndex(elem => elem.Equals(silo));
-                if (index == -1)
-                {
-                    log.Warn(ErrorCode.Runtime_Error_100203, "Got request to find successors of silo " + silo + ", which is not in the list of members");
-                    return null;
-                }
-
-                var result = new List<SiloAddress>();
-                int numMembers = membershipRingList.Count;
-                for (int i = index + 1; i % numMembers != index && result.Count < count; i++)
-                {
-                    result.Add(membershipRingList[i % numMembers]);
-                }
-
-                return result;
+                log.Warn(ErrorCode.Runtime_Error_100203, "Got request to find successors of silo " + silo + ", which is not in the list of members");
+                return null;
             }
+
+            var result = new List<SiloAddress>();
+            int numMembers = existing.MembershipRingList.Count;
+            for (int i = index + 1; i % numMembers != index && result.Count < count; i++)
+            {
+                result.Add(existing.MembershipRingList[i % numMembers]);
+            }
+
+            return result;
         }
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
@@ -508,37 +527,36 @@ namespace Orleans.Runtime.GrainDirectory
             // is doing something valuable. 
             bool excludeMySelf = !Running;
 
-            lock (membershipCache)
+            var existing = this.directoryMembership;
+            if (existing.MembershipRingList.Count == 0)
             {
-                if (membershipRingList.Count == 0)
-                {
-                    // If the membership ring is empty, then we're the owner by default unless we're stopping.
-                    return !Running ? null : MyAddress;
-                }
+                // If the membership ring is empty, then we're the owner by default unless we're stopping.
+                return !Running ? null : MyAddress;
+            }
 
-                // need to implement a binary search, but for now simply traverse the list of silos sorted by their hashes
-                for (var index = membershipRingList.Count - 1; index >= 0; --index)
+            // need to implement a binary search, but for now simply traverse the list of silos sorted by their hashes
+            for (var index = existing.MembershipRingList.Count - 1; index >= 0; --index)
+            {
+                var item = existing.MembershipRingList[index];
+                if (IsSiloNextInTheRing(item, hash, excludeMySelf))
                 {
-                    var item = membershipRingList[index];
-                    if (IsSiloNextInTheRing(item, hash, excludeMySelf))
-                    {
-                        siloAddress = item;
-                        break;
-                    }
-                }
-                
-                if (siloAddress == null)
-                {
-                    // If not found in the traversal, last silo will do (we are on a ring).
-                    // We checked above to make sure that the list isn't empty, so this should always be safe.
-                    siloAddress = membershipRingList[membershipRingList.Count - 1];
-                    // Make sure it's not us...
-                    if (siloAddress.Equals(MyAddress) && excludeMySelf)
-                    {
-                        siloAddress = membershipRingList.Count > 1 ? membershipRingList[membershipRingList.Count - 2] : null;
-                    }
+                    siloAddress = item;
+                    break;
                 }
             }
+                
+            if (siloAddress == null)
+            {
+                // If not found in the traversal, last silo will do (we are on a ring).
+                // We checked above to make sure that the list isn't empty, so this should always be safe.
+                siloAddress = existing.MembershipRingList[existing.MembershipRingList.Count - 1];
+                // Make sure it's not us...
+                if (siloAddress.Equals(MyAddress) && excludeMySelf)
+                {
+                    siloAddress = existing.MembershipRingList.Count > 1 ? existing.MembershipRingList[existing.MembershipRingList.Count - 2] : null;
+                }
+            }
+
             if (log.IsEnabled(LogLevel.Trace)) log.Trace("Silo {0} calculated directory partition owner silo {1} for grain {2}: {3} --> {4}", MyAddress, siloAddress, grainId, hash, siloAddress?.GetConsistentHashCode());
             return siloAddress;
         }
@@ -657,7 +675,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             log.Trace("UnregisterAfterNonexistingActivation addr={0} origin={1}", addr, origin);
 
-            if (origin == null || membershipCache.Contains(origin))
+            if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
                 // the request originated in this cluster, call unregister here
                 return UnregisterAsync(addr, UnregistrationCause.NonexistentActivation, 0);
@@ -1098,25 +1116,6 @@ namespace Orleans.Runtime.GrainDirectory
             return distance;
         }
 
-        private string RingDistanceToSuccessor_2()
-        {
-            const long ringSize = int.MaxValue * 2L;
-            long distance;
-            List<SiloAddress> successorList = FindSuccessors(MyAddress, 1);
-            if (successorList == null || successorList.Count == 0)
-            {
-                distance = 0;
-            }
-            else
-            {
-                SiloAddress successor = successorList.First();
-                distance = successor == null ? 0 : CalcRingDistance(MyAddress, successor);
-            }
-            double averageRingSpace = membershipRingList.Count == 0 ? 0 : (1.0 / (double)membershipRingList.Count);
-            return string.Format("RingDistance={0:X}, %Ring Space {1:0.00000}%, Average %Ring Space {2:0.00000}%", 
-                distance, ((double)distance / (double)ringSize) * 100.0, averageRingSpace * 100.0);
-        }
-
         private static long CalcRingDistance(SiloAddress silo1, SiloAddress silo2)
         {
             const long ringSize = int.MaxValue * 2L;
@@ -1135,11 +1134,10 @@ namespace Orleans.Runtime.GrainDirectory
 
             sb.AppendFormat("Silo address is {0}, silo consistent hash is {1:X}.", MyAddress, MyAddress.GetConsistentHashCode()).AppendLine();
             sb.AppendLine("Ring is:");
-            lock (membershipCache)
-            {
-                foreach (var silo in membershipRingList)
-                    sb.AppendFormat("    Silo {0}, consistent hash is {1:X}", silo, silo.GetConsistentHashCode()).AppendLine();
-            }
+
+            var membershipRingList = this.directoryMembership.MembershipRingList;
+            foreach (var silo in membershipRingList)
+                sb.AppendFormat("    Silo {0}, consistent hash is {1:X}", silo, silo.GetConsistentHashCode()).AppendLine();
 
             sb.AppendFormat("My predecessors: {0}", FindPredecessors(MyAddress, 1).ToStrings(addr => String.Format("{0}/{1:X}---", addr, addr.GetConsistentHashCode()), " -- ")).AppendLine();
             sb.AppendFormat("My successors: {0}", FindSuccessors(MyAddress, 1).ToStrings(addr => String.Format("{0}/{1:X}---", addr, addr.GetConsistentHashCode()), " -- "));
@@ -1178,10 +1176,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool IsSiloInCluster(SiloAddress silo)
         {
-            lock (membershipCache)
-            {
-                return membershipCache.Contains(silo);
-            }
+            return this.directoryMembership.MembershipCache.Contains(silo);
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -20,29 +20,6 @@ namespace Orleans.Runtime.GrainDirectory
         MarshalByRefObject,
         ILocalGrainDirectory, ISiloStatusListener
     {
-        /// <summary>
-        /// list of silo members sorted by the hash value of their address
-        /// </summary>
-        private readonly List<SiloAddress> mutableMembershipRingList = new List<SiloAddress>();
-        private readonly HashSet<SiloAddress> mutableMembershipCache = new HashSet<SiloAddress>();
-        private readonly object writeLock = new object();
-
-        private DirectoryMembership directoryMembership = DirectoryMembership.Default;
-
-        private class DirectoryMembership
-        {
-            public DirectoryMembership(ImmutableList<SiloAddress> membershipRingList, ImmutableHashSet<SiloAddress> membershipCache)
-            {
-                this.MembershipRingList = membershipRingList;
-                this.MembershipCache = membershipCache;
-            }
-
-            public static DirectoryMembership Default { get; }  = new DirectoryMembership(ImmutableList<SiloAddress>.Empty, ImmutableHashSet<SiloAddress>.Empty);
-
-            public ImmutableList<SiloAddress> MembershipRingList { get; }
-            public ImmutableHashSet<SiloAddress> MembershipCache { get; }
-        }        
-
         private readonly DedicatedAsynchAgent maintainer;
         private readonly ILogger log;
         private readonly SiloAddress seed;
@@ -50,7 +27,9 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IMultiClusterOracle multiClusterOracle;
         private readonly IInternalGrainFactory grainFactory;
+        private readonly object writeLock = new object();
         private Action<SiloAddress, SiloStatus> catalogOnSiloRemoved;
+        private DirectoryMembership directoryMembership = DirectoryMembership.Default;
 
         // Consider: move these constants into an apropriate place
         internal const int HOP_LIMIT = 6; // forward a remote request no more than 5 times
@@ -1177,6 +1156,20 @@ namespace Orleans.Runtime.GrainDirectory
         public bool IsSiloInCluster(SiloAddress silo)
         {
             return this.directoryMembership.MembershipCache.Contains(silo);
+        }
+
+        private class DirectoryMembership
+        {
+            public DirectoryMembership(ImmutableList<SiloAddress> membershipRingList, ImmutableHashSet<SiloAddress> membershipCache)
+            {
+                this.MembershipRingList = membershipRingList;
+                this.MembershipCache = membershipCache;
+            }
+
+            public static DirectoryMembership Default { get; } = new DirectoryMembership(ImmutableList<SiloAddress>.Empty, ImmutableHashSet<SiloAddress>.Empty);
+
+            public ImmutableList<SiloAddress> MembershipRingList { get; }
+            public ImmutableHashSet<SiloAddress> MembershipCache { get; }
         }
     }
 }

--- a/src/Orleans.Runtime/Utilities/ImmutableCollectionExtensions.cs
+++ b/src/Orleans.Runtime/Utilities/ImmutableCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Immutable;
+
+namespace Orleans.Runtime.Utilities
+{
+    internal static class ImmutableCollectionExtensions
+    {
+        public static int FindIndex<T>(this ImmutableArray<T> collection, Func<T, bool> predicate)
+        {
+            var index = 0;
+            foreach (var item in collection)
+            {
+                if (predicate(item)) return index;
+            }
+
+            return -1;
+        }
+
+        public static int FindLastIndex<T>(this ImmutableArray<T> collection, Func<T, bool> predicate)
+        {
+            for (var index = collection.Length - 1; index >= 0; --index)
+            {
+                if (predicate(collection[index])) return index;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/Orleans.Runtime/Utilities/ImmutableCollectionExtensions.cs
+++ b/src/Orleans.Runtime/Utilities/ImmutableCollectionExtensions.cs
@@ -7,10 +7,9 @@ namespace Orleans.Runtime.Utilities
     {
         public static int FindIndex<T>(this ImmutableArray<T> collection, Func<T, bool> predicate)
         {
-            var index = 0;
-            foreach (var item in collection)
+            for(var index=0; index <collection.Length; index++)
             {
-                if (predicate(item)) return index;
+                if (predicate(collection[index])) return index;
             }
 
             return -1;


### PR DESCRIPTION
We've identified a potential silo deadlock:
* `LocalGrainDirectory.RemoveServer` (called on membership change) **locks** `membershipCache` and calls into the catalog which deactivates grains (taking a **lock** on each activation it's deactivating)
* `Catalog.RecoverFailedInitActivation` (called when a new activation cannot be added to the directory, eg because that silo just shut down) is executed under the activation's **lock** and calls into `LocalGrainDirectory.CalculateGrainDirectoryPartition` which tries to **lock** `membershipCache`

This PR is an attempt to fix that.