### PR TITLE
Implement CLR type name parser and rewriter

### DIFF
--- a/src/Orleans.Core/Utils/RuntimeTypeNameFormatter.cs
+++ b/src/Orleans.Core/Utils/RuntimeTypeNameFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Orleans.Runtime;
@@ -7,15 +8,24 @@ namespace Orleans.Utilities
 {
     /// <summary>
     /// Utility methods for formatting <see cref="Type"/> instances in a way which can be parsed by
-    /// <see cref="Type.GetType(string)"/>.
+    /// <see cref="Type.GetType(string)"/> and <see cref="RuntimeTypeNameParser"/>.
     /// </summary>
     public static class RuntimeTypeNameFormatter
     {
         private static readonly Assembly SystemAssembly = typeof(int).Assembly;
         private static readonly char[] SimpleNameTerminators = { '`', '*', '[', '&' };
 
-        private static readonly CachedReadConcurrentDictionary<Type, string> Cache =
-            new CachedReadConcurrentDictionary<Type, string>();
+        private static readonly ConcurrentDictionary<Type, string> Cache = new ConcurrentDictionary<Type, string>();
+
+        static RuntimeTypeNameFormatter()
+        {
+            IncludeAssemblyName = type => !SystemAssembly.Equals(type.Assembly);
+        }
+
+        /// <summary>
+        /// Gets or sets the delegate used to determine whether an assembly name should be printed for the provided type.
+        /// </summary>
+        public static Func<Type, bool> IncludeAssemblyName { get; set; }
 
         /// <summary>
         /// Returns a <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
@@ -65,7 +75,10 @@ namespace Orleans.Utilities
 
             // Types which are used as elements are not formatted with their assembly name, since that is added after the
             // element type's adornments.
-            if (!isElementType) AddAssembly(builder, type);
+            if (!isElementType && IncludeAssemblyName(type))
+            {
+                AddAssembly(builder, type);
+            }
         }
 
         private static void AddNamespace(StringBuilder builder, Type type)
@@ -96,7 +109,7 @@ namespace Orleans.Utilities
         {
             // Generic type definitions (eg, List<> without parameters) and non-generic types do not include any
             // parameters in their formatting.
-            if (!type.IsConstructedGenericType) return;
+            if (!type.IsConstructedGenericType || type.ContainsGenericParameters) return;
 
             var args = type.GetGenericArguments();
             builder.Append('[');

--- a/src/Orleans.Core/Utils/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Core/Utils/RuntimeTypeNameParser.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Utilities
+{
+    /// <summary>
+    /// Utility class for parsing CLR type names, as formatted by <see cref="RuntimeTypeNameFormatter"/>.
+    /// </summary>
+    internal static class RuntimeTypeNameParser
+    {
+        private const int MaxAllowedGenericArity = 64;
+        private const char PointerIndicator = '*';
+        private const char ReferenceIndicator = '&';
+        private const char ArrayStartIndicator = '[';
+        private const char ArrayDimensionIndicator = ',';
+        private const char ArrayEndIndicator = ']';
+        private const char ParameterSeparator = ',';
+        private const char GenericTypeIndicator = '`';
+        private const char NestedTypeIndicator = '+';
+        private const char AssemblyIndicator = ',';
+        private static ReadOnlySpan<char> AssemblyDelimiters => new[] { ArrayEndIndicator };
+        private static ReadOnlySpan<char> TypeNameDelimiters => new[] { ArrayStartIndicator, ArrayEndIndicator, PointerIndicator, ReferenceIndicator, AssemblyIndicator, GenericTypeIndicator, NestedTypeIndicator };
+
+        /// <summary>
+        /// Parse the provided value as a type name.
+        /// </summary>
+        public static TypeSpec Parse(string input) => Parse(input.AsSpan());
+
+        /// <summary>
+        /// Parse the provided value as a type name.
+        /// </summary>
+        public static TypeSpec Parse(ReadOnlySpan<char> input) => ParseInternal(ref input);
+
+        private static TypeSpec ParseInternal(ref ReadOnlySpan<char> input)
+        {
+            TypeSpec result;
+            char c;
+            Reader s = default;
+            s.Input = input;
+
+            // Read namespace and class name, including generic arity, which is a part of the class name.
+            NamedTypeSpec named = null;
+            while (true)
+            {
+                var typeName = ParseTypeName(ref s);
+                named = new NamedTypeSpec(named, typeName.ToString(), s.TotalGenericArity);
+
+                if (s.TryPeek(out c) && c == NestedTypeIndicator)
+                {
+                    // Consume the nested type indicator, then loop to parse the nested type.
+                    s.ConsumeCharacter(NestedTypeIndicator);
+                    continue;
+                }
+
+                break;
+            }
+
+            // Parse generic type parameters
+            if (s.TotalGenericArity > 0 && s.TryPeek(out c) && c == ArrayStartIndicator)
+            {
+                s.ConsumeCharacter(ArrayStartIndicator);
+
+                var arguments = new TypeSpec[s.TotalGenericArity];
+                for (var i = 0; i < s.TotalGenericArity; i++)
+                {
+                    if (i > 0)
+                    {
+                        s.ConsumeCharacter(ParameterSeparator);
+                    }
+
+                    // Parse the argument type
+                    s.ConsumeCharacter(ArrayStartIndicator);
+                    var remaining = s.Remaining;
+                    arguments[i] = ParseInternal(ref remaining);
+                    var consumed = s.Remaining.Length - remaining.Length;
+                    s.Consume(consumed);
+                    s.ConsumeCharacter(ArrayEndIndicator);
+                }
+
+                s.ConsumeCharacter(ArrayEndIndicator);
+                result = new ConstructedGenericTypeSpec(named, arguments);
+            }
+            else
+            {
+                // This is not a constructed generic type
+                result = named;
+            }
+
+            // Parse modifiers
+            bool hadModifier;
+            do
+            {
+                hadModifier = false;
+
+                if (!s.TryPeek(out c))
+                {
+                    break;
+                }
+
+                switch (c)
+                {
+                    case ArrayStartIndicator:
+                        var dimensions = ParseArraySpecifier(ref s);
+                        result = new ArrayTypeSpec(result, dimensions);
+                        hadModifier = true;
+                        break;
+                    case PointerIndicator:
+                        result = new PointerTypeSpec(result);
+                        s.ConsumeCharacter(PointerIndicator);
+                        hadModifier = true;
+                        break;
+                    case ReferenceIndicator:
+                        result = new ReferenceTypeSpec(result);
+                        s.ConsumeCharacter(ReferenceIndicator);
+                        hadModifier = true;
+                        break;
+                }
+            } while (hadModifier);
+
+            // Extract the assembly, if specified.
+            if (s.TryPeek(out c) && c == AssemblyIndicator)
+            {
+                s.ConsumeCharacter(AssemblyIndicator);
+                var assembly = ExtractAssemblySpec(ref s);
+                result = new AssemblyQualifiedTypeSpec(result, assembly.ToString());
+            }
+
+            input = s.Remaining;
+            return result;
+        }
+
+        private static ReadOnlySpan<char> ParseTypeName(ref Reader s)
+        {
+            char c;
+            var start = s.Index;
+            var typeName = ParseSpan(ref s, TypeNameDelimiters);
+            var genericArityStart = -1;
+            while (s.TryPeek(out c))
+            {
+                if (genericArityStart < 0 && c == GenericTypeIndicator)
+                {
+                    genericArityStart = s.Index + 1;
+                }
+                else if (genericArityStart < 0 || !char.IsDigit(c))
+                {
+                    break;
+                }
+
+                s.ConsumeCharacter(c);
+            }
+
+            if (genericArityStart >= 0)
+            {
+                // The generic arity is additive, so that a generic class nested in a generic class has an arity
+                // equal to the sum of specified arity values. For example, "C`1+N`2" has an arity of 3.
+                var aritySlice = s.Input.Slice(genericArityStart, s.Index - genericArityStart);
+#if NETCOREAPP
+                var arity = int.Parse(aritySlice);
+#else
+                var arity = int.Parse(aritySlice.ToString());
+#endif
+                s.TotalGenericArity += arity;
+                if (s.TotalGenericArity > MaxAllowedGenericArity)
+                {
+                    ThrowGenericArityTooLarge(s.TotalGenericArity);
+                }
+
+                // Include the generic arity in the type name.
+                typeName = s.Input.Slice(start, s.Index - start);
+            }
+
+            return typeName;
+        }
+
+        private static int ParseArraySpecifier(ref Reader s)
+        {
+            s.ConsumeCharacter(ArrayStartIndicator);
+            var dimensions = 1;
+
+            while (s.TryPeek(out var c) && c != ArrayEndIndicator)
+            {
+                s.ConsumeCharacter(ArrayDimensionIndicator);
+                ++dimensions;
+            }
+
+            s.ConsumeCharacter(ArrayEndIndicator);
+            return dimensions;
+        }
+
+        private static ReadOnlySpan<char> ExtractAssemblySpec(ref Reader s)
+        {
+            s.ConsumeWhitespace();
+            return ParseSpan(ref s, AssemblyDelimiters);
+        }
+
+        private static ReadOnlySpan<char> ParseSpan(ref Reader s, ReadOnlySpan<char> delimiters)
+        {
+            ReadOnlySpan<char> result;
+            if (s.Remaining.IndexOfAny(delimiters) is int index && index > 0)
+            {
+                result = s.Remaining.Slice(0, index);
+            }
+            else
+            {
+                result = s.Remaining;
+            }
+
+            s.Consume(result.Length);
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowGenericArityTooLarge(int arity) => throw new NotSupportedException($"An arity of {arity} is not supported");
+
+        private ref struct Reader
+        {
+            public ReadOnlySpan<char> Input;
+            public int Index;
+            public int TotalGenericArity;
+
+            public readonly ReadOnlySpan<char> Remaining => this.Input.Slice(Index);
+
+            public bool TryPeek(out char c)
+            {
+                if (Index < Input.Length)
+                {
+                    c = Input[Index];
+                    return true;
+                }
+
+                c = default;
+                return false;
+            }
+
+            public void Consume(int chars)
+            {
+                if (Index < Input.Length)
+                {
+                    Index += chars;
+                    return;
+                }
+
+                ThrowEndOfInput();
+            }
+
+            public void ConsumeCharacter(char assertChar)
+            {
+                if (Index < Input.Length)
+                {
+                    var c = Input[Index];
+                    if (assertChar != c)
+                    {
+                        ThrowUnexpectedCharacter(assertChar, c);
+                        return;
+                    }
+
+                    ++Index;
+                    return;
+                }
+
+                ThrowEndOfInput();
+            }
+
+            public void ConsumeWhitespace()
+            {
+                while (char.IsWhiteSpace(Input[Index]))
+                {
+                    ++Index;
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
+        }
+    }
+}

--- a/src/Orleans.Core/Utils/RuntimeTypeNameRewriter.cs
+++ b/src/Orleans.Core/Utils/RuntimeTypeNameRewriter.cs
@@ -1,0 +1,194 @@
+using System;
+
+namespace Orleans.Utilities
+{
+    /// <summary>
+    /// Rewrites <see cref="TypeSpec"/> graphs.
+    /// </summary>
+    internal static class RuntimeTypeNameRewriter
+    {
+        /// <summary>
+        /// Rewrites a <see cref="TypeSpec"/> using the provided rewriter delegate.
+        /// </summary>
+        public static TypeSpec Rewrite(TypeSpec input, Func<QualifiedType, QualifiedType> rewriter)
+        {
+            var result = ApplyInner(input, null, rewriter);
+            if (result.Assembly is object)
+            {
+                // If the rewriter bubbled up an assembly, add it here. 
+                return new AssemblyQualifiedTypeSpec(result.Type, result.Assembly);
+            }
+
+            return result.Type;
+        }
+
+        private static (TypeSpec Type, string Assembly) ApplyInner(TypeSpec input, string assemblyName, Func<QualifiedType, QualifiedType> replaceFunc)
+        {
+            // A type's assembly is passed downwards through the graph, and modifications to the assembly (from the user-provided delegate) flow upwards.
+            switch (input)
+            {
+                case ConstructedGenericTypeSpec type:
+                    return HandleGeneric(type, assemblyName, replaceFunc);
+                case NamedTypeSpec type:
+                    return HandleNamedType(type, assemblyName, replaceFunc);
+                case AssemblyQualifiedTypeSpec type:
+                    return HandleAssembly(type, assemblyName, replaceFunc);
+                case ArrayTypeSpec type:
+                    return HandleArray(type, assemblyName, replaceFunc);
+                case PointerTypeSpec type:
+                    return HandlePointer(type, assemblyName, replaceFunc);
+                case ReferenceTypeSpec type:
+                    return HandleReference(type, assemblyName, replaceFunc);
+                case null:
+                    throw new ArgumentNullException(nameof(input));
+                default:
+                    throw new NotSupportedException($"Argument of type {input.GetType()} is nut supported");
+            }
+        }
+
+        private static (TypeSpec Type, string Assembly) HandleGeneric(ConstructedGenericTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var (unconstructed, replacementAssembly) = ApplyInner(type.UnconstructedType, assemblyName, replaceTypeName);
+
+            var newArguments = new TypeSpec[type.Arguments.Length];
+            var didChange = false;
+            for (var i = 0; i < type.Arguments.Length; i++)
+            {
+                // Generic type parameters do not inherit the assembly of the generic type.
+                var args = ApplyInner(type.Arguments[i], null, replaceTypeName);
+
+                if (args.Assembly is object)
+                {
+                    newArguments[i] = new AssemblyQualifiedTypeSpec(args.Type, args.Assembly);
+                }
+                else
+                {
+                    newArguments[i] = args.Type;
+                }
+
+                didChange |= !ReferenceEquals(newArguments[i], type.Arguments[i]);
+            }
+
+            if (ReferenceEquals(type.UnconstructedType, unconstructed) && !didChange)
+            {
+                return (type, replacementAssembly);
+            }
+
+            return (new ConstructedGenericTypeSpec((NamedTypeSpec)unconstructed, newArguments), replacementAssembly);
+        }
+
+        private static (TypeSpec Type, string Assembly) HandleNamedType(NamedTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var nsQualified = type.GetNamespaceQualifiedName();
+            var names = replaceTypeName(new QualifiedType(assembly: assemblyName, type: nsQualified));
+
+            if (!string.Equals(nsQualified, names.Type, StringComparison.Ordinal))
+            {
+                // Change the type name and potentially the assembly.
+                var resultType = RuntimeTypeNameParser.Parse(names.Type);
+                if (!(resultType is NamedTypeSpec))
+                {
+                    throw new InvalidOperationException($"Replacement type name, \"{names.Type}\", can not deviate from the original type structure of the input, \"{nsQualified}\"");
+                }
+
+                return (resultType, names.Assembly);
+            }
+            else if (!string.Equals(assemblyName, names.Assembly, StringComparison.Ordinal))
+            {
+                // Only change the assembly;
+                return (type, names.Assembly);
+            }
+            else if (type.ContainingType is object)
+            {
+                // Give the user an opportunity to change the parent, including the assembly.
+                var replacementParent = ApplyInner(type.ContainingType, assemblyName, replaceTypeName);
+                if (ReferenceEquals(replacementParent.Type, type.ContainingType))
+                {
+                    // No change to the type.
+                    return (type, replacementParent.Assembly);
+                }
+
+                // The parent type changed.
+                var typedReplacement = (NamedTypeSpec)replacementParent.Type;
+                return (new NamedTypeSpec(typedReplacement, type.Name, type.Arity), replacementParent.Assembly);
+            }
+            else
+            {
+                return (type, names.Assembly);
+            }
+        }
+
+        private static (TypeSpec Type, string Assembly) HandleAssembly(AssemblyQualifiedTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var replacement = ApplyInner(type.Type, type.Assembly, replaceTypeName);
+
+            // Assembly name changes never bubble up past the assembly qualifier node.
+            if (string.IsNullOrWhiteSpace(replacement.Assembly))
+            {
+                // Remove the assembly qualification
+                return (replacement.Type, assemblyName);
+            }
+            else if (!string.Equals(replacement.Assembly, type.Assembly) || !ReferenceEquals(replacement.Type, type.Type))
+            {
+                // Update the assembly or the type.
+                return (new AssemblyQualifiedTypeSpec(replacement.Type, replacement.Assembly), assemblyName);
+            }
+
+            // No update.
+            return (type, assemblyName);
+        }
+
+        private static (TypeSpec Type, string Assembly) HandleArray(ArrayTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            if (ReferenceEquals(element.Type, type.ElementType))
+            {
+                return (type, element.Assembly);
+            }
+
+            return (new ArrayTypeSpec(element.Type, type.Dimensions), element.Assembly);
+        }
+
+        private static (TypeSpec Type, string Assembly) HandleReference(ReferenceTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            if (ReferenceEquals(element.Type, type.ElementType))
+            {
+                return (type, element.Assembly);
+            }
+
+            return (new ReferenceTypeSpec(element.Type), element.Assembly);
+        }
+
+        private static (TypeSpec Type, string Assembly) HandlePointer(PointerTypeSpec type, string assemblyName, Func<QualifiedType, QualifiedType> replaceTypeName)
+        {
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            if (ReferenceEquals(element.Type, type.ElementType))
+            {
+                return (type, element.Assembly);
+            }
+
+            return (new PointerTypeSpec(element.Type), element.Assembly);
+        }
+    }
+
+    public readonly struct QualifiedType
+    {
+        public QualifiedType(string assembly, string type)
+        {
+            this.Assembly = assembly;
+            this.Type = type;
+        }
+
+        public void Deconstruct(out string assembly, out string type)
+        {
+            assembly = this.Assembly;
+            type = this.Type;
+        }
+
+        public static implicit operator QualifiedType((string Assembly, string Type) args) => new QualifiedType(args.Assembly, args.Type);
+
+        public string Assembly { get; }
+        public string Type { get; }
+    }
+}

--- a/src/Orleans.Core/Utils/TypeSpec.cs
+++ b/src/Orleans.Core/Utils/TypeSpec.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Orleans.Utilities
+{
+    /// <summary>
+    /// Represents a type.
+    /// </summary>
+    internal abstract class TypeSpec
+    {
+        /// <summary>
+        /// Formats this instance in a way that can be parsed by <see cref="RuntimeTypeNameParser"/>.
+        /// </summary>
+        public abstract string Format();
+    }
+
+    /// <summary>
+    /// Represents a pointer (*) type.
+    /// </summary>
+    internal class PointerTypeSpec : TypeSpec
+    {
+        public PointerTypeSpec(TypeSpec elementType)
+        {
+            if (elementType is null) throw new ArgumentNullException(nameof(ElementType));
+            this.ElementType = elementType;
+        }
+
+        /// <summary>
+        /// Gets the element type.
+        /// </summary>
+        public TypeSpec ElementType { get; }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{this.ElementType}*";
+    }
+
+    /// <summary>
+    /// Represents a reference (&amp;) type.
+    /// </summary>
+    internal class ReferenceTypeSpec : TypeSpec
+    {
+        public ReferenceTypeSpec(TypeSpec elementType)
+        {
+            if (elementType is null) throw new ArgumentNullException(nameof(ElementType));
+            this.ElementType = elementType;
+        }
+
+        /// <summary>
+        /// Gets the element type.
+        /// </summary>
+        public TypeSpec ElementType { get; }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{this.ElementType}&";
+    }
+
+    /// <summary>
+    /// Represents an array type.
+    /// </summary>
+    internal class ArrayTypeSpec : TypeSpec
+    {
+        public ArrayTypeSpec(TypeSpec elementType, int dimensions)
+        {
+            if (elementType is null) throw new ArgumentNullException(nameof(ElementType));
+            if (dimensions <= 0) throw new ArgumentOutOfRangeException($"An array cannot have a dimension count of {dimensions}");
+
+            this.ElementType = elementType;
+            this.Dimensions = dimensions;
+        }
+
+        /// <summary>
+        /// Gets the number of array dimensions.
+        /// </summary>
+        public int Dimensions { get; }
+
+        /// <summary>
+        /// Gets the element type.
+        /// </summary>
+        public TypeSpec ElementType { get; }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{this.ElementType}[{new string(',', this.Dimensions - 1)}]";
+    }
+
+    /// <summary>
+    /// Represents an constructed generic type.
+    /// </summary>
+    internal class ConstructedGenericTypeSpec : TypeSpec
+    {
+        public ConstructedGenericTypeSpec(NamedTypeSpec unconstructedType, TypeSpec[] arguments)
+        {
+            if (unconstructedType is null) throw new ArgumentNullException(nameof(unconstructedType));
+            if (arguments is null) throw new ArgumentNullException(nameof(arguments));
+            if (unconstructedType.Arity != arguments.Length)
+            {
+                throw new ArgumentException($"Invalid number of arguments {arguments.Length} provided while constructing generic type of arity {unconstructedType.Arity}: {unconstructedType}");
+            }
+
+            foreach (var arg in arguments)
+            {
+                if (arg is null)
+                {
+                    throw new ArgumentNullException("Cannot construct a generic type using a null argument");
+                }
+            }
+
+            this.UnconstructedType = unconstructedType;
+            this.Arguments = arguments;
+        }
+
+        /// <summary>
+        /// Gets the unconstructed type.
+        /// </summary>
+        public NamedTypeSpec UnconstructedType { get; }
+
+        /// <summary>
+        /// Gets the type arguments.
+        /// </summary>
+        public TypeSpec[] Arguments { get; }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{this.UnconstructedType}[{string.Join(",", this.Arguments.Select(a => $"[{a}]"))}]";
+    }
+
+    /// <summary>
+    /// Represents a named type, which may be an unconstructed generic type.
+    /// </summary>
+    internal class NamedTypeSpec : TypeSpec
+    {
+        public NamedTypeSpec(NamedTypeSpec containingType, string name, int arity)
+        {
+            this.ContainingType = containingType;
+            this.Name = name;
+            if (containingType is NamedTypeSpec c && c.Arity > arity)
+            {
+                throw new ArgumentException("A named type cannot have an arity less than that of its containing type");
+            }
+
+            if (arity < 0)
+            {
+                throw new ArgumentOutOfRangeException("A type cannot have a negative arity");
+            }
+
+            this.Arity = arity;
+        }
+
+        /// <summary>
+        /// Gets the number of generic parameters which this type requires.
+        /// </summary>
+        public int Arity { get; }
+
+        /// <summary>
+        /// Gets the type name, which includes the namespace if this is not a nested type.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the containing type.
+        /// </summary>
+        public NamedTypeSpec ContainingType { get; }
+
+        /// <summary>
+        /// Gets the namespace-qualified type name, including containing types (for nested types).
+        /// </summary>
+        /// <returns></returns>
+        public string GetNamespaceQualifiedName()
+        {
+            var builder = new StringBuilder();
+            GetQualifiedNameInternal(this, builder);
+            return builder.ToString();
+
+            static void GetQualifiedNameInternal(NamedTypeSpec n, StringBuilder b)
+            {
+                if (n.ContainingType is object)
+                {
+                    GetQualifiedNameInternal(n.ContainingType, b);
+                    b.Append('+');
+                }
+
+                b.Append(n.Name);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => ContainingType is object ? $"{this.ContainingType}+{this.Name}" : this.Name;
+    }
+
+    /// <summary>
+    /// Represents an assembly-qualified type.
+    /// </summary>
+    internal class AssemblyQualifiedTypeSpec : TypeSpec
+    {
+        public AssemblyQualifiedTypeSpec(TypeSpec type, string assembly)
+        {
+            if (type is null) throw new ArgumentNullException(nameof(type));
+            if (string.IsNullOrWhiteSpace(assembly)) throw new ArgumentNullException(nameof(assembly));
+
+            this.Type = type;
+            this.Assembly = assembly;
+        }
+
+        /// <summary>
+        /// Gets the assembly specification.
+        /// </summary>
+        public string Assembly { get; }
+
+        /// <summary>
+        /// Gets the qualified type.
+        /// </summary>
+        public TypeSpec Type { get; }
+
+        /// <inheritdoc/>
+        public override string Format() => this.ToString();
+
+        /// <inheritdoc/>
+        public override string ToString() => string.IsNullOrWhiteSpace(this.Assembly) ? this.Type.ToString() : $"{this.Type},{this.Assembly}";
+    }
+}

--- a/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
+++ b/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Orleans.Runtime;
@@ -15,19 +15,7 @@ namespace NonSilo.Tests
     public class RuntimeTypeNameFormatterTests
     {
         private readonly ITestOutputHelper output;
-
-        public RuntimeTypeNameFormatterTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
-
-        /// <summary>
-        /// Tests that various strings formatted with <see cref="RuntimeTypeNameFormatter"/> can be loaded using <see cref="Type.GetType(string)"/>.
-        /// </summary>
-        [Fact]
-        public void FormattedTypeNamesAreRecoverable()
-        {
-            var types = new[]
+        private readonly Type[] types = new[]
             {
                 typeof(NameValueCollection),
                 typeof(int),
@@ -48,7 +36,18 @@ namespace NonSilo.Tests
                     .MakeByRefType(),
                 typeof(NameValueCollection)
             };
-            
+
+        public RuntimeTypeNameFormatterTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        /// <summary>
+        /// Tests that various strings formatted with <see cref="RuntimeTypeNameFormatter"/> can be loaded using <see cref="Type.GetType(string)"/>.
+        /// </summary>
+        [Fact]
+        public void FormattedTypeNamesAreRecoverable()
+        {
             foreach (var type in types)
             {
                 var formatted = RuntimeTypeNameFormatter.Format(type);
@@ -59,6 +58,27 @@ namespace NonSilo.Tests
             }
         }
 
+        /// <summary>
+        /// Tests that various strings parsed by <see cref="RuntimeTypeNameParser"/> are reformatted identically to their input, when the input was produced by <see cref="RuntimeTypeNameFormatter"/>.
+        /// </summary>
+        [Fact]
+        public void ParsedTypeNamesAreIdenticalToFormattedNames()
+        {
+            foreach (var type in types)
+            {
+                var formatted = RuntimeTypeNameFormatter.Format(type);
+                var parsed = RuntimeTypeNameParser.Parse(formatted);
+                this.output.WriteLine($"Type.FullName: {type.FullName}");
+                this.output.WriteLine($"Formatted    : {formatted}");
+                this.output.WriteLine($"Parsed       : {parsed}");
+                Assert.Equal(formatted, parsed.Format());
+
+                var reparsed = RuntimeTypeNameParser.Parse(parsed.Format());
+                this.output.WriteLine($"Reparsed     : {reparsed}");
+                Assert.Equal(formatted, reparsed.Format());
+            }
+        } 
+        
         public class Inner<T>
         {
             public class InnerInner<U, V>


### PR DESCRIPTION
This is split out of the GrainId/InterfaceId work.

The purpose of this is to allow us to more easily parse CLR type names so that we can modify them, principally for supporting generics.