### PR TITLE
Remove GrainId clusterId constructor parameter and associated code

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
             return FindOrCreateGrainId(UniqueKey.NewKey(Guid.NewGuid(), UniqueKey.Category.Grain));
         }
 
-        public static GrainId NewClientId(string clusterId = null)
+        public static GrainId NewClientId()
         {
             return NewClientId(Guid.NewGuid());
         }

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -494,11 +494,6 @@ namespace UnitTests.General
             grainRef = GrainReference.NewObserverGrainReference(observerGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient.GrainReferenceRuntime);
             this.environment.GrainFactory.BindGrainReference(grainRef);
             TestGrainReference(grainRef);
-
-            GrainId geoObserverGrainId = GrainId.NewClientId("clusterid");
-            grainRef = GrainReference.NewObserverGrainReference(geoObserverGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient.GrainReferenceRuntime);
-            this.environment.GrainFactory.BindGrainReference(grainRef);
-            TestGrainReference(grainRef);
         }
 
         private void TestGrainReference(GrainReference grainRef)


### PR DESCRIPTION
As of #6305, the code removed by this PR is no longer useful.