### PR TITLE
Avoid most cases of loggers with non-static category names

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,26 +18,30 @@ namespace Orleans.Clustering.DynamoDB
         private DynamoDBStorage storage;
         private string clusterId;
         private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString();
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILogger logger;
         private readonly DynamoDBGatewayOptions options;
-        private readonly TimeSpan maxStaleness;
 
         public DynamoDBGatewayListProvider(
-            ILoggerFactory loggerFactory, 
+            ILogger<DynamoDBGatewayListProvider> logger, 
             IOptions<DynamoDBGatewayOptions> options,
             IOptions<ClusterOptions> clusterOptions, 
             IOptions<GatewayOptions> gatewayOptions)
         {
-            this.loggerFactory = loggerFactory;
+            this.logger = logger;
             this.options = options.Value;
             this.clusterId = clusterOptions.Value.ClusterId;
-            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
+            this.MaxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 
         public Task InitializeGatewayListProvider()
         {
-            this.storage = new DynamoDBStorage(this.loggerFactory, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(
+                this.logger,
+                this.options.Service,
+                this.options.AccessKey,
+                this.options.SecretKey,
+                this.options.ReadCapacityUnits,
+                this.options.WriteCapacityUnits);
 
             return this.storage.InitializeTable(this.options.TableName,
                 new List<KeySchemaElement>
@@ -79,10 +83,7 @@ namespace Orleans.Clustering.DynamoDB
             return records;
         }
 
-        public TimeSpan MaxStaleness
-        {
-            get { return this.maxStaleness; }
-        }
+        public TimeSpan MaxStaleness { get; }
 
         public bool IsUpdatable
         {

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -23,7 +23,6 @@ namespace Orleans.Clustering.DynamoDB
         private const int MAX_BATCH_SIZE = 25;
 
         private readonly ILogger logger;
-        private readonly ILoggerFactory loggerFactory;
         private DynamoDBStorage storage;
         private readonly DynamoDBClusteringOptions options;
         private readonly string clusterId;
@@ -33,7 +32,6 @@ namespace Orleans.Clustering.DynamoDB
             IOptions<DynamoDBClusteringOptions> clusteringOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
-            this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();
             this.options = clusteringOptions.Value;
             this.clusterId = clusterOptions.Value.ClusterId;
@@ -41,7 +39,7 @@ namespace Orleans.Clustering.DynamoDB
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            this.storage = new DynamoDBStorage(this.loggerFactory, this.options.Service, this.options.AccessKey, this.options.SecretKey,
+            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
                   this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -35,7 +35,6 @@ namespace Orleans.Storage
 
         private readonly DynamoDBStorageOptions options;
         private readonly SerializationManager serializationManager;
-        private readonly ILoggerFactory loggerFactory;
         private readonly ILogger logger;
         private readonly IGrainFactory grainFactory;
         private readonly ITypeResolver typeResolver;
@@ -47,13 +46,16 @@ namespace Orleans.Storage
         /// <summary>
         /// Default Constructor
         /// </summary>
-        public DynamoDBGrainStorage(string name, DynamoDBStorageOptions options, SerializationManager serializationManager,
-            IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
+        public DynamoDBGrainStorage(
+            string name,
+            DynamoDBStorageOptions options,
+            SerializationManager serializationManager,
+            IGrainFactory grainFactory,
+            ITypeResolver typeResolver,
+            ILogger<DynamoDBGrainStorage> logger)
         {
             this.name = name;
-            this.loggerFactory = loggerFactory;
-            var loggerName = $"{typeof(DynamoDBGrainStorage).FullName}.{name}";
-            this.logger = loggerFactory.CreateLogger(loggerName);
+            this.logger = logger;
             this.options = options;
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;
@@ -82,7 +84,7 @@ namespace Orleans.Storage
 
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
-                this.storage = new DynamoDBStorage(this.loggerFactory, this.options.Service, this.options.AccessKey, this.options.SecretKey,
+                this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
 
                 await storage.InitializeTable(this.options.TableName,

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -30,7 +30,6 @@ namespace Orleans.Reminders.DynamoDB
 
         private readonly ILogger logger;
         private readonly IGrainReferenceConverter grainReferenceConverter;
-        private readonly ILoggerFactory loggerFactory;
         private readonly DynamoDBReminderStorageOptions options;
         private readonly string serviceId;
 
@@ -49,7 +48,6 @@ namespace Orleans.Reminders.DynamoDB
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = loggerFactory.CreateLogger<DynamoDBReminderTable>();
-            this.loggerFactory = loggerFactory;
             this.serviceId = clusterOptions.Value.ServiceId;
             this.options = storageOptions.Value;
         }
@@ -57,7 +55,7 @@ namespace Orleans.Reminders.DynamoDB
         /// <summary>Initialize current instance with specific global configuration and logger</summary>
         public Task Init()
         {
-            this.storage = new DynamoDBStorage(this.loggerFactory, this.options.Service, this.options.AccessKey, this.options.SecretKey,
+            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -45,15 +45,18 @@ namespace Orleans.Transactions.DynamoDB
         /// <summary>
         /// Create a DynamoDBStorage instance
         /// </summary>
-        /// <param name="loggerFactory"></param>
+        /// <param name="logger"></param>
         /// <param name="accessKey"></param>
         /// <param name="secretKey"></param>
         /// <param name="service"></param>
         /// <param name="readCapacityUnits"></param>
         /// <param name="writeCapacityUnits"></param>
         /// <param name="useProvisionedThroughput"></param>
-        public DynamoDBStorage(ILoggerFactory loggerFactory, string service,
-            string accessKey = "", string secretKey = "",
+        public DynamoDBStorage(
+            ILogger logger,
+            string service,
+            string accessKey = "",
+            string secretKey = "",
             int readCapacityUnits = DefaultReadCapacityUnits,
             int writeCapacityUnits = DefaultWriteCapacityUnits,
             bool useProvisionedThroughput = true)
@@ -65,7 +68,7 @@ namespace Orleans.Transactions.DynamoDB
             this.readCapacityUnits = readCapacityUnits;
             this.writeCapacityUnits = writeCapacityUnits;
             this.useProvisionedThroughput = useProvisionedThroughput;
-            Logger = loggerFactory.CreateLogger<DynamoDBStorage>();
+            Logger = logger;
             CreateClient();
         }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -35,7 +35,9 @@ namespace Orleans.AzureUtils
             TableName = tableName;
             logger = loggerFactory.CreateLogger<OrleansSiloInstanceManager>();
             storage = new AzureTableDataManager<SiloInstanceTableEntry>(
-                tableName, storageConnectionString, loggerFactory);
+                tableName,
+                storageConnectionString,
+                loggerFactory.CreateLogger<AzureTableDataManager<SiloInstanceTableEntry>>());
         }
 
         public static async Task<OrleansSiloInstanceManager> GetManager(string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
@@ -55,7 +55,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             this.tableDataManager = new AzureTableDataManager<GrainDirectoryEntity>(
                 tableName: directoryOptions.Value.TableName,
                 storageConnectionString: directoryOptions.Value.ConnectionString,
-                loggerFactory: loggerFactory);
+                loggerFactory.CreateLogger<AzureTableDataManager<GrainDirectoryEntity>>());
             this.clusterId = clusterOptions.Value.ClusterId;
         }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -33,7 +33,6 @@ namespace Orleans.Storage
         private SerializationManager serializationManager;
         private IGrainFactory grainFactory;
         private ITypeResolver typeResolver;
-        private ILoggerFactory loggerFactory;
 
         /// <summary> Default constructor </summary>
         public AzureBlobGrainStorage(
@@ -42,15 +41,14 @@ namespace Orleans.Storage
             SerializationManager serializationManager,
             IGrainFactory grainFactory,
             ITypeResolver typeResolver,
-            ILoggerFactory loggerFactory)
+            ILogger<AzureBlobGrainStorage> logger)
         {
             this.name = name;
             this.options = options;
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;
             this.typeResolver = typeResolver;
-            this.loggerFactory = loggerFactory;
-            this.logger = this.loggerFactory.CreateLogger($"{typeof(AzureTableGrainStorageFactory).FullName}.{name}");
+            this.logger = logger;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -32,7 +32,6 @@ namespace Orleans.Storage
         private readonly SerializationManager serializationManager;
         private readonly IGrainFactory grainFactory;
         private readonly ITypeResolver typeResolver;
-        private readonly ILoggerFactory loggerFactory;
         private readonly ILogger logger;
 
         private GrainStateTableDataManager tableDataManager;
@@ -49,8 +48,14 @@ namespace Orleans.Storage
         private string name;
 
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, IOptions<ClusterOptions> clusterOptions, SerializationManager serializationManager,
-            IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
+        public AzureTableGrainStorage(
+            string name,
+            AzureTableStorageOptions options,
+            IOptions<ClusterOptions> clusterOptions,
+            SerializationManager serializationManager,
+            IGrainFactory grainFactory,
+            ITypeResolver typeResolver,
+            ILogger<AzureTableGrainStorage> logger)
         {
             this.options = options;
             this.clusterOptions = clusterOptions.Value;
@@ -58,9 +63,7 @@ namespace Orleans.Storage
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;
             this.typeResolver = typeResolver;
-            this.loggerFactory = loggerFactory;
-            var loggerName = $"{typeof(AzureTableGrainStorageFactory).FullName}.{name}";
-            this.logger = this.loggerFactory.CreateLogger(loggerName);
+            this.logger = logger;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>
@@ -397,11 +400,11 @@ namespace Orleans.Storage
             private readonly AzureTableDataManager<DynamicTableEntity> tableManager;
             private readonly ILogger logger;
 
-            public GrainStateTableDataManager(string tableName, string storageConnectionString, ILoggerFactory loggerFactory)
+            public GrainStateTableDataManager(string tableName, string storageConnectionString, ILogger logger)
             {
-                this.logger = loggerFactory.CreateLogger<GrainStateTableDataManager>();
+                this.logger = logger;
                 TableName = tableName;
-                tableManager = new AzureTableDataManager<DynamicTableEntity>(tableName, storageConnectionString, loggerFactory);
+                tableManager = new AzureTableDataManager<DynamicTableEntity>(tableName, storageConnectionString, logger);
             }
 
             public Task InitTableAsync()
@@ -477,7 +480,7 @@ namespace Orleans.Storage
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, $"AzureTableGrainStorage {name} is using DataConnectionString: {ConfigUtilities.RedactConnectionStringInfo(this.options.ConnectionString)}");
                 this.JsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.typeResolver, this.grainFactory), this.options.UseFullAssemblyNames, this.options.IndentJson, this.options.TypeNameHandling);
                 this.options.ConfigureJsonSerializerSettings?.Invoke(this.JsonSettings);
-                this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.ConnectionString, this.loggerFactory);
+                this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.ConnectionString, this.logger);
                 await this.tableDataManager.InitTableAsync();
                 stopWatch.Stop();
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"Initializing provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} took {stopWatch.ElapsedMilliseconds} Milliseconds.");

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -100,7 +100,7 @@ namespace Orleans.Runtime.ReminderService
         }
 
         private RemindersTableManager(string serviceId, string clusterId, string storageConnectionString, string tableName, ILoggerFactory loggerFactory)
-            : base(tableName, storageConnectionString, loggerFactory)
+            : base(tableName, storageConnectionString, loggerFactory.CreateLogger<RemindersTableManager>())
         {
             ClusterId = clusterId;
             ServiceId = serviceId;

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -48,7 +48,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
             this.clusterId = clusterId;
             ShouldFaultSubsriptionOnError = faultOnFailure;
             this.createEntity = createEntity ?? DefaultCreateEntity;
-            dataManager = new AzureTableDataManager<TEntity>(tableName, storageConnectionString, loggerFactory);
+            dataManager = new AzureTableDataManager<TEntity>(tableName, storageConnectionString, loggerFactory.CreateLogger<AzureTableDataManager<TEntity>>());
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Streams;
@@ -89,7 +89,7 @@ namespace Orleans.ServiceBus.Providers
             this.logger = loggerFactory.CreateLogger<EventHubCheckpointer>();
             this.logger.LogInformation($"Creating EventHub checkpointer for partition {partition} of stream provider {streamProviderName} with serviceId {serviceId}.");
             persistInterval = options.PersistInterval;
-            dataManager = new AzureTableDataManager<EventHubPartitionCheckpointEntity>(options.TableName, options.ConnectionString, loggerFactory);
+            dataManager = new AzureTableDataManager<EventHubPartitionCheckpointEntity>(options.TableName, options.ConnectionString, loggerFactory.CreateLogger<AzureTableDataManager<EventHubPartitionCheckpointEntity>>());
             entity = EventHubPartitionCheckpointEntity.Create(streamProviderName, serviceId, partition);
         }
 

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -58,7 +58,7 @@ namespace Orleans.Transactions.AzureStorage
 
         private async Task CreateTable()
         {
-            var tableManager = new AzureTableDataManager<TableEntity>(this.options.TableName, this.options.ConnectionString, this.loggerFactory);
+            var tableManager = new AzureTableDataManager<TableEntity>(this.options.TableName, this.options.ConnectionString, this.loggerFactory.CreateLogger<AzureTableDataManager<TableEntity>>());
             await tableManager.InitTableAsync().ConfigureAwait(false);
             this.table = tableManager.Table;
         }

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -57,10 +57,10 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// </summary>
         /// <param name="tableName">Name of the table to be connected to.</param>
         /// <param name="storageConnectionString">Connection string for the Azure storage account used to host this table.</param>
-        /// <param name="loggerFactory">Logger factory to use.</param>
-        public AzureTableDataManager(string tableName, string storageConnectionString, ILoggerFactory loggerFactory)
+        /// <param name="logger">Logger to use.</param>
+        public AzureTableDataManager(string tableName, string storageConnectionString, ILogger logger)
         {
-            Logger = loggerFactory.CreateLogger<AzureTableDataManager<T>>();
+            Logger = logger;
             TableName = tableName;
             ConnectionString = storageConnectionString;
 

--- a/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
+++ b/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,7 +45,7 @@ namespace Orleans.Hosting
             var codeGenerator = new RoslynCodeGenerator(tempPartManager, loggerFactory);
             var generatedAssembly = codeGenerator.GenerateAndLoadForAssemblies(manager.Assemblies);
             stopWatch.Stop();
-            var logger = loggerFactory.CreateLogger("RuntimeCodeGen");
+            var logger = loggerFactory.CreateLogger("Orleans.CodeGenerator.RuntimeCodeGen");
             logger?.LogInformation(0, $"Runtime code generation for assemblies {String.Join(",", manager.Assemblies.ToStrings())} took {stopWatch.ElapsedMilliseconds} milliseconds");
             return manager.AddApplicationPart(generatedAssembly);
         }

--- a/src/Orleans.Core/Diagnostics/MessagingTrace.cs
+++ b/src/Orleans.Core/Diagnostics/MessagingTrace.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
 {
     internal class MessagingTrace : DiagnosticListener, ILogger
     {
-        public const string Category = "Microsoft.Orleans.Messaging";
+        public const string Category = "Orleans.Messaging";
 
         public const string CreateMessageEventName = Category + ".CreateMessage";
         public const string SendMessageEventName = Category + ".Outbound.Send";

--- a/src/Orleans.Core/Diagnostics/MessagingTrace.cs
+++ b/src/Orleans.Core/Diagnostics/MessagingTrace.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
 {
     internal class MessagingTrace : DiagnosticListener, ILogger
     {
-        public const string Category = "Orleans.Messaging";
+        public const string Category = "Microsoft.Orleans.Messaging";
 
         public const string CreateMessageEventName = Category + ".CreateMessage";
         public const string SendMessageEventName = Category + ".Outbound.Send";

--- a/src/Orleans.Core/Networking/NetworkingTrace.cs
+++ b/src/Orleans.Core/Networking/NetworkingTrace.cs
@@ -9,9 +9,9 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly ILogger log;
 
-        public NetworkingTrace(ILoggerFactory loggerFactory) : base("Orleans.Networking")
+        public NetworkingTrace(ILoggerFactory loggerFactory) : base("Microsoft.Orleans.Networking")
         {
-            this.log = loggerFactory.CreateLogger("Orleans.Networking");
+            this.log = loggerFactory.CreateLogger("Microsoft.Orleans.Networking");
         }
 
         public IDisposable BeginScope<TState>(TState state)

--- a/src/Orleans.Core/Networking/NetworkingTrace.cs
+++ b/src/Orleans.Core/Networking/NetworkingTrace.cs
@@ -9,9 +9,9 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly ILogger log;
 
-        public NetworkingTrace(ILoggerFactory loggerFactory) : base("Microsoft.Orleans.Networking")
+        public NetworkingTrace(ILoggerFactory loggerFactory) : base("Orleans.Networking")
         {
-            this.log = loggerFactory.CreateLogger("Microsoft.Orleans.Networking");
+            this.log = loggerFactory.CreateLogger("Orleans.Networking");
         }
 
         public IDisposable BeginScope<TState>(TState state)

--- a/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Runtime/TaskSchedulerAgent.cs
@@ -24,40 +24,27 @@ namespace Orleans.Runtime
         protected CancellationTokenSource Cts;
         protected object Lockable;
         protected ILogger Log;
-        protected ILoggerFactory loggerFactory;
-        protected readonly string type;
         protected FaultBehavior OnFault;
         protected bool disposed;
 
         public AgentState State { get; private set; }
         internal string Name { get; private set; }
 
-        protected TaskSchedulerAgent(ILoggerFactory loggerFactory) : this(null, loggerFactory) { }
-
-        protected TaskSchedulerAgent(string nameSuffix, ILoggerFactory loggerFactory)
+        protected TaskSchedulerAgent(ILoggerFactory loggerFactory)
         {
             Cts = new CancellationTokenSource();
-            var thisType = GetType();
 
-            type = thisType.Namespace + "." + thisType.Name;
-            if (type.StartsWith("Orleans.", StringComparison.Ordinal))
+            this.Log = loggerFactory.CreateLogger(this.GetType());
+            var typeName = GetType().FullName;
+            if (typeName.StartsWith("Orleans.", StringComparison.Ordinal))
             {
-                type = type.Substring(8);
+                typeName = typeName.Substring(8);
             }
-            if (!string.IsNullOrEmpty(nameSuffix))
-            {
-                Name = type + "/" + nameSuffix;
-            }
-            else
-            {
-                Name = type;
-            }
+
+            Name = typeName;
 
             Lockable = new object();
             OnFault = FaultBehavior.IgnoreFault;
-
-            this.loggerFactory = loggerFactory;
-            this.Log = loggerFactory.CreateLogger(Name);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/Orleans.Core/Statistics/LogStatistics.cs
+++ b/src/Orleans.Core/Statistics/LogStatistics.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime
             this.loggerFactory = loggerFactory;
             reportFrequency = writeInterval;
             this.serializationStatistics = serializationStatistics;
-            logger = loggerFactory.CreateLogger("Orleans.Runtime" + (isSilo ? "SiloLogStatistics" : "ClientLogStatistics"));
+            logger = loggerFactory.CreateLogger("Orleans.Runtime." + (isSilo ? "SiloLogStatistics" : "ClientLogStatistics"));
         }
 
         internal void Start()

--- a/src/Orleans.Core/Streams/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/PersistentStreamProducer.cs
@@ -22,7 +22,7 @@ namespace Orleans.Streams
             this.queueAdapter = queueAdapter;
             this.serializationManager = serializationManager;
             IsRewindable = isRewindable;
-            var logger = providerUtilities.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(this.GetType().Name);
+            var logger = providerUtilities.ServiceProvider.GetRequiredService<ILogger<PersistentStreamProducer<T>>>();
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Created PersistentStreamProducer for stream {0}, of type {1}, and with Adapter: {2}.",
                 stream.ToString(), typeof (T), this.queueAdapter.Name);
         }

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -26,17 +26,15 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private readonly bool                       fireAndForgetDelivery;
         private readonly bool                       optimizeForImmutableData;
         private readonly ILogger                    logger;
-        private readonly ILoggerFactory             loggerFactory;
 
-        internal SimpleMessageStreamProducerExtension(IStreamProviderRuntime providerRt, IStreamPubSub pubsub, ILoggerFactory loggerFactory, bool fireAndForget, bool optimizeForImmutable)
+        internal SimpleMessageStreamProducerExtension(IStreamProviderRuntime providerRt, IStreamPubSub pubsub, ILogger logger, bool fireAndForget, bool optimizeForImmutable)
         {
             providerRuntime = providerRt;
             streamPubSub = pubsub;
             fireAndForgetDelivery = fireAndForget;
             optimizeForImmutableData = optimizeForImmutable;
             remoteConsumers = new Dictionary<StreamId, StreamConsumerExtensionCollection>();
-            logger = loggerFactory.CreateLogger<SimpleMessageStreamProducerExtension>();
-            this.loggerFactory = loggerFactory;
+            this.logger = logger;
         }
 
         internal void AddStream(StreamId streamId)
@@ -46,7 +44,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             // so this call is only made once, when StreamProducer is created.
             if (remoteConsumers.TryGetValue(streamId, out obs)) return;
 
-            obs = new StreamConsumerExtensionCollection(streamPubSub, this.loggerFactory);
+            obs = new StreamConsumerExtensionCollection(streamPubSub, this.logger);
             remoteConsumers.Add(streamId, obs);
         }
 
@@ -170,11 +168,11 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             private readonly IStreamPubSub streamPubSub;
             private readonly ILogger logger;
 
-            internal StreamConsumerExtensionCollection(IStreamPubSub pubSub, ILoggerFactory loggerFactory)
+            internal StreamConsumerExtensionCollection(IStreamPubSub pubSub, ILogger logger)
             {
-                streamPubSub = pubSub;
-                this.logger = loggerFactory.CreateLogger<StreamConsumerExtensionCollection>();
-                consumers = new ConcurrentDictionary<GuidId, Tuple<IStreamConsumerExtension, IStreamFilterPredicateWrapper>>();
+                this.streamPubSub = pubSub;
+                this.logger = logger;
+                this.consumers = new ConcurrentDictionary<GuidId, Tuple<IStreamConsumerExtension, IStreamFilterPredicateWrapper>>();
             }
 
             internal void AddRemoteSubscriber(GuidId subscriptionId, IStreamConsumerExtension streamConsumer, IStreamFilterPredicateWrapper filter)

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -28,7 +28,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             this.loggerFactory = loggerFactory;
             this.Name = name;
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}");
+            this.logger = loggerFactory.CreateLogger<SimpleMessageStreamProvider>();
             this.options = options;
             this.providerRuntime = providerRuntime as IStreamProviderRuntime;
             this.runtimeClient = providerRuntime.ServiceProvider.GetService<IRuntimeClient>();
@@ -61,9 +61,16 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
-            return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime,
-                this.options.FireAndForgetDelivery, this.options.OptimizeForImmutableData, providerRuntime.PubSub(this.options.PubSubType), IsRewindable,
-                this.serializationManager, this.loggerFactory);
+            return new SimpleMessageStreamProducer<T>(
+                (StreamImpl<T>)stream,
+                Name,
+                providerRuntime,
+                this.options.FireAndForgetDelivery,
+                this.options.OptimizeForImmutableData,
+                providerRuntime.PubSub(this.options.PubSubType),
+                IsRewindable,
+                this.serializationManager,
+                this.loggerFactory.CreateLogger<SimpleMessageStreamProducer<T>>());
         }
 
         IInternalAsyncObservable<T> IInternalStreamProvider.GetConsumerInterface<T>(IAsyncStream<T> streamId)

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.GrainDirectory
             AdaptiveGrainDirectoryCache cache,
             IInternalGrainFactory grainFactory,
             ILoggerFactory loggerFactory)
