### PR TITLE
Stateless worker local compatibility check

### DIFF
--- a/src/Orleans.Runtime/Placement/StatelessWorkerDirector.cs
+++ b/src/Orleans.Runtime/Placement/StatelessWorkerDirector.cs
@@ -25,12 +25,21 @@ namespace Orleans.Runtime.Placement
 
         public Task<SiloAddress> OnAddActivation(PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {
-            // If the current silo is not shutting down, place locally
+            var compatibleSilos = context.GetCompatibleSilos(target);
+
+            // If the current silo is not shutting down, place locally if we are compatible
             if (!context.LocalSiloStatus.IsTerminating())
-                return Task.FromResult(context.LocalSilo);
+            {
+                foreach (var silo in compatibleSilos)
+                {
+                    if (silo == context.LocalSilo)
+                    {
+                        return Task.FromResult(context.LocalSilo);
+                    }
+                }
+            }
 
             // otherwise, place somewhere else
-            var compatibleSilos = context.GetCompatibleSilos(target);
             return Task.FromResult(compatibleSilos[random.Next(compatibleSilos.Count)]);
         }
 


### PR DESCRIPTION
This changes the placement of stateless workers to not just blindly choose the local silo as the target. Instead we check if the local silo is compatible first, if it is then we choose it, otherwise we back off to the random logic which we previously used when the silo was shutting down.