### PR TITLE
Improve graceful deactivation of grains performing transaction work

### DIFF
--- a/src/Orleans.Core/Timers/TimerManager.cs
+++ b/src/Orleans.Core/Timers/TimerManager.cs
@@ -8,40 +8,45 @@ namespace Orleans.Timers.Internal
 {
     public interface ITimerManager
     {
-        Task Delay(TimeSpan timeSpan);
+        Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default(CancellationToken));
     }
 
     internal class TimerManagerImpl : ITimerManager
     {
-        public Task Delay(TimeSpan timeSpan) => TimerManager.Delay(timeSpan);
+        public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default(CancellationToken)) => TimerManager.Delay(timeSpan, cancellationToken);
     }
 
     internal static class TimerManager
     {
-        public static Task Delay(TimeSpan timeSpan) => DelayUntil(DateTime.UtcNow + timeSpan);
+        public static Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default(CancellationToken)) => DelayUntil(DateTime.UtcNow + timeSpan, cancellationToken);
 
-        public static Task DelayUntil(DateTime dueTime)
+        public static Task<bool> DelayUntil(DateTime dueTime, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var result = new DelayTimer(dueTime);
+            var result = new DelayTimer(dueTime, cancellationToken);
             TimerManager<DelayTimer>.Register(result);
             return result.Completion;
         }
 
         private sealed class DelayTimer : ITimerCallback, ILinkedListElement<DelayTimer>
         {
-            private readonly TaskCompletionSource<int> completion =
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> completion =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            public DelayTimer(DateTime dueTime)
+            public DelayTimer(DateTime dueTime, CancellationToken cancellationToken)
             {
                 this.DueTime = dueTime;
+                this.CancellationToken = cancellationToken;
             }
 
-            public Task Completion => this.completion.Task;
+            public Task<bool> Completion => this.completion.Task;
 
             public DateTime DueTime { get; }
-            
-            public void OnTimeout() => this.completion.TrySetResult(0);
+
+            public CancellationToken CancellationToken { get; }
+
+            public void OnTimeout() => this.completion.TrySetResult(true);
+
+            public void OnCanceled() => this.completion.TrySetResult(false);
 
             DelayTimer ILinkedListElement<DelayTimer>.Next { get; set; }
         }
@@ -69,9 +74,9 @@ namespace Orleans.Timers.Internal
         // ReSharper disable once StaticMemberInGenericType
         private static readonly object AllQueuesLock = new object();
 
-        // ReSharper disable once StaticMemberInGenericType
-        // ReSharper disable once NotAccessedField.Local
+#pragma warning disable IDE0052 // Remove unread private members
         private static readonly Timer QueueChecker;
+#pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
         /// Collection of all thread-local timer queues.
