### PR TITLE
Proof of concept: Remove Grain Base Requirement

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -51,7 +51,7 @@ namespace Orleans.Transactions.AzureStorage
 
         private string MakePartitionKey(IGrainActivationContext context, string stateName)
         {
-            string grainKey = context.GrainInstance.GrainReference.ToShortKeyString();
+            string grainKey = context.GrainInstance.AsWeaklyTypedReference().ToShortKeyString();
             var key = $"{grainKey}_{this.clusterOptions.ServiceId}_{stateName}";
             return AzureTableUtils.SanitizeTableProperty(key);
         }

--- a/src/Orleans.CodeGeneration/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGeneration/GrainReferenceGenerator.cs
@@ -336,7 +336,11 @@ namespace Orleans.CodeGenerator
             {
                 return
                     SF.ConditionalExpression(
-                        SF.BinaryExpression(SyntaxKind.IsExpression, argIdentifier, typeof(Grain).GetTypeSyntax()),
+                        SF.BinaryExpression(SyntaxKind.LogicalAndExpression,
+                            SF.BinaryExpression(SyntaxKind.IsExpression, argIdentifier, typeof(IGrain).GetTypeSyntax()),
+                            SF.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression,
+                                SF.ParenthesizedExpression(
+                                    SF.BinaryExpression(SyntaxKind.IsExpression, argIdentifier, typeof(GrainReference).GetTypeSyntax())))),
                         SF.InvocationExpression(argIdentifier.Member("AsReference", arg.ParameterType)),
                         argIdentifier);
             }

--- a/src/Orleans.CodeGenerator/Compatibility/OrleansLegacyCompat.cs
+++ b/src/Orleans.CodeGenerator/Compatibility/OrleansLegacyCompat.cs
@@ -167,11 +167,16 @@ namespace Orleans.CodeGenerator.Compatibility
             if (type.TypeKind != TypeKind.Class) return false;
 
             var orig = type.OriginalDefinition;
-            return HasBase(orig, types.Grain) && !IsMarkerType(types, orig);
+            return Implements(orig, types.IGrain) && !IsMarkerType(types, orig) && !HasBase(orig, types.GrainReference);
 
             bool IsMarkerType(WellKnownTypes l, INamedTypeSymbol t)
             {
                 return SymbolEqualityComparer.Default.Equals(t, l.Grain) || SymbolEqualityComparer.Default.Equals(t, l.GrainOfT);
+            }
+
+            bool Implements(INamedTypeSymbol symbol, ITypeSymbol type)
+            {
+                return symbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(type,i));
             }
 
             bool HasBase(INamedTypeSymbol t, INamedTypeSymbol baseType)

--- a/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
@@ -269,7 +269,11 @@ namespace Orleans.CodeGenerator.Generators
                 {
                     return
                         ConditionalExpression(
-                            BinaryExpression(SyntaxKind.IsExpression, identifier, wellKnownTypes.Grain.ToTypeSyntax()),
+                            BinaryExpression(SyntaxKind.LogicalAndExpression,
+                                BinaryExpression(SyntaxKind.IsExpression, identifier, wellKnownTypes.Grain.ToTypeSyntax()),
+                                PrefixUnaryExpression(SyntaxKind.LogicalNotExpression,
+                                    ParenthesizedExpression(
+                                        BinaryExpression(SyntaxKind.IsExpression, identifier, wellKnownTypes.GrainReference.ToTypeSyntax())))),
                             InvocationExpression(identifier.Member("AsReference".ToGenericName().AddTypeArgumentListArguments(arg.Type.ToTypeSyntax()))),
                             identifier);
                 }

