### PR TITLE
Add note about Visual Studio Community Edition

### DIFF
--- a/Samples/OneBoxDeployment/Readme.md
+++ b/Samples/OneBoxDeployment/Readme.md
@@ -20,6 +20,8 @@ At any time the database can be reset or snapshots deleted. There shouldn't be a
 
 ## Setting up the SQL Server Database
 
+0. (_optional_) If you are using Visual Studio 2019 Community Edition, you need to edit the `OneBoxDeployment.Database.sqlproj` file, and set the `ArtifactReference` and `HintPath` to point to `Community`, instead of `Enterprise`.
+
 1. This needs to be done only the first time
 Open the _OneBoxDeployment.Database_ project and open _Debug_ tab. If the target connection string isn't set, put _Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=OneBoxDeployment.Database;Integrated Security=True;Persist Security Info=False;Pooling=True;MultipleActiveResultSets=True;Connect Timeout=60;Encrypt=False;TrustServerCertificate=True_ to it. This deploys the database to LocalDb with the current user rights.
 


### PR DESCRIPTION
The `ArtifactReference` and `HintPath` in `OneBoxDeployment.Database.sqlproj` assume that Visual Studio 2019 **Enterprise** edition are installed.

If the user is using Visual Studio 2019 Community edition, she will observe ~115 build errors, where the first is:

`SQL72027: File "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\Microsoft\SQLDB\Extensions\SqlServer\150\SqlSchemas\master.dacpac" does not exist.`

I understand if this PR is not merged *as-is*, but I just spent ~1h and went through adding a bunch of options to my Visual Studio 2019 Community Edition, before actually figuring out what the issue was.

It is my hope that this single line can help at least my future self.