### PR TITLE
Improves queries by adding lock hinting to membership protocol

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
@@ -56,11 +56,11 @@ VALUES
 	SELECT @DeploymentId
 	WHERE NOT EXISTS
 	(
-	SELECT 1
-	FROM
-		OrleansMembershipVersionTable
-	WHERE
-		DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
+		SELECT 1
+		FROM
+			OrleansMembershipVersionTable WITH(HOLDLOCK, XLOCK, ROWLOCK)
+		WHERE
+			DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
 	);
 
 	SELECT @@ROWCOUNT;
@@ -99,14 +99,14 @@ VALUES
 		@IAmAliveTime
 	WHERE NOT EXISTS
 	(
-	SELECT 1
-	FROM
-		OrleansMembershipTable
-	WHERE
-		DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
-		AND Address = @Address AND @Address IS NOT NULL
-		AND Port = @Port AND @Port IS NOT NULL
-		AND Generation = @Generation AND @Generation IS NOT NULL
+		SELECT 1
+		FROM
+			OrleansMembershipTable WITH(HOLDLOCK, XLOCK, ROWLOCK)
+		WHERE
+			DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
+			AND Address = @Address AND @Address IS NOT NULL
+			AND Port = @Port AND @Port IS NOT NULL
+			AND Generation = @Generation AND @Generation IS NOT NULL
 	);
 
 	UPDATE OrleansMembershipVersionTable


### PR DESCRIPTION
In OneBoxDeployment sample if there are approximately 8-16 siloes starting
simultaneously, one or a few can end up in a primary key constraint
violation since the IF NOT EXISTS check followed by INSERT is not atomic.
This commit remedies that situation according to OneBoxDeployment
(it already has this fix).

Notable that it's not optimal to enforce the query engine with hints like
this and there is a better way, but it would require a larger change.