### PR TITLE
Improve codegen's .NET Core 3 compatibility 2

### DIFF
--- a/src/BootstrapBuild/Orleans.CodeGeneration.Build/runtimeconfig.template.json
+++ b/src/BootstrapBuild/Orleans.CodeGeneration.Build/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/runtimeconfig.template.json
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Orleans.CodeGeneration.Build/runtimeconfig.template.json
+++ b/src/Orleans.CodeGeneration.Build/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
fixes #5880 

The fix allows the codegen for dotnet to use a runtime >= 3.0.0 as fallback if the 2.0 runtime cannot be found. This allow code generation in only dotnet 3.0 environments.

The changes are the same as for #5799 for the MSBuild codegenerator.

I also included the codegenerator in Bootstrap, so that building Orleans itself is now possible only with a dotnet 3.0 runtime.

It maybe a good idea to do that for the MSBuild codegen in Bootstrap, too. Should I include the change in this pull request?

Thanks,

Frank