### PR TITLE
DOCS: Fix TOC entry

### DIFF
--- a/src/Documentation/grains/toc.yml
+++ b/src/Documentation/grains/toc.yml
@@ -2,7 +2,7 @@
   href: index.md
 - name: Grain Identity
   href: grain_identity.md
-  name: Grain Placement
+- name: Grain Placement
   hred: grain_placement.md
 - name: Timers and Reminders
   href: timers_and_reminders.md


### PR DESCRIPTION
Grain Identity and Grain placement topics got confused in the TOC.
Currently on the documentation site, the table of contents shows
a label that says "Grain Placement", but links to the grain Identity page.

This should fix that.