### PR TITLE
Enable Grains TTL on DynamoDB persistency table

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -60,6 +60,12 @@ namespace Orleans.Configuration
         public bool UseFullAssemblyNames { get; set; }
         public bool IndentJson { get; set; }
         public TypeNameHandling? TypeNameHandling { get; set; }
+
+        /// <summary>
+        /// Specifies a time span in which the item would be expired in the future
+        /// every StateWrite will increase the TTL of the grain
+        /// </summary>
+        public TimeSpan? TimeToLive { get; set; }
         public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
     }
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -30,6 +30,7 @@ namespace Orleans.Storage
         private const string BINARY_STATE_PROPERTY_NAME = "BinaryState";
         private const string GRAIN_TYPE_PROPERTY_NAME = "GrainType";
         private const string ETAG_PROPERTY_NAME = "ETag";
+        private const string GRAIN_TTL_PROPERTY_NAME = "Ttl";
         private const string CURRENT_ETAG_ALIAS = ":currentETag";
 
         private readonly DynamoDBStorageOptions options;
@@ -87,14 +88,14 @@ namespace Orleans.Storage
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>
                     {
-                    new KeySchemaElement { AttributeName = GRAIN_REFERENCE_PROPERTY_NAME, KeyType = KeyType.HASH },
-                    new KeySchemaElement { AttributeName = GRAIN_TYPE_PROPERTY_NAME, KeyType = KeyType.RANGE }
+                        new KeySchemaElement { AttributeName = GRAIN_REFERENCE_PROPERTY_NAME, KeyType = KeyType.HASH },
+                        new KeySchemaElement { AttributeName = GRAIN_TYPE_PROPERTY_NAME, KeyType = KeyType.RANGE }
                     },
                     new List<AttributeDefinition>
                     {
-                    new AttributeDefinition { AttributeName = GRAIN_REFERENCE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S },
-                    new AttributeDefinition { AttributeName = GRAIN_TYPE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S }
-                    });
+                        new AttributeDefinition { AttributeName = GRAIN_REFERENCE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S },
+                        new AttributeDefinition { AttributeName = GRAIN_TYPE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S }
+                    }, this.options.TimeToLive.HasValue ? GRAIN_TTL_PROPERTY_NAME : null);
                 stopWatch.Stop();
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase,
                     $"Initializing provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} took {stopWatch.ElapsedMilliseconds} Milliseconds.");
@@ -183,6 +184,10 @@ namespace Orleans.Storage
         private async Task WriteStateInternal(IGrainState grainState, GrainStateRecord record, bool clear = false)
         {
             var fields = new Dictionary<string, AttributeValue>();
+            if (this.options.TimeToLive.HasValue)
+            {                                
+                fields.Add(GRAIN_TTL_PROPERTY_NAME, new AttributeValue { N = ((DateTimeOffset)DateTime.UtcNow.Add(this.options.TimeToLive.Value)).ToUnixTimeSeconds().ToString() });
+            }
 
             if (record.BinaryState != null && record.BinaryState.Length > 0)
             {


### PR DESCRIPTION
Support a TimeToLive option for Grains Persistency on DynamoDB.
Value is provides as a TimeSpan to the the DynamoDBStorageOptions class.
and each "StateWrite" will update the record Attribute.

Table creation process was also updated to enable the TTL feature when needed.
