### PR TITLE
Fixes packaging of analyzers

### DIFF
--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -4,10 +4,20 @@
     <Title>Microsoft Orleans Analyzers</Title>
     <Description>C# Analyzers for Microsoft Orleans.</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).xml" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes packaging of analyzers. Tested locally and works now.
![image](https://user-images.githubusercontent.com/7863439/62806758-645f4180-bafc-11e9-8e96-9477e9a6db0f.png)

Trick is to add assemblies in `analyzers\dotnet\cs` as per https://roslyn-analyzers.readthedocs.io/en/latest/create-nuget-package.html. Also made the package a development dependency. This will make sure it `<PrivateAssets>all</PrivateAssets>` is added when installed via package manager.

//cc @ReubenBond @bddckr
