### PR TITLE
Fix SQL Server connection string

### DIFF
--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/TestEnvironmentInvariant.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/TestEnvironmentInvariant.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using Orleans.Tests.SqlUtils;
 using Orleans.TestingHost.Utils;
 using System;
@@ -59,7 +59,7 @@ namespace UnitTests.StorageTests.Relational
                 new StorageConnection
                 {
                     StorageInvariant = AdoNetInvariants.InvariantNameSqlServer,
-                    ConnectionString = @"Data Source = (localdb)\MSSQLLocalDB; Database = master; Integrated Security = True; Asynchronous Processing = True; Max Pool Size = 200; MultipleActiveResultSets = True"
+                    ConnectionString = @"Data Source = (localdb)\MSSQLLocalDB; Database = master; Integrated Security = True; Max Pool Size = 200; MultipleActiveResultSets = True"
                 },
                 new StorageConnection
                 {


### PR DESCRIPTION
The new .NET Core SQL Server connector library has made
has removed the obsolote "asynchronous processing = true"
attribute and the tests crash to exception that tells this
keyword is unsupported. Removing it from the connection string
allows the tests run green again.