### PR TITLE
Avoid capturing ExecutionContext in GrainTimer and other timers

### DIFF
--- a/src/Orleans.Core/Timers/AsyncTaskSafeTimer.cs
+++ b/src/Orleans.Core/Timers/AsyncTaskSafeTimer.cs
@@ -4,44 +4,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime
 {
-    internal class AsyncTaskSafeTimer : IDisposable
+    internal class AsyncTaskSafeTimer : SafeTimerBase
     {
-        private readonly SafeTimerBase safeTimerBase;
-
-        public AsyncTaskSafeTimer(ILogger logger, Func<object, Task> asynTaskCallback, object state)
+        public AsyncTaskSafeTimer(ILogger logger, Func<object, Task> asyncTaskCallback, object state) : base(logger, asyncTaskCallback, state)
         {
-            safeTimerBase = new SafeTimerBase(logger, asynTaskCallback, state);
         }
 
-        public AsyncTaskSafeTimer(ILogger logger, Func<object, Task> asynTaskCallback, object state, TimeSpan dueTime, TimeSpan period)
+        public AsyncTaskSafeTimer(ILogger logger, Func<object, Task> asyncTaskCallback, object state, TimeSpan dueTime, TimeSpan period) : base(logger, asyncTaskCallback, state, dueTime, period)
         {
-            safeTimerBase = new SafeTimerBase(logger, asynTaskCallback, state, dueTime, period);
-        }
-
-        public void Start(TimeSpan dueTime, TimeSpan period)
-        {
-            safeTimerBase.Start(dueTime, period);
-        }
-
-        public void Dispose()
-        {
-            safeTimerBase.Dispose();
-        }
-
-        // Maybe called by finalizer thread with disposing=false. As per guidelines, in such a case do not touch other objects.
-        // Dispose() may be called multiple times
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "safeTimerBase")]
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                safeTimerBase.DisposeTimer();
-            }
-        }
-
-        public bool CheckTimerFreeze(DateTime lastCheckTime, Func<string> callerName)
-        {
-            return safeTimerBase.CheckTimerFreeze(lastCheckTime, callerName);
         }
     }
 }

