### PR TITLE
Add TLS middleware with sample

### DIFF
--- a/Orleans.sln
+++ b/Orleans.sln
@@ -202,6 +202,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Analyzers", "src\Or
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analyzers.Tests", "test\Analyzers.Tests\Analyzers.Tests.csproj", "{B94232D8-B8C2-45D8-AE09-7D8A0B0D88ED}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Connections.Security", "src\Orleans.Connections.Security\Orleans.Connections.Security.csproj", "{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orleans.Connections.Security.Tests", "test\Orleans.Connections.Security.Tests\Orleans.Connections.Security.Tests.csproj", "{D53D80CC-3E14-4499-B03F-610A5D3F6359}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1220,6 +1224,30 @@ Global
 		{B94232D8-B8C2-45D8-AE09-7D8A0B0D88ED}.Release|x64.Build.0 = Release|Any CPU
 		{B94232D8-B8C2-45D8-AE09-7D8A0B0D88ED}.Release|x86.ActiveCfg = Release|Any CPU
 		{B94232D8-B8C2-45D8-AE09-7D8A0B0D88ED}.Release|x86.Build.0 = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|x64.Build.0 = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372}.Release|x86.Build.0 = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|x64.Build.0 = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Debug|x86.Build.0 = Debug|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|x64.ActiveCfg = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|x64.Build.0 = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|x86.ActiveCfg = Release|Any CPU
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1322,6 +1350,8 @@ Global
 		{49E24301-040C-4C23-A985-AF30005A413C} = {FE2E08C6-9C3B-4AEE-AE07-CCA387580D7A}
 		{8CE65361-7EFA-41B2-AE13-D6CC2A68105F} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
 		{B94232D8-B8C2-45D8-AE09-7D8A0B0D88ED} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
+		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372} = {FE2E08C6-9C3B-4AEE-AE07-CCA387580D7A}
+		{D53D80CC-3E14-4499-B03F-610A5D3F6359} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/Samples/3.0/Directory.Build.props
+++ b/Samples/3.0/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <OrleansPackageVersion Condition=" '$(OrleansPackageVersion)'=='' ">3.0.0</OrleansPackageVersion>
+  </PropertyGroup>
+
+</Project>

--- a/Samples/3.0/TransportLayerSecurity/README.md
+++ b/Samples/3.0/TransportLayerSecurity/README.md
@@ -1,0 +1,35 @@
+# Transport Layer Security (TLS) Sample
+
+This sample demonstrates a client and silo which communicate over a channel secured by Transport Layer Security (TLS).
+
+## Running the sample
+
+For the purpose of the sample, we will generate and use a self-signed certificate.
+
+***NOTE:*** Ensure that security best practices are followed when deploying your application to a production environment.
+
+A self-signed certificate can be generated & installed using PowerShell:
+
+``` powershell
+$cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My -DnsName "fakedomain.faketld"
+```
+
+Now that the certificate configured in the sample is installed, run the client and silo:
+
+Start the silo using the following command:
+
+``` powershell
+dotnet run --project src\SiloHost
+```
+
+Start the client in a different command window using the following command:
+
+``` powershell
+dotnet run --project src\OrleansClient\
+```
+
+Once you have successfully run the sample, remove the self-signed certificate which was generated above:
+
+``` powershell
+Remove-Item "Cert:\LocalMachine\My\$($cert.ThumbPrint)"
+```

