### PR TITLE
Fix errors reported by GitHub Semmle code analysis tools.

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -38,7 +38,7 @@ call %_dotnet% build --no-restore %BUILD_FLAGS% /bl:%BuildConfiguration%-Build.b
 
 
 :Package
-@echo Package BuildConfiguration ============================
+@echo Package %BuildConfiguration% ============================
 SET STEP=Pack %BuildConfiguration%
 
 call %_dotnet% pack --no-build --no-restore %BUILD_FLAGS% /bl:%BuildConfiguration%-Pack.binlog /p:Configuration=%BuildConfiguration%%AdditionalConfigurationProperties% "%SOLUTION%"

--- a/Ensure-DotNetSdk.cmd
+++ b/Ensure-DotNetSdk.cmd
@@ -1,7 +1,7 @@
 @if not defined _echo @echo off
 setlocal enabledelayedexpansion
 
-:: Locate dotnet.exe, we're processing multi-line output of where.exe and only matchin the first tag of the 
+:: Locate dotnet.exe, we're processing multi-line output of where.exe and only matching the first tag of the 
 :: found version number
 
 set /p REQUIRED_DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"

--- a/Parallel-Tests.ps1
+++ b/Parallel-Tests.ps1
@@ -3,7 +3,7 @@ param(
     [string] $testFilter,
     [string] $dotnet)
 
-$maxDegreeOfParallelism = ($env:NUMBER_OF_PROCESSORS, 4).Minimum
+$maxDegreeOfParallelism = [math]::min($env:NUMBER_OF_PROCESSORS, 4)
 Write-Host "Max Job Parallelism = $maxDegreeOfParallelism"
 
 $failed = $false

--- a/Parallel-Tests.ps1
+++ b/Parallel-Tests.ps1
@@ -3,7 +3,7 @@ param(
     [string] $testFilter,
     [string] $dotnet)
 
-$maxDegreeOfParallelism = $env:NUMBER_OF_PROCESSORS
+$maxDegreeOfParallelism = ($env:NUMBER_OF_PROCESSORS, 4).Minimum
 Write-Host "Max Job Parallelism = $maxDegreeOfParallelism"
 
 $failed = $false

--- a/Parallel-Tests.ps1
+++ b/Parallel-Tests.ps1
@@ -1,10 +1,11 @@
 param(
     [string[]] $directories,
     [string] $testFilter,
-    [string] $outDir,
     [string] $dotnet)
 