-            :base(nameSuffix: null, loggerFactory)
+            : base(loggerFactory)
         {
             this.grainFactory = grainFactory;
             this.router = router;

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.MembershipService
             this.stopping = this.stoppingCancellation.Token.WhenCancelled();
             this.SiloAddress = siloAddress;
             this.prober = remoteSiloProber;
-            this.log = loggerFactory.CreateLogger($"{nameof(SiloHealthMonitor)}/{this.SiloAddress}");
+            this.log = loggerFactory.CreateLogger<SiloHealthMonitor>();
         }
 
         internal interface ITestAccessor

--- a/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
@@ -20,13 +20,13 @@ namespace Orleans.Runtime.MembershipService
         public SiloStatusOracle(
             ILocalSiloDetails localSiloDetails,
             MembershipTableManager membershipTableManager,
-            ILoggerFactory loggerFactory,
+            ILogger<SiloStatusOracle> logger,
             SiloStatusListenerManager listenerManager)
         {
             this.localSiloDetails = localSiloDetails;
             this.membershipTableManager = membershipTableManager;
             this.listenerManager = listenerManager;
-            this.log = loggerFactory.CreateLogger("MembershipOracle");
+            this.log = logger;
         }
 
         public SiloStatus CurrentStatus => this.membershipTableManager.CurrentStatus;

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -21,9 +21,9 @@ namespace Orleans.Runtime.Scheduler
         private readonly CounterStatistic turnsExecutedStatistic;
 #endif
 