@@ -172,7 +177,7 @@ namespace Orleans.Timers.Internal
 
             for (var current = queue.Head; current != null; current = current.Next)
             {
-                if (current.DueTime < now)
+                if (current.CancellationToken.IsCancellationRequested || current.DueTime < now)
                 {
                     // Dequeue and add to expired list for later execution.
                     queue.Remove(previous, current);
@@ -258,7 +263,14 @@ namespace Orleans.Timers.Internal
                 {
                     try
                     {
-                        current.OnTimeout();
+                        if (current.CancellationToken.IsCancellationRequested)
+                        {
+                            current.OnCanceled();
+                        }
+                        else
+                        {
+                            current.OnTimeout();
+                        }
                     }
                     catch
                     {
@@ -277,8 +289,12 @@ namespace Orleans.Timers.Internal
         /// The UTC time when this timer is due.
         /// </summary>
         DateTime DueTime { get; }
-        
+
+        CancellationToken CancellationToken { get; }
+
         void OnTimeout();
+
+        void OnCanceled();
     }
 
     /// <summary>

--- a/src/Orleans.Transactions/State/ActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/ActivationLifetime.cs
@@ -13,7 +13,8 @@ namespace Orleans.Transactions.State
 
         public ActivationLifetime(IGrainActivationContext activationContext)
         {
-            activationContext.ObservableLifecycle.Subscribe(GrainLifecycleStage.Activate, this);
+            activationContext.ObservableLifecycle.Subscribe(GrainLifecycleStage.First, this);
+            activationContext.ObservableLifecycle.Subscribe(GrainLifecycleStage.Last, this);
         }
 
         public CancellationToken OnDeactivating => this.onDeactivating.Token;

--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -80,17 +80,21 @@ namespace Orleans.Transactions.State
 
             // attempts to confirm all, will retry every ConfirmationRetryDelay until all succeed
             var ct = this.activationLifetime.OnDeactivating;
-            while (!ct.IsCancellationRequested && await HasPendingConfirmations(confirmations))
-            {
-                await this.timerManager.Delay(this.options.ConfirmationRetryDelay);
-            }
-
-            async Task<bool> HasPendingConfirmations(List<Confirmation> values)
+            var hasPendingConfirmations = true;
+            while (!ct.IsCancellationRequested && hasPendingConfirmations)
             {
                 using (this.activationLifetime.BlockDeactivation())
                 {
-                    var results = await Task.WhenAll(confirmations.Select(c => c.Confirmed()));
-                    return results.Any(b => !b);
+                    var confirmationResults = await Task.WhenAll(confirmations.Select(c => c.Confirmed()));
+                    hasPendingConfirmations = false;
+                    foreach (var confirmed in confirmationResults)
+                    {
+                        hasPendingConfirmations |= !confirmed;
+                    }
+
+                    if (!hasPendingConfirmations) break;
+
+                    await this.timerManager.Delay(this.options.ConfirmationRetryDelay, ct);
                 }
             }
         }
@@ -104,9 +108,9 @@ namespace Orleans.Transactions.State
                 using (this.activationLifetime.BlockDeactivation())
                 {
                     if (await TryCollect(transactionId)) break;
-                }
 
-                await this.timerManager.Delay(this.options.ConfirmationRetryDelay);
+                    await this.timerManager.Delay(this.options.ConfirmationRetryDelay, ct);
+                }
             }
         }
 

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -59,7 +59,7 @@ namespace Orleans.Transactions.State
             this.storageWorker = storageWorker;
             this.logger = logger;
             this.activationLifetime = activationLifetime;
-            this.lockWorker = new BatchWorkerFromDelegate(LockWork);
+            this.lockWorker = new BatchWorkerFromDelegate(LockWork, this.activationLifetime.OnDeactivating);
         }
 
         public async Task<TResult> EnterLock<TResult>(Guid transactionId, DateTime priority,

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -64,7 +64,7 @@ namespace Orleans.Transactions.State
             this.Clock = new CausalClock(clock);
             this.logger = logger;
             this.activationLifetime = activationLifetime;
-            this.storageWorker = new BatchWorkerFromDelegate(StorageWork);
+            this.storageWorker = new BatchWorkerFromDelegate(StorageWork, this.activationLifetime.OnDeactivating);
             this.RWLock = new ReadWriteLock<TState>(options, this, this.storageWorker, logger, activationLifetime);
             this.confirmationWorker = new ConfirmationWorker<TState>(options, this.resource, this.storageWorker, () => this.storageBatch, this.logger, timerManager, activationLifetime);
             this.unprocessedPreparedMessages = new Dictionary<DateTime, PreparedMessages>();


### PR DESCRIPTION
This PR is mostly intended to reduce log noise since this behavior is benign. Nevertheless, I believe it's worthwhile to clean up the behavior here.

If a grain fails to fully activate and has some transaction processing work which need to be performed then it's possible for the grain to get into a state where the background transaction workers will never terminate.

Additionally, when a grain deactivates while it's performing background transaction work, we may emit a warning to the effect of `"Enqueuing task {Task} to a work item group which should have terminated. Likely reasons are that the task is not being 'awaited' properly or a TaskScheduler was captured and is being used to schedule tasks after a grain has been deactivated."`
This PR attempts to prevent this situation by blocking deactivation until the background workers are aware of it and can gracefully terminate.