### PR TITLE
WIP: Logging categories

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -52,7 +52,7 @@ namespace Orleans.Storage
         {
             this.name = name;
             this.loggerFactory = loggerFactory;
-            var loggerName = $"{typeof(DynamoDBGrainStorage).FullName}.{name}";
+            var loggerName = $"{typeof(DynamoDBGrainStorage).FullName}.{name}"; // dynamic data
             this.logger = loggerFactory.CreateLogger(loggerName);
             this.options = options;
             this.serializationManager = serializationManager;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -50,7 +50,7 @@ namespace Orleans.Storage
             this.grainFactory = grainFactory;
             this.typeResolver = typeResolver;
             this.loggerFactory = loggerFactory;
-            this.logger = this.loggerFactory.CreateLogger($"{typeof(AzureTableGrainStorageFactory).FullName}.{name}");
+            this.logger = this.loggerFactory.CreateLogger($"{typeof(AzureTableGrainStorageFactory).FullName}.{name}"); // dynamic data
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -59,7 +59,7 @@ namespace Orleans.Storage
             this.grainFactory = grainFactory;
             this.typeResolver = typeResolver;
             this.loggerFactory = loggerFactory;
-            var loggerName = $"{typeof(AzureTableGrainStorageFactory).FullName}.{name}";
+            var loggerName = $"{typeof(AzureTableGrainStorageFactory).FullName}.{name}"; // dynamic data
             this.logger = this.loggerFactory.CreateLogger(loggerName);
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -160,7 +160,7 @@ namespace Orleans.ServiceBus.Providers
                 this.ReceiverMonitorFactory = (dimensions, logger, telemetryProducer) => new DefaultEventHubReceiverMonitor(dimensions, telemetryProducer);
             }
 
-            this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{this.ehOptions.Path}");
+            this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{this.ehOptions.Path}"); // Dynamic data
         }
 
         //should only need checkpointer on silo side, so move its init logic when it is used

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -79,7 +79,7 @@ namespace Orleans.ServiceBus.Providers
             this.cacheFactory = cacheFactory ?? throw new ArgumentNullException(nameof(cacheFactory));
             this.checkpointerFactory = checkpointerFactory ?? throw new ArgumentNullException(nameof(checkpointerFactory));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{settings.Hub.Path}.{settings.Partition}");
+            this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{settings.Hub.Path}.{settings.Partition}"); // Dynamic Data
             this.monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
             this.telemetryProducer = telemetryProducer ?? throw new ArgumentNullException(nameof(telemetryProducer));
             this.loadSheddingOptions = loadSheddingOptions ?? throw new ArgumentNullException(nameof(loadSheddingOptions));

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -67,7 +67,7 @@ namespace Orleans.ServiceBus.Providers
             string blockPoolId;
             var blockPool = CreateBufferPool(this.statisticOptions, loggerFactory, this.sharedDimensions, telemetryProducer, out blockPoolId);
             var cache = CreateCache(partition, dataAdater, this.statisticOptions, checkpointer, loggerFactory, blockPool, blockPoolId, this.timePurge, this.serializationManager, this.sharedDimensions, telemetryProducer);
-            AddCachePressureMonitors(cache, this.cacheOptions, loggerFactory.CreateLogger($"{typeof(EventHubQueueCache).FullName}.{this.sharedDimensions.EventHubPath}.{partition}"));
+            AddCachePressureMonitors(cache, this.cacheOptions, loggerFactory.CreateLogger($"{typeof(EventHubQueueCache).FullName}.{this.sharedDimensions.EventHubPath}.{partition}")); //Dynamic Data
             return cache;
         }
 