--- a/Samples/3.0/TransportLayerSecurity/TransportLayerSecurity.sln
+++ b/Samples/3.0/TransportLayerSecurity/TransportLayerSecurity.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SiloHost", "src\SiloHost\SiloHost.csproj", "{8833CADE-80B5-4AA1-835E-594E907C58DF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansClient", "src\OrleansClient\OrleansClient.csproj", "{18DFEAE0-0000-4EFF-825F-2150B0C509F8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloWorld.Interfaces", "src\HelloWorld.Interfaces\HelloWorld.Interfaces.csproj", "{1977C291-BE23-415A-8305-9E6F7B23203D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloWorld.Grains", "src\HelloWorld.Grains\HelloWorld.Grains.csproj", "{C8097F83-2D0E-4FFD-AEAE-AA075141289C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3C202E56-5082-4C00-9438-E0DFAAEC9326}"
+	ProjectSection(SolutionItems) = preProject
+		BuildAndRun.ps1 = BuildAndRun.ps1
+		BuildAndRun.sh = BuildAndRun.sh
+		..\Directory.Build.props = ..\Directory.Build.props
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8833CADE-80B5-4AA1-835E-594E907C58DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8833CADE-80B5-4AA1-835E-594E907C58DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8833CADE-80B5-4AA1-835E-594E907C58DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8833CADE-80B5-4AA1-835E-594E907C58DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18DFEAE0-0000-4EFF-825F-2150B0C509F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18DFEAE0-0000-4EFF-825F-2150B0C509F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18DFEAE0-0000-4EFF-825F-2150B0C509F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18DFEAE0-0000-4EFF-825F-2150B0C509F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1977C291-BE23-415A-8305-9E6F7B23203D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1977C291-BE23-415A-8305-9E6F7B23203D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1977C291-BE23-415A-8305-9E6F7B23203D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1977C291-BE23-415A-8305-9E6F7B23203D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8097F83-2D0E-4FFD-AEAE-AA075141289C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8097F83-2D0E-4FFD-AEAE-AA075141289C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8097F83-2D0E-4FFD-AEAE-AA075141289C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8097F83-2D0E-4FFD-AEAE-AA075141289C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {770CE15D-FCF4-4F37-BBC3-B62DEEFFB973}
+	EndGlobalSection
+EndGlobal

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloArchiveGrain.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloArchiveGrain.cs
@@ -1,0 +1,29 @@
+﻿using HelloWorld.Interfaces;
+using Orleans;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HelloWorld.Grains
+{
+    public class HelloArchiveGrain : Grain<GreetingArchive>, IHelloArchive
+    {
+        public async Task<string> SayHello(string greeting)
+        {
+            State.Greetings.Add(greeting);
+
+            await WriteStateAsync();
+
+            return $"You said: '{greeting}', I say: Hello!";
+        }
+
+        public Task<IEnumerable<string>> GetGreetings()
+        {
+            return Task.FromResult<IEnumerable<string>>(State.Greetings);
+        }
+    }
+
+    public class GreetingArchive
+    {
+        public List<string> Greetings { get; } = new List<string>();
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloGrain.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloGrain.cs
@@ -1,0 +1,25 @@
+using HelloWorld.Interfaces;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace HelloWorld.Grains
+{
+    /// <summary>
+    /// Orleans grain implementation class HelloGrain.
+    /// </summary>
+    public class HelloGrain : Orleans.Grain, IHello
+    {
+        private readonly ILogger logger;
+
+        public HelloGrain(ILogger<HelloGrain> logger)
+        {
+            this.logger = logger;
+        }  
+
+        Task<string> IHello.SayHello(string greeting)
+        {
+            logger.LogInformation($"SayHello message received: greeting = '{greeting}'");
+            return Task.FromResult($"You said: '{greeting}', I say: Hello!");
+        }
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloWorld.Grains.csproj
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Grains/HelloWorld.Grains.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="$(OrleansPackageVersion)" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorld.Interfaces\HelloWorld.Interfaces.csproj" />
+  </ItemGroup>
+</Project>

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/HelloWorld.Interfaces.csproj
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/HelloWorld.Interfaces.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="$(OrleansPackageVersion)" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/IHello.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/IHello.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace HelloWorld.Interfaces
+{
+    /// <summary>
+    /// Orleans grain communication interface IHello
+    /// </summary>
+    public interface IHello : Orleans.IGrainWithIntegerKey
+    {
+        Task<string> SayHello(string greeting);
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/IHelloArchive.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/HelloWorld.Interfaces/IHelloArchive.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HelloWorld.Interfaces
+{
+    /// <summary>
+    /// Orleans grain communication interface that will save all greetings
+    /// </summary>
+    public interface IHelloArchive : Orleans.IGrainWithIntegerKey
+    {
+        Task<string> SayHello(string greeting);
+
+        Task<IEnumerable<string>> GetGreetings();
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/OrleansClient/OrleansClient.csproj
+++ b/Samples/3.0/TransportLayerSecurity/src/OrleansClient/OrleansClient.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorld.Interfaces\HelloWorld.Interfaces.csproj" />
+  </ItemGroup>
+</Project>

--- a/Samples/3.0/TransportLayerSecurity/src/OrleansClient/Program.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/OrleansClient/Program.cs
@@ -1,0 +1,74 @@
+using HelloWorld.Interfaces;
+using Orleans;
+using Orleans.Hosting;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using System.Security.Cryptography.X509Certificates;
+
+namespace OrleansClient
+{
+    /// <summary>
+    /// Orleans test silo client
+    /// </summary>
+    public class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            try
+            {
+                // Configure a client and connect to the service.
+                var client = new ClientBuilder()
+                    .UseLocalhostClustering(serviceId: "HelloWorldApp", clusterId: "dev")
+                    .UseTls(StoreName.My, "fakedomain.faketld", allowInvalid: true, StoreLocation.LocalMachine, options =>
+                    {
+                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
+                        {
+                            sslOptions.TargetHost = "fakedomain.faketld";
+                        };
+                        // NOTE: Do not do this in a production environment
+                        options.AllowAnyRemoteCertificate();
+                    })
+                    .ConfigureLogging(logging => logging.AddConsole())
+                    .Build();
+
+                await client.Connect(CreateRetryFilter());
+                Console.WriteLine("Client successfully connect to silo host");
+
+                // Use the connected client to call a grain, writing the result to the terminal.
+                var friend = client.GetGrain<IHello>(0);
+                var response = await friend.SayHello("Good morning, my friend!");
+                Console.WriteLine("\n\n{0}\n\n", response);
+
+                Console.ReadKey();
+                return 0;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                Console.ReadKey();
+                return 1;
+            }
+        }
+
+        private static Func<Exception, Task<bool>> CreateRetryFilter(int maxAttempts = 5)
+        {
+            var attempt = 0;
+            return RetryFilter;
+
+            async Task<bool> RetryFilter(Exception exception)
+            {
+                attempt++;
+                Console.WriteLine($"Cluster client attempt {attempt} of {maxAttempts} failed to connect to cluster.  Exception: {exception}");
+                if (attempt > maxAttempts)
+                {
+                    return false;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(4));
+                return true;
+            }
+        }
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/SiloHost/Program.cs
+++ b/Samples/3.0/TransportLayerSecurity/src/SiloHost/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Hosting;
+using System.Security.Cryptography.X509Certificates;
+using System.Net;
+using Orleans.Configuration;
+
+namespace OrleansSiloHost
+{
+    public class Program
+    {
+        public static async Task<int> Main(string[] args)
+        {
+            try
+            {
+                var host = new HostBuilder()
+                    .UseEnvironment(Environments.Development)
+                    .UseOrleans((context, siloBuilder) =>
+                    {
+                        var isDevelopment = context.HostingEnvironment.IsDevelopment();
+                        siloBuilder
+                            .UseLocalhostClustering(serviceId: "HelloWorldApp", clusterId: "dev")
+                            .Configure<ConnectionOptions>(options =>
+                            {
+                                options.ProtocolVersion = Orleans.Runtime.Messaging.NetworkProtocolVersion.Version2;
+                            })
+                            .UseTls(StoreName.My, "fakedomain.faketld", allowInvalid: isDevelopment, StoreLocation.LocalMachine, options =>
+                            {
+                                // In this sample there is only one silo, however if tehre are multiple silos then the TargetHost must be set
+                                // for each connection which is initiated.
+                                options.OnAuthenticateAsClient = (connection, sslOptions) =>
+                                {
+                                    sslOptions.TargetHost = "fakedomain.faketld";
+                                };
+
+                                if (isDevelopment)
+                                {
+                                    // NOTE: Do not do this in a production environment
+                                    options.AllowAnyRemoteCertificate();
+                                }
+                            });
+                    })
+                    .ConfigureLogging(logging => logging.AddConsole())
+                    .Build();
+                await host.RunAsync();
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return 1;
+            }
+        }
+    }
+}

--- a/Samples/3.0/TransportLayerSecurity/src/SiloHost/SiloHost.csproj
+++ b/Samples/3.0/TransportLayerSecurity/src/SiloHost/SiloHost.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorld.Grains\HelloWorld.Grains.csproj" />
+    <ProjectReference Include="..\HelloWorld.Interfaces\HelloWorld.Interfaces.csproj" />
+  </ItemGroup>
+</Project>

--- a/Test.cmd
+++ b/Test.cmd
@@ -40,6 +40,11 @@ set TESTS=^
 %CMDHOME%\test\Transactions\Orleans.Transactions.Azure.Test,^
 %CMDHOME%\test\TestInfrastructure\Orleans.TestingHost.Tests,^
 %CMDHOME%\test\DependencyInjection.Tests
+
+:: Add to TESTS once dotnet-xunit supports .NET Core 3.0 (post dotnet-xunit v2.4.1)
+rem %CMDHOME%\test\Orleans.Connections.Security.Tests
+rem %CMDHOME%\test\NetCore.Tests
+
 rem %CMDHOME%\test\Analyzers.Tests
 
 if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait Category=BVT -trait Category=SlowBVT

--- a/src/Orleans.Connections.Security/Directory.Build.props
+++ b/src/Orleans.Connections.Security/Directory.Build.props
@@ -1,0 +1,42 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <PropertyGroup Condition="$(OrleansExtensionsVersion) != $(VersionPrefix)">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansCodegenVersion)">
+      <ItemGroup>
+        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansExtensionsVersion)">
+      <ItemGroup>
+        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.IClientBuilder.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.IClientBuilder.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Orleans.Configuration;
+using Orleans.Connections.Security;
+
+namespace Orleans
+{
+    public static class OrleansConnectionSecurityHostingExtensions
+    {
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="storeName">The certificate store to load the certificate from.</param>
+        /// <param name="subject">The subject name for the certificate to load.</param>
+        /// <param name="allowInvalid">Indicates if invalid certificates should be considered, such as self-signed certificates.</param>
+        /// <param name="location">The store location to load the certificate from.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder UseTls(
+            this IClientBuilder builder,
+            StoreName storeName,
+            string subject,
+            bool allowInvalid,
+            StoreLocation location,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(
+                CertificateLoader.LoadFromStoreCert(subject, storeName.ToString(), location, allowInvalid, server: false),
+                configureOptions);
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder UseTls(
+            this IClientBuilder builder,
+            X509Certificate2 certificate,
+            Action<TlsOptions> configureOptions)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+                configureOptions(options);
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder UseTls(
+            this IClientBuilder builder,
+            X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder UseTls(
+            this IClientBuilder builder,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            var options = new TlsOptions();
+            configureOptions(options);
+            if (options.LocalCertificate is null && options.LocalServerCertificateSelector is null)
+            {
+                throw new InvalidOperationException("No certificate specified");
+            }
+
+            return builder.Configure<ClientConnectionOptions>(connectionOptions =>
+            {
+                connectionOptions.ConfigureConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseClientTls(options);
+                });
+            });
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.ISiloBuilder.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.ISiloBuilder.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Orleans.Configuration;
+using Orleans.Connections.Security;
+
+namespace Orleans.Hosting
+{
+    public static partial class OrleansConnectionSecurityHostingExtensions
+    {
+        public static ISiloBuilder UseMutualTls(
+            this ISiloBuilder builder,
+            X509Certificate2 certificate,
+            Action<TlsOptions> configureOptions)
+        {
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+                options.RemoteCertificateMode = RemoteCertificateMode.RequireCertificate;
+                options.RemoteCertificateValidation = ValidateClientCertificate;
+                configureOptions(options);
+            });
+
+            bool ValidateClientCertificate(X509Certificate2 clientCertificate, X509Chain certificateChain, SslPolicyErrors sslPolicyErrors)
+            {
+                return clientCertificate.Equals(certificate);
+            }
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="storeName">The certificate store to load the certificate from.</param>
+        /// <param name="subject">The subject name for the certificate to load.</param>
+        /// <param name="allowInvalid">Indicates if invalid certificates should be considered, such as self-signed certificates.</param>
+        /// <param name="location">The store location to load the certificate from.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloBuilder UseTls(
+            this ISiloBuilder builder,
+            StoreName storeName,
+            string subject,
+            bool allowInvalid,
+            StoreLocation location,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(
+                CertificateLoader.LoadFromStoreCert(subject, storeName.ToString(), location, allowInvalid, server: true),
+                configureOptions);
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloBuilder UseTls(
+            this ISiloBuilder builder,
+            X509Certificate2 certificate,
+            Action<TlsOptions> configureOptions)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+                configureOptions(options);
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloBuilder UseTls(
+            this ISiloBuilder builder,
+            X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloBuilder UseTls(
+            this ISiloBuilder builder,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            var options = new TlsOptions();
+            configureOptions(options);
+            if (options.LocalCertificate is null && options.LocalServerCertificateSelector is null)
+            {
+                throw new InvalidOperationException("No certificate specified");
+            }
+
+            return builder.Configure<SiloConnectionOptions>(connectionOptions =>
+            {
+                connectionOptions.ConfigureSiloInboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseServerTls(options);
+                });
+
+                connectionOptions.ConfigureGatewayInboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseServerTls(options);
+                });
+
+                connectionOptions.ConfigureSiloOutboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseClientTls(options);
+                });
+            });
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.ISiloHostBuilder.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.ISiloHostBuilder.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Orleans.Configuration;
+using Orleans.Connections.Security;
+
+namespace Orleans.Hosting
+{
+    public static partial class OrleansConnectionSecurityHostingExtensions
+    {
+        public static ISiloHostBuilder UseMutualTls(
+            this ISiloHostBuilder builder,
+            X509Certificate2 certificate,
+            Action<TlsOptions> configureOptions)
+        {
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+                options.RemoteCertificateMode = RemoteCertificateMode.RequireCertificate;
+                options.RemoteCertificateValidation = ValidateClientCertificate;
+                configureOptions(options);
+            });
+
+            bool ValidateClientCertificate(X509Certificate2 clientCertificate, X509Chain certificateChain, SslPolicyErrors sslPolicyErrors)
+            {
+                return clientCertificate.Equals(certificate);
+            }
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="storeName">The certificate store to load the certificate from.</param>
+        /// <param name="subject">The subject name for the certificate to load.</param>
+        /// <param name="allowInvalid">Indicates if invalid certificates should be considered, such as self-signed certificates.</param>
+        /// <param name="location">The store location to load the certificate from.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder UseTls(
+            this ISiloHostBuilder builder,
+            StoreName storeName,
+            string subject,
+            bool allowInvalid,
+            StoreLocation location,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(
+                CertificateLoader.LoadFromStoreCert(subject, storeName.ToString(), location, allowInvalid, server: true),
+                configureOptions);
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder UseTls(
+            this ISiloHostBuilder builder,
+            X509Certificate2 certificate,
+            Action<TlsOptions> configureOptions)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+                configureOptions(options);
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="certificate">The server certificate.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder UseTls(
+            this ISiloHostBuilder builder,
+            X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            return builder.UseTls(options =>
+            {
+                options.LocalCertificate = certificate;
+            });
+        }
+
+        /// <summary>
+        /// Configures TLS.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="configureOptions">An Action to configure the <see cref="TlsOptions"/>.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder UseTls(
+            this ISiloHostBuilder builder,
+            Action<TlsOptions> configureOptions)
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            var options = new TlsOptions();
+            configureOptions(options);
+            if (options.LocalCertificate is null && options.LocalServerCertificateSelector is null)
+            {
+                throw new InvalidOperationException("No certificate specified");
+            }
+
+            return builder.Configure<SiloConnectionOptions>(connectionOptions =>
+            {
+                connectionOptions.ConfigureSiloInboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseServerTls(options);
+                });
+
+                connectionOptions.ConfigureGatewayInboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseServerTls(options);
+                });
+
+                connectionOptions.ConfigureSiloOutboundConnection(connectionBuilder =>
+                {
+                    connectionBuilder.UseClientTls(options);
+                });
+            });
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Connections.Security;
+
+namespace Orleans
+{
+    public static class TlsConnectionBuilderExtensions
+    {
+        public static void UseServerTls(
+            this IConnectionBuilder builder,
+            TlsOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var loggerFactory = builder.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory ?? NullLoggerFactory.Instance;
+            builder.Use(next =>
+            {
+                var middleware = new TlsServerConnectionMiddleware(next, options, loggerFactory);
+                return middleware.OnConnectionAsync;
+            });
+        }
+
+        public static void UseClientTls(
+            this IConnectionBuilder builder,
+            TlsOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var loggerFactory = builder.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory ?? NullLoggerFactory.Instance;
+            builder.Use(next =>
+            {
+                var middleware = new TlsClientConnectionMiddleware(next, options, loggerFactory);
+                return middleware.OnConnectionAsync;
+            });
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Orleans.Connections.Security.csproj
+++ b/src/Orleans.Connections.Security/Orleans.Connections.Security.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Orleans.Connections.Security</PackageId>
+    <Title>Microsoft Orleans TLS support</Title>
+    <Description>Support for security communication using TLS in Microsoft Orleans.</Description>
+    <PackageTags>$(PackageTags) TLS SSL</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Orleans.Connections.Security/Security/CertificateLoader.cs
+++ b/src/Orleans.Connections.Security/Security/CertificateLoader.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Orleans.Connections.Security
+{
+    public static class CertificateLoader
+    {
+        // See http://oid-info.com/get/1.3.6.1.5.5.7.3.1
+        // Indicates that a certificate can be used as a TLS server certificate
+        private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
+        // See http://oid-info.com/get/1.3.6.1.5.5.7.3.2
+        // Indicates that a certificate can be used as a TLS client certificate
+        private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+
+        public static X509Certificate2 LoadFromStoreCert(string subject, string storeName, StoreLocation storeLocation, bool allowInvalid, bool server)
+        {
+            using (var store = new X509Store(storeName, storeLocation))
+            {
+                X509Certificate2Collection storeCertificates = null;
+                X509Certificate2 foundCertificate = null;
+
+                try
+                {
+                    store.Open(OpenFlags.ReadOnly);
+                    storeCertificates = store.Certificates;
+                    var foundCertificates = storeCertificates.Find(X509FindType.FindBySubjectName, subject, !allowInvalid);
+                    foundCertificate = foundCertificates
+                        .OfType<X509Certificate2>()
+                        .Where(c => server ? IsCertificateAllowedForServerAuth(c) : IsCertificateAllowedForClientAuth(c))
+                        .Where(DoesCertificateHaveAnAccessiblePrivateKey)
+                        .OrderByDescending(certificate => certificate.NotAfter)
+                        .FirstOrDefault();
+
+                    if (foundCertificate == null)
+                    {
+                        throw new InvalidOperationException($"Certificate {subject} not found in store {storeLocation} / {storeName}. AllowInvalid: {allowInvalid}");
+                    }
+
+                    return foundCertificate;
+                }
+                finally
+                {
+                    DisposeCertificates(storeCertificates, except: foundCertificate);
+                }
+            }
+        }
+
+        internal static bool IsCertificateAllowedForServerAuth(X509Certificate2 certificate) => IsCertificateAllowedForKeyUsage(certificate, ServerAuthenticationOid);
+
+        internal static bool IsCertificateAllowedForClientAuth(X509Certificate2 certificate) => IsCertificateAllowedForKeyUsage(certificate, ClientAuthenticationOid);
+
+        private static bool IsCertificateAllowedForKeyUsage(X509Certificate2 certificate, string purposeOid)
+        {
+            /* If the Extended Key Usage extension is included, then we check that the serverAuth usage is included. (http://oid-info.com/get/1.3.6.1.5.5.7.3.1)
+             * If the Extended Key Usage extension is not included, then we assume the certificate is allowed for all usages.
+             *
+             * See also https://blogs.msdn.microsoft.com/kaushal/2012/02/17/client-certificates-vs-server-certificates/
+             *
+             * From https://tools.ietf.org/html/rfc3280#section-4.2.1.13 "Certificate Extensions: Extended Key Usage"
+             *
+             * If the (Extended Key Usage) extension is present, then the certificate MUST only be used
+             * for one of the purposes indicated.  If multiple purposes are
+             * indicated the application need not recognize all purposes indicated,
+             * as long as the intended purpose is present.  Certificate using
+             * applications MAY require that a particular purpose be indicated in
+             * order for the certificate to be acceptable to that application.
+             */
+
+            var hasEkuExtension = false;
+
+            foreach (var extension in certificate.Extensions.OfType<X509EnhancedKeyUsageExtension>())
+            {
+                hasEkuExtension = true;
+                foreach (var oid in extension.EnhancedKeyUsages)
+                {
+                    if (oid.Value.Equals(purposeOid, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return !hasEkuExtension;
+        }
+
+        internal static bool DoesCertificateHaveAnAccessiblePrivateKey(X509Certificate2 certificate)
+            => certificate.HasPrivateKey;
+
+        private static void DisposeCertificates(X509Certificate2Collection certificates, X509Certificate2 except)
+        {
+            if (certificates != null)
+            {
+                foreach (var certificate in certificates)
+                {
+                    if (!certificate.Equals(except))
+                    {
+                        certificate.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Connections.Security
+{
+    internal class DuplexPipeStream : Stream
+    {
+        private readonly PipeReader _input;
+        private readonly PipeWriter _output;
+        private readonly bool _throwOnCancelled;
+        private volatile bool _cancelCalled;
+
+        public DuplexPipeStream(PipeReader input, PipeWriter output, bool throwOnCancelled = false)
+        {
+            _input = input;
+            _output = output;
+            _throwOnCancelled = throwOnCancelled;
+        }
+
+        public void CancelPendingRead()
+        {
+            _cancelCalled = true;
+            _input.CancelPendingRead();
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // ValueTask uses .GetAwaiter().GetResult() if necessary
+            // https://github.com/dotnet/corefx/blob/f9da3b4af08214764a51b2331f3595ffaf162abe/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs#L156
+            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), default).Result;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+        {
+            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        }
+
+#if NETCOREAPP
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+        {
+            return ReadAsyncInternal(destination, cancellationToken);
+        }
+#endif
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (buffer != null)
+            {
+                _output.Write(new ReadOnlySpan<byte>(buffer, offset, count));
+            }
+
+            await _output.FlushAsync(cancellationToken);
+        }
+
+#if NETCOREAPP
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        {
+            _output.Write(source.Span);
+            await _output.FlushAsync(cancellationToken);
+        }
+#endif
+
+        public override void Flush()
+        {
+            FlushAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return WriteAsync(null, 0, 0, cancellationToken);
+        }
+
+        private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var result = await _input.ReadAsync(cancellationToken);
+                var readableBuffer = result.Buffer;
+                try
+                {
+                    if (_throwOnCancelled && result.IsCanceled && _cancelCalled)
+                    {
+                        // Reset the bool
+                        _cancelCalled = false;
+                        throw new OperationCanceledException();
+                    }
+
+                    if (!readableBuffer.IsEmpty)
+                    {
+                        // buffer.Count is int
+                        var count = (int)Math.Min(readableBuffer.Length, destination.Length);
+                        readableBuffer = readableBuffer.Slice(0, count);
+                        readableBuffer.CopyTo(destination.Span);
+                        return count;
+                    }
+
+                    if (result.IsCompleted)
+                    {
+                        return 0;
+                    }
+                }
+                finally
+                {
+                    _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                }
+            }
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            var task = ReadAsync(buffer, offset, count, default, state);
+            if (callback != null)
+            {
+                task.ContinueWith(t => callback.Invoke(t));
+            }
+            return task;
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return ((Task<int>)asyncResult).GetAwaiter().GetResult();
+        }
+
+        private Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
+        {
+            var tcs = new TaskCompletionSource<int>(state);
+            var task = ReadAsync(buffer, offset, count, cancellationToken);
+            task.ContinueWith((task2, state2) =>
+            {
+                var tcs2 = (TaskCompletionSource<int>)state2;
+                if (task2.IsCanceled)
+                {
+                    tcs2.SetCanceled();
+                }
+                else if (task2.IsFaulted)
+                {
+                    tcs2.SetException(task2.Exception);
+                }
+                else
+                {
+                    tcs2.SetResult(task2.Result);
+                }
+            }, tcs, cancellationToken);
+            return tcs.Task;
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            var task = WriteAsync(buffer, offset, count, default, state);
+            if (callback != null)
+            {
+                task.ContinueWith(t => callback.Invoke(t));
+            }
+            return task;
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            ((Task<object>)asyncResult).GetAwaiter().GetResult();
+        }
+
+        private Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
+        {
+            var tcs = new TaskCompletionSource<object>(state);
+            var task = WriteAsync(buffer, offset, count, cancellationToken);
+            task.ContinueWith((task2, state2) =>
+            {
+                var tcs2 = (TaskCompletionSource<object>)state2;
+                if (task2.IsCanceled)
+                {
+                    tcs2.SetCanceled();
+                }
+                else if (task2.IsFaulted)
+                {
+                    tcs2.SetException(task2.Exception);
+                }
+                else
+                {
+                    tcs2.SetResult(null);
+                }
+            }, tcs, cancellationToken);
+            return tcs.Task;
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+
+namespace Orleans.Connections.Security
+{
+    /// <summary>
+    /// A helper for wrapping a Stream decorator from an <see cref="IDuplexPipe"/>.
+    /// </summary>
+    /// <typeparam name="TStream"></typeparam>
+    internal class DuplexPipeStreamAdapter<TStream> : DuplexPipeStream, IDuplexPipe where TStream : Stream
+    {
+        private bool _disposed;
+        private readonly object _disposeLock = new object();
+
+        public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, Func<Stream, TStream> createStream) :
+            this(duplexPipe, new StreamPipeReaderOptions(leaveOpen: true), new StreamPipeWriterOptions(leaveOpen: true), createStream)
+        {
+        }
+
+        public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) :
+            base(duplexPipe.Input, duplexPipe.Output)
+        {
+            var stream = createStream(this);
+            Stream = stream;
+            Input = PipeReader.Create(stream, readerOptions);
+            Output = PipeWriter.Create(stream, writerOptions);
+        }
+
+        public TStream Stream { get; }
+
+        public PipeReader Input { get; }
+
+        public PipeWriter Output { get; }
+
+        public override async ValueTask DisposeAsync()
+        {
+            lock (_disposeLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+            }
+
+            await Input.CompleteAsync();
+            await Output.CompleteAsync();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/ITlsApplicationProtocolFeature.cs
+++ b/src/Orleans.Connections.Security/Security/ITlsApplicationProtocolFeature.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Orleans.Connections.Security
+{
+    public interface ITlsApplicationProtocolFeature
+    {
+        ReadOnlyMemory<byte> ApplicationProtocol { get; }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/ITlsConnectionFeature.cs
+++ b/src/Orleans.Connections.Security/Security/ITlsConnectionFeature.cs
@@ -1,0 +1,20 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Orleans.Connections.Security
+{
+    public interface ITlsConnectionFeature
+    {
+        /// <summary>
+        /// Synchronously retrieves the remote endpoint's certificate, if any.
+        /// </summary>
+        X509Certificate2 RemoteCertificate { get; set; }
+
+        /// <summary>
+        /// Asynchronously retrieves the remote endpoint's certificate, if any.
+        /// </summary>
+        /// <returns></returns>
+        Task<X509Certificate2> GetRemoteCertificateAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Orleans.Connections.Security/Security/ITlsHandshakeFeature.cs
+++ b/src/Orleans.Connections.Security/Security/ITlsHandshakeFeature.cs
@@ -1,0 +1,21 @@
+using System.Security.Authentication;
+
+namespace Orleans.Connections.Security
+{
+    public interface ITlsHandshakeFeature
+    {
+        SslProtocols Protocol { get; }
+
+        CipherAlgorithmType CipherAlgorithm { get; }
+
+        int CipherStrength { get; }
+
+        HashAlgorithmType HashAlgorithm { get; }
+
+        int HashStrength { get; }
+
+        ExchangeAlgorithmType KeyExchangeAlgorithm { get; }
+
+        int KeyExchangeStrength { get; }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/MemoryPoolExtensions.cs
+++ b/src/Orleans.Connections.Security/Security/MemoryPoolExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Buffers;
+
+namespace Orleans.Connections.Security
+{
+    internal static class MemoryPoolExtensions
+    {
+        /// <summary>
+        /// Computes a minimum segment size
+        /// </summary>
+        /// <param name="pool"></param>
+        /// <returns></returns>
+        public static int GetMinimumSegmentSize(this MemoryPool<byte> pool)
+        {
+            if (pool == null)
+            {
+                return 4096;
+            }
+
+            return Math.Min(4096, pool.MaxBufferSize);
+        }
+
+        public static int GetMinimumAllocSize(this MemoryPool<byte> pool)
+        {
+            // 1/2 of a segment
+            return pool.GetMinimumSegmentSize() / 2;
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/RemoteCertificateMode.cs
+++ b/src/Orleans.Connections.Security/Security/RemoteCertificateMode.cs
@@ -1,0 +1,23 @@
+namespace Orleans.Connections.Security
+{
+    /// <summary>
+    /// Describes the remote certificate requirements for a TLS connection.
+    /// </summary>
+    public enum RemoteCertificateMode
+    {
+        /// <summary>
+        /// A remote certificate is not required and will not be requested from remote endpoints.
+        /// </summary>
+        NoCertificate,
+
+        /// <summary>
+        /// A remote certificate will be requested; however, authentication will not fail if a certificate is not provided by the remote endpoint.
+        /// </summary>
+        AllowCertificate,
+
+        /// <summary>
+        /// A remote certificate will be requested, and the remote endpoint must provide a valid certificate for authentication.
+        /// </summary>
+        RequireCertificate
+    }
+}

--- a/src/Orleans.Connections.Security/Security/SslDuplexPipe.cs
+++ b/src/Orleans.Connections.Security/Security/SslDuplexPipe.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net.Security;
+
+namespace Orleans.Connections.Security
+{
+    internal class SslDuplexPipe : DuplexPipeStreamAdapter<SslStream>
+    {
+        public SslDuplexPipe(IDuplexPipe transport, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions)
+            : this(transport, readerOptions, writerOptions, s => new SslStream(s))
+        {
+
+        }
+
+        public SslDuplexPipe(IDuplexPipe transport, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, SslStream> factory) :
+            base(transport, readerOptions, writerOptions, factory)
+        {
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Connections.Security
+{
+    internal class TlsClientConnectionMiddleware
+    {
+        private readonly ConnectionDelegate _next;
+        private readonly TlsOptions _options;
+        private readonly ILogger _logger;
+        private readonly X509Certificate2 _certificate;
+
+        public TlsClientConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory loggerFactory)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _next = next;
+
+            // capture the certificate now so it can't be switched after validation
+            _certificate = options.LocalCertificate;
+
+            EnsureCertificateIsAllowedForClientAuth(_certificate);
+
+            _options = options;
+            _logger = loggerFactory?.CreateLogger<TlsServerConnectionMiddleware>();
+        }
+
+        public Task OnConnectionAsync(ConnectionContext context)
+        {
+            return Task.Run(() => InnerOnConnectionAsync(context));
+        }
+
+        private async Task InnerOnConnectionAsync(ConnectionContext context)
+        {
+            var feature = new TlsConnectionFeature();
+            context.Features.Set<ITlsConnectionFeature>(feature);
+            context.Features.Set<ITlsHandshakeFeature>(feature);
+
+            var memoryPool = context.Features.Get<IMemoryPoolFeature>()?.MemoryPool;
+
+            var inputPipeOptions = new StreamPipeReaderOptions
+            (
+                pool: memoryPool,
+                bufferSize: memoryPool.GetMinimumSegmentSize(),
+                minimumReadSize: memoryPool.GetMinimumAllocSize(),
+                leaveOpen: true
+            );
+
+            var outputPipeOptions = new StreamPipeWriterOptions
+            (
+                pool: memoryPool,
+                leaveOpen: true
+            );
+
+            SslDuplexPipe sslDuplexPipe = null;
+
+            if (_options.RemoteCertificateMode == RemoteCertificateMode.NoCertificate)
+            {
+                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions);
+            }
+            else
+            {
+                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions, s => new SslStream(
+                    s,
+                    leaveInnerStreamOpen: false,
+                    userCertificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) =>
+                    {
+                        if (certificate == null)
+                        {
+                            return _options.RemoteCertificateMode != RemoteCertificateMode.RequireCertificate;
+                        }
+
+                        if (_options.RemoteCertificateValidation == null)
+                        {
+                            if (sslPolicyErrors != SslPolicyErrors.None)
+                            {
+                                return false;
+                            }
+                        }
+
+                        var certificate2 = ConvertToX509Certificate2(certificate);
+                        if (certificate2 == null)
+                        {
+                            return false;
+                        }
+
+                        if (_options.RemoteCertificateValidation != null)
+                        {
+                            if (!_options.RemoteCertificateValidation(certificate2, chain, sslPolicyErrors))
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }));
+            }
+
+            var sslStream = sslDuplexPipe.Stream;
+
+            using (var cancellationTokeSource = new CancellationTokenSource(_options.HandshakeTimeout))
+            using (cancellationTokeSource.Token.UnsafeRegister(state => ((ConnectionContext)state).Abort(), context))
+            {
+                try
+                {
+                    var sslOptions = new SslClientAuthenticationOptions
+                    {
+                        ClientCertificates = new X509CertificateCollection(new[] { _certificate }),
+                        EnabledSslProtocols = _options.SslProtocols,
+                        CertificateRevocationCheckMode = _options.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                        ApplicationProtocols = new List<SslApplicationProtocol>(),
+                    };
+
+                    _options.OnAuthenticateAsClient?.Invoke(context, sslOptions);
+
+                    await sslStream.AuthenticateAsClientAsync(sslOptions, CancellationToken.None);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger?.LogDebug(2, "Authentication timed out");
+                    await sslStream.DisposeAsync();
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException || ex is AuthenticationException)
+                {
+                    _logger?.LogDebug(1, ex, "Authentication failed");
+                    await sslStream.DisposeAsync();
+                    return;
+                }
+            }
+
+            feature.ApplicationProtocol = sslStream.NegotiatedApplicationProtocol.Protocol;
+            context.Features.Set<ITlsApplicationProtocolFeature>(feature);
+            feature.LocalCertificate = ConvertToX509Certificate2(sslStream.LocalCertificate);
+            feature.RemoteCertificate = ConvertToX509Certificate2(sslStream.RemoteCertificate);
+            feature.CipherAlgorithm = sslStream.CipherAlgorithm;
+            feature.CipherStrength = sslStream.CipherStrength;
+            feature.HashAlgorithm = sslStream.HashAlgorithm;
+            feature.HashStrength = sslStream.HashStrength;
+            feature.KeyExchangeAlgorithm = sslStream.KeyExchangeAlgorithm;
+            feature.KeyExchangeStrength = sslStream.KeyExchangeStrength;
+            feature.Protocol = sslStream.SslProtocol;
+
+            var originalTransport = context.Transport;
+
+            try
+            {
+                context.Transport = sslDuplexPipe;
+
+                // Disposing the stream will dispose the sslDuplexPipe
+                await using (sslStream)
+                await using (sslDuplexPipe)
+                {
+                    await _next(context);
+                    // Dispose the inner stream (SslDuplexPipe) before disposing the SslStream
+                    // as the duplex pipe can hit an ODE as it still may be writing.
+                }
+            }
+            finally
+            {
+                // Restore the original so that it gets closed appropriately
+                context.Transport = originalTransport;
+            }
+        }
+
+        protected static void EnsureCertificateIsAllowedForClientAuth(X509Certificate2 certificate)
+        {
+            if (!CertificateLoader.IsCertificateAllowedForClientAuth(certificate))
+            {
+                throw new InvalidOperationException($"Invalid client certificate for client authentication: {certificate.Thumbprint}");
+            }
+        }
+
+        private static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)
+        {
+            if (certificate is null)
+            {
+                return null;
+            }
+
+            return certificate as X509Certificate2 ?? new X509Certificate2(certificate);
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/TlsConnectionFeature.cs
+++ b/src/Orleans.Connections.Security/Security/TlsConnectionFeature.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Connections.Security
+{
+    internal class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature
+    {
+        public X509Certificate2 LocalCertificate { get; set; }
+
+        public X509Certificate2 RemoteCertificate { get; set; }
+
+        public ReadOnlyMemory<byte> ApplicationProtocol { get; set; }
+
+        public SslProtocols Protocol { get; set; }
+
+        public CipherAlgorithmType CipherAlgorithm { get; set; }
+
+        public int CipherStrength { get; set; }
+
+        public HashAlgorithmType HashAlgorithm { get; set; }
+
+        public int HashStrength { get; set; }
+
+        public ExchangeAlgorithmType KeyExchangeAlgorithm { get; set; }
+
+        public int KeyExchangeStrength { get; set; }
+
+        public Task<X509Certificate2> GetRemoteCertificateAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(RemoteCertificate);
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/TlsOptions.cs
+++ b/src/Orleans.Connections.Security/Security/TlsOptions.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Connections.Security
+{
+    public delegate bool RemoteCertificateValidator(X509Certificate2 certificate, X509Chain chain, SslPolicyErrors policyErrors);
+
+    /// <summary>
+    /// Settings for how TLS connections are handled.
+    /// </summary>
+    public class TlsOptions
+    {
+        private TimeSpan _handshakeTimeout;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TlsOptions"/>.
+        /// </summary>
+        public TlsOptions()
+        {
+            RemoteCertificateMode = RemoteCertificateMode.RequireCertificate;
+            SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11;
+            HandshakeTimeout = TimeSpan.FromSeconds(10);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Specifies the local certificate used to authenticate TLS connections. This is ignored if LocalCertificateSelector is set.
+        /// </para>
+        /// <para>
+        /// If the certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
+        /// </para>
+        /// </summary>
+        public X509Certificate2 LocalCertificate { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// A callback that will be invoked to dynamically select a local server certificate. This is higher priority than LocalCertificate.
+        /// If SNI is not available then the name parameter will be null.
+        /// </para>
+        /// <para>
+        /// If the certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
+        /// </para>
+        /// </summary>
+        public Func<ConnectionContext, string, X509Certificate2> LocalServerCertificateSelector { get; set; }
+
+        /// <summary>
+        /// Specifies the remote endpoint certificate requirements for a TLS connection. Defaults to <see cref="RemoteCertificateMode.RequireCertificate"/>.
+        /// </summary>
+        public RemoteCertificateMode RemoteCertificateMode { get; set; } = RemoteCertificateMode.RequireCertificate;
+
+        /// <summary>
+        /// Specifies a callback for additional remote certificate validation that will be invoked during authentication. This will be ignored
+        /// if <see cref="AllowAnyRemoteCertificate"/> is called after this callback is set.
+        /// </summary>
+        public RemoteCertificateValidator RemoteCertificateValidation { get; set; }
+
+        /// <summary>
+        /// Specifies allowable SSL protocols. Defaults to <see cref="SslProtocols.Tls12" /> and <see cref="SslProtocols.Tls11"/>.
+        /// </summary>
+        public SslProtocols SslProtocols { get; set; }
+
+        /// <summary>
+        /// Specifies whether the certificate revocation list is checked during authentication.
+        /// </summary>
+        public bool CheckCertificateRevocation { get; set; }
+
+        /// <summary>
+        /// Overrides the current <see cref="RemoteCertificateValidation"/> callback and allows any client certificate.
+        /// </summary>
+        public void AllowAnyRemoteCertificate()
+        {
+            RemoteCertificateValidation = (_, __, ___) => true;
+        }
+
+        /// <summary>
+        /// Provides direct configuration of the <see cref="SslServerAuthenticationOptions"/> on a per-connection basis.
+        /// This is called after all of the other settings have already been applied.
+        /// </summary>
+        public Action<ConnectionContext, SslServerAuthenticationOptions> OnAuthenticateAsServer { get; set; }
+
+        /// <summary>
+        /// Provides direct configuration of the <see cref="SslClientAuthenticationOptions"/> on a per-connection basis.
+        /// This is called after all of the other settings have already been applied.
+        /// </summary>
+        public Action<ConnectionContext, SslClientAuthenticationOptions> OnAuthenticateAsClient { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite.
+        /// </summary>
+        public TimeSpan HandshakeTimeout
+        {
+            get => _handshakeTimeout;
+            set
+            {
+                if (value <= TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), nameof(HandshakeTimeout) + " must be positive");
+                }
+                _handshakeTimeout = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
+            }
+        }
+    }
+}

--- a/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Connections.Security
+{
+    internal class TlsServerConnectionMiddleware
+    {
+        private readonly ConnectionDelegate _next;
+        private readonly TlsOptions _options;
+        private readonly ILogger _logger;
+        private readonly X509Certificate2 _certificate;
+        private readonly Func<ConnectionContext, string, X509Certificate2> _certificateSelector;
+
+        public TlsServerConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory loggerFactory)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _next = next;
+
+            // capture the certificate now so it can't be switched after validation
+            _certificate = options.LocalCertificate;
+            _certificateSelector = options.LocalServerCertificateSelector;
+            if (_certificate == null && _certificateSelector == null)
+            {
+                throw new ArgumentException("Server certificate is required", nameof(options));
+            }
+
+            // If a selector is provided then ignore the cert, it may be a default cert.
+            if (_certificateSelector != null)
+            {
+                // SslStream doesn't allow both.
+                _certificate = null;
+            }
+            else
+            {
+                EnsureCertificateIsAllowedForServerAuth(_certificate);
+            }
+
+            _options = options;
+            _logger = loggerFactory?.CreateLogger<TlsServerConnectionMiddleware>();
+        }
+
+        public Task OnConnectionAsync(ConnectionContext context)
+        {
+            return Task.Run(() => InnerOnConnectionAsync(context));
+        }
+
+        private async Task InnerOnConnectionAsync(ConnectionContext context)
+        {
+            bool certificateRequired;
+            var feature = new TlsConnectionFeature();
+            context.Features.Set<ITlsConnectionFeature>(feature);
+            context.Features.Set<ITlsHandshakeFeature>(feature);
+
+            var memoryPool = context.Features.Get<IMemoryPoolFeature>()?.MemoryPool;
+
+            var inputPipeOptions = new StreamPipeReaderOptions
+            (
+                pool: memoryPool,
+                bufferSize: memoryPool.GetMinimumSegmentSize(),
+                minimumReadSize: memoryPool.GetMinimumAllocSize(),
+                leaveOpen: true
+            );
+
+            var outputPipeOptions = new StreamPipeWriterOptions
+            (
+                pool: memoryPool,
+                leaveOpen: true
+            );
+
+            SslDuplexPipe sslDuplexPipe = null;
+
+            if (_options.RemoteCertificateMode == RemoteCertificateMode.NoCertificate)
+            {
+                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions);
+                certificateRequired = false;
+            }
+            else
+            {
+                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions, s => new SslStream(
+                    s,
+                    leaveInnerStreamOpen: false,
+                    userCertificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) =>
+                    {
+                        if (certificate == null)
+                        {
+                            return _options.RemoteCertificateMode != RemoteCertificateMode.RequireCertificate;
+                        }
+
+                        if (_options.RemoteCertificateValidation == null)
+                        {
+                            if (sslPolicyErrors != SslPolicyErrors.None)
+                            {
+                                return false;
+                            }
+                        }
+
+                        var certificate2 = ConvertToX509Certificate2(certificate);
+                        if (certificate2 == null)
+                        {
+                            return false;
+                        }
+
+                        if (_options.RemoteCertificateValidation != null)
+                        {
+                            if (!_options.RemoteCertificateValidation(certificate2, chain, sslPolicyErrors))
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }));
+
+                certificateRequired = true;
+            }
+
+            var sslStream = sslDuplexPipe.Stream;
+
+            using (var cancellationTokeSource = new CancellationTokenSource(_options.HandshakeTimeout))
+            using (cancellationTokeSource.Token.UnsafeRegister(state => ((ConnectionContext)state).Abort(), context))
+            {
+                try
+                {
+                    // Adapt to the SslStream signature
+                    ServerCertificateSelectionCallback selector = null;
+                    if (_certificateSelector != null)
+                    {
+                        selector = (sender, name) =>
+                        {
+                            context.Features.Set(sslStream);
+                            var cert = _certificateSelector(context, name);
+                            if (cert != null)
+                            {
+                                EnsureCertificateIsAllowedForServerAuth(cert);
+                            }
+                            return cert;
+                        };
+                    }
+
+                    var sslOptions = new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = _certificate,
+                        ServerCertificateSelectionCallback = selector,
+                        ClientCertificateRequired = certificateRequired,
+                        EnabledSslProtocols = _options.SslProtocols,
+                        CertificateRevocationCheckMode = _options.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                        ApplicationProtocols = new List<SslApplicationProtocol>()
+                    };
+
+                    _options.OnAuthenticateAsServer?.Invoke(context, sslOptions);
+
+                    await sslStream.AuthenticateAsServerAsync(sslOptions, CancellationToken.None);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger?.LogDebug(2, "Authentication timed out");
+                    await sslStream.DisposeAsync();
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException || ex is AuthenticationException)
+                {
+                    _logger?.LogDebug(1, ex, "Authentication failed");
+                    await sslStream.DisposeAsync();
+                    return;
+                }
+            }
+
+            feature.ApplicationProtocol = sslStream.NegotiatedApplicationProtocol.Protocol;
+            context.Features.Set<ITlsApplicationProtocolFeature>(feature);
+            feature.LocalCertificate = ConvertToX509Certificate2(sslStream.LocalCertificate);
+            feature.RemoteCertificate = ConvertToX509Certificate2(sslStream.RemoteCertificate);
+            feature.CipherAlgorithm = sslStream.CipherAlgorithm;
+            feature.CipherStrength = sslStream.CipherStrength;
+            feature.HashAlgorithm = sslStream.HashAlgorithm;
+            feature.HashStrength = sslStream.HashStrength;
+            feature.KeyExchangeAlgorithm = sslStream.KeyExchangeAlgorithm;
+            feature.KeyExchangeStrength = sslStream.KeyExchangeStrength;
+            feature.Protocol = sslStream.SslProtocol;
+
+            var originalTransport = context.Transport;
+
+            try
+            {
+                context.Transport = sslDuplexPipe;
+
+                // Disposing the stream will dispose the sslDuplexPipe
+                await using (sslStream)
+                await using (sslDuplexPipe)
+                {
+                    await _next(context);
+                    // Dispose the inner stream (SslDuplexPipe) before disposing the SslStream
+                    // as the duplex pipe can hit an ODE as it still may be writing.
+                }
+            }
+            finally
+            {
+                // Restore the original so that it gets closed appropriately
+                context.Transport = originalTransport;
+            }
+        }
+
+        protected static void EnsureCertificateIsAllowedForServerAuth(X509Certificate2 certificate)
+        {
+            if (!CertificateLoader.IsCertificateAllowedForServerAuth(certificate))
+            {
+                throw new InvalidOperationException($"Invalid server certificate for server authentication: {certificate.Thumbprint}");
+            }
+        }
+
+        private static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)
+        {
+            if (certificate is null)
+            {
+                return null;
+            }
+
+            return certificate as X509Certificate2 ?? new X509Certificate2(certificate);
+        }
+    }
+}

--- a/src/Orleans.Core/Networking/ClientConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/ClientConnectionOptions.cs
@@ -1,0 +1,14 @@
+using System;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Configuration
+{
+    public class ClientConnectionOptions
+    {
+        private readonly ConnectionBuilderDelegates delegates = new ConnectionBuilderDelegates();
+
+        public void ConfigureConnection(Action<IConnectionBuilder> configure) => this.delegates.Add(configure);
+
+        internal void ConfigureConnectionBuilder(IConnectionBuilder builder) => this.delegates.Invoke(builder);
+    }
+}

--- a/src/Orleans.Core/Networking/ConnectionBuilderDelegates.cs
+++ b/src/Orleans.Core/Networking/ConnectionBuilderDelegates.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Configuration
+{
+    internal class ConnectionBuilderDelegates
+    {
+        private readonly List<Action<IConnectionBuilder>> configurationDelegates = new List<Action<IConnectionBuilder>>();
+
+        public void Add(Action<IConnectionBuilder> configure)
+            => this.configurationDelegates.Add(configure ?? throw new ArgumentNullException(nameof(configure)));
+
+        public void Invoke(IConnectionBuilder builder)
+        {
+            foreach (var configureDelegate in this.configurationDelegates)
+            {
+                configureDelegate(builder);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -37,12 +37,14 @@ namespace Orleans.Runtime.Messaging
 
                     // Configure the connection builder using the user-defined options.
                     var connectionBuilder = new ConnectionBuilder(this.serviceProvider);
-                    this.ConnectionOptions.ConfigureConnectionBuilder(connectionBuilder);
+                    this.ConfigureConnectionBuilder(connectionBuilder);
                     Connection.ConfigureBuilder(connectionBuilder);
                     return this.connectionDelegate = connectionBuilder.Build();
                 }
             }
         }
+
+        protected virtual void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder) { }
 
         protected abstract Connection CreateConnection(SiloAddress address, ConnectionContext context);
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -26,11 +26,11 @@ namespace Orleans.Runtime.Messaging
 
         public ConnectionManager(
             IOptions<ConnectionOptions> connectionOptions,
-            ConnectionFactory connectionBuilder,
+            ConnectionFactory connectionFactory,
             INetworkingTrace trace)
         {
             this.connectionOptions = connectionOptions.Value;
-            this.connectionFactory = connectionBuilder;
+            this.connectionFactory = connectionFactory;
             this.trace = trace;
         }
 

--- a/src/Orleans.Core/Networking/ConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/ConnectionOptions.cs
@@ -1,14 +1,10 @@
 using System;
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Connections;
 using Orleans.Runtime.Messaging;
 
 namespace Orleans.Configuration
 {
     public class ConnectionOptions
     {
-        private readonly ConnectionBuilderDelegates connectionBuilder = new ConnectionBuilderDelegates();
-
         /// <summary>
         /// The network protocol version to negotiate with.
         /// </summary>
@@ -29,25 +25,5 @@ namespace Orleans.Configuration
         /// </summary>
         public TimeSpan OpenConnectionTimeout { get; set; } = DEFAULT_OPENCONNECTION_TIMEOUT;
         public static readonly TimeSpan DEFAULT_OPENCONNECTION_TIMEOUT = TimeSpan.FromSeconds(5);
-
-        public void ConfigureConnection(Action<IConnectionBuilder> configure) => this.connectionBuilder.Add(configure);
-
-        internal void ConfigureConnectionBuilder(IConnectionBuilder builder) => this.connectionBuilder.Invoke(builder);
-
-        internal class ConnectionBuilderDelegates
-        {
-            private readonly List<Action<IConnectionBuilder>> configurationDelegates = new List<Action<IConnectionBuilder>>();
-
-            public void Add(Action<IConnectionBuilder> configure)
-                => this.configurationDelegates.Add(configure ?? throw new ArgumentNullException(nameof(configure)));
-
-            public void Invoke(IConnectionBuilder builder)
-            {
-                foreach (var configureDelegate in this.configurationDelegates)
-                {
-                    configureDelegate(builder);
-                }
-            }
-        }
     }
 }

--- a/src/Orleans.Core/Networking/IConnectionDirectionFeature.cs
+++ b/src/Orleans.Core/Networking/IConnectionDirectionFeature.cs
@@ -1,0 +1,7 @@
+namespace Orleans.Runtime.Messaging
+{
+    public interface IConnectionDirectionFeature
+    {
+        bool IsOutboundConnection { get; }
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Configuration/SiloConnectionOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Configuration/SiloConnectionOptions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Configuration
+{
+    public class SiloConnectionOptions : SiloConnectionOptions.ISiloConnectionBuilderOptions
+    {
+        private readonly ConnectionBuilderDelegates siloOutboundDelegates = new ConnectionBuilderDelegates();
+        private readonly ConnectionBuilderDelegates siloInboundDelegates = new ConnectionBuilderDelegates();
+        private readonly ConnectionBuilderDelegates gatewayInboundDelegates = new ConnectionBuilderDelegates();
+
+        public void ConfigureSiloOutboundConnection(Action<IConnectionBuilder> configure) => this.siloOutboundDelegates.Add(configure);
+
+        public void ConfigureSiloInboundConnection(Action<IConnectionBuilder> configure) => this.siloInboundDelegates.Add(configure);
+
+        public void ConfigureGatewayInboundConnection(Action<IConnectionBuilder> configure) => this.gatewayInboundDelegates.Add(configure);
+
+        void ISiloConnectionBuilderOptions.ConfigureSiloOutboundBuilder(IConnectionBuilder builder) => this.siloOutboundDelegates.Invoke(builder);
+
+        void ISiloConnectionBuilderOptions.ConfigureSiloInboundBuilder(IConnectionBuilder builder) => this.siloInboundDelegates.Invoke(builder);
+
+        void ISiloConnectionBuilderOptions.ConfigureGatewayInboundBuilder(IConnectionBuilder builder) => this.gatewayInboundDelegates.Invoke(builder);
+
+        public interface ISiloConnectionBuilderOptions
+        {
+            public void ConfigureSiloOutboundBuilder(IConnectionBuilder builder);
+            public void ConfigureSiloInboundBuilder(IConnectionBuilder builder);
+            public void ConfigureGatewayInboundBuilder(IConnectionBuilder builder);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -57,12 +57,13 @@ namespace Orleans.Runtime.Messaging
 
                     // Configure the connection builder using the user-defined options.
                     var connectionBuilder = new ConnectionBuilder(this.ServiceProvider);
-                    this.ConnectionOptions.ConfigureConnectionBuilder(connectionBuilder);
+                    this.ConfigureConnectionBuilder(connectionBuilder);
                     Connection.ConfigureBuilder(connectionBuilder);
                     return this.connectionDelegate = connectionBuilder.Build();
                 }
             }
         }
+        protected virtual void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder) { }
 
         public async Task BindAsync(CancellationToken cancellationToken)
         {

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
+        private readonly SiloConnectionOptions siloConnectionOptions;
         private readonly MessageCenter messageCenter;
         private readonly MessageFactory messageFactory;
         private readonly EndpointOptions endpointOptions;
@@ -21,6 +22,7 @@ namespace Orleans.Runtime.Messaging
         public SiloConnectionListener(
             IServiceProvider serviceProvider,
             IOptions<ConnectionOptions> connectionOptions,
+            IOptions<SiloConnectionOptions> siloConnectionOptions,
             IConnectionListenerFactory listenerFactory,
             MessageCenter messageCenter,
             MessageFactory messageFactory,
@@ -30,6 +32,7 @@ namespace Orleans.Runtime.Messaging
             ConnectionManager connectionManager)
             : base(serviceProvider, listenerFactory, connectionOptions, connectionManager, trace)
         {
+            this.siloConnectionOptions = siloConnectionOptions.Value;
             this.messageCenter = messageCenter;
             this.messageFactory = messageFactory;
             this.trace = trace;
@@ -53,6 +56,13 @@ namespace Orleans.Runtime.Messaging
                 this.localSiloDetails,
                 this.connectionManager,
                 this.ConnectionOptions);
+        }
+
+        protected override void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder)
+        {
+            var configureDelegate = (SiloConnectionOptions.ISiloConnectionBuilderOptions)this.siloConnectionOptions;
+            configureDelegate.ConfigureSiloInboundBuilder(connectionBuilder);
+            base.ConfigureConnectionBuilder(connectionBuilder);
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)

--- a/test/Orleans.Connections.Security.Tests/CertificateCreator.cs
+++ b/test/Orleans.Connections.Security.Tests/CertificateCreator.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+
+namespace Orleans.Connections.Security.Tests
+{
+    internal static class TestCertificateHelper
+    {
+        // See http://oid-info.com/get/1.3.6.1.5.5.7.3.1
+        // Indicates that a certificate can be used as a TLS server certificate
+        public const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
+        // See http://oid-info.com/get/1.3.6.1.5.5.7.3.2
+        // Indicates that a certificate can be used as a TLS client certificate
+        public const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+
+        private const X509KeyUsageFlags KeyUsageFlags = X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.NonRepudiation | X509KeyUsageFlags.DataEncipherment | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.KeyAgreement;
+
+        public static X509Certificate2 CreateSelfSignedCertificate(string subjectName, string[] extendedKeyUsageOids = null)
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest($"CN={subjectName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(false, false, 0, true));
+
+            request.CertificateExtensions.Add(
+                new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(KeyUsageFlags, false));
+
+            var extendedKeyUsages = new OidCollection();
+            foreach (var oid in extendedKeyUsageOids ?? Array.Empty<string>())
+            {
+                extendedKeyUsages.Add(new Oid(oid));
+            }
+
+            var extension = new X509EnhancedKeyUsageExtension(extendedKeyUsages, false);
+            request.CertificateExtensions.Add(extension);
+
+            var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(10)), DateTimeOffset.UtcNow.AddYears(5));
+
+            return certificate;
+        }
+
+        public static string ConvertToBase64(X509Certificate2 certificate)
+        {
+            return Convert.ToBase64String(certificate.Export(X509ContentType.Pfx, "testing-only"));
+        }
+
+        public static X509Certificate2 ConvertFromBase64(string encodedCertificate)
+        {
+            var rawData = Convert.FromBase64String(encodedCertificate);
+            return new X509Certificate2(rawData, "testing-only");
+        }
+    }
+}

--- a/test/Orleans.Connections.Security.Tests/Directory.Build.props
+++ b/test/Orleans.Connections.Security.Tests/Directory.Build.props
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
+
+  <Choose>
+    <When Condition="$(OrleansRuntimeVersion) == $(VersionPrefix)">
+      <ItemGroup>
+        <ProjectReference Include="..\..\src\Orleans.Runtime\Orleans.Runtime.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="$(OrleansRuntimeVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
+  <Choose>
+    <When Condition="$(OrleansExtensionsVersion) == $(VersionPrefix)">
+      <ItemGroup>
+        <ProjectReference Include="..\..\src\Orleans.Connections.Security\Orleans.Connections.Security.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="$(OrleansExtensionsVersion)"/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.csproj
+++ b/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="Orleans.Connections.Security.Tests.xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetxUnitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(BuildingInsideVisualStudio)' == 'true'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.xunit.runner.json
+++ b/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.xunit.runner.json
@@ -1,0 +1,8 @@
+{
+  "appDomain": "denied",
+  "diagnosticMessages": true,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "methodDisplay": "classAndMethod",
+  "shadowCopy": false
+}

--- a/test/Orleans.Connections.Security.Tests/TlsConnectionTests.cs
+++ b/test/Orleans.Connections.Security.Tests/TlsConnectionTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Connections.Security.Tests;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace NetCore.Tests
+{
+    [Trait("Category", "BVT")]
+    public class TlsConnectionTests
+    {
+        private const string CertificateSubjectName = "fakedomain.faketld";
+        private const string CertificateConfigKey = "certificate";
+
+        [Fact]
+        public void CanCreateCertificates()
+        {
+            var original = TestCertificateHelper.CreateSelfSignedCertificate(
+                CertificateSubjectName,
+                new[] { TestCertificateHelper.ClientAuthenticationOid, TestCertificateHelper.ServerAuthenticationOid });
+            var encoded = TestCertificateHelper.ConvertToBase64(original);
+            var decoded = TestCertificateHelper.ConvertFromBase64(encoded);
+            Assert.Equal(original, decoded);
+        }
+
+        private class TlsConfigurator : ISiloBuilderConfigurator, IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IPingGrain).Assembly));
+
+                var encodedCertificate = configuration[CertificateConfigKey];
+                var localCertificate = TestCertificateHelper.ConvertFromBase64(encodedCertificate);
+                clientBuilder.UseTls(localCertificate, options =>
+                {
+                    options.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
+                    options.RemoteCertificateValidation = (remoteCertificate, chain, errors) =>
+                    {
+                        return true;
+                    };
+
+                    options.OnAuthenticateAsClient = (connection, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = CertificateSubjectName;
+                    };
+                });
+            }
+
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IPingGrain).Assembly));
+
+                var config = hostBuilder.GetConfiguration();
+                var encodedCertificate = config[CertificateConfigKey];
+                var localCertificate = TestCertificateHelper.ConvertFromBase64(encodedCertificate);
+                hostBuilder.UseTls(localCertificate, options =>
+                {
+                    options.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
+                    options.RemoteCertificateValidation = (remoteCertificate, chain, errors) =>
+                    {
+                        return true;
+                    };
+
+                    options.OnAuthenticateAsClient = (connection, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = CertificateSubjectName;
+                    };
+                });
+            }
+        }
+
+        [Fact]
+        public async Task TlsBasicEndToEnd()
+        {
+            TestCluster testCluster = default;
+            try
+            {
+                var builder = new TestClusterBuilder()
+                    .AddSiloBuilderConfigurator<TlsConfigurator>()
+                    .AddClientBuilderConfigurator<TlsConfigurator>();
+
+                var certificate = TestCertificateHelper.CreateSelfSignedCertificate(
+                    CertificateSubjectName,
+                    new[] { TestCertificateHelper.ClientAuthenticationOid, TestCertificateHelper.ServerAuthenticationOid });
+                var encodedCertificate = TestCertificateHelper.ConvertToBase64(certificate);
+                builder.Properties[CertificateConfigKey] = encodedCertificate;
+
+                testCluster = builder.Build();
+                await testCluster.DeployAsync();
+
+                var client = testCluster.Client;
+
+                var grain = client.GetGrain<IPingGrain>("pingu");
+                var expected = "secret chit chat";
+                var actual = await grain.Echo(expected);
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                await testCluster?.StopAllSilosAsync();
+                testCluster?.Dispose();
+            }
+        }
+    }
+
+    public interface IPingGrain : IGrainWithStringKey
+    {
+        Task<string> Echo(string value);
+    }
+
+    public class PingGrain : Grain, IPingGrain
+    {
+        public Task<string> Echo(string value) => Task.FromResult(value);
+    }
+}


### PR DESCRIPTION
This PR adds support for securing client-to-silo and silo-to-silo connections using mutual-TLS.
Adds several `UseTls` methods to `ISiloBuilder`, `IClientBuilder`, and `ISiloHostBuilder`.

TLS can be configured on the silo like so:

``` C#
var host = new HostBuilder()
    .UseOrleans((context, siloBuilder) =>
    {
        var isDevelopment = context.HostingEnvironment.IsDevelopment();
        siloBuilder
            .UseLocalhostClustering(serviceId: "HelloWorldApp", clusterId: "dev")
            .UseTls(StoreName.My, "fakedomain.faketld", allowInvalid: isDevelopment, StoreLocation.LocalMachine, options =>
            {
                if (isDevelopment)
                {
                    options.AllowAnyRemoteCertificate();
                }
            });
    })
    .ConfigureLogging(logging => logging.AddConsole())
    .Build();
```

By default, when the `UseTls` extension method is used, both sides of all connections are required to present a certificate.

This adds a new package: `Microsoft.Orleans.Connections.Security` which targets `netcoreapp3.0` ***only*** and therefore .NET Core 3.0 is required to use this functionality.

A sample application is included under Samples\3.0\TransportLayerSecurity.

There are some rough edges here which I would especially like feedback on.  For example, a `TargetHost` must be set whenever a connection is made. I would like to know how users would expect to set this value. In the provided sample the value is set to a fixed value:

``` C#
.UseTls(StoreName.My, "fakedomain.faketld", allowInvalid: true, StoreLocation.LocalMachine, options =>
{
    options.OnAuthenticateAsClient = (connection, sslOptions) =>
    {
        sslOptions.TargetHost = "fakedomain.faketld";
    };
    // NOTE: Do not do this in a production environment
    options.AllowAnyRemoteCertificate();
})
```

I understand that this will not suffice for all cases. The `connection` parameter has a `Features` property which allows the users to determine which endpoint is being connected to (among other things). This could be used to determine the correct `TargetHost` value.

Fixes #828

xref https://github.com/aspnet/AspNetCore/issues/12809