### PR TITLE
Default to cleaning up dead silo entries in the cluster membership table after 7 days

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -99,7 +99,7 @@ namespace Orleans.Configuration
         /// entries older than <see cref="DefunctSiloExpiration" /> are removed. This value is per-silo.
         /// </summary>
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD;
-        public static readonly TimeSpan? DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD = null;
+        public static readonly TimeSpan? DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD = TimeSpan.FromDays(7);
 
         /// <summary>
         /// TEST ONLY - Do not modify in production environments


### PR DESCRIPTION
Fixes #5733.