@@ -133,7 +133,7 @@ namespace Orleans.ServiceBus.Providers
         {
             var cacheMonitorDimensions = new EventHubCacheMonitorDimensions(sharedDimensions, partition, blockPoolId);
             var cacheMonitor = this.CacheMonitorFactory(cacheMonitorDimensions, loggerFactory, telemetryProducer);
-            var logger = loggerFactory.CreateLogger($"{typeof(EventHubQueueCache).FullName}.{sharedDimensions.EventHubPath}.{partition}");
+            var logger = loggerFactory.CreateLogger($"{typeof(EventHubQueueCache).FullName}.{sharedDimensions.EventHubPath}.{partition}"); // Dynamic Data
             var evictionStrategy = new ChronologicalEvictionStrategy(logger, timePurge, cacheMonitor, statisticOptions.StatisticMonitorWriteInterval);
             return new EventHubQueueCache(partition, EventHubAdapterReceiver.MaxMessagesPerRead, bufferPool, dataAdatper, evictionStrategy, checkpointer, logger,  
                 cacheMonitor, statisticOptions.StatisticMonitorWriteInterval);

--- a/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
+++ b/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,7 +45,7 @@ namespace Orleans.Hosting
             var codeGenerator = new RoslynCodeGenerator(tempPartManager, loggerFactory);
             var generatedAssembly = codeGenerator.GenerateAndLoadForAssemblies(manager.Assemblies);
             stopWatch.Stop();
-            var logger = loggerFactory.CreateLogger("RuntimeCodeGen");
+            var logger = loggerFactory.CreateLogger("Orleans.CodeGenerator.RuntimeCodeGen");
             logger?.LogInformation(0, $"Runtime code generation for assemblies {String.Join(",", manager.Assemblies.ToStrings())} took {stopWatch.ElapsedMilliseconds} milliseconds");
             return manager.AddApplicationPart(generatedAssembly);
         }

