### PR TITLE
Avoid potential NullReferenceException when re-initializing statistics

### DIFF
--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -36,7 +36,7 @@ namespace Orleans
 
         private ClientProviderRuntime clientProviderRuntime;
 
-        internal ClientStatisticsManager ClientStatistics;
+        internal readonly ClientStatisticsManager ClientStatistics;
         private GrainId clientId;
         private readonly GrainId handshakeClientId;
         private ThreadTrackingStatistic incomingMessagesThreadTimeTracking;
@@ -137,7 +137,6 @@ namespace Orleans
                 }
 
                 this.InternalGrainFactory = this.ServiceProvider.GetRequiredService<IInternalGrainFactory>();
-                this.ClientStatistics = this.ServiceProvider.GetRequiredService<ClientStatisticsManager>();
                 this.messageFactory = this.ServiceProvider.GetService<MessageFactory>();
 
                 var serializationManager = this.ServiceProvider.GetRequiredService<SerializationManager>();
@@ -596,7 +595,6 @@ namespace Orleans
             if (ClientStatistics != null)
             {
                 Utils.SafeExecute(() => ClientStatistics.Dispose());
-                ClientStatistics = null;
             }
 
             Utils.SafeExecute(() => (this.ServiceProvider as IDisposable)?.Dispose());

--- a/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
@@ -23,26 +23,26 @@ namespace Orleans.Runtime
 
         internal static void Init()
         {
-            dispatcherMessagesProcessedOkPerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            dispatcherMessagesProcessedOkPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 dispatcherMessagesProcessedOkPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_OK_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
-            dispatcherMessagesProcessedErrorsPerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            dispatcherMessagesProcessedErrorsPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 dispatcherMessagesProcessedErrorsPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_ERRORS_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
-            dispatcherMessagesProcessedReRoutePerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            dispatcherMessagesProcessedReRoutePerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 dispatcherMessagesProcessedReRoutePerDirection[(int)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_REROUTE_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
 
-            dispatcherMessagesProcessingReceivedPerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            dispatcherMessagesProcessingReceivedPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 dispatcherMessagesProcessingReceivedPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
@@ -56,12 +56,12 @@ namespace Orleans.Runtime
             igcMessagesReRoute = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_IGC_REROUTE);
 
             imaReceived = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_IMA_RECEIVED);
-            imaEnqueuedByContext = new CounterStatistic[3];
+            imaEnqueuedByContext ??= new CounterStatistic[3];
             imaEnqueuedByContext[0] = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_IMA_ENQUEUED_TO_NULL);
             imaEnqueuedByContext[1] = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_IMA_ENQUEUED_TO_SYSTEM_TARGET);
             imaEnqueuedByContext[2] = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_IMA_ENQUEUED_TO_ACTIVATION);
 
-            dispatcherReceivedByContext = new CounterStatistic[2];
+            dispatcherReceivedByContext ??= new CounterStatistic[2];
             dispatcherReceivedByContext[0] = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_DISPATCHER_RECEIVED_ON_NULL);
             dispatcherReceivedByContext[1] = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_DISPATCHER_RECEIVED_ON_ACTIVATION);
         }

--- a/src/Orleans.Core/Statistics/MessagingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/MessagingStatisticsGroup.cs
@@ -85,7 +85,7 @@ namespace Orleans.Runtime
             ConnectedClientCount = CounterStatistic.FindOrCreate(StatisticNames.GATEWAY_CONNECTED_CLIENTS, false);
 
             MessagesSentTotal = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_SENT_MESSAGES_TOTAL);
-            MessagesSentPerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            MessagesSentPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 MessagesSentPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
@@ -93,7 +93,7 @@ namespace Orleans.Runtime
             }
 
             MessagesReceived = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_RECEIVED_MESSAGES_TOTAL);
-            MessagesReceivedPerDirection = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            MessagesReceivedPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 MessagesReceivedPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
@@ -104,11 +104,11 @@ namespace Orleans.Runtime
             totalBytesReceived = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_RECEIVED_BYTES_TOTAL);
             HeaderBytesSent = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_SENT_BYTES_HEADER);
             headerBytesReceived = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_RECEIVED_BYTES_HEADER);