-$maxDegreeOfParallelism = 4
+$maxDegreeOfParallelism = $env:NUMBER_OF_PROCESSORS
+Write-Host "Max Job Parallelism = $maxDegreeOfParallelism"
+
 $failed = $false
 
 if( 
@@ -67,9 +68,10 @@ foreach ($d in $directories)
     if (-not $testFilter.StartsWith('"')) { $testFilter = "`"$testFilter"; }
     if (-not $testFilter.EndsWith('"')) { $testFilter = "$testFilter`""; }
 
+    $jobName = $([System.IO.Path]::GetFileName($d))
     $cmdLine = 'test --no-build --configuration "' + $env:BuildConfiguration + '" --filter ' + $testFilter + ' --logger "trx" -- -parallel none -noshadow'
-    Write-Host $dotnet $cmdLine
-    Start-Job $ExecuteCmd -ArgumentList @($dotnet, $cmdLine, $d) -Name $([System.IO.Path]::GetFileName($d)) | Out-Null
+    Write-Host $jobName $dotnet $cmdLine
+    Start-Job $ExecuteCmd -ArgumentList @($dotnet, $cmdLine, $d) -Name $jobName | Out-Null
     Write-Host ''
 }
 

--- a/Samples/1.x/AzureWebSample/WebRole/Web.config
+++ b/Samples/1.x/AzureWebSample/WebRole/Web.config
@@ -29,6 +29,11 @@
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/GPSTracker/GPSTracker.Web/Views/Web.config
+++ b/Samples/1.x/GPSTracker/GPSTracker.Web/Views/Web.config
@@ -31,5 +31,10 @@
       <remove name="BlockViewHandler"/>
       <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
     </handlers>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
 </configuration>

--- a/Samples/1.x/GPSTracker/GPSTracker.Web/Web.config
+++ b/Samples/1.x/GPSTracker/GPSTracker.Web/Web.config
@@ -44,6 +44,11 @@
     <modules>
       <remove name="FormsAuthenticationModule" />
     </modules>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/HelloGeoSample/WebRole/Web.config
+++ b/Samples/1.x/HelloGeoSample/WebRole/Web.config
@@ -20,6 +20,11 @@
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/Presence/Host/packages.config
+++ b/Samples/1.x/Presence/Host/packages.config
@@ -35,7 +35,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />

--- a/Samples/1.x/Presence/LoadGenerator/packages.config
+++ b/Samples/1.x/Presence/LoadGenerator/packages.config
@@ -33,7 +33,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />

--- a/Samples/1.x/Presence/PlayerWatcher/packages.config
+++ b/Samples/1.x/Presence/PlayerWatcher/packages.config
@@ -33,7 +33,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />

--- a/Samples/1.x/Presence/PresenceGrainInterfaces/packages.config
+++ b/Samples/1.x/Presence/PresenceGrainInterfaces/packages.config
@@ -27,7 +27,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />

--- a/Samples/1.x/Presence/PresenceGrains/packages.config
+++ b/Samples/1.x/Presence/PresenceGrains/packages.config
@@ -27,7 +27,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />

--- a/Samples/1.x/ReplicatedChatGrainSample/WebRole/Web.config
+++ b/Samples/1.x/ReplicatedChatGrainSample/WebRole/Web.config
@@ -20,6 +20,11 @@
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/ReplicatedEventSample/WebRole/Web.config
+++ b/Samples/1.x/ReplicatedEventSample/WebRole/Web.config
@@ -29,6 +29,11 @@
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/ReplicatedEventSample/WebRole2/Web.config
+++ b/Samples/1.x/ReplicatedEventSample/WebRole2/Web.config
@@ -29,6 +29,11 @@
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/TicTacToe/Host/packages.config
+++ b/Samples/1.x/TicTacToe/Host/packages.config
@@ -35,7 +35,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />

--- a/Samples/1.x/TicTacToe/OrleansXO.GrainInterfaces/packages.config
+++ b/Samples/1.x/TicTacToe/OrleansXO.GrainInterfaces/packages.config
@@ -27,7 +27,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />

--- a/Samples/1.x/TicTacToe/OrleansXO.Grains/packages.config
+++ b/Samples/1.x/TicTacToe/OrleansXO.Grains/packages.config
@@ -27,7 +27,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />

--- a/Samples/1.x/TicTacToe/OrleansXO.Web/Web.config
+++ b/Samples/1.x/TicTacToe/OrleansXO.Web/Web.config
@@ -27,6 +27,11 @@
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Samples/1.x/TicTacToe/OrleansXO.Web/packages.config
+++ b/Samples/1.x/TicTacToe/OrleansXO.Web/packages.config
@@ -38,7 +38,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />

--- a/Samples/1.x/TicTacToe/OrleansXO.WorkerRole/packages.config
+++ b/Samples/1.x/TicTacToe/OrleansXO.WorkerRole/packages.config
@@ -34,7 +34,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />

--- a/Samples/1.x/TwitterSentiment/TwitterWebApplication/Views/Web.config
+++ b/Samples/1.x/TwitterSentiment/TwitterWebApplication/Views/Web.config
@@ -31,5 +31,10 @@
       <remove name="BlockViewHandler"/>
       <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
     </handlers>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
 </configuration>

--- a/Samples/1.x/TwitterSentiment/TwitterWebApplication/Web.config
+++ b/Samples/1.x/TwitterSentiment/TwitterWebApplication/Web.config
@@ -22,6 +22,13 @@
     <compilation debug="true" targetFramework="4.5.2" />
     <httpRuntime targetFramework="4.5.1" />
   </system.web>
+  <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/Samples/2.0/docker-aspnet-core/API/API.csproj
+++ b/Samples/2.0/docker-aspnet-core/API/API.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.Orleans.Client" Version="$(OrleansPackageVersion)" />
     <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(OrleansPackageVersion)" />
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="$(OrleansPackageVersion)" />

--- a/Test.cmd
+++ b/Test.cmd
@@ -19,6 +19,12 @@ call Ensure-DotNetSdk.cmd
 pushd "%CMDHOME%"
 @cd
 
+SET TestResultDir=%CMDHOME%\Binaries\%BuildConfiguration%\TestResults
+
+if not exist %TestResultDir% md %TestResultDir%
+
+SET _Directory=bin\%BuildConfiguration%\net461\win10-x64
+
 set TESTS=^
 %CMDHOME%\test\Extensions\TesterAzureUtils,^
 %CMDHOME%\test\TesterInternal,^

--- a/Test.cmd
+++ b/Test.cmd
@@ -7,6 +7,10 @@ SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
 set CMDHOME=%CMDHOME:~0,-1%
 
+:: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and
+:: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
+set Platform=
+
 :: Disable multilevel lookup https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/multilevel-sharedfx-lookup.md
 set DOTNET_MULTILEVEL_LOOKUP=0 
 
@@ -14,12 +18,6 @@ call Ensure-DotNetSdk.cmd
 
 pushd "%CMDHOME%"
 @cd
-
-SET TestResultDir=%CMDHOME%\Binaries\%BuildConfiguration%\TestResults
-
-if not exist %TestResultDir% md %TestResultDir%
-
-SET _Directory=bin\%BuildConfiguration%\net461\win10-x64
 
 set TESTS=^
 %CMDHOME%\test\Extensions\TesterAzureUtils,^
@@ -49,7 +47,7 @@ if []==[%TEST_FILTERS%] set "TEST_FILTERS=Category=BVT^|Category=SlowBVT"
 @Echo Test assemblies = %TESTS%
 @Echo Test filters = %TEST_FILTERS%
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& ./Parallel-Tests.ps1 -directories %TESTS% -testFilter '%TEST_FILTERS%' -outDir '%TestResultDir%' -dotnet '%_dotnet%'"
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& ./Parallel-Tests.ps1 -directories %TESTS% -testFilter '%TEST_FILTERS%' -dotnet '%_dotnet%'"
 set testresult=%errorlevel%
 popd
 endlocal&set testresult=%testresult%

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -12,7 +12,7 @@ if [%1]==[force] (
   if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
 )
 
-:: If sempahore exists do nothing
+:: If semaphore exists do nothing
 if exist "%BUILD_TOOLS_SEMAPHORE%" (
   echo Tools are already initialized.
   goto :EOF
@@ -39,7 +39,7 @@ if NOT exist "%DOTNET_LOCAL_PATH%" (
 
 :afterdotnetrestore
 
-:: Create sempahore file
+:: Create semaphore file
 echo Done initializing tools.
 echo Init-Tools.cmd completed. > "%BUILD_TOOLS_SEMAPHORE%"
 exit /b 0

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -131,7 +131,7 @@ namespace Orleans.Runtime.MembershipService
         private async Task ValidateInitialConnectivity()
         {
             // Continue attempting to validate connectivity until some reasonable timeout.
-            var maxAttemptTime = this.clusterMembershipOptions.ProbeTimeout.Multiply(5 * this.clusterMembershipOptions.NumMissedProbesLimit);
+            var maxAttemptTime = this.clusterMembershipOptions.ProbeTimeout.Multiply(5.0 * this.clusterMembershipOptions.NumMissedProbesLimit);
             var attemptNumber = 1;
             var now = this.getUtcDateTime();
             var attemptUntil = now + maxAttemptTime;

--- a/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestGrain.cs
@@ -4,7 +4,6 @@ using Orleans.Transactions.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Orleans.Transactions.TestKit.Consistency
@@ -36,7 +35,7 @@ namespace Orleans.Transactions.TestKit.Consistency
 
         private int MyNumber => (int)(this.GetPrimaryKeyLong() % ConsistencyTestOptions.MaxGrains);
 
-        public const double recursionProbability = .1 - .9 * (1 / (10 * 40 - 1));
+        public const double recursionProbability = .1 - .9 * (1.0 / (10 * 40 - 1));
 
         public async Task<Observation[]> Run(ConsistencyTestOptions options, int depth, string stack, int maxgrain, DateTime stopAfter)
         {


### PR DESCRIPTION
https://lgtm.com/projects/g/dotnet/orleans/?mode=list&severity=error

Fix errors reported by GitHub Semmle code analysis tools:

- Missing X-Frame-Options HTTP header - https://lgtm.com/rules/1506102236348/
- Using a package with a known vulnerability - https://lgtm.com/rules/1506697777412/
- Possible loss of precision - https://lgtm.com/rules/1506096756023/

Ensure Test.cmd clears the `Platform` environment variable (same as in Build.cmd) in case it is run on separate cmd session (eg Appveyor builds)

Remove unused $outDir param from Parallel-Tests.ps1 script.