### PR TITLE
Fix Connect blocked when ConnectAsync completed synchronously

### DIFF
--- a/src/Orleans.Core/Messaging/SocketManager.cs
+++ b/src/Orleans.Core/Messaging/SocketManager.cs
@@ -199,9 +199,9 @@ namespace Orleans.Runtime
             var e = new SocketAsyncEventArgs();
             e.RemoteEndPoint = endPoint;
             e.Completed += (sender, eventArgs) => signal.Set();
-            s.ConnectAsync(e);
+            bool pending = s.ConnectAsync(e);
 
-            if (!signal.WaitOne(connectionTimeout))
+            if (pending && !signal.WaitOne(connectionTimeout))
                 throw new TimeoutException($"Connection to {endPoint} could not be established in {connectionTimeout}");
 
             if (e.SocketError != SocketError.Success || !s.Connected)


### PR DESCRIPTION
Fix for #5158

Acccodring to [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.connectasync?view=netcore-2.2), `ConnectAsync(SocketAsyncEventArgs)` will return bool 

> true if the I/O operation is pending. The Completed event on the e parameter will be raised upon completion of the operation.
> 
> false if the I/O operation completed synchronously. In this case, The Completed event on the e parameter will not be raised and the e object passed as a parameter may be examined immediately after the method call returns to retrieve the result of the operation.

In windows, looks like `ConnectAsync` will alwasy return true (pending) even if operation is done immediately https://github.com/dotnet/corefx/blob/d391103/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs#L163-L164 . 

But in Linux host, the [corefx](https://github.com/dotnet/corefx/blob/d391103/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs#L14-L33) says:
```csharp
    // The asynchronous socket operations here generally do the following:
    // (1) If the operation queue is Ready (queue is empty), try to perform the operation immediately, non-blocking.
    // If this completes (i.e. does not return EWOULDBLOCK), then we return the results immediately
    // for both success (SocketError.Success) or failure.
    // No callback will happen; callers are expected to handle these synchronous completions themselves.
```

That means if operation completed synchronously, the Completed callback will be never invoked, which will make `AutoResetEvent.WaitOne` keeping waiting until timeout. That's why the server did not receive `Preamble` and timeout [here](https://github.com/dotnet/orleans/blob/v2.4.2/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs#L207)

I see you plan to rewrite network stack in 3.0.0. I don't if this bug will be solved. But as for 2.x version, my possible solution is to change Connect method https://github.com/dotnet/orleans/blob/2.4.3/src/Orleans.Core/Messaging/SocketManager.cs#L196-L209 like 
```csharp
        internal static void Connect(Socket s, IPEndPoint endPoint, TimeSpan connectionTimeout)
        {
            var signal = new AutoResetEvent(false);
            var e = new SocketAsyncEventArgs();
            e.RemoteEndPoint = endPoint;
            e.Completed += (sender, eventArgs) => signal.Set();
            bool pending = s.ConnectAsync(e);

            if (pending && !signal.WaitOne(connectionTimeout))
                throw new TimeoutException($"Connection to {endPoint} could not be established in {connectionTimeout}");

            if (e.SocketError != SocketError.Success || !s.Connected)
                throw new OrleansException($"Could not connect to {endPoint}: {e.SocketError}");
        }
```