### PR TITLE
Fix flakiness in Azure Storage providers introduced by #6462

### DIFF
--- a/src/Azure/Shared/Storage/AzureStoragePolicyOptions.cs
+++ b/src/Azure/Shared/Storage/AzureStoragePolicyOptions.cs
@@ -35,9 +35,9 @@ namespace Orleans.GrainDirectory.AzureStorage
         public int MaxCreationRetries { get; set; } = 60;
         public int MaxOperationRetries { get; set; } = 5;
 
-        public TimeSpan PauseBetweenCreationRetries { get; set; } = Debugger.IsAttached ? TimeSpan.FromSeconds(100) : TimeSpan.FromSeconds(1);
+        public TimeSpan PauseBetweenCreationRetries { get; set; } = TimeSpan.FromSeconds(1);
 
-        public TimeSpan PauseBetweenOperationRetries { get; set; } = Debugger.IsAttached ? TimeSpan.FromSeconds(10) : TimeSpan.FromMilliseconds(100);
+        public TimeSpan PauseBetweenOperationRetries { get; set; } = TimeSpan.FromMilliseconds(100);
 
         public TimeSpan CreationTimeout
         {

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -717,7 +717,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 CloudStorageAccount storageAccount = AzureTableUtils.GetCloudStorageAccount(ConnectionString);
                 CloudTableClient operationsClient = storageAccount.CreateCloudTableClient();
                 operationsClient.DefaultRequestOptions.RetryPolicy = this.StoragePolicyOptions.OperationRetryPolicy;
-                operationsClient.DefaultRequestOptions.MaximumExecutionTime = this.StoragePolicyOptions.OperationTimeout;
+                operationsClient.DefaultRequestOptions.ServerTimeout = this.StoragePolicyOptions.OperationTimeout;
                 // Values supported can be AtomPub, Json, JsonFullMetadata or JsonNoMetadata with Json being the default value
                 operationsClient.DefaultRequestOptions.PayloadFormat = TablePayloadFormat.JsonNoMetadata;
                 return operationsClient;
@@ -736,7 +736,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 CloudStorageAccount storageAccount = AzureTableUtils.GetCloudStorageAccount(ConnectionString);
                 CloudTableClient creationClient = storageAccount.CreateCloudTableClient();
                 creationClient.DefaultRequestOptions.RetryPolicy = this.StoragePolicyOptions.CreationRetryPolicy;
-                creationClient.DefaultRequestOptions.MaximumExecutionTime = this.StoragePolicyOptions.CreationTimeout;
+                creationClient.DefaultRequestOptions.ServerTimeout = this.StoragePolicyOptions.CreationTimeout;
                 // Values supported can be AtomPub, Json, JsonFullMetadata or JsonNoMetadata with Json being the default value
                 creationClient.DefaultRequestOptions.PayloadFormat = TablePayloadFormat.JsonNoMetadata;
                 return creationClient;


### PR DESCRIPTION
`AzureStoragePolicyOptions.CreationTimeout` and `OperationTimeout` should be the timeouts for individual attempts, not the maximum overall timeout. When there is contention, as we see in some tests, the behavioral change introduced in #6462 can lead to flakiness.