### PR TITLE
Bound retries for failed send in ClientMessageCenter and simplify

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -46,6 +46,7 @@ namespace Orleans.Messaging
     // </summary>
     internal class ClientMessageCenter : IMessageCenter, IDisposable
     {
+        private readonly object grainBucketUpdateLock = new object();
         internal readonly SerializationManager SerializationManager;
 
         internal static readonly TimeSpan MINIMUM_INTERCONNECT_DELAY = TimeSpan.FromMilliseconds(100);   // wait one tenth of a second between connect attempts
@@ -187,7 +188,7 @@ namespace Orleans.Messaging
                         ErrorCode.ProxyClient_QueueRequest,
                         "Sending message {0} via gateway {1}",
                         msg,
-                        connection.RemoteEndpoint);
+                        connection.RemoteEndPoint);
                 }
             }
             else
@@ -209,12 +210,26 @@ namespace Orleans.Messaging
                                 ErrorCode.ProxyClient_QueueRequest,
                                 "Sending message {0} via gateway {1}",
                                 message,
-                                connection.RemoteEndpoint);
+                                connection.RemoteEndPoint);
                         }
                     }
-                    catch
+                    catch (Exception exception)
                     {
-                        this.SendMessage(message);
+                        if (message.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
+                        {
+                            ++message.RetryCount;
+
+                            _ = Task.Factory.StartNew(
+                                state => this.SendMessage((Message)state),
+                                message,
+                                CancellationToken.None,
+                                TaskCreationOptions.DenyChildAttach,
+                                TaskScheduler.Default);
+                        }
+                        else
+                        {
+                            this.RejectMessage(message, $"Unable to send message due to exception {exception}", exception);
+                        }
                     }
                 }
             }
@@ -225,7 +240,8 @@ namespace Orleans.Messaging
             // If there's a specific gateway specified, use it
             if (msg.TargetSilo != null && gatewayManager.GetLiveGateways().Contains(msg.TargetSilo))
             {
-                var connectionTask = this.connectionManager.GetConnection(msg.TargetSilo);
+                var siloAddress = SiloAddress.New(msg.TargetSilo.Endpoint, 0);
+                var connectionTask = this.connectionManager.GetConnection(siloAddress);
                 if (connectionTask.IsCompletedSuccessfully) return connectionTask;
 
                 return ConnectAsync(msg.TargetSilo, connectionTask, msg, directGatewayMessage: true);
@@ -293,32 +309,28 @@ namespace Orleans.Messaging
             var gatewayConnection = this.connectionManager.GetConnection(addr);
             if (gatewayConnection.IsCompletedSuccessfully)
             {
-                var result = this.TryUpdateConnection(index, gatewayConnection.Result, weakRef);
-                if (result == null) return this.GetGatewayConnection(msg);
-                return new ValueTask<Connection>(result);
+                this.UpdateBucket(index, gatewayConnection.Result);
+                return gatewayConnection;
             }
 
-            return AddToBucketAsync(index, msg, gatewayConnection, weakRef, addr);
+            return AddToBucketAsync(index, gatewayConnection, addr);
 
             async ValueTask<Connection> AddToBucketAsync(
-                uint i,
-                Message message,
-                ValueTask<Connection> c,
-                WeakReference<Connection> existing,
+                uint bucketIndex,
+                ValueTask<Connection> connectionTask,
                 SiloAddress gatewayAddress)
             {
                 try
                 {
-                    var connection = await c;
-
-                    var result = this.TryUpdateConnection(i, connection, existing);
-                    if (result == null) return await this.GetGatewayConnection(message);
-                    return result;
+                    var connection = await connectionTask.ConfigureAwait(false);
+                    this.UpdateBucket(bucketIndex, connection);
+                    return connection;
                 }
-                catch (Exception)
+                catch
                 {
                     this.gatewayManager.MarkAsDead(gatewayAddress);
-                    return await this.GetGatewayConnection(message);
+                    this.UpdateBucket(bucketIndex, null);
+                    throw;
                 }
             }
 
@@ -345,28 +357,13 @@ namespace Orleans.Messaging
             }
         }
 