--- a/src/Orleans.Core/Timers/NonCapturingTimer.cs
+++ b/src/Orleans.Core/Timers/NonCapturingTimer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// A convenience API for interacting with System.Threading.Timer in a way
+    /// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+    /// everywhere we use timers to avoid rooting any values stored in AsyncLocals.
+    /// </summary>
+    /// <see href="https://github.com/dotnet/extensions/blob/a1389576a3bbc85a48bdcadce4f16bcf7cdfa088/src/Shared/src/NonCapturingTimer/NonCapturingTimer.cs"/>
+    internal static class NonCapturingTimer
+    {
+        public static Timer Create(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+        {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+            bool restoreFlow = false;
+            try
+            {
+                if (!ExecutionContext.IsFlowSuppressed())
+                {
+                    ExecutionContext.SuppressFlow();
+                    restoreFlow = true;
+                }
+
+                return new Timer(callback, state, dueTime, period);
+            }
+            finally
+            {
+                // Restore the current ExecutionContext
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Timers/SafeTimer.cs
+++ b/src/Orleans.Core/Timers/SafeTimer.cs
@@ -12,51 +12,10 @@ namespace Orleans.Runtime
     /// 
     /// Log levels used: Recovered faults => Warning, Per-Timer operations => Verbose, Per-tick operations => Verbose3
     /// </summary>
-    internal class SafeTimer : IDisposable
+    internal class SafeTimer : SafeTimerBase
     {
-        private readonly SafeTimerBase safeTimerBase;
-        private readonly TimerCallback callbackFunc;
-
-        public SafeTimer(ILogger logger, TimerCallback callback, object state)
+        public SafeTimer(ILogger logger, TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period) : base(logger, callback, state, dueTime, period)
         {
-            callbackFunc = callback;
-            safeTimerBase = new SafeTimerBase(logger, callbackFunc, state);
-        }
-
-        public SafeTimer(ILogger logger, TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
-        {
-            callbackFunc = callback;
-            safeTimerBase = new SafeTimerBase(logger, callbackFunc, state, dueTime, period);
-        }
-
-        public void Start(TimeSpan dueTime, TimeSpan period)
-        {
-            safeTimerBase.Start(dueTime, period);
-        }
-
-        public void Dispose()
-        {
-            safeTimerBase.Dispose();
-        }
-
-        // May be called by finalizer thread with disposing=false. As per guidelines, in such a case do not touch other objects.
-        // Dispose() may be called multiple times
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                safeTimerBase.DisposeTimer();
-            }
-        }
-
-        internal string GetFullName()
-        {
-            return String.Format("SafeTimer: {0}. ", callbackFunc != null ? callbackFunc.GetType().FullName : "");
-        }
-
-        public bool CheckTimerFreeze(DateTime lastCheckTime, Func<string> callerName)
-        {
-            return safeTimerBase.CheckTimerFreeze(lastCheckTime, callerName);
         }
     }
 }

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
             this.logger = logger;
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.TimerChanging, "Creating timer {0} with dueTime={1} period={2}", GetFullName(), due, period);
 
-            timer = new Timer(HandleTimerCallback, state, Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
+            timer = NonCapturingTimer.Create(HandleTimerCallback, state, Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
         }
 
         public void Dispose()

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -8,15 +8,14 @@ namespace Orleans.Runtime
 {
     /// <summary>
     /// SafeTimerBase - an internal base class for implementing sync and async timers in Orleans.
-    /// 
     /// </summary>
     internal class SafeTimerBase : IDisposable
     {
-        private const string asyncTimerName ="Orleans.Runtime.asynTask.SafeTimerBase";
-        private const string syncTimerName = "Orleans.Runtime.sync.SafeTimerBase";
+        private const string asyncTimerName ="Orleans.Runtime.AsyncTaskSafeTimer";
+        private const string syncTimerName = "Orleans.Runtime.SafeTimerBase";
 
         private Timer               timer;
-        private Func<object, Task>  asynTaskCallback;
+        private Func<object, Task>  asyncTaskCallback;
         private TimerCallback       syncCallbackFunc;
         private TimeSpan            dueTime;
         private TimeSpan            timerFrequency;
@@ -25,14 +24,14 @@ namespace Orleans.Runtime
         private int                 totalNumTicks;
         private ILogger      logger;
 
-        internal SafeTimerBase(ILogger logger, Func<object, Task> asynTaskCallback, object state)
+        internal SafeTimerBase(ILogger logger, Func<object, Task> asyncTaskCallback, object state)
         {
-            Init(logger, asynTaskCallback, null, state, Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
+            Init(logger, asyncTaskCallback, null, state, Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
         }
 
-        internal SafeTimerBase(ILogger logger, Func<object, Task> asynTaskCallback, object state, TimeSpan dueTime, TimeSpan period)
+        internal SafeTimerBase(ILogger logger, Func<object, Task> asyncTaskCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            Init(logger, asynTaskCallback, null, state, dueTime, period);
+            Init(logger, asyncTaskCallback, null, state, dueTime, period);
             Start(dueTime, period);
         }
 
@@ -66,7 +65,7 @@ namespace Orleans.Runtime
             if (numNonNulls > 1) throw new ArgumentNullException("synCallback", "Cannot define more than one timer callbacks. Pick one.");
             if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException("period", period, "Cannot use TimeSpan.Zero for timer period");
 
-            this.asynTaskCallback = asynCallback;
+            this.asyncTaskCallback = asynCallback;
             syncCallbackFunc = synCallback;
             timerFrequency = period;
             this.dueTime = due;
@@ -119,7 +118,7 @@ namespace Orleans.Runtime
             // the type information is really useless and just too long. 
             if (syncCallbackFunc != null)
                 return syncTimerName;
-            if (asynTaskCallback != null)
+            if (asyncTaskCallback != null)
                 return asyncTimerName;
 
             throw new InvalidOperationException("invalid SafeTimerBase state");
@@ -199,7 +198,7 @@ namespace Orleans.Runtime
         {
             if (timer == null) return;
 
-            if (asynTaskCallback != null)
+            if (asyncTaskCallback != null)
             {
                 HandleAsyncTaskTimerCallback(state);
             }
@@ -246,7 +245,7 @@ namespace Orleans.Runtime
             try
             {
                 if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerBeforeCallback, "About to make async task timer callback for timer {0}", GetFullName());
-                await asynTaskCallback(state);
+                await asyncTaskCallback(state);
                 if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerAfterCallback, "Completed async task timer callback for timer {0}", GetFullName());
             }
             catch (Exception exc)

--- a/src/Orleans.Core/Timers/TimerManager.cs
+++ b/src/Orleans.Core/Timers/TimerManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 using Orleans.Threading;
 
 namespace Orleans.Timers.Internal
@@ -92,7 +93,7 @@ namespace Orleans.Timers.Internal
         static TimerManager()
         {
             var timerPeriod = TimeSpan.FromMilliseconds(TIMER_TICK_MILLISECONDS);
-            QueueChecker = new Timer(_ => CheckQueues(), null, timerPeriod, timerPeriod);
+            QueueChecker = NonCapturingTimer.Create(_ => CheckQueues(), null, timerPeriod, timerPeriod);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5563

This means that `RequestContext` will not automatically flow into timers, etc. My belief is that this is the correct behavior and that the current behavior is a likely source of bugs.