### PR TITLE
Adds MySqlConnector library using invariant MySql.Data.MySqlConnector

### DIFF
--- a/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
+++ b/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
@@ -21,13 +21,18 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// A list of the supported invariants.
         /// </summary>
+        /// <remarks>The invariant names here do not match the namespaces as is often the convention.
+        /// Current exception is MySQL Connector library that uses the same invariant as MySQL compared
+        /// to the official Oracle distribution.</remarks>
         public static ICollection<string> Invariants { get; } = new Collection<string>(new List<string>(new[]
         {
             InvariantNameMySql,
             InvariantNameOracleDatabase,
             InvariantNamePostgreSql,
             InvariantNameSqlLite,
-            InvariantNameSqlServer
+            InvariantNameSqlServer,
+            InvariantNameSqlServerDotnetCore,
+            InvariantNameMySqlConnector
         }));
 
         /// <summary>
@@ -59,5 +64,10 @@ namespace Orleans.Tests.SqlUtils
         /// Dotnet core Microsoft SQL Server invariant name string.
         /// </summary>
         public const string InvariantNameSqlServerDotnetCore = "Microsoft.Data.SqlClient";
+
+        /// <summary>
+        /// An open source implementation of the MySQL connector library.
+        /// </summary>
+        public const string InvariantNameMySqlConnector = "MySql.Data.MySqlConnector";
     }
 }

--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -32,6 +32,7 @@ namespace Orleans.Tests.SqlUtils
                 { AdoNetInvariants.InvariantNamePostgreSql, new Tuple<string, string>("Npgsql", "Npgsql.NpgsqlFactory") },
                 { AdoNetInvariants.InvariantNameSqlLite, new Tuple<string, string>("Microsoft.Data.SQLite", "Microsoft.Data.SQLite.SqliteFactory") },
                 { AdoNetInvariants.InvariantNameSqlServerDotnetCore, new Tuple<string, string>("Microsoft.Data.SqlClient", "Microsoft.Data.SqlClient.SqlClientFactory") },
+                { AdoNetInvariants.InvariantNameMySqlConnector, new Tuple<string, string>("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory") },
             };
 
         private static CachedFactory GetFactory(string invariantName)
@@ -55,7 +56,7 @@ namespace Orleans.Tests.SqlUtils
             {
                 throw new InvalidOperationException($"Unable to find and/or load a candidate assembly for '{invariantName}' invariant name.", exc);
             }
-            
+
             if (asm == null)
                 throw new InvalidOperationException($"Can't find database provider factory with '{invariantName}' invariant name. Please make sure that your ADO.Net provider package library is deployed with your application.");
 

--- a/src/AdoNet/Shared/Storage/DbConstantsStore.cs
+++ b/src/AdoNet/Shared/Storage/DbConstantsStore.cs
@@ -43,8 +43,8 @@ namespace Orleans.Tests.SqlUtils
                                     isSynchronousAdoNetImplementation: true, //there are some intermittent PostgreSQL problems too, see more discussion at https://github.com/dotnet/orleans/pull/2949.
                                     supportsStreamNatively: true,
                                     supportsCommandCancellation: true, // See https://dev.mysql.com/doc/connector-net/en/connector-net-ref-mysqlclient-mysqlcommandmembers.html.
-                                    commandInterceptor: NoOpCommandInterceptor.Instance) 
-                                    
+                                    commandInterceptor: NoOpCommandInterceptor.Instance)
+
                 },
                 {AdoNetInvariants.InvariantNameOracleDatabase, new DbConstants(
                                     startEscapeIndicator: '\"',
@@ -53,8 +53,8 @@ namespace Orleans.Tests.SqlUtils
                                     isSynchronousAdoNetImplementation: true,
                                     supportsStreamNatively: false,
                                     supportsCommandCancellation: false, // Is supported but the remarks sound scary: https://docs.oracle.com/cd/E11882_01/win.112/e23174/OracleCommandClass.htm#DAFIEHHG.
-                                    commandInterceptor: OracleCommandInterceptor.Instance) 
-                    
+                                    commandInterceptor: OracleCommandInterceptor.Instance)
+
                 },
                 {
                     AdoNetInvariants.InvariantNameSqlServerDotnetCore,
@@ -66,6 +66,16 @@ namespace Orleans.Tests.SqlUtils
                                     supportsCommandCancellation: true,
                                     commandInterceptor: NoOpCommandInterceptor.Instance)
                 },
+                {
+                    AdoNetInvariants.InvariantNameMySqlConnector,
+                    new DbConstants(startEscapeIndicator: '[',
+                                    endEscapeIndicator: ']',
+                                    unionAllSelectTemplate: " UNION ALL SELECT ",
+                                    isSynchronousAdoNetImplementation: false,
+                                    supportsStreamNatively: true,
+                                    supportsCommandCancellation: true,
+                                    commandInterceptor: NoOpCommandInterceptor.Instance)
+                }
             };
 
         public static DbConstants GetDbConstants(string invariantName)
@@ -124,7 +134,7 @@ namespace Orleans.Tests.SqlUtils
         /// <returns></returns>
         public static bool IsSynchronousAdoNetImplementation(this IRelationalStorage storage)
         {
-            //Currently the assumption is all but MySQL are asynchronous.            
+            //Currently the assumption is all but MySQL are asynchronous.
             return IsSynchronousAdoNetImplementation(storage.InvariantName);
         }
 

--- a/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
+++ b/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+    <PackageReference Include="MySqlConnector" Version="0.61.0" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />


### PR DESCRIPTION
This adds support for MySqlConnector library using MySql.Data.MySqlConnector
invariant string.

Note: MySql.Data.MySqlConnector library uses the same namespace as the
official Oracle library 'MySql.Data.MySql' which has traditionally
interpreted as the invariant name also. Hence in Orleans the invariant
string is different than in the library used. Likely support for
DbProviderFactory changes this as using that one can use load library
separate from the invariant.

Fixes #6230.