### PR TITLE
Fix CleanupDefunctSiloMembership & MembershipTableTests

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
-using Amazon.Util;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -546,21 +545,14 @@ namespace Orleans.Clustering.DynamoDB
                 var keys = new Dictionary<string, AttributeValue>
                 {
                     { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(this.clusterId) },
-                    { $":{SiloInstanceRecord.STATUS_PROPERTY_NAME}", new AttributeValue(((int)SiloStatus.Dead).ToString()) },
-                    { $":{SiloInstanceRecord.I_AM_ALIVE_TIME_PROPERTY_NAME}", new AttributeValue(beforeDate.ToString(AWSSDKUtils.ISO8601DateFormat)) }
                 };
-                var filters = new List<string>
-                {
-                    $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}",
-                    $"{SiloInstanceRecord.STATUS_PROPERTY_NAME} = :{SiloInstanceRecord.STATUS_PROPERTY_NAME}",
-                    $"{SiloInstanceRecord.I_AM_ALIVE_TIME_PROPERTY_NAME} < :{SiloInstanceRecord.I_AM_ALIVE_TIME_PROPERTY_NAME}"
-                };
-                var compoundFilter = string.Join(" and ", filters);
-
-                var defunctRecords = await this.storage.QueryAllAsync(this.options.TableName, keys, compoundFilter, item => new SiloInstanceRecord(item));
+                var filter = $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}";
+                
+                var records = await this.storage.QueryAllAsync(this.options.TableName, keys, filter, item => new SiloInstanceRecord(item));
+                var defunctRecordKeys = records.Where(r => SiloIsDefunct(r, beforeDate)).Select(r => r.GetKeys());
 
                 var tasks = new List<Task>();
-                foreach (var batch in defunctRecords.Select(r => r.GetKeys()).BatchIEnumerable(MAX_BATCH_SIZE))
+                foreach (var batch in defunctRecordKeys.BatchIEnumerable(MAX_BATCH_SIZE))
                 {
                     tasks.Add(this.storage.DeleteEntriesAsync(this.options.TableName, batch));
                 }
@@ -571,6 +563,13 @@ namespace Orleans.Clustering.DynamoDB
                 this.logger.Error(ErrorCode.MembershipBase, $"Unable to clean up defunct membership records on table {this.options.TableName} for clusterId {this.clusterId}", exc);
                 throw;
             }
+        }
+
+        private static bool SiloIsDefunct(SiloInstanceRecord silo, DateTimeOffset beforeDate)
+        {
+            return DateTimeOffset.TryParse(silo.IAmAliveTime, out var iAmAliveTime)
+                    && iAmAliveTime < beforeDate
+                    && silo.Status == (int)SiloStatus.Dead;
         }
     }
 }

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -166,8 +166,8 @@ namespace AWSUtils.Tests.StorageTests
 
         private async Task<DynamoDBGrainStorage> InitDynamoDBGrainStorage(DynamoDBStorageOptions options)
         {
-            DynamoDBGrainStorage store = ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(this.providerRuntime.ServiceProvider, options);
-            ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(this.providerRuntime.ServiceProvider, new LifecycleSubject(null));
+            DynamoDBGrainStorage store = ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(this.providerRuntime.ServiceProvider, "StorageProviderTests", options);
+            ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(this.providerRuntime.ServiceProvider, NullLogger<SiloLifecycleSubject>.Instance);
             store.Participate(lifecycle);
             await lifecycle.OnStart();
             return store;

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -9,6 +9,7 @@ using Orleans.TestingHost;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using TesterInternal;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -186,8 +187,8 @@ namespace AWSUtils.Tests.StorageTests
             var options = new DynamoDBStorageOptions();
             options.Service = AWSTestConstants.Service;
 
-            DynamoDBGrainStorage store = ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(runtime.ServiceProvider, options);
-            ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(runtime.ServiceProvider, new LifecycleSubject(null));
+            DynamoDBGrainStorage store = ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(runtime.ServiceProvider, "PersistenceGrainTests", options);
+            ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(runtime.ServiceProvider, NullLogger<SiloLifecycleSubject>.Instance);
             store.Participate(lifecycle);
             await lifecycle.OnStart();
             return store;

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -416,6 +416,7 @@ namespace UnitTests.MembershipTests
             MembershipEntry oldEntry = CreateMembershipEntryForTest();
             oldEntry.IAmAliveTime = oldEntry.IAmAliveTime.AddDays(-10);
             oldEntry.StartTime = oldEntry.StartTime.AddDays(-10);
+            oldEntry.Status = SiloStatus.Dead;
             bool ok = await membershipTable.InsertRow(oldEntry, newTableVersion);
             var table = await membershipTable.ReadAll();
 


### PR DESCRIPTION
So I got DynamoDB running locally in a Docker container so that I could run the AWSUtils.Tests and verify my change.

It seems that for DynamoDB-related things, these tests are mostly broken. The constructors for DynamoDBGrainStorage and SiloLifecycleSubject have changed, so the attempts to instantiate these fail in DynamoDBStorageProviderTests.cs. I fixed this, but then also found that the maximum size DynamoDB allows for an item is 400KB and some of those tests are trying to write items considerably larger than that. 

Other AWSUtils.Tests are failing too. I may take a stab at fixing these later in the week, but this is what I had time for today. The Membership ones pass, and that's the code I was changing.