-        internal ActivationTaskScheduler(WorkItemGroup workGroup, ILoggerFactory loggerFactory)
+        internal ActivationTaskScheduler(WorkItemGroup workGroup, ILogger<ActivationTaskScheduler> logger)
         {
-            this.logger = loggerFactory.CreateLogger<ActivationTaskScheduler>();
+            this.logger = logger;
             myId = Interlocked.Increment(ref idCounter);
             workerGroup = workGroup;
 #if EXTRA_STATS

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.Scheduler
         private readonly ILogger log;
         private readonly OrleansTaskScheduler masterScheduler;
         private WorkGroupStatus state;
-        private readonly Object lockable;
+        private readonly object lockable;
         private readonly Queue<Task> workItems;
 
         private long totalItemsEnQueued;    // equals total items queued, + 1
@@ -119,7 +119,8 @@ namespace Orleans.Runtime.Scheduler
         internal WorkItemGroup(
             OrleansTaskScheduler sched,
             IGrainContext grainContext,
-            ILoggerFactory loggerFactory,
+            ILogger<WorkItemGroup> logger,
+            ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
             CancellationToken ct,
             SchedulerStatisticsGroup schedulerStatistics,
             IOptions<StatisticsOptions> statisticsOptions)
@@ -130,13 +131,13 @@ namespace Orleans.Runtime.Scheduler
             this.schedulerStatistics = schedulerStatistics;
             state = WorkGroupStatus.Waiting;
             workItems = new Queue<Task>();
-            lockable = new Object();
+            lockable = new object();
             totalItemsEnQueued = 0;
             totalItemsProcessed = 0;
             totalQueuingDelay = TimeSpan.Zero;
             quantumExpirations = 0;
-            TaskScheduler = new ActivationTaskScheduler(this, loggerFactory);
-            log = IsSystemPriority ? loggerFactory.CreateLogger($"{this.GetType().Namespace} {Name}.{this.GetType().Name}") : loggerFactory.CreateLogger<WorkItemGroup>();
+            TaskScheduler = new ActivationTaskScheduler(this, activationTaskSchedulerLogger);
+            log = logger;
 
             if (schedulerStatistics.CollectShedulerQueuesStats)
             {

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -43,7 +43,7 @@ namespace Orleans.Core
             if (store == null) throw new ArgumentNullException(nameof(store));
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));
 
