### PR TITLE
WIP: AWS S3 Grain Storage Provider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -185,6 +185,8 @@ csharp_new_line_before_members_in_anonymous_types                        = true
 csharp_new_line_before_members_in_object_initializers                    = true
 csharp_new_line_before_open_brace                                        = all
 csharp_new_line_between_query_expression_clauses                         = true
+csharp_new_line_before_members_in_object_initializers                    = false
+
 # Spacing Options
 csharp_space_after_cast                                                  = false
 csharp_space_after_colon_in_inheritance_clause                           = true

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -200,7 +200,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Connections.Securit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Connections.Security.Tests", "test\Orleans.Connections.Security.Tests\Orleans.Connections.Security.Tests.csproj", "{D53D80CC-3E14-4499-B03F-610A5D3F6359}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orleans.GrainDirectory.AzureStorage", "src\Azure\Orleans.GrainDirectory.AzureStorage\Orleans.GrainDirectory.AzureStorage.csproj", "{16B9B850-ED3B-4B45-B0F2-3F802D44F382}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.GrainDirectory.AzureStorage", "src\Azure\Orleans.GrainDirectory.AzureStorage\Orleans.GrainDirectory.AzureStorage.csproj", "{16B9B850-ED3B-4B45-B0F2-3F802D44F382}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Persistence.S3", "src\AWS\Orleans.Persistence.S3\Orleans.Persistence.S3.csproj", "{7A261F31-76F6-4BE4-9A82-C496A094B46E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1220,6 +1222,18 @@ Global
 		{16B9B850-ED3B-4B45-B0F2-3F802D44F382}.Release|x64.Build.0 = Release|Any CPU
 		{16B9B850-ED3B-4B45-B0F2-3F802D44F382}.Release|x86.ActiveCfg = Release|Any CPU
 		{16B9B850-ED3B-4B45-B0F2-3F802D44F382}.Release|x86.Build.0 = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|x64.Build.0 = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Debug|x86.Build.0 = Debug|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|x64.ActiveCfg = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|x64.Build.0 = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|x86.ActiveCfg = Release|Any CPU
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1322,6 +1336,7 @@ Global
 		{8E01A6EB-DE96-4DFD-AA7D-B07078F12372} = {FE2E08C6-9C3B-4AEE-AE07-CCA387580D7A}
 		{D53D80CC-3E14-4499-B03F-610A5D3F6359} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
 		{16B9B850-ED3B-4B45-B0F2-3F802D44F382} = {4C5D66BF-EE1C-4DD8-8551-D1B7F3768A34}
+		{7A261F31-76F6-4BE4-9A82-C496A094B46E} = {DA8E126B-BCDB-4E8F-BFB9-2DBFD41F8F70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/src/AWS/Orleans.Persistence.S3/DefaultS3GrainStorageKeyFormatter.cs
+++ b/src/AWS/Orleans.Persistence.S3/DefaultS3GrainStorageKeyFormatter.cs
@@ -1,0 +1,9 @@
+using Orleans.Runtime;
+
+namespace Orleans.Persistence.S3
+{
+    public class DefaultS3GrainStorageKeyFormatter : IS3GrainStorageKeyFormatter
+    {
+        public string FormatKey(string name, string grainType, GrainReference grainReference) => $"{name}/{grainReference.ToShortKeyString()}/{grainType}";
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/GrainStateExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/GrainStateExtensions.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Orleans.Persistence.S3 {
+    internal static class GrainStateExtensions
+    {
+        public static object CreateDefaultState(this IGrainState grainState) => Activator.CreateInstance(grainState.Type);
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Orleans.Persistence.S3.Hosting
         /// <summary>
         /// Configure silo to use AWS S3 storage for grain storage.
         /// </summary>
-        public static ISiloHostBuilder AddS3GrainStorageAsDefault(this ISiloHostBuilder builder, string name, Action<S3StorageOptions> configureOptions) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
+        public static ISiloHostBuilder AddS3GrainStorage(this ISiloHostBuilder builder, string name, Action<S3StorageOptions> configureOptions) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
 
         /// <summary>
         /// Configure silo to use AWS S3 storage as the default grain storage.

--- a/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
@@ -1,0 +1,89 @@
+using System;
+using Amazon.S3;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Persistence.S3.Options;
+using Orleans.Persistence.S3.Provider;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.S3.Hosting
+{
+    public static class S3SiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static ISiloHostBuilder AddS3GrainStorageAsDefault(this ISiloHostBuilder builder, Action<S3StorageOptions> configureOptions) => builder.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static ISiloHostBuilder AddS3GrainStorageAsDefault(this ISiloHostBuilder builder, string name, Action<S3StorageOptions> configureOptions) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static ISiloHostBuilder AddS3GrainStorageAsDefault(this ISiloHostBuilder builder, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null) => builder.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static ISiloHostBuilder AddS3GrainStorage(this ISiloHostBuilder builder, string name, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static ISiloBuilder AddS3GrainStorage(this ISiloBuilder builder, Action<S3StorageOptions> configureOptions) => builder.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static ISiloBuilder AddS3GrainStorage(this ISiloBuilder builder, string name, Action<S3StorageOptions> configureOptions) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static ISiloBuilder AddS3GrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null) => builder.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static ISiloBuilder AddS3GrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null) => builder.ConfigureServices(services => services.AddS3GrainStorage(name, configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static IServiceCollection AddS3GrainStorageAsDefault(this IServiceCollection services, Action<S3StorageOptions> configureOptions) => services.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, ob => ob.Configure(configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static IServiceCollection AddS3GrainStorage(this IServiceCollection services, string name, Action<S3StorageOptions> configureOptions) => services.AddS3GrainStorage(name, ob => ob.Configure(configureOptions));
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage as the default grain storage.
+        /// </summary>
+        public static IServiceCollection AddS3GrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null) => services.AddS3GrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+
+        /// <summary>
+        /// Configure silo to use AWS S3 storage for grain storage.
+        /// </summary>
+        public static IServiceCollection AddS3GrainStorage(this IServiceCollection services, string name, Action<OptionsBuilder<S3StorageOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<S3StorageOptions>(name));
+            //services.AddTransient<IConfigurationValidator>(sp => new S3GrainStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<S3StorageOptions>>().Get(name), name));
+            services.ConfigureNamedOptionForLogging<S3StorageOptions>(name);
+            services.AddSingletonNamedService<IS3GrainStorageKeyFormatter, DefaultS3GrainStorageKeyFormatter>(name);
+            services.AddSingletonNamedService<IAmazonS3, AmazonS3Client>(name);
+            services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            return services
+                .AddSingletonNamedService<IGrainStorage>(name, (s, n) => ActivatorUtilities.CreateInstance<S3GrainStorage>(s, name, s.GetOptionsByName<S3StorageOptions>(name)))
+                .AddSingletonNamedService(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/Hosting/S3SiloBuilderExtensions.cs
@@ -83,7 +83,7 @@ namespace Orleans.Persistence.S3.Hosting
             services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             return services
                 .AddSingletonNamedService<IGrainStorage>(name, (s, n) => ActivatorUtilities.CreateInstance<S3GrainStorage>(s, name, s.GetOptionsByName<S3StorageOptions>(name)))
-                .AddSingletonNamedService(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+                ;
         }
     }
 }

--- a/src/AWS/Orleans.Persistence.S3/IS3GrainStorageKeyFormatter.cs
+++ b/src/AWS/Orleans.Persistence.S3/IS3GrainStorageKeyFormatter.cs
@@ -1,0 +1,9 @@
+using Orleans.Runtime;
+
+namespace Orleans.Persistence.S3
+{
+    public interface IS3GrainStorageKeyFormatter
+    {
+        string FormatKey(string name, string grainType, GrainReference grainReference);
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/Options/S3StorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.S3/Options/S3StorageOptions.cs
@@ -1,9 +1,6 @@
 namespace Orleans.Persistence.S3.Options {
     public class S3StorageOptions
     {
-        public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
-
-        public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
         public string BucketName { get; set; }
     }
 }

--- a/src/AWS/Orleans.Persistence.S3/Options/S3StorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.S3/Options/S3StorageOptions.cs
@@ -1,0 +1,9 @@
+namespace Orleans.Persistence.S3.Options {
+    public class S3StorageOptions
+    {
+        public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
+
+        public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
+        public string BucketName { get; set; }
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/Orleans.Persistence.S3.csproj
+++ b/src/AWS/Orleans.Persistence.S3/Orleans.Persistence.S3.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Microsoft.Orleans.Persistence.S3</PackageId>
+    <Title>Microsoft Orleans Persistence S3</Title>
+    <Description>Microsoft Orleans persistence providers for AWS S3</Description>
+    <PackageTags>$(PackageTags) AWS S3</PackageTags>
+    <TargetFrameworks>$(StandardTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyName>Orleans.Persistence.S3</AssemblyName>
+    <RootNamespace>Orleans.Persistence.S3</RootNamespace>
+    <DefineConstants>$(DefineConstants);PERSISTENCE_S3</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.3.110.38" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/AWS/Orleans.Persistence.S3/Provider/S3GrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.S3/Provider/S3GrainStorage.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+using Orleans.Persistence.S3.Options;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.S3.Provider
+{
+    public class S3GrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
+    {
+        private readonly string name;
+        private readonly S3StorageOptions options;
+        private readonly SerializationManager serializationManager;
+        private readonly IAmazonS3 s3;
+        private readonly IS3GrainStorageKeyFormatter keyFormatter;
+        private readonly ILogger logger;
+
+        public S3GrainStorage(
+            string name,
+            S3StorageOptions options,
+            SerializationManager serializationManager,
+            IAmazonS3 s3,
+            IS3GrainStorageKeyFormatter keyFormatter,
+            ILoggerFactory loggerFactory)
+        {
+            this.name = name;
+            this.options = options;
+            this.serializationManager = serializationManager;
+            this.s3 = s3;
+            this.keyFormatter = keyFormatter;
+
+            this.logger = loggerFactory.CreateLogger($"{typeof(S3GrainStorage).FullName}.{name}");
+        }
+
+        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            this.logger.Trace(ErrorCode.StorageProviderBase,
+                "Reading: GrainType={GrainType} GrainId={GrainId} from Bucket={BucketName}",
+                grainType, grainReference, this.options.BucketName);
+            try
+            {
+                using (var response = await this.s3.GetObjectAsync(new GetObjectRequest
+                {
+                    BucketName = this.options.BucketName,
+                    EtagToMatch = grainState.ETag,
+                    Key = this.keyFormatter.FormatKey(this.name, grainType, grainReference)
+                }).ConfigureAwait(false))
+                using (response.ResponseStream)
+                {
+                    grainState.ETag = response.ETag;
+
+                    var data = await response.ResponseStream
+                        .AsArraySegmentAsync((int)response.ContentLength)
+                        .ConfigureAwait(false);
+
+                    this.serializationManager.DeserializeToState(grainState, data);
+                }
+            }
+            catch (AmazonS3Exception e) when (e.StatusCode == HttpStatusCode.NotFound)
+            {
+                grainState.State = grainState.CreateDefaultState();
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(new EventId((int)ErrorCode.StorageProviderBase), e,
+                    "Error Reading: GrainType={GrainType} GrainId={GrainId} ETag={ETag} to BucketName={BucketName} Exception={Exception}",
+                    grainType, grainReference, grainState.ETag, this.options.BucketName, e.Message);
+                throw;
+            }
+        }
+
+        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            if (this.logger.IsEnabled(LogLevel.Trace))
+            {
+                this.logger.Trace(ErrorCode.StorageProviderBase,
+                    "Writing: GrainType={GrainType} GrainId={GrainId} from Bucket={BucketName}",
+                    grainType, grainReference, this.options.BucketName);
+            }
+
+            try
+            {
+                await this.s3.PutObjectAsync(new PutObjectRequest
+                {
+                    BucketName = this.options.BucketName,
+                    Key = this.keyFormatter.FormatKey(this.name, grainType, grainReference),
+                    InputStream = this.serializationManager
+                        .SerializeFromState(grainState)
+                        .AsMemoryStream()
+                }).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(new EventId((int)ErrorCode.StorageProviderBase), e,
+                    "Error Writing: GrainType={GrainType} GrainId={GrainId} ETag={ETag} to BucketName={BucketName} Exception={Exception}",
+                    grainType, grainReference, grainState.ETag, this.options.BucketName, e.Message);
+                throw;
+            }
+        }
+
+        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            try
+            {
+                await this.s3.DeleteObjectAsync(new DeleteObjectRequest
+                {
+                    BucketName = this.options.BucketName,
+                    Key = this.keyFormatter.FormatKey(this.name, grainType, grainReference)
+                }).ConfigureAwait(false);
+            }
+            catch (AmazonS3Exception e) when (e.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Ignore not found errors
+            }
+        }
+
+        public void Participate(ISiloLifecycle lifecycle) => lifecycle.Subscribe<S3GrainStorage>(this.options.InitStage, this);
+        public Task OnStart(CancellationToken ct) => Task.CompletedTask;
+        public Task OnStop(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/Provider/S3GrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.S3/Provider/S3GrainStorage.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Net;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -13,7 +11,7 @@ using Orleans.Storage;
 
 namespace Orleans.Persistence.S3.Provider
 {
-    public class S3GrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
+    public class S3GrainStorage : IGrainStorage
     {
         private readonly string name;
         private readonly S3StorageOptions options;
@@ -120,9 +118,5 @@ namespace Orleans.Persistence.S3.Provider
                 // Ignore not found errors
             }
         }
-
-        public void Participate(ISiloLifecycle lifecycle) => lifecycle.Subscribe<S3GrainStorage>(this.options.InitStage, this);
-        public Task OnStart(CancellationToken ct) => Task.CompletedTask;
-        public Task OnStop(CancellationToken ct) => Task.CompletedTask;
     }
 }

--- a/src/AWS/Orleans.Persistence.S3/SerializationManagerExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/SerializationManagerExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Orleans.Serialization;
+
+namespace Orleans.Persistence.S3 {
+    internal static class SerializationManagerExtensions
+    {
+
+        public static object Deserialize(this SerializationManager serializationManager, ArraySegment<byte> data) =>
+            data.Count > 0
+                ? serializationManager.Deserialize(new BinaryTokenStreamReader(data))
+                : null;
+
+        public static void DeserializeToState(this SerializationManager serializationManager, IGrainState grainState, ArraySegment<byte> data) =>
+            grainState.State =
+                serializationManager.Deserialize(data)
+                ?? grainState.CreateDefaultState();
+
+        public static ArraySegment<byte> SerializeFromState(this SerializationManager serializationManager, IGrainState grainState)
+        {
+            var writer = new BinaryTokenStreamWriter();
+            serializationManager.Serialize(grainState.State, writer);
+            return writer
+                .ToBytes()
+                .MergeToSingleSegment();
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/StreamExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/StreamExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Persistence.S3 {
+    internal static class StreamExtensions
+    {
+        public static ArraySegment<byte> AsArraySegment(this MemoryStream mem)
+            => mem.TryGetBuffer(out var buffer)
+                ? buffer
+                : new ArraySegment<byte>(mem.ToArray());
+
+        public static async Task<ArraySegment<byte>> AsArraySegmentAsync(this Stream stream, int initialCapacity, CancellationToken cancellationToken = default)
+        {
+            if (!(stream is MemoryStream mem))
+            {
+                mem = initialCapacity == 0 ? new MemoryStream() : new MemoryStream(initialCapacity);
+                await stream
+                    .CopyToAsync(mem, 8192, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return mem.AsArraySegment();
+        }
+
+        public static ArraySegment<byte> MergeToSingleSegment(this IReadOnlyList<ArraySegment<byte>> segments)
+        {
+            if (segments.Count == 1)
+            {
+                return segments[0];
+            }
+
+            var size = segments.Sum(x => x.Count);
+            var buffer = new byte[size];
+            var offset = 0;
+            foreach (var segment in segments)
+            {
+                Buffer.BlockCopy(segment.Array, segment.Offset, buffer, offset, segment.Count);
+                offset += segment.Count;
+            }
+
+            return new ArraySegment<byte>(buffer);
+        }
+
+        public static MemoryStream AsMemoryStream(this ArraySegment<byte> bytes, bool writable = false) => new MemoryStream(bytes.Array, bytes.Offset, bytes.Count, writable, true);
+
+
+        public static async Task<IReadOnlyList<ArraySegment<byte>>> ReadSegmentsAsync(this Stream stream)
+        {
+            var result = new List<ArraySegment<byte>>();
+            const int bufferSize = 8192;
+            while (true)
+            {
+                var buffer = new byte[bufferSize];
+                var bytesRead = await stream
+                    .ReadAsync(buffer, 0, buffer.Length)
+                    .ConfigureAwait(false);
+                if (bytesRead > 0)
+                {
+                    result.Add(new ArraySegment<byte>(buffer, 0, bytesRead));
+                }
+
+                if (bytesRead < bufferSize)
+                {
+                    break;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.S3/StreamExtensions.cs
+++ b/src/AWS/Orleans.Persistence.S3/StreamExtensions.cs
@@ -5,7 +5,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Orleans.Persistence.S3 {
+namespace Orleans.Persistence.S3
+{
     internal static class StreamExtensions
     {
         public static ArraySegment<byte> AsArraySegment(this MemoryStream mem)
@@ -28,9 +29,9 @@ namespace Orleans.Persistence.S3 {
 
         public static ArraySegment<byte> MergeToSingleSegment(this IReadOnlyList<ArraySegment<byte>> segments)
         {
-            if (segments.Count == 1)
-            {
-                return segments[0];
+            switch( segments.Count ) {
+                case 0: return default(ArraySegment<byte>);
+                case 1: return segments[0];
             }
 
             var size = segments.Sum(x => x.Count);
@@ -46,30 +47,5 @@ namespace Orleans.Persistence.S3 {
         }
 
         public static MemoryStream AsMemoryStream(this ArraySegment<byte> bytes, bool writable = false) => new MemoryStream(bytes.Array, bytes.Offset, bytes.Count, writable, true);
-
-
-        public static async Task<IReadOnlyList<ArraySegment<byte>>> ReadSegmentsAsync(this Stream stream)
-        {
-            var result = new List<ArraySegment<byte>>();
-            const int bufferSize = 8192;
-            while (true)
-            {
-                var buffer = new byte[bufferSize];
-                var bytesRead = await stream
-                    .ReadAsync(buffer, 0, buffer.Length)
-                    .ConfigureAwait(false);
-                if (bytesRead > 0)
-                {
-                    result.Add(new ArraySegment<byte>(buffer, 0, bytesRead));
-                }
-
-                if (bytesRead < bufferSize)
-                {
-                    break;
-                }
-            }
-
-            return result;
-        }
     }
 }


### PR DESCRIPTION
S3 is a viable alternative for slow state access grains that have a small or large state.

It's very inexpensive and supports a huge read/write capacity, although much slower than `DynamoDB`

Typical costs:
```
  $5   / million writes
  $0.4 / million reads
 (+ data transfer costs)
```

It's very efficient for heavy reads but can get pretty expensive on heavy writes compared to DynamoDB.

Heads up; This is *NOT* a slower 1:1 alternative to `DynamoDB` as `S3` offers fewer data guarantees compared `DynamoDB`. For example, putting an existing object on S3 has eventual consistency while creating an object has instant consistency. There is no way that I know of that allows for optimistic locking or conditional writes.