### PR TITLE
Remove new() constraint for grain persistence

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -248,7 +248,7 @@ namespace Orleans
     /// Base class for a Grain with declared persistent state.
     /// </summary>
     /// <typeparam name="TGrainState">The class of the persistent state object</typeparam>
-    public class Grain<TGrainState> : Grain where TGrainState : new()
+    public class Grain<TGrainState> : Grain
     {
         private IStorage<TGrainState> storage;
 

--- a/src/Orleans.Core.Abstractions/Core/IStorage.cs
+++ b/src/Orleans.Core.Abstractions/Core/IStorage.cs
@@ -1,9 +1,8 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Orleans.Core
 {
     public interface IStorage<TState>
-        where TState : new()
     {
         TState State { get; set; }
 

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Orleans.Core;
 using Orleans.Streams;
 using Orleans.Timers;
@@ -38,6 +38,6 @@ namespace Orleans.Runtime
 
         void DelayDeactivation(Grain grain, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new();
+        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain);
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentState.cs
@@ -3,7 +3,6 @@ using Orleans.Core;
 namespace Orleans.Runtime
 {
     public interface IPersistentState<TState> : IStorage<TState>
-        where TState : new()
     {
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
+++ b/src/Orleans.Runtime.Abstractions/Facet/Persistent/IPersistentStateFactory.cs
@@ -3,6 +3,6 @@ namespace Orleans.Runtime
 {
     public interface IPersistentStateFactory
     {
-        IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration config) where TState : new();
+        IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration config);
     }
 }

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -94,7 +94,7 @@ namespace Orleans.Runtime
             grain.Data.DelayDeactivation(timeSpan);
         }
 
-        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new()
+        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain)
         {
             IGrainStorage grainStorage = grain.GetGrainStorage(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -11,7 +11,6 @@ namespace Orleans.Runtime
     public class PersistentStateFactory : IPersistentStateFactory
     {
         public IPersistentState<TState> Create<TState>(IGrainActivationContext context, IPersistentStateConfiguration cfg)
-            where TState : new()
         {
             IGrainStorage storageProvider = !string.IsNullOrWhiteSpace(cfg.StorageName)
                 ? context.ActivationServices.GetServiceByName<IGrainStorage>(cfg.StorageName)
@@ -48,7 +47,6 @@ namespace Orleans.Runtime
         }
 
         private class PersistentStateBridge<TState> : IPersistentState<TState>, ILifecycleParticipant<IGrainLifecycle>
-            where TState : new()
         {
             private readonly string fullStateName;
             private readonly IGrainActivationContext context;

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -9,7 +9,6 @@ using Orleans.Storage;
 namespace Orleans.Core
 {
     public class StateStorageBridge<TState> : IStorage<TState>
-        where TState : new()
     {
         private readonly string name;
         private readonly GrainReference grainRef;
@@ -48,7 +47,7 @@ namespace Orleans.Core
             this.name = name;
             this.grainRef = grainRef;
             this.store = store;
-            this.grainState = new GrainState<TState>(new TState());
+            this.grainState = new GrainState<TState>(Activator.CreateInstance<TState>());
         }
 
         /// <summary>
@@ -130,7 +129,7 @@ namespace Orleans.Core
                 sw.Stop();
 
                 // Reset the in-memory copy of the state
-                grainState.State = new TState();
+                grainState.State = Activator.CreateInstance<TState>();
 
                 // Update counters
                 StorageStatisticsGroup.OnStorageDelete(name, grainRef, sw.Elapsed);


### PR DESCRIPTION
See #6334 - though I don't believe this fully resolves the issue

This is a compilation-breaking change for anyone who has a custom IPersistentState/IStorage/IGrainRuntime implementation, but the fix is simple (remove the constraint from the implementation)

I don't consider accepting this PR a given - we can discuss it and decide whether to merge or close it.