-            this.logger = loggerFactory.CreateLogger(store.GetType().FullName);
+            this.logger = loggerFactory.CreateLogger(store.GetType());
             this.name = name;
             this.grainRef = grainRef;
             this.store = store;

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -63,7 +63,7 @@ namespace Orleans.Streams
             this.options = options;
             numMessages = 0;
 
-            logger = runtime.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger($"{this.GetType().Namespace}.{((ISystemTargetBase)this).GrainId}.{streamProviderName}");
+            logger = runtime.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger($"{this.GetType().Namespace}.{streamProviderName}");
             logger.Info(ErrorCode.PersistentStreamPullingAgent_01,
                 "Created {0} {1} for Stream Provider {2} on silo {3} for Queue {4}.",
                 GetType().Name, ((ISystemTargetBase)this).GrainId.ToDetailedString(), streamProviderName, Silo, QueueId.ToStringWithHashCode());

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -76,7 +76,7 @@ namespace Orleans.Streams
             this.adapterFactory = adapterFactory;
 
             queueAdapterCache = adapterFactory.GetQueueAdapterCache();
-            logger = loggerFactory.CreateLogger($"{GetType().FullName}-{streamProviderName}");
+            logger = loggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}");
             Log(ErrorCode.PersistentStreamPullingManager_01, "Created {0} for Stream Provider {1}.", GetType().Name, streamProviderName);
             this.loggerFactory = loggerFactory;
             IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS, strProviderName), () => queuesToAgentsMap.Count);

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -50,7 +50,7 @@ namespace Orleans.Streams
         /// Constructor
         /// </summary>
         public LeaseBasedQueueBalancer(string name, LeaseBasedQueueBalancerOptions options, ILeaseProvider leaseProvider, ITimerRegistry timerRegistry, IServiceProvider services, ILoggerFactory loggerFactory)
