### PR TITLE
Provide exception to FailFast in FatalErrorHandler

### DIFF
--- a/src/Orleans.Runtime/Core/FatalErrorHandler.cs
+++ b/src/Orleans.Runtime/Core/FatalErrorHandler.cs
@@ -58,7 +58,7 @@ namespace Orleans.Runtime
 
                 if (Debugger.IsAttached) Debugger.Break();
 
-                Environment.FailFast(msg);
+                Environment.FailFast(msg, exception);
             }
             else
             {


### PR DESCRIPTION
This allows proper error report bucketing.