### PR TITLE
Remove Message.DebugContext and related code

### DIFF
--- a/src/Orleans.Core.Abstractions/Exceptions/DeadlockException.cs
+++ b/src/Orleans.Core.Abstractions/Exceptions/DeadlockException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
     [Serializable]
     public class DeadlockException : OrleansException
     {
-        internal IEnumerable<Tuple<GrainId, string>> CallChain { get; private set; }
+        internal IEnumerable<GrainId> CallChain { get; private set; }
 
         public DeadlockException() : base("Deadlock between grain calls") {}
 
@@ -29,7 +29,7 @@ namespace Orleans.Runtime
 
         public DeadlockException(string message, Exception innerException) : base(message, innerException) { }
 
-        internal DeadlockException(string message, IList<Tuple<GrainId, string>> callChain)
+        internal DeadlockException(string message, IList<GrainId> callChain)
             : base(message)
         {
             CallChain = callChain;
@@ -40,7 +40,7 @@ namespace Orleans.Runtime
         {
             if (info != null)
             {
-                CallChain = (IEnumerable<Tuple<GrainId, string>>)info.GetValue("CallChain", typeof(IEnumerable<Tuple<GrainId, string>>));
+                CallChain = (IEnumerable<GrainId>)info.GetValue("CallChain", typeof(IEnumerable<GrainId>));
             }
         }
 
@@ -48,7 +48,7 @@ namespace Orleans.Runtime
         {
             if (info != null)
             {
-                info.AddValue("CallChain", this.CallChain, typeof(IEnumerable<Tuple<GrainId, string>>));
+                info.AddValue("CallChain", this.CallChain, typeof(IEnumerable<GrainId>));
             }
 
             base.GetObjectData(info, context);

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -123,11 +123,6 @@ namespace Orleans.Runtime
                 }
             }
 
-            if (request.DebugContext != null)
-            {
-                response.DebugContext = request.DebugContext;
-            }
-
             response.CacheInvalidationHeader = request.CacheInvalidationHeader;
             response.TimeToLive = request.TimeToLive;
 

--- a/src/Orleans.Core/Messaging/RequestInvocationHistory.cs
+++ b/src/Orleans.Core/Messaging/RequestInvocationHistory.cs
@@ -8,18 +8,16 @@ namespace Orleans.Runtime
     {
         public GrainId GrainId { get; private set; }
         public ActivationId ActivationId { get; private set; }
+
+        [Obsolete("Removed and unused. This member is retained only for serialization compatibility purposes.")]
         public string DebugContext { get; private set; }
 
-        public RequestInvocationHistory(GrainId grainId, ActivationId activationId, string debugContext)
+        public RequestInvocationHistory(GrainId grainId, ActivationId activationId)
         {
             this.GrainId = grainId;
             this.ActivationId = activationId;
-            DebugContext = debugContext;
         }
 
-        public override string ToString()
-        {
-            return String.Format("RequestInvocationHistory {0}:{1}:{2}", GrainId, ActivationId, DebugContext);
-        }
+        public override string ToString() => $"RequestInvocationHistory {GrainId}:{ActivationId}";
     }
 }

--- a/src/Orleans.Core/Runtime/IRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/IRuntimeClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
-using Orleans.Serialization;
 
 namespace Orleans.Runtime
 {
@@ -49,7 +48,7 @@ namespace Orleans.Runtime
         /// <param name="timeout">New response timeout value</param>
         void SetResponseTimeout(TimeSpan timeout);
 
-        void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null);
+        void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, InvokeMethodOptions options, string genericArguments);
 
         void SendResponse(Message request, Response response);
 

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
@@ -12,8 +12,7 @@ namespace Orleans.Runtime
     {
         private readonly InvokeMethodRequest request;
         private readonly InvokeMethodOptions options;
-        private readonly string debugContext;
-        private readonly Func<GrainReference, InvokeMethodRequest, string, InvokeMethodOptions, Task<object>> sendRequest;
+        private readonly Func<GrainReference, InvokeMethodRequest, InvokeMethodOptions, Task<object>> sendRequest;
         private readonly InterfaceToImplementationMappingCache mapping;
         private readonly IOutgoingGrainCallFilter[] filters;
         private readonly GrainReference grainReference;
@@ -25,7 +24,6 @@ namespace Orleans.Runtime
         /// <param name="grain">The grain reference.</param>
         /// <param name="request">The request.</param>
         /// <param name="options"></param>
-        /// <param name="debugContext"></param>
         /// <param name="sendRequest"></param>
         /// <param name="filters">The invocation interceptors.</param>
         /// <param name="mapping">The implementation map.</param>
@@ -33,14 +31,12 @@ namespace Orleans.Runtime
             GrainReference grain,
             InvokeMethodRequest request,
             InvokeMethodOptions options,
-            string debugContext,
-            Func<GrainReference, InvokeMethodRequest, string, InvokeMethodOptions, Task<object>> sendRequest,
+            Func<GrainReference, InvokeMethodRequest, InvokeMethodOptions, Task<object>> sendRequest,
             InterfaceToImplementationMappingCache mapping,
             IOutgoingGrainCallFilter[] filters)
         {
             this.request = request;
             this.options = options;
-            this.debugContext = debugContext;
             this.sendRequest = sendRequest;
             this.mapping = mapping;
             this.grainReference = grain;
@@ -96,7 +92,7 @@ namespace Orleans.Runtime
             {
                 // Finally call the root-level invoker.
                 stage++;
-                var resultTask = this.sendRequest(this.grainReference, this.request, this.debugContext, this.options);
+                var resultTask = this.sendRequest(this.grainReference, this.request, this.options);
                 if (resultTask != null)
                 {
                     this.Result = await resultTask;

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -349,14 +349,14 @@ namespace Orleans
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "CallbackData is IDisposable but instances exist beyond lifetime of this method so cannot Dispose yet.")]
-        public void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null)
+        public void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, InvokeMethodOptions options, string genericArguments)
         {
             var message = this.messageFactory.CreateMessage(request, options);
             OrleansOutsideRuntimeClientEvent.Log.SendRequest(message);
-            SendRequestMessage(target, message, context, debugContext, options, genericArguments);
+            SendRequestMessage(target, message, context, options, genericArguments);
         }
 
