### PR TITLE
Add separate SiloMessagingOptions.SystemResponseTimeout option

### DIFF
--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -106,7 +106,8 @@ namespace Orleans
                 msg => this.UnregisterCallback(msg.Id),
                 this.loggerFactory.CreateLogger<CallbackData>(),
                 this.clientMessagingOptions,
-                this.appRequestStatistics);
+                this.appRequestStatistics,
+                this.clientMessagingOptions.ResponseTimeout);
         }
 
         internal void ConsumeServices(IServiceProvider services)

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -11,29 +11,31 @@ namespace Orleans.Runtime
         public readonly Action<Message> Unregister;
         public readonly ILogger Logger;
         public readonly MessagingOptions MessagingOptions;
+        private TimeSpan responseTimeout;
         public long ResponseTimeoutStopwatchTicks;
 
         public SharedCallbackData(
             Action<Message> unregister,
             ILogger logger,
             MessagingOptions messagingOptions,
-            ApplicationRequestsStatisticsGroup requestStatistics)
+            ApplicationRequestsStatisticsGroup requestStatistics,
+            TimeSpan responseTimeout)
         {
             RequestStatistics = requestStatistics;
             this.Unregister = unregister;
             this.Logger = logger;
             this.MessagingOptions = messagingOptions;
-            this.ResponseTimeout = messagingOptions.ResponseTimeout;
+            this.ResponseTimeout = responseTimeout;
         }
 
         public ApplicationRequestsStatisticsGroup RequestStatistics { get; }
 
         public TimeSpan ResponseTimeout
         {
-            get => this.MessagingOptions.ResponseTimeout;
+            get => this.responseTimeout;
             set
             {
-                this.MessagingOptions.ResponseTimeout = value;
+                this.responseTimeout = value;
                 this.ResponseTimeoutStopwatchTicks = (long)(value.TotalSeconds * Stopwatch.Frequency);
             }
         }

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
+using System.Diagnostics;
 using Orleans.Runtime;
 
 namespace Orleans.Configuration
@@ -10,6 +9,11 @@ namespace Orleans.Configuration
     /// </summary>
     public class SiloMessagingOptions : MessagingOptions
     {
+        /// <summary>
+        /// <see cref="SystemResponseTimeout"/>.
+        /// </summary>
+        private TimeSpan systemResponseTimeout = DEFAULT_RESPONSE_TIMEOUT;
+
         /// <summary>
         /// The SiloSenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo to send outbound
         /// messages (requests, responses, and notifications) to other silos.
@@ -84,5 +88,15 @@ namespace Orleans.Configuration
         /// </summary>
         public TimeSpan ShutdownRerouteTimeout { get; set; } =
             DEFAULT_SHUTDOWN_REROUTE_TIMEOUT;
+
+        /// <summary>
+        /// The SystemResponseTimeout attribute specifies the default timeout before an internal system request is assumed to have failed.
+        /// <seealso cref="MessagingOptions.ResponseTimeoutWithDebugger"/>
+        /// </summary>
+        public TimeSpan SystemResponseTimeout
+        {
+            get { return Debugger.IsAttached ? ResponseTimeoutWithDebugger : this.systemResponseTimeout; }
+            set { this.systemResponseTimeout = value; }
+        }
     }
 }


### PR DESCRIPTION
This PR adds an option to set the response timeout for `SystemTarget` messages sent from a silo. The default value is 30s but in future that may be changed to a lower value, such as 2s.