### PR TITLE
Disable analyzer tests

### DIFF
--- a/test/Analyzers.Tests/AlwaysInterleaveDiagnosticAnalyzerTests.cs
+++ b/test/Analyzers.Tests/AlwaysInterleaveDiagnosticAnalyzerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Analyzers.Tests
 {
-    [TestCategory("BVT"), TestCategory("Analyzer")]
+    //[TestCategory("BVT"), TestCategory("Analyzer")]
     public class AlwaysInterleaveDiagnosticAnalyzerTest : DiagnosticAnalyzerTestBase<AlwaysInterleaveDiagnosticAnalyzer>
     {
         protected override Task<(Diagnostic[], string)> GetDiagnosticsAsync(string source, params string[] extraUsings)


### PR DESCRIPTION
These tests appear to be blocking test execution on a regular basis. Let's disable them for now.