--- a/src/Orleans.Core.Abstractions/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/GrainFactoryBase.cs
@@ -12,7 +12,7 @@ namespace Orleans.CodeGeneration
     public static class GrainFactoryBase
     {
         /// <summary>
-        /// Check that a grain observer parameter is of the correct underlying concurrent type -- either extending from <c>GrainRefereence</c> or <c>Grain</c>
+        /// Check that a grain observer parameter is of the correct underlying concurrent type -- either extending from <c>GrainRefereence</c> or <c>IGrain</c>
         /// </summary>
         /// <param name="grainObserver">Grain observer parameter to be checked.</param>
         /// <exception cref="ArgumentNullException">If grainObserver is <c>null</c></exception>
@@ -23,13 +23,13 @@ namespace Orleans.CodeGeneration
             {
                 throw new ArgumentNullException("grainObserver", "IGrainObserver parameters cannot be null");
             }
-            if (grainObserver is GrainReference || grainObserver is Grain)
+            if (grainObserver is GrainReference || grainObserver is IGrain)
             {
                 // OK
             }
             else
             {
-                string errMsg = string.Format("IGrainObserver parameters must be GrainReference or Grain and cannot be type {0}. Did you forget to CreateObjectReference?", grainObserver.GetType());
+                string errMsg = string.Format("IGrainObserver parameters must be GrainReference or IGrain and cannot be type {0}. Did you forget to CreateObjectReference?", grainObserver.GetType());
                 throw new NotSupportedException(errMsg);
             }
         }

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -12,7 +12,7 @@ namespace Orleans
     /// <summary>
     /// The abstract base class for all grain classes.
     /// </summary>
-    public abstract class Grain : IAddressable, ILifecycleParticipant<IGrainLifecycle>
+    public abstract class Grain : IGrain, ILifecycleParticipant<IGrainLifecycle>
     {
         // Do not use this directly because we currently don't provide a way to inject it;
         // any interaction with it will result in non unit-testable code. Any behaviour that can be accessed 

--- a/src/Orleans.Core.Abstractions/Runtime/ActivationDataLookup.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/ActivationDataLookup.cs
@@ -1,0 +1,40 @@
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// This class holds information regarding the mapping of grains
+    /// to their activation data.
+    /// </summary>
+    /// <remarks>
+    /// Classic grains directly hold a reference to their activation data. However
+    /// to support grains that do not inherit from `Grain`, we need a way to statically
+    /// map from the grain to the ActivationData. Enter ConditionalWeakTable, which
+    /// is deigned to associate an extra value with an object instance as if it were
+    /// a property on said object. It has special garbage collector support.
+    /// </remarks>
+    internal static class ActivationDataLookup
+    {
+        internal static ConditionalWeakTable<IGrain, IActivationData> mappingTable = new ConditionalWeakTable<IGrain, IActivationData>();
+
+        internal static IActivationData GetActivationData(this IGrain grain)
+        {
+            if (grain is Grain classicGrain)
+            {
+                return classicGrain.Data;
+            }
+            
+            return mappingTable.TryGetValue(grain, out var activationData) ? activationData : null;
+        }
+
+        internal static void AssociateActivationData(IGrain grain, IActivationData activationData)
+        {
+            if (grain is Grain classicGrain)
+            {
+                classicGrain.Data = activationData;
+            }
+
+            mappingTable.Add(grain, activationData);
+        }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
@@ -34,10 +34,10 @@ namespace Orleans.Runtime
 
         IServiceProvider ServiceProvider { get; }
 
-        void DeactivateOnIdle(Grain grain);
+        void DeactivateOnIdle(IGrain grain);
 
-        void DelayDeactivation(Grain grain, TimeSpan timeSpan);
+        void DelayDeactivation(IGrain grain, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain);
+        IStorage<TGrainState> GetStorage<TGrainState>(IGrain grain);
     }
 }

