### PR TITLE
Streamline MemoryStorage and InMemoryReminderTable

### DIFF
--- a/src/Orleans.Core/AssemblyLoader/CachedTypeResolver.cs
+++ b/src/Orleans.Core/AssemblyLoader/CachedTypeResolver.cs
@@ -110,7 +110,7 @@ namespace Orleans.Runtime
             // For types in an Orleans namespace, allow remapping the assembly to another assembly.
             // This is in order to support migration from version 1.x to 2.x, during which assemblies
             // were split and renamed.
-            if (fullName.StartsWith("Orleans."))
+            if (fullName.StartsWith("Orleans.", StringComparison.Ordinal))
             {
                 var asmSeparator = fullName.LastIndexOf(',');
                 if (asmSeparator > -1)

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime
 
                 return GetTemplatedName(type.DeclaringType) + "." + GetUntemplatedTypeName(type.Name);
             }
-            
+
             if (type.IsGenericType) return GetSimpleTypeName(fullName != null && fullName(type) ? GetFullName(type) : type.Name);
 
             return fullName != null && fullName(type) ? GetFullName(type) : type.Name;
@@ -229,7 +229,7 @@ namespace Orleans.Runtime
 
             foreach (var innerType in innerTypes)
             {
-                if (innerType.StartsWith("[[")) // Resolve and load generic types recursively
+                if (innerType.StartsWith("[[", StringComparison.Ordinal)) // Resolve and load generic types recursively
                 {
                     InnerGenericTypeArgs(GenericTypeArgsString(innerType));
                     string genericTypeArg = className.Trim('[', ']');
@@ -258,7 +258,7 @@ namespace Orleans.Runtime
             int endTokensNeeded = 0;
             string curStartToken = "";
             string curEndToken = "";
-            var tokenPairs = new[] { new { Start = "[[", End = "]]" }, new { Start = "[", End = "]" } }; // Longer tokens need to come before shorter ones
+            var tokenPairs = new[] { (Start: "[[", End: "]]"), (Start: "[", End: "]") }; // Longer tokens need to come before shorter ones
 
             foreach (var candidate in candidatesWithPositions)
             {
@@ -266,7 +266,7 @@ namespace Orleans.Runtime
                 {
                     foreach (var token in tokenPairs)
                     {
-                        if (candidate.Str.StartsWith(token.Start))
+                        if (candidate.Str.StartsWith(token.Start, StringComparison.Ordinal))
                         {
                             curStartToken = token.Start;
                             curEndToken = token.End;
@@ -276,10 +276,10 @@ namespace Orleans.Runtime
                     }
                 }
 
-                if (curStartToken != "" && candidate.Str.StartsWith(curStartToken))
+                if (curStartToken != "" && candidate.Str.StartsWith(curStartToken, StringComparison.Ordinal))
                     endTokensNeeded++;
 
-                if (curEndToken != "" && candidate.Str.EndsWith(curEndToken))
+                if (curEndToken != "" && candidate.Str.EndsWith(curEndToken, StringComparison.Ordinal))
                 {
                     endPos = candidate.Pos;
                     endTokensNeeded--;
@@ -525,7 +525,7 @@ namespace Orleans.Runtime
             return assembly.IsDynamic ? Enumerable.Empty<Type>() : GetDefinedTypes(assembly, logger).Where(type => !type.IsNestedPrivate && whereFunc(type));
         }
 
-        public static IEnumerable<Type> GetDefinedTypes(Assembly assembly, ILogger logger=null)
+        public static IEnumerable<Type> GetDefinedTypes(Assembly assembly, ILogger logger = null)
         {
             try
             {

--- a/src/Orleans.Core/Serialization/TypeUtilities.cs
+++ b/src/Orleans.Core/Serialization/TypeUtilities.cs
@@ -165,7 +165,7 @@ namespace Orleans.Serialization
         private static string GetBaseTypeKey(Type t)
         {
             string namespacePrefix = "";
-            if ((t.Namespace != null) && !t.Namespace.StartsWith("System.") && !t.Namespace.Equals("System"))
+            if ((t.Namespace != null) && !t.Namespace.StartsWith("System.", StringComparison.Ordinal) && !t.Namespace.Equals("System"))
             {
                 namespacePrefix = t.Namespace + '.';
             }

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -302,7 +302,7 @@ namespace Orleans.Runtime.Management
             var first = path.FirstOrDefault();
             if (first == null) return;
 
-            if (first.StartsWith("@"))
+            if (first.StartsWith("@", StringComparison.Ordinal))
             {
                 first = first.Substring(1);
                 if (path.Count() != 1)

--- a/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
@@ -1,22 +1,21 @@
 using System;
-using System.Threading.Tasks;
-using Orleans.Concurrency;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Concurrency;
 
 namespace Orleans.Runtime.ReminderService
 {
     [Reentrant]
     internal class GrainBasedReminderTable : Grain, IReminderTableGrain
     {
-        private readonly Table remTable;
+        private readonly Dictionary<GrainReference, Dictionary<string, ReminderEntry>> reminderTable = new Dictionary<GrainReference, Dictionary<string, ReminderEntry>>();
         private readonly ILogger logger;
 
         public GrainBasedReminderTable(ILogger<GrainBasedReminderTable> logger)
         {
             this.logger = logger;
-            remTable = new Table(logger);
         }
 
         public override Task OnActivateAsync()
@@ -32,39 +31,92 @@ namespace Orleans.Runtime.ReminderService
             return Task.CompletedTask;
         }
 
+        public Task TestOnlyClearTable()
+        {
+            logger.LogInformation("TestOnlyClearTable");
+            reminderTable.Clear();
+            return Task.CompletedTask;
+        }
+
         public Task<ReminderTableData> ReadRows(GrainReference grainRef)
         {
-            return Task.FromResult(remTable.ReadRows(grainRef));
+            Dictionary<string, ReminderEntry> reminders;
+            reminderTable.TryGetValue(grainRef, out reminders);
+            var result = reminders == null ? new ReminderTableData() : new ReminderTableData(reminders.Values.ToList());
+            return Task.FromResult(result);
         }
 
         public Task<ReminderTableData> ReadRows(uint begin, uint end)
         {
-            ReminderTableData t = remTable.ReadRows(begin, end);
-            if (logger.IsEnabled(LogLevel.Debug))
+            var range = RangeFactory.CreateRange(begin, end);
+
+            var list = reminderTable.Where(e => range.InRange(e.Key)).SelectMany(e => e.Value.Values).ToList();
+
+            if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.LogDebug("Read {ReminderCount} reminders from memory: {Reminders}", t.Reminders.Count, Utils.EnumerableToString(t.Reminders));
+                logger.LogTrace(
+                    "Selected {SelectCount} out of {TotalCount} reminders from memory for {Range}. Selected: {Reminders}",
+                    list.Count,
+                    reminderTable.Values.Sum(r => r.Count),
+                    range.ToString(),
+                    Utils.EnumerableToString(list, e => e.ToString()));
             }
 
-            return Task.FromResult(t);
+            var result = new ReminderTableData(list);
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Read {ReminderCount} reminders from memory: {Reminders}", result.Reminders.Count, Utils.EnumerableToString(result.Reminders));
+            }
+
+            return Task.FromResult(result);
         }
 
         public Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
         {
-            return Task.FromResult(remTable.ReadRow(grainRef, reminderName));
+            ReminderEntry result = null;
+            Dictionary<string, ReminderEntry> reminders;
+            if (reminderTable.TryGetValue(grainRef, out reminders))
+            {
+                reminders.TryGetValue(reminderName, out result);
+            }
+
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                if (result is null)
+                {
+                    logger.LogTrace("Reminder not found for grain {Grain} reminder {ReminderName} ", grainRef, reminderName);
+                }
+                else
+                {
+                    logger.LogTrace("Read for grain {Grain} reminder {ReminderName} row {Reminder}", grainRef, reminderName, result.ToString());
+                }
+            }
+
+            return Task.FromResult(result);
         }
 
         public Task<string> UpsertRow(ReminderEntry entry)
         {
-            return Task.FromResult(remTable.UpsertRow(entry));
+            entry.ETag = Guid.NewGuid().ToString();
+            Dictionary<string, ReminderEntry> d;
+            if (!reminderTable.TryGetValue(entry.GrainRef, out d))
+            {
+                d = new Dictionary<string, ReminderEntry>();
+                reminderTable.Add(entry.GrainRef, d);
+            }
+
+            ReminderEntry old; // tracing purposes only
+            d.TryGetValue(entry.ReminderName, out old); // tracing purposes only
+                                                        // add or over-write
+            d[entry.ReminderName] = entry;
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Upserted entry {Updated}, replaced {Replaced}", entry, old);
+            }
+
+            return Task.FromResult(entry.ETag);
         }
 
-        /// <summary>
-        /// Remove a row from the table
-        /// </summary>
-        /// <param name="grainRef"></param>
-        /// <param name="reminderName"></param>
-        /// <param name="eTag"></param>
-        /// <returns>true if a row with <paramref name="grainRef"/> and <paramref name="reminderName"/> existed and was removed successfully, false otherwise</returns>
         public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
         {
             if (logger.IsEnabled(LogLevel.Debug))
@@ -72,167 +124,31 @@ namespace Orleans.Runtime.ReminderService
                 logger.LogDebug("RemoveRow Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}", grainRef, reminderName, eTag);
             }
 
-            var result = remTable.RemoveRow(grainRef, reminderName, eTag);
-            if (!result)
+            if (reminderTable.TryGetValue(grainRef, out var data)
+                && data.TryGetValue(reminderName, out var e)
+                && e.ETag == eTag)
             {
-                logger.LogWarning(
-                    (int)ErrorCode.RS_Table_Remove,
-                    "RemoveRow Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}. Table now is: {3}",
-                    grainRef,
-                    reminderName,
-                    eTag,
-                    Utils.EnumerableToString(remTable.ReadAll().Reminders));
-            }
-
-            return Task.FromResult(result);
-        }
-
-        public Task TestOnlyClearTable()
-        {
-            logger.LogInformation("TestOnlyClearTable");
-            remTable.Reset();
-            return Task.CompletedTask;
-        }
-
-        private class Table
-        {
-            // key: GrainReference
-            // value: V
-            //      V.key: ReminderName
-            //      V.Value: ReminderEntry
-            private readonly Dictionary<GrainReference, Dictionary<string, ReminderEntry>> reminderTable = new Dictionary<GrainReference, Dictionary<string, ReminderEntry>>();
-            private readonly ILogger logger;
-
-            public Table(ILogger logger)
-            {
-                this.logger = logger;
-            }
-
-            public ReminderTableData ReadRows(GrainReference grainRef)
-            {
-                Dictionary<string, ReminderEntry> reminders;
-                reminderTable.TryGetValue(grainRef, out reminders);
-                return reminders == null ? new ReminderTableData() :
-                    new ReminderTableData(reminders.Values.ToList());
-            }
-
-            public ReminderTableData ReadRows(uint begin, uint end)
-            {
-                var range = RangeFactory.CreateRange(begin, end);
-                IEnumerable<GrainReference> keys = reminderTable.Keys.Where(range.InRange);
-
-                // is there a sleaker way of doing this in C#?
-                var list = new List<ReminderEntry>();
-                foreach (GrainReference k in keys)
+                if (data.Count > 1)
                 {
-                    list.AddRange(reminderTable[k].Values);
+                    data.Remove(reminderName);
                 }
-
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace(
-                        "Selected {SelectCount} out of {TotalCount} reminders from memory for {Range}. Selected: {Reminders}",
-                        list.Count,
-                        reminderTable.Count,
-                        range.ToString(),
-                        Utils.EnumerableToString(list, e => e.ToString()));
-                }
-
-                return new ReminderTableData(list);
-            }
-
-            public ReminderEntry ReadRow(GrainReference grainRef, string reminderName)
-            {
-                ReminderEntry result = null;
-                Dictionary<string, ReminderEntry> reminders;
-                if (reminderTable.TryGetValue(grainRef, out reminders))
-                {
-                    reminders.TryGetValue(reminderName, out result);
-                }
-
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    if (result is null)
-                    {
-                        logger.LogTrace("Reminder not found for grain {Grain} reminder {ReminderName} ", grainRef, reminderName);
-                    }
-                    else
-                    {
-                        logger.LogTrace("Read for grain {Grain} reminder {ReminderName} row {Reminder}", grainRef, reminderName, result.ToString());
-                    }
-                }
-
-                return result;
-            }
-
-            public string UpsertRow(ReminderEntry entry)
-            {
-                entry.ETag = Guid.NewGuid().ToString();
-                Dictionary<string, ReminderEntry> d;
-                if (!reminderTable.ContainsKey(entry.GrainRef))
-                {
-                    d = new Dictionary<string, ReminderEntry>();
-                    reminderTable.Add(entry.GrainRef, d);
-                }
-
-                d = reminderTable[entry.GrainRef];
-
-                ReminderEntry old; // tracing purposes only
-                d.TryGetValue(entry.ReminderName, out old); // tracing purposes only
-                                                            // add or over-write
-                d[entry.ReminderName] = entry;
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace("Upserted entry {Updated}, replaced {Replaced}", entry, old);
-                }
-
-                return entry.ETag;
-            }
-
-            public bool RemoveRow(GrainReference grainRef, string reminderName, string eTag)
-            {
-                // assuming the calling grain executes one call at a time, so no need to lock
-                if (!reminderTable.TryGetValue(grainRef, out var data))
-                {
-                    return false;
-                }
-
-                data.TryGetValue(reminderName, out var e); // check if eTag matches
-                if (e == null || !e.ETag.Equals(eTag))
-                {
-                    return false;
-                }
-
-                if (!data.Remove(reminderName))
-                {
-                    return false;
-                }
-
-                if (data.Count == 0)
+                else
                 {
                     reminderTable.Remove(grainRef);
                 }
 
-                return true;
+                return Task.FromResult(true);
             }
 
-            // use only for internal printing during testing ... the reminder table can be huge in a real deployment!
-            public ReminderTableData ReadAll()
-            {
-                // is there a sleaker way of doing this in C#?
-                var list = new List<ReminderEntry>();
-                foreach (GrainReference k in reminderTable.Keys)
-                {
-                    list.AddRange(reminderTable[k].Values);
-                }
+            logger.LogWarning(
+                (int)ErrorCode.RS_Table_Remove,
+                "RemoveRow failed for Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}. Table now is: {3}",
+                grainRef,
+                reminderName,
+                eTag,
+                Utils.EnumerableToString(reminderTable.Values.SelectMany(x => x.Values)));
 
-                return new ReminderTableData(list);
-            }
-
-            public void Reset()
-            {
-                reminderTable.Clear();
-            }
+            return Task.FromResult(false);
         }
     }
 }

