### PR TITLE
Cherry-pick #5838 for 2.4.1

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Sockets;
 
 namespace Orleans.Configuration
@@ -26,5 +27,10 @@ namespace Orleans.Configuration
         /// The Interface attribute specifies the name of the network interface to use to work out an IP address for this machine.
         /// </summary>
         public string NetworkInterfaceName { get; set; }
+
+        /// <summary>
+        /// The IP address used for cluster client.
+        /// </summary>
+        public IPAddress LocalAddress { get; set; }
     }
 }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -153,7 +153,7 @@ namespace Orleans
 
                 this.clientProviderRuntime = this.ServiceProvider.GetRequiredService<ClientProviderRuntime>();
 
-                this.localAddress = ConfigUtilities.GetLocalIPAddress(this.clientMessagingOptions.PreferredFamily, this.clientMessagingOptions.NetworkInterfaceName);
+                this.localAddress = this.clientMessagingOptions.LocalAddress ?? ConfigUtilities.GetLocalIPAddress(this.clientMessagingOptions.PreferredFamily, this.clientMessagingOptions.NetworkInterfaceName);
 
                 // Client init / sign-on message
                 logger.Info(ErrorCode.ClientInitializing, string.Format(


### PR DESCRIPTION
Added ClientMessagingOptions.LocalAddress to ignore ConfigUtilities.GetLocalIPAddress that automatic pickups network interfaces. (#5838)
