### PR TITLE
Remove activation from message target list if constructor threw an ex…

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -505,8 +505,17 @@ namespace Orleans.Runtime
                 CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_NON_EXISTENT_ACTIVATIONS).Increment();
                 throw new NonExistentActivationException(msg, address, placement is StatelessWorkerPlacement);
             }
-   
-            SetupActivationInstance(result, grainType, genericArguments);
+
+            try
+            {
+                SetupActivationInstance(result, grainType, genericArguments);
+            }
+            catch
+            {
+                // Exception was thrown when trying to constuct the grain
+                UnregisterMessageTarget(result);
+                throw;
+            }
             activatedPromise = InitActivation(result, grainType, genericArguments, requestContextData);
             return result;
         }

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -28,6 +28,17 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorkerThrowExceptionConstructor()
+        {
+            var grain = this.GrainFactory.GetGrain<IStatelessWorkerExceptionGrain>(0);
+
+            for (int i=0; i<100; i++)
+            {
+                await Assert.ThrowsAsync<OrleansException>(() => grain.Ping());
+            }
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
         public async Task StatelessWorkerActivationsPerSiloDoNotExceedMaxLocalWorkersCount()
         {
             var gatewayOptions = this.Fixture.Client.ServiceProvider.GetRequiredService<IOptions<StaticGatewayListProviderOptions>>();

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerExceptionGrain.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IStatelessWorkerExceptionGrain : IGrainWithIntegerKey
+    {
+        Task Ping();
+    }
+}

--- a/test/Grains/TestGrains/StatelessWorkerExceptionGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerExceptionGrain.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+
+namespace UnitTests.Grains
+{
+    [StatelessWorker(MaxLocalWorkers)]
+    public class StatelessWorkerExceptionGrain : Grain, IStatelessWorkerExceptionGrain
+    {
+        public const int MaxLocalWorkers = 1;
+
+        public StatelessWorkerExceptionGrain()
+        {
+            throw new Exception("oops");
+        }
+
+        public Task Ping()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Fix for #5947

StatelessWorker and "regular" Grain are in fact impacted by this bug. We never saw this behavior for Grains since if the constructor throw, they are not registered in the directory, whereas StatelessWorker doesn't use the directory.