-            : base(services, loggerFactory.CreateLogger($"{nameof(LeaseBasedQueueBalancer)}-{name}"))
+            : base(services, loggerFactory.CreateLogger($"{typeof(LeaseBasedQueueBalancer).FullName}.{name}"))
         {
             this.options = options;
             this.leaseProvider = leaseProvider;

--- a/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime
@@ -13,7 +13,7 @@ namespace Orleans.Runtime
 
         public IAsyncTimer Create(TimeSpan period, string name)
         {
-            var log = this.loggerFactory.CreateLogger($"{nameof(AsyncTimer)}-{name}");
+            var log = this.loggerFactory.CreateLogger($"{typeof(AsyncTimer).FullName}.{name}");
             return new AsyncTimer(period, log);
         }
     }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -23,9 +23,8 @@ namespace Orleans.Transactions
         private readonly IGrainActivationContext context;
         private readonly ITransactionDataCopier<OperationState> copier;
         private readonly IGrainRuntime grainRuntime;
-        private readonly ILoggerFactory loggerFactory;
         private readonly ActivationLifetime activationLifetime;
-        private ILogger logger;
+        private readonly ILogger logger;
         private ParticipantId participantId;
         private TransactionQueue<OperationState> queue;
 
@@ -36,13 +35,13 @@ namespace Orleans.Transactions
             IGrainActivationContext context,
             ITransactionDataCopier<OperationState> copier,
             IGrainRuntime grainRuntime,
