### PR TITLE
Cleanup GrainBasedReminderTable

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IReminderTable.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans
 {

--- a/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
-using Orleans.MultiCluster;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,22 +10,25 @@ namespace Orleans.Runtime.ReminderService
     [Reentrant]
     internal class GrainBasedReminderTable : Grain, IReminderTableGrain
     {
-        private Table remTable;
-        private ILogger logger;
+        private readonly Table remTable;
+        private readonly ILogger logger;
+
+        public GrainBasedReminderTable(ILogger<GrainBasedReminderTable> logger)
+        {
+            this.logger = logger;
+            remTable = new Table(logger);
+        }
 
         public override Task OnActivateAsync()
         {
-            var loggerFactory = this.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            logger = loggerFactory.CreateLogger(String.Format("{0}_{1}", typeof(GrainBasedReminderTable).FullName, Data.Address.ToString()));
-            logger.Info("GrainBasedReminderTable {0} Activated. Full identity: {1}", Identity, Data.Address.ToFullString());
-            remTable = new Table(loggerFactory);
+            logger.LogInformation("Activated");
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for GrainBasedReminderTable virtually indefinitely.
             return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("GrainBasedReminderTable {0} OnDeactivateAsync. Full identity: {1}", Identity, Data.Address.ToFullString());
+            logger.LogInformation("Deactivated");
             return Task.CompletedTask;
         }
 
@@ -39,7 +40,11 @@ namespace Orleans.Runtime.ReminderService
         public Task<ReminderTableData> ReadRows(uint begin, uint end)
         {
             ReminderTableData t = remTable.ReadRows(begin, end);
-            logger.Debug("Read {0} reminders from memory: {1}, {2}", t.Reminders.Count, Environment.NewLine, Utils.EnumerableToString(t.Reminders));
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Read {ReminderCount} reminders from memory: {Reminders}", t.Reminders.Count, Utils.EnumerableToString(t.Reminders));
+            }
+
             return Task.FromResult(t);
         }
 
@@ -62,39 +67,45 @@ namespace Orleans.Runtime.ReminderService
         /// <returns>true if a row with <paramref name="grainRef"/> and <paramref name="reminderName"/> existed and was removed successfully, false otherwise</returns>
         public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("RemoveRow entry grainRef = {0}, reminderName = {1}, eTag = {2}", grainRef, reminderName, eTag);
-            bool result = remTable.RemoveRow(grainRef, reminderName, eTag);
-            if (result == false)
+            if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.Warn(ErrorCode.RS_Table_Remove, "RemoveRow failed for grainRef = {0}, ReminderName = {1}, eTag = {2}. Table now is: {3}",
-                    grainRef.ToDetailedString(), reminderName, eTag, remTable.ReadAll());
+                logger.LogDebug("RemoveRow Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}", grainRef, reminderName, eTag);
             }
+
+            var result = remTable.RemoveRow(grainRef, reminderName, eTag);
+            if (!result)
+            {
+                logger.LogWarning(
+                    (int)ErrorCode.RS_Table_Remove,
+                    "RemoveRow Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}. Table now is: {3}",
+                    grainRef,
+                    reminderName,
+                    eTag,
+                    Utils.EnumerableToString(remTable.ReadAll().Reminders));
+            }
+
             return Task.FromResult(result);
         }
 
         public Task TestOnlyClearTable()
         {
-            logger.Info("TestOnlyClearTable");
+            logger.LogInformation("TestOnlyClearTable");
             remTable.Reset();
             return Task.CompletedTask;
         }
 
