### PR TITLE
Azure table grain storage inconsistent state on not found

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -158,7 +158,7 @@ namespace Orleans.Storage
             {
                 await updateOperation.Invoke().ConfigureAwait(false);
             }
-            catch (StorageException ex) when (ex.IsPreconditionFailed() || ex.IsConflict())
+            catch (StorageException ex) when (ex.IsPreconditionFailed() || ex.IsConflict() || ex.IsNotFound())
             {
                 throw new TableStorageUpdateConditionNotSatisfiedException(grainType, grainReference, tableName, "Unknown", currentETag, ex);
             }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Storage/StorageExceptionExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Storage/StorageExceptionExtensions.cs
@@ -16,6 +16,11 @@ namespace Orleans.Storage
             return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.Conflict;
         }
 
+        public static bool IsNotFound(this Microsoft.Azure.Cosmos.Table.StorageException storageException)
+        {
+            return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotFound;
+        }
+
         public static bool IsPreconditionFailed(this StorageException storageException)
         {
             return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed;


### PR DESCRIPTION
Azure table grain storage returns inconsistent state if modifying state that does not exist.