-            ILoggerFactory loggerFactory)
+            ILogger<TransactionCommitter<TService>> logger)
         {
             this.config = config;
             this.context = context;
             this.copier = copier;
             this.grainRuntime = grainRuntime;
-            this.loggerFactory = loggerFactory;
+            this.logger = logger;
             this.activationLifetime = new ActivationLifetime(this.context);
         }
 
@@ -128,8 +127,6 @@ namespace Orleans.Transactions
             if (ct.IsCancellationRequested) return;
 
             this.participantId = new ParticipantId(this.config.ServiceName, this.context.GrainInstance.GrainReference, ParticipantId.Role.Resource | ParticipantId.Role.PriorityManager);
-
-            this.logger = loggerFactory.CreateLogger($"{context.GrainType.Name}.{this.config.ServiceName}.{this.context.GrainIdentity.IdentityString}");
 
             var storageFactory = this.context.ActivationServices.GetRequiredService<INamedTransactionalStateStorageFactory>();
             ITransactionalStateStorage<OperationState> storage = storageFactory.Create<OperationState>(this.config.StorageName, this.config.ServiceName);

--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -41,10 +41,10 @@ namespace Orleans.Storage
         private readonly string name;
 
         /// <summary> Default constructor. </summary>
-        public MemoryGrainStorage(string name, MemoryGrainStorageOptions options, ILoggerFactory loggerFactory, IGrainFactory grainFactory)
+        public MemoryGrainStorage(string name, MemoryGrainStorageOptions options, ILogger<MemoryGrainStorage> logger, IGrainFactory grainFactory)
         {
             this.name = name;
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}");
+            this.logger = logger;
 
             //Init
             logger.LogInformation("Init: Name={Name} NumStorageGrains={NumStorageGrains}", name, options.NumStorageGrains);

