### PR TITLE
Setting eventIndex

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -67,6 +67,7 @@ namespace Orleans.ServiceBus.Providers
                 StreamGuid = streamPosition.StreamIdentity.Guid,
                 StreamNamespace = streamPosition.StreamIdentity.Namespace != null ? string.Intern(streamPosition.StreamIdentity.Namespace) : null,
                 SequenceNumber = queueMessage.SystemProperties.SequenceNumber,
+                EventIndex = streamPosition.SequenceToken.EventIndex,
                 EnqueueTimeUtc = queueMessage.SystemProperties.EnqueuedTimeUtc,
                 DequeueTimeUtc = dequeueTime,
                 Segment = EncodeMessageIntoSegment(queueMessage, getSegment)


### PR DESCRIPTION
Setting EventIndex in FromQueueMessage method. In our use case we get a message from eventhub and then duplicate that message to go to multiple grains, while duplicating we set different EventIndex for each message. 

So, setting EventIndex in FromQueueMessage method will cause us to copy and modify one less function from orleans code to support our use case, if this doesn't cause any other issue in orleans