### PR TITLE
Minor perf tweak for RequestContext when removing last item

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -111,10 +111,19 @@ namespace Orleans.Runtime
             {
                 return false;
             }
-            var newValues = new Dictionary<string, object>(values);
-            bool retValue = newValues.Remove(key);
-            CallContextData.Value = newValues;
-            return retValue;
+
+            if (values.Count == 1)
+            {
+                CallContextData.Value = null;
+                return true;
+            }
+            else
+            {
+                var newValues = new Dictionary<string, object>(values);
+                newValues.Remove(key);
+                CallContextData.Value = newValues;
+                return true;
+            }
         }
 
         public static void Clear()


### PR DESCRIPTION
When removing the last entry from a RequestContext, set the value to null instead of creating a new dictionary with a copy of the current context and removing the last item.