### PR TITLE
Undo unnecessary RequestContext.Clear in networking

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -8,9 +8,12 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.ObjectPool;
 using Orleans.Configuration;
 using Orleans.Messaging;
+
+#if NETCOREAPP
+using Microsoft.Extensions.ObjectPool;
+#endif
 
 namespace Orleans.Runtime.Messaging
 {
@@ -81,8 +84,6 @@ namespace Orleans.Runtime.Messaging
         /// <returns>A <see cref="Task"/> which completes when the connection terminates and has completed processing.</returns>
         public async Task Run()
         {
-            RequestContext.Clear();
-
             Exception error = default;
             try
             {

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -74,8 +74,6 @@ namespace Orleans.Runtime.Messaging
 
         private async Task<Connection> GetConnectionAsync(SiloAddress endpoint)
         {
-            RequestContext.Clear();
-
             while (true)
             {
                 await Task.Yield();


### PR DESCRIPTION
See also #5974, which was the original version of this, and what this undoes.
This hasn't been needed since #6014