### PR TITLE
configures cache by size

### DIFF
--- a/src/Documentation/implementation/streams_implementation/azure_queue_streams.md
+++ b/src/Documentation/implementation/streams_implementation/azure_queue_streams.md
@@ -106,9 +106,7 @@ hostBuilder
         };
         options.MessageVisibilityTimeout = TimeSpan.FromSeconds(72);
       }));
-    configurator.ConfigurePullingAgent(ob => ob.Configure(options => {
-      options.GetQueueMsgsTimerPeriod = TimeSpan.FromMinutes(1);
-    }));
+    configurator.ConfigureCacheSize(1200);
   })
 ```
 


### PR DESCRIPTION
This PR follows the already merged [PR 6441](https://github.com/dotnet/orleans/pull/6441). It fixes the confusion between `ConfigureCacheSize` and `GetQueueMsgsTimerPeriod` in the code example.

Collecting input from @jason-bragg and issue [6345](https://github.com/dotnet/orleans/issues/6345#issuecomment-595419498) about tuning azure queue streams. I found it very interesting and helpful to better understand how the system works. I thought was smart to share it in the docs.