### PR TITLE
CodeGenerator fixes

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -36,7 +36,7 @@ namespace Orleans.CodeGenerator
             this.compilation = compilation;
             this.options = options;
             this.log = log;
-            this.wellKnownTypes = WellKnownTypes.FromCompilation(compilation);
+            this.wellKnownTypes = new WellKnownTypes(compilation);
             this.compilationAnalyzer = new CompilationAnalyzer(log, this.wellKnownTypes, compilation);
 
             var firstSyntaxTree = compilation.SyntaxTrees.FirstOrDefault() ?? throw new InvalidOperationException("Compilation has no syntax trees.");
@@ -390,6 +390,16 @@ namespace Orleans.CodeGenerator
                 return;
             }
 
+            if (type.TypeKind == TypeKind.Enum)
+            {
+                if (this.log.IsEnabled(LogLevel.Trace))
+                {
+                    this.log.LogTrace($"{nameof(ProcessSerializableType)} type {type} is an enum type and no serializer will be generated for it");
+                }
+
+                return;
+            }
+
             if (type.TypeParameters.Any(p => p.ConstraintTypes.Any(c => SymbolEqualityComparer.Default.Equals(c, this.wellKnownTypes.Delegate))))
             {
                 if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace($"{nameof(ProcessSerializableType)} skipping type with Delegate parameter constraint, {type}");
@@ -397,7 +407,7 @@ namespace Orleans.CodeGenerator
             }
 
             var isSerializable = this.compilationAnalyzer.IsSerializable(type);
-            if (this.compilationAnalyzer.IsFromKnownAssembly(type) && isSerializable)
+            if (isSerializable && this.compilationAnalyzer.IsFromKnownAssembly(type))
             {
                 // Skip types which have fields whose types are inaccessible from generated code.
                 foreach (var field in type.GetInstanceMembers<IFieldSymbol>())
@@ -489,16 +499,16 @@ namespace Orleans.CodeGenerator
                 case TypeKind.Pointer:
                 case TypeKind.TypeParameter:
                 case TypeKind.Submission:
-                {
-                    return false;
-                }
+                    {
+                        return false;
+                    }
             }
 
             if (type.IsStatic)
             {
                 return false;
             }
-            
+
             if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace($"{nameof(ValidForKnownTypes)} adding type {type}");
 
             return true;

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -478,11 +478,6 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            if (type.HasUnsupportedMetadata)
-            {
-                return false;
-            }
-
             if (type.SpecialType != SpecialType.None)
             {
                 return false;
@@ -499,12 +494,15 @@ namespace Orleans.CodeGenerator
                 case TypeKind.Pointer:
                 case TypeKind.TypeParameter:
                 case TypeKind.Submission:
-                    {
-                        return false;
-                    }
+                    return false;
             }
 
             if (type.IsStatic)
+            {
+                return false;
+            }
+
+            if (type.HasUnsupportedMetadata)
             {
                 return false;
             }

--- a/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
@@ -231,9 +231,8 @@ namespace Orleans.CodeGenerator.Generators
 
                     var methodResult = asyncMethod ? AwaitExpression(invocation) : (ExpressionSyntax)invocation;
 
-                    var isUntypedValueTaskMethod =
-                        SymbolEqualityComparer.Default.Equals(wellKnownTypes.ValueTask, methodReturnType);
-                    if (isUntypedValueTaskMethod)
+                    if (this.wellKnownTypes.ValueTask is WellKnownTypes.Some valueTask
+                        && SymbolEqualityComparer.Default.Equals(valueTask.Value, methodReturnType))
                     {
                         body.Add(ExpressionStatement(methodResult));
                     }
@@ -312,7 +311,7 @@ namespace Orleans.CodeGenerator.Generators
                 var enumType = wellKnownTypes.TransactionOption;
                 var txRequirement = (int)attr.ConstructorArguments.First().Value;
                 var values = enumType.GetMembers().OfType<IFieldSymbol>().ToList();
-                var mapping = values.ToDictionary(m => (int) m.ConstantValue, m => m.Name);
+                var mapping = values.ToDictionary(m => (int)m.ConstantValue, m => m.Name);
                 if (!mapping.TryGetValue(txRequirement, out var value))
                 {
                     throw new NotSupportedException(

--- a/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
@@ -88,7 +88,7 @@ namespace Orleans.CodeGenerator.Utilities
                 return interfaceName;
             }
         }
