### PR TITLE
Made ShouldPurge protected and virtual in eviction strategy.

### DIFF
--- a/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -84,8 +84,10 @@ namespace Orleans.Providers.Streams.Common
             this.periodicMonitoring?.TryAction(nowUtc);
         }
 
-        /// <inheritdoc />
-        public virtual bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc)
+        /// <summary>
+        /// Given a purge cached message, indicates whether it should be purged from the cache.
+        /// </summary>
+        protected virtual bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc)
         {
             TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
             // age of message relative to the most recent event in the cache.

--- a/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -84,6 +84,16 @@ namespace Orleans.Providers.Streams.Common
             this.periodicMonitoring?.TryAction(nowUtc);
         }
 
+        /// <inheritdoc />
+        public virtual bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc)
+        {
+            TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
+            // age of message relative to the most recent event in the cache.
+            TimeSpan relativeAge = newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
+
+            return timePurge.ShouldPurgFromTime(timeInCache, relativeAge);
+        }
+
         private void PerformPurgeInternal(DateTime nowUtc)
         {
             //if the cache is empty, then nothing to purge, return
@@ -143,16 +153,6 @@ namespace Orleans.Providers.Streams.Common
                 this.cacheSizeInByte -= memoryReleasedInByte;
                 this.cacheMonitor?.TrackMemoryReleased(memoryReleasedInByte);
             }
-        }
-
-        // Given a purge cached message, indicates whether it should be purged from the cache
-        private bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc)
-        {
-            TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
-            // age of message relative to the most recent event in the cache.
-            TimeSpan relativeAge =  newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
-
-            return timePurge.ShouldPurgFromTime(timeInCache, relativeAge);
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
@@ -28,15 +28,6 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="newBlock"></param>
         void OnBlockAllocated(FixedSizeBuffer newBlock);
-
-        /// <summary>
-        /// Given a purge cached message, indicates whether it should be purged from the cache.
-        /// </summary>
-        /// <param name="cachedMessage"></param>
-        /// <param name="newestCachedMessage"></param>
-        /// <param name="nowUtc"></param>
-        /// <returns></returns>
-        bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc);
     }
 
     /// <summary>

--- a/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
@@ -28,6 +28,15 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="newBlock"></param>
         void OnBlockAllocated(FixedSizeBuffer newBlock);
+
+        /// <summary>
+        /// Given a purge cached message, indicates whether it should be purged from the cache.
+        /// </summary>
+        /// <param name="cachedMessage"></param>
+        /// <param name="newestCachedMessage"></param>
+        /// <param name="nowUtc"></param>
+        /// <returns></returns>
+        bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, DateTime nowUtc);
     }
 
     /// <summary>


### PR DESCRIPTION
We are seeing some cases where some items from cache are purged before they get delivered to a grain, as they satisfy the time purge criteria. It could also be because of some customizations we have done to Orleans streaming. 

So, just making ShouldPurge as public method so that we can customize it, like only purge cache messages whose sequence token is less than min read sequence token in last 15 mins or something. 