-        [Serializable]
         private class Table
         {
             // key: GrainReference
             // value: V
             //      V.key: ReminderName
             //      V.Value: ReminderEntry
-            private Dictionary<GrainReference, Dictionary<string, ReminderEntry>> reminderTable;
-
-            [NonSerialized]
+            private readonly Dictionary<GrainReference, Dictionary<string, ReminderEntry>> reminderTable = new Dictionary<GrainReference, Dictionary<string, ReminderEntry>>();
             private readonly ILogger logger;
 
-            public Table(ILoggerFactory loggerFactory)
+            public Table(ILogger logger)
             {
-                this.logger = loggerFactory.CreateLogger<ILoggerFactory>();
-                Reset();
+                this.logger = logger;
             }
 
             public ReminderTableData ReadRows(GrainReference grainRef)
@@ -113,10 +124,19 @@ namespace Orleans.Runtime.ReminderService
                 // is there a sleaker way of doing this in C#?
                 var list = new List<ReminderEntry>();
                 foreach (GrainReference k in keys)
+                {
                     list.AddRange(reminderTable[k].Values);
+                }
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Selected {0} out of {1} reminders from memory for {2}. List is: {3}{4}", list.Count, reminderTable.Count, range.ToString(),
-                    Environment.NewLine, Utils.EnumerableToString(list, e => e.ToString()));
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    logger.LogTrace(
+                        "Selected {SelectCount} out of {TotalCount} reminders from memory for {Range}. Selected: {Reminders}",
+                        list.Count,
+                        reminderTable.Count,
+                        range.ToString(),
+                        Utils.EnumerableToString(list, e => e.ToString()));
+                }
 
                 return new ReminderTableData(list);
             }
@@ -132,11 +152,16 @@ namespace Orleans.Runtime.ReminderService
 
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    if (result == null)
-                        logger.Trace("Reminder not found for grain {0} reminder {1} ", grainRef, reminderName);
+                    if (result is null)
+                    {
+                        logger.LogTrace("Reminder not found for grain {Grain} reminder {ReminderName} ", grainRef, reminderName);
+                    }
                     else
-                        logger.Trace("Read for grain {0} reminder {1} row {2}", grainRef, reminderName, result.ToString());
+                    {
+                        logger.LogTrace("Read for grain {Grain} reminder {ReminderName} row {Reminder}", grainRef, reminderName, result.ToString());
+                    }
                 }
+
                 return result;
             }
 
@@ -149,28 +174,30 @@ namespace Orleans.Runtime.ReminderService
                     d = new Dictionary<string, ReminderEntry>();
                     reminderTable.Add(entry.GrainRef, d);
                 }
+
                 d = reminderTable[entry.GrainRef];
 
                 ReminderEntry old; // tracing purposes only
                 d.TryGetValue(entry.ReminderName, out old); // tracing purposes only
                                                             // add or over-write
                 d[entry.ReminderName] = entry;
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Upserted entry {0}, replaced {1}", entry, old);
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    logger.LogTrace("Upserted entry {Updated}, replaced {Replaced}", entry, old);
+                }
+
                 return entry.ETag;
             }
 
             public bool RemoveRow(GrainReference grainRef, string reminderName, string eTag)
             {
-                Dictionary<string, ReminderEntry> data = null;
-                ReminderEntry e = null;
-
                 // assuming the calling grain executes one call at a time, so no need to lock
-                if (!reminderTable.TryGetValue(grainRef, out data))
+                if (!reminderTable.TryGetValue(grainRef, out var data))
                 {
                     return false;
                 }
 
-                data.TryGetValue(reminderName, out e); // check if eTag matches
+                data.TryGetValue(reminderName, out var e); // check if eTag matches
                 if (e == null || !e.ETag.Equals(eTag))
                 {
                     return false;
@@ -185,6 +212,7 @@ namespace Orleans.Runtime.ReminderService
                 {
                     reminderTable.Remove(grainRef);
                 }
+
                 return true;
             }
 
@@ -197,12 +225,13 @@ namespace Orleans.Runtime.ReminderService
                 {
                     list.AddRange(reminderTable[k].Values);
                 }
+
                 return new ReminderTableData(list);
             }
 
             public void Reset()
             {
-                reminderTable = new Dictionary<GrainReference, Dictionary<string, ReminderEntry>>();
+                reminderTable.Clear();
             }
         }
     }


### PR DESCRIPTION
Drive-by because of some code which was being referenced (ActivationData.Address)

EDIT: Let's merge https://github.com/dotnet/orleans/pull/6315 first, since it does much of the same. After that, I'll rebase and reassess.