### PR TITLE
Use MemFree when MemAvailable is not present

### DIFF
--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
@@ -173,8 +173,11 @@ namespace Orleans.Statistics
 
             if (string.IsNullOrWhiteSpace(memAvailableLine))
             {
-                _logger.LogWarning($"Couldn't read 'MemAvailable' line from '{MEMINFO_FILEPATH}'");
-                return;
+                memAvailableLine = await ReadLineStartingWithAsync(MEMINFO_FILEPATH, "MemFree");
+                if (string.IsNullOrWhiteSpace(memAvailableLine)) {
+                    _logger.LogWarning($"Couldn't read 'MemAvailable' or 'MemFree' line from '{MEMINFO_FILEPATH}'");
+                    return;
+                }
             }
 
             if (!long.TryParse(new string(memAvailableLine.Where(char.IsDigit).ToArray()), out var availableMemInKb))

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
@@ -174,7 +174,8 @@ namespace Orleans.Statistics
             if (string.IsNullOrWhiteSpace(memAvailableLine))
             {
                 memAvailableLine = await ReadLineStartingWithAsync(MEMINFO_FILEPATH, "MemFree");
-                if (string.IsNullOrWhiteSpace(memAvailableLine)) {
+                if (string.IsNullOrWhiteSpace(memAvailableLine))
+                {
                     _logger.LogWarning($"Couldn't read 'MemAvailable' or 'MemFree' line from '{MEMINFO_FILEPATH}'");
                     return;
                 }


### PR DESCRIPTION
On Windows WSL1, there is no MemAvailable line in meminfo file.
Use MemFree which gives similiar information.