--- a/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
+++ b/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
@@ -5,6 +5,6 @@ namespace Orleans.Timers
 {
     public interface ITimerRegistry
     {
-        IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
+        IDisposable RegisterTimer(IGrain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
     }
 }

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -360,12 +360,15 @@ namespace Orleans.Runtime
             => (field.Attributes & FieldAttributes.NotSerialized) == FieldAttributes.NotSerialized;
 
         /// <summary>
-        /// decide whether the class is derived from Grain
+        /// decide whether the class is a grain implementation
         /// </summary>
         public static bool IsGrainClass(Type type)
         {
             var grainType = typeof(Grain);
             var grainChevronType = typeof(Grain<>);
+
+            var grainInterfaceType = typeof(IGrain);
+            var grainReferenceType = typeof(GrainReference);
 
             if (type.Assembly.ReflectionOnly)
             {
@@ -374,8 +377,11 @@ namespace Orleans.Runtime
             }
 
             if (grainType == type || grainChevronType == type) return false;
+            if (grainReferenceType.IsAssignableFrom(type)) return false;
 
-            if (!grainType.IsAssignableFrom(type)) return false;
+            if (!type.IsClass) return false;
+
+            if (!grainInterfaceType.IsAssignableFrom(type)) return false;
 
             // exclude generated classes.
             return !IsGeneratedType(type);

--- a/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
+++ b/src/Orleans.Core/LogConsistency/LogConsistentGrain.cs
@@ -65,7 +65,7 @@ namespace Orleans.LogConsistency
         {
             if (ct.IsCancellationRequested) return Task.CompletedTask;
             IGrainActivationContext activationContext = this.ServiceProvider.GetRequiredService<IGrainActivationContext>();
-            Factory<Grain, ILogConsistencyProtocolServices> protocolServicesFactory = this.ServiceProvider.GetRequiredService<Factory<Grain, ILogConsistencyProtocolServices>>();
+            Factory<IGrain, ILogConsistencyProtocolServices> protocolServicesFactory = this.ServiceProvider.GetRequiredService<Factory<IGrain, ILogConsistencyProtocolServices>>();
             ILogViewAdaptorFactory consistencyProvider = SetupLogConsistencyProvider(activationContext);
             IGrainStorage grainStorage = consistencyProvider.UsesStorageProvider ? this.GetGrainStorage(this.ServiceProvider) : null;
             InstallLogViewAdaptor(protocolServicesFactory, consistencyProvider, grainStorage);
@@ -83,7 +83,7 @@ namespace Orleans.LogConsistency
         }
 
         private void InstallLogViewAdaptor(
-            Factory<Grain, ILogConsistencyProtocolServices> protocolServicesFactory,
+            Factory<IGrain, ILogConsistencyProtocolServices> protocolServicesFactory,
             ILogViewAdaptorFactory factory,
             IGrainStorage grainStorage)
         {

--- a/src/Orleans.Core/Providers/GrainStorageExtensions.cs
+++ b/src/Orleans.Core/Providers/GrainStorageExtensions.cs
@@ -13,7 +13,7 @@ namespace Orleans.Storage
         /// Acquire the storage provider associated with the grain type.
         /// </summary>
         /// <returns></returns>
-        public static IGrainStorage GetGrainStorage(this Grain grain, IServiceProvider services) 
+        public static IGrainStorage GetGrainStorage(this IGrain grain, IServiceProvider services)
             => GetGrainStorage(grain.GetType(), services);
 
         /// <summary>

--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -118,7 +118,7 @@ namespace Orleans.Runtime
         private static void CheckForGrainArguments(object[] arguments)
         {
             foreach (var argument in arguments)
-                if (argument is Grain)
+                if (argument is IGrain && !(argument is GrainReference))
                     throw new ArgumentException(String.Format("Cannot pass a grain object {0} as an argument to a method. Pass this.AsReference<GrainInterface>() instead.", argument.GetType().FullName));
         }
 

--- a/src/Orleans.Core/Runtime/IGrainActivationContext.cs
+++ b/src/Orleans.Core/Runtime/IGrainActivationContext.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
 
         /// <summary>Gets the instance of the grain associated with this activation context. 
         /// The value will be <see langword="null"/> if the grain is being created.</summary>
-        Grain GrainInstance { get; }
+        IGrain GrainInstance { get; }
 
         /// <summary>Gets a key/value collection that can be used to share data within the scope of the grain activation.</summary>
         IDictionary<object, object> Items { get; }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -469,7 +469,7 @@ namespace Orleans
             if (obj is GrainReference)
                 throw new ArgumentException("Argument obj is already a grain reference.", nameof(obj));
 
-            if (obj is Grain)
+            if (obj is IGrain)
                 throw new ArgumentException("Argument must not be a grain class.", nameof(obj));
 
             GrainReference gr = GrainReference.NewObserverGrainReference(clientId, GuidId.GetNewGuidId(), this.GrainReferenceRuntime);

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
 
         internal Type GrainInstanceType => GrainTypeData?.Type;
 
-        internal void SetGrainInstance(Grain grainInstance)
+        internal void SetGrainInstance(IGrain grainInstance)
         {
             GrainInstance = grainInstance;
         }
@@ -180,7 +180,7 @@ namespace Orleans.Runtime
 
         public GrainTypeData GrainTypeData { get; private set; }
 
-        public Grain GrainInstance { get; private set; }
+        public IGrain GrainInstance { get; private set; }
 
         IAddressable IGrainContext.GrainInstance => this.GrainInstance;
 

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -707,13 +707,14 @@ namespace Orleans.Runtime
             {
                 data.SetupContext(grainTypeData, this.serviceProvider);
 
-                Grain grain = grainCreator.CreateGrainInstance(data);
+                IGrain grain = grainCreator.CreateGrainInstance(data);
                 
                 //if grain implements IStreamSubscriptionObserver, then install stream consumer extension on it
                 if(grain is IStreamSubscriptionObserver)
                     InstallStreamConsumerExtension(data, grain as IStreamSubscriptionObserver);
 
-                grain.Data = data;
+                ActivationDataLookup.AssociateActivationData(grain, data);
+
                 data.SetGrainInstance(grain);
             }
             
@@ -1019,7 +1020,7 @@ namespace Orleans.Runtime
                 // step 4 - UnregisterMessageTarget and OnFinishedGrainDeactivate
                 foreach (var activationData in list)
                 {
-                    Grain grainInstance = activationData.GrainInstance;
+                    IGrain grainInstance = activationData.GrainInstance;
                     try
                     {
                         lock (activationData)

--- a/src/Orleans.Runtime/Catalog/GrainCreator.cs
+++ b/src/Orleans.Runtime/Catalog/GrainCreator.cs
@@ -29,13 +29,17 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
         /// <returns>The newly created grain.</returns>
-        public Grain CreateGrainInstance(IGrainActivationContext context)
+        public IGrain CreateGrainInstance(IGrainActivationContext context)
         {
-            var grain = (Grain)grainActivator.Create(context);
+            var grain = (IGrain)grainActivator.Create(context);
 
-            // Inject runtime hooks into grain instance
-            grain.Runtime = this.grainRuntime.Value;
-            grain.Identity = context.GrainIdentity;
+            if (grain is Grain grainBase)
+            {
+                // Inject runtime hooks into grain instance
+                grainBase.Runtime = this.grainRuntime.Value;
+                grainBase.Identity = context.GrainIdentity;
+            }
+            // TODO: consider making Identity mockable for POCOs. (Runtime will inherently be mockable via Manual DI)
 
             // wire up to lifecycle
             var participant = grain as ILifecycleParticipant<IGrainLifecycle>;

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -82,23 +82,26 @@ namespace Orleans.Runtime
             }
         }
 
-        public void DeactivateOnIdle(Grain grain)
+        public void DeactivateOnIdle(IGrain grain)
         {
+            if (grain is GrainReference) throw new ArgumentException("Passing a GrainReference as an argument. This method requires a grain implementation", nameof(grain));
             CheckRuntimeContext();
-            this.runtimeClient.DeactivateOnIdle(grain.Data.ActivationId);
+            this.runtimeClient.DeactivateOnIdle(grain.GetActivationData().ActivationId);
         }
 
-        public void DelayDeactivation(Grain grain, TimeSpan timeSpan)
+        public void DelayDeactivation(IGrain grain, TimeSpan timeSpan)
         {
+            if (grain is GrainReference) throw new ArgumentException("Passing a GrainReference as an argument. This method requires a grain implementation", nameof(grain));
             CheckRuntimeContext();
-            grain.Data.DelayDeactivation(timeSpan);
+            grain.GetActivationData().DelayDeactivation(timeSpan);
         }
 
-        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain)
+        public IStorage<TGrainState> GetStorage<TGrainState>(IGrain grain)
         {
+            if (grain is GrainReference) throw new ArgumentException("Passing a GrainReference as an argument. This method requires a grain implementation", nameof(grain));
             IGrainStorage grainStorage = grain.GetGrainStorage(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;
-            return new StateStorageBridge<TGrainState>(grainTypeName, grain.GrainReference, grainStorage, this.loggerFactory);
+            return new StateStorageBridge<TGrainState>(grainTypeName, grain.AsWeaklyTypedReference(), grainStorage, this.loggerFactory);
         }
 
         public static void CheckRuntimeContext()

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -384,7 +384,7 @@ namespace Orleans.Runtime
                         // Mark the exception so that it doesn't deactivate any other activations.
                         ise.IsSourceActivation = false;
 
-                        var activation = (target as Grain)?.Data;
+                        var activation = (target as IGrain)?.GetActivationData();
                         if (activation != null)
                         {
                             this.invokeExceptionLogger.Info($"Deactivating {activation} due to inconsistent state.");

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -92,7 +92,7 @@ namespace Orleans.Runtime
             {
                 if (ct.IsCancellationRequested)
                     return Task.CompletedTask;
-                this.storage = new StateStorageBridge<TState>(this.fullStateName, context.GrainInstance.GrainReference, this.storageProvider, context.ActivationServices.GetService<ILoggerFactory>());
+                this.storage = new StateStorageBridge<TState>(this.fullStateName, context.GrainInstance.AsWeaklyTypedReference(), this.storageProvider, context.ActivationServices.GetService<ILoggerFactory>());
                 return this.ReadStateAsync();
             }
         }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -175,7 +175,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ImplicitStreamSubscriberTable>();
             services.TryAddSingleton<MessageFactory>();
 
-            services.TryAddSingleton<Factory<Grain, ILogConsistencyProtocolServices>>(FactoryUtility.Create<Grain, ProtocolServices>);
+            services.TryAddSingleton<Factory<IGrain, ILogConsistencyProtocolServices>>(FactoryUtility.Create<IGrain, ProtocolServices>);
             services.TryAddSingleton(FactoryUtility.Create<GrainDirectoryPartition>);
 
             // Placement

--- a/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
@@ -24,10 +24,10 @@ namespace Orleans.Runtime.LogConsistency
 
         private readonly ILogger log;
         private readonly IInternalGrainFactory grainFactory;
-        private readonly Grain grain;   // links to the grain that owns this service object
+        private readonly IGrain grain;   // links to the grain that owns this service object
 
         public ProtocolServices(
-            Grain gr,
+            IGrain gr,
             ILoggerFactory loggerFactory,
             SerializationManager serializationManager,
             IInternalGrainFactory grainFactory,
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.LogConsistency
             this.MyClusterId = siloDetails.ClusterId;
         }
         
-        public GrainReference GrainReference => grain.GrainReference;
+        public GrainReference GrainReference => grain.AsWeaklyTypedReference();
 
         /// <inheritdoc />
         public SerializationManager SerializationManager { get; }
@@ -52,20 +52,20 @@ namespace Orleans.Runtime.LogConsistency
 
             log?.Error((int)(throwexception ? ErrorCode.LogConsistency_ProtocolFatalError : ErrorCode.LogConsistency_ProtocolError),
                 string.Format("{0} Protocol Error: {1}",
-                    grain.GrainReference,
+                    grain.AsWeaklyTypedReference(),
                     msg));
 
             if (!throwexception)
                 return;
 
-            throw new OrleansException(string.Format("{0} (grain={1}, cluster={2})", msg, grain.GrainReference, this.MyClusterId));
+            throw new OrleansException(string.Format("{0} (grain={1}, cluster={2})", msg, grain.AsWeaklyTypedReference(), this.MyClusterId));
         }
 
         public void CaughtException(string where, Exception e)
         {
             log?.Error((int)ErrorCode.LogConsistency_CaughtException,
                string.Format("{0} Exception Caught at {1}",
-                   grain.GrainReference,
+                   grain.AsWeaklyTypedReference(),
                    where),e);
         }
 
@@ -73,7 +73,7 @@ namespace Orleans.Runtime.LogConsistency
         {
             log?.Warn((int)ErrorCode.LogConsistency_UserCodeException,
                 string.Format("{0} Exception caught in user code for {1}, called from {2}",
-                   grain.GrainReference,
+                   grain.AsWeaklyTypedReference(),
                    callback,
                    where), e);
         }
@@ -83,7 +83,7 @@ namespace Orleans.Runtime.LogConsistency
             if (log != null && log.IsEnabled(level))
             {
                 var msg = string.Format("{0} {1}",
-                        grain.GrainReference,
+                        grain.AsWeaklyTypedReference(),
                         string.Format(format, args));
                 log.Log(level, 0, msg, null, (m, exc) => $"{m}");
             }

--- a/src/Orleans.Runtime/Timers/TimerRegistry.cs
+++ b/src/Orleans.Runtime/Timers/TimerRegistry.cs
@@ -16,10 +16,11 @@ namespace Orleans.Timers
             this.timerLogger = loggerFactory.CreateLogger<GrainTimer>();
         }
 
-        public IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+        public IDisposable RegisterTimer(IGrain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            var timer = GrainTimer.FromTaskCallback(this.scheduler, this.timerLogger, asyncCallback, state, dueTime, period, activationData: grain?.Data);
-            grain?.Data.OnTimerCreated(timer);
+            if (grain is GrainReference) throw new ArgumentException("Passing a GrainReference as an argument. This method requires a grain implementation", nameof(grain));
+            var timer = GrainTimer.FromTaskCallback(this.scheduler, this.timerLogger, asyncCallback, state, dueTime, period, activationData: grain?.GetActivationData());
+            grain?.GetActivationData().OnTimerCreated(timer);
             timer.Start();
             return timer;
         }

--- a/src/Orleans.Runtime/Utilities/OrleansDebuggerHelper.cs
+++ b/src/Orleans.Runtime/Utilities/OrleansDebuggerHelper.cs
@@ -19,8 +19,6 @@ namespace Orleans.Runtime.Utilities
         {
             switch (grainReference)
             {
-                case Grain _:
-                    return grainReference;
                 case GrainReference reference:
                     {
                         var runtime = (reference.Runtime as GrainReferenceRuntime)?.RuntimeClient;
@@ -32,6 +30,8 @@ namespace Orleans.Runtime.Utilities
                         var grains = activations.FindTargets(reference.GrainId);
                         return grains?.FirstOrDefault()?.GrainInstance;
                     }
+                case IGrain _:
+                    return grainReference;
                 default:
                     return null;
             }

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -200,7 +200,7 @@ namespace Orleans.Transactions
         {
             if (ct.IsCancellationRequested) return;
 
-            this.participantId = new ParticipantId(this.config.StateName, this.context.GrainInstance.GrainReference, this.config.SupportedRoles);
+            this.participantId = new ParticipantId(this.config.StateName, this.context.GrainInstance.AsWeaklyTypedReference(), this.config.SupportedRoles);
 
             var storageFactory = this.context.ActivationServices.GetRequiredService<INamedTransactionalStateStorageFactory>();
             ITransactionalStateStorage<TState> storage = storageFactory.Create<TState>(this.config.StorageName, this.config.StateName);

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -103,7 +103,7 @@ namespace Orleans.Transactions
         {
             string formattedTypeName = RuntimeTypeNameFormatter.Format(this.context.GrainInstance.GetType());
             string fullStateName = $"{formattedTypeName}-{this.stateName}";
-            return new StateStorageBridge<TransactionalStateRecord<TState>>(fullStateName, this.context.GrainInstance.GrainReference, grainStorage, this.loggerFactory);
+            return new StateStorageBridge<TransactionalStateRecord<TState>>(fullStateName, this.context.GrainInstance.AsWeaklyTypedReference(), grainStorage, this.loggerFactory);
         }
     }
 

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -126,7 +126,7 @@ namespace Orleans.Transactions
         {
             if (ct.IsCancellationRequested) return;
 
-            this.participantId = new ParticipantId(this.config.ServiceName, this.context.GrainInstance.GrainReference, ParticipantId.Role.Resource | ParticipantId.Role.PriorityManager);
+            this.participantId = new ParticipantId(this.config.ServiceName, this.context.GrainInstance.AsWeaklyTypedReference(), ParticipantId.Role.Resource | ParticipantId.Role.PriorityManager);
 
             var storageFactory = this.context.ActivationServices.GetRequiredService<INamedTransactionalStateStorageFactory>();
             ITransactionalStateStorage<OperationState> storage = storageFactory.Create<OperationState>(this.config.StorageName, this.config.ServiceName);

--- a/test/Grains/TestGrains/ExceptionGrain.cs
+++ b/test/Grains/TestGrains/ExceptionGrain.cs
@@ -5,8 +5,15 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    public class ExceptionGrain : Grain, IExceptionGrain
+    public class ExceptionGrain : IExceptionGrain
     {
+        private readonly IGrainFactory grainFactory;
+
+        public ExceptionGrain(IGrainFactory grainFactory)
+        {
+            this.grainFactory = grainFactory;
+        }
+
         /// <summary>
         /// Returns a canceled <see cref="Task"/>.
         /// </summary>
@@ -43,13 +50,13 @@ namespace UnitTests.Grains
 
         public Task GrainCallToThrowsInvalidOperationException(long otherGrainId)
         {
-            var otherGrain = GrainFactory.GetGrain<IExceptionGrain>(otherGrainId);
+            var otherGrain = grainFactory.GetGrain<IExceptionGrain>(otherGrainId);
             return otherGrain.ThrowsInvalidOperationException();
         }
 
         public Task GrainCallToThrowsAggregateExceptionWrappingInvalidOperationException(long otherGrainId)
         {
-            var otherGrain = GrainFactory.GetGrain<IExceptionGrain>(otherGrainId);
+            var otherGrain = grainFactory.GetGrain<IExceptionGrain>(otherGrainId);
             return otherGrain.ThrowsAggregateExceptionWrappingInvalidOperationException();
         }
 

--- a/test/Grains/TestGrains/GrainInterfaceHierarchyGrains.cs
+++ b/test/Grains/TestGrains/GrainInterfaceHierarchyGrains.cs
@@ -1,11 +1,11 @@
-﻿
+
 using System.Threading.Tasks;
 using Orleans;
 using TestGrainInterfaces;
 
 namespace TestGrains
 {
-    public class DoSomethingEmptyGrain : Grain, IDoSomethingEmptyGrain
+    public class DoSomethingEmptyGrain : IDoSomethingEmptyGrain
     {
         private int A;
 
@@ -32,7 +32,7 @@ namespace TestGrains
         }
     }
 
-    public class DoSomethingEmptyWithMoreGrain : Grain, IDoSomethingEmptyWithMoreGrain
+    public class DoSomethingEmptyWithMoreGrain : IDoSomethingEmptyWithMoreGrain
     {
         private int A;
 
@@ -64,7 +64,7 @@ namespace TestGrains
         }
     }
 
-    public class DoSomethingWithMoreGrain : Grain, IDoSomethingWithMoreGrain
+    public class DoSomethingWithMoreGrain : IDoSomethingWithMoreGrain
     {
         private int A;
         private int B;
@@ -115,7 +115,7 @@ namespace TestGrains
 
     }
 
-    public class DoSomethingWithMoreEmptyGrain : Grain, IDoSomethingWithMoreEmptyGrain
+    public class DoSomethingWithMoreEmptyGrain : IDoSomethingWithMoreEmptyGrain
     {
         private int A;
 
@@ -149,7 +149,7 @@ namespace TestGrains
 
 
 
-    public class DoSomethingCombinedGrain : Grain, IDoSomethingCombinedGrain
+    public class DoSomethingCombinedGrain : IDoSomethingCombinedGrain
     {
         private int A;
         private int B;

--- a/test/Grains/TestGrains/NoOpTestGrain.cs
+++ b/test/Grains/TestGrains/NoOpTestGrain.cs
@@ -1,9 +1,9 @@
-﻿using Orleans;
+using Orleans;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    public class NoOpTestGrain : Grain, INoOpTestGrain
+    public class NoOpTestGrain : INoOpTestGrain
     {
     }
 }

--- a/test/Grains/TestGrains/ReminderTestGrain.cs
+++ b/test/Grains/TestGrains/ReminderTestGrain.cs
@@ -1,14 +1,21 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Orleans;
+using Orleans.Timers;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    internal class ReminderTestGrain : Grain, IReminderTestGrain
+    internal class ReminderTestGrain : IReminderTestGrain
     {
+        private readonly IReminderRegistry reminderRegistry;
+
+        public ReminderTestGrain(IReminderRegistry reminderRegistry)
+        {
+            this.reminderRegistry = reminderRegistry;
+        }
         public async Task<bool> IsReminderExists(string reminderName)
         {
-            var reminder = await this.GetReminder(reminderName);
+            var reminder = await reminderRegistry.GetReminder(reminderName);
             return reminder != null;
         }
     }

--- a/test/Grains/TestInternalGrainInterfaces/IClientAddressableTestClientObject.cs
+++ b/test/Grains/TestInternalGrainInterfaces/IClientAddressableTestClientObject.cs
@@ -1,9 +1,9 @@
-﻿using System.Threading.Tasks;
-using Orleans;
+using System.Threading.Tasks;
+using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
-    public interface IClientAddressableTestClientObject : IGrainWithIntegerKey
+    public interface IClientAddressableTestClientObject : IAddressable
     {
         Task<string> OnHappyPath(string message);
         Task OnSadPath(string message);

--- a/test/Grains/TestInternalGrainInterfaces/IClientAddressableTestProducer.cs
+++ b/test/Grains/TestInternalGrainInterfaces/IClientAddressableTestProducer.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Orleans;
+using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
-    public interface IClientAddressableTestProducer : IGrainWithIntegerKey
+    public interface IClientAddressableTestProducer : IAddressable
     {
         Task<int> Poll();
     }


### PR DESCRIPTION
I present here a proof-of-concept for allowing grains to not inherit from the `Grain` base class. However, **this pull request is intended to get a conversation started** about this topic as much as it is a code suggestion. Even if none of this code gets used, I'm hopefull that the table of how to access the base class's functionality without without using the base class might be useful, as might the the other analysis in the message, or the following ones. 

This result allows for these classes to use basically all Orleans functionality with the exception of log-consistency/event-sourcing, since we do not have a facet version of those yet. This arguably is not yet fully POCO, since we still require the grain interface, and some functionality requires implementing specific interfaces.

## Philosophy

The goal here was implementing the simplest thing that works, and documenting how it is possible to inject all the needed functionality (and analyze where the current options appear suboptimal). I know in the meetup. Ruben talked about one of the benefits of POCO classes being reduced magic, and that certainly happens to an extent here, but there is still magic remaining, and arguably some additional magic added by this pull request.

Rather than trying to reduce that remaining magic further, this pull request simply does what is needed to keep that working. Instead, I will outline one way to a decent chunk  of the remaining magic, in a later post in this pull request.

## Approach
The approach used here is that every object that implements `IGrain` (except for the proxies derived from `GrainReference`) is a grain by definition. If manually constructed, it is a half-baked grain, that the runtime knows nothing about, but that is not really different from manually constructing a classic grain. 

This was surprising easy to accomplish, with the main complication being that we needed a way to get from a grain instance to its activation data. Beyond that, it was mostly changing `Grain` to `IGrain` in quite a few API, adding some checks that we were passed a grain and not a generated `GrainReference` proxy, and changing some code that used properties on the grain base class to get information via the existing extension methods instead. 

Handling activation data lookup is especially tricky, because we want to be able to access that data in static contexts, like the previously mentioned extension methods. For classic grains derived from `Grain`, I continue to use the existing `Data` field as a performance optimization. For other grains, I use a static `ConditionalWeakTable` for associating this data. (If anybody is not familiar, that class is designed to enable associating additional data to an arbitrary CLR reference type object, with the garbage collector effectively treating the data as being stored in a field of the object, rather than in the table itself.)

## Mapping of `Grain` base class functionality
**Note:** Some of these are not ideal, and are discussed more in the footnotes:

| Functionality | How To Use |
|---------------|------------|
| `this.GrainFactory` | Receive `IGrainFactory` as constructor parameter |
| State | use the `IPersistentState` facet |
| `this.IdentityString` | `this.GetGrainIdentity().IdentityString` |
| `this.RegisterTimer(...)` |  Receive `ITimerRegistry` as constructor parameter |
| `this.RegisterOrUpdateReminder(...)`<br>`this.UnregisterReminder(...)`<br>`this.GetReminder(...)`<br>`this.GetReminders()` |  Receive `IReminderRegistry` as constructor parameter, and use its methods [0] |
| `this.GetStreamProvider(name)` | See Footnote [1] |
| `this.DeactivateOnIdle()`<br>`this.DelayDeactivation(timeSpan)` | Receive `IGrainRuntime` as constructor parameter and use its methods [2] 
| overriding `OnActivateAsync`<br>overriding `OnDeactivateAsync` | Implement `ILifecycleParticipant<IGrainLifecycle>` [3] |
| `this.RuntimeIdentity` | Receive `IGrainRuntime` as constructor parameter and use `SiloIdentity` property [2] |
| `this.ServiceProvider` | Receive `IServiceProvider` as constructor parameter |
| `this.GrainReference` | `this.AsWeaklyTypedReference` [4] |

**Footnotes**:

**[0]:** Note that some checks from the `Grain` base class may be missing, like the check that grain implements `IRemindable` for registering a reminder. We might want to migrate the check?
**[1]:** Currently this requires either injecting `IClusterClient` (which would be overkill), or injecting `IServiceProvider` and calling `serviceProvider.GetRequiredServiceByName<IStreamProvider>(name)`. For the latter, users should probably not need to know about the named registrations. A nicer option might be something like an `IStreamProviderFactory` (#3917).
**[2]:** `IGrainRuntime` feels too low level to recommend users inject, so introducing some new user friendly injectable or facet for this would make better sense.
**[3]:** There are a bunch of alternative ways we can implement this which may be nicer for users, like an interface with those two methods that the grain can optionally implement, and have `GrainCreator` wire them to the lifecycle if it does implement the interface. 
**[4]:** I had to make that public, as a few places in the existing code base need to get the untyped Grain Reference for a grain, but did not have access to internals.