### PR TITLE
Upgrade to .NET Core 3.0-preview9 release train

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,6 +49,8 @@
   <PropertyGroup>
     <!-- System packages -->
     <SystemRuntimeVersion>4.3.0</SystemRuntimeVersion>
+    <SystemDataSqlClientVersion>4.7.0</SystemDataSqlClientVersion>
+    <SystemDataCommonVersion>4.3.0</SystemDataCommonVersion>
 
     <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.6.0</SystemRuntimeCompilerServicesUnsafeVersion>
@@ -67,17 +69,17 @@
     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
 
     <MicrosoftAspNetCoreConnectionsAbstractionsVersion>3.0.0</MicrosoftAspNetCoreConnectionsAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationBinderVersion>2.1.1</MicrosoftExtensionsConfigurationBinderVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>2.1.1</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>2.1.1</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsConfigurationVersion>2.1.1</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyModelVersion>2.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsLoggingVersion>2.0.0</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsVersion>2.1.1</MicrosoftExtensionsOptionsConfigurationExtensionsVersion>
-    <MicrosoftExtensionsOptionsVersion>2.1.1</MicrosoftExtensionsOptionsVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>2.1.0</MicrosoftExtensionsHostingAbstractionsVersion>
-    <MicrosoftExtensionsHostingVersion>2.1.0</MicrosoftExtensionsHostingVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>3.0.0</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>3.0.0</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>3.0.0</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsConfigurationVersion>3.0.0</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>3.0.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyModelVersion>3.0.0</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsLoggingVersion>3.0.0</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsVersion>3.0.0</MicrosoftExtensionsOptionsConfigurationExtensionsVersion>
+    <MicrosoftExtensionsOptionsVersion>3.0.0</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>3.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsHostingVersion>3.0.0</MicrosoftExtensionsHostingVersion>
 
     <MicrosoftApplicationInsightsVersion>2.4.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftAzureEventHubsVersion>2.2.1</MicrosoftAzureEventHubsVersion>

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.Common" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Data.Common" Version="$(SystemDataCommonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.Common" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Data.Common" Version="$(SystemDataCommonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.Common" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Data.Common" Version="$(SystemDataCommonVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Requests" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Requests" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 

--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Requests" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Requests" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
+++ b/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="$(MicrosoftAzureEventHubsVersion)" />
-    <PackageReference Include="System.Net.Requests" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 

--- a/src/BootstrapBuild/Orleans.CodeGeneration/Orleans.CodeGeneration.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGeneration/Orleans.CodeGeneration.Bootstrap.csproj
@@ -20,8 +20,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="System.Reflection" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 </Project>

--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
@@ -30,26 +30,18 @@
   
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
   <Target Name="PostBuildPublish" AfterTargets="Build">

--- a/src/BootstrapBuild/Orleans.Core/Orleans.Core.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.Core/Orleans.Core.Bootstrap.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsVersion)" />
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />

--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -8,6 +8,7 @@ using Orleans.CodeGenerator;
 using Orleans.Serialization;
 using Orleans.Runtime;
 using Orleans.Metadata;
+using Microsoft.Extensions.DependencyInjection;
 #if NETCOREAPP
 using System.Runtime.Loader;
 #endif
@@ -66,9 +67,17 @@ namespace Orleans.CodeGeneration
 
         private static string GenerateSourceForAssembly(Assembly grainAssembly, LogLevel logLevel)
         {
-            using (var loggerFactory = new LoggerFactory())
+            var serviceCollection = new ServiceCollection()
+                .AddLogging(logging =>
+                {
+                    logging
+                    .AddConsole()
+                    .SetMinimumLevel(logLevel);
+                });
+
+            using (var services = serviceCollection.BuildServiceProvider())
             {
-                loggerFactory.AddConsole(logLevel);
+                var loggerFactory = services.GetRequiredService<ILoggerFactory>();
                 var parts = new ApplicationPartManager()
                     .AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator())
                     .AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainInterfaceFeature>())

--- a/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
+++ b/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
@@ -7,9 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="System.Reflection" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
 

--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -42,24 +42,17 @@
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Orleans.CodeGenerator.MSBuild/Program.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/Program.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.CodeGenerator.MSBuild;
 
@@ -47,7 +48,6 @@ namespace Microsoft.Orleans.CodeGenerator.MSBuild
                 return -2;
             }
 
-            var loggerFactory = new LoggerFactory();
             using (new AssemblyResolver())
             {
                 var cmd = new CodeGeneratorCommand();
@@ -119,9 +119,16 @@ namespace Microsoft.Orleans.CodeGenerator.MSBuild
                     }
                 }
 
-                loggerFactory.AddConsole(logLevel);
-                loggerFactory.AddDebug(logLevel);
-                cmd.Log = loggerFactory.CreateLogger("Orleans.CodeGenerator");
+                var services = new ServiceCollection()
+                    .AddLogging(logging =>
+                    {
+                        logging
+                        .SetMinimumLevel(logLevel)
+                        .AddConsole()
+                        .AddDebug();
+                    })
+                    .BuildServiceProvider();
+                cmd.Log = services.GetRequiredService<ILoggerFactory>().CreateLogger("Orleans.CodeGenerator");
                 var stopwatch = Stopwatch.StartNew();
                 var ok = cmd.Execute(CancellationToken.None).GetAwaiter().GetResult();
                 cmd.Log.LogInformation($"Total code generation time: {stopwatch.ElapsedMilliseconds}ms.");

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="System.Reflection" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
+++ b/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
   
 </Project>

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -51,7 +51,7 @@ namespace Orleans
                     services.AddSingleton(this.hostingEnvironment);
                     services.AddSingleton(this.hostBuilderContext);
                     services.AddSingleton(this.appConfiguration);
