### PR TITLE
Disable ILBasedSerializer by default

### DIFF
--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -12,6 +12,9 @@ using Orleans.ApplicationParts;
 using Orleans.CodeGeneration;
 using Orleans.Messaging;
 using Orleans.Runtime;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Serialization;
+using Orleans.Configuration.Internal;
 
 namespace Orleans
 {
@@ -290,6 +293,20 @@ namespace Orleans
 
             configure(builder.GetApplicationPartManager());
             return builder;
+        }
+
+        /// <summary>
+        /// Enabled legacy <see cref="ILBasedSerializer"/> support.
+        /// </summary>
+        public static IClientBuilder EnableLegacyILBasedSerializer(this IClientBuilder builder)
+        {
+            return builder.ConfigureServices(services =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                services.TryAddSingleton<ILBasedSerializer>();
+                services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
         }
     }
 }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -67,10 +67,6 @@ namespace Orleans
             services.AddSingleton<BinaryFormatterSerializer>();
             services.AddSingleton<BinaryFormatterISerializableSerializer>();
             services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
-#pragma warning disable CS0618 // Type or member is obsolete
-            services.TryAddSingleton<ILBasedSerializer>();
-            services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
-#pragma warning restore CS0618 // Type or member is obsolete
 
             // Application parts
             var parts = builder.GetApplicationPartManager();

--- a/src/Orleans.Runtime.Abstractions/Hosting/Generic/SiloHostBuilderExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/Generic/SiloHostBuilderExtensions.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Orleans.ApplicationParts;
-using Orleans.Configuration;
+using Orleans.Configuration.Internal;
+using Orleans.Serialization;
 
 namespace Orleans.Hosting
 {
@@ -151,6 +153,20 @@ namespace Orleans.Hosting
 
             configure(builder.GetApplicationPartManager());
             return builder;
+        }
+
+        /// <summary>
+        /// Enabled legacy <see cref="ILBasedSerializer"/> support.
+        /// </summary>
+        public static ISiloHostBuilder EnableLegacyILBasedSerializer(this ISiloHostBuilder builder)
+        {
+            return builder.ConfigureServices(services =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                services.TryAddSingleton<ILBasedSerializer>();
+                services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
         }
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/SiloBuilderExtensions.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Logging;
 using Orleans.ApplicationParts;
 using Orleans.Configuration;
 using Orleans;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Configuration.Internal;
+using Orleans.Serialization;
 
 namespace Orleans.Hosting
 {
@@ -98,6 +101,20 @@ namespace Orleans.Hosting
 
             configure(builder.GetApplicationPartManager());
             return builder;
+        }
+
+        /// <summary>
+        /// Enabled legacy <see cref="ILBasedSerializer"/> support.
+        /// </summary>
+        public static ISiloBuilder EnableLegacyILBasedSerializer(this ISiloBuilder builder)
+        {
+            return builder.ConfigureServices(services =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                services.TryAddSingleton<ILBasedSerializer>();
+                services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -263,10 +263,6 @@ namespace Orleans.Hosting
             services.AddSingleton<BinaryFormatterSerializer>();
             services.AddSingleton<BinaryFormatterISerializableSerializer>();
             services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
-#pragma warning disable CS0618 // Type or member is obsolete
-            services.AddSingleton<ILBasedSerializer>();
-            services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
-#pragma warning restore CS0618 // Type or member is obsolete
 
             // Transactions
             services.TryAddSingleton<ITransactionAgent, DisabledTransactionAgent>();


### PR DESCRIPTION
Fixes #5729

Users can re-enable `ILBasedSerializer` by calling `siloBuilder.EnableLegacyILBasedSerializer()` and `clientBuilder.EnableLegacyILBasedSerializer()`