### PR TITLE
Grammar in Reentrancy docs.

### DIFF
--- a/src/Documentation/grains/reentrancy.md
+++ b/src/Documentation/grains/reentrancy.md
@@ -4,7 +4,7 @@ title: Reentrancy
 ---
 # Reentrancy
 
-Grain activations are single-threaded and, by default, process each request from beginning to completion before the next request can begin being processing. In some circumstances, it may be desirable for an activation to process other requests while one request is waiting for an asynchronous operation to complete. For this and other reasons, Orleans gives the developer some control over the request interleaving behavior. Multiple requests may be interleaved in the following cases:
+Grain activations are single-threaded and, by default, process each request from beginning to completion before the next request can begin processing. In some circumstances, it may be desirable for an activation to process other requests while one request is waiting for an asynchronous operation to complete. For this and other reasons, Orleans gives the developer some control over the request interleaving behavior. Multiple requests may be interleaved in the following cases:
 
 * The grain class is marked as `[Reentrant]`
 * The interface method is marked as `[AlwaysInterleave]`


### PR DESCRIPTION
>Grain activations are single-threaded and, by default, process each request from beginning to completion before the next request can begin ***being*** processing. In some circumstances, it may be desirable for ....

Removed ***being*** above.