### PR TITLE
Make Deployment and Multi-Cluster Support documentation visible in sidebar

### DIFF
--- a/src/Documentation/toc.yml
+++ b/src/Documentation/toc.yml
@@ -14,7 +14,6 @@
     href: index.md
   - name: Deployment
     href: deployment/toc.yml
-  items:
   - name: Multi-Cluster Support
     href: index.md
 - name: Tutorials and Samples


### PR DESCRIPTION
toc.yml appears to be invalid (has duplicate items nodes), which seems to prevent Deployment and Multi-cluster support documentation links from being rendered.


