### PR TITLE
Deduplicate test categories

### DIFF
--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -23,7 +23,7 @@ namespace DefaultCluster.Tests.General
         private TimeSpan GetResponseTimeout() => this.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>().GetResponseTimeout();
         private void SetResponseTimeout(TimeSpan value) => this.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>().SetResponseTimeout(value);
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_ActivateAndUpdate()
         {
             long g1Key = GetRandomGrainId();
@@ -44,7 +44,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("one", g1a.GetLabel().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_Guid_ActivateAndUpdate()
         {
             Guid guid1 = Guid.NewGuid();
@@ -66,7 +66,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("one", g1a.GetLabel().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("ErrorHandling"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("ErrorHandling"), TestCategory("GetGrain")]
         public async Task BasicActivation_Fail()
         {
             bool failed;
@@ -86,7 +86,7 @@ namespace DefaultCluster.Tests.General
             if (!failed) Assert.True(false, "Should have failed, but instead returned " + key);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_ULong_MaxValue()
         {
             ulong key1AsUlong = UInt64.MaxValue; // == -1L
@@ -129,7 +129,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal((long)key1AsUlong, g1a.GetKey().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_Long_MaxValue()
         {
             long key1 = Int32.MaxValue;
@@ -150,7 +150,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal((long)key1AsUlong, g1a.GetKey().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_Long_MinValue()
         {
             long key1 = Int64.MinValue;
@@ -171,7 +171,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal((long)key1AsUlong, g1a.GetKey().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public void BasicActivation_MultipleGrainInterfaces()
         {
             ITestGrain simple = this.GrainFactory.GetGrain<ITestGrain>(GetRandomGrainId());
@@ -232,7 +232,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("RequestContext"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("RequestContext"), TestCategory("GetGrain")]
         public void BasicActivation_TestRequestContext()
         {
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(GetRandomGrainId());

--- a/test/DefaultCluster.Tests/ClientAddressableTests.cs
+++ b/test/DefaultCluster.Tests/ClientAddressableTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +74,7 @@ namespace DefaultCluster.Tests
             this.runtimeClient = this.HostedCluster.ServiceProvider.GetRequiredService<IRuntimeClient>();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable")]
         public async Task TestClientAddressableHappyPath()
         {
             var myOb = new MyPseudoGrain();
@@ -89,7 +89,7 @@ namespace DefaultCluster.Tests
             this.runtimeClient.DeleteObjectReference(myRef);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable")]
         public async Task TestClientAddressableSadPath()
         {
             const string message = "o hai!";
@@ -107,7 +107,7 @@ namespace DefaultCluster.Tests
             this.runtimeClient.DeleteObjectReference(myRef);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable")]
         public async Task GrainShouldSuccessfullyPullFromClientObject()
         {
             var myOb = new MyProducer();
@@ -124,7 +124,7 @@ namespace DefaultCluster.Tests
             this.runtimeClient.DeleteObjectReference(myRef);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable")]
         public async Task MicroClientAddressableSerialStressTest()
         {
             const int iterationCount = 1000;
@@ -139,7 +139,7 @@ namespace DefaultCluster.Tests
             this.runtimeClient.DeleteObjectReference(myRef);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("ClientAddressable")]
         public async Task MicroClientAddressableParallelStressTest()
         {
             const int iterationCount = 1000;

--- a/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_KnownAssemblyAttribute.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_KnownAssemblyAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 using Orleans.Serialization;
@@ -30,37 +30,37 @@ namespace DefaultCluster.Tests.General
             Assert.True(this.HostedCluster.SerializationManager.HasSerializer(t));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public async Task Silo_Serializer_Exists_for_Type_In_Grain_Assembly()
         {
             await SiloSerializerExists(typeof(UnitTests.Grains.SimpleGrainState));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public void Client_Serializer_Exists_for_Type_In_Grain_Assembly()
         {
             ClientSerializerExists(typeof(UnitTests.Grains.SimpleGrainState));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public async Task Silo_Serializer_Exists_for_Type_In_Known_Assembly()
         {
             await SiloSerializerExists(typeof(FSharpOption<>));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public void Client_Serializer_Exists_for_Type_In_Known_Assembly()
         {
             ClientSerializerExists(typeof(FSharpOption<>));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public async Task Silo_Serializer_Exists_for_Type_In_Grain_Assembly_containing_KnownAssemblyAttribute()
         {
             await SiloSerializerExists(typeof(UnitTests.FSharpTypes.SingleCaseDU));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public void Client_Serializer_Exists_for_Type_In_Grain_Assembly_containing_KnownAssemblyAttribute()
         {
             ClientSerializerExists(typeof(UnitTests.FSharpTypes.SingleCaseDU));

--- a/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_RequiringSilo.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_RequiringSilo.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -19,7 +19,7 @@ namespace DefaultCluster.Tests.CodeGeneration
             this.output = output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("UniqueKey")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("UniqueKey")]
         public void CodeGen_GrainId_TypeCode()
         {
             var g1Key = GetRandomGrainId();
@@ -32,7 +32,7 @@ namespace DefaultCluster.Tests.CodeGeneration
             Assert.Equal(1146670029, k1.BaseTypeCode);  // "Encoded type code data should match"
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("UniqueKey"), TestCategory("ActivationCollector")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("UniqueKey"), TestCategory("ActivationCollector")]
         public void CollectionTest_GrainId_TypeCode()
         {
             var g1Key = GetRandomGrainId();

--- a/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_TakeSerializedData.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/CodeGeneratorTests_TakeSerializedData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -15,14 +15,14 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public async Task TakeSerializedDataNotRefOrleans()
         {
             var grain = this.GrainFactory.GetGrain<ISerializerPresenceTest>(Guid.NewGuid());
             await grain.TakeSerializedData(new UnitTests.Dtos.ClassNotReferencingOrleansTypeDto { MyProperty = "Test" });
         }
 
-        [Fact(Skip = "reproduces issue #1480"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Serialization")]
+        [Fact(Skip = "reproduces issue #1480"), TestCategory("BVT"), TestCategory("CodeGen"), TestCategory("Serialization")]
         public async Task TakeSerializedDataRefOrleans()
         {
             var grain = this.GrainFactory.GetGrain<ISerializerPresenceTest>(Guid.NewGuid());

--- a/test/DefaultCluster.Tests/ConcreteStateClassTests.cs
+++ b/test/DefaultCluster.Tests/ConcreteStateClassTests.cs
@@ -17,7 +17,7 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task StateClassTests_StateClass()
         {
             await StateClassTests_Test("UnitTests.Grains.SimplePersistentGrain");

--- a/test/DefaultCluster.Tests/DeactivationTests.cs
+++ b/test/DefaultCluster.Tests/DeactivationTests.cs
@@ -13,7 +13,7 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DeactivateReactivateTiming()
         {
             var x = GetRandomGrainId();

--- a/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
+++ b/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
@@ -267,7 +267,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expectedEcho, received); // CallMethodTask_Await
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Echo")]
+        [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoTaskGrain_Await_Reentrant()
         {
             IReentrantBlockingEchoTaskGrain g = this.GrainFactory.GetGrain<IReentrantBlockingEchoTaskGrain>(GetRandomGrainId());

--- a/test/DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/DefaultCluster.Tests/ErrorGrainTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace DefaultCluster.Tests
             this.output = output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         public async Task ErrorGrain_GetGrain()
         {
             var grainFullName = typeof(ErrorGrain).FullName;
@@ -33,7 +33,7 @@ namespace DefaultCluster.Tests
             int ignored = await grain.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         public async Task ErrorHandlingLocalError()
         {
             LocalErrorGrain localGrain = new LocalErrorGrain();
@@ -52,7 +52,7 @@ namespace DefaultCluster.Tests
             Assert.True(intPromise.Status == TaskStatus.Faulted);                
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         // check that grain that throws an error breaks its promise and later Wait and GetValue on it will throw
         public void ErrorHandlingGrainError1()
         {
@@ -84,7 +84,7 @@ namespace DefaultCluster.Tests
             Assert.True(intPromise.Status == TaskStatus.Faulted);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         // check that premature wait finishes on time with false.
         public void ErrorHandlingTimedMethod()
         {
@@ -107,7 +107,7 @@ namespace DefaultCluster.Tests
             Assert.True(promise.Status == TaskStatus.RanToCompletion);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         // check that premature wait finishes on time but does not throw with false and later wait throws.
         public void ErrorHandlingTimedMethodWithError()
         {
@@ -150,7 +150,7 @@ namespace DefaultCluster.Tests
             await Task.WhenAll(tasks).WithTimeout(TimeSpan.FromSeconds(20));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ErrorHandling"), TestCategory("GrainReference")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling"), TestCategory("GrainReference")]
         public void ArgumentTypes_ListOfGrainReferences()
         {
             var grainFullName = typeof(ErrorGrain).FullName;
@@ -162,7 +162,7 @@ namespace DefaultCluster.Tests
             if (!ok) throw new TimeoutException();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("AsynchronyPrimitives"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("AsynchronyPrimitives"), TestCategory("ErrorHandling")]
         public async Task AC_DelayedExecutor_2()
         {
             var grainFullName = typeof(ErrorGrain).FullName;
@@ -172,7 +172,7 @@ namespace DefaultCluster.Tests
             Assert.True(result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("SimpleGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("SimpleGrain")]
         public void SimpleGrain_AsyncMethods()
         {
             ISimpleGrainWithAsyncMethods grain = this.GrainFactory.GetGrain<ISimpleGrainWithAsyncMethods>(GetRandomGrainId());
@@ -186,7 +186,7 @@ namespace DefaultCluster.Tests
             Assert.Equal(300, intPromise.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("SimpleGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("SimpleGrain")]
         public void SimpleGrain_PromiseForward()
         {
             ISimpleGrain forwardGrain = this.GrainFactory.GetGrain<IPromiseForwardGrain>(GetRandomGrainId());
@@ -195,7 +195,7 @@ namespace DefaultCluster.Tests
             Assert.Equal(30, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("SimpleGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("SimpleGrain")]
         public void SimpleGrain_GuidDistribution()
         {
             int n = 0x1111;

--- a/test/DefaultCluster.Tests/ExternalTypesTests.cs
+++ b/test/DefaultCluster.Tests/ExternalTypesTests.cs
@@ -14,14 +14,14 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public async Task ExternalTypesTest_GrainWithAbstractExternalTypeParam()
         {
             var grainWitAbstractTypeParam = this.GrainFactory.GetGrain<IExternalTypeGrain>(0);
             await grainWitAbstractTypeParam.GetAbstractModel(new List<NameObjectCollectionBase>() { new NameValueCollection() });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public async Task ExternalTypesTest_GrainWithEnumExternalTypeParam()
         {
             var grainWithEnumTypeParam = this.GrainFactory.GetGrain<IExternalTypeGrain>(0);

--- a/test/DefaultCluster.Tests/FSharpGrainTests.cs
+++ b/test/DefaultCluster.Tests/FSharpGrainTests.cs
@@ -25,20 +25,20 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(input, output);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp")]
         public async Task FSharpGrains_Ping()
         {
             await PingTest<int>(1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofInt()
         {
             await PingTest<UnitTests.FSharpTypes.Record>(UnitTests.FSharpTypes.Record.ofInt(1));
         }
 
         /// F# record without Serializable and Immutable attributes applied - yields a more meaningful error message
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some_WithNoAttributes()
         {
             await PingTest<RecordOfIntOptionWithNoAttributes>(RecordOfIntOptionWithNoAttributes.ofInt(1));
@@ -46,47 +46,47 @@ namespace DefaultCluster.Tests.General
 
         /// F# record with Serializable and Immutable attributes applied - grain call times out,
         /// Debugging the test reveals the same root cause as for FSharpGrains_Record_ofIntOption_WithNoAttributes
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some()
         {
             await PingTest<RecordOfIntOption>(RecordOfIntOption.ofInt(1));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_None()
         {
             await PingTest<RecordOfIntOption>(RecordOfIntOption.Empty);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofInt()
         {
             var input = GenericRecord<int>.ofT(0);
             await PingTest<GenericRecord<int>>(input);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofIntOption_Some()
         {
             var input = GenericRecord<FSharpOption<int>>.ofT(FSharpOption<int>.Some(0));
             await PingTest< GenericRecord<FSharpOption<int>>>(input);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofIntOption_None()
         {
             var input = GenericRecord<FSharpOption<int>>.ofT(FSharpOption<int>.None);
             await PingTest<GenericRecord<FSharpOption<int>>>(input);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(10);
             await PingTest<FSharpOption<int>>(input);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_None()
         {
             var input = FSharpOption<int>.None;

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -35,7 +35,7 @@ namespace DefaultCluster.Tests.General
 
         /// Can instantiate multiple concrete grain types that implement
         /// different specializations of the same generic interface
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
         {
 
@@ -57,7 +57,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -72,7 +72,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Can instantiate generic grain specializations
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_SimpleGenericGrainGetGrain()
         {
 
@@ -99,7 +99,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Can instantiate grains that implement generic interfaces with generic type parameters
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_GenericInterfaceWithGenericParametersGetGrain()
         {
 
@@ -116,7 +116,7 @@ namespace DefaultCluster.Tests.General
 
 
         /// Multiple GetGrain requests with the same id return the same generic grain specialization
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_SimpleGenericGrainMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -133,7 +133,7 @@ namespace DefaultCluster.Tests.General
 
         /// If both a concrete implementation and a generic implementation of a 
         /// generic interface exist, prefer the concrete implementation.
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
         {
             var grainOfDouble1 = GetGrain<ISimpleGenericGrain<double>>();
@@ -154,7 +154,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -172,7 +172,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Can instantiate concrete grains that implement multiple generic interfaces
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesGetGrain()
         {
             var grain1 = GetGrain<ISimpleGenericGrain<int>>();
@@ -193,7 +193,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id and interface return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity1()
         {
             var grainId = GetRandomGrainId();
@@ -213,7 +213,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id and different interfaces return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity2()
         {
             var grainId = GetRandomGrainId();
@@ -231,7 +231,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("100", floatResult);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_UseGenericFactoryInsideGrain()
         {
             var grainId = GetRandomGrainId();
@@ -242,14 +242,14 @@ namespace DefaultCluster.Tests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrain_GetGrain()
         {
             var grain =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
             await grain.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainControlFlow()
         {
             var a = random.Next(100);
@@ -266,7 +266,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, stringPromise.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public void Generic_SimpleGrainControlFlow_Blocking()
         {
             var a = random.Next(100);
@@ -284,7 +284,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, stringPromise.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainDataFlow()
         {
             var a = random.Next(100);
@@ -301,7 +301,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, x);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrain2_GetGrain()
         {
             var g1 =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
@@ -312,14 +312,14 @@ namespace DefaultCluster.Tests.General
             await g3.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainGenericParameterWithMultipleArguments_GetGrain()
         {
             var g1 =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<Dictionary<int, int>>>(GetRandomGrainId());
             await g1.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainControlFlow2_GetAB()
         {
             var a = random.Next(100);
@@ -338,7 +338,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, r3);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainControlFlow3()
         {
             ISimpleGenericGrain2<int, float> g =  this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, float>>(grainId++);
@@ -347,7 +347,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("3x1.25", await g.GetAxB());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_BasicGrainControlFlow()
         {
             IBasicGenericGrain<int, float> g =  this.GrainFactory.GetGrain<IBasicGenericGrain<int, float>>(0);
@@ -356,7 +356,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("3x1.25", await g.GetAxB());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GrainWithListFields()
         {
             string a = random.Next(100).ToString(CultureInfo.InvariantCulture);
@@ -375,7 +375,7 @@ namespace DefaultCluster.Tests.General
                 string.Format("Result: r[0]={0}, r[1]={1}", r1[0], r1[1]));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_GrainWithListFields()
         {
             int a = random.Next(100);
@@ -395,7 +395,7 @@ namespace DefaultCluster.Tests.General
                 string.Format("Result: r[0]={0}, r[1]={1}", r1[0], r1[1]));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_GrainWithNoProperties_ControlFlow()
         {
             int a = random.Next(100);
@@ -408,7 +408,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, r1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GrainWithNoProperties_ControlFlow()
         {
             int a = random.Next(100);
@@ -422,7 +422,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, r1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_ReaderWriterGrain1()
         {
             int a = random.Next(100);
@@ -432,7 +432,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(a, res);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_ReaderWriterGrain2()
         {
             int a = random.Next(100);
@@ -447,7 +447,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(b, r2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_ReaderWriterGrain3()
         {
             int a = random.Next(100);
@@ -466,7 +466,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(c, r3);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Non_Primitive_Type_Argument()
         {
             IEchoHubGrain<Guid, string> g1 =  this.GrainFactory.GetGrain<IEchoHubGrain<Guid, string>>(1);
@@ -486,7 +486,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(3m, await g3.GetX());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_1()
         {
             const string msg1 = "Hello from EchoGenericChainGrain-1";
@@ -497,7 +497,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg1, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_2()
         {
             const string msg2 = "Hello from EchoGenericChainGrain-2";
@@ -508,7 +508,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg2, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_3()
         {
             const string msg3 = "Hello from EchoGenericChainGrain-3";
@@ -519,7 +519,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg3, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_4()
         {
             const string msg4 = "Hello from EchoGenericChainGrain-4";
@@ -530,7 +530,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg4, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_5()
         {
             const string msg5 = "Hello from EchoGenericChainGrain-5";
@@ -541,7 +541,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg5, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_6()
         {
             const string msg6 = "Hello from EchoGenericChainGrain-6";
@@ -553,7 +553,7 @@ namespace DefaultCluster.Tests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_1Argument_GenericCallOnly()
         {
             var grain =  this.GrainFactory.GetGrain<IGeneric1Argument<string>>(Guid.NewGuid(), "UnitTests.Grains.Generic1ArgumentGrain");
@@ -562,7 +562,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_1Argument_NonGenericCallFirst()
         {
 
@@ -581,7 +581,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_1Argument_GenericCallFirst()
         {
             var id = Guid.NewGuid();
@@ -603,7 +603,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task DifferentTypeArgsProduceIndependentActivations()
         {
             var grain1 =  this.GrainFactory.GetGrain<IDbGrain<int>>(0);
@@ -614,7 +614,7 @@ namespace DefaultCluster.Tests.General
             Assert.Null(v);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
         public async Task Generic_PingSelf()
         {
             var id = Guid.NewGuid();
@@ -624,7 +624,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
         public async Task Generic_PingOther()
         {
             var id = Guid.NewGuid();
@@ -636,7 +636,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
         public async Task Generic_PingSelfThroughOther()
         {
             var id = Guid.NewGuid();
@@ -648,7 +648,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("ActivateDeactivate")]
         public async Task Generic_ScheduleDelayedPingAndDeactivate()
         {
             var id = Guid.NewGuid();
@@ -662,7 +662,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Serialization")]
         public async Task SerializationTests_Generic_CircularReferenceTest()
         {
             var grainId = Guid.NewGuid();
@@ -670,7 +670,7 @@ namespace DefaultCluster.Tests.General
             var c1 = await grain.GetState();
         }
                 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_GrainWithTypeConstraints()
         {
             var grainId = Guid.NewGuid().ToString();
@@ -682,7 +682,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(1, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact, TestCategory("BVT"), TestCategory("Persistence")]
         public async Task Generic_GrainWithValueTypeState()
         {
             Guid id = Guid.NewGuid();
@@ -722,7 +722,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("Hello!", result);
         }
         
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task Generic_CastToDifferentlyConcretizedInterfaceBeforeActivation() {
             var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
 
@@ -733,7 +733,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("Hello!", result);
         }
         
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Generic_CastGenericInterfaceToNonGenericInterfaceBeforeActivation() {
             var grain =  this.GrainFactory.GetGrain<IGenericCastableGrain<string>>(Guid.NewGuid());
 

--- a/test/DefaultCluster.Tests/GeoClusterTests/SimpleGlobalSingleInstanceGrainTests.cs
+++ b/test/DefaultCluster.Tests/GeoClusterTests/SimpleGlobalSingleInstanceGrainTests.cs
@@ -18,7 +18,7 @@ namespace DefaultCluster.Tests.GeoClusterTests
             return this.GrainFactory.GetGrain<ISimpleGlobalSingleInstanceGrain>(GetRandomGrainId(), SimpleGrainNamePrefix);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GeoCluster")]
+        [Fact, TestCategory("BVT"), TestCategory("GeoCluster")]
         public async Task SimpleGlobalSingleInstanceGrainTest()
         {
             int i = 0;

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -24,14 +24,14 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             watcher.Clear().Wait();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public async Task WatcherGrain_GetGrain()
         {
             IActivateDeactivateWatcherGrain grain = this.GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(1);
             await grain.Clear();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Activate_Simple()
         {
             int id = random.Next();
@@ -42,7 +42,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 0, activation, "After activation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Deactivate_Simple()
         {
             int id = random.Next();
@@ -58,7 +58,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 1, activation, "After deactivation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Reactivate_Simple()
         {
             int id = random.Next();
@@ -79,7 +79,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(2, 1, new[] { activation, activation2 }, "After reactivation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Activate_TailCall()
         {
             int id = random.Next();
@@ -90,7 +90,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 0, activation, "After activation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Deactivate_TailCall()
         {
             int id = random.Next();
@@ -106,7 +106,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 1, activation, "After deactivation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Reactivate_TailCall()
         {
             int id = random.Next();
@@ -127,7 +127,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(2, 1, new[] { activation, activation2 }, "After reactivation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("Reentrancy")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("Reentrancy")]
         public async Task LongRunning_Deactivate()
         {
             int id = random.Next();
@@ -152,7 +152,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(2, 1, new[] { activation, activation2 }, "After reactivation");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task BadActivate_Await()
         {
             try
@@ -170,7 +170,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task BadActivate_GetValue()
         {
             try
@@ -188,7 +188,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task BadActivate_Await_ViaOtherGrain()
         {
             try
@@ -206,7 +206,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Constructor_Bad_Await()
         {
             try
@@ -229,7 +229,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task Constructor_CreateGrainReference()
         {
             int id = random.Next();
@@ -239,7 +239,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             Assert.NotNull(activation);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task TaskAction_Deactivate()
         {
             int id = random.Next();
@@ -255,7 +255,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 1, activation.ToString());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate")]
         public async Task DeactivateOnIdleWhileActivate()
         {
             int id = random.Next();

--- a/test/DefaultCluster.Tests/GrainFactoryTests.cs
+++ b/test/DefaultCluster.Tests/GrainFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -14,7 +14,7 @@ namespace DefaultCluster.Tests
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Ambiguous()
         {
             Assert.Throws<OrleansException>(() =>
@@ -23,14 +23,14 @@ namespace DefaultCluster.Tests
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Ambiguous_WithDefault()
         {
             var g = this.GrainFactory.GetGrain<IBase4>(GetRandomGrainId());
             Assert.False(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_WithFullName()
         {
             var grainFullName = typeof(BaseGrain).FullName;
@@ -38,14 +38,14 @@ namespace DefaultCluster.Tests
             Assert.True(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_WithPrefix()
         {
             var g = this.GrainFactory.GetGrain<IBase>(GetRandomGrainId(), BaseGrain.GrainPrefix);
             Assert.True(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_AmbiguousPrefix()
         {
             Assert.Throws<OrleansException>(() =>
@@ -54,7 +54,7 @@ namespace DefaultCluster.Tests
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_WrongPrefix()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -63,7 +63,7 @@ namespace DefaultCluster.Tests
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Derived_NoPrefix()
         {
             var g = this.GrainFactory.GetGrain<IDerivedFromBase>(GetRandomGrainId());
@@ -71,7 +71,7 @@ namespace DefaultCluster.Tests
             Assert.True(g.Bar().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Derived_WithFullName()
         {
             var grainFullName = typeof(DerivedFromBaseGrain).FullName;
@@ -80,7 +80,7 @@ namespace DefaultCluster.Tests
             Assert.True(g.Bar().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Derived_WithFullName_FromBase()
         {
             var grainFullName = typeof(DerivedFromBaseGrain).FullName;
@@ -88,7 +88,7 @@ namespace DefaultCluster.Tests
             Assert.False(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Derived_WithPrefix()
         {
             var g = this.GrainFactory.GetGrain<IDerivedFromBase>(GetRandomGrainId(), "UnitTests.Grains");
@@ -96,7 +96,7 @@ namespace DefaultCluster.Tests
             Assert.True(g.Bar().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_Derived_WithWrongPrefix()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -105,14 +105,14 @@ namespace DefaultCluster.Tests
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_OneImplementation_NoPrefix()
         {
             var g = this.GrainFactory.GetGrain<IBase1>(GetRandomGrainId());
             Assert.False(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_OneImplementation_Prefix()
         {
             var grainFullName = typeof(BaseGrain1).FullName;
@@ -120,7 +120,7 @@ namespace DefaultCluster.Tests
             Assert.False(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGrain_MultipleUnrelatedInterfaces()
         {
             var g1 = this.GrainFactory.GetGrain<IBase3>(GetRandomGrainId());
@@ -129,14 +129,14 @@ namespace DefaultCluster.Tests
             Assert.True(g2.Bar().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetStringGrain()
         {
             var g = this.GrainFactory.GetGrain<IStringGrain>(Guid.NewGuid().ToString());
             Assert.True(g.Foo().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Factory"), TestCategory("GetGrain")]
+        [Fact, TestCategory("BVT"), TestCategory("Factory"), TestCategory("GetGrain")]
         public void GetGuidGrain()
         {
             var g = this.GrainFactory.GetGrain<IGuidGrain>(Guid.NewGuid());

--- a/test/DefaultCluster.Tests/GrainInterfaceHierarchyTests.cs
+++ b/test/DefaultCluster.Tests/GrainInterfaceHierarchyTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Orleans;
 using TestExtensions;
 using TestGrainInterfaces;
@@ -17,14 +17,14 @@ namespace DefaultCluster.Tests
             return GrainFactory.GetGrain<T>(GetRandomGrainId());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingGrainEmptyTest()
         {
             IDoSomethingEmptyGrain doSomething = GetHierarchyGrain<IDoSomethingEmptyGrain>();
             Assert.Equal("DoSomethingEmptyGrain", await doSomething.DoIt());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingGrainEmptyWithMoreTest()
         {
             IDoSomethingEmptyWithMoreGrain doSomething = GetHierarchyGrain<IDoSomethingEmptyWithMoreGrain>();
@@ -32,7 +32,7 @@ namespace DefaultCluster.Tests
             Assert.Equal("DoSomethingEmptyWithMoreGrain", await doSomething.DoMore());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingWithMoreEmptyGrainTest()
         {
             IDoSomethingWithMoreEmptyGrain doSomething = GetHierarchyGrain<IDoSomethingWithMoreEmptyGrain>();
@@ -40,7 +40,7 @@ namespace DefaultCluster.Tests
             Assert.Equal("DoSomethingWithMoreEmptyGrain", await doSomething.DoMore());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingWithMoreGrainTest()
         {
             IDoSomethingWithMoreGrain doSomething = GetHierarchyGrain<IDoSomethingWithMoreGrain>();
@@ -48,7 +48,7 @@ namespace DefaultCluster.Tests
             Assert.Equal("DoSomethingWithMoreGrain", await doSomething.DoThat());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingCombinedGrainTest()
         {
             IDoSomethingCombinedGrain doSomething = GetHierarchyGrain<IDoSomethingCombinedGrain>();
@@ -57,7 +57,7 @@ namespace DefaultCluster.Tests
             Assert.Equal("DoSomethingCombinedGrain", await doSomething.DoThat());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DoSomethingValidateSingleGrainTest()
         {
             var doSomethingEmptyGrain = GetHierarchyGrain<IDoSomethingEmptyGrain>();

--- a/test/DefaultCluster.Tests/GrainReferenceCacheTests.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceCacheTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -13,7 +13,7 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GetGrain"), TestCategory("Cache")]
+        [Fact, TestCategory("BVT"), TestCategory("GetGrain"), TestCategory("Cache")]
         public void GetGrain()
         {
             int size = 1;
@@ -33,7 +33,7 @@ namespace DefaultCluster.Tests.General
             //Assert.Equal(id, grain.A.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GetGrain"), TestCategory("Cache")]
+        [Fact, TestCategory("BVT"), TestCategory("GetGrain"), TestCategory("Cache")]
         public void GetGrain2()
         {
             int size = 1;
@@ -64,7 +64,7 @@ namespace DefaultCluster.Tests.General
             //Assert.Equal(id1, grain1.A.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GetGrain"), TestCategory("Cache")]
+        [Fact, TestCategory("BVT"), TestCategory("GetGrain"), TestCategory("Cache")]
         public void Get2GrainsFromCache()
         {
             int size = 2;

--- a/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
@@ -23,7 +23,7 @@ namespace DefaultCluster.Tests
             this.internalGrainFactory = client.ServiceProvider.GetRequiredService<IInternalGrainFactory>();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastGrainRefCastFromMyType()
         {
             GrainReference grain = (GrainReference)this.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), SimpleGrain.SimpleGrainNamePrefix);
@@ -32,7 +32,7 @@ namespace DefaultCluster.Tests
             Assert.IsAssignableFrom<ISimpleGrain>(cast);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastGrainRefCastFromMyTypePolymorphic()
         {
             // MultifacetTestGrain implements IMultifacetReader
@@ -53,7 +53,7 @@ namespace DefaultCluster.Tests
         }
 
         // Test case currently fails intermittently
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastMultifacetRWReference()
         {
             // MultifacetTestGrain implements IMultifacetReader
@@ -76,7 +76,7 @@ namespace DefaultCluster.Tests
         }
 
         // Test case currently fails
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastMultifacetRWReferenceWaitForResolve()
         {
             // MultifacetTestGrain implements IMultifacetReader
@@ -101,7 +101,7 @@ namespace DefaultCluster.Tests
             Assert.Equal(newValue, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void ConfirmServiceInterfacesListContents()
         {
             // GeneratorTestDerivedDerivedGrainReference extends GeneratorTestDerivedGrain2Reference
@@ -121,7 +121,7 @@ namespace DefaultCluster.Tests
             Assert.True(interfaces.Keys.Contains(id3), "id3 is present");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastCheckExpectedCompatIds()
         {
             Type t = typeof(ISimpleGrain);
@@ -130,7 +130,7 @@ namespace DefaultCluster.Tests
             Assert.True(grain.IsCompatible(expectedInterfaceId));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastCheckExpectedCompatIds2()
         {
             // GeneratorTestDerivedDerivedGrainReference extends GeneratorTestDerivedGrain2Reference
@@ -147,7 +147,7 @@ namespace DefaultCluster.Tests
             Assert.True(grain.IsCompatible(id3));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastFailInternalCastFromBadType()
         {
             var grain = this.GrainFactory.GetGrain<ISimpleGrain>(
@@ -158,7 +158,7 @@ namespace DefaultCluster.Tests
             Assert.Throws<InvalidCastException>(() => this.internalGrainFactory.Cast(grain, typeof(bool)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastInternalCastFromMyType()
         {
             var serviceName = typeof(SimpleGrain).FullName;
@@ -171,7 +171,7 @@ namespace DefaultCluster.Tests
             Assert.IsAssignableFrom<ISimpleGrain>(cast);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastInternalCastUpFromChild()
         {
             // GeneratorTestDerivedGrain1Reference extends GeneratorTestGrainReference
@@ -184,7 +184,7 @@ namespace DefaultCluster.Tests
             Assert.IsAssignableFrom<IGeneratorTestGrain>(cast);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastGrainRefUpCastFromChild()
         {
             // GeneratorTestDerivedGrain1Reference extends GeneratorTestGrainReference
@@ -194,7 +194,7 @@ namespace DefaultCluster.Tests
             Assert.IsAssignableFrom<IGeneratorTestGrain>(cast);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task FailSideCastAfterResolve()
         {
             // GeneratorTestDerivedGrain1Reference extends GeneratorTestGrainReference
@@ -208,7 +208,7 @@ namespace DefaultCluster.Tests
             await Assert.ThrowsAsync<InvalidCastException>(() => cast.StringConcat("a", "b", "c"));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task FailOperationAfterSideCast()
         {
             // GeneratorTestDerivedGrain1Reference extends GeneratorTestGrainReference
@@ -223,7 +223,7 @@ namespace DefaultCluster.Tests
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void FailSideCastAfterContinueWith()
         {
             Assert.Throws<InvalidCastException>(() =>
@@ -251,7 +251,7 @@ namespace DefaultCluster.Tests
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastGrainRefUpCastFromGrandchild()
         {
             // GeneratorTestDerivedGrain1Reference derives from GeneratorTestGrainReference
@@ -279,7 +279,7 @@ namespace DefaultCluster.Tests
             Assert.False(cast is IGeneratorTestDerivedGrain1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastGrainRefUpCastFromDerivedDerivedChild()
         {
             // GeneratorTestDerivedDerivedGrainReference extends GeneratorTestDerivedGrain2Reference
@@ -292,7 +292,7 @@ namespace DefaultCluster.Tests
             Assert.False(cast is IGeneratorTestDerivedGrain1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastAsyncGrainRefCastFromSelf()
         {
             IAddressable grain = this.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), SimpleGrain.SimpleGrainNamePrefix); ;
@@ -429,7 +429,7 @@ namespace DefaultCluster.Tests
             Assert.True(false, "Exception should have been raised");
         }
 #endif
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastCallMethodInheritedFromBaseClass()
         {
             // GeneratorTestDerivedGrain1Reference derives from GeneratorTestGrainReference

--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -19,7 +19,7 @@ namespace DefaultCluster.Tests.General
     /// <summary>
     /// Summary description for GrainReferenceTest
     /// </summary>
-    [TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainReference")]
+    [TestCategory("BVT"), TestCategory("GrainReference")]
     public class GrainReferenceTest : HostedTestClusterEnsureDefaultStarted
     {
         public GrainReferenceTest(DefaultClusterFixture fixture) : base(fixture)
@@ -39,7 +39,7 @@ namespace DefaultCluster.Tests.General
             Assert.False(ref2.Equals(ref1));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("AsynchronyPrimitives")]
+        [Fact, TestCategory("BVT"), TestCategory("AsynchronyPrimitives")]
         public void TaskCompletionSource_Resolve()
         {
             string str = "Hello TaskCompletionSource";

--- a/test/DefaultCluster.Tests/KeyExtensionTests.cs
+++ b/test/DefaultCluster.Tests/KeyExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
@@ -15,7 +15,7 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public async Task PrimaryKeyExtensionsShouldDifferentiateGrainsUsingTheSameBasePrimaryKey()
         {
             var baseKey = Guid.NewGuid();
@@ -35,7 +35,7 @@ namespace DefaultCluster.Tests.General
             Assert.NotEqual(activationId1, activationId2); // Mismatched key extensions should differentiate an identical base primary key.
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public async Task PrimaryKeyExtensionsShouldDifferentiateGrainsUsingDifferentBaseKeys()
         {
             var baseKey1 = Guid.NewGuid();
@@ -55,7 +55,7 @@ namespace DefaultCluster.Tests.General
             Assert.NotEqual(activationId1, activationId2); // Mismatched base keys should differentiate between identical extended keys.
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void EmptyKeyExtensionsAreDisallowed()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -66,7 +66,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void WhiteSpaceKeyExtensionsAreDisallowed()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -77,7 +77,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void NullKeyExtensionsAreDisallowed()
         {
             Assert.Throws<ArgumentNullException>(() =>
@@ -88,7 +88,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public async Task PrimaryKeyExtensionsShouldPermitStringsLongerThan127BytesLong()
         {
             var baseKey = Guid.NewGuid();
@@ -101,7 +101,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(localGrainRef, remoteGrainRef); // Mismatched grain ID.
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void GetPrimaryKeyStringOnGrainReference()
         {
             const string key = "foo";
@@ -112,7 +112,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(key, key2); // Unexpected key was returned.
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void KeysAllowPlusSymbols()
         {
             const string key = "foo+bar+zaz";
@@ -147,7 +147,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        [Fact, TestCategory("BVT"), TestCategory("PrimaryKeyExtension")]
         public void GetPrimaryKeyStringOnWrongGrainReference()
         {
             var grain = this.GrainFactory.GetGrain<ISimpleGrain>(0);

--- a/test/DefaultCluster.Tests/Lease/GoldenPathInMemoryLeaseProviderTests.cs
+++ b/test/DefaultCluster.Tests/Lease/GoldenPathInMemoryLeaseProviderTests.cs
@@ -7,7 +7,7 @@ using TestExtensions.Runners;
 
 namespace DefaultCluster.Tests
 {
-    [TestCategory("BVT"), TestCategory("Functional"), TestCategory("Lease")]
+    [TestCategory("BVT"), TestCategory("Lease")]
     public class GoldenPathInMemoryLeaseProviderTests : GoldenPathLeaseProviderTestRunner, IClassFixture<GoldenPathInMemoryLeaseProviderTests.Fixture>
     {
         public GoldenPathInMemoryLeaseProviderTests(Fixture fixture, ITestOutputHelper output)

--- a/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
+++ b/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
@@ -17,14 +17,14 @@ namespace DefaultCluster.Tests.StorageTests
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task MemoryStorageProvider_RestoreStateTest()
         {
             var grainWithState = this.GrainFactory.GetGrain<IInitialStateGrain>(0);
             Assert.NotNull(await grainWithState.GetNames());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task MemoryStorageProvider_NullState()
         {
             var grainWithState = this.GrainFactory.GetGrain<INullStateGrain>(0);
@@ -34,7 +34,7 @@ namespace DefaultCluster.Tests.StorageTests
             await grainWithState.SetStateAndDeactivate(new NullableState { Name = "Thrall" });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task MemoryStorageProvider_WriteReadStateTest()
         {
             var grainWithState = this.GrainFactory.GetGrain<IInitialStateGrain>(0);
@@ -59,7 +59,7 @@ namespace DefaultCluster.Tests.StorageTests
             Assert.Equal("Alice", names[1]);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task MemoryStorageGrainEnforcesEtagsTest()
         {
             var memoryStorageGrain = this.GrainFactory.GetGrain<IMemoryStorageGrain>(random.Next());

--- a/test/DefaultCluster.Tests/MultifacetGrainTest.cs
+++ b/test/DefaultCluster.Tests/MultifacetGrainTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans;
 using TestExtensions;
@@ -33,7 +33,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(x, y);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void RWReferencesInvalidCastException()
         {
             Assert.Throws<InvalidCastException>(() =>
@@ -43,7 +43,7 @@ namespace DefaultCluster.Tests.General
             });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task MultifacetFactory()
         {
             IMultifacetFactoryTestGrain factory = this.GrainFactory.GetGrain<IMultifacetFactoryTestGrain>(GetRandomGrainId());
@@ -56,7 +56,7 @@ namespace DefaultCluster.Tests.General
             
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task Multifacet_InterfacesAsArguments()
         {
             IMultifacetFactoryTestGrain factory = this.GrainFactory.GetGrain<IMultifacetFactoryTestGrain>(GetRandomGrainId());

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -44,7 +44,7 @@ namespace DefaultCluster.Tests.General
             return this.GrainFactory.GetGrain<ISimpleObserverableGrain>(GetRandomGrainId());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ObserverTest_SimpleNotification()
         {
             TestInitialize();
@@ -62,7 +62,7 @@ namespace DefaultCluster.Tests.General
             await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ObserverTest_SimpleNotification_GeneratedFactory()
         {
             TestInitialize();
@@ -190,7 +190,7 @@ namespace DefaultCluster.Tests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ObserverTest_Unsubscribe()
         {
             TestInitialize();
@@ -215,7 +215,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ObserverTest_DoubleSubscriptionDifferentReferences()
         {
             TestInitialize();
@@ -279,7 +279,7 @@ namespace DefaultCluster.Tests.General
             result.Continue = true;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ObserverTest_SubscriberMustBeGrainReference()
         {
             TestInitialize();

--- a/test/DefaultCluster.Tests/PolymorphicInterfaceTest.cs
+++ b/test/DefaultCluster.Tests/PolymorphicInterfaceTest.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Orleans;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -13,7 +13,7 @@ namespace DefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void Polymorphic_SimpleTest()
         {
             var grainFullName = typeof(PolymorphicTestGrain).FullName;
@@ -23,7 +23,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("A3", IARef.A3Method().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void Polymorphic_UpCastTest()
         {
             var grainFullName = typeof(PolymorphicTestGrain).FullName;
@@ -51,7 +51,7 @@ namespace DefaultCluster.Tests.General
             
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void Polymorphic_FactoryMethods()
         {
             var grainFullName = typeof(PolymorphicTestGrain).FullName;
@@ -62,7 +62,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("A1", IARef.A1Method().Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void Polymorphic_ServiceType()
         {
             var grainFullName = typeof(ServiceType).FullName;
@@ -78,7 +78,7 @@ namespace DefaultCluster.Tests.General
         /// <summary>
         /// This unit test should consolidate all the use cases we are trying to cover with regard to polymorphic grain references
         /// </summary>
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cast")]
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void Polymorphic__DerivedServiceType()
         {
             var grainFullName = typeof(DerivedServiceType).FullName;

--- a/test/DefaultCluster.Tests/ProviderTests.cs
+++ b/test/DefaultCluster.Tests/ProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 using Orleans;
@@ -36,7 +36,7 @@ namespace DefaultCluster.Tests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Providers")]
+        [Fact, TestCategory("BVT"), TestCategory("Providers")]
         public void Providers_TestExtensions()
         {
             IExtensionTestGrain grain = this.fixture.GrainFactory.GetGrain<IExtensionTestGrain>(GetRandomGrainId());
@@ -101,7 +101,7 @@ namespace DefaultCluster.Tests
             }
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact, TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Providers_ActivateNonGenericExtensionOfGenericInterface()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
@@ -119,7 +119,7 @@ namespace DefaultCluster.Tests
             Assert.True(true);
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact, TestCategory("Providers"), TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Providers_ReferenceNonGenericExtensionOfGenericInterface() {
             var grain = this.fixture.GrainFactory.GetGrain<IGenericGrainWithNonGenericExtension<int>>(GetRandomGrainId());
             await grain.DoSomething(); //original generic grain activates here
@@ -135,7 +135,7 @@ namespace DefaultCluster.Tests
             Assert.True(true);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Providers")]
+        [Fact, TestCategory("BVT"), TestCategory("Providers")]
         public async Task Providers_AutoInstallExtensionTest()
         {
             INoOpTestGrain grain = this.fixture.GrainFactory.GetGrain<INoOpTestGrain>(GetRandomGrainId());

--- a/test/DefaultCluster.Tests/ReminderTest.cs
+++ b/test/DefaultCluster.Tests/ReminderTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -11,7 +11,7 @@ namespace DefaultCluster.Tests
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Reminders")]
+        [Fact, TestCategory("BVT"), TestCategory("Reminders")]
         public async Task SimpleGrainGetGrain()
         {
             IReminderTestGrain grain = this.GrainFactory.GetGrain<IReminderTestGrain>(GetRandomGrainId());

--- a/test/DefaultCluster.Tests/RequestContextTest.cs
+++ b/test/DefaultCluster.Tests/RequestContextTest.cs
@@ -12,7 +12,7 @@ namespace UnitTDefaultCluster.Tests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("RequestContext"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT"), TestCategory("RequestContext")]
         public async Task RequestContextCallerToCalleeFlow()
         {
             var grain = this.GrainFactory.GetGrain<ISimplePersistentGrain>(random.Next());

--- a/test/DefaultCluster.Tests/SerializationTests/RoundTripSerializerTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/RoundTripSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Orleans;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace UnitTests.SerializerTests
 {
-    [TestCategory("Serialization"), TestCategory("BVT"), TestCategory("Functional")]
+    [TestCategory("Serialization"), TestCategory("BVT")]
     public class RoundTripSerializerTests : HostedTestClusterEnsureDefaultStarted
     {
         public RoundTripSerializerTests(DefaultClusterFixture fixture) : base(fixture)

--- a/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NodaTime;
 using Orleans.Serialization;
 using TestExtensions;
@@ -13,7 +13,7 @@ namespace DefaultCluster.Tests
         {
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("BVT"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void Serialization_LargeTestData()
         {
             var data = new LargeTestData
@@ -32,7 +32,7 @@ namespace DefaultCluster.Tests
             Assert.IsAssignableFrom<LargeTestData>(copy);
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("BVT"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void Serialization_ValueTypePhase1()
         {
             ValueTypeTestData data = new ValueTypeTestData(4);

--- a/test/DefaultCluster.Tests/SimpleGrainTests.cs
+++ b/test/DefaultCluster.Tests/SimpleGrainTests.cs
@@ -20,14 +20,14 @@ namespace DefaultCluster.Tests.General
             return this.GrainFactory.GetGrain<ISimpleGrain>(GetRandomGrainId(), SimpleGrain.SimpleGrainNamePrefix);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SimpleGrainGetGrain()
         {
             ISimpleGrain grain = GetSimpleGrain();
             int ignored = await grain.GetAxB();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SimpleGrainControlFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();
@@ -42,7 +42,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(6, await intPromise);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SimpleGrainDataFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();
@@ -56,7 +56,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact(Skip = "Grains with multiple constructors are not supported without being explicitly registered.")]
-        [TestCategory("BVT"), TestCategory("Functional")]
+        [TestCategory("BVT")]
         public async Task GettingGrainWithMultipleConstructorsActivesViaDefaultConstructor()
         {
             ISimpleGrain grain = this.GrainFactory.GetGrain<ISimpleGrain>(GetRandomGrainId(), grainClassNamePrefix: MultipleConstructorsSimpleGrain.MultipleConstructorsSimpleGrainPrefix);

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -46,7 +46,7 @@ namespace DefaultCluster.Tests.TimerTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("BVT"), TestCategory("Timers")]
         public async Task TimerOrleansTest_Parallel()
         {
             TimeSpan period = TimeSpan.Zero;
@@ -88,7 +88,7 @@ namespace DefaultCluster.Tests.TimerTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("BVT"), TestCategory("Timers")]
         public async Task TimerOrleansTest_Migration()
         {
             ITimerGrain grain = GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());

--- a/test/Extensions/Serializers/BondUtils.Tests/Serialization/BondSerializationTests.cs
+++ b/test/Extensions/Serializers/BondUtils.Tests/Serialization/BondSerializationTests.cs
@@ -21,7 +21,7 @@ namespace BondUtils.Tests.Serialization
                     options => options.SerializationProviders.Add(typeof(BondSerializer))));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleBondSchemaSerializationTest()
         {
             var schema = new SimpleBondSchema { SomeValue = int.MaxValue };
@@ -30,7 +30,7 @@ namespace BondUtils.Tests.Serialization
             Assert.Equal(schema.SomeValue, output.SomeValue); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleGenericBondSchemaSerializationTest()
         {
             var schema = new SimpleGenericSchema<int> { SomeValue = int.MaxValue };
@@ -39,7 +39,7 @@ namespace BondUtils.Tests.Serialization
             Assert.Equal(schema.SomeValue, output.SomeValue); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleNestedGenericBondSchemaSerializationTest()
         {
             var schema = new SimpleGenericSchema<SimpleGenericSchema<SimpleBondSchema>>
@@ -59,7 +59,7 @@ namespace BondUtils.Tests.Serialization
             Assert.Equal(schema.SomeValue.SomeValue.SomeValue, output.SomeValue.SomeValue.SomeValue); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleBondSchemaCopyTest()
         {
             var schema = new SimpleBondSchema { SomeValue = int.MaxValue };
@@ -68,7 +68,7 @@ namespace BondUtils.Tests.Serialization
             Assert.Equal(schema.SomeValue, output.SomeValue); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleGenericBondSchemaCopyTest()
         {
             var schema = new SimpleGenericSchema<int> { SomeValue = int.MaxValue };
@@ -77,7 +77,7 @@ namespace BondUtils.Tests.Serialization
             Assert.Equal(schema.SomeValue, output.SomeValue); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SimpleNestedGenericBondSchemaCopyTest()
         {
             var schema = new SimpleGenericSchema<SimpleGenericSchema<SimpleBondSchema>>

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/GoogleProtoBufSerializationTests.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/GoogleProtoBufSerializationTests.cs
@@ -24,7 +24,7 @@ namespace ProtoBuf.Serialization.Tests
 
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_1_DirectGoogleProtoBuf()
         {
             var book = CreateAddressBook();

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/ProtobufNetSerializationTests.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/ProtobufNetSerializationTests.cs
@@ -24,7 +24,7 @@ namespace ProtoBuf.Serialization.Tests
 
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_2_DirectProtoBufNet()
         {
             var person = CreatePerson();

--- a/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/SerializationTestsBase.cs
+++ b/test/Extensions/Serializers/ProtoBuf.Serialization.Tests/SerializationTestsBase.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Serialization.ProtobufNet;
+using Orleans.Serialization.ProtobufNet;
 using System;
 using System.Reflection;
 using TestExtensions;
@@ -86,7 +86,7 @@ namespace ProtoBuf.Serialization.Tests
             return book;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_3_RegularOrleansSerializationStillWorks()
         {
             var input = new OrleansType();
@@ -95,7 +95,7 @@ namespace ProtoBuf.Serialization.Tests
             input.ShouldBeEquivalentTo(output); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_4_OtherPersonProtoBufType()
         {
             var input = CreatePerson();
@@ -104,7 +104,7 @@ namespace ProtoBuf.Serialization.Tests
             input.ShouldBeEquivalentTo(output); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_5_CounterProtoBufSerialization()
         {
             var input = CreateCounter();
@@ -113,7 +113,7 @@ namespace ProtoBuf.Serialization.Tests
             input.ShouldBeEquivalentTo(output); //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_6_DeepCopy()
         {
             var input = CreatePerson();
@@ -122,7 +122,7 @@ namespace ProtoBuf.Serialization.Tests
             input.ShouldBeEquivalentTo(output); ; //The serialization didn't preserve the proper value
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_7_DeepCopyImmutableType()
         {
             var input = CreateImmutablePerson();
@@ -130,7 +130,7 @@ namespace ProtoBuf.Serialization.Tests
             Assert.Same(input, output); //The serializer returned an instance of the same object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("ProtoBuf")]
         public void ProtoBufSerializationTest_8_DefaultCounterMessageSerialization()
         {
             var input = CreateDefaultCounter();

--- a/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 
 namespace Tester.AzureUtils.Streaming
 {
-    [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Functional"), TestCategory("AQStreaming")]
+    [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("AQStreaming")]
     public class AQProgrammaticSubscribeTest : ProgrammaticSubcribeTestsRunner, IClassFixture<AQProgrammaticSubscribeTest.Fixture>
     {
         private const int queueCount = 8;

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -202,7 +202,7 @@ namespace Tester.AzureUtils.Streaming
                 this.HostedCluster.StartAdditionalSilo);
         }
 
-        //[SkippableFact, TestCategory("BVT"), TestCategory("Functional")]
+        //[SkippableFact, TestCategory("BVT")]
         /*public async Task AQ_18_MultipleStreams_1J_1F_ManyProducerGrainsManyConsumerGrains()
         {
             var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 18, false);

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -85,7 +85,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ID_IsSystem()
         {
             GrainId testGrain = Orleans.Runtime.Constants.DirectoryServiceId;
@@ -103,28 +103,28 @@ namespace UnitTests.General
             Assert.True(testActivation.IsSystem); // System activation ID is not flagged as a system ID
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeyKeyExtGrainCategoryDisallowsNullKeyExtension()
         {
             Assert.Throws<ArgumentNullException>(() =>
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: null));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeyKeyExtGrainCategoryDisallowsEmptyKeyExtension()
         {
             Assert.Throws<ArgumentException>(() =>
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: ""));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeyKeyExtGrainCategoryDisallowsWhiteSpaceKeyExtension()
         {
             Assert.Throws<ArgumentException>(() =>
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: " \t\n\r"));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeySerializationShouldReproduceAnIdenticalObject()
         {
             {
@@ -157,7 +157,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ParsingUniqueKeyStringificationShouldReproduceAnIdenticalObject()
         {
             UniqueKey expected1 = UniqueKey.NewKey(Guid.NewGuid());
@@ -186,7 +186,7 @@ namespace UnitTests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void GrainIdShouldEncodeAndDecodePrimaryKeyGuidCorrectly()
         {
             const int repeat = 100;
@@ -243,7 +243,7 @@ namespace UnitTests.General
             return output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueTypeCodeDataShouldStore32BitsOfInformation()
         {
             const int expected = unchecked((int)0xfabccbaf);
@@ -253,7 +253,7 @@ namespace UnitTests.General
             Assert.Equal(expected, actual);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeysShouldPreserveTheirPrimaryKeyValueIfItIsGuid()
         {
             const int all32Bits = unchecked((int)0xffffffff);
@@ -274,7 +274,7 @@ namespace UnitTests.General
             Assert.Equal(expectedKeyExt2, actualKeyExt2); // "UniqueKey objects should preserve the value of their key extension (Guid case #2).");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeysShouldPreserveTheirPrimaryKeyValueIfItIsLong()
         {
             const int all32Bits = unchecked((int)0xffffffff);
@@ -292,7 +292,7 @@ namespace UnitTests.General
             Assert.Equal(expectedKeyExt, actualKeyExt); // "UniqueKey objects should preserve the value of their key extension (long case).");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ID_HashCorrectness()
         {
             // This tests that our optimized Jenkins hash computes the same value as the reference implementation
@@ -310,7 +310,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ID_Interning_GrainID()
         {
             Guid guid = new Guid();
@@ -327,7 +327,7 @@ namespace UnitTests.General
             Assert.Same(gid2, gid3); // Should be same / intern'ed GrainId object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ID_Interning_string_equals()
         {
             Interner<string, string> interner = new Interner<string, string>();
@@ -345,7 +345,7 @@ namespace UnitTests.General
             Assert.Equal(r2, r3); // 4: Should be equal
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void ID_Intern_FindOrCreate_derived_class()
         {
             Interner<int, A> interner = new Interner<int, A>();
@@ -377,7 +377,7 @@ namespace UnitTests.General
             Assert.Same(obj2, r5); // FindOrCreate return previously cached object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void Interning_SiloAddress()
         {
             //string addrStr1 = "1.2.3.4@11111@1";
@@ -394,7 +394,7 @@ namespace UnitTests.General
             Assert.Same(a2, a3); // Should be same / intern'ed SiloAddress object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void Interning_SiloAddress2()
         {
             SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
@@ -403,7 +403,7 @@ namespace UnitTests.General
             Assert.NotSame(a1, a2); // Should not be same / intern'ed SiloAddress object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void Interning_SiloAddress_Serialization()
         {
             SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
@@ -414,7 +414,7 @@ namespace UnitTests.General
             Assert.Same(a1, a3); // Should be same / intern'ed SiloAddress object
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void GrainID_AsGuid()
         {
             string guidString = "0699605f-884d-4343-9977-f40a39ab7b2b";
@@ -441,7 +441,7 @@ namespace UnitTests.General
             Assert.NotEqual(guidString, grainIdKeyString); // GrainId.Key.ToString
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void SiloAddress_ToFrom_ParsableString()
         {
             SiloAddress address1 = SiloAddressUtils.NewLocalSiloAddress(12345);
@@ -474,7 +474,7 @@ namespace UnitTests.General
             return pkGuidString;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers"), TestCategory("GrainReference")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers"), TestCategory("GrainReference")]
         public void GrainReference_Test1()
         {
             Guid guid = Guid.NewGuid();

--- a/test/NonSilo.Tests/General/InterfaceRules.cs
+++ b/test/NonSilo.Tests/General/InterfaceRules.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -148,90 +148,90 @@ namespace UnitTests.General
             Assert.True(isConcreteGrainClass, $"IsConcreteGrainClass {grainClass}");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_VoidMethod()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_VoidMethod)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_IntMethod()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_IntMethod)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_IntProperty()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_IntProperty)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_PropertySetter()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_PropertySetter)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_Observer_NonVoidMethod()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestObserver_NonVoidMethod)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_Observer_Property()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestObserver_Property)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_OutArgument()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_OutArgument)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_RefArgument()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_RefArgument)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_ValueTask()
         {
             GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_ValueTask));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_VoidMethod()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_VoidMethod)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_IntMethod()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntMethod)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_IntProperty()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
             GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntProperty)));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        [Fact, TestCategory("BVT"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_PropertySetter()
         {
             Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>

--- a/test/NonSilo.Tests/General/LruTest.cs
+++ b/test/NonSilo.Tests/General/LruTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Orleans.Runtime;
 using Xunit;
@@ -11,7 +11,7 @@ namespace UnitTests
     ///</summary>
     public class LruTest
     {
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("LRU")]
+        [Fact, TestCategory("BVT"), TestCategory("LRU")]
         public void LruCountTest()
         {
             const int maxSize = 10;
@@ -28,7 +28,7 @@ namespace UnitTests
             Assert.Equal(2, target.Count);  // "Count wrong after adding two items"
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("LRU")]
+        [Fact, TestCategory("BVT"), TestCategory("LRU")]
         public void LruMaximumSizeTest()
         {
             const int maxSize = 10;
@@ -51,7 +51,7 @@ namespace UnitTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("LRU")]
+        [Fact, TestCategory("BVT"), TestCategory("LRU")]
         public void LruUsageTest()
         {
             const int maxSize = 10;

--- a/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
+++ b/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
@@ -20,13 +20,13 @@ namespace UnitTests.Serialization
                     options => options.SerializationProviders.Add(typeof(FakeSerializer))));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SerializationTests_CustomSerializerInitialized()
         {
             Assert.True(FakeSerializer.Initialized, "The fake serializer wasn't discovered");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SerializationTests_CustomSerializerIsSupportedType()
         {
             var data = new FakeSerialized { SomeData = "some data" };
@@ -35,7 +35,7 @@ namespace UnitTests.Serialization
             Assert.True(FakeSerializer.IsSupportedTypeCalled, "type discovery failed");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SerializationTests_ThatSerializeAndDeserializeWereInvoked()
         {
             var data = new FakeSerialized { SomeData = "some data" };
@@ -44,7 +44,7 @@ namespace UnitTests.Serialization
             Assert.True(FakeSerializer.DeserializeCalled);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SerializationTests_ThatCopyWasInvoked()
         {
             var data = new FakeSerialized { SomeData = "some data" };
@@ -52,7 +52,7 @@ namespace UnitTests.Serialization
             Assert.True(FakeSerializer.DeepCopyCalled);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SerializationTests_ExternalSerializerUsedEvenIfCodegenDidntGenerateSerializersForIt()
         {
             var data = new FakeSerializedWithNoCodegenSerializers { SomeData = "some data", SomeMoreData = "more data" };

--- a/test/NonSilo.Tests/Serialization/SerializationOrderTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationOrderTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Serialization
                      options => options.SerializationProviders.AddRange(new[] { typeof(FakeSerializer1), typeof(FakeSerializer2) })));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationOrder_VerifyThatExternalIsHigherPriorityThanAttributeDefined()
         {
             FakeSerializer1.SupportedTypes = FakeSerializer2.SupportedTypes = new[] { typeof(FakeTypeToSerialize) };
@@ -41,7 +41,7 @@ namespace UnitTests.Serialization
                 "Deserialize on the type should NOT have been called");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationOrder_VerifyThatAttributeDefinedCalledIfNoExternalSerializersSupportType()
         {
             var serializationItem = new FakeTypeToSerialize { SomeValue = 1 };
@@ -51,7 +51,7 @@ namespace UnitTests.Serialization
             Assert.True(FakeTypeToSerialize.DeserializeWasCalled, "FakeTypeToSerialize.Deserialize should have been called");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationOrder_VerifyExternalSerializersInvokedInOrder()
         {
             FakeSerializer1.SupportedTypes = FakeSerializer2.SupportedTypes = new[] { typeof(FakeTypeToSerialize) };

--- a/test/NonSilo.Tests/Serialization/SerializationTests.DifferentTypes.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationTests.DifferentTypes.cs
@@ -23,7 +23,7 @@ namespace UnitTests.Serialization
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_DateTime()
         {
             // Local Kind
@@ -48,7 +48,7 @@ namespace UnitTests.Serialization
             Assert.Equal(inputUnspecified.Kind, outputUnspecified.Kind);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_DateTimeOffset()
         {
             // Local Kind
@@ -115,7 +115,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_RecursiveSerialization()
         {
             TestTypeA input = new TestTypeA();
@@ -127,7 +127,7 @@ namespace UnitTests.Serialization
             TestTypeA output2 = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_CultureInfo()
         {
             var input = new List<CultureInfo> { CultureInfo.GetCultureInfo("en"), CultureInfo.GetCultureInfo("de") };
@@ -139,7 +139,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_CultureInfoList()
         {
             var input = new List<CultureInfo> { CultureInfo.GetCultureInfo("en"), CultureInfo.GetCultureInfo("de") };
@@ -148,7 +148,7 @@ namespace UnitTests.Serialization
             Assert.True(input.SequenceEqual(output));
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple()
         {
             var input = new List<ValueTuple<int>> { ValueTuple.Create(1), ValueTuple.Create(100) };
@@ -160,7 +160,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple2()
         {
             var input = new List<ValueTuple<int, int>> { ValueTuple.Create(1, 2), ValueTuple.Create(100, 200) };
@@ -172,7 +172,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple3()
         {
             var input = new List<ValueTuple<int, int, int>>
@@ -188,7 +188,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple4()
         {
             var input = new List<ValueTuple<int, int, int, int>>
@@ -204,7 +204,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple5()
         {
             var input = new List<ValueTuple<int, int, int, int, int>>
@@ -220,7 +220,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple6()
         {
             var input = new List<ValueTuple<int, int, int, int, int, int>>
@@ -236,7 +236,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple7()
         {
             var input = new List<ValueTuple<int, int, int, int, int, int, int>>
@@ -252,7 +252,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact(Skip = "See https://github.com/dotnet/orleans/issues/3531"), TestCategory("BVT"), TestCategory("Serialization")]
         public void SerializationTests_ValueTuple8()
         {
             var valueTuple = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, 8);

--- a/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Serialization
             Assert.Equal<T>(input,output);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_Dictionary()
         {
             var original = ImmutableDictionary.CreateBuilder<string, string>();
@@ -32,14 +32,14 @@ namespace UnitTests.Serialization
             RoundTripCollectionSerializationTest(dict);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_Array()
         {
             var original = ImmutableArray.Create("1","2","3");
             RoundTripCollectionSerializationTest(original);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_ArrayDefault()
         {
             var input = default(ImmutableArray<int>);
@@ -47,35 +47,35 @@ namespace UnitTests.Serialization
             Assert.Equal(input, output);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_HashSet()
         {
             var original = ImmutableHashSet.Create("1", "2", "3");
             RoundTripCollectionSerializationTest(original);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_List()
         {
             var original = ImmutableList.Create("1", "2", "3");
             RoundTripCollectionSerializationTest(original);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_Queue()
         {
             var original = ImmutableQueue.Create("1", "2", "3");
             RoundTripCollectionSerializationTest(original);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_SortedSet()
         {
             var original = ImmutableSortedSet.Create("1", "2", "3");
             RoundTripCollectionSerializationTest(original);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("ImmutableCollections"), TestCategory("Serialization")]
         public void SerializationTests_ImmutableCollections_SortedDictionary()
         {
             var original = ImmutableSortedDictionary.CreateBuilder<string, string>();

--- a/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
@@ -21,7 +21,7 @@ namespace UnitTests.CancellationTests
             this.fixture = fixture;
         }
 
-        [Theory, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]
@@ -35,7 +35,7 @@ namespace UnitTests.CancellationTests
             await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
         }
 
-        [Theory, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]
@@ -51,7 +51,7 @@ namespace UnitTests.CancellationTests
             await Task.WhenAll(grainTasks);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
         public async Task TokenPassingWithoutCancellation_NoExceptionShouldBeThrown()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
@@ -66,7 +66,7 @@ namespace UnitTests.CancellationTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
         public async Task PreCancelledTokenPassing()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
@@ -76,7 +76,7 @@ namespace UnitTests.CancellationTests
             await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
         public async Task CancellationTokenCallbacksExecutionContext()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
@@ -88,7 +88,7 @@ namespace UnitTests.CancellationTests
             Assert.True(result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
         public async Task CancellationTokenCallbacksTaskSchedulerContext()
         {
             var grains = await GetGrains<bool>(false);
@@ -120,7 +120,7 @@ namespace UnitTests.CancellationTests
             Assert.True(false, "No exception was thrown");
         }
 
-        [Theory, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]
@@ -129,7 +129,7 @@ namespace UnitTests.CancellationTests
             await GrainGrainCancellation(false, delay);
         }
 
-        [Theory, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]
@@ -138,7 +138,7 @@ namespace UnitTests.CancellationTests
             await GrainGrainCancellation(true, delay);
         }
 
-        [SkippableTheory(Skip="https://github.com/dotnet/orleans/issues/5654"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [SkippableTheory(Skip="https://github.com/dotnet/orleans/issues/5654"), TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]
@@ -147,7 +147,7 @@ namespace UnitTests.CancellationTests
             await ClientGrainGrainTokenPassing(delay, true);
         }
 
-        [Theory, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(300)]

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.General
         {
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task BasicExceptionPropagation()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -41,7 +41,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", exception.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void ExceptionContainsOriginalStackTrace()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -57,7 +57,7 @@ namespace UnitTests.General
             Assert.Contains("ThrowsInvalidOperationException", exception.StackTrace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ExceptionContainsOriginalStackTraceWhenRethrowingLocally()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -76,7 +76,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ExceptionPropagationDoesNotUnwrapAggregateExceptions()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -87,7 +87,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", nestedEx.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task ExceptionPropagationDoesNoFlattenAggregateExceptions()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -99,7 +99,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", doubleNestedEx.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task TaskCancelationPropagation()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -107,7 +107,7 @@ namespace UnitTests.General
                 () => grain.Canceled());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task GrainForwardingExceptionPropagation()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -118,7 +118,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", exception.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task GrainForwardingExceptionPropagationDoesNotUnwrapAggregateExceptions()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -130,7 +130,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", nestedEx.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SynchronousExceptionThrownShouldResultInFaultedTask()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -147,7 +147,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", exception2.Message);
         }
 
-        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT")]
         public void ExceptionPropagationForwardsEntireAggregateException()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -173,7 +173,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SynchronousAggregateExceptionThrownShouldResultInFaultedTaskWithOriginalAggregateExceptionUnmodifiedAsInnerException()
         {
             IExceptionGrain grain = this.fixture.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());

--- a/test/Tester/GeoClusterTests/MultiClusterDataTests.cs
+++ b/test/Tester/GeoClusterTests/MultiClusterDataTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using Orleans.MultiCluster;
@@ -13,7 +13,7 @@ namespace Tester.GeoClusterTests
     /// </summary>
     public class MultiClusterDataTests
     {
-        [Fact, TestCategory("GeoCluster"), TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("GeoCluster"), TestCategory("BVT")]
         public void MultiClusterData_Configuration()
         {
             var ts1 = new DateTime(year: 2011, month: 1, day: 1);
@@ -34,7 +34,7 @@ namespace Tester.GeoClusterTests
             TestAlgebraicProperties(gd3, gd2);
         }
 
-        [Fact, TestCategory("GeoCluster"), TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("GeoCluster"), TestCategory("BVT")]
         public void MultiClusterData_Gateways()
         {
             var ts1 = DateTime.UtcNow;

--- a/test/Tester/GrainActivatorTests.cs
+++ b/test/Tester/GrainActivatorTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.General
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task CanUseCustomGrainActivatorToCreateGrains()
         {
             ISimpleDIGrain grain = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
@@ -49,7 +49,7 @@ namespace UnitTests.General
             Assert.Equal(HardcodedGrainActivator.HardcodedValue, actual);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task CanUseCustomGrainActivatorToReleaseGrains()
         {
             ISimpleDIGrain grain1 = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -34,7 +34,7 @@ namespace Tester
 
         public IGrainFactory GrainFactory { get; set; }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        [Fact, TestCategory("BVT"), TestCategory("GrainServices")]
         public async Task SimpleInvokeGrainService()
         {
             IGrainServiceTestGrain grain = this.GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
@@ -44,7 +44,7 @@ namespace Tester
             Assert.Equal("abc", prop);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        [Fact, TestCategory("BVT"), TestCategory("GrainServices")]
         public async Task GrainServiceWasStarted()
         {
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
@@ -52,7 +52,7 @@ namespace Tester
             Assert.True(prop);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        [Fact, TestCategory("BVT"), TestCategory("GrainServices")]
         public async Task GrainServiceWasStartedInBackground()
         {
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
@@ -60,7 +60,7 @@ namespace Tester
             Assert.True(prop);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        [Fact, TestCategory("BVT"), TestCategory("GrainServices")]
         public async Task GrainServiceWasInit()
         {
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
@@ -68,7 +68,7 @@ namespace Tester
             Assert.True(prop);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        [Fact, TestCategory("BVT"), TestCategory("GrainServices")]
         public async Task GrainServiceExtensionTest()
         {
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);

--- a/test/Tester/ManagementGrainTests.cs
+++ b/test/Tester/ManagementGrainTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.Management
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Management")]
+        [Fact, TestCategory("BVT"), TestCategory("Management")]
         public async Task GetHosts()
         {
             if (HostedCluster.SecondarySilos.Count == 0)
@@ -56,7 +56,7 @@ namespace UnitTests.Management
             Assert.Equal(numberOfActiveSilos, siloStatuses.Count);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Management")]
+        [Fact, TestCategory("BVT"), TestCategory("Management")]
         public async Task GetDetailedHosts()
         {
             if (HostedCluster.SecondarySilos.Count == 0)
@@ -72,7 +72,7 @@ namespace UnitTests.Management
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Management")]
+        [Fact, TestCategory("BVT"), TestCategory("Management")]
         public void GetSimpleGrainStatistics()
         {
             SimpleGrainStatistic[] stats = this.GetSimpleGrainStatisticsRunner("Initial");
@@ -83,13 +83,13 @@ namespace UnitTests.Management
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Management")]
+        [Fact, TestCategory("BVT"), TestCategory("Management")]
         public void GetSimpleGrainStatistics_ActivationCounts()
         {
             RunGetStatisticsTest<ISimpleGrain, SimpleGrain>(g => g.GetA().Wait());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Management")]
+        [Fact, TestCategory("BVT"), TestCategory("Management")]
         public void GetTestGrainStatistics_ActivationCounts()
         {
             RunGetStatisticsTest<ITestGrain, TestGrain>(g => g.GetKey().Wait());

--- a/test/Tester/SerializationTests/DeepCopyTests.cs
+++ b/test/Tester/SerializationTests/DeepCopyTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.FSharp.Collections;
+using Microsoft.FSharp.Collections;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -23,7 +23,7 @@ namespace UnitTests.Serialization
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void DeepCopyTests_BuiltinCollections()
         {
             {
@@ -77,7 +77,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void DeepCopyTests_ImmutableCollections()
         {
             {
@@ -127,7 +127,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void DeepCopyTests_UserDefinedType()
         {
             {
@@ -152,7 +152,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void DeepCopyTests_FSharp_Collections()
         {
             // F# list
@@ -197,7 +197,7 @@ namespace UnitTests.Serialization
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void DeepCopyTests_FSharp_Types()
         {
             // discriminated union case with an array field

--- a/test/Tester/SerializationTests/NonStaticSerializerTests.cs
+++ b/test/Tester/SerializationTests/NonStaticSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿using Orleans;
+using Orleans;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using System;
@@ -17,7 +17,7 @@ namespace Tester.SerializationTests
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void ConstructorIsCalled()
         {
             SimplePocoClassSerializer.CallCounter = 0;
@@ -27,7 +27,7 @@ namespace Tester.SerializationTests
             Assert.Equal(input.A, output.A);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
         public void StaticMethodStillRegistered()
         {
             SimplePocoClassSerializer.CallCounter = 0;

--- a/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
@@ -28,43 +28,43 @@ namespace UnitTests.Serialization
             Assert.Equal(input, output);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_Some()
         {
             RoundtripSerializationTest(FSharpOption<int>.Some(10));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_None()
         {
             RoundtripSerializationTest(FSharpOption<int>.None);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofInt()
         {
             RoundtripSerializationTest(FSharpTypes.Record.ofInt(1));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_Some()
         {
             RoundtripSerializationTest(RecordOfIntOption.ofInt(1));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_None()
         {
             RoundtripSerializationTest(RecordOfIntOption.Empty);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Single_Case_Union()
         {
             RoundtripSerializationTest(SingleCaseDU.ofInt(1));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Discriminated_Union()
         {
 
@@ -86,7 +86,7 @@ namespace UnitTests.Serialization
 
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Fact, TestCategory("BVT"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Collections()
         {
             var elements = new List<int>() { 0, 1, 2 };

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Serialization
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_JObject_Example1()
         {
             const string json = @"{ 
@@ -38,7 +38,7 @@ namespace UnitTests.Serialization
             Assert.Equal(input.ToString(), output.ToString());
         }
         
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_TypeNameHandling()
         {
             var original = new RootType();
@@ -55,7 +55,7 @@ namespace UnitTests.Serialization
             Assert.Equal(original, orleansDeser);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_NoTypeNameHandling()
         {
             var original = new RootType();
@@ -84,7 +84,7 @@ namespace UnitTests.Serialization
             //Assert.Equal(jsonDeser, orleansJsonDeser);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_POCO()
         {
             var obj = new SimplePOCO();

--- a/test/Tester/StorageFacet/StorageFacetTests.cs
+++ b/test/Tester/StorageFacet/StorageFacetTests.cs
@@ -50,13 +50,13 @@ namespace Tester
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Facet")]
+        [Fact, TestCategory("BVT"), TestCategory("Facet")]
         public Task ExampleStorageFacetHappyPath()
         {
             return ExampleStorageHappyPath<IStorageFacetGrain>();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Facet")]
+        [Fact, TestCategory("BVT"), TestCategory("Facet")]
         public Task ExampleStorageFactoryHappyPath()
         {
             return ExampleStorageHappyPath<IStorageFactoryGrain>();
@@ -76,13 +76,13 @@ namespace Tester
             Assert.Equal("Table:second-ActivateCalled:True, StateType:String", info[1]);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Facet")]
+        [Fact, TestCategory("BVT"), TestCategory("Facet")]
         public Task ExampleStorageFacetDefaultPath()
         {
             return ExampleStorageDefaultPath<IStorageDefaultFacetGrain>();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Facet")]
+        [Fact, TestCategory("BVT"), TestCategory("Facet")]
         public Task ExampleStorageFactoryDefaultPath()
         {
             return ExampleStorageDefaultPath<IStorageDefaultFactoryGrain>();

--- a/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -59,14 +59,14 @@ namespace UnitTests.StreamingTests
             this.fixture = fixture;
         }
         
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ValidateControllableGeneratedStreamsTest()
         {
             this.fixture.Logger.Info("************************ ValidateControllableGeneratedStreamsTest *********************************");
             await ValidateControllableGeneratedStreams();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task Validate2ControllableGeneratedStreamsTest()
         {
             this.fixture.Logger.Info("************************ Validate2ControllableGeneratedStreamsTest *********************************");

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 
 namespace Tester.StreamingTests.ProgrammaticSubscribeTests
 {
-    [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Functional")]
+    [TestCategory("BVT"), TestCategory("Streaming")]
     public class ProgrammaticSubscribeTestSMSStreamProvider : ProgrammaticSubcribeTestsRunner, IClassFixture<ProgrammaticSubscribeTestSMSStreamProvider.Fixture>
     {
         public class Fixture : BaseTestClusterFixture

--- a/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -49,42 +49,42 @@ namespace UnitTests.StreamingTests
             runner = new SubscriptionMultiplicityTestRunner(Fixture.StreamProvider, fixture.HostedCluster);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSMultipleSubscriptionTest()
         {
             this.fixture.Logger.Info("************************ SMSMultipleSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSAddAndRemoveSubscriptionTest()
         {
             this.fixture.Logger.Info("************************ SMSAddAndRemoveSubscriptionTest *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSResubscriptionTest()
         {
             this.fixture.Logger.Info("************************ SMSResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSResubscriptionAfterDeactivationTest()
         {
             this.fixture.Logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSActiveSubscriptionTest()
         {
             this.fixture.Logger.Info("************************ SMSActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSSubscribeFromClientTest()
         {
             this.fixture.Logger.Info("************************ SMSSubscribeFromClientTest *********************************");

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.StreamingTests
             logger = this.fixture.Logger;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void SampleStreamingTests_StreamTypeMismatch_ShouldThrowOrleansException()
         {
             var streamId = Guid.NewGuid();
@@ -67,7 +67,7 @@ namespace UnitTests.StreamingTests
                 });
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task SampleStreamingTests_1()
         {
             this.logger.Info("************************ SampleStreamingTests_1 *********************************");

--- a/test/Tester/StreamingTests/StreamFilteringTests_SMS.cs
+++ b/test/Tester/StreamingTests/StreamFilteringTests_SMS.cs
@@ -45,32 +45,32 @@ namespace Tester.StreamingTests
             streamProviderName = Fixture.StreamProvider;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_Basic()
         {
             await Test_Filter_EvenOdd(true);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_EvenOdd()
         {
             await Test_Filter_EvenOdd();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_BadFunc()
         {
             await Assert.ThrowsAsync<ArgumentException>(() =>
                  Test_Filter_BadFunc());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_TwoObsv_Different()
         {
             await Test_Filter_TwoObsv_Different();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_TwoObsv_Same()
         {
             await Test_Filter_TwoObsv_Same();

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -65,7 +65,7 @@ namespace UnitTests.StreamingTests
 
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(3);
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ValidateGeneratedStreamsTest()
         {
             this.fixture.Logger.Info("************************ ValidateGeneratedStreamsTest *********************************");

--- a/test/TesterInternal/AgentTests.cs
+++ b/test/TesterInternal/AgentTests.cs
@@ -44,7 +44,7 @@ namespace UnitTests
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public async Task DedicatedAsynchAgentRestartsTest()
         {
             IAgentTestGrain grain = this.fixture.GrainFactory.GetGrain<IAgentTestGrain>(GetRandomGrainId());

--- a/test/TesterInternal/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GatewaySelectionTest.cs
@@ -33,7 +33,7 @@ namespace UnitTests.MessageCenterTests
             this.output = output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Gateway")]
+        [Fact, TestCategory("BVT"), TestCategory("Gateway")]
         public void GatewaySelection()
         {
             var listProvider = new TestListProvider(gatewayAddressUris);

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -81,7 +81,7 @@ namespace UnitTests.General
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("RequestContext")]
+        [Fact, TestCategory("BVT"), TestCategory("RequestContext")]
         public async Task RequestContext_LegacyActivityId_Simple()
         {
             Guid activityId = Guid.NewGuid();

--- a/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
@@ -208,7 +208,7 @@ namespace UnitTests
             await Do_FanOut_Task_Join(0, false, true);
         }
 
-        // TODO: [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
+        // TODO: [Fact, TestCategory("BVT"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         [Fact(Skip ="Ignore"), TestCategory("Failures"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task FanOut_Task_NonReentrant_Chain()
         {

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.StreamingTests
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task RegisterConsumerFaultTest()
         {
             this.fixture.Logger.Info("************************ RegisterConsumerFaultTest *********************************");
@@ -65,7 +65,7 @@ namespace UnitTests.StreamingTests
             Assert.Equal(2, consumers);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task UnregisterConsumerFaultTest()
         {
             this.fixture.Logger.Info("************************ UnregisterConsumerFaultTest *********************************");
@@ -113,7 +113,7 @@ namespace UnitTests.StreamingTests
         /// TODO: Fix rendezvous implementation.
         /// </summary>
         /// <returns></returns>
-        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task RegisterProducerFaultTest()
         {
             this.fixture.Logger.Info("************************ RegisterProducerFaultTest *********************************");
@@ -145,7 +145,7 @@ namespace UnitTests.StreamingTests
         /// This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension in the producer management calls.
         /// TODO: Fix rendezvous implementation.
         /// </summary>
-        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task UnregisterProducerFaultTest()
         {
             this.fixture.Logger.Info("************************ UnregisterProducerFaultTest *********************************");

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -548,7 +548,7 @@ namespace UnitTests.StreamingTests
 //    await BasicTestAsync(producer, consumer);
 //}
 
-//[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+//[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_2_ProducerJoinsFirstConsumerLater()
 //{
 //    logger.Info("\n\n ************************ StreamTest_2_ProducerJoinsFirstConsumerLater ********************************* \n\n");
@@ -562,7 +562,7 @@ namespace UnitTests.StreamingTests
 
 
 
-//[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+//[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTestProducerOnly()
 //{
 //    streamId = Guid.NewGuid();
@@ -570,7 +570,7 @@ namespace UnitTests.StreamingTests
 //    await TestGrainProducerOnlyAsync(streamId, this.streamProviderName);
 //}
 
-//[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+//[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public void AQProducerOnly()
 //{
 //    streamId = Guid.NewGuid();
@@ -598,7 +598,7 @@ namespace UnitTests.StreamingTests
 
 ////------------------------ MANY to One ----------------------//
 
-//[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+//[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_Many_5_ManyProducerGrainsOneConsumerGrain()
 //{
 //    logger.Info("\n\n ************************ StreamTest_6_ManyProducerGrainsOneConsumerGrain ********************************* \n\n");
@@ -609,7 +609,7 @@ namespace UnitTests.StreamingTests
 //    await BasicTestAsync(producer, consumer);
 //}
 
-//[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+//[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_Many6_OneProducerGrainManyConsumerGrains()
 //{
 //    logger.Info("\n\n ************************ StreamTest_7_OneProducerGrainManyConsumerGrains ********************************* \n\n");


### PR DESCRIPTION
Test cases should be either BVT or Functional but not both. This PR makes removes the Functional trait from test cases which are also marked as BVT.