### PR TITLE
Use current element for SimpleQueueCacheCursor.Element

### DIFF
--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -237,9 +237,6 @@ namespace Orleans.Providers.Streams.Common
             batch = null;
             if (!cursor.IsSet) return false;
 
-            // Capture the current element and advance to the next one.
-            batch = cursor.Element.Value.Batch;
-
             // If we are at the end of the cache unset cursor and move offset one forward
             if (cursor.Element == cachedMessages.First)
             {
@@ -249,7 +246,9 @@ namespace Orleans.Providers.Streams.Common
             {
                 AdvanceCursor(cursor, cursor.Element.Previous);
             }
-            return true;
+
+            batch = cursor.Element?.Value.Batch;
+            return (batch != null);
         }
 
         private void AdvanceCursor(SimpleQueueCacheCursor cursor, LinkedListNode<SimpleQueueCacheItem> item)

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -16,10 +16,13 @@ namespace Orleans.Providers.Streams.Common
         private readonly ILogger logger;
         private IBatchContainer current; // this is a pointer to the current element in the cache. It is what will be returned by GetCurrent().
 
-        // This is a pointer to the NEXT element in the cache.
-        // After the cursor is first created it should be called MoveNext before the call to GetCurrent().
-        // After MoveNext returns, the current points to the current element that will be returned by GetCurrent()
-        // and Element will point to the next element (since MoveNext actualy advanced it to the next).
+        // This is also a pointer to the current element in the cache. It differs from current, in
+        // that current is just the batch, and is null before the first call to MoveNext after
+        // construction. (Or after refreshing if we had previously run out of batches). Upon MoveNext
+        // being called in that situation, current gets set to the batch included in Element. That is
+        // needed to implement the Enumerator pattern properly, since in that pattern MoveNext gets called
+        // before the first access of (Get)Current.
+
         internal LinkedListNode<SimpleQueueCacheItem> Element { get; private set; }
         internal StreamSequenceToken SequenceToken { get; private set; }
 
@@ -83,16 +86,22 @@ namespace Orleans.Providers.Streams.Common
         /// <returns></returns>
         public virtual bool MoveNext()
         {
+            if (current == null && IsSet && IsInStream(Element.Value.Batch))
+            {
+                current = Element.Value.Batch;
+                return true;
+            }
+
             IBatchContainer next;
             while (cache.TryGetNextMessage(this, out next))
             {
                 if(IsInStream(next))
                     break;
             }
+            current = next;
             if (!IsInStream(next))
                 return false;
 
-            current = next;
             return true;
         }
 
@@ -143,6 +152,7 @@ namespace Orleans.Providers.Streams.Common
             if (disposing)
             {
                 cache.UnsetCursor(this, null);
+                current = null;
             }
         }
 


### PR DESCRIPTION
Fixes #6298 
Fixes #6281

For brevity I am `using SQC = SimpleQueueCache; using SQCC = SimpleQueueCacheCursor;`, within this post.

The whole idea of this change is to chance SQCC so that its `Element` value always points to the cursors current element, rather than its next value. This change is remarkably small, especially if you do not count the comment changes.

Specifically it has the invariant that: whenever a method is not currently executing, if `current` is not null, then it always equals `Element.Value.Batch`. (Note: Invariant does not need to hold at end of re-entrant calls while some other `SQCC` method is running.) I will informally prove that invariant holds a little further below. I will also informally argue as to why this change is safe.

While there are further changes or refactorings that could be made, I've tried to keep this a minimal change, viewing this as a bug-fix rather than a substantial refactoring.

While I have tried to be thorough in my analysis of the impact of this, it is possible I am overlooking something. If you see (or think you see) any scenarios where this change would break things, please let me know. 

## Why this is safe
`PersistentStreamPullingAgent` will not notice any difference between this version of the code, and the previous one, except as a side effect of any tiny changes in the execution time of the code in question. All calls to `SQC` or `SQCC` will return the same values. They won't always have exactly the same effect, but there is no observable difference from the pulling agent's perspective.

From `SQC`'s perspective, not much changes. It sees one fewer call to `TryGetNextMessage(...)` per cursor, but that would have been the call when `SQCC.current` was not null, but `SQC.Element` is null, so that would be a call that does an early return anyway. It also returns a different value from the `TryGetNextMessage(...)` call, but that does not really impact the rest of the class in any meaningful way.

The real difference to `SQC` is the timing of the remaining calls to `TryGetNextMessage(...)`, which occur one cursor `MoveNext()` cycle later than they previously did, ensuring that that the cursor's `Element` value always contains the current batch being processed, so that batch does not get cleaned up while it is processing. 

For `SQCC`, the semantics of the `Element` property change substantially, to become the current value the cursor is pointing at, rather than the next value. Since `SQC` was already treating the value of `Element` as the current element this is desirable. There are two other minor differences: If `MoveNext()` returns false, the value of `current` is changed to null, rather than remaining the same. This is not an issue since the Enumerator pattern on which the cursors are based already says that the current value is undefined after `MoveNext()` returns false. Similarly upon calling `Dispose()`, the value of `current` is also set to null, which is needed to maintain the invariant, and accessing a cursor after disposing it would be a bug already anyway.

## Proof that the invariant holds
<details><summary>Proof collapsed by default. Click to Expand</summary>
Inductive base case: When the `SQCC` class is constructed both values are null, so the invariant holds.

Inductive recursive state: Our goal here is to show that any changes made to the object that impact the fields in question will preserve the invariant, assuming it already holds at the start. 

In all cases where `current` changes it is either being set to `Element.Value.Batch`, or `Element` is also changing at the same time and `current` gets set to the same value. This happens in two places: `SQCC.Dispose(...)` ends up setting both values to null, while `SQCC.MoveNext()` sets `current` to `Element.Value.Batch` if `current` is null, and `Element`. Otherwise it calls `SQC.TryGetNextMessage(...)`, one or many times, and will end up setting `current` to the value it output. `SQC.TryGetNextMessage(...)` will output null if `Element` was already null. In all other cases it will update `Element`, and return `Element.Value.Batch`.

Therefore we can conclude that `current` will never change in a way that will break the invariant. So the invariant can only be broken if `Element` changes while `current` is not null (unless current changes to match). (Note: I am ignoring somebody setting `Element.Value` or `Element.Value.Batch`, since no code actually does that).

So when does `Element` change? It changes when `SQCC.Set(...)` or `SQCC.UnSet(...)` are called. Analyzing these:
* `SQCC.Set(...)` called by:
    * `SQC.AdvanceCursor(...)` which is only called by:
        * `SQC.TryGetNextMessage(...)` which is only called by `SQCC.MoveNext()`, which also changes `current` to match.
    * `SQC.SetCursor(...)` which is only called by:
        * `SQC.InitializeCursor(...)` which is called by:
            * `SQC.GetCacheCursor(...)`, which calls it immediately after constructing `SQCC`, so both `current` and `Element` are null.
            * `SQC.RefreshCursor(...)` which is called by `SQC.Refresh(...)`, but only if `Element` is null. In that case, either `current` is either also null, per the invariant, or something else has already broken the invariant..
* `SQCC.Unset(...)` called by:
    * `SQC.UnsetCursor(...)` which is called by:
        * `SQCC.Dispose(...)` which also sets `current` to match.
        * `SQC.InitializeCursor(...)` which was analyzed above.
        * `SQC.TryGetNextMessage(...)` which was analyzed above.

Thus I have shown that the the invariant holds when constructed, and no method calls modify the the members in question in a way that breaks the invariant, unless the invariant is already broken. Therefore by induction, I have shown that the invariant always holds.
</details>