### PR TITLE
Use the overload of ConcurrentDictionary.GetOrAdd that takes a method

### DIFF
--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -245,7 +245,7 @@ namespace Orleans.Providers
         /// <returns></returns>
         private IMemoryStreamQueueGrain GetQueueGrain(QueueId queueId)
         {
-            return queueGrains.GetOrAdd(queueId, grainFactory.GetGrain<IMemoryStreamQueueGrain>(GenerateDeterministicGuid(queueId)));
+            return queueGrains.GetOrAdd(queueId, id => grainFactory.GetGrain<IMemoryStreamQueueGrain>(GenerateDeterministicGuid(id)));
         }
 
         public static MemoryAdapterFactory<TSerializer> Create(IServiceProvider services, string name)


### PR DESCRIPTION
I was just browsing the code, and noticed this randomly.
It seems like it wasn't actually useful previously, as the dictionary seems to be an attempt to not have to call `GenerateDeterministicGuid` every time it tries to get the queue grain.