### PR TITLE
Close client connection on serialization error.

### DIFF
--- a/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
@@ -50,6 +50,8 @@ namespace Orleans.Messaging
             catch (Exception ex)
             {
                 buffer.Reset();
+                gatewayConnection.MarkAsDisconnected(socket);
+                socket = null;
                 Log.Warn(ErrorCode.ProxyClientUnhandledExceptionWhileReceiving, $"Unexpected/unhandled exception while receiving: {ex}. Restarting gateway receiver for {gatewayConnection.Address}.", ex);
                 throw;
             }


### PR DESCRIPTION
Close client connection on serialization error, to avoid data corruption from client.