-        private void SendRequestMessage(GrainReference target, Message message, TaskCompletionSource<object> context, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null)
+        private void SendRequestMessage(GrainReference target, Message message, TaskCompletionSource<object> context, InvokeMethodOptions options, string genericArguments)
         {
             var targetGrainId = target.GrainId;
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
@@ -381,10 +381,6 @@ namespace Orleans
                 message.TargetObserverId = target.ObserverId;
             }
 
-            if (debugContext != null)
-            {
-                message.DebugContext = debugContext;
-            }
             if (message.IsExpirableMessage(this.clientMessagingOptions.DropExpiredMessages))
             {
                 // don't set expiration for system target messages.

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -368,15 +368,15 @@ namespace Orleans.Runtime
 
                 var newChain = new List<RequestInvocationHistory>();
                 newChain.AddRange(prevChain.Cast<RequestInvocationHistory>());
-                newChain.Add(new RequestInvocationHistory(message.TargetGrain, message.TargetActivation, message.DebugContext));
+                newChain.Add(new RequestInvocationHistory(message.TargetGrain, message.TargetActivation));
 
                 throw new DeadlockException(
                     string.Format(
                         "Deadlock Exception for grain call chain {0}.",
                         Utils.EnumerableToString(
                             newChain,
-                            elem => string.Format("{0}.{1}", elem.GrainId, elem.DebugContext))),
-                    newChain.Select(req => new Tuple<GrainId, string>(req.GrainId, req.DebugContext)).ToList());
+                            elem => elem.GrainId.ToString())),
+                    newChain.Select(req => req.GrainId).ToList());
             }
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -134,9 +134,8 @@ namespace Orleans.Runtime
             GrainReference target,
             InvokeMethodRequest request,
             TaskCompletionSource<object> context,
-            string debugContext,
             InvokeMethodOptions options,
-            string genericArguments = null)
+            string genericArguments)
         {
             var message = this.messageFactory.CreateMessage(request, options);
 
@@ -200,11 +199,6 @@ namespace Orleans.Runtime
             if (target.IsObserverReference)
             {
                 message.TargetObserverId = target.ObserverId;
-            }
-
-            if (debugContext != null)
-            {
-                message.DebugContext = debugContext;
             }
 
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
@@ -316,7 +310,7 @@ namespace Orleans.Runtime
                 RequestContextExtensions.Import(message.RequestContextData);
                 if (schedulingOptions.PerformDeadlockDetection && !message.TargetGrain.IsSystemTarget)
                 {
-                    UpdateDeadlockInfoInRequestContext(new RequestInvocationHistory(message.TargetGrain, message.TargetActivation, message.DebugContext));
+                    UpdateDeadlockInfoInRequestContext(new RequestInvocationHistory(message.TargetGrain, message.TargetActivation));
                     // RequestContext is automatically saved in the msg upon send and propagated to the next hop
                     // in RuntimeClient.CreateMessage -> RequestContextExtensions.ExportToMessage(message);
                 }

--- a/src/Orleans.Runtime/Scheduler/InvokeWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/InvokeWorkItem.cs
@@ -35,7 +35,7 @@ namespace Orleans.Runtime.Scheduler
 
         public override string Name
         {
-            get { return String.Format("InvokeWorkItem:Id={0} {1}", message.Id, message.DebugContext); }
+            get { return  $"InvokeWorkItem:Id={message.Id}"; }
         }
 
         public override void Execute()

--- a/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.Scheduler
 
         public override string Name
         {
-            get { return String.Format("RequestWorkItem:Id={0} {1}", request.Id, request.DebugContext); }
+            get { return $"RequestWorkItem:Id={request.Id}"; }
         }
 
         public override void Execute()

--- a/src/Orleans.Runtime/Scheduler/ResponseWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ResponseWorkItem.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.Scheduler
 
         public override string Name
         {
-            get { return String.Format("ResponseWorkItem:Id={0},Type={1} {2}", response.Id, response.Result, response.DebugContext); }
+            get { return $"ResponseWorkItem:Id={response.Id},Type={response.Result}"; }
         }
 
         public override void Execute()


### PR DESCRIPTION
This has been disabled via hard-coded switch for a long, long time. It's time we removed it.