### PR TITLE
Fixing code gen for ValueTask

### DIFF
--- a/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
@@ -230,7 +230,17 @@ namespace Orleans.CodeGenerator.Generators
                     }
 
                     var methodResult = asyncMethod ? AwaitExpression(invocation) : (ExpressionSyntax)invocation;
-                    body.Add(ReturnStatement(methodResult));
+
+                    var isUntypedValueTaskMethod =
+                        SymbolEqualityComparer.Default.Equals(wellKnownTypes.ValueTask, methodReturnType);
+                    if (isUntypedValueTaskMethod)
+                    {
+                        body.Add(ExpressionStatement(methodResult));
+                    }
+                    else
+                    {
+                        body.Add(ReturnStatement(methodResult));
+                    }
                 }
                 else throw new NotSupportedException($"Method {method} has unsupported return type, {method.ReturnType}.");
 
@@ -403,7 +413,7 @@ namespace Orleans.CodeGenerator.Generators
 
             var interfaceIdArgument = parameters[0].Name.ToIdentifierName();
             var methodIdArgument = parameters[1].Name.ToIdentifierName();
-            
+
             var callThrowMethodNotImplemented = InvocationExpression(IdentifierName("ThrowMethodNotImplemented"))
                 .WithArgumentList(ArgumentList(SeparatedList(new[]
                 {

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -72,6 +72,7 @@ namespace Orleans.CodeGenerator
                 String = compilation.GetSpecialType(SpecialType.System_String),
                 Task = Type("System.Threading.Tasks.Task"),
                 Task_1 = Type("System.Threading.Tasks.Task`1"),
+                ValueTask = Type("System.Threading.Tasks.ValueTask"),
                 TimeSpan = Type("System.TimeSpan"),
                 IPAddress = Type("System.Net.IPAddress"),
                 IPEndPoint = Type("System.Net.IPEndPoint"),
@@ -222,6 +223,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol String { get; private set; }
         public INamedTypeSymbol Task { get; private set; }
         public INamedTypeSymbol Task_1 { get; private set; }
+        public INamedTypeSymbol ValueTask { get; private set; }
         public INamedTypeSymbol TransactionAttribute { get; private set; }
         public INamedTypeSymbol TransactionOption { get; private set; }
         public INamedTypeSymbol Type { get; private set; }


### PR DESCRIPTION
Currently `ValueTask<T>` is supported for grain interfaces, but `ValueTask` isn't because it generates a return. This PR just removes the return in that case.