### PR TITLE
docs: fixed dead page link.

### DIFF
--- a/src/Documentation/resources/toc.yml
+++ b/src/Documentation/resources/toc.yml
@@ -2,7 +2,7 @@
   href: index.md
 - name: Frequently Asked Questions
   href: frequently_asked_questions.md
-- name: Nuget Packages
+- name: NuGet Packages
   href: nuget_packages.md
 - name: Documentation Guidelines
   href: documentation_guidelines.md

--- a/src/Documentation/resources/toc.yml
+++ b/src/Documentation/resources/toc.yml
@@ -2,6 +2,8 @@
   href: index.md
 - name: Frequently Asked Questions
   href: frequently_asked_questions.md
+- name: Nuget Packages
+  href: nuget_packages.md
 - name: Documentation Guidelines
   href: documentation_guidelines.md
 - name: Links


### PR DESCRIPTION
The public page [exists](https://dotnet.github.io/orleans/Documentation/resources/nuget_packages.html?q=packages), but there was no way to get to it, this fixes it.

Signed-off-by: Mike Lloyd <mike@reboot3times.org>