--- a/src/Orleans.Core/Runtime/AsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchAgent.cs
@@ -33,9 +33,9 @@ namespace Orleans.Runtime
         protected AsynchAgent(string nameSuffix, ExecutorService executorService, ILoggerFactory loggerFactory)
         {
             Cts = new CancellationTokenSource();
-            var thisType = GetType();
 
-            type = thisType.Namespace + "." + thisType.Name;
+            type = GetType().FullName;
+            string loggerName = type;
             if (type.StartsWith("Orleans.", StringComparison.Ordinal))
             {
                 type = type.Substring(8);
@@ -43,6 +43,7 @@ namespace Orleans.Runtime
             if (!string.IsNullOrEmpty(nameSuffix))
             {
                 Name = type + "/" + nameSuffix;
+                loggerName = loggerName + "/" + nameSuffix;
             }
             else
             {
@@ -54,7 +55,7 @@ namespace Orleans.Runtime
             OnFault = FaultBehavior.IgnoreFault;
 
             this.loggerFactory = loggerFactory;
-            this.Log = loggerFactory.CreateLogger(Name);
+            this.Log = loggerFactory.CreateLogger(loggerName);
             this.executorService = executorService;
             this.executorFaultHandler = new ExecutorFaultHandler(this);
         }

--- a/src/Orleans.Core/Runtime/AsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchAgent.cs
@@ -55,7 +55,7 @@ namespace Orleans.Runtime
             OnFault = FaultBehavior.IgnoreFault;
 
             this.loggerFactory = loggerFactory;
-            this.Log = loggerFactory.CreateLogger(loggerName);
+            this.Log = loggerFactory.CreateLogger(loggerName);  // Still ends with dynamic "/"+nameSuffix for SchedulerAsyncAgents currently.
             this.executorService = executorService;
             this.executorFaultHandler = new ExecutorFaultHandler(this);
         }

--- a/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
@@ -35,9 +35,9 @@ namespace Orleans.Runtime
         protected TaskSchedulerAgent(string nameSuffix, ILoggerFactory loggerFactory)
         {
             Cts = new CancellationTokenSource();
-            var thisType = GetType();
-
-            type = thisType.Namespace + "." + thisType.Name;
+            
+            type = GetType().FullName;
+            string loggerName = type;
             if (type.StartsWith("Orleans.", StringComparison.Ordinal))
             {
                 type = type.Substring(8);
@@ -45,6 +45,7 @@ namespace Orleans.Runtime
             if (!string.IsNullOrEmpty(nameSuffix))
             {
                 Name = type + "/" + nameSuffix;
+                loggerName = loggerName + "/" + nameSuffix;
             }
             else
             {
@@ -55,7 +56,7 @@ namespace Orleans.Runtime
             OnFault = FaultBehavior.IgnoreFault;
 
             this.loggerFactory = loggerFactory;
-            this.Log = loggerFactory.CreateLogger(Name);
+            this.Log = loggerFactory.CreateLogger(loggerName);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime
             OnFault = FaultBehavior.IgnoreFault;
 
             this.loggerFactory = loggerFactory;
-            this.Log = loggerFactory.CreateLogger(loggerName);
+            this.Log = loggerFactory.CreateLogger(loggerName); // Still ends with dynamic "/"+nameSuffix for IncomingMessageAgents
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/Orleans.Core/Statistics/LogStatistics.cs
+++ b/src/Orleans.Core/Statistics/LogStatistics.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime
             this.loggerFactory = loggerFactory;
             reportFrequency = writeInterval;
             this.serializationStatistics = serializationStatistics;
-            logger = loggerFactory.CreateLogger("Orleans.Runtime" + (isSilo ? "SiloLogStatistics" : "ClientLogStatistics"));
+            logger = loggerFactory.CreateLogger("Orleans.Runtime." + (isSilo ? "SiloLogStatistics" : "ClientLogStatistics"));
         }
 
         internal void Start()

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -28,7 +28,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             this.loggerFactory = loggerFactory;
             this.Name = name;
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}");
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}"); // Dynamic data
             this.options = options;
             this.providerRuntime = providerRuntime as IStreamProviderRuntime;
             this.runtimeClient = providerRuntime.ServiceProvider.GetService<IRuntimeClient>();

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.MembershipService
             this.stopping = this.stoppingCancellation.Token.WhenCancelled();
             this.SiloAddress = siloAddress;
             this.prober = remoteSiloProber;
-            this.log = loggerFactory.CreateLogger($"{nameof(SiloHealthMonitor)}/{this.SiloAddress}");
+            this.log = loggerFactory.CreateLogger<SiloHealthMonitor>();
         }
 
         internal interface ITestAccessor

--- a/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.MembershipService
             this.localSiloDetails = localSiloDetails;
             this.membershipTableManager = membershipTableManager;
             this.listenerManager = listenerManager;
-            this.log = loggerFactory.CreateLogger("MembershipOracle");
+            this.log = loggerFactory.CreateLogger($"{typeof(SiloStatusOracle).Namespace}.MembershipOracle");
         }
 
         public SiloStatus CurrentStatus => this.membershipTableManager.CurrentStatus;

