### PR TITLE
Fix for MySql clustering script

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql
@@ -1,3 +1,11 @@
+CREATE TABLE OrleansQuery
+(
+    QueryKey VARCHAR(64) NOT NULL,
+    QueryText VARCHAR(8000) NOT NULL,
+
+    CONSTRAINT OrleansQuery_Key PRIMARY KEY(QueryKey)
+);
+
 -- For each deployment, there will be only one (active) membership version table version column which will be updated periodically.
 CREATE TABLE OrleansMembershipVersionTable
 (


### PR DESCRIPTION
The script is failing because the `OrleansQuery` table is not created before trying to insert something there. I think it was lost during "Split something" refactoring which this fix is copied from. I think all other clustering ADO.Net scripts have the same problem