### PR TITLE
CodeGen: fix ambiguous reference to Orleans namespace

### DIFF
--- a/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
@@ -134,7 +134,7 @@ namespace Orleans.CodeGenerator.Generators
                     {
                         body.Add(
                             ExpressionStatement(
-                                InvocationExpression(wellKnownTypes.GrainFactoryBase.ToDisplayString().ToIdentifierName().Member("CheckGrainObserverParamInternal"))
+                                InvocationExpression(wellKnownTypes.GrainFactoryBase.ToNameSyntax().Member("CheckGrainObserverParamInternal"))
                                     .AddArgumentListArguments(Argument(parameter.Name.ToIdentifierName()))));
                     }
                 }


### PR DESCRIPTION
Fixes #6165

I didn't spot any other instances of the same bug, so hopefully this is it.