-            FailedSentMessages = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
-            DroppedSentMessages = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
-            RejectedMessages = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            FailedSentMessages ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            DroppedSentMessages ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            RejectedMessages ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
 
-            ReroutedMessages = new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
+            ReroutedMessages ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
                 ReroutedMessages[(int)direction] = CounterStatistic.FindOrCreate(
@@ -124,8 +124,8 @@ namespace Orleans.Runtime
             expiredAtInvokeCounter = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_EXPIRED_ATINVOKE);
             expiredAtRespondCounter = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_EXPIRED_ATRESPOND);
 
-            perSocketDirectionStatsSend = new PerSocketDirectionStats[Enum.GetValues(typeof(ConnectionDirection)).Length];
-            perSocketDirectionStatsReceive = new PerSocketDirectionStats[Enum.GetValues(typeof(ConnectionDirection)).Length];
+            perSocketDirectionStatsSend ??= new PerSocketDirectionStats[Enum.GetValues(typeof(ConnectionDirection)).Length];
+            perSocketDirectionStatsReceive ??= new PerSocketDirectionStats[Enum.GetValues(typeof(ConnectionDirection)).Length];
 
             perSocketDirectionStatsSend[(int)ConnectionDirection.SiloToSilo] = new PerSocketDirectionStats(true, ConnectionDirection.SiloToSilo);
             perSocketDirectionStatsReceive[(int)ConnectionDirection.SiloToSilo] = new PerSocketDirectionStats(false, ConnectionDirection.SiloToSilo);

--- a/src/Orleans.Core/Statistics/NetworkingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/NetworkingStatisticsGroup.cs
@@ -10,8 +10,8 @@ namespace Orleans.Runtime
 
         internal static void Init()
         {
-            closedSockets = new CounterStatistic[Enum.GetValues(typeof(ConnectionDirection)).Length];
-            openedSockets = new CounterStatistic[Enum.GetValues(typeof(ConnectionDirection)).Length];
+            closedSockets ??= new CounterStatistic[Enum.GetValues(typeof(ConnectionDirection)).Length];
+            openedSockets ??= new CounterStatistic[Enum.GetValues(typeof(ConnectionDirection)).Length];
 
             openedSockets[(int)ConnectionDirection.SiloToSilo] = CounterStatistic.FindOrCreate(StatisticNames.NETWORKING_SOCKETS_SILO_OPENED);
             closedSockets[(int)ConnectionDirection.SiloToSilo] = CounterStatistic.FindOrCreate(StatisticNames.NETWORKING_SOCKETS_SILO_CLOSED);

--- a/src/Orleans.Core/Statistics/SchedulerStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/SchedulerStatisticsGroup.cs
@@ -74,10 +74,10 @@ namespace Orleans.Runtime
                 turnsExecutedStartTotal = CounterStatistic.FindOrCreate(StatisticNames.SCHEDULER_TURNSEXECUTED_TOTAL_START);
                 turnsExecutedEndTotal = CounterStatistic.FindOrCreate(StatisticNames.SCHEDULER_TURNSEXECUTED_TOTAL_END);
 
-                turnsExecutedPerWorkerThreadApplicationTurns = new CounterStatistic[1];
-                turnsExecutedPerWorkerThreadSystemTurns = new CounterStatistic[1];
-                turnsExecutedPerWorkerThreadNull = new CounterStatistic[1];
-                turnsExecutedPerWorkItemGroup = new CounterStatistic[1];
+                turnsExecutedPerWorkerThreadApplicationTurns ??= new CounterStatistic[1];
+                turnsExecutedPerWorkerThreadSystemTurns ??= new CounterStatistic[1];
+                turnsExecutedPerWorkerThreadNull ??= new CounterStatistic[1];
+                turnsExecutedPerWorkItemGroup ??= new CounterStatistic[1];
             }
 
             NumLongRunningTurns = CounterStatistic.FindOrCreate(StatisticNames.SCHEDULER_NUM_LONG_RUNNING_TURNS);


### PR DESCRIPTION
When running multiple TestClusters in the same process (and same AppDomain), it's possible that there can be a `NullReferenceException` caused by a call to one of the `Init()` methods in the statistics groups while those groups are being accessed by an existing node.