### PR TITLE
Fix GatewayPerSilo setting in TestClusterOptions

### DIFF
--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -34,6 +34,7 @@ namespace Orleans.TestingHost
                 [nameof(ApplicationBaseDirectory)] = this.ApplicationBaseDirectory,
                 [nameof(ConfigureFileLogging)] = this.ConfigureFileLogging.ToString(),
                 [nameof(AssumeHomogenousSilosForTesting)] = this.AssumeHomogenousSilosForTesting.ToString(),
+                [nameof(GatewayPerSilo)] = this.GatewayPerSilo.ToString(),
             };
             
             if (this.SiloBuilderConfiguratorTypes != null)


### PR DESCRIPTION
 Propagate `TestClusterOptions.GatewayPerSilo` value in `TestClusterOptions.ToDictionary()`