### PR TITLE
Set Socket.NoDelay = true by default

### DIFF
--- a/src/Orleans.Core/Networking/Shared/SocketConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionOptions.cs
@@ -13,7 +13,7 @@ namespace Orleans.Networking.Shared
         /// </remarks>
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
-        public bool NoDelay { get; set; }
+        public bool NoDelay { get; set; } = true;
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => KestrelMemoryPool.Create();
     }


### PR DESCRIPTION
This was always supposed to be enabled but looks like it was missed in one of the refactorings.