### PR TITLE
 Prevent Orleans + Kestrel from interfering with each other's networking services

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -99,7 +99,11 @@ namespace Orleans
             // Networking
             services.TryAddSingleton<ConnectionManager>();
             services.AddSingleton<ILifecycleParticipant<IClusterClientLifecycle>, ConnectionManagerLifecycleAdapter<IClusterClientLifecycle>>();
-            services.TryAddSingleton<IConnectionFactory, SocketConnectionFactory>();
+
+            services.AddSingletonKeyedService<object, IConnectionFactory>(
+                ClientOutboundConnectionFactory.ServicesKey,
+                (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionFactory>(sp));
+
             services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(sp,
                 sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageHeaderSize,
                 sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageBodySize));

--- a/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
@@ -9,6 +9,7 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class ClientOutboundConnectionFactory : ConnectionFactory, IConnectionDirectionFeature
     {
+        internal static readonly object ServicesKey = new object();
         private readonly IServiceProvider serviceProvider;
         private readonly ClientConnectionOptions clientConnectionOptions;
         private readonly MessageFactory messageFactory;
@@ -22,10 +23,9 @@ namespace Orleans.Runtime.Messaging
             IServiceProvider serviceProvider,
             IOptions<ConnectionOptions> connectionOptions,
             IOptions<ClientConnectionOptions> clientConnectionOptions,
-            IConnectionFactory connectionFactory,
             MessageFactory messageFactory,
             INetworkingTrace trace)
-            : base(connectionFactory, serviceProvider, connectionOptions)
+            : base(serviceProvider.GetRequiredServiceByKey<object, IConnectionFactory>(ServicesKey), serviceProvider, connectionOptions)
         {
             this.serviceProvider = serviceProvider;
             this.clientConnectionOptions = clientConnectionOptions.Value;

--- a/src/Orleans.Runtime.Abstractions/Configuration/SiloConnectionOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Configuration/SiloConnectionOptions.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Connections;
 
 namespace Orleans.Configuration

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -351,8 +351,17 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ConnectionManager>();
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, ConnectionManagerLifecycleAdapter<ISiloLifecycle>>();
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, SiloConnectionMaintainer>();
-            services.TryAddSingleton<IConnectionFactory, SocketConnectionFactory>();
-            services.TryAddSingleton<IConnectionListenerFactory, SocketConnectionListenerFactory>();
+
+            services.AddSingletonKeyedService<object, IConnectionFactory>(
+                SiloConnectionFactory.ServicesKey,
+                (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionFactory>(sp));
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(
+                SiloConnectionListener.ServicesKey,
+                (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionListenerFactory>(sp));
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(
+                GatewayConnectionListener.ServicesKey,
+                (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionListenerFactory>(sp));
+
             services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(sp,
                 sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value.MaxMessageHeaderSize,
                 sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value.MaxMessageBodySize));

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -11,6 +11,7 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class GatewayConnectionListener : ConnectionListener, ILifecycleParticipant<ISiloLifecycle>
     {
+        internal static readonly object ServicesKey = new object();
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IOptions<MultiClusterOptions> multiClusterOptions;
@@ -25,7 +26,6 @@ namespace Orleans.Runtime.Messaging
             IServiceProvider serviceProvider,
             IOptions<ConnectionOptions> connectionOptions,
             IOptions<SiloConnectionOptions> siloConnectionOptions,
-            IConnectionListenerFactory listenerFactory,
             MessageFactory messageFactory,
             OverloadDetector overloadDetector,
             Gateway gateway,
@@ -35,7 +35,7 @@ namespace Orleans.Runtime.Messaging
             IOptions<EndpointOptions> endpointOptions,
             MessageCenter messageCenter,
             ConnectionManager connectionManager)
-            : base(serviceProvider, listenerFactory, connectionOptions, connectionManager, trace)
+            : base(serviceProvider, serviceProvider.GetRequiredServiceByKey<object, IConnectionListenerFactory>(ServicesKey), connectionOptions, connectionManager, trace)
         {
             this.siloConnectionOptions = siloConnectionOptions.Value;
             this.messageFactory = messageFactory;

--- a/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
@@ -10,6 +10,7 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class SiloConnectionFactory : ConnectionFactory
     {
+        internal static readonly object ServicesKey = new object();
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IServiceProvider serviceProvider;
@@ -25,11 +26,10 @@ namespace Orleans.Runtime.Messaging
             IServiceProvider serviceProvider,
             IOptions<ConnectionOptions> connectionOptions,
             IOptions<SiloConnectionOptions> siloConnectionOptions,
-            IConnectionFactory connectionFactory,
             MessageFactory messageFactory,
             INetworkingTrace trace,
             ILocalSiloDetails localSiloDetails)
-            : base(connectionFactory, serviceProvider, connectionOptions)
+            : base(serviceProvider.GetRequiredServiceByKey<object, IConnectionFactory>(ServicesKey), serviceProvider, connectionOptions)
         {
             this.serviceProvider = serviceProvider;
             this.siloConnectionOptions = siloConnectionOptions.Value;

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -11,6 +11,7 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class SiloConnectionListener : ConnectionListener, ILifecycleParticipant<ISiloLifecycle>
     {
+        internal static readonly object ServicesKey = new object();
         private readonly INetworkingTrace trace;
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly SiloConnectionOptions siloConnectionOptions;
@@ -23,14 +24,13 @@ namespace Orleans.Runtime.Messaging
             IServiceProvider serviceProvider,
             IOptions<ConnectionOptions> connectionOptions,
             IOptions<SiloConnectionOptions> siloConnectionOptions,
-            IConnectionListenerFactory listenerFactory,
             MessageCenter messageCenter,
             MessageFactory messageFactory,
             INetworkingTrace trace,
             IOptions<EndpointOptions> endpointOptions,
             ILocalSiloDetails localSiloDetails,
             ConnectionManager connectionManager)
-            : base(serviceProvider, listenerFactory, connectionOptions, connectionManager, trace)
+            : base(serviceProvider, serviceProvider.GetRequiredServiceByKey<object, IConnectionListenerFactory>(ServicesKey), connectionOptions, connectionManager, trace)
         {
             this.siloConnectionOptions = siloConnectionOptions.Value;
             this.messageCenter = messageCenter;


### PR DESCRIPTION
This is a quick fix for #6040. Ideally we will implement something more robust and configurable but this will suffice for 3.0.0

Fixes #6040

Note that this is based on top of #6035, so that comes first after which I will rebase this.
