### PR TITLE
Use RegionEndpoint.GetBySystemName() to resolve AWS region

### DIFF
--- a/src/AWS/Shared/AWSUtils.cs
+++ b/src/AWS/Shared/AWSUtils.cs
@@ -1,4 +1,4 @@
-﻿using Amazon;
+using Amazon;
 using System;
 
 #if CLUSTERING_DYNAMODB
@@ -29,41 +29,7 @@ namespace Orleans.Transactions.DynamoDB
             // us-west-2 is the default
             //
 
-            switch (zone)
-            {
-                case "us-east-1":
-                    return RegionEndpoint.USEast1;
-                case "ca-central-1":
-                    return RegionEndpoint.CACentral1;
-                case "cn-north-1":
-                    return RegionEndpoint.CNNorth1;
-                case "us-gov-west-1":
-                    return RegionEndpoint.USGovCloudWest1;
-                case "sa-east-1":
-                    return RegionEndpoint.SAEast1;
-                case "ap-southeast-1":
-                    return RegionEndpoint.APSoutheast1;
-                case "ap-south-1":
-                    return RegionEndpoint.APSouth1;
-                case "ap-northeast-2":
-                    return RegionEndpoint.APNortheast2;
-                case "ap-southeast-2":
-                    return RegionEndpoint.APSoutheast2;
-                case "eu-central-1":
-                    return RegionEndpoint.EUCentral1;
-                case "eu-west-2":
-                    return RegionEndpoint.EUWest2;
-                case "eu-west-1":
-                    return RegionEndpoint.EUWest1;
-                case "us-west-1":
-                    return RegionEndpoint.USWest1;
-                case "us-east-2":
-                    return RegionEndpoint.USEast2;
-                case "ap-northeast-1":
-                    return RegionEndpoint.APNortheast1;
-                default:
-                    return RegionEndpoint.USWest2;
-            }
+            return RegionEndpoint.GetBySystemName(zone) ?? RegionEndpoint.USWest2;
         }
 
         /// <summary>

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -100,12 +100,12 @@ namespace Orleans.Transactions.DynamoDB
             {
                 // AWS DynamoDB instance (auth via explicit credentials)
                 var credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
-                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
             }
             else
             {
                 // AWS DynamoDB instance (implicit auth - EC2 IAM Roles etc)
-                this.ddbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+                this.ddbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig {ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
             }
         }
 

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -89,23 +89,23 @@ namespace Orleans.Transactions.DynamoDB
 
         private void CreateClient()
         {
-            if (service.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-                service.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            if (this.service.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                this.service.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
                 // Local DynamoDB instance (for testing)
                 var credentials = new BasicAWSCredentials("dummy", "dummyKey");
-                ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = service });
+                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = this.service });
             }
-            else if (!string.IsNullOrEmpty(accessKey) && !string.IsNullOrEmpty(secretKey))
+            else if (!string.IsNullOrEmpty(this.accessKey) && !string.IsNullOrEmpty(this.secretKey))
             {
                 // AWS DynamoDB instance (auth via explicit credentials)
-                var credentials = new BasicAWSCredentials(accessKey, secretKey);
-                ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(service) });
+                var credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
             }
             else
             {
                 // AWS DynamoDB instance (implicit auth - EC2 IAM Roles etc)
-                ddbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig { ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(service) });
+                this.ddbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
             }
         }
 


### PR DESCRIPTION
 - [x] remove bad `ServiceURL` setter
 - [x] use AWS `RegionEndpoint.GetBySystemName` to resolve regions, but still default to `us-west-2`

Why is `us-west-2` the default btw?