--- a/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.ReminderService
         public override Task OnActivateAsync()
         {
             var loggerFactory = this.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            logger = loggerFactory.CreateLogger(String.Format("{0}_{1}", typeof(GrainBasedReminderTable).FullName, Data.Address.ToString()));
+            logger = loggerFactory.CreateLogger(String.Format("{0}_{1}", typeof(GrainBasedReminderTable).FullName, Data.Address.ToString())); // Dynamic data
             logger.Info("GrainBasedReminderTable {0} Activated. Full identity: {1}", Identity, Data.Address.ToFullString());
             remTable = new Table(loggerFactory);
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for GrainBasedReminderTable virtually indefinitely.
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.ReminderService
         public Task<ReminderTableData> ReadRows(uint begin, uint end)
         {
             ReminderTableData t = remTable.ReadRows(begin, end);
-            logger.Debug("Read {0} reminders from memory: {1}, {2}", t.Reminders.Count, Environment.NewLine, Utils.EnumerableToString(t.Reminders));
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Read {0} reminders from memory: {1}, {2}", t.Reminders.Count, Environment.NewLine, Utils.EnumerableToString(t.Reminders));
             return Task.FromResult(t);
         }
 

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -143,7 +143,7 @@ namespace Orleans.Runtime.Scheduler
             totalQueuingDelay = TimeSpan.Zero;
             quantumExpirations = 0;
             TaskScheduler = new ActivationTaskScheduler(this, loggerFactory);
-            log = IsSystemPriority ? loggerFactory.CreateLogger($"{this.GetType().Namespace} {Name}.{this.GetType().Name}") : loggerFactory.CreateLogger<WorkItemGroup>();
+            log = IsSystemPriority ? loggerFactory.CreateLogger($"{this.GetType().Namespace} {Name}.{this.GetType().Name}") : loggerFactory.CreateLogger<WorkItemGroup>(); //Nasty Dynamic Data
 
             if (schedulerStatistics.CollectShedulerQueuesStats)
             {

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -62,7 +62,7 @@ namespace Orleans.Streams
             this.options = options;
             numMessages = 0;
 
-            logger = runtime.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger($"{this.GetType().Namespace}.{((ISystemTargetBase)this).GrainId}.{streamProviderName}");
+            logger = runtime.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger($"{this.GetType().Namespace}.{((ISystemTargetBase)this).GrainId}.{streamProviderName}"); // dynamic data
             logger.Info(ErrorCode.PersistentStreamPullingAgent_01,
                 "Created {0} {1} for Stream Provider {2} on silo {3} for Queue {4}.",
                 GetType().Name, ((ISystemTargetBase)this).GrainId.ToDetailedString(), streamProviderName, Silo, QueueId.ToStringWithHashCode());

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -75,7 +75,7 @@ namespace Orleans.Streams
             this.adapterFactory = adapterFactory;
 
             queueAdapterCache = adapterFactory.GetQueueAdapterCache();
-            logger = loggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}");
+            logger = loggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}"); // dynamic data
             Log(ErrorCode.PersistentStreamPullingManager_01, "Created {0} for Stream Provider {1}.", GetType().Name, streamProviderName);
             this.loggerFactory = loggerFactory;
             IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS, strProviderName), () => queuesToAgentsMap.Count);

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -75,7 +75,7 @@ namespace Orleans.Streams
             this.adapterFactory = adapterFactory;
 
             queueAdapterCache = adapterFactory.GetQueueAdapterCache();
-            logger = loggerFactory.CreateLogger($"{GetType().FullName}-{streamProviderName}");
+            logger = loggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}");
             Log(ErrorCode.PersistentStreamPullingManager_01, "Created {0} for Stream Provider {1}.", GetType().Name, streamProviderName);
             this.loggerFactory = loggerFactory;
             IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS, strProviderName), () => queuesToAgentsMap.Count);

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -50,7 +50,7 @@ namespace Orleans.Streams
         /// Constructor
         /// </summary>
         public LeaseBasedQueueBalancer(string name, LeaseBasedQueueBalancerOptions options, ILeaseProvider leaseProvider, ITimerRegistry timerRegistry, IServiceProvider services, ILoggerFactory loggerFactory)
