### PR TITLE
Fix useful queries database name

### DIFF
--- a/Samples/OneBoxDeployment/OneBoxDeployment.sln
+++ b/Samples/OneBoxDeployment/OneBoxDeployment.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E9EBB47B-BE3E-44FD-B401-4F9958B21DC7}"
+	ProjectSection(SolutionItems) = preProject
+		UsefulQueries.sql = UsefulQueries.sql
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneBoxDeployment.Api", "src\OneBoxDeployment.Api\OneBoxDeployment.Api.csproj", "{408791CD-84A2-43C5-A9AE-427AD66FD617}"
 EndProject

--- a/Samples/OneBoxDeployment/UsefulQueries.sql
+++ b/Samples/OneBoxDeployment/UsefulQueries.sql
@@ -1,10 +1,10 @@
 -- If the database gets stuck to single user mode.
-ALTER DATABASE [BigSample.Database] SET MULTI_USER;
+ALTER DATABASE [OneBoxDeployment.Database] SET MULTI_USER;
 
 -- Check what data there is in version tables if the system takes long time to start.
-SELECT * FROM [BigSample.Database].Orleans.OrleansMembershipTable;
-SELECT * FROM [BigSample.Database].Orleans.OrleansMembershipVersionTable;
+SELECT * FROM [OneBoxDeployment.Database].[Orleans].[OrleansMembershipTable];
+SELECT * FROM [OneBoxDeployment.Database].[Orleans].[OrleansMembershipVersionTable];
 
 -- Just remove everything.
-DELETE [BigSample.Database].Orleans.OrleansMembershipTable;
-DELETE [BigSample.Database].Orleans.OrleansMembershipVersionTable;
+DELETE [OneBoxDeployment.Database].[Orleans].[OrleansMembershipTable];
+DELETE [OneBoxDeployment.Database].[Orleans].[OrleansMembershipVersionTable];


### PR DESCRIPTION
Before this sample was committed to the repository, it was
renamed from BigSample to OneBoxDeployment. However, these queries
had the previous name. This commit fixes that.