### PR TITLE
[2.4.2] Fix header deserialization error handling

### DIFF
--- a/src/Orleans.Core/Messaging/IncomingMessageBuffer.cs
+++ b/src/Orleans.Core/Messaging/IncomingMessageBuffer.cs
@@ -172,10 +172,13 @@ namespace Orleans.Runtime
             this.deserializationContext.Reset();
             this.deserializationContext.StreamReader.Reset(header);
 
-            msg = new Message
-            {
-                Headers = SerializationManager.DeserializeMessageHeaders(this.deserializationContext)
-            };
+            // First deserialize headers
+            var headers = SerializationManager.DeserializeMessageHeaders(this.deserializationContext);
+
+            // Do not call inline SerializationManager.DeserializeMessageHeaders in there, we want msg to be null
+            // if headers deserialization failed
+            msg = new Message { Headers = headers };
+
             try
             {
                 if (this.supportForwarding)

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
@@ -668,7 +668,7 @@ namespace Orleans.Runtime.Messaging
                         {
                             // If deserialization completely failed or the message was one-way, rethrow the exception
                             // so that it can be handled at another level.
-                            if (msg?.Headers == null || msg.Direction != Message.Directions.Request)
+                            if (msg == null || msg.Direction != Message.Directions.Request)
                             {
                                 throw;
                             }


### PR DESCRIPTION
In `IncomingMessageBuffer.TryDecodeMessage`, do not set the `out` parameter `msg` if headers deserialization fails.

Otherwise, since `Message.Headers` is never `null`, we do not clear the buffer and close the socket. It might provoke some `NullReferenceException` later too.