### PR TITLE
DynamoDB: support extended membership protocol

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -96,7 +96,7 @@
     <FSharpCoreVersion>4.7.0</FSharpCoreVersion>
 
     <!-- 3rd party packages -->
-    <AWSSDKDynamoDBv2Version>3.3.4.17</AWSSDKDynamoDBv2Version>
+    <AWSSDKDynamoDBv2Version>3.3.102.2</AWSSDKDynamoDBv2Version>
     <AWSSDKSQSVersion>3.3.2.7</AWSSDKSQSVersion>
     <BondCoreCSharpVersion>5.3.1</BondCoreCSharpVersion>
     <ConsulVersion>0.7.2.3</ConsulVersion>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
@@ -42,7 +42,7 @@ namespace Orleans.Runtime.MembershipService
         public string IAmAliveTime { get; set; }
         public int ETag { get; set; }
 
-        public string MembershipVersion      { get; set; }               // Special version row (for serializing table updates). // We'll have a designated row with only MembershipVersion column.
+        public int MembershipVersion { get; set; }
 
         public SiloInstanceRecord() { }
 
@@ -100,8 +100,9 @@ namespace Orleans.Runtime.MembershipService
                 int.TryParse(fields[ETAG_PROPERTY_NAME].N, out etag))
                 ETag = etag;
 
-            if (fields.ContainsKey(MEMBERSHIP_VERSION_PROPERTY_NAME))
-                MembershipVersion = fields[MEMBERSHIP_VERSION_PROPERTY_NAME].S;
+            if (fields.ContainsKey(MEMBERSHIP_VERSION_PROPERTY_NAME) &&
+                int.TryParse(fields[MEMBERSHIP_VERSION_PROPERTY_NAME].N, out int version))
+                MembershipVersion = version;
         }
 
         internal static SiloAddress UnpackRowKey(string rowKey)
@@ -197,8 +198,7 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrWhiteSpace(IAmAliveTime))
                 fields.Add(I_AM_ALIVE_TIME_PROPERTY_NAME, new AttributeValue(IAmAliveTime));
 
-            if (!string.IsNullOrWhiteSpace(MembershipVersion))
-                fields.Add(MEMBERSHIP_VERSION_PROPERTY_NAME, new AttributeValue(MembershipVersion));
+            fields.Add(MEMBERSHIP_VERSION_PROPERTY_NAME, new AttributeValue { N = MembershipVersion.ToString() });
 
             fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = ETag.ToString() });
             return fields;

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Orleans.Runtime.MembershipService
 {
-    internal class SiloInstanceRecord 
+    internal class SiloInstanceRecord
     {
         public const string DEPLOYMENT_ID_PROPERTY_NAME = "DeploymentId";
         public const string SILO_IDENTITY_PROPERTY_NAME = "SiloIdentity";
@@ -24,6 +24,8 @@ namespace Orleans.Runtime.MembershipService
         public const string START_TIME_PROPERTY_NAME = "StartTime";
         public const string I_AM_ALIVE_TIME_PROPERTY_NAME = "IAmAliveTime";
         internal const char Seperator = '-';
+        internal const string TABLE_VERSION_ROW = "VersionRow"; // Range key for version row.
+        public const string MEMBERSHIP_VERSION_PROPERTY_NAME = "MembershipVersion";
 
         public string DeploymentId { get; set; }
         public string SiloIdentity { get; set; }
@@ -40,6 +42,8 @@ namespace Orleans.Runtime.MembershipService
         public string IAmAliveTime { get; set; }
         public int ETag { get; set; }
 
+        public string MembershipVersion      { get; set; }               // Special version row (for serializing table updates). // We'll have a designated row with only MembershipVersion column.
+
         public SiloInstanceRecord() { }
 
         public SiloInstanceRecord(Dictionary<string, AttributeValue> fields)
@@ -54,7 +58,7 @@ namespace Orleans.Runtime.MembershipService
                 Address = fields[ADDRESS_PROPERTY_NAME].S;
 
             int port;
-            if (fields.ContainsKey(PORT_PROPERTY_NAME) && 
+            if (fields.ContainsKey(PORT_PROPERTY_NAME) &&
                 int.TryParse(fields[PORT_PROPERTY_NAME].N, out port))
                 Port = port;
 
@@ -95,6 +99,9 @@ namespace Orleans.Runtime.MembershipService
             if (fields.ContainsKey(ETAG_PROPERTY_NAME) &&
                 int.TryParse(fields[ETAG_PROPERTY_NAME].N, out etag))
                 ETag = etag;
+
+            if (fields.ContainsKey(MEMBERSHIP_VERSION_PROPERTY_NAME))
+                MembershipVersion = fields[MEMBERSHIP_VERSION_PROPERTY_NAME].S;
         }
 
         internal static SiloAddress UnpackRowKey(string rowKey)
@@ -160,9 +167,9 @@ namespace Orleans.Runtime.MembershipService
             if (includeKeys)
             {
                 fields.Add(DEPLOYMENT_ID_PROPERTY_NAME, new AttributeValue(DeploymentId));
-                fields.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue(SiloIdentity)); 
+                fields.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue(SiloIdentity));
             }
