### PR TITLE
Amended LinuxEnvironmentStatistics registration to register services on Linux only

### DIFF
--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Orleans.Configuration.Internal
 {
@@ -16,12 +17,23 @@ namespace Orleans.Configuration.Internal
         /// <param name="services">The service collection.</param>
         public static void AddFromExisting<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService
         {
-            var registration = services.FirstOrDefault(service => service.ServiceType == typeof(TImplementation));
+            services.AddFromExisting(typeof(TService), typeof(TImplementation));
+        }
+
+        /// <summary>
+        /// Registers an existing registration of <paramref name="implementation"/> as a provider of service type <paramref name="service"/>.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="service">The service type being provided.</param>
+        /// <param name="implementation">The implementation of <paramref name="service"/>.</param>
+        public static void AddFromExisting(this IServiceCollection services, Type service, Type implementation)
+        {
+            var registration = services.FirstOrDefault(s => s.ServiceType == implementation);
             if (registration != null)
             {
                 var newRegistration = new ServiceDescriptor(
-                    typeof(TService),
-                    sp => sp.GetRequiredService<TImplementation>(),
+                    service,
+                    sp => sp.GetRequiredService(implementation),
                     registration.Lifetime);
                 services.Add(newRegistration);
             }


### PR DESCRIPTION
* Added `AddFromExisting` overload to support `Type`s for service and implementation instead of generics.
* Reverted `LinuxEnvironmentStatisticsValidator` since it fails on other OSes after warning is thrown.
* Consolidated `UseLinuxEnvironmentStatistics` registrations.
* Added platform check in `UseLinuxEnvironmentStatistics` to avoid registrations in other OSes.