### PR TITLE
Cherry-pick #5859 and #5863 for 2.4.1

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -23,7 +23,8 @@ namespace Orleans
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));
 
-            services.TryAddSingleton<ILifecycleParticipant<IClusterClientLifecycle>, ClientOptionsLogger>();
+            services.AddSingleton<ClientOptionsLogger>();
+            services.AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, ClientOptionsLogger>();
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
             services.TryAddSingleton<IHostEnvironmentStatistics, NoOpHostEnvironmentStatistics>();

--- a/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
+++ b/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
@@ -37,7 +37,9 @@ namespace Orleans.Runtime
                 entries[localSiloEntry.SiloAddress] = localSiloEntry;
             }
 
-            var version = new MembershipVersion(table.Version.Version);
+            var version = (table.Version.Version == 0 && table.Version.VersionEtag == "0")
+                ? MembershipVersion.MinValue
+                : new MembershipVersion(table.Version.Version);
             return new MembershipTableSnapshot(version, entries.ToImmutable());
         }
 

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -61,7 +61,8 @@ namespace Orleans.Hosting
             services.TryAddSingleton<SiloLifecycleSubject>();
             services.TryAddFromExisting<ISiloLifecycleSubject, SiloLifecycleSubject>();
             services.TryAddFromExisting<ISiloLifecycle, SiloLifecycleSubject>();
-            services.TryAddSingleton<ILifecycleParticipant<ISiloLifecycle>, SiloOptionsLogger>();
+            services.AddSingleton<SiloOptionsLogger>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, SiloOptionsLogger>();
             services.PostConfigure<SiloMessagingOptions>(options =>
             {
                 //

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime
         {
             this.snapshot = membershipTableManager.MembershipTableSnapshot.CreateClusterMembershipSnapshot();
             this.updates = new AsyncEnumerable<ClusterMembershipSnapshot>(
-                (previous, proposed) => proposed.Version > previous.Version,
+                (previous, proposed) => proposed.Version == MembershipVersion.MinValue || proposed.Version > previous.Version,
                 this.snapshot)
             {
                 OnPublished = update => Interlocked.Exchange(ref this.snapshot, update)
@@ -39,7 +39,8 @@ namespace Orleans.Runtime
 
         public ValueTask Refresh(MembershipVersion targetVersion)
         {
-            if (targetVersion != default && this.snapshot.Version >= targetVersion) return default;
+            if (targetVersion != default && targetVersion != MembershipVersion.MinValue && this.snapshot.Version >= targetVersion)
+                return default;
 
             return RefreshAsync(targetVersion);
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime.MembershipService
                     MembershipVersion.MinValue,
                     initialEntries);
             this.updates = new AsyncEnumerable<MembershipTableSnapshot>(
-                (previous, proposed) => proposed.Version > previous.Version,
+                (previous, proposed) => proposed.Version == MembershipVersion.MinValue || proposed.Version > previous.Version,
                 this.snapshot)
             {
                 OnPublished = update => Interlocked.Exchange(ref this.snapshot, update)
@@ -101,6 +101,9 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task RefreshFromSnapshot(MembershipTableSnapshot snapshot)
         {
+            if (snapshot.Version == MembershipVersion.MinValue)
+                throw new ArgumentException("Cannot call RefreshFromSnapshot with Version == MembershipVersion.MinValue");
+
             // Check if a refresh is underway
             var pending = this.pendingRefresh;
             if (pending != null && !pending.IsCompleted)

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -83,7 +83,7 @@ namespace Orleans.Runtime.MembershipService
                 {
                     var snapshot = enumerator.Current.CreateClusterMembershipSnapshot();
 
-                    var update = (previous is null) ? snapshot.AsUpdate() : snapshot.CreateUpdate(previous);
+                    var update = (previous is null || snapshot.Version == MembershipVersion.MinValue) ? snapshot.AsUpdate() : snapshot.CreateUpdate(previous);
                     this.NotifyObservers(update);
                     previous = snapshot;
                 }


### PR DESCRIPTION
Log options on silo and client startup (#5859)
Handle the case where the clustering provider does not support TableVersion (#5863)