--- a/src/OrleansProviders/Storage/MemoryStorageWithLatency.cs
+++ b/src/OrleansProviders/Storage/MemoryStorageWithLatency.cs
@@ -48,7 +48,7 @@ namespace Orleans.Storage
         public MemoryGrainStorageWithLatency(string name, MemoryStorageWithLatencyOptions options,
             ILoggerFactory loggerFactory, IGrainFactory grainFactory)
         {
-            this.baseGranStorage = new MemoryGrainStorage(name, options, loggerFactory, grainFactory);
+            this.baseGranStorage = new MemoryGrainStorage(name, options, loggerFactory.CreateLogger<MemoryGrainStorage>(), grainFactory);
             this.options = options;
         }
 

--- a/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
@@ -297,8 +297,12 @@ namespace Orleans.Providers.Streams.Generator
             CreateBufferPoolIfNotCreatedYet();
             var dimensions = new CacheMonitorDimensions(queueId.ToString(), this.blockPoolMonitorDimensions.BlockPoolId);
             var cacheMonitor = this.CacheMonitorFactory(dimensions, this.telemetryProducer);
-            return new GeneratorPooledCache(bufferPool, this.loggerFactory.CreateLogger($"{typeof(GeneratorPooledCache).FullName}.{this.Name}.{queueId}"), serializationManager, 
-                cacheMonitor, this.statisticOptions.StatisticMonitorWriteInterval);
+            return new GeneratorPooledCache(
+                bufferPool,
+                this.loggerFactory.CreateLogger($"{typeof(GeneratorPooledCache).FullName}.{this.Name}.{queueId}"),
+                serializationManager,
+                cacheMonitor,
+                this.statisticOptions.StatisticMonitorWriteInterval);
         }
 
         public static GeneratorAdapterFactory Create(IServiceProvider services, string name)

