### PR TITLE
Fix typo in Adventure sample

### DIFF
--- a/Samples/2.0/Adventure/AdventureGrainInterfaces/IRoomGrain.cs
+++ b/Samples/2.0/Adventure/AdventureGrainInterfaces/IRoomGrain.cs
@@ -19,7 +19,7 @@ namespace AdventureGrainInterfaces
         Task Enter(PlayerInfo player);
         Task Exit(PlayerInfo player);
 
-        // Players can enter or exit a room
+        // Monsters can enter or exit a room
         Task Enter(MonsterInfo monster);
         Task Exit(MonsterInfo monster);
 


### PR DESCRIPTION
This PR fixes a small typo I noticed while studying the source of the Adventure sample.