-            : base(services, loggerFactory.CreateLogger($"{typeof(LeaseBasedQueueBalancer).FullName}.{name}")) 
+            : base(services, loggerFactory.CreateLogger($"{typeof(LeaseBasedQueueBalancer).FullName}.{name}")) // dynamic data
         {
             this.options = options;
             this.leaseProvider = leaseProvider;

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -50,7 +50,7 @@ namespace Orleans.Streams
         /// Constructor
         /// </summary>
         public LeaseBasedQueueBalancer(string name, LeaseBasedQueueBalancerOptions options, ILeaseProvider leaseProvider, ITimerRegistry timerRegistry, IServiceProvider services, ILoggerFactory loggerFactory)
-            : base(services, loggerFactory.CreateLogger($"{nameof(LeaseBasedQueueBalancer)}-{name}"))
+            : base(services, loggerFactory.CreateLogger($"{typeof(LeaseBasedQueueBalancer).FullName}.{name}")) 
         {
             this.options = options;
             this.leaseProvider = leaseProvider;

--- a/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime
@@ -13,7 +13,7 @@ namespace Orleans.Runtime
 
         public IAsyncTimer Create(TimeSpan period, string name)
         {
-            var log = this.loggerFactory.CreateLogger($"{nameof(AsyncTimer)}-{name}");
+            var log = this.loggerFactory.CreateLogger($"{typeof(AsyncTimer).FullName}.{name}");
             return new AsyncTimer(period, log);
         }
     }

--- a/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime
 
         public IAsyncTimer Create(TimeSpan period, string name)
         {
-            var log = this.loggerFactory.CreateLogger($"{typeof(AsyncTimer).FullName}.{name}");
+            var log = this.loggerFactory.CreateLogger($"{typeof(AsyncTimer).FullName}.{name}"); // dynamic data (although arguably used staticly), as the name is always nameof(sometype)
             return new AsyncTimer(period, log);
         }
     }

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
@@ -1,4 +1,4 @@
-﻿using Google.Cloud.PubSub.V1;
+using Google.Cloud.PubSub.V1;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
@@ -44,7 +44,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             if (dataAdapter == null) throw new ArgumentNullException(nameof(dataAdapter));
             _dataAdapter = dataAdapter;
 
-            _logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{topicId}.{queueId}");
+            _logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{topicId}.{queueId}"); // dynamic data
             _pending = new List<PendingDelivery>();
         }
 

--- a/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -26,7 +26,7 @@ namespace Orleans.TestingHost
         public override async Task OnActivateAsync()
         {
             await base.OnActivateAsync();
-            logger = this.ServiceProvider.GetService<ILoggerFactory>().CreateLogger($"{typeof (StorageFaultGrain).FullName}-{IdentityString}-{RuntimeIdentity}");
+            logger = this.ServiceProvider.GetService<ILoggerFactory>().CreateLogger($"{typeof (StorageFaultGrain).FullName}-{IdentityString}-{RuntimeIdentity}"); //dynamic data, but because this is for tests, I'm not worried about it
             readFaults = new Dictionary<GrainReference, Exception>();
             writeFaults = new Dictionary<GrainReference, Exception>();
             clearfaults = new Dictionary<GrainReference, Exception>();

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -203,7 +203,7 @@ namespace Orleans.Transactions
 
             this.participantId = new ParticipantId(this.config.StateName, this.context.GrainInstance.GrainReference, this.config.SupportedRoles);
 
-            this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.StateName}.{this.context.GrainIdentity.IdentityString}");
+            this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.StateName}.{this.context.GrainIdentity.IdentityString}"); // Dynamic Data
 
             var storageFactory = this.context.ActivationServices.GetRequiredService<INamedTransactionalStateStorageFactory>();
             ITransactionalStateStorage<TState> storage = storageFactory.Create<TState>(this.config.StorageName, this.config.StateName);

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -129,7 +129,7 @@ namespace Orleans.Transactions
 
             this.participantId = new ParticipantId(this.config.ServiceName, this.context.GrainInstance.GrainReference, ParticipantId.Role.Resource | ParticipantId.Role.PriorityManager);
 
-            this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.ServiceName}.{this.context.GrainIdentity.IdentityString}");
+            this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.ServiceName}.{this.context.GrainIdentity.IdentityString}"); //dynamic data
 
             var storageFactory = this.context.ActivationServices.GetRequiredService<INamedTransactionalStateStorageFactory>();
             ITransactionalStateStorage<OperationState> storage = storageFactory.Create<OperationState>(this.config.StorageName, this.config.ServiceName);

