### PR TITLE
Expose exception when initializing PerfCounterEnvironmentStatistics

### DIFF
--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -118,10 +118,11 @@ namespace Orleans.Statistics
                 TotalPhysicalMemory = Capacity;
                 countersAvailable = true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 logger.Warn(ErrorCode.PerfCounterConnectError,
-                    "Error initializing CPU & Memory perf counters - you need to repair Windows perf counter config on this machine with 'lodctr /r' command");
+                    "Error initializing CPU & Memory perf counters - you need to repair Windows perf counter config on this machine with 'lodctr /r' command",
+                    ex);
             }
         }
 


### PR DESCRIPTION
This exposes the exception thrown when failing to connect to performance counters. This is to help troubleshoot the underlying issue when repairing the counter config does not work. Note that I couldn't find any test class to update. Do you want one? And is there a cleaner solution than this?