### PR TITLE
AdoNet: Rename Storage table to OrleansStorage for consistency with other tables.

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/MySQL-Persistence.sql
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/MySQL-Persistence.sql
@@ -43,7 +43,7 @@
 --
 -- 7. In the storage operations queries the columns need to be in the exact same order
 -- since the storage table operations support optionally streaming.
-CREATE TABLE Storage
+CREATE TABLE OrleansStorage
 (
     -- These are for the book keeping. Orleans calculates
     -- these hashes (see RelationalStorageProvide implementation),
@@ -84,12 +84,12 @@ CREATE TABLE Storage
     -- by using the fields. That is, after the indexed queries have pinpointed the right
     -- rows down to [0, n] relevant ones, n being the number of collided value pairs.
 ) ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 16;
-ALTER TABLE Storage ADD INDEX IX_Storage (GrainIdHash, GrainTypeHash);
+ALTER TABLE OrleansStorage ADD INDEX IX_OrleansStorage (GrainIdHash, GrainTypeHash);
 
 -- The following alters the column to JSON format if MySQL is at least of version 5.7.8.
 -- See more at https://dev.mysql.com/doc/refman/5.7/en/json.html for JSON and
 -- http://dev.mysql.com/doc/refman/5.7/en/comments.html for the syntax.
-/*!50708 ALTER TABLE Storage MODIFY COLUMN PayloadJson JSON */;
+/*!50708 ALTER TABLE OrleansStorage MODIFY COLUMN PayloadJson JSON */;
 
 DELIMITER $$
 
@@ -112,7 +112,7 @@ BEGIN
     SET _newGrainStateVersion = _GrainStateVersion;
 
     START TRANSACTION;
-    UPDATE Storage
+    UPDATE OrleansStorage
     SET
         PayloadBinary = NULL,
         PayloadJson = NULL,
@@ -183,7 +183,7 @@ BEGIN
     -- See further information at https://dotnet.github.io/orleans/Documentation/Core-Features/Grain-Persistence.html.
     IF _GrainStateVersion IS NOT NULL
     THEN
-        UPDATE Storage
+        UPDATE OrleansStorage
         SET
             PayloadBinary = _PayloadBinary,
             PayloadJson = _PayloadJson,
@@ -212,7 +212,7 @@ BEGIN
     -- to ensure only on INSERT succeeds.
     IF _GrainStateVersion IS NULL
     THEN
-        INSERT INTO Storage
+        INSERT INTO OrleansStorage
         (
             GrainIdHash,
             GrainIdN0,
@@ -244,7 +244,7 @@ BEGIN
         (
             -- There should not be any version of this grain state.
             SELECT 1
-            FROM Storage
+            FROM OrleansStorage
             WHERE
                 GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
                 AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
@@ -278,7 +278,7 @@ VALUES
         UTC_TIMESTAMP(),
         Version
     FROM
-        Storage
+        OrleansStorage
     WHERE
         GrainIdHash = @GrainIdHash
         AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL

--- a/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql
@@ -1,4 +1,4 @@
-CREATE TABLE Storage
+CREATE TABLE OrleansStorage
 (
     grainidhash integer NOT NULL,
     grainidn0 bigint NOT NULL,
@@ -14,8 +14,8 @@ CREATE TABLE Storage
     version integer
 );
 
-CREATE INDEX ix_storage
-    ON storage USING btree
+CREATE INDEX ix_orleansstorage
+    ON orleansstorage USING btree
     (grainidhash, graintypehash);
 
 CREATE OR REPLACE FUNCTION writetostorage(
@@ -59,7 +59,7 @@ AS $function$
     -- See further information at https://dotnet.github.io/orleans/Documentation/Core-Features/Grain-Persistence.html. 
     IF _GrainStateVersion IS NOT NULL
     THEN
-        UPDATE Storage
+        UPDATE OrleansStorage
         SET
             PayloadBinary = _PayloadBinary,
             PayloadJson = _PayloadJson,
@@ -88,7 +88,7 @@ AS $function$
     -- to ensure only on INSERT succeeds.
     IF _GrainStateVersion IS NULL
     THEN
-        INSERT INTO Storage
+        INSERT INTO OrleansStorage
         (
             GrainIdHash,
             GrainIdN0,
@@ -120,7 +120,7 @@ AS $function$
          (
             -- There should not be any version of this grain state.
             SELECT 1
-            FROM Storage
+            FROM OrleansStorage
             WHERE
                 GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
                 AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
@@ -162,7 +162,7 @@ VALUES
         (now() at time zone ''utc''),
         Version
     FROM
-        Storage
+        OrleansStorage
     WHERE
         GrainIdHash = @GrainIdHash
         AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
@@ -177,7 +177,7 @@ INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (
     'ClearStorageKey','
-    UPDATE Storage
+    UPDATE OrleansStorage
     SET
         PayloadBinary = NULL,
         PayloadJson = NULL,


### PR DESCRIPTION
This table is the odd one out:

```
test=# \d
                        List of relations
 Schema |             Name              | Type  | Owner
--------+-------------------------------+-------+-------
 public | orleansmembershiptable        | table | test
 public | orleansmembershipversiontable | table | test
 public | orleansquery                  | table | test
 public | orleansreminderstable         | table | test
 public | storage                       | table | test

```

This shouldn't affect existing deployments, I think, since the queries that access the table are all written into the `OrleansQuery` table in these scripts in the first place.