### PR TITLE
Fix text mistake in code.

### DIFF
--- a/src/Documentation/clusters_and_clients/configuration_guide/local_development_configuration.md
+++ b/src/Documentation/clusters_and_clients/configuration_guide/local_development_configuration.md
@@ -96,7 +96,7 @@ You can create an empty console application project targeting .NET Framework 4.6
 Here is an example of how a client can connect to a local silo:
 
 ```csharp
-client = new ClientBuilder()
+var builder = new ClientBuilder()
     // Use localhost clustering for a single local silo
     .UseLocalhostClustering()
     // Configure ClusterId and ServiceId


### PR DESCRIPTION
Someone forgot to declare variable of a client builder.