### PR TITLE
Serialization optimizations for .NET Core 3.1

### DIFF
--- a/src/Orleans.Core/Serialization/BinaryTokenStreamReader2.cs
+++ b/src/Orleans.Core/Serialization/BinaryTokenStreamReader2.cs
@@ -32,18 +32,6 @@ namespace Orleans.Serialization
         {
             this.PartialReset(input);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void PartialReset(ReadOnlySequence<byte> input)
-        {
-            this.input = input;
-            this.nextSequencePosition = input.Start;
-            this.currentSpan = input.First;
-            this.bufferPos = 0;
-            this.bufferSize = this.currentSpan.Length;
-            this.previousBuffersSize = 0;
-        }
-
         public long Length => this.input.Length;
         
         public long Position
@@ -56,6 +44,17 @@ namespace Orleans.Serialization
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)this.previousBuffersSize + this.bufferPos;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void PartialReset(ReadOnlySequence<byte> input)
+        {
+            this.input = input;
+            this.nextSequencePosition = input.Start;
+            this.currentSpan = input.First;
+            this.bufferPos = 0;
+            this.bufferSize = this.currentSpan.Length;
+            this.previousBuffersSize = 0;
         }
 
         public void Skip(long count)
@@ -289,41 +288,38 @@ namespace Orleans.Serialization
         public string ReadString()
         {
             var n = this.ReadInt32();
-            if (n == 0)
+            if (n <= 0)
             {
-                return String.Empty;
+                if (n == 0) return string.Empty;
+
+                // a length of -1 indicates that the string is null.
+                if (n == -1) return null;
             }
 
-            string s = null;
-            // a length of -1 indicates that the string is null.
-            if (-1 != n)
+#if NETCOREAPP
+            if (this.bufferSize - this.bufferPos >= n)
             {
-#if NETSTANDARD2_1
-                if (this.bufferSize - this.bufferPos >= n)
-                {
-                    s = Encoding.UTF8.GetString(this.currentSpan.Slice(this.bufferPos, n).Span);
-                    this.bufferPos += n;
-                }
-                else if (n <= 256)
-                {
-                    Span<byte> bytes = stackalloc byte[n];
-                    this.ReadBytes(in bytes);
-                    s = Encoding.UTF8.GetString(bytes);
-                }
-                else
-                {
-                    var bytes = this.ReadBytes((uint)n);
-                    s = Encoding.UTF8.GetString(bytes);
-                }
-#else
-                var bytes = this.ReadBytes((uint)n);
-                s = Encoding.UTF8.GetString(bytes);
-#endif
+                var s = Encoding.UTF8.GetString(this.currentSpan.Slice(this.bufferPos, n).Span);
+                this.bufferPos += n;
+                return s;
             }
-            
-            return s;
+            else if (n <= 256)
+            {
+                Span<byte> bytes = stackalloc byte[n];
+                this.ReadBytes(in bytes);
+                return Encoding.UTF8.GetString(bytes);
+            }
+            else
+            {
+                var bytes = this.ReadBytes((uint)n);
+                return Encoding.UTF8.GetString(bytes);
+            }
+#else
+            var bytes = this.ReadBytes((uint)n);
+            return Encoding.UTF8.GetString(bytes);
+#endif
         }
-        
+
         /// <summary> Read the next bytes from the stream. </summary>
         /// <param name="destination">Output array to store the returned data in.</param>
         /// <param name="offset">Offset into the destination array to write to.</param>
@@ -410,7 +406,6 @@ namespace Orleans.Serialization
             byte[] bytes = ReadBytes(16);
             return new Guid(bytes);
 #endif
-
         }
 
         /// <summary> Read an <c>IPEndPoint</c> value from the stream. </summary>


### PR DESCRIPTION
String serialization:

```md
|   Method |      Mean |  Gen 0 | Allocated |
|--------- |----------:|-------:|----------:|
|   Before |  94.83 ns | 0.0194 |     112 B |
|    After |  68.11 ns |      - |         - |
```

String deserialization:

``` md
|   Method |      Mean |  Gen 0 | Allocated |
|--------- |----------:|-------:|----------:|
|   Before | 134.18 ns | 0.0527 |     304 B |
|    After | 109.08 ns | 0.0334 |     192 B |
```