### PR TITLE
[AWS:DynamoDB] Explicit setting for `UseProvisionedThroughput`

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -25,9 +25,14 @@ namespace Orleans.Configuration
         public string SecretKey { get; set; }
 
         /// <summary>
-        /// DynamoDB Service name 
+        /// DynamoDB Service name
         /// </summary>
         public string Service { get; set; }
+
+        /// <summary>
+        /// Use Provisioned Throughput for tables
+        /// </summary>
+        public bool UseProvisionedThroughput { get; set; } = true;
 
         /// <summary>
         /// Read capacity unit for DynamoDB storage
@@ -94,13 +99,16 @@ namespace Orleans.Configuration
                 throw new OrleansConfigurationException(
                     $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.TableName)} is not valid.");
 
-            if (this.options.ReadCapacityUnits == 0)
-                throw new OrleansConfigurationException(
-                    $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.ReadCapacityUnits)} is not valid.");
+            if (this.options.UseProvisionedThroughput)
+            {
+                if (this.options.ReadCapacityUnits == 0)
+                    throw new OrleansConfigurationException(
+                        $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.ReadCapacityUnits)} is not valid.");
 
-            if (this.options.WriteCapacityUnits == 0)
-                throw new OrleansConfigurationException(
-                    $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.WriteCapacityUnits)} is not valid.");
+                if (this.options.WriteCapacityUnits == 0)
+                    throw new OrleansConfigurationException(
+                        $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.WriteCapacityUnits)} is not valid.");
+            }
         }
     }
 }

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -83,7 +83,7 @@ namespace Orleans.Storage
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
                 this.storage = new DynamoDBStorage(this.loggerFactory, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>
@@ -187,7 +187,7 @@ namespace Orleans.Storage
         {
             var fields = new Dictionary<string, AttributeValue>();
             if (this.options.TimeToLive.HasValue)
-            {                                
+            {
                 fields.Add(GRAIN_TTL_PROPERTY_NAME, new AttributeValue { N = ((DateTimeOffset)DateTime.UtcNow.Add(this.options.TimeToLive.Value)).ToUnixTimeSeconds().ToString() });
             }
 


### PR DESCRIPTION
This fixes a previous issue where a Read/Write capacity of `0` would imply a non-provisioned strategy. Setting `UseProvisionedThroughput` to `false` now changes the `BILLING_MODE` to `PAY_PER_REQUEST` as expected.

Defaults are kept (`UseProvisionedThroughput = true`) to not change or break existing behavior.