-            
+
             if (!string.IsNullOrWhiteSpace(Address))
                 fields.Add(ADDRESS_PROPERTY_NAME, new AttributeValue(Address));
 
@@ -189,6 +196,9 @@ namespace Orleans.Runtime.MembershipService
 
             if (!string.IsNullOrWhiteSpace(IAmAliveTime))
                 fields.Add(I_AM_ALIVE_TIME_PROPERTY_NAME, new AttributeValue(IAmAliveTime));
+
+            if (!string.IsNullOrWhiteSpace(MembershipVersion))
+                fields.Add(MEMBERSHIP_VERSION_PROPERTY_NAME, new AttributeValue(MembershipVersion));
 
             fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = ETag.ToString() });
             return fields;

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -638,7 +638,7 @@ namespace Orleans.Transactions.DynamoDB
 
                 var response = await ddbClient.TransactGetItemsAsync(request);
 
-                return response.Responses.Select(r => resolver(r.Item));
+                return response.Responses.Where(r => r?.Item?.Count > 0).Select(r => resolver(r.Item));
             }
             catch (Exception)
             {

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -51,7 +51,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <param name="readCapacityUnits"></param>
         /// <param name="writeCapacityUnits"></param>
         public DynamoDBStorage(ILoggerFactory loggerFactory, string service,
-            string accessKey = "", string secretKey = "",  
+            string accessKey = "", string secretKey = "",
             int readCapacityUnits = DefaultReadCapacityUnits,
             int writeCapacityUnits = DefaultWriteCapacityUnits)
         {
@@ -242,47 +242,14 @@ namespace Orleans.Transactions.DynamoDB
                 {
                     TableName = tableName,
                     Key = keys,
-                    ExpressionAttributeValues = new Dictionary<string, AttributeValue>(),
                     ReturnValues = ReturnValue.UPDATED_NEW
                 };
 
-                var updateExpression = new StringBuilder();
-                foreach (var field in fields.Keys)
-                {
-                    var valueKey = ":" + field;
-                    request.ExpressionAttributeValues.Add(valueKey, fields[field]);
-                    updateExpression.Append($" {field} = {valueKey},");
-                }
-                updateExpression.Insert(0, "SET");
-
-                if (string.IsNullOrWhiteSpace(extraExpression))
-                {
-                    updateExpression.Remove(updateExpression.Length - 1, 1);
-                }
-                else
-                {
-                    updateExpression.Append($" {extraExpression}");
-                    if (extraExpressionValues != null && extraExpressionValues.Count > 0)
-                    {
-                        foreach (var key in extraExpressionValues.Keys)
-                        {
-                            request.ExpressionAttributeValues.Add(key, extraExpressionValues[key]);
-                        }
-                    }
-                }
-
-                request.UpdateExpression = updateExpression.ToString();
+                (request.UpdateExpression, request.ExpressionAttributeValues) = ConvertUpdate(fields, conditionValues,
+                    extraExpression, extraExpressionValues);
 
                 if (!string.IsNullOrWhiteSpace(conditionExpression))
                     request.ConditionExpression = conditionExpression;
-
-                if (conditionValues != null && conditionValues.Keys.Count > 0)
-                {
-                    foreach (var item in conditionValues)
-                    {
-                        request.ExpressionAttributeValues.Add(item.Key, item.Value);
-                    }
-                }
 
                 var result = await ddbClient.UpdateItemAsync(request);
 
@@ -304,6 +271,49 @@ namespace Orleans.Transactions.DynamoDB
                     $"Intermediate error upserting to the table {tableName}", exc);
                 throw;
             }
