### PR TITLE
Make CollectionAgeLimitAttribute easy to use!

### DIFF
--- a/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
+++ b/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
@@ -8,6 +8,8 @@ namespace Orleans.Configuration
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class CollectionAgeLimitAttribute : Attribute
     {
+        public static readonly TimeSpan DEFAULT_COLLECTION_AGE_LIMIT = TimeSpan.FromHours(2);
+
         public readonly TimeSpan MinAgeLimit = TimeSpan.FromMinutes(1);
 
         public double Days { get; set; } 

--- a/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
+++ b/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
@@ -10,9 +10,9 @@ namespace Orleans.Configuration
     {
         public readonly TimeSpan MinAgeLimit = TimeSpan.FromMinutes(1);
 
-        public int Days { get; set; } 
-        public int Hours { get; set; } 
-        public int Minutes { get; set; } 
+        public double Days { get; set; } 
+        public double Hours { get; set; } 
+        public double Minutes { get; set; } 
 
         public bool AlwaysActive { get; set; }
 

--- a/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
+++ b/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Orleans.Configuration
 {
@@ -8,6 +8,25 @@ namespace Orleans.Configuration
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class CollectionAgeLimitAttribute : Attribute
     {
-        public double Minutes { get; set; }
+        public const int DefaultAgeMinutes = 10;
+
+        public int Days { get; set; } = 0;
+        public int Hours { get; set; } = 0;
+        public int Minutes { get; set; } = 0;
+
+        public bool AlwaysActive { get; set; }
+
+        public TimeSpan Amount
+        {
+            get
+            {
+                var span = AlwaysActive
+                ? TimeSpan.FromDays(short.MaxValue)
+                : TimeSpan.FromDays(Days) + TimeSpan.FromHours(Hours) + TimeSpan.FromMinutes(Minutes);
+                return span < TimeSpan.FromMinutes(DefaultAgeMinutes)
+                    ? TimeSpan.FromMinutes(DefaultAgeMinutes)
+                    : span;
+            }
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
+++ b/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
@@ -8,11 +8,11 @@ namespace Orleans.Configuration
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class CollectionAgeLimitAttribute : Attribute
     {
-        public const int DefaultAgeMinutes = 10;
+        public readonly TimeSpan MinAgeLimit = TimeSpan.FromMinutes(1);
 
-        public int Days { get; set; } = 0;
-        public int Hours { get; set; } = 0;
-        public int Minutes { get; set; } = 0;
+        public int Days { get; set; } 
+        public int Hours { get; set; } 
+        public int Minutes { get; set; } 
 
         public bool AlwaysActive { get; set; }
 
@@ -23,8 +23,8 @@ namespace Orleans.Configuration
                 var span = AlwaysActive
                 ? TimeSpan.FromDays(short.MaxValue)
                 : TimeSpan.FromDays(Days) + TimeSpan.FromHours(Hours) + TimeSpan.FromMinutes(Minutes);
-                return span < TimeSpan.FromMinutes(DefaultAgeMinutes)
-                    ? TimeSpan.FromMinutes(DefaultAgeMinutes)
+                return span <= TimeSpan.Zero
+                    ? MinAgeLimit
                     : span;
             }
         }

--- a/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
@@ -18,8 +18,9 @@ namespace Orleans.Configuration
         /// <summary>
         /// Default period of inactivity necessary for a grain to be available for collection and deactivation.
         /// </summary>
-        public TimeSpan CollectionAge { get; set; } = DEFAULT_COLLECTION_AGE_LIMIT;
-        public static readonly TimeSpan DEFAULT_COLLECTION_AGE_LIMIT = TimeSpan.FromHours(2);
+        public TimeSpan CollectionAge { get; set; } = CollectionAgeLimitAttribute.DEFAULT_COLLECTION_AGE_LIMIT;
+        [Obsolete("Use CollectionAgeLimitAttribute.DEFAULT_COLLECTION_AGE_LIMIT instead")]
+        public static readonly TimeSpan DEFAULT_COLLECTION_AGE_LIMIT = CollectionAgeLimitAttribute.DEFAULT_COLLECTION_AGE_LIMIT;
 
         /// <summary>
         /// Period of inactivity necessary for a grain to be available for collection and deactivation by grain type.

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -70,7 +70,7 @@ namespace Orleans.Configuration
         /// Specifies the maximum time that a request can take before the activation is reported as "blocked"
         /// </summary>
         public TimeSpan MaxRequestProcessingTime { get; set; } = DEFAULT_MAX_REQUEST_PROCESSING_TIME;
-        public static readonly TimeSpan DEFAULT_MAX_REQUEST_PROCESSING_TIME = GrainCollectionOptions.DEFAULT_COLLECTION_AGE_LIMIT;
+        public static readonly TimeSpan DEFAULT_MAX_REQUEST_PROCESSING_TIME = CollectionAgeLimitAttribute.DEFAULT_COLLECTION_AGE_LIMIT;
 
         /// <summary>
         /// For test only - Do not use in production

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -327,7 +327,7 @@ namespace Orleans.Hosting
                         if (attr != null)
                         {
                             var className = TypeUtils.GetFullName(grainClass.ClassType);
-                            options.ClassSpecificCollectionAge[className] = TimeSpan.FromMinutes(attr.Minutes);
+                            options.ClassSpecificCollectionAge[className] = attr.Amount;
                         }
                     }
                 });


### PR DESCRIPTION
This PR make CollectionAgeLimitAttribute user friendly . 

```C#
// This grain has 10 hours age limit
[CollectionAgeLimit(Hours = 10)]
class SampleGrainClass1 : Grain ...
{
}

// This grain has 1 day +10 hours + 30 minutes age limit
[CollectionAgeLimit(Days = 1, Hours = 10 , Minutes = 30)]
class SampleGrainClass2 : Grain ...
{
}

//This grains has 32767 days age limit
[CollectionAgeLimit(AlwaysActive = true)]
class SampleGrainClass3 : Grain ...
{
}
```