### PR TITLE
Make IFatalErrorHandler public so that it can be replaced by users

### DIFF
--- a/src/Orleans.Runtime/Core/IFatalErrorHandler.cs
+++ b/src/Orleans.Runtime/Core/IFatalErrorHandler.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Orleans.Runtime
 {
-    internal interface IFatalErrorHandler
+    public interface IFatalErrorHandler
     {
         bool IsUnexpected(Exception exception);
         void OnFatalException(object sender = null, string context = null, Exception exception = null);


### PR DESCRIPTION
This can be useful for troubleshooting