### PR TITLE
Support adding [DebuggerStepThrough] to generated classes via project option

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
@@ -76,6 +76,11 @@ namespace Orleans.CodeGenerator.MSBuild
         /// </summary>
         public string AssemblyName { get; set; }
 
+        /// <summary>
+        /// Whether or not to add <see cref="DebuggerStepThroughAttribute"/> to generated code.
+        /// </summary>
+        public bool DebuggerStepThrough { get; set; }
+
         public async Task<bool> Execute(CancellationToken cancellationToken)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -135,7 +140,11 @@ namespace Orleans.CodeGenerator.MSBuild
                 return false;
             }
 
-            var generator = new CodeGenerator(compilation, this.Log);
+            var options = new CodeGeneratorOptions
+            {
+                DebuggerStepThrough = this.DebuggerStepThrough
+            };
+            var generator = new CodeGenerator(compilation, options, this.Log);
             var syntax = generator.GenerateCode(cancellationToken);
             this.Log.LogDebug($"GenerateCode completed in {stopwatch.ElapsedMilliseconds}ms.");
             stopwatch.Restart();

--- a/src/Orleans.CodeGenerator.MSBuild/Program.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/Program.cs
@@ -105,6 +105,9 @@ namespace Microsoft.Orleans.CodeGenerator.MSBuild
                         case nameof(cmd.CodeGenOutputFile):
                             cmd.CodeGenOutputFile = value;
                             break;
