### PR TITLE
Do not include grain identifier in the ILogger category name

### DIFF
--- a/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Streams.Core;
-using Orleans.Providers;
 
 namespace Orleans.Streams
 {
@@ -20,7 +19,7 @@ namespace Orleans.Streams
     [StorageProvider(ProviderName = "PubSubStore")]
     internal class PubSubRendezvousGrain : Grain<PubSubGrainState>, IPubSubRendezvousGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private const bool DEBUG_PUB_SUB = false;
 
         private static readonly CounterStatistic counterProducersAdded;
@@ -40,13 +39,13 @@ namespace Orleans.Streams
             counterConsumersTotal   = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_TOTAL);
         }
 
-        public PubSubRendezvousGrain()
+        public PubSubRendezvousGrain(ILogger<PubSubRendezvousGrain> logger)
         {
+            this.logger = logger;
         }
 
         public override Task OnActivateAsync()
         {
-            logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger($"{GetType().FullName}.{RuntimeIdentity}.{IdentityString}");
             LogPubSubCounts("OnActivateAsync");
             return Task.CompletedTask;
         }
@@ -112,8 +111,8 @@ namespace Orleans.Streams
 
         public async Task RegisterConsumer(
             GuidId subscriptionId,
-            StreamId streamId, 
-            IStreamConsumerExtension streamConsumer, 
+            StreamId streamId,
+            IStreamConsumerExtension streamConsumer,
             IStreamFilterPredicateWrapper filter)
         {
             counterConsumersAdded.Increment();
@@ -149,9 +148,9 @@ namespace Orleans.Streams
                 return;
 
             if (logger.IsEnabled(LogLevel.Debug))
-                logger.Debug("Notifying {0} existing producer(s) about new consumer {1}. Producers={2}", 
+                logger.Debug("Notifying {0} existing producer(s) about new consumer {1}. Producers={2}",
                     numProducers, streamConsumer, Utils.EnumerableToString(State.Producers));
-                
+
             // Notify producers about a new streamConsumer.
             var tasks = new List<Task>();
             var producers = State.Producers.ToList();
@@ -269,7 +268,7 @@ namespace Orleans.Streams
                     numProducers = State.Producers.Count;
                 if (State?.Consumers != null)
                     numConsumers = State.Consumers.Count;
-                
+
                 string when = args != null && args.Length != 0 ? string.Format(fmt, args) : fmt;
                 logger.Info("{0}. Now have total of {1} producers and {2} consumers. All Consumers = {3}, All Producers = {4}",
                     when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers), Utils.EnumerableToString(State?.Producers));
@@ -283,7 +282,7 @@ namespace Orleans.Streams
             var captureConsumers = State.Consumers;
 
             await ReadStateAsync();
-            
+
             if (captureProducers.Count != State.Producers.Count)
             {
                 throw new OrleansException(


### PR DESCRIPTION
In the constructor of PubSubRendezvousGrain, it requests an ILogger using category name based on the grain identifier. This might not be an issue depending on the ILoggerFactory implementation, but the one in Microsoft.Extensions.Logging caches them all in a dictionary based on that category name.