--- a/test/Extensions/AWSUtils.Tests/LivenessTests.cs
+++ b/test/Extensions/AWSUtils.Tests/LivenessTests.cs
@@ -26,7 +26,7 @@ namespace AWSUtils.Tests.Liveness
                 Orleans.AWSUtils.Tests.DynamoDBStorage storage;
                 try
                 {
-                    storage = new Orleans.AWSUtils.Tests.DynamoDBStorage(NullLoggerFactory.Instance, "http://localhost:8000");
+                    storage = new Orleans.AWSUtils.Tests.DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), "http://localhost:8000");
                 }
                 catch (AmazonServiceException)
                 {

--- a/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -45,7 +45,7 @@ namespace AWSUtils.Tests.MembershipTests
         {
             var options = new DynamoDBGatewayOptions();
             DynamoDBGatewayListProviderHelper.ParseDataConnectionString(this.connectionString, options);
-            return new DynamoDBGatewayListProvider(this.loggerFactory, Options.Create(options), this.clusterOptions, this.gatewayOptions);
+            return new DynamoDBGatewayListProvider(this.loggerFactory.CreateLogger<DynamoDBGatewayListProvider>(), Options.Create(options), this.clusterOptions, this.gatewayOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
@@ -18,7 +18,7 @@ namespace AWSUtils.Tests.StorageTests
                 DynamoDBStorage storage;
                 try
                 {
-                    storage = new DynamoDBStorage(NullLoggerFactory.Instance, Service);
+                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), Service);
                 }
                 catch (AmazonServiceException)
                 {

--- a/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using System;
 using System.Collections.Generic;
@@ -88,7 +88,7 @@ namespace AWSUtils.Tests.StorageTests
         public const string INSTANCE_TABLE_NAME = "UnitTestDDBTableData";
 
         public UnitTestDynamoDBStorage()
-            : base(NullLoggerFactory.Instance, AWSTestConstants.Service)
+            : base(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), AWSTestConstants.Service)
         {
             if (AWSTestConstants.IsDynamoDbAvailable)
             {

--- a/test/Extensions/TesterAzureUtils/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/TesterAzureUtils/UnitTestAzureTableDataManager.cs
@@ -51,7 +51,7 @@ namespace Tester.AzureUtils
         protected const string INSTANCE_TABLE_NAME = "UnitTestAzureData";
 
         public UnitTestAzureTableDataManager(string storageConnectionString, ILoggerFactory loggerFactory)
-            : base(INSTANCE_TABLE_NAME, storageConnectionString, loggerFactory)
+            : base(INSTANCE_TABLE_NAME, storageConnectionString, loggerFactory.CreateLogger<UnitTestAzureTableDataManager>())
         {
             InitTableAsync().WithTimeout(AzureTableDefaultPolicies.TableCreationTimeout).Wait();
         }

--- a/test/Tester/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
+++ b/test/Tester/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
@@ -31,7 +31,7 @@ namespace Tester.TestStreamProviders
 
         public static async Task<int> GetDeliveryFailureCount(string streamProviderName, ILoggerFactory loggerFactory)
         {
-            var dataManager = new AzureTableDataManager<TableEntity>(TableName, TestDefaultConfiguration.DataConnectionString, loggerFactory);
+            var dataManager = new AzureTableDataManager<TableEntity>(TableName, TestDefaultConfiguration.DataConnectionString, loggerFactory.CreateLogger<AzureTableDataManager<TableEntity>>());
             await dataManager.InitTableAsync();
             IEnumerable<Tuple<TableEntity, string>> deliveryErrors =
                 await
@@ -42,7 +42,7 @@ namespace Tester.TestStreamProviders
 
         public static async Task DeleteAll()
         {
-            var dataManager = new AzureTableDataManager<TableEntity>(TableName, TestDefaultConfiguration.DataConnectionString, NullLoggerFactory.Instance);
+            var dataManager = new AzureTableDataManager<TableEntity>(TableName, TestDefaultConfiguration.DataConnectionString, NullLoggerFactory.Instance.CreateLogger<AzureTableDataManager<TableEntity>>());
             await dataManager.InitTableAsync();
             await dataManager.DeleteTableAsync();
         }


### PR DESCRIPTION
Replaces #6303
Fixes #6289

There are several instances where some dynamic data is included in the logger name where I left it largely as-is because there should be relatively few instances which do not grow unbounded over the life of a process.

/cc @KevinCathcart 