### PR TITLE
Propagate message [de]serialization exceptions to callers

### DIFF
--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -624,7 +624,7 @@ namespace Orleans
         Messaging_IMA_ExceptionAccepting        = MessagingBase + 26,
         Messaging_IMA_BadBufferReceived         = MessagingBase + 27,
         Messaging_IMA_ActivationOverloaded      = MessagingBase + 28,
-        Messaging_Gateway_SerializationError    = MessagingBase + 29,
+        Messaging_SerializationError            = MessagingBase + 29,
         Messaging_UnableToDeserializeBody       = MessagingBase + 30,
         Messaging_Dispatcher_TryForward         = MessagingBase + 31,
         Messaging_Dispatcher_TryForwardFailed   = MessagingBase + 32,

--- a/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
@@ -38,22 +38,30 @@ namespace UnitTests.GrainInterfaces
 
     public interface IMessageSerializationGrain : IGrainWithIntegerKey
     {
-        Task Send(UndeserializableType input);
-        Task<UnserializableType> Get();
+        Task SendUnserializable(UnserializableType input);
+        Task SendUndeserializable(UndeserializableType input);
+        Task<UnserializableType> GetUnserializable();
+        Task<UndeserializableType> GetUndeserializable();
 
-        Task SendToOtherSilo();
-        Task GetFromOtheSilo();
+        Task SendUnserializableToOtherSilo();
+        Task SendUndeserializableToOtherSilo();
+        Task GetUnserializableFromOtherSilo();
+        Task GetUndeserializableFromOtherSilo();
 
-        Task SendToClient(IMessageSerializationClientObject obj);
-        Task GetFromClient(IMessageSerializationClientObject obj);
+        Task SendUnserializableToClient(IMessageSerializationClientObject obj);
+        Task SendUndeserializableToClient(IMessageSerializationClientObject obj);
+        Task GetUnserializableFromClient(IMessageSerializationClientObject obj);
+        Task GetUndeserializableFromClient(IMessageSerializationClientObject obj);
 
         Task<string> GetSiloIdentity();
     }
 
     public interface IMessageSerializationClientObject : IAddressable
     {
-        Task Send(UndeserializableType input);
-        Task<UnserializableType> Get();
+        Task SendUnserializable(UnserializableType input);
+        Task SendUndeserializable(UndeserializableType input);
+        Task<UnserializableType> GetUnserializable();
+        Task<UndeserializableType> GetUndeserializable();
     }
 
     [Serializable]


### PR DESCRIPTION
Currently when deserialization fails for a response message we do not propagate that deserialization exception to the caller. This PR adds behavior to propate such exceptions back to the original caller.

Fixes #4748

Fixes #5397

xref #5978