### PR TITLE
Free SerializationContext and DeserializationContext between calls

### DIFF
--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -17,5 +17,13 @@ namespace Orleans.Configuration
         /// Serializer used if no serializer is found for a type.
         /// </summary>
         public Type FallbackSerializationProvider { get; set; }
+
+        /// <summary>
+        /// The maximum retained size for serialization and deserialization contexts.
+        /// </summary>
+        /// <remarks>
+        /// This should reflect the expected object graph size for messages.
+        /// </remarks>
+        public int MaxSustainedSerializationContextCapacity { get; set; } = 64;
     }
 }

--- a/src/Orleans.Core/Serialization/DeserializationContext.cs
+++ b/src/Orleans.Core/Serialization/DeserializationContext.cs
@@ -24,15 +24,13 @@ namespace Orleans.Serialization
 
     public sealed class DeserializationContext : SerializationContextBase, IDeserializationContext
     {
-        private readonly Dictionary<int, object> taggedObjects;
+        private Dictionary<int, object> taggedObjects;
 
-        public DeserializationContext(SerializationManager serializationManager)
-            : base(serializationManager)
+        public DeserializationContext(SerializationManager serializationManager) : base(serializationManager)
         {
-            this.taggedObjects = new Dictionary<int, object>();
+            this.Reset();
         }
 
-        /// <inheritdoc />
         /// <inheritdoc />
         public IBinaryTokenStreamReader StreamReader { get; set; }
 
@@ -66,7 +64,15 @@ namespace Orleans.Serialization
 
         internal void Reset()
         {
-            this.taggedObjects.Clear();
+            if (this.taggedObjects is null || this.taggedObjects.Count > this.MaxSustainedSerializationContextCapacity)
+            {
+                this.taggedObjects = new Dictionary<int, object>();
+            }
+            else
+            {
+                this.taggedObjects.Clear();
+            }
+
             this.CurrentObjectOffset = 0;
         }
 

--- a/src/Orleans.Core/Serialization/SerializationContext.cs
+++ b/src/Orleans.Core/Serialization/SerializationContext.cs
@@ -58,17 +58,23 @@ namespace Orleans.Serialization
         /// </summary>
         public IBinaryTokenStreamWriter StreamWriter { get; set; }
 
-        private readonly Dictionary<object, Record> processedObjects;
+        private Dictionary<object, Record> processedObjects;
 
-        public SerializationContext(SerializationManager serializationManager) : 
-            base(serializationManager)
+        public SerializationContext(SerializationManager serializationManager) : base(serializationManager)
         {
-            processedObjects = new Dictionary<object, Record>(ReferenceEqualsComparer.Instance);
+            this.Reset();
         }
 
         internal void Reset()
         {
-            processedObjects.Clear();
+            if (this.processedObjects is null || this.processedObjects.Count > this.MaxSustainedSerializationContextCapacity)
+            {
+                processedObjects = new Dictionary<object, Record>(ReferenceEqualsComparer.Instance);
+            }
+            else
+            {
+                processedObjects.Clear();
+            }
         }
 
         /// <summary>

--- a/src/Orleans.Core/Serialization/SerializationContextBase.cs
+++ b/src/Orleans.Core/Serialization/SerializationContextBase.cs
@@ -18,9 +18,12 @@ namespace Orleans.Serialization
         public IServiceProvider ServiceProvider => this.SerializationManager.ServiceProvider;
         public abstract object AdditionalContext { get; }
 
+        protected int MaxSustainedSerializationContextCapacity { get; }
+
         protected SerializationContextBase(SerializationManager serializationManager)
         {
             this.SerializationManager = serializationManager;
+            this.MaxSustainedSerializationContextCapacity = serializationManager.SerializationProviderOptions.MaxSustainedSerializationContextCapacity;
         }
     }
 }

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -101,12 +101,14 @@ namespace Orleans.Serialization
             deserializers = new Dictionary<Type, Deserializer>();
             grainRefConstructorDictionary = new ConcurrentDictionary<Type, Func<GrainReference, GrainReference>>();
 
-            var options = serializationProviderOptions.Value;
+            this.SerializationProviderOptions = serializationProviderOptions.Value;
 
-            fallbackSerializer = GetFallbackSerializer(serviceProvider, options.FallbackSerializationProvider);
+            fallbackSerializer = GetFallbackSerializer(serviceProvider, SerializationProviderOptions.FallbackSerializationProvider);
             
-            RegisterSerializationProviders(options.SerializationProviders);
+            RegisterSerializationProviders(SerializationProviderOptions.SerializationProviders);
         }
+
+        internal SerializationProviderOptions SerializationProviderOptions { get; }
 
         public void RegisterSerializers(IApplicationPartManager applicationPartManager)
         {


### PR DESCRIPTION
* Adds `SerializationProviderOptions.MaxSustainedSerializationContextCapacity`, which is the maximum capacity (in terms of number of entries), in the `SerializationContext` and `DeserializationContext` objects, which is kept allocated between successive uses.
* If a context object exceeds this capacity, its internal collection is freed (allowed to be collected by GC) and a new one is allocated. Therefore, large object graphs will trigger a reset.
* Setting the capacity to `int.MaxValue` will enable behavior comparable to the pre-existing behavior
* The default maximum sustained capacity is 64 entries
* Perf in our distributed tests shows no degradation, which is as expected