### PR TITLE
[2.4.2] Cleanup Message constructors & Headers assignment

### DIFF
--- a/src/Orleans.Core/Messaging/IncomingMessageBuffer.cs
+++ b/src/Orleans.Core/Messaging/IncomingMessageBuffer.cs
@@ -177,8 +177,7 @@ namespace Orleans.Runtime
 
             // Do not call inline SerializationManager.DeserializeMessageHeaders in there, we want msg to be null
             // if headers deserialization failed
-            msg = new Message { Headers = headers };
-
+            msg = new Message(headers);
             try
             {
                 if (this.supportForwarding)

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -63,9 +63,14 @@ namespace Orleans.Runtime
         // Cache values of TargetAddess and SendingAddress as they are used very frequently
         private ActivationAddress targetAddress;
         private ActivationAddress sendingAddress;
-        
-        static Message()
+
+        public Message() : this(new HeadersContainer())
         {
+        }
+
+        public Message(HeadersContainer headers)
+        {
+            this.Headers = headers;
         }
 
         public enum Categories
@@ -99,7 +104,7 @@ namespace Orleans.Runtime
             CacheInvalidation
         }
 
-        internal HeadersContainer Headers { get; set; } = new HeadersContainer();
+        internal HeadersContainer Headers { get; }
 
         public Categories Category
         {
@@ -437,13 +442,6 @@ namespace Orleans.Runtime
 
             var stream = new BinaryTokenStreamReader(bytes);
             return serializationManager.Deserialize(stream);
-        }
-
-        public Message()
-        {
-            bodyObject = null;
-            bodyBytes = null;
-            headerBytes = null;
         }
         
         /// <summary>

--- a/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
@@ -146,10 +146,7 @@ namespace UnitTests.Serialization
             {
                 StreamReader = new BinaryTokenStreamReader(headerList)
             };
-            var deserializedMessage = new Message
-            {
-                Headers = SerializationManager.DeserializeMessageHeaders(context)
-            };
+            var deserializedMessage = new Message(SerializationManager.DeserializeMessageHeaders(context));
             deserializedMessage.SetBodyBytes(bodyList);
             return deserializedMessage;
         }


### PR DESCRIPTION
Use clearer construction semantics, save an allocation, & remove superfluous code