+        }
+
+        public (string updateExpression, Dictionary<string, AttributeValue> expressionAttributeValues)
+            ConvertUpdate(Dictionary<string, AttributeValue> fields,
+                Dictionary<string, AttributeValue> conditionValues = null,
+                string extraExpression = "", Dictionary<string, AttributeValue> extraExpressionValues = null)
+        {
+            var expressionAttributeValues = new Dictionary<string, AttributeValue>();
+
+            var updateExpression = new StringBuilder();
+            foreach (var field in fields.Keys)
+            {
+                var valueKey = ":" + field;
+                expressionAttributeValues.Add(valueKey, fields[field]);
+                updateExpression.Append($" {field} = {valueKey},");
+            }
+            updateExpression.Insert(0, "SET");
+
+            if (string.IsNullOrWhiteSpace(extraExpression))
+            {
+                updateExpression.Remove(updateExpression.Length - 1, 1);
+            }
+            else
+            {
+                updateExpression.Append($" {extraExpression}");
+                if (extraExpressionValues != null && extraExpressionValues.Count > 0)
+                {
+                    foreach (var key in extraExpressionValues.Keys)
+                    {
+                        expressionAttributeValues.Add(key, extraExpressionValues[key]);
+                    }
+                }
+            }
+
+            if (conditionValues != null && conditionValues.Keys.Count > 0)
+            {
+                foreach (var item in conditionValues)
+                {
+                    expressionAttributeValues.Add(item.Key, item.Value);
+                }
+            }
+
+            return (updateExpression.ToString(), expressionAttributeValues);
         }
 
         /// <summary>