-        
+
         public static IEnumerable<INamedTypeSymbol> GetDeclaredTypes(this IAssemblySymbol reference)
         {
             foreach (var module in reference.Modules)
@@ -124,9 +124,11 @@ namespace Orleans.CodeGenerator.Utilities
 
         public static bool HasBaseType(this ITypeSymbol typeSymbol, INamedTypeSymbol baseType)
         {
-            if (SymbolEqualityComparer.Default.Equals(baseType, typeSymbol.BaseType)) return true;
-            if (typeSymbol.BaseType is null) return false;
-            return typeSymbol.BaseType.HasBaseType(baseType);
+            for (; typeSymbol != null; typeSymbol = typeSymbol.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(baseType, typeSymbol)) return true;
+            }
+            return false;
         }
 
         public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
@@ -173,7 +175,7 @@ namespace Orleans.CodeGenerator.Utilities
             var temp = default(List<AttributeData>);
             foreach (var attr in symbol.GetAttributes())
             {
-                if (!SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType) && !attr.AttributeClass.HasBaseType(attributeType)) continue;
+                if (!attr.AttributeClass.HasBaseType(attributeType)) continue;
 
                 if (temp == null) temp = new List<AttributeData>();
                 temp.Add(attr);
@@ -246,7 +248,7 @@ namespace Orleans.CodeGenerator.Utilities
 
             return results[0];
         }
-        
+
         public static IMethodSymbol Method(this ITypeSymbol type, string name, Func<IMethodSymbol, bool> predicate = null) => type.Member(name, predicate);
 
         public static IMethodSymbol Method(this ITypeSymbol type, string name, params INamedTypeSymbol[] parameters) =>

