### PR TITLE
Add OrleansDebuggerHelper.GetGrainInstance to aid in local debugging

### DIFF
--- a/src/Orleans.Runtime/Utilities/OrleansDebuggerHelper.cs
+++ b/src/Orleans.Runtime/Utilities/OrleansDebuggerHelper.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime.Utilities
+{
+    /// <summary>
+    /// Utility methods for aiding debugger sessions.
+    /// </summary>
+    public static class OrleansDebuggerHelper
+    {
+        /// <summary>
+        /// Returns the grain instance corresponding to the provided <paramref name="grainReference"/> if it is activated on current silo.
+        /// </summary>
+        /// <param name="grainReference">The grain reference.</param>
+        /// <returns>
+        /// The grain instance corresponding to the provided <paramref name="grainReference"/> if it is activated on current silo, or <see langword="null"/> otherwise.
+        /// </returns>
+        public static object GetGrainInstance(object grainReference)
+        {
+            switch (grainReference)
+            {
+                case Grain _:
+                    return grainReference;
+                case GrainReference reference:
+                    {
+                        var runtime = (reference.Runtime as GrainReferenceRuntime)?.RuntimeClient;
+                        if (runtime is null) return null;
+
+                        var activations = runtime.ServiceProvider.GetService<ActivationDirectory>();
+                        if (activations is null) return null;
+
+                        var grains = activations.FindTargets(reference.GrainId);
+                        return grains?.FirstOrDefault()?.GrainInstance;
+                    }
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/test/DefaultCluster.Tests/DebuggerHelperTests.cs
+++ b/test/DefaultCluster.Tests/DebuggerHelperTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests.General
+{
+    public class DebuggerHelperTests : HostedTestClusterEnsureDefaultStarted
+    {
+        public DebuggerHelperTests(DefaultClusterFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact, TestCategory("BVT")]
+        public async Task DebuggerHelper_GetGrainInstance()
+        {
+            var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid()).Cast<IDebuggerHelperTestGrain>();
+            await grain.OrleansDebuggerHelper_GetGrainInstance_Test();
+        }
+    }
+}

--- a/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
@@ -60,4 +60,9 @@ namespace UnitTests.GrainInterfaces
         Task<string> CallMethodTask_Block(string data);
         Task<string> CallMethodAV_Block(string data);
     }
+
+    public interface IDebuggerHelperTestGrain : IGrain
+    {
+        Task OrleansDebuggerHelper_GetGrainInstance_Test();
+    }
 }

--- a/test/Grains/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/Grains/TestInternalGrains/EchoTaskGrain.cs
@@ -8,7 +8,9 @@ using Orleans;
 using Orleans.Concurrency;
 using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Runtime.Utilities;
 using UnitTests.GrainInterfaces;
+using Xunit;
 
 namespace UnitTests.Grains
 {
@@ -58,7 +60,7 @@ namespace UnitTests.Grains
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    internal class EchoTaskGrain : Grain<EchoTaskGrainState>, IEchoTaskGrain
+    internal class EchoTaskGrain : Grain<EchoTaskGrainState>, IEchoTaskGrain, IDebuggerHelperTestGrain
     {
         private readonly IInternalGrainFactory internalGrainFactory;
         private ILogger logger;
@@ -182,6 +184,23 @@ namespace UnitTests.Grains
         private ISiloControl GetSiloControlReference(SiloAddress silo)
         {
             return this.internalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
+        }
+
+        public Task OrleansDebuggerHelper_GetGrainInstance_Test()
+        {
+            var result = OrleansDebuggerHelper.GetGrainInstance(null);
+            Assert.Null(result);
+
+            result = OrleansDebuggerHelper.GetGrainInstance(this);
+            Assert.Same(this, result);
+
+            result = OrleansDebuggerHelper.GetGrainInstance(this.AsReference<IDebuggerHelperTestGrain>());
+            Assert.Same(this, result);
+
+            result = OrleansDebuggerHelper.GetGrainInstance(this.GrainFactory.GetGrain<IEchoGrain>(Guid.NewGuid()));
+            Assert.Null(result);
+
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
Fixes #6220 
cc @OracPrime

Example usage (from Immediate Window in VS debugger):

```C#
Orleans.Runtime.Utilities.OrleansDebuggerHelper.GetGrainInstance(myGrainReference)
```