### PR TITLE
Fixed wrong condition for getting logContext

### DIFF
--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -211,7 +211,7 @@ namespace Orleans.CodeGenerator
                                 logContext = $"known assembly {assembly.GetName().Name} where 'TreatTypesAsSerializable' = true";
                             else if (type.IsSerializable)
                                 logContext = $"known assembly {assembly.GetName().Name} where type is [Serializable]";
-                            else if (type.IsSerializable)
+                            else if (TypeHasKnownBase(type))
                                 logContext = $"known assembly {assembly.GetName().Name} where type has known base type.";
                         }
 


### PR DESCRIPTION
The condition type.IsSerializable already exists. Need to replace it with TypeHasKnownBase.