+                        case nameof(cmd.DebuggerStepThrough):
+                            cmd.DebuggerStepThrough = bool.Parse(value);
+                            break;
                         case nameof(LogLevel):
                             if (!Enum.TryParse(ignoreCase: true, value: value, result: out logLevel))
                             {

--- a/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -98,6 +98,7 @@
     <ItemGroup>
       <Orleans_CodeGenArgs Include="WaitForDebugger" Condition="'$(OrleansCodeGenWaitForDebugger)' != ''" />
       <Orleans_CodeGenArgs Include="LogLevel:$(OrleansCodeGenLogLevel)" />
+      <Orleans_CodeGenArgs Include="DebuggerStepThrough:true" Condition="'$(OrleansCodeGenDebuggerStepThrough)' == 'true'" />
       <Orleans_CodeGenArgs Include="ProjectPath:$(MSBuildProjectFullPath)"/>
       <Orleans_CodeGenArgs Include="ProjectGuid:$(ProjectGuid)"/>
       <Orleans_CodeGenArgs Include="AssemblyName:$(AssemblyName)"/>

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -26,10 +26,15 @@ namespace Orleans.CodeGenerator
         private readonly SemanticModel semanticModelForAccessibility;
         private readonly CompilationAnalyzer compilationAnalyzer;
         private readonly SerializerTypeAnalyzer serializerTypeAnalyzer;
+        private readonly SerializerGenerator serializerGenerator;
+        private readonly GrainMethodInvokerGenerator grainMethodInvokerGenerator;
+        private readonly GrainReferenceGenerator grainReferenceGenerator;
+        private readonly CodeGeneratorOptions options;
 
-        public CodeGenerator(Compilation compilation, ILogger log)
+        public CodeGenerator(Compilation compilation, CodeGeneratorOptions options, ILogger log)
         {
             this.compilation = compilation;
+            this.options = options;
             this.log = log;
             this.wellKnownTypes = WellKnownTypes.FromCompilation(compilation);
             this.compilationAnalyzer = new CompilationAnalyzer(log, this.wellKnownTypes, compilation);
@@ -37,6 +42,9 @@ namespace Orleans.CodeGenerator
             var firstSyntaxTree = compilation.SyntaxTrees.FirstOrDefault() ?? throw new InvalidOperationException("Compilation has no syntax trees.");
             this.semanticModelForAccessibility = compilation.GetSemanticModel(firstSyntaxTree);
             this.serializerTypeAnalyzer = SerializerTypeAnalyzer.Create(this.wellKnownTypes);
+            this.serializerGenerator = new SerializerGenerator(this.options, this.wellKnownTypes);
+            this.grainMethodInvokerGenerator = new GrainMethodInvokerGenerator(this.options, this.wellKnownTypes);
+            this.grainReferenceGenerator = new GrainReferenceGenerator(this.options, this.wellKnownTypes);
         }
 
         public CompilationUnitSyntax GenerateCode(CancellationToken cancellationToken)
@@ -140,8 +148,8 @@ namespace Orleans.CodeGenerator
             foreach (var grainInterface in model.GrainInterfaces)
             {
                 var nsMembers = GetNamespace(namespaceGroupings, grainInterface.Type.ContainingNamespace);
-                nsMembers.Add(GrainMethodInvokerGenerator.GenerateClass(this.wellKnownTypes, grainInterface));
-                nsMembers.Add(GrainReferenceGenerator.GenerateClass(this.wellKnownTypes, grainInterface));
+                nsMembers.Add(grainMethodInvokerGenerator.GenerateClass(grainInterface));
+                nsMembers.Add(grainReferenceGenerator.GenerateClass(grainInterface));
             }
 
             var serializersToGenerate = model.Serializers.SerializerTypes
@@ -151,7 +159,7 @@ namespace Orleans.CodeGenerator
             {
                 var nsMembers = GetNamespace(namespaceGroupings, serializerType.Target.ContainingNamespace);
                 TypeDeclarationSyntax generated;
-                (generated, serializerType.SerializerTypeSyntax) = SerializerGenerator.GenerateClass(this.wellKnownTypes, this.semanticModelForAccessibility, serializerType, this.log);
+                (generated, serializerType.SerializerTypeSyntax) = this.serializerGenerator.GenerateClass(this.semanticModelForAccessibility, serializerType, this.log);
                 nsMembers.Add(generated);
             }
 
@@ -395,7 +403,7 @@ namespace Orleans.CodeGenerator
                 foreach (var field in type.GetInstanceMembers<IFieldSymbol>())
                 {
                     // Ignore fields which won't be serialized anyway.
-                    if (!SerializerGenerator.ShouldSerializeField(this.wellKnownTypes, field))
+                    if (!this.serializerGenerator.ShouldSerializeField(field))
                     {
                         if (this.log.IsEnabled(LogLevel.Trace))
                         {

--- a/src/Orleans.CodeGenerator/CodeGeneratorOptions.cs
+++ b/src/Orleans.CodeGenerator/CodeGeneratorOptions.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace Orleans.CodeGenerator
+{
+    public class CodeGeneratorOptions
+    {
+        /// <summary>
+        /// Whether or not to add <see cref="DebuggerStepThroughAttribute"/> to generated code.
+        /// </summary>
+        public bool DebuggerStepThrough { get; set; }
+    }
+}

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -20,6 +20,7 @@ namespace Orleans.CodeGenerator
                 CopierMethodAttribute = Type("Orleans.CodeGeneration.CopierMethodAttribute"),
                 DeserializerMethodAttribute = Type("Orleans.CodeGeneration.DeserializerMethodAttribute"),
                 Delegate = compilation.GetSpecialType(SpecialType.System_Delegate),
+                DebuggerStepThroughAttribute = Type("System.Diagnostics.DebuggerStepThroughAttribute"),
                 Exception = Type("System.Exception"),
                 ExcludeFromCodeCoverageAttribute = Type("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"),
                 FormatterServices = Type("System.Runtime.Serialization.FormatterServices"),
@@ -167,6 +168,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol CopierMethodAttribute { get; private set; }
         public INamedTypeSymbol Delegate { get; private set; }
         public INamedTypeSymbol DeserializerMethodAttribute { get; private set; }
+        public INamedTypeSymbol DebuggerStepThroughAttribute { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }
         public INamedTypeSymbol ExcludeFromCodeCoverageAttribute { get; private set; }
         public INamedTypeSymbol FormatterServices { get; private set; }


### PR DESCRIPTION
Fixes #5001

Enable by adding this to your csproj:

``` xml 
  <PropertyGroup>
    <OrleansCodeGenDebuggerStepThrough>true</OrleansCodeGenDebuggerStepThrough>
  </PropertyGroup>
```

With this enabled, all generated `GrainReference`, serializer, and `IGrainMethodInvoker` implementations will be decorated with `[DebuggerStepThrough]`.