### PR TITLE
Update local_development_configuration.md

### DIFF
--- a/src/Documentation/clusters_and_clients/configuration_guide/list_of_options_classes.md
+++ b/src/Documentation/clusters_and_clients/configuration_guide/list_of_options_classes.md
@@ -20,7 +20,7 @@ All Options classes used to configure Orleans should be in the `Orleans.Configur
 
 | Option type | Used for |
 |-------------|----------|
-| `ClientMessagingOptions` | Setting the number of connection to keep open, and specify what network interface to use |
+| `ClientMessagingOptions` | Setting the number of connections to keep open, and specify what network interface to use |
 | `ClientStatisticsOption` | Setting various setting related to statistics output |
 | `GatewayOptions` | Setting the refresh period of the list of available gateways |
 | `StaticGatewayListProviderOptions` | Setting URIs a client will use to connect to cluster |

--- a/src/Documentation/clusters_and_clients/configuration_guide/local_development_configuration.md
+++ b/src/Documentation/clusters_and_clients/configuration_guide/local_development_configuration.md
@@ -5,13 +5,14 @@ title: Local development configuration
 
 # Local development configuration
 
-For a working sample application that targets Orleans 2.0 see: https://github.com/dotnet/orleans/tree/master/Samples/2.0/HelloWorld
-The sample hosts the client and the silo in .NET Core console applications that work in different platforms, but the same can be done with .NET Framework 4.6.1+ console applications (that work only on Windows).
+For a working sample application that targets Orleans 3.0 see: https://github.com/dotnet/orleans/tree/master/Samples/3.0/HelloWorld. The sample hosts the client and the silo in .NET Core console applications that work in different platforms, while the grains and interfaces target .NET Standard 2.0.
+
+For older versions of Orleans please see their respective Sample projects: https://github.com/dotnet/orleans/tree/master/Samples/.
 
 ## Silo configuration
 
 For local development, please refer to the below example of how to configure a silo for that case.
-It configures and starts a silo listening on `loopback' address and 11111 and 30000 as silo and gateway ports respectively.
+It configures and starts a silo listening on `loopback` address and 11111 and 30000 as silo and gateway ports respectively.
 
 Add the `Microsoft.Orleans.Server` NuGet meta-package to the project. After you get comfortable with the API, you can pick and choose which exact packages included in `Microsoft.Orleans.Server` you actually need, and reference them instead.
 
@@ -19,11 +20,9 @@ Add the `Microsoft.Orleans.Server` NuGet meta-package to the project. After you 
 PM> Install-Package Microsoft.Orleans.Server
 ```
 
-You need to configure `ClusterOptions` via `ISiloBuilder.Configure`method, specify that you want `DevelopmentClustering` as your clustering choice with this silo being the primary, and then configure silo endpoints.
+You need to configure `ClusterOptions` via `ISiloBuilder.Configure` method, specify that you want `DevelopmentClustering` as your clustering choice with this silo being the primary, and then configure silo endpoints.
 
-`ConfigureApplicationParts` call explicitly adds the assembly with grain classes to the application setup.
-It also adds any referenced assembly due to the `WithReferences` extension.
-After these steps are completed, the silo host gets built and the silo gets started.
+`ConfigureApplicationParts` call explicitly adds the assembly with grain classes to the application setup. It also adds any referenced assembly due to the `WithReferences` extension. After these steps are completed, the silo host gets built and the silo gets started.
 
 You can create an empty console application project targeting .NET Framework 4.6.1 or higher for hosting a silo, as well as a .NET Core console application.
 


### PR DESCRIPTION
Adds link to Orleans 3.0 Hello World sample, while directing readers to older versions if wanted.
Fixes loopback wrapper ending character.  Was a ' instead of a \`.
Adds space between `ISiloBuilder.Configure` and "method".

