### PR TITLE
Stream configuration namespace cleanup.

### DIFF
--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSStreamBuilder.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSStreamBuilder.cs
@@ -1,12 +1,12 @@
-using Orleans.Configuration;
-using OrleansAWSUtils.Streams;
 using System;
-using Orleans.Providers.Streams.Common;
-using Orleans.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using OrleansAWSUtils.Streams;
+using Orleans.Providers.Streams.Common;
+using Orleans.ApplicationParts;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public class SiloSqsStreamConfigurator : SiloPersistentStreamConfigurator
     {

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/QueueBalancers/AzureDeploymentQueueBalancer.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/QueueBalancers/AzureDeploymentQueueBalancer.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime.Host;
 using Orleans.Configuration;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public static class SiloPersistentStreamConfiguratorExtension
     {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -7,8 +7,9 @@ using Orleans.Providers.Streams.Common;
 using Orleans.ApplicationParts;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Configuration;
 
-namespace Orleans.Configuration
+namespace Orleans.Hosting
 {
     public interface IAzureQueueStreamConfigurator : INamedServiceConfigurator { }
 
@@ -65,10 +66,6 @@ namespace Orleans.Configuration
     }
 
     public interface IClusterClientAzureQueueStreamConfigurator : IAzureQueueStreamConfigurator, IClusterClientPersistentStreamConfigurator { }
-
-    public static class ClusterClientAzureQueueStreamConfiguratorExtensions
-    {
-    }
 
     public class ClusterClientAzureQueueStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueStreamConfigurator
     {

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using Orleans.Configuration;
-using Orleans.ServiceBus.Providers;
-using Orleans.Streams;
 
 namespace Orleans.Hosting
 {

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/DeveloperExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/DeveloperExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Orleans.Hosting.Developer
+{
+    public static class SiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure silo to use event data generator streams.
+        /// </summary>
+        public static ISiloHostBuilder AddEventDataGeneratorStreams(
+            this ISiloHostBuilder builder,
+            string name,
+            Action<IEventDataGeneratorStreamConfigurator> configure)
+        {
+            var configurator = new EventDataGeneratorStreamConfigurator(name,
+                configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate),
+                configureAppPartsDelegate => builder.ConfigureApplicationParts(configureAppPartsDelegate));
+            configure?.Invoke(configurator);
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure silo to use event data generator streams.
+        /// </summary>
+        public static ISiloBuilder AddEventDataGeneratorStreams(
+            this ISiloBuilder builder,
+            string name,
+            Action<IEventDataGeneratorStreamConfigurator> configure)
+        {
+            var configurator = new EventDataGeneratorStreamConfigurator(name,
+                configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate),
+                configureAppPartsDelegate => builder.ConfigureApplicationParts(configureAppPartsDelegate));
+            configure?.Invoke(configurator);
+            return builder;
+        }
+    }
+}

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/SiloBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using Orleans.Configuration;
-using Orleans.Streams;
 
 namespace Orleans.Hosting
 {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs;
 using Orleans.Streams;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Orleans.ServiceBus.Providers.Testing

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataGeneratorStreamConfigurator.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataGeneratorStreamConfigurator.cs
@@ -1,0 +1,46 @@
+
+using System;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.ServiceBus.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.ApplicationParts;
+using Orleans.ServiceBus.Providers.Testing;
+
+namespace Orleans.Hosting.Developer
+{
+    public interface IEventDataGeneratorStreamConfigurator : ISiloRecoverableStreamConfigurator { }
+
+    public static class EventDataGeneratorConfiguratorExtensions
+    {
+        public static void UseDataAdapter(this IEventDataGeneratorStreamConfigurator configurator, Func<IServiceProvider, string, IEventHubDataAdapter> factory)
+        {
+            configurator.ConfigureComponent(factory);
+        }
+
+        public static void ConfigureCachePressuring(this IEventDataGeneratorStreamConfigurator configurator, Action<OptionsBuilder<EventHubStreamCachePressureOptions>> configureOptions)
+        {
+            configurator.Configure(configureOptions);
+        }
+    }
+    
+    public class EventDataGeneratorStreamConfigurator : SiloRecoverableStreamConfigurator, IEventDataGeneratorStreamConfigurator
+    {
+        public EventDataGeneratorStreamConfigurator(string name,
+            Action<Action<IServiceCollection>> configureServicesDelegate, Action<Action<IApplicationPartManager>> configureAppPartsDelegate)
+            : base(name, configureServicesDelegate, EventDataGeneratorAdapterFactory.Create)
+        {
+            configureAppPartsDelegate(parts =>
+            {
+                parts.AddFrameworkPart(typeof(EventHubAdapterFactory).Assembly)
+                    .AddFrameworkPart(typeof(EventSequenceTokenV2).Assembly);
+            });
+            this.ConfigureDelegate(services => services.ConfigureNamedOptionForLogging<EventHubOptions>(name)
+                .ConfigureNamedOptionForLogging<EventHubReceiverOptions>(name)
+                .ConfigureNamedOptionForLogging<EventHubStreamCachePressureOptions>(name)
+                .AddTransient<IConfigurationValidator>(sp => new EventHubOptionsValidator(sp.GetOptionsByName<EventHubOptions>(name), name))
+                .AddTransient<IConfigurationValidator>(sp => new StreamCheckpointerConfigurationValidator(sp, name)));
+        }
+    }
+}

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamBuilder.cs
@@ -5,8 +5,9 @@ using Orleans.Configuration;
 using Orleans.ServiceBus.Providers;
 using Orleans.Providers.Streams.Common;
 using Orleans.ApplicationParts;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public interface IEventHubStreamConfigurator : INamedServiceConfigurator {}
 

--- a/src/Orleans.Core/Configuration/NamedServiceConfigurator.cs
+++ b/src/Orleans.Core/Configuration/NamedServiceConfigurator.cs
@@ -1,9 +1,10 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
 
-namespace Orleans.Configuration
+namespace Orleans.Hosting
 {
     public interface INamedServiceConfigurator
     {

--- a/src/Orleans.Core/Streams/ClusterClientPersistentStreamConfigurator.cs
+++ b/src/Orleans.Core/Streams/ClusterClientPersistentStreamConfigurator.cs
@@ -2,8 +2,9 @@ using System;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers.Streams.Common;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public interface IPersistentStreamConfigurator : INamedServiceConfigurator { }
 

--- a/src/Orleans.Core/Streams/SimpleMessageStreamConfigurator.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStreamConfigurator.cs
@@ -1,9 +1,8 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Configuration;
 using Orleans.Providers.Streams.SimpleMessageStream;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public interface ISimpleMessageStreamConfigurator : INamedServiceConfigurator { }
 

--- a/src/Orleans.Runtime.Abstractions/Streams/ISiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Runtime.Abstractions/Streams/ISiloPersistentStreamConfigurator.cs
@@ -1,8 +1,9 @@
 using System;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public interface ISiloPersistentStreamConfigurator : IPersistentStreamConfigurator { }
 

--- a/src/Orleans.Runtime.Abstractions/Streams/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Runtime.Abstractions/Streams/SiloPersistentStreamConfigurator.cs
@@ -5,8 +5,9 @@ using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Storage;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public class PersistentStreamStorageConfigurationValidator : IConfigurationValidator
     {

--- a/src/Orleans.Runtime/Streams/QueueBalancer/PersistentStreamConfiguratorExtension.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/PersistentStreamConfiguratorExtension.cs
@@ -2,9 +2,9 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
-using Orleans.Hosting;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public static class SiloPersistentStreamConfiguratorExtension
     {

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubStreamConfigurator.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubStreamConfigurator.cs
@@ -1,5 +1,4 @@
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers.GCP.Streams.PubSub;
 using System;
 using Orleans.Providers.Streams.Common;
@@ -7,7 +6,7 @@ using Orleans.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public class SiloPubSubStreamConfigurator<TDataAdapter> : SiloPersistentStreamConfigurator
          where TDataAdapter : IPubSubDataAdapter

--- a/src/OrleansProviders/Streams/Common/RecoverableStreamConfigurator.cs
+++ b/src/OrleansProviders/Streams/Common/RecoverableStreamConfigurator.cs
@@ -2,8 +2,9 @@ using System;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
+using Orleans.Streams;
 
-namespace Orleans.Streams
+namespace Orleans.Hosting
 {
     public interface ISiloRecoverableStreamConfigurator : ISiloPersistentStreamConfigurator {}
 

--- a/src/OrleansProviders/Streams/Memory/MemoryStreamBuilder.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryStreamBuilder.cs
@@ -1,14 +1,14 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.ApplicationParts;
 using Orleans.Configuration;
-using Orleans.Streams;
-using System;
+using Orleans.Providers;
 
-namespace Orleans.Providers
+namespace Orleans.Hosting
 {
     public interface IMemoryStreamConfigurator : INamedServiceConfigurator { }
 
-    public static class SiloRecoverableStreamConfiguratorExtensions
+    public static class MemoryStreamConfiguratorExtensions
     {
         public static void ConfigurePartitioning(this IMemoryStreamConfigurator configurator, int numOfQueues = HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES)
         {

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
@@ -4,8 +4,6 @@ using Microsoft.Extensions.Configuration;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers.GCP.Streams.PubSub;
-using Orleans.Runtime.Configuration;
-using Orleans.Storage;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.Streaming;

--- a/test/Extensions/ServiceBus.Tests/PluggableQueueBalancerTests.cs
+++ b/test/Extensions/ServiceBus.Tests/PluggableQueueBalancerTests.cs
@@ -1,11 +1,10 @@
 using System.Threading.Tasks;
 using Orleans.Configuration;
 using Orleans.Hosting;
-using Orleans.ServiceBus.Providers.Testing;
+using Orleans.Hosting.Developer;
 using Orleans.TestingHost;
 using Tester.StreamingTests;
 using TestExtensions;
-using Orleans.Streams;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -34,9 +33,8 @@ namespace ServiceBus.Tests
                 {
                     hostBuilder
                         .AddMemoryGrainStorage("PubSubStore")
-                        .AddPersistentStreams(
+                        .AddEventDataGeneratorStreams(
                             StreamProviderName,
-                            EventDataGeneratorAdapterFactory.Create,
                             b=>
                             {
                                 b.Configure<EventDataGeneratorStreamOptions>(ob => ob.Configure(

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Hosting;
-using Orleans.Streams;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.StreamingTests;

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -12,7 +13,6 @@ using UnitTests.Grains;
 using Xunit;
 using Orleans.Hosting;
 using Orleans;
-using Microsoft.Extensions.Configuration;
 
 namespace ServiceBus.Tests.StreamingTests
 {

--- a/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
-using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;

--- a/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
@@ -7,7 +7,6 @@ using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;

--- a/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -1,15 +1,12 @@
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
@@ -2,13 +2,10 @@ using Microsoft.Extensions.Configuration;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Runtime.Configuration;
-using Orleans.Storage;
 using Orleans.TestingHost;
 using System.Threading.Tasks;
 using TestExtensions;
 using Xunit;
-using Orleans.Streams;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Tester.StreamingTests.PlugableQueueBalancerTests

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Orleans;
 using Orleans.Hosting;
-using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using TestExtensions;

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestsUsingSMS.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestsUsingSMS.cs
@@ -1,15 +1,8 @@
-using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using Orleans.TestingHost;
-using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Orleans;
 using Orleans.Hosting;
 using TestExtensions;
-using UnitTests.GrainInterfaces;
 using Xunit;
-using UnitTests.Grains.ProgrammaticSubscribe;
 using Xunit.Abstractions;
 
 namespace Tester.StreamingTests.ProgrammaticSubscribeTests

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 using System.Threading.Tasks;
 using Orleans.Hosting;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using UnitTests.StorageTests;
 using Orleans.Storage;
 using Orleans.Providers;

--- a/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
+++ b/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Orleans;
-using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;


### PR DESCRIPTION
Inconsistent name spaces harm configuration discoverability.
- Move all configurators in Orleans.Streams namespace to Orleans.Hosting
- Move all configurators in Orleans.Configuration namespace to Orleans.Hosting
- Added developer extension functions for EventDataGeneratorStream
- Cleaned up naming issues with Memory Stream Configurator.