### PR TITLE
Schedule IMembershipTable.CleanupDefunctSiloEntries more frequently

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -99,7 +99,7 @@ namespace Orleans.Configuration
         /// entries older than <see cref="DefunctSiloExpiration" /> are removed. This value is per-silo.
         /// </summary>
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD;
-        public static readonly TimeSpan? DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD = TimeSpan.FromDays(7);
+        public static readonly TimeSpan? DEFAULT_DEFUNCT_SILO_CLEANUP_PERIOD = TimeSpan.FromHours(1);
 
         /// <summary>
         /// TEST ONLY - Do not modify in production environments

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task CleanupDefunctSilos()
         {
-            if (this.clusterMembershipOptions.DefunctSiloCleanupPeriod == default)
+            if (!this.clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
             {
                 if (this.log.IsEnabled(LogLevel.Debug))
                 {
@@ -53,21 +53,29 @@ namespace Orleans.Runtime.MembershipService
                 return;
             }
 
-            var dateLimit = DateTime.UtcNow - this.clusterMembershipOptions.DefunctSiloExpiration;
             if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug("Starting membership table cleanup agent");
             try
             {
-                while (await this.cleanupDefunctSilosTimer.NextTick())
+                var random = new SafeRandom();
+                var period = this.clusterMembershipOptions.DefunctSiloCleanupPeriod.Value;
+
+                // The first cleanup should be scheduled for shortly after silo startup.
+                var delay = random.NextTimeSpan(TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(10));
+                while (await this.cleanupDefunctSilosTimer.NextTick(delay))
                 {
+                    // Select a random time within the next window.
+                    // The purpose of this is to add jitter to a process which could be affected by contention with other silos.
+                    delay = random.NextTimeSpan(period, period + TimeSpan.FromMinutes(5));
                     try
                     {
+                        var dateLimit = DateTime.UtcNow - this.clusterMembershipOptions.DefunctSiloExpiration;
                         await this.membershipTableProvider.CleanupDefunctSiloEntries(dateLimit);
                     }
                     catch (Exception exception) when (exception is NotImplementedException || exception is MissingMethodException)
                     {
-                        this.log.Error(
-                            ErrorCode.MembershipCleanDeadEntriesFailure,
-                            "DeleteDeadMembershipTableEntries operation is not supported by the current implementation of IMembershipTable. Disabling the timer now.");
+                        this.log.LogError(
+                            (int)ErrorCode.MembershipCleanDeadEntriesFailure,
+                            $"{nameof(IMembershipTable.CleanupDefunctSiloEntries)} operation is not supported by the current implementation of {nameof(IMembershipTable)}. Disabling the timer now.");
                         return;
                     }
                     catch (Exception exception)


### PR DESCRIPTION
* Set default `DefunctSiloCleanupPeriod` to 1 hour (currently 7 days)
* Add random 5 minute jitter around cleanup period on each iteration
* Schedule first cleanup for a random time within the first 10 minutes of a silo starting