### PR TITLE
Send rejections for messages enqueued on stopped outbound queue

### DIFF
--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -29,13 +29,11 @@ namespace Orleans.Runtime.Messaging
 
         public void SetHostedClient(IHostedClient client) => this.hostedClient = client;
 
-        public bool IsProxying => this.Gateway != null || this.hostedClient?.ClientId != null;
-
         public bool TryDeliverToProxy(Message msg)
         {
-            if (msg.TargetGrain == null || !msg.TargetGrain.IsClient) return false;
-            if (this.Gateway != null && this.Gateway.TryDeliverToProxy(msg)) return true;
-            return this.hostedClient?.TryDispatchToClient(msg) ?? false;
+            if (msg.TargetGrain is null || !msg.TargetGrain.IsClient) return false;
+            if (this.Gateway is Gateway gateway && gateway.TryDeliverToProxy(msg)) return true;
+            return this.hostedClient is IHostedClient client && client.TryDispatchToClient(msg);
         }
         
         // This is determined by the IMA but needed by the OMS, and so is kept here in the message center itself.

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -86,7 +86,10 @@ namespace Orleans.Runtime.Messaging
             if ((msg.TargetSilo == null) || msg.TargetSilo.Matches(this.LocalSiloAddress))
             {
                 // See if it's a message for a client we're proxying.
-                if (messageCenter.IsProxying && messageCenter.TryDeliverToProxy(msg)) return;
+                if (messageCenter.TryDeliverToProxy(msg))
+                {
+                    return;
+                }
 
                 // Nope, it's for us
                 messageCenter.OnReceivedMessage(msg);


### PR DESCRIPTION
We shouldn't drop messages, unless they are expired or we have no reasonable action to take on them.

In this case, I think we can reject messages sent to a stopped OutboundMessagingQueue (which happens during shutdown), to make some problems easier to debug.