--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -52,7 +52,7 @@ namespace Orleans.Storage
         {
             this.options = options;
             this.name = name;
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}");
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}"); //dynamic data
             this.grainFactory = grainFactory;
 
             //Init

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueAdapterCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueAdapterCache.cs
@@ -38,7 +38,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="queueId"></param>
         public IQueueCache CreateQueueCache(QueueId queueId)
         {
-            return new SimpleQueueCache(cacheSize, this.loggerFactory.CreateLogger($"{typeof(SimpleQueueCache).FullName}.{providerName}.{queueId}"));
+            return new SimpleQueueCache(cacheSize, this.loggerFactory.CreateLogger($"{typeof(SimpleQueueCache).FullName}.{providerName}.{queueId}")); //dynamic data
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
@@ -297,7 +297,7 @@ namespace Orleans.Providers.Streams.Generator
             CreateBufferPoolIfNotCreatedYet();
             var dimensions = new CacheMonitorDimensions(queueId.ToString(), this.blockPoolMonitorDimensions.BlockPoolId);
             var cacheMonitor = this.CacheMonitorFactory(dimensions, this.telemetryProducer);
-            return new GeneratorPooledCache(bufferPool, this.loggerFactory.CreateLogger($"{typeof(GeneratorPooledCache).FullName}.{this.Name}.{queueId}"), serializationManager, 
+            return new GeneratorPooledCache(bufferPool, this.loggerFactory.CreateLogger($"{typeof(GeneratorPooledCache).FullName}.{this.Name}.{queueId}"), serializationManager, //dynamic data
                 cacheMonitor, this.statisticOptions.StatisticMonitorWriteInterval);
         }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -154,7 +154,7 @@ namespace Orleans.Providers
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
             var dimensions = new ReceiverMonitorDimensions(queueId.ToString());
-            var receiverLogger = this.loggerFactory.CreateLogger($"{typeof(MemoryAdapterReceiver<TSerializer>).FullName}.{this.Name}.{queueId}");
+            var receiverLogger = this.loggerFactory.CreateLogger($"{typeof(MemoryAdapterReceiver<TSerializer>).FullName}.{this.Name}.{queueId}"); //dynamic data
             var receiverMonitor = this.ReceiverMonitorFactory(dimensions, this.telemetryProducer);
             IQueueAdapterReceiver receiver = new MemoryAdapterReceiver<TSerializer>(GetQueueGrain(queueId), receiverLogger, this.serializer, receiverMonitor);
             return receiver;
@@ -195,7 +195,7 @@ namespace Orleans.Providers
         {
             //move block pool creation from init method to here, to avoid unnecessary block pool creation when stream provider is initialized in client side. 
             CreateBufferPoolIfNotCreatedYet();
-            var logger = this.loggerFactory.CreateLogger($"{typeof(MemoryPooledCache<TSerializer>).FullName}.{this.Name}.{queueId}");
+            var logger = this.loggerFactory.CreateLogger($"{typeof(MemoryPooledCache<TSerializer>).FullName}.{this.Name}.{queueId}"); //dynamic data
             var monitor = this.CacheMonitorFactory(new CacheMonitorDimensions(queueId.ToString(), this.blockPoolMonitorDimensions.BlockPoolId), this.telemetryProducer);
             return new MemoryPooledCache<TSerializer>(bufferPool, purgePredicate, logger, this.serializer, monitor, this.statisticOptions.StatisticMonitorWriteInterval);
         }


### PR DESCRIPTION
Fixes #6289.

The first commit is proposed changes. The second one flags all the dynamic data cases with comments, as some decision still needs to be made for each one.

I've not done anything with the `Microsoft.Orleans.` categories, as I'm not sure if changing them are worth any possible breakage of existing deployment's log filtering schemes. 