### PR TITLE
Use half-duplex connections when accepting pre-v3 silo connections

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -164,7 +164,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        public void Send(Message message)
+        public virtual void Send(Message message)
         {
             if (!this.outgoingMessageWriter.TryWrite(message))
             {


### PR DESCRIPTION
This change is required to support rolling upgrades from pre-v3.0 silos. Those silos abort outgoing connections when the remote endpoint sends data.