--- a/src/Orleans.Runtime/ReminderService/InMemoryReminderTable.cs
+++ b/src/Orleans.Runtime/ReminderService/InMemoryReminderTable.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Orleans.Runtime.ReminderService
 {
@@ -16,41 +16,39 @@ namespace Orleans.Runtime.ReminderService
 
         public Task Init() => Task.CompletedTask;
 
-        public async Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
+        public Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
         {
             this.ThrowIfNotAvailable();
-            return await this.reminderTableGrain.ReadRow(grainRef, reminderName);
+            return this.reminderTableGrain.ReadRow(grainRef, reminderName);
         }
 
-        public async Task<ReminderTableData> ReadRows(GrainReference key)
+        public Task<ReminderTableData> ReadRows(GrainReference key)
         {
             this.ThrowIfNotAvailable();
-            return await this.reminderTableGrain.ReadRows(key);
+            return this.reminderTableGrain.ReadRows(key);
         }
 
-        public async Task<ReminderTableData> ReadRows(uint begin, uint end)
+        public Task<ReminderTableData> ReadRows(uint begin, uint end)
         {
-            if (!this.isAvailable) return new ReminderTableData();
-
-            return await this.reminderTableGrain.ReadRows(begin, end);
+            return this.isAvailable ? this.reminderTableGrain.ReadRows(begin, end) : Task.FromResult(new ReminderTableData());
         }
 
-        public async Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
+        public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
         {
             this.ThrowIfNotAvailable();
-            return await this.reminderTableGrain.RemoveRow(grainRef, reminderName, eTag);
+            return this.reminderTableGrain.RemoveRow(grainRef, reminderName, eTag);
         }
 
-        public async Task TestOnlyClearTable()
+        public Task TestOnlyClearTable()
         {
             this.ThrowIfNotAvailable();
-            await this.reminderTableGrain.TestOnlyClearTable();
+            return this.reminderTableGrain.TestOnlyClearTable();
         }
 
-        public async Task<string> UpsertRow(ReminderEntry entry)
+        public Task<string> UpsertRow(ReminderEntry entry)
         {
             this.ThrowIfNotAvailable();
-            return await this.reminderTableGrain.UpsertRow(entry);
+            return this.reminderTableGrain.UpsertRow(entry);
         }
 
         private void ThrowIfNotAvailable()

--- a/src/OrleansProviders/Storage/MemoryStorageGrain.cs
+++ b/src/OrleansProviders/Storage/MemoryStorageGrain.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Orleans.Runtime;
 using Orleans.Storage.Internal;
 
 namespace Orleans.Storage
@@ -15,12 +14,12 @@ namespace Orleans.Storage
     /// </summary>
     internal class MemoryStorageGrain : Grain, IMemoryStorageGrain
     {
-        private IDictionary<string, GrainStateStore> grainStore;
+        private Dictionary<(string, string), IGrainState> grainStore;
         private ILogger logger;
 
         public override Task OnActivateAsync()
         {
-            grainStore = new Dictionary<string, GrainStateStore>();
+            grainStore = new Dictionary<(string, string), IGrainState>();
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for MemoryStorageGrain virtually indefinitely.
             logger = this.ServiceProvider.GetRequiredService<ILogger<MemoryStorageGrain>>();
             logger.LogInformation("OnActivateAsync");
@@ -37,124 +36,76 @@ namespace Orleans.Storage
         public Task<IGrainState> ReadStateAsync(string stateStore, string grainStoreKey)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("ReadStateAsync for {StateStore} grain: {GrainStoreKey}", stateStore, grainStoreKey);
-            GrainStateStore storage = GetStoreForGrain(stateStore);
-            var grainState = storage.GetGrainState(grainStoreKey);
-            return Task.FromResult(grainState);
+            grainStore.TryGetValue((stateStore, grainStoreKey), out var entry);
+            return Task.FromResult(entry is DeletedState ? null : entry);
         }
 
         public Task<string> WriteStateAsync(string stateStore, string grainStoreKey, IGrainState grainState)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("WriteStateAsync for {StateStore} grain: {GrainStoreKey} eTag: {ETag}", stateStore, grainStoreKey, grainState.ETag);
-            GrainStateStore storage = GetStoreForGrain(stateStore);
-            storage.UpdateGrainState(grainStoreKey, grainState);
+            string currentETag = null;
+            if (grainStore.TryGetValue((stateStore, grainStoreKey), out var entry))
+            {
+                currentETag = entry.ETag;
+            }
+
+            ValidateEtag(currentETag, grainState.ETag, grainStoreKey, "Update");
+            grainState.ETag = NewEtag();
+            grainStore[(stateStore, grainStoreKey)] = grainState;
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Done WriteStateAsync for {StateStore} grain: {GrainStoreKey} eTag: {ETag}", stateStore, grainStoreKey, grainState.ETag);
             return Task.FromResult(grainState.ETag);
         }
 
         public Task DeleteStateAsync(string grainType, string grainId, string etag)
         {
-            GrainStateStore storage = GetStoreForGrain(grainType);
-            storage.DeleteGrainState(grainId, etag);
+            string currentETag = null;
+            if (grainStore.TryGetValue((grainType, grainId), out var entry))
+            {
+                currentETag = entry.ETag;
+            }
+
+            ValidateEtag(currentETag, etag, grainId, "Delete");
+            grainStore[(grainType, grainId)] = deleted;
             return Task.CompletedTask;
         }
 
-        private GrainStateStore GetStoreForGrain(string grainType)
+        private static string NewEtag()
         {
-            GrainStateStore storage;
-            if (!grainStore.TryGetValue(grainType, out storage))
-            {
-                storage = new GrainStateStore(logger);
-                grainStore.Add(grainType, storage);
-            }
-
-            return storage;
+            return Guid.NewGuid().ToString("N");
         }
 
-        private class GrainStateStore
+        private void ValidateEtag(string currentETag, string receivedEtag, string grainStoreKey, string operation)
         {
-            private readonly ILogger logger;
-            public GrainStateStore(ILogger logger)
+            // if we have no current etag, we will accept the users data.
+            // This is a mitigation for when the memory storage grain is lost due to silo crash.
+            if (currentETag == null)
+                return;
+
+            // if this is our first write, and we have an empty etag, we're good
+            if (string.IsNullOrEmpty(currentETag) && receivedEtag == null)
+                return;
+
+            // if current state and new state have matching etags, or we're to ignore the ETag, we're good
+            if (receivedEtag == currentETag || receivedEtag == StorageProviderUtils.ANY_ETAG)
+                return;
+
+            // else we have an etag mismatch
+            if (logger.IsEnabled(LogLevel.Warning))
             {
-                this.logger = logger;
+                logger.LogWarning(0, "Etag mismatch during {Operation} for grain {GrainStoreKey}: Expected = {Expected} Received = {Received}", operation, grainStoreKey, currentETag, receivedEtag);
             }
-            private readonly IDictionary<string, IGrainState> grainStateStorage = new Dictionary<string, IGrainState>();
-
-            public IGrainState GetGrainState(string grainId)
-            {
-                IGrainState entry;
-                grainStateStorage.TryGetValue(grainId, out entry);
-                return ReferenceEquals(entry, Deleted) ? null : entry;
-            }
-
-            public void UpdateGrainState(string grainId, IGrainState grainState)
-            {
-                IGrainState entry;
-                string currentETag = null;
-                if (grainStateStorage.TryGetValue(grainId, out entry))
-                {
-                    currentETag = entry.ETag;
-                }
-
-                ValidateEtag(currentETag, grainState.ETag, grainId, "Update");
-                grainState.ETag = NewEtag();
-                grainStateStorage[grainId] = grainState;
-            }
-
-            public void DeleteGrainState(string grainId, string receivedEtag)
-            {
-                IGrainState entry;
-                string currentETag = null;
-                if (grainStateStorage.TryGetValue(grainId, out entry))
-                {
-                    currentETag = entry.ETag;
-                }
-
-                ValidateEtag(currentETag, receivedEtag, grainId, "Delete");
-                grainStateStorage[grainId] = Deleted;
-            }
-
-            private static string NewEtag()
-            {
-                return Guid.NewGuid().ToString("N");
-            }
-
-            private void ValidateEtag(string currentETag, string receivedEtag, string grainStoreKey, string operation)
-            {
-                // if we have no current etag, we will accept the users data.
-                // This is a mitigation for when the memory storage grain is lost due to silo crash.
-                if (currentETag == null)
-                    return;
-
-                // if this is our first write, and we have an empty etag, we're good
-                if (string.IsNullOrEmpty(currentETag) && receivedEtag == null)
-                    return;
-
-                // if current state and new state have matching etags, or we're to ignore the ETag, we're good
-                if (receivedEtag == currentETag || receivedEtag == StorageProviderUtils.ANY_ETAG)
-                    return;
-
-                // else we have an etag mismatch
-                if (logger.IsEnabled(LogLevel.Warning))
-                {
-                    logger.LogWarning(0, "Etag mismatch during {Operation} for grain {GrainStoreKey}: Expected = {Expected} Received = {Received}", operation, grainStoreKey, currentETag ?? "null", receivedEtag);
-                }
-                throw new MemoryStorageEtagMismatchException(currentETag, receivedEtag);
-            }
-
-            /// <summary>
-            /// Marker to record deleted state so we can detect the difference between deleted state and state that never existed.
-            /// </summary>
-            private class DeletedState : IGrainState
-            {
-                public DeletedState()
-                {
-                    ETag = string.Empty;
-                }
-                public object State { get; set; }
-                public Type Type => typeof(object);
-                public string ETag { get; set; }
-            }
-            private static readonly IGrainState Deleted = new DeletedState();
+            throw new MemoryStorageEtagMismatchException(currentETag, receivedEtag);
         }
+
+        /// <summary>
+        /// Marker to record deleted state so we can detect the difference between deleted state and state that never existed.
+        /// </summary>
+        private sealed class DeletedState : IGrainState
+        {
+            public object State { get; set; }
+            public Type Type => typeof(object);
+            public string ETag { get; set; } = string.Empty;
+        }
+        private readonly IGrainState deleted = new DeletedState();
     }
 }