@@ -563,6 +573,85 @@ namespace Orleans.Transactions.DynamoDB
             {
                 Logger.Warn(ErrorCode.StorageProviderBase,
                     $"Intermediate error bulk inserting entries to table {tableName}.", exc);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Transactionally reads entries from a DynamoDB table
+        /// </summary>
+        /// <typeparam name="TResult">The result type</typeparam>
+        /// <param name="tableName">The name of the table to search for the entry</param>
+        /// <param name="keys">The table entry keys to search for</param>
+        /// <param name="resolver">Function that will be called to translate the returned fields into a concrete type. This Function is only called if the result is != null</param>
+        /// <returns>The object translated by the resolver function</returns>
+        public async Task<IEnumerable<TResult>> GetEntriesTxAsync<TResult>(string tableName, IEnumerable<Dictionary<string, AttributeValue>> keys, Func<Dictionary<string, AttributeValue>, TResult> resolver) where TResult : class
+        {
+            try
+            {
+                var request = new TransactGetItemsRequest
+                {
+                    TransactItems = keys.Select(key => new TransactGetItem
+                    {
+                        Get = new Get
+                        {
+                            TableName = tableName,
+                            Key = key
+                        }
+                    }).ToList()
+                };
+
+                var response = await ddbClient.TransactGetItemsAsync(request);
+
+                return response.Responses.Select(r => resolver(r.Item));
+            }
+            catch (Exception)
+            {
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to find table entry for Keys = {0}", Utils.EnumerableToString(keys, d => Utils.DictionaryToString(d)));
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Transactionally performs write requests
+        /// </summary>
+        /// <param name="puts">Any puts to be performed</param>
+        /// <param name="updates">Any updated to be performed</param>
+        /// <param name="deletes">Any deletes to be performed</param>
+        /// <param name="conditionChecks">Any condition checks to be performed</param>
+        /// <returns></returns>
+        public Task WriteTxAsync(IEnumerable<Put> puts = null, IEnumerable<Update> updates = null, IEnumerable<Delete> deletes = null, IEnumerable<ConditionCheck> conditionChecks = null)
+        {
+            try
+            {
+                var transactItems = new List<TransactWriteItem>();
+                if (puts != null)
+                {
+                    transactItems.AddRange(puts.Select(p => new TransactWriteItem{Put = p}));
+                }
+                if (updates != null)
+                {
+                    transactItems.AddRange(updates.Select(u => new TransactWriteItem{Update = u}));
+                }
+                if (deletes != null)
+                {
+                    transactItems.AddRange(deletes.Select(d => new TransactWriteItem{Delete = d}));
+                }
+                if (conditionChecks != null)
+                {
+                    transactItems.AddRange(conditionChecks.Select(c => new TransactWriteItem{ConditionCheck = c}));
+                }
+
+                var request = new TransactWriteItemsRequest
+                {
+                    TransactItems = transactItems
+                };
+
+                return ddbClient.TransactWriteItemsAsync(request);
+            }
+            catch (Exception)
+            {
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to write tx");
                 throw;
             }
         }

--- a/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -16,7 +16,7 @@ namespace AWSUtils.Tests.MembershipTests
     /// <summary>
     /// Tests for operation of Orleans Membership Table using AWS DynamoDB - Requires access to external DynamoDB storage
     /// </summary>
-    [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")] 
+    [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")]
     public class DynamoDBMembershipTableTest : MembershipTableTestsBase, IClassFixture<DynamoDBStorageTestsFixture>
     {
         public DynamoDBMembershipTableTest(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment, CreateFilters())
@@ -50,7 +50,7 @@ namespace AWSUtils.Tests.MembershipTests
 
         protected override Task<string> GetConnectionString()
         {
-            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? "http://localhost:8000" : null);
+            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.Service}" : null);
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -68,37 +68,37 @@ namespace AWSUtils.Tests.MembershipTests
         [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_DynamoDB_InsertRow()
         {
-            await MembershipTable_InsertRow(false);
+            await MembershipTable_InsertRow();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_DynamoDB_ReadRow_Insert_Read()
         {
-            await MembershipTable_ReadRow_Insert_Read(false);
+            await MembershipTable_ReadRow_Insert_Read();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_DynamoDB_ReadAll_Insert_ReadAll()
         {
-            await MembershipTable_ReadAll_Insert_ReadAll(false);
+            await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_DynamoDB_UpdateRow()
         {
-            await MembershipTable_UpdateRow(false);
+            await MembershipTable_UpdateRow();
         }
 
         [SkippableFact]
         public async Task MembershipTable_DynamoDB_UpdateRowInParallel()
         {
-            await MembershipTable_UpdateRowInParallel(false);
+            await MembershipTable_UpdateRowInParallel();
         }
 
         [SkippableFact]
         public async Task MembershipTable_DynamoDB_UpdateIAmAlive()
         {
-            await MembershipTable_UpdateIAmAlive(false);
+            await MembershipTable_UpdateIAmAlive();
         }
     }
 }


### PR DESCRIPTION
Implements the extended membership protocol for DynamoDB.

Fixes #6099 

Still need to go through testing.

I noticed a few things while implementing this:

1. `ReadAll` isn't guaranteed to return all silo entries at the same version. It seemed like other implementations can also be inconsistent, but I'm not familiar enough to say for certain.
2. The Azure implementation seems to be more aggressive at throwing exceptions when rows don't exist than other implementations. I'm not sure what the preference is.
3. `DynamoDBMembershipTable` is getting a bit hard to read with all the low level dynamo db. It could be broken up, but it may be better to use a higher level api. That type of refactoring seems outside the scope of this PR though.