--- a/src/Orleans.CodeGenerator/WellKnownTypes.cs
+++ b/src/Orleans.CodeGenerator/WellKnownTypes.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
@@ -8,107 +7,109 @@ namespace Orleans.CodeGenerator
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "These property names reflect type names.")]
     internal class WellKnownTypes
     {
-        public static WellKnownTypes FromCompilation(Compilation compilation)
+        public WellKnownTypes(Compilation compilation)
         {
-            return new WellKnownTypes
+            Attribute = Type("System.Attribute");
+            Action_2 = Type("System.Action`2");
+            AlwaysInterleaveAttribute = Type("Orleans.Concurrency.AlwaysInterleaveAttribute");
+            CopierMethodAttribute = Type("Orleans.CodeGeneration.CopierMethodAttribute");
+            DeserializerMethodAttribute = Type("Orleans.CodeGeneration.DeserializerMethodAttribute");
+            Delegate = compilation.GetSpecialType(SpecialType.System_Delegate);
+            DebuggerStepThroughAttribute = Type("System.Diagnostics.DebuggerStepThroughAttribute");
+            Exception = Type("System.Exception");
+            ExcludeFromCodeCoverageAttribute = Type("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute");
+            FormatterServices = Type("System.Runtime.Serialization.FormatterServices");
+            FieldInfo = Type("System.Reflection.FieldInfo");
+            Func_2 = Type("System.Func`2");
+            GeneratedCodeAttribute = Type("System.CodeDom.Compiler.GeneratedCodeAttribute");
+            Grain = Type("Orleans.Grain");
+            GrainFactoryBase = Type("Orleans.CodeGeneration.GrainFactoryBase");
+            GrainOfT = Type("Orleans.Grain`1");
+            GrainReference = Type("Orleans.Runtime.GrainReference");
+            GrainReferenceAttribute = Type("Orleans.CodeGeneration.GrainReferenceAttribute");
+            IAddressable = Type("Orleans.Runtime.IAddressable");
+            ICopyContext = Type("Orleans.Serialization.ICopyContext");
+            IDeserializationContext = Type("Orleans.Serialization.IDeserializationContext");
+            IFieldUtils = Type("Orleans.Serialization.IFieldUtils");
+            IGrain = Type("Orleans.IGrain");
+            IGrainExtension = Type("Orleans.Runtime.IGrainExtension");
+            IGrainExtensionMethodInvoker = Type("Orleans.CodeGeneration.IGrainExtensionMethodInvoker");
+            IGrainMethodInvoker = Type("Orleans.CodeGeneration.IGrainMethodInvoker");
+            IGrainObserver = Type("Orleans.IGrainObserver");
+            IGrainWithGuidCompoundKey = Type("Orleans.IGrainWithGuidCompoundKey");
+            IGrainWithGuidKey = Type("Orleans.IGrainWithGuidKey");
+            IGrainWithIntegerCompoundKey = Type("Orleans.IGrainWithIntegerCompoundKey");
+            IGrainWithIntegerKey = Type("Orleans.IGrainWithIntegerKey");
+            IGrainWithStringKey = Type("Orleans.IGrainWithStringKey");
+            Immutable_1 = Type("Orleans.Concurrency.Immutable`1");
+            ImmutableAttribute = Type("Orleans.Concurrency.ImmutableAttribute");
+            Int32 = compilation.GetSpecialType(SpecialType.System_Int32);
+            InvokeMethodOptions = Type("Orleans.CodeGeneration.InvokeMethodOptions");
+            InvokeMethodRequest = Type("Orleans.CodeGeneration.InvokeMethodRequest");
+            IOnDeserialized = Type("Orleans.Serialization.IOnDeserialized");
+            ISerializationContext = Type("Orleans.Serialization.ISerializationContext");
+            ISystemTarget = Type("Orleans.ISystemTarget");
+            MarshalByRefObject = Type("System.MarshalByRefObject");
+            MethodInvokerAttribute = Type("Orleans.CodeGeneration.MethodInvokerAttribute");
+            NonSerializedAttribute = Type("System.NonSerializedAttribute");
+            NotImplementedException = Type("System.NotImplementedException");
+            Object = compilation.GetSpecialType(SpecialType.System_Object);
+            ObsoleteAttribute = Type("System.ObsoleteAttribute");
+            OneWayAttribute = Type("Orleans.Concurrency.OneWayAttribute");
+            ReadOnlyAttribute = Type("Orleans.Concurrency.ReadOnlyAttribute");
+            SerializableAttribute = Type("System.SerializableAttribute");
+            SerializerAttribute = Type("Orleans.CodeGeneration.SerializerAttribute");
+            SerializerMethodAttribute = Type("Orleans.CodeGeneration.SerializerMethodAttribute");
+            SerializerFeature = Type("Orleans.Serialization.SerializerFeature");
+            String = compilation.GetSpecialType(SpecialType.System_String);
+            Task = Type("System.Threading.Tasks.Task");
+            Task_1 = Type("System.Threading.Tasks.Task`1");
+            ValueTask = OptionalType("System.Threading.Tasks.ValueTask");
+            TimeSpan = Type("System.TimeSpan");
+            IPAddress = Type("System.Net.IPAddress");
+            IPEndPoint = Type("System.Net.IPEndPoint");
+            SiloAddress = Type("Orleans.Runtime.SiloAddress");
+            GrainId = Type("Orleans.Runtime.GrainId");
+            GrainInterfaceMetadata = Type("Orleans.Metadata.GrainInterfaceMetadata");
+            GrainClassMetadata = Type("Orleans.Metadata.GrainClassMetadata");
+            IFeaturePopulator_1 = Type("Orleans.Metadata.IFeaturePopulator`1");
+            FeaturePopulatorAttribute = Type("Orleans.Metadata.FeaturePopulatorAttribute");
+            GrainClassFeature = Type("Orleans.Metadata.GrainClassFeature");
+            GrainInterfaceFeature = Type("Orleans.Metadata.GrainInterfaceFeature");
+            ActivationId = Type("Orleans.Runtime.ActivationId");
+            ActivationAddress = Type("Orleans.Runtime.ActivationAddress");
+            CorrelationId = OptionalType("Orleans.Runtime.CorrelationId");
+            CancellationToken = Type("System.Threading.CancellationToken");
+            TransactionAttribute = Type("Orleans.TransactionAttribute");
+            TransactionOption = Type("Orleans.TransactionOption");
+            this.Type = Type("System.Type");
+            TypeCodeOverrideAttribute = Type("Orleans.CodeGeneration.TypeCodeOverrideAttribute");
+            MethodIdAttribute = Type("Orleans.CodeGeneration.MethodIdAttribute");
+            UInt16 = compilation.GetSpecialType(SpecialType.System_UInt16);
+            UnorderedAttribute = Type("Orleans.Concurrency.UnorderedAttribute");
+            ValueTypeSetter_2 = Type("Orleans.Serialization.ValueTypeSetter`2");
+            VersionAttribute = Type("Orleans.CodeGeneration.VersionAttribute");
+            Void = compilation.GetSpecialType(SpecialType.System_Void);
+            GenericMethodInvoker = OptionalType("Orleans.CodeGeneration.GenericMethodInvoker");
+            KnownAssemblyAttribute = Type("Orleans.CodeGeneration.KnownAssemblyAttribute");
+            KnownBaseTypeAttribute = Type("Orleans.CodeGeneration.KnownBaseTypeAttribute");
+            ConsiderForCodeGenerationAttribute = Type("Orleans.CodeGeneration.ConsiderForCodeGenerationAttribute");
+            OrleansCodeGenerationTargetAttribute = Type("Orleans.CodeGeneration.OrleansCodeGenerationTargetAttribute");
+            SupportedRefAsmBaseTypes = new[]
             {
-                AbstractionsAssembly = Type("Orleans.IGrain").ContainingAssembly,
-                Attribute = Type("System.Attribute"),
-                Action_2 = Type("System.Action`2"),
-                AlwaysInterleaveAttribute = Type("Orleans.Concurrency.AlwaysInterleaveAttribute"),
-                ArgumentNullException = Type("System.ArgumentNullException"),
-                CopierMethodAttribute = Type("Orleans.CodeGeneration.CopierMethodAttribute"),
-                DeserializerMethodAttribute = Type("Orleans.CodeGeneration.DeserializerMethodAttribute"),
-                Delegate = compilation.GetSpecialType(SpecialType.System_Delegate),
-                DebuggerStepThroughAttribute = Type("System.Diagnostics.DebuggerStepThroughAttribute"),
-                Exception = Type("System.Exception"),
-                ExcludeFromCodeCoverageAttribute = Type("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"),
-                FormatterServices = Type("System.Runtime.Serialization.FormatterServices"),
-                FieldInfo = Type("System.Reflection.FieldInfo"),
-                Func_2 = Type("System.Func`2"),
-                GeneratedCodeAttribute = Type("System.CodeDom.Compiler.GeneratedCodeAttribute"),
-                Grain = Type("Orleans.Grain"),
-                GrainFactoryBase = Type("Orleans.CodeGeneration.GrainFactoryBase"),
-                GrainOfT = Type("Orleans.Grain`1"),
-                GrainReference = Type("Orleans.Runtime.GrainReference"),
-                GrainReferenceAttribute = Type("Orleans.CodeGeneration.GrainReferenceAttribute"),
-                IAddressable = Type("Orleans.Runtime.IAddressable"),
-                ICopyContext = Type("Orleans.Serialization.ICopyContext"),
-                IDeserializationContext = Type("Orleans.Serialization.IDeserializationContext"),
-                IFieldUtils = Type("Orleans.Serialization.IFieldUtils"),
-                IGrain = Type("Orleans.IGrain"),
-                IGrainExtension = Type("Orleans.Runtime.IGrainExtension"),
-                IGrainExtensionMethodInvoker = Type("Orleans.CodeGeneration.IGrainExtensionMethodInvoker"),
-                IGrainMethodInvoker = Type("Orleans.CodeGeneration.IGrainMethodInvoker"),
-                IGrainObserver = Type("Orleans.IGrainObserver"),
-                IGrainWithGuidCompoundKey = Type("Orleans.IGrainWithGuidCompoundKey"),
-                IGrainWithGuidKey = Type("Orleans.IGrainWithGuidKey"),
-                IGrainWithIntegerCompoundKey = Type("Orleans.IGrainWithIntegerCompoundKey"),
-                IGrainWithIntegerKey = Type("Orleans.IGrainWithIntegerKey"),
-                IGrainWithStringKey = Type("Orleans.IGrainWithStringKey"),
-                Immutable_1 = Type("Orleans.Concurrency.Immutable`1"),
-                ImmutableAttribute = Type("Orleans.Concurrency.ImmutableAttribute"),
-                Int32 = compilation.GetSpecialType(SpecialType.System_Int32),
-                IntPtr = compilation.GetSpecialType(SpecialType.System_IntPtr),
-                InvokeMethodOptions = Type("Orleans.CodeGeneration.InvokeMethodOptions"),
-                InvokeMethodRequest = Type("Orleans.CodeGeneration.InvokeMethodRequest"),
-                IOnDeserialized = Type("Orleans.Serialization.IOnDeserialized"),
-                ISerializationContext = Type("Orleans.Serialization.ISerializationContext"),
-                ISystemTarget = Type("Orleans.ISystemTarget"),
-                MarshalByRefObject = Type("System.MarshalByRefObject"),
-                MethodInvokerAttribute = Type("Orleans.CodeGeneration.MethodInvokerAttribute"),
-                NonSerializedAttribute = Type("System.NonSerializedAttribute"),
-                NotImplementedException = Type("System.NotImplementedException"),
-                Object = compilation.GetSpecialType(SpecialType.System_Object),
-                ObsoleteAttribute = Type("System.ObsoleteAttribute"),
-                OneWayAttribute = Type("Orleans.Concurrency.OneWayAttribute"),
-                ReadOnlyAttribute = Type("Orleans.Concurrency.ReadOnlyAttribute"),
-                ReentrantAttribute = Type("Orleans.Concurrency.ReentrantAttribute"),
-                SerializableAttribute = Type("System.SerializableAttribute"),
-                SerializerAttribute = Type("Orleans.CodeGeneration.SerializerAttribute"),
-                SerializerMethodAttribute = Type("Orleans.CodeGeneration.SerializerMethodAttribute"),
-                StatelessWorkerAttribute = Type("Orleans.Concurrency.StatelessWorkerAttribute"),
-                SerializerFeature = Type("Orleans.Serialization.SerializerFeature"),
-                String = compilation.GetSpecialType(SpecialType.System_String),
-                Task = Type("System.Threading.Tasks.Task"),
-                Task_1 = Type("System.Threading.Tasks.Task`1"),
-                ValueTask = Type("System.Threading.Tasks.ValueTask"),
-                TimeSpan = Type("System.TimeSpan"),
-                IPAddress = Type("System.Net.IPAddress"),
-                IPEndPoint = Type("System.Net.IPEndPoint"),
-                SiloAddress = Type("Orleans.Runtime.SiloAddress"),
-                GrainId = Type("Orleans.Runtime.GrainId"),
-                GrainInterfaceMetadata = Type("Orleans.Metadata.GrainInterfaceMetadata"),
-                GrainClassMetadata = Type("Orleans.Metadata.GrainClassMetadata"),
-                IFeaturePopulator_1 = Type("Orleans.Metadata.IFeaturePopulator`1"),
-                FeaturePopulatorAttribute = Type("Orleans.Metadata.FeaturePopulatorAttribute"),
-                GrainClassFeature = Type("Orleans.Metadata.GrainClassFeature"),
-                GrainInterfaceFeature = Type("Orleans.Metadata.GrainInterfaceFeature"),
-                ActivationId = Type("Orleans.Runtime.ActivationId"),
-                ActivationAddress = Type("Orleans.Runtime.ActivationAddress"),
-                CorrelationId = OptionalType("Orleans.Runtime.CorrelationId"),
-                CancellationToken = Type("System.Threading.CancellationToken"),
-                TransactionAttribute = Type("Orleans.TransactionAttribute"),
-                TransactionOption = Type("Orleans.TransactionOption"),
-                Type = Type("System.Type"),
-                TypeCodeOverrideAttribute = Type("Orleans.CodeGeneration.TypeCodeOverrideAttribute"),
-                MethodIdAttribute = Type("Orleans.CodeGeneration.MethodIdAttribute"),
-                UInt16 = compilation.GetSpecialType(SpecialType.System_UInt16),
-                UIntPtr = compilation.GetSpecialType(SpecialType.System_UIntPtr),
-                UnorderedAttribute = Type("Orleans.Concurrency.UnorderedAttribute"),
-                ValueTypeSetter_2 = Type("Orleans.Serialization.ValueTypeSetter`2"),
-                VersionAttribute = Type("Orleans.CodeGeneration.VersionAttribute"),
-                Void = compilation.GetSpecialType(SpecialType.System_Void),
-                GenericMethodInvoker = OptionalType("Orleans.CodeGeneration.GenericMethodInvoker"),
-                KnownAssemblyAttribute = Type("Orleans.CodeGeneration.KnownAssemblyAttribute"),
-                KnownBaseTypeAttribute = Type("Orleans.CodeGeneration.KnownBaseTypeAttribute"),
-                ConsiderForCodeGenerationAttribute = Type("Orleans.CodeGeneration.ConsiderForCodeGenerationAttribute"),
-                OrleansCodeGenerationTargetAttribute = Type("Orleans.CodeGeneration.OrleansCodeGenerationTargetAttribute"),
-                SupportedRefAsmBaseTypes =
-                {
-                    Type("System.Collections.Generic.EqualityComparer`1"),
-                    Type("System.Collections.Generic.Comparer`1")
-                }
+                Type("System.Collections.Generic.EqualityComparer`1"),
+                Type("System.Collections.Generic.Comparer`1")
+            };
+            TupleTypes = new[]
+            {
+                Type("System.Tuple`1"),
+                Type("System.Tuple`2"),
+                Type("System.Tuple`3"),
+                Type("System.Tuple`4"),
+                Type("System.Tuple`5"),
+                Type("System.Tuple`6"),
+                Type("System.Tuple`7"),
+                Type("System.Tuple`8"),
             };
 
             INamedTypeSymbol Type(string type)
@@ -146,107 +147,103 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        public List<INamedTypeSymbol> SupportedRefAsmBaseTypes { get; } = new List<INamedTypeSymbol>();
-        public IAssemblySymbol AbstractionsAssembly { get; private set; }
-        public INamedTypeSymbol Attribute { get; private set; }
-        public INamedTypeSymbol TimeSpan { get; private set; }
-        public INamedTypeSymbol GrainClassMetadata { get; private set; }
-        public INamedTypeSymbol GrainInterfaceMetadata { get; private set; }
-        public INamedTypeSymbol IPAddress { get; private set; }
-        public INamedTypeSymbol IPEndPoint { get; private set; }
-        public INamedTypeSymbol SiloAddress { get; private set; }
-        public INamedTypeSymbol GrainId { get; private set; }
-        public INamedTypeSymbol IFeaturePopulator_1 { get; private set; }
-        public INamedTypeSymbol FeaturePopulatorAttribute { get; private set; }
-        public INamedTypeSymbol GrainInterfaceFeature { get; private set; }
-        public INamedTypeSymbol ActivationId { get; private set; }
-        public INamedTypeSymbol ActivationAddress { get; private set; }
-        public OptionalType CorrelationId { get; private set; }
-        public INamedTypeSymbol CancellationToken { get; private set; }
-        public INamedTypeSymbol Action_2 { get; private set; }
-        public INamedTypeSymbol AlwaysInterleaveAttribute { get; private set; }
-        public INamedTypeSymbol ArgumentNullException { get; private set; }
-        public INamedTypeSymbol CopierMethodAttribute { get; private set; }
-        public INamedTypeSymbol Delegate { get; private set; }
-        public INamedTypeSymbol DeserializerMethodAttribute { get; private set; }
-        public INamedTypeSymbol DebuggerStepThroughAttribute { get; private set; }
-        public INamedTypeSymbol Exception { get; private set; }
-        public INamedTypeSymbol ExcludeFromCodeCoverageAttribute { get; private set; }
-        public INamedTypeSymbol FormatterServices { get; private set; }
-        public INamedTypeSymbol FieldInfo { get; private set; }
-        public INamedTypeSymbol Func_2 { get; private set; }
-        public INamedTypeSymbol GeneratedCodeAttribute { get; private set; }
-        public OptionalType GenericMethodInvoker { get; private set; }
-        public INamedTypeSymbol Grain { get; private set; }
-        public INamedTypeSymbol GrainFactoryBase { get; private set; }
-        public INamedTypeSymbol GrainOfT { get; private set; }
-        public INamedTypeSymbol GrainReference { get; private set; }
-        public INamedTypeSymbol GrainReferenceAttribute { get; private set; }
-        public INamedTypeSymbol IAddressable { get; private set; }
-        public INamedTypeSymbol ICopyContext { get; private set; }
-        public INamedTypeSymbol IDeserializationContext { get; private set; }
-        public INamedTypeSymbol IFieldUtils { get; private set; }
-        public INamedTypeSymbol IGrain { get; private set; }
-        public INamedTypeSymbol IGrainExtension { get; private set; }
-        public INamedTypeSymbol IGrainExtensionMethodInvoker { get; private set; }
-        public INamedTypeSymbol GrainClassFeature { get; private set; }
-        public INamedTypeSymbol SerializerFeature { get; private set; }
-        public INamedTypeSymbol IGrainMethodInvoker { get; private set; }
-        public INamedTypeSymbol IGrainObserver { get; private set; }
-        public INamedTypeSymbol IGrainWithGuidCompoundKey { get; private set; }
-        public INamedTypeSymbol IGrainWithGuidKey { get; private set; }
-        public INamedTypeSymbol IGrainWithIntegerCompoundKey { get; private set; }
-        public INamedTypeSymbol IGrainWithIntegerKey { get; private set; }
-        public INamedTypeSymbol IGrainWithStringKey { get; private set; }
-        public INamedTypeSymbol Immutable_1 { get; private set; }
-        public INamedTypeSymbol ImmutableAttribute { get; private set; }
-        public INamedTypeSymbol Int32 { get; private set; }
-        public INamedTypeSymbol IntPtr { get; private set; }
-        public INamedTypeSymbol InvokeMethodOptions { get; private set; }
-        public INamedTypeSymbol InvokeMethodRequest { get; private set; }
-        public INamedTypeSymbol IOnDeserialized { get; private set; }
-        public INamedTypeSymbol ISerializationContext { get; private set; }
-        public INamedTypeSymbol ISystemTarget { get; private set; }
-        public INamedTypeSymbol MarshalByRefObject { get; private set; }
-        public INamedTypeSymbol MethodInvokerAttribute { get; private set; }
-        public INamedTypeSymbol NonSerializedAttribute { get; private set; }
-        public INamedTypeSymbol NotImplementedException { get; private set; }
-        public INamedTypeSymbol Object { get; private set; }
-        public INamedTypeSymbol ObsoleteAttribute { get; private set; }
-        public INamedTypeSymbol OneWayAttribute { get; private set; }
-        public INamedTypeSymbol ReadOnlyAttribute { get; private set; }
-        public INamedTypeSymbol ReentrantAttribute { get; private set; }
-        public INamedTypeSymbol SerializableAttribute { get; private set; }
-        public INamedTypeSymbol SerializerAttribute { get; private set; }
-        public INamedTypeSymbol SerializerMethodAttribute { get; private set; }
-        public INamedTypeSymbol StatelessWorkerAttribute { get; private set; }
-        public INamedTypeSymbol String { get; private set; }
-        public INamedTypeSymbol Task { get; private set; }
-        public INamedTypeSymbol Task_1 { get; private set; }
-        public INamedTypeSymbol ValueTask { get; private set; }
-        public INamedTypeSymbol TransactionAttribute { get; private set; }
-        public INamedTypeSymbol TransactionOption { get; private set; }
-        public INamedTypeSymbol Type { get; private set; }
-        public INamedTypeSymbol TypeCodeOverrideAttribute { get; private set; }
-        public INamedTypeSymbol MethodIdAttribute { get; private set; }
-        public INamedTypeSymbol UInt16 { get; private set; }
-        public INamedTypeSymbol UIntPtr { get; private set; }
-        public INamedTypeSymbol UnorderedAttribute { get; private set; }
-        public INamedTypeSymbol ValueTypeSetter_2 { get; private set; }
-        public INamedTypeSymbol VersionAttribute { get; private set; }
-        public INamedTypeSymbol Void { get; private set; }
-        public INamedTypeSymbol KnownAssemblyAttribute { get; private set; }
-        public INamedTypeSymbol KnownBaseTypeAttribute { get; private set; }
-        public INamedTypeSymbol ConsiderForCodeGenerationAttribute { get; private set; }
-        public INamedTypeSymbol OrleansCodeGenerationTargetAttribute { get; private set; }
-        public class OptionalType { }
+        public INamedTypeSymbol[] SupportedRefAsmBaseTypes { get; }
+        public INamedTypeSymbol[] TupleTypes { get; }
+        public INamedTypeSymbol Attribute { get; }
+        public INamedTypeSymbol TimeSpan { get; }
+        public INamedTypeSymbol GrainClassMetadata { get; }
+        public INamedTypeSymbol GrainInterfaceMetadata { get; }
+        public INamedTypeSymbol IPAddress { get; }
+        public INamedTypeSymbol IPEndPoint { get; }
+        public INamedTypeSymbol SiloAddress { get; }
+        public INamedTypeSymbol GrainId { get; }
+        public INamedTypeSymbol IFeaturePopulator_1 { get; }
+        public INamedTypeSymbol FeaturePopulatorAttribute { get; }
+        public INamedTypeSymbol GrainInterfaceFeature { get; }
+        public INamedTypeSymbol ActivationId { get; }
+        public INamedTypeSymbol ActivationAddress { get; }
+        public OptionalType CorrelationId { get; }
+        public INamedTypeSymbol CancellationToken { get; }
+        public INamedTypeSymbol Action_2 { get; }
+        public INamedTypeSymbol AlwaysInterleaveAttribute { get; }
+        public INamedTypeSymbol CopierMethodAttribute { get; }
+        public INamedTypeSymbol Delegate { get; }
+        public INamedTypeSymbol DeserializerMethodAttribute { get; }
+        public INamedTypeSymbol DebuggerStepThroughAttribute { get; }
+        public INamedTypeSymbol Exception { get; }
+        public INamedTypeSymbol ExcludeFromCodeCoverageAttribute { get; }
+        public INamedTypeSymbol FormatterServices { get; }
+        public INamedTypeSymbol FieldInfo { get; }
+        public INamedTypeSymbol Func_2 { get; }
+        public INamedTypeSymbol GeneratedCodeAttribute { get; }
+        public OptionalType GenericMethodInvoker { get; }
+        public INamedTypeSymbol Grain { get; }
+        public INamedTypeSymbol GrainFactoryBase { get; }
+        public INamedTypeSymbol GrainOfT { get; }
+        public INamedTypeSymbol GrainReference { get; }
+        public INamedTypeSymbol GrainReferenceAttribute { get; }
+        public INamedTypeSymbol IAddressable { get; }
+        public INamedTypeSymbol ICopyContext { get; }
+        public INamedTypeSymbol IDeserializationContext { get; }
+        public INamedTypeSymbol IFieldUtils { get; }
+        public INamedTypeSymbol IGrain { get; }
+        public INamedTypeSymbol IGrainExtension { get; }
+        public INamedTypeSymbol IGrainExtensionMethodInvoker { get; }
+        public INamedTypeSymbol GrainClassFeature { get; }
+        public INamedTypeSymbol SerializerFeature { get; }
+        public INamedTypeSymbol IGrainMethodInvoker { get; }
+        public INamedTypeSymbol IGrainObserver { get; }
+        public INamedTypeSymbol IGrainWithGuidCompoundKey { get; }
+        public INamedTypeSymbol IGrainWithGuidKey { get; }
+        public INamedTypeSymbol IGrainWithIntegerCompoundKey { get; }
+        public INamedTypeSymbol IGrainWithIntegerKey { get; }
+        public INamedTypeSymbol IGrainWithStringKey { get; }
+        public INamedTypeSymbol Immutable_1 { get; }
+        public INamedTypeSymbol ImmutableAttribute { get; }
+        public INamedTypeSymbol Int32 { get; }
+        public INamedTypeSymbol InvokeMethodOptions { get; }
+        public INamedTypeSymbol InvokeMethodRequest { get; }
+        public INamedTypeSymbol IOnDeserialized { get; }
+        public INamedTypeSymbol ISerializationContext { get; }
+        public INamedTypeSymbol ISystemTarget { get; }
+        public INamedTypeSymbol MarshalByRefObject { get; }
+        public INamedTypeSymbol MethodInvokerAttribute { get; }
+        public INamedTypeSymbol NonSerializedAttribute { get; }
+        public INamedTypeSymbol NotImplementedException { get; }
+        public INamedTypeSymbol Object { get; }
+        public INamedTypeSymbol ObsoleteAttribute { get; }
+        public INamedTypeSymbol OneWayAttribute { get; }
+        public INamedTypeSymbol ReadOnlyAttribute { get; }
+        public INamedTypeSymbol SerializableAttribute { get; }
+        public INamedTypeSymbol SerializerAttribute { get; }
+        public INamedTypeSymbol SerializerMethodAttribute { get; }
+        public INamedTypeSymbol String { get; }
+        public INamedTypeSymbol Task { get; }
+        public INamedTypeSymbol Task_1 { get; }
+        public OptionalType ValueTask { get; }
+        public INamedTypeSymbol TransactionAttribute { get; }
+        public INamedTypeSymbol TransactionOption { get; }
+        public INamedTypeSymbol Type { get; }
+        public INamedTypeSymbol TypeCodeOverrideAttribute { get; }
+        public INamedTypeSymbol MethodIdAttribute { get; }
+        public INamedTypeSymbol UInt16 { get; }
+        public INamedTypeSymbol UnorderedAttribute { get; }
+        public INamedTypeSymbol ValueTypeSetter_2 { get; }
+        public INamedTypeSymbol VersionAttribute { get; }
+        public INamedTypeSymbol Void { get; }
+        public INamedTypeSymbol KnownAssemblyAttribute { get; }
+        public INamedTypeSymbol KnownBaseTypeAttribute { get; }
+        public INamedTypeSymbol ConsiderForCodeGenerationAttribute { get; }
+        public INamedTypeSymbol OrleansCodeGenerationTargetAttribute { get; }
 
-        public class None : OptionalType
+        public abstract class OptionalType { }
+
+        public sealed class None : OptionalType
         {
             public static None Instance { get; } = new None();
         }
 
-        public class Some : OptionalType
+        public sealed class Some : OptionalType
         {
             public Some(INamedTypeSymbol value)
             {

--- a/test/CodeGeneration/CodeGenerator.Tests/RoslynTypeNameFormatterTests.cs
+++ b/test/CodeGeneration/CodeGenerator.Tests/RoslynTypeNameFormatterTests.cs
@@ -152,7 +152,7 @@ namespace CodeGenerator.Tests
         [Fact]
         public void TypeCodesMatch()
         {
-            var wellKnownTypes = WellKnownTypes.FromCompilation(this.compilation);
+            var wellKnownTypes = new WellKnownTypes(this.compilation);
             foreach (var (type, symbol) in GetTypeSymbolPairs(nameof(Grains)))
             {
                 this.output.WriteLine($"Type: {RuntimeTypeNameFormatter.Format(type)}");
@@ -191,7 +191,7 @@ namespace CodeGenerator.Tests
         [Fact]
         public void MethodIdsMatch()
         {
-            var wellKnownTypes = WellKnownTypes.FromCompilation(this.compilation);
+            var wellKnownTypes = new WellKnownTypes(this.compilation);
             foreach (var (type, typeSymbol) in GetTypeSymbolPairs(nameof(Grains)))
             {
                 this.output.WriteLine($"Type: {RuntimeTypeNameFormatter.Format(type)}");


### PR DESCRIPTION
We're in the process of upgrading to Orleans 3.x and trying out the new code generator (again).
I discovered several bugs and regressions compared to the legacy code-gen:
* Fix `ValueTask` type loading to be optional (for netstandard 2.0).
* Fix `ImmutableAttribute` to actually work.
* Don't generate (invalid) serializer types for enums.
* Don't record invalid (empty) copies of value types using `RecordCopy`.
Theoretically this might result in observable changes in behavior, but the current logic is invalid anyway.
Probably should remove `RecordCopy` calls from `BuiltInTypes` also for value types (but the copies are at least valid objects there).
`ILSerializerGenerator.EmitCopier` has the same bug - it boxes and records invalid (empty) objects for value types.
* For shallow copyable types don't create a new object in DeepCopier. In case of value types a new box is still created, but no field-by-field copying is done.
* Mark `enum, Type, nullable, Tuple, ValueTuple` types shallow copyable when suitable.