-        private Connection TryUpdateConnection(uint index, Connection connection, WeakReference<Connection> existing)
+        private void UpdateBucket(uint index, Connection connection)
         {
-            WeakReference<Connection> result;
-            var replacement = new WeakReference<Connection>(connection);
-            var newWeakRef = Interlocked.CompareExchange(ref grainBuckets[index], replacement, existing);
-            if (newWeakRef == existing)
+            lock (this.grainBucketUpdateLock)
             {
-                result = replacement;
-            }
-            else
-            {
-                result = newWeakRef;
-            }
-
-            if (result != null && result.TryGetTarget(out var existingConnection))
-            {
-                return existingConnection;
-            }
-            else
-            {
-                // If the reference has expired, retry with this non-expired reference.
-                return this.TryUpdateConnection(index, connection, result);
+                var value = this.grainBuckets[index] ?? new WeakReference<Connection>(connection);
+                value.SetTarget(connection);
+                this.grainBuckets[index] = value;
             }
         }
 

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -141,7 +141,7 @@ namespace Orleans.Messaging
         /// <returns></returns>
         public SiloAddress GetLiveGateway()
         {
-            IList<SiloAddress> live = GetLiveGateways();
+            List<SiloAddress> live = GetLiveGateways();
             int count = live.Count;
             if (count > 0)
             {

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -13,7 +13,6 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly MessageFactory messageFactory;
         private readonly ClientMessageCenter messageCenter;
-        private readonly GatewayManager gatewayManager;
         private readonly ConnectionManager connectionManager;
         private readonly ConnectionOptions connectionOptions;
 
@@ -24,7 +23,6 @@ namespace Orleans.Runtime.Messaging
             MessageFactory messageFactory,
             IServiceProvider serviceProvider,
             ClientMessageCenter messageCenter,
-            GatewayManager gatewayManager,
             INetworkingTrace trace,
             ConnectionManager connectionManager,
             ConnectionOptions connectionOptions)
@@ -32,7 +30,6 @@ namespace Orleans.Runtime.Messaging
         {
             this.messageFactory = messageFactory;
             this.messageCenter = messageCenter;
-            this.gatewayManager = gatewayManager;
             this.connectionManager = connectionManager;
             this.connectionOptions = connectionOptions;
             this.RemoteSiloAddress = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));

--- a/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Messaging;
@@ -43,7 +44,6 @@ namespace Orleans.Runtime.Messaging
                 this.messageFactory,
                 this.serviceProvider,
                 this.messageCenter,
-                this.gatewayManager,
                 this.trace,
                 this.connectionManager,
                 this.ConnectionOptions);

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -242,7 +242,7 @@ namespace Orleans.Runtime.Messaging
                     }
                     else
                     {
-                        this.trace.LogInformation(
+                        this.trace.LogDebug(
                             "Connection to endpoint {EndPoint} closed",
                             address);
                     }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -74,7 +74,7 @@ namespace Orleans.Runtime.Messaging
         {
             lock (lockable)
             {
-                logger.LogInformation((int)ErrorCode.GatewayClientOpenedSocket, "Recorded opened connection from endpoint {EndPoint}, client ID {ClientId}.", connection.RemoteEndpoint, clientId);
+                logger.LogInformation((int)ErrorCode.GatewayClientOpenedSocket, "Recorded opened connection from endpoint {EndPoint}, client ID {ClientId}.", connection.RemoteEndPoint, clientId);
                 ClientState clientState;
                 if (clients.TryGetValue(clientId, out clientState))
                 {
@@ -111,7 +111,7 @@ namespace Orleans.Runtime.Messaging
                 logger.LogInformation(
                     (int)ErrorCode.GatewayClientClosedSocket,
                     "Recorded closed socket from endpoint {Endpoint}, client ID {clientId}.",
-                    connection.RemoteEndpoint?.ToString() ?? "null",
+                    connection.RemoteEndPoint?.ToString() ?? "null",
                     clientState.Id);
             }
         }


### PR DESCRIPTION
It's possible for the client to get into a loop when it's unable to find an available gateway. This PR bounds the number of send attempts and attempts to simplify the ClientMessageCenter code for managing gateways by using a lock instead of CompareExchange