--- a/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
+++ b/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using Orleans.Configuration;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.Storage;
 using Xunit;
 
@@ -28,93 +27,6 @@ namespace UnitTests.StorageTests
         private const string ValueName3 = "Value3";
 
         private static int _keyCounter = 1;
-
-        [Fact, TestCategory("Functional"), TestCategory("MemoryStore")]
-        public void Comparer_InsideRange()
-        {
-            string testName = Guid.NewGuid().ToString(); //TestContext.TestName;
-
-            string rangeParamName = "Column1";
-            string fromValue = "Rem10";
-            string toValue = "Rem11";
-
-            var compareClause = MemoryGrainStorage.GetComparer(rangeParamName, fromValue, toValue);
-
-            var data = new Dictionary<string, object>();
-
-            data[rangeParamName] = "Rem09";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem10";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem11";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem12";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = testName;
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("MemoryStore")]
-        public void Comparer_OutsideRange()
-        {
-            string testName = Guid.NewGuid().ToString(); //TestContext.TestName;
-
-            string rangeParamName = "Column1";
-            string toValue = "Rem10";
-            string fromValue = "Rem12";
-
-            var compareClause = MemoryGrainStorage.GetComparer(rangeParamName, fromValue, toValue);
-
-            var data = new Dictionary<string, object>();
-
-            data[rangeParamName] = "Rem09";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem10";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem11";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem12";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = testName;
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("MemoryStore")]
-        public void Comparer_SameRange()
-        {
-            string testName = Guid.NewGuid().ToString(); //TestContext.TestName;
-
-            string rangeParamName = "Column1";
-            string fromValue = "Rem11";
-            string toValue = "Rem11";
-
-            var compareClause = MemoryGrainStorage.GetComparer(rangeParamName, fromValue, toValue);
-
-            var data = new Dictionary<string, object>();
-
-            data[rangeParamName] = "Rem09";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem10";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem11";
-            Assert.True(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = "Rem12";
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-
-            data[rangeParamName] = testName;
-            Assert.False(compareClause(data), $"From={fromValue} To={toValue} Compare Value={data[rangeParamName]}");
-        }
 
         [Fact, TestCategory("Functional"), TestCategory("MemoryStore")]
         public void HKS_MakeKey()


### PR DESCRIPTION
* Replace two-level dictionary in `MemoryStorageGrain` with a single flat dictionary.
* Remove one level of indirection/code-duplication from `GrainBasedReminderTable`
* Streamline dictionary method use and remove some dead code.