-                    services.AddSingleton<IApplicationLifetime, ClientApplicationLifetime>();
+                    services.AddSingleton<IHostApplicationLifetime, ClientApplicationLifetime>();
                     services.AddOptions();
                     services.AddLogging();
                 });

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -66,7 +66,7 @@ namespace Orleans
             }
 
             // It is fine for this field to be null in the case that the client is not the host.
-            this.applicationLifetime = runtimeClient.ServiceProvider.GetService<IApplicationLifetime>() as ClientApplicationLifetime;
+            this.applicationLifetime = runtimeClient.ServiceProvider.GetService<IHostApplicationLifetime>() as ClientApplicationLifetime;
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Hosting/ApplicationLifetime.cs
+++ b/src/Orleans.Core/Hosting/ApplicationLifetime.cs
@@ -8,7 +8,7 @@ namespace Orleans.Hosting
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    internal abstract class ApplicationLifetime : IApplicationLifetime
+    internal abstract class ApplicationLifetime : IHostApplicationLifetime
     {
         private readonly CancellationTokenSource startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource stoppingSource = new CancellationTokenSource();

--- a/src/Orleans.Core/Logging/FileLogger.cs
+++ b/src/Orleans.Core/Logging/FileLogger.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 using Orleans.Runtime;
 
 namespace Orleans.Logging
@@ -137,7 +134,6 @@ namespace Orleans.Logging
         /// <inheritdoc />
         public IDisposable BeginScope<TState>(TState state)
         {
-            //TODO: implemente scope 
             return NullScope.Instance;
         }
 
@@ -146,11 +142,25 @@ namespace Orleans.Logging
         {
             return true;
         }
+
         /// <inheritdoc />
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             this.output.Log(logLevel, eventId, state, exception, formatter, this.category);
 
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            private NullScope()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -30,29 +30,15 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Linq.Expressions" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
-    <PackageReference Include="System.Net.NameResolution" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Reflection.Emit" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsVersion)" />
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
-    <PackageReference Include="System.Threading.Thread" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemRuntimeVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Reflection.Emit" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -96,7 +96,6 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ExecutorService>();
             // queue balancer contructing related
             services.TryAddTransient<IStreamQueueBalancer, ConsistentRingQueueBalancer>();
-            services.TryAddSingleton<IStreamSubscriptionHandleFactory, StreamSubscriptionHandlerFactory>();
 
             services.TryAddSingleton<FallbackSystemTarget>();
             services.TryAddSingleton<LifecycleSchedulingSystemTarget>();

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
@@ -147,7 +147,7 @@ namespace Orleans.Hosting
                     services.AddSingleton(this.hostingEnvironment);
                     services.AddSingleton(this.hostBuilderContext);
                     services.AddSingleton(this.appConfiguration);
-                    services.AddSingleton<IApplicationLifetime, SiloApplicationLifetime>();
+                    services.AddSingleton<IHostApplicationLifetime, SiloApplicationLifetime>();
                     services.AddOptions();
                     services.AddLogging();
                 });

--- a/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
@@ -20,7 +20,7 @@ namespace Orleans.Hosting
             this.Stopped = silo.SiloTerminated;
 
             // It is fine for this field to be null in the case that the silo is not the host.
-            this.applicationLifetime = services.GetService<IApplicationLifetime>() as SiloApplicationLifetime;
+            this.applicationLifetime = services.GetService<IHostApplicationLifetime>() as SiloApplicationLifetime;
         }
 
         /// <inheritdoc />

--- a/test/Extensions/TestServiceFabric/TestOutputLogger.cs
+++ b/test/Extensions/TestServiceFabric/TestOutputLogger.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit.Abstractions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 namespace TestServiceFabric
 {
     public class TestOutputLogger<TCategoryName> : TestOutputLogger, ILogger<TCategoryName>
@@ -42,6 +41,18 @@ namespace TestServiceFabric
             this.Output.WriteLine($"{logLevel} {eventId} [{this.Name}] {formatter(state, exception)}");
         }
 
+        private class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            private NullScope()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
     }
 
     public class TestOutputLoggerProvider : ILoggerProvider

--- a/test/Misc/TestInterfaces/TestInterfaces.csproj
+++ b/test/Misc/TestInterfaces/TestInterfaces.csproj
@@ -4,8 +4,4 @@
     <AssemblyName>TestInterfaces</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeVersion)" />
-  </ItemGroup>
 </Project>

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Orleans;
@@ -73,11 +74,17 @@ namespace NonSilo.Tests
         public void SiloBuilderTest()
         {
             var host = new HostBuilder()
-                .UseOrleans(siloBuilder =>
+                .UseOrleans((ctx, siloBuilder) =>
                 {
                     siloBuilder
+                        .UseLocalhostClustering()
                         .Configure<ClusterOptions>(options => options.ClusterId = "someClusterId")
                         .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback);
+                })
+                .UseDefaultServiceProvider((context, options) =>
+                {
+                    options.ValidateScopes = true;
+                    options.ValidateOnBuild = true;
                 })
                 .Build();
 


### PR DESCRIPTION
Upgrades packages to 3.0-preview9 and fixes some associated issues:

Fixes #5925 - Unable to use TestSilo on 3.0 (Removal of internal `NullScope.Instance` from logging)
Fixes #5611 - Exceptions when using aspnetcore preview 5 (Dependency Injection validation issue)