### PR TITLE
Improve ClusterClient disposal

### DIFF
--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -19,7 +19,7 @@ namespace Orleans
     /// </summary>
     internal class ClusterClient : IInternalClusterClient
     {
-        private readonly IRuntimeClient runtimeClient;
+        private readonly OutsideRuntimeClient runtimeClient;
         private readonly ClusterClientLifecycle clusterClientLifecycle;
         private readonly AsyncLock initLock = new AsyncLock();
         private readonly ClientApplicationLifetime applicationLifetime;
@@ -41,12 +41,12 @@ namespace Orleans
         /// <param name="runtimeClient">The runtime client.</param>
         /// <param name="loggerFactory">Logger factory used to create loggers</param>
         /// <param name="clientMessagingOptions">Messaging parameters</param>
-        public ClusterClient(IRuntimeClient runtimeClient, ILoggerFactory loggerFactory, IOptions<ClientMessagingOptions> clientMessagingOptions)
+        public ClusterClient(OutsideRuntimeClient runtimeClient, ILoggerFactory loggerFactory, IOptions<ClientMessagingOptions> clientMessagingOptions)
         {
             this.runtimeClient = runtimeClient;
             this.clusterClientLifecycle = new ClusterClientLifecycle(loggerFactory.CreateLogger<LifecycleSubject>());
 
-            //set PropagateActivityId flag from node cofnig
+            //set PropagateActivityId flag from node config
             RequestContext.PropagateActivityId |= clientMessagingOptions.Value.PropagateActivityId;
 
             // register all lifecycle participants
@@ -120,9 +120,9 @@ namespace Orleans
                 {
                     throw new InvalidOperationException("A prior connection attempt failed. This instance must be disposed.");
                 }
-                
+
                 this.state = LifecycleState.Starting;
-                if (this.runtimeClient is OutsideRuntimeClient orc) await orc.Start(retryFilter).ConfigureAwait(false);
+                await this.runtimeClient.Start(retryFilter).ConfigureAwait(false);
                 await this.clusterClientLifecycle.OnStart().ConfigureAwait(false);
                 this.state = LifecycleState.Started;
             }
@@ -131,14 +131,15 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public Task Close() => this.Stop(gracefully: true);
+        public Task Close() => this.StopAsync(gracefully: true);
 
         /// <inheritdoc />
-        public Task AbortAsync() => this.Stop(gracefully: false);
+        public Task AbortAsync() => this.StopAsync(gracefully: false);
 
-        private async Task Stop(bool gracefully)
+        private async Task StopAsync(bool gracefully)
         {
             if (this.IsDisposing) return;
+
             this.applicationLifetime?.StopApplication();
             using (await this.initLock.LockAsync().ConfigureAwait(false))
             {
@@ -154,10 +155,9 @@ namespace Orleans
                         canceled = cts.Token;
                     }
 
-                    await this.clusterClientLifecycle.OnStop(canceled);
+                    await this.clusterClientLifecycle.OnStop(canceled).ConfigureAwait(false);
 
-                    Utils.SafeExecute(() => (this.runtimeClient as OutsideRuntimeClient)?.Reset(gracefully));
-                    this.Dispose(true);
+                    this.runtimeClient?.Reset(gracefully);
                 }
                 finally
                 {
@@ -170,7 +170,46 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        void IDisposable.Dispose() => this.AbortAsync().GetAwaiter().GetResult();
+        void IDisposable.Dispose()
+        {
+            if (this.IsDisposing) return;
+
+            this.AbortAsync().GetAwaiter().GetResult();
+
+            // Only dispose the service container if this client owns the application lifetime.
+            // If the lifetime isn't owned by this client, then the owner is responsible for disposing the container.
+            if (this.applicationLifetime is object)
+            {
+                (this.ServiceProvider as IDisposable)?.Dispose();
+            }
+
+            this.state = LifecycleState.Disposed;
+        }
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            if (this.IsDisposing) return;
+
+            await this.AbortAsync().ConfigureAwait(false);
+
+            // Only dispose the service container if this client owns the application lifetime.
+            // If the lifetime isn't owned by this client, then the owner is responsible for disposing the container.
+            if (this.applicationLifetime is object)
+            {
+                switch (this.ServiceProvider)
+                {
+                    case IAsyncDisposable asyncDisposable:
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        break;
+                    case IDisposable disposabe:
+                        await Task.Run(() => disposabe.Dispose()).ConfigureAwait(false);
+                        break;
+                }
+            }
+
+            this.state = LifecycleState.Disposed;
+        }
 
         /// <inheritdoc />
         public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
@@ -256,16 +295,6 @@ namespace Orleans
             return this.InternalGrainFactory.GetGrain(grainId);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed")]
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                Utils.SafeExecute(() => (this.runtimeClient as OutsideRuntimeClient)?.Dispose());
-                this.state = LifecycleState.Disposed;
-            }
-        }
-
         private void ThrowIfDisposedOrNotInitialized()
         {
             this.ThrowIfDisposed();
@@ -281,9 +310,9 @@ namespace Orleans
         private void ThrowIfDisposed()
         {
             if (this.IsDisposing)
-                throw new ObjectDisposedException(
-                    nameof(ClusterClient),
-                    $"Client has been disposed either by a call to {nameof(Dispose)} or because it has been stopped.");
+            {
+                throw new ObjectDisposedException(nameof(ClusterClient), "Client has been disposed.");
+            }
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Core/IClusterClient.cs
+++ b/src/Orleans.Core/Core/IClusterClient.cs
@@ -9,7 +9,7 @@ namespace Orleans
     /// <summary>
     /// Client interface for interacting with an Orleans cluster.
     /// </summary>
-    public interface IClusterClient : IDisposable, IGrainFactory
+    public interface IClusterClient : IGrainFactory, IAsyncDisposable, IDisposable
     {
         /// <summary>
         /// Gets a value indicating whether or not this client is initialized.

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -443,17 +443,10 @@ namespace Orleans
             Utils.SafeExecute(() => this.callbackTimer?.Dispose());
             
             Utils.SafeExecute(() => MessageCenter?.Dispose());
-            if (ClientStatistics != null)
-            {
-                Utils.SafeExecute(() => ClientStatistics.Dispose());
-            }
 
-            Utils.SafeExecute(() => (this.ServiceProvider as IDisposable)?.Dispose());
+            this.ClusterConnectionLost = null;
+            this.GatewayCountChanged = null;
 
-            Utils.SafeExecute(() => this.ClusterConnectionLost = null);
-            Utils.SafeExecute(() => this.GatewayCountChanged = null);
-
-            this.ServiceProvider = null;
             GC.SuppressFinalize(this);
         }
 

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -57,6 +57,9 @@ namespace Orleans.Runtime
         void IDisposable.Dispose() { }
 
         /// <inheritdoc />
+        ValueTask IAsyncDisposable.DisposeAsync() => default;
+
+        /// <inheritdoc />
         public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithGuidKey
         {

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -99,6 +99,23 @@ namespace Orleans.TestingHost
             }
         }
 
+        public override async ValueTask DisposeAsync()
+        {
+            if (!this.IsActive) return;
+
+            try
+            {
+                await StopSiloAsync(true).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (this.SiloHost is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+
         private void WriteLog(object value)
         {
             Console.WriteLine(value?.ToString());

--- a/src/Orleans.TestingHost/SiloHandle.cs
+++ b/src/Orleans.TestingHost/SiloHandle.cs
@@ -8,7 +8,7 @@ namespace Orleans.TestingHost
     /// <summary>
     /// Represents a handle to a silo that is remotely deployed
     /// </summary>
-    public abstract class SiloHandle : IDisposable
+    public abstract class SiloHandle : IDisposable, IAsyncDisposable
     {
         /// <summary> Get or set configuration of the cluster </summary>
         public TestClusterOptions ClusterOptions { get; set; }
@@ -55,6 +55,9 @@ namespace Orleans.TestingHost
                 StopSiloAsync(true).GetAwaiter().GetResult();
             }
         }
+
+        /// <inheritdoc />
+        public abstract ValueTask DisposeAsync();
 
         /// <inheritdoc />
         ~SiloHandle()

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -22,7 +22,6 @@ namespace AWSUtils.Tests.StorageTests
     [TestCategory("Persistence"), TestCategory("AWS"), TestCategory("DynamoDb")]
     public class PersistenceGrainTests_AWSDynamoDBStore : Base_PersistenceGrainTests_AWSStore, IClassFixture<PersistenceGrainTests_AWSDynamoDBStore.Fixture>
     {
-        private static readonly string DataConnectionString = $"Service={AWSTestConstants.Service}";
         public class Fixture : TestExtensions.BaseTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -23,7 +23,7 @@ namespace AWSUtils.Tests.Streaming
 {
     [TestCategory("AWS"), TestCategory("SQS")]
     [Collection(TestEnvironmentFixture.DefaultCollection)]
-    public class SQSAdapterTests : IDisposable
+    public class SQSAdapterTests : IAsyncLifetime
     {
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture fixture;
@@ -46,9 +46,18 @@ namespace AWSUtils.Tests.Streaming
             this.clusterId = MakeClusterId();
         }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, this.clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+            if (!string.IsNullOrWhiteSpace(AWSTestConstants.DefaultSQSConnectionString))
+            {
+                await SQSStreamProviderUtils.DeleteAllUsedQueues(
+                    SQS_STREAM_PROVIDER_NAME,
+                    this.clusterId,
+                    AWSTestConstants.DefaultSQSConnectionString,
+                    NullLoggerFactory.Instance);
+            }
         }
 
         [SkippableFact]

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -79,16 +79,20 @@ namespace AWSUtils.Tests.Streaming
             }
         }
         
-        public SQSStreamTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SingleStreamTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME);
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
             var clusterId = HostedCluster.Options.ClusterId;
-            base.Dispose();
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(AWSTestConstants.DefaultSQSConnectionString))
+            {
+                SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+            }
         }
 
         ////------------------------ One to One ----------------------//

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -2,18 +2,15 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 using AWSUtils.Tests.StorageTests;
 using Xunit;
 using Orleans;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using OrleansAWSUtils.Streams;
 using Orleans.Hosting;
 using TestExtensions;
 using UnitTests.StreamingTests;
-using Orleans.Configuration;
 
 namespace AWSUtils.Tests.Streaming
 {
@@ -22,7 +19,7 @@ namespace AWSUtils.Tests.Streaming
         private const string SQSStreamProviderName = "SQSProvider";
         private const string StreamNamespace = "SQSSubscriptionMultiplicityTestsNamespace";
         private string StreamConnectionString = AWSTestConstants.DefaultSQSConnectionString;
-        private readonly SubscriptionMultiplicityTestRunner runner;
+        private SubscriptionMultiplicityTestRunner runner;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -60,16 +57,20 @@ namespace AWSUtils.Tests.Streaming
             }
         }
 
-        public SQSSubscriptionMultiplicityTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SubscriptionMultiplicityTestRunner(SQSStreamProviderName, this.HostedCluster);
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
             var clusterId = HostedCluster.Options.ClusterId;
-            base.Dispose();
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StreamConnectionString, NullLoggerFactory.Instance).Wait();
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(StreamConnectionString))
+            {
+                await SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StreamConnectionString, NullLoggerFactory.Instance);
+            }
         }
 
         [SkippableFact, TestCategory("AWS")]

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using Tester.StreamingTests;
 using TestExtensions;
@@ -23,12 +21,17 @@ namespace GoogleUtils.Tests.Streaming
         private const string STREAM_NAMESPACE = "PubSubSubscriptionMultiplicityTestsNamespace";
 
         private readonly ITestOutputHelper output;
-        private readonly ClientStreamTestRunner runner;
+        private ClientStreamTestRunner runner;
 
         public PubSubClientStreamTests(ITestOutputHelper output)
         {
             this.output = output;
-            runner = new ClientStreamTestRunner(HostedCluster);
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+            runner = new ClientStreamTestRunner(this.HostedCluster);
         }
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
@@ -63,8 +63,9 @@ namespace GoogleUtils.Tests.Streaming
             }
         }
 
-        public PubSubStreamTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SingleStreamTestRunner(InternalClient, PUBSUB_STREAM_PROVIDER_NAME);
         }
 

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
@@ -18,7 +18,7 @@ namespace GoogleUtils.Tests.Streaming
     {
         private const string PROVIDER_NAME = "PubSubProvider";
         private const string STREAM_NAMESPACE = "PubSubSubscriptionMultiplicityTestsNamespace";
-        private readonly SubscriptionMultiplicityTestRunner runner;
+        private SubscriptionMultiplicityTestRunner runner;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -61,8 +61,9 @@ namespace GoogleUtils.Tests.Streaming
             }
         }
 
-        public PubSubSubscriptionMultiplicityTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SubscriptionMultiplicityTestRunner(PROVIDER_NAME, HostedCluster);
         }
 

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Extensions.Configuration;
 using Orleans.Runtime;
 using Orleans.Hosting;
 using Orleans;
 using Orleans.Configuration;
-using Orleans.Runtime.Configuration;
-using Orleans.Streaming.EventHubs;
 using Orleans.TestingHost;
 using Tester.TestStreamProviders;
 using ServiceBus.Tests.TestStreamProviders.EventHub;
@@ -32,10 +29,15 @@ namespace ServiceBus.Tests.StreamingTests
         private const string EHConsumerGroup = "orleansnightly";
 
         private readonly ITestOutputHelper output;
-        private readonly ClientStreamTestRunner runner;
+        private ClientStreamTestRunner runner;
         public EHClientStreamTests(ITestOutputHelper output)
         {
             this.output = output;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             runner = new ClientStreamTestRunner(this.HostedCluster);
         }
 

--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/MySqlStorageTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/MySqlStorageTests.cs
@@ -1,4 +1,4 @@
-﻿using Orleans;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Tests.SqlUtils;
 using System;

--- a/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Tester.AzureUtils
 {
     [TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
-    public class AzureQueueDataManagerTests : IClassFixture<AzureStorageBasicTests>, IDisposable
+    public class AzureQueueDataManagerTests : IClassFixture<AzureStorageBasicTests>, IAsyncLifetime
     {
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
@@ -28,12 +28,13 @@ namespace Tester.AzureUtils
             this.loggerFactory = loggerFactory;
         }
 
-        public void Dispose()
-        {
-            AzureQueueDataManager manager = GetTableManager(queueName).Result;
-            manager.DeleteQueue().Wait();
-        }
+        public Task InitializeAsync() => Task.CompletedTask;
 
+        public async Task DisposeAsync()
+        {
+            AzureQueueDataManager manager = await GetTableManager(queueName);
+            await manager.DeleteQueue();
+        }
 
         private async Task<AzureQueueDataManager> GetTableManager(string qName, TimeSpan? visibilityTimeout = null)
         {

--- a/test/Extensions/TesterAzureUtils/Streaming/AQClientStreamTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQClientStreamTests.cs
@@ -24,11 +24,16 @@ namespace Tester.AzureUtils.Streaming
         private const string StreamNamespace = "AQSubscriptionMultiplicityTestsNamespace";
 
         private readonly ITestOutputHelper output;
-        private readonly ClientStreamTestRunner runner;
+        private ClientStreamTestRunner runner;
 
         public AQClientStreamTests(ITestOutputHelper output)
         {
             this.output = output;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             runner = new ClientStreamTestRunner(this.HostedCluster);
         }
 
@@ -67,15 +72,15 @@ namespace Tester.AzureUtils.Streaming
             }
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            base.Dispose();
-            if (this.HostedCluster != null)
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
                 var serviceId = this.HostedCluster.Client.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ServiceId;
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(serviceId, AQStreamProviderName),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
-                TestAzureTableStorageStreamFailureHandler.DeleteAll().Wait();
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(serviceId, AQStreamProviderName),
+                    TestDefaultConfiguration.DataConnectionString);
+                await TestAzureTableStorageStreamFailureHandler.DeleteAll();
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -45,17 +46,17 @@ namespace Tester.AzureUtils.Streaming
                 }
             }
 
-            public override void Dispose()
+            public override async Task DisposeAsync()
             {
-                base.Dispose();
+                await base.DisposeAsync();
 
                 // Only perform cleanup if this suite was not skipped.
-                if (this.HostedCluster != null)
+                if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
-                        AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount), TestDefaultConfiguration.DataConnectionString).Wait();
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
-                        AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount), TestDefaultConfiguration.DataConnectionString).Wait();
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                        AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount), TestDefaultConfiguration.DataConnectionString);
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                        AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount), TestDefaultConfiguration.DataConnectionString);
                 }
             }
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -20,7 +20,7 @@ namespace Tester.AzureUtils.Streaming
     {
         public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
         public const string SmsStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
-        private readonly SingleStreamTestRunner runner;
+        private SingleStreamTestRunner runner;
         private const int queueCount = 8;
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -72,17 +72,21 @@ namespace Tester.AzureUtils.Streaming
             }
         }
 
-        public AQStreamingTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SingleStreamTestRunner(this.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME);
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            base.Dispose();
-            AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
-                AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                TestDefaultConfiguration.DataConnectionString).Wait();
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
+            {
+                await AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
+                    TestDefaultConfiguration.DataConnectionString);
+            }
         }
 
         ////------------------------ One to One ----------------------//

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamsBatchingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamsBatchingTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -67,17 +68,17 @@ namespace Tester.AzureUtils.Streaming
                 }
             }
 
-            public override void Dispose()
+            public override async Task DisposeAsync()
             {
-                base.Dispose();
-                if (this.HostedCluster != null)
+                await base.DisposeAsync();
+                if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                        TestDefaultConfiguration.DataConnectionString);
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
+                        TestDefaultConfiguration.DataConnectionString);
                 }
             }
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -21,7 +21,7 @@ namespace Tester.AzureUtils.Streaming
     {
         private const string AQStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
         private const string StreamNamespace = "AQSubscriptionMultiplicityTestsNamespace";
-        private readonly SubscriptionMultiplicityTestRunner runner;
+        private SubscriptionMultiplicityTestRunner runner;
         private const int queueCount = 8;
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -59,17 +59,21 @@ namespace Tester.AzureUtils.Streaming
             }
         }
 
-        public AQSubscriptionMultiplicityTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new SubscriptionMultiplicityTestRunner(AQStreamProviderName, this.HostedCluster);
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            base.Dispose();
-            if (this.HostedCluster != null)
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount), TestDefaultConfiguration.DataConnectionString).Wait();
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(
+                    NullLoggerFactory.Instance,
+                    AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
+                    TestDefaultConfiguration.DataConnectionString);
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -23,18 +24,18 @@ namespace Tester.AzureUtils.Streaming
                 builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             }
 
-            public override void Dispose()
+            public override async Task DisposeAsync()
             {
-                base.Dispose();
-                if (this.HostedCluster != null)
+                await base.DisposeAsync();
+                if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}{StreamProviderName}", queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
+                        TestDefaultConfiguration.DataConnectionString);
 
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}{StreamProviderName2}", queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
+                        TestDefaultConfiguration.DataConnectionString);
                 }
             }
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -24,7 +24,7 @@ namespace Tester.AzureUtils.Streaming
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
     [TestCategory("Azure"), TestCategory("Streaming")]
-    public class AzureQueueAdapterTests : AzureStorageBasicTests, IDisposable
+    public class AzureQueueAdapterTests : AzureStorageBasicTests, IAsyncLifetime
     {
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture fixture;
@@ -43,11 +43,13 @@ namespace Tester.AzureUtils.Streaming
             BufferPool.InitGlobalBufferPool(new SiloMessagingOptions());
         }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
             if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, azureQueueNames, TestDefaultConfiguration.DataConnectionString).Wait();
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, azureQueueNames, TestDefaultConfiguration.DataConnectionString);
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
@@ -70,14 +70,14 @@ namespace Tester.AzureUtils.Streaming
             }
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            base.Dispose();
-            if (this.HostedCluster != null)
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
+                    TestDefaultConfiguration.DataConnectionString);
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace UnitTests.HaloTests.Streaming
 {
     [TestCategory("Streaming"), TestCategory("Halo")]
-    public class HaloStreamSubscribeTests : OrleansTestingBase, IClassFixture<HaloStreamSubscribeTests.Fixture>, IDisposable
+    public class HaloStreamSubscribeTests : OrleansTestingBase, IClassFixture<HaloStreamSubscribeTests.Fixture>
     {
         private readonly Fixture fixture;
         private const int queueCount = 8;
@@ -70,17 +70,17 @@ namespace UnitTests.HaloTests.Streaming
                 }
             }
 
-            public override void Dispose()
+            public override async Task DisposeAsync()
             {
-                base.Dispose();
-                if (this.HostedCluster != null)
+                await base.DisposeAsync();
+                if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                        TestDefaultConfiguration.DataConnectionString);
+                    await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                         AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
-                        TestDefaultConfiguration.DataConnectionString).Wait();
+                        TestDefaultConfiguration.DataConnectionString);
                 }
             }
         }
@@ -100,16 +100,6 @@ namespace UnitTests.HaloTests.Streaming
             HostedCluster = fixture.HostedCluster;
             fixture.EnsurePreconditionsMet();
             this.loggerFactory = fixture.HostedCluster.ServiceProvider.GetService<ILoggerFactory>();
-        }
-
-        public void Dispose()
-        {
-            AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
-                AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                TestDefaultConfiguration.DataConnectionString).Wait();
-            AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
-                AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
-                TestDefaultConfiguration.DataConnectionString).Wait();
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -40,13 +40,14 @@ namespace Tester.AzureUtils.Streaming
             }
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            if (this.HostedCluster != null)
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
+                    TestDefaultConfiguration.DataConnectionString);
             }
         }
 

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -94,6 +94,11 @@ namespace UnitTests.StreamingTests
         public StreamLifecycleTests(ITestOutputHelper output)
         {
             this.output = output;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             this.watcher = this.GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
             StreamId = Guid.NewGuid();
             StreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
@@ -110,21 +115,16 @@ namespace UnitTests.StreamingTests
             {
                 await base.DisposeAsync();
             }
-        }
 
-        public override void Dispose()
-        {
-            if (this.HostedCluster != null)
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    TestDefaultConfiguration.DataConnectionString);
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
+                    TestDefaultConfiguration.DataConnectionString);
             }
-
-            base.Dispose();
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -82,22 +82,26 @@ namespace UnitTests.StreamingTests
         {
             this.output = output;
             StreamNamespace = StreamTestsConstants.StreamLifecycleTestsNamespace;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             this.mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
         }
 
-        public override void Dispose()
+        public override async Task DisposeAsync()
         {
-            if (this.HostedCluster != null)
+            await base.DisposeAsync();
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                    TestDefaultConfiguration.DataConnectionString);
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
                     AzureQueueUtilities.GenerateQueueNames($"{this.HostedCluster.Options.ClusterId}2", queueCount),
-                    TestDefaultConfiguration.DataConnectionString).Wait();
+                    TestDefaultConfiguration.DataConnectionString);
             }
-
-            base.Dispose();
         }
         [SkippableFact]
         public async Task SMS_Limits_FindMax_Consumers()

--- a/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHandle.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHandle.cs
@@ -151,6 +151,12 @@ namespace Orleans.TestingHost
             }
         }
 
+        public override ValueTask DisposeAsync()
+        {
+            this.Dispose(true);
+            return default;
+        }
+
         private void WriteLog(object value)
         {
             // TODO: replace

--- a/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHost.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHost.cs
@@ -31,6 +31,16 @@ namespace Orleans.TestingHost
         public void Start() => this.host.StartAsync().GetAwaiter().GetResult();
 
         /// <summary>Gracefully shuts down the silo</summary>
-        public void Shutdown() => this.host.StopAsync().GetAwaiter().GetResult();
+        public void Shutdown()
+        {
+            try
+            {
+                this.host.StopAsync().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                this.host.Dispose();
+            }
+        }
     }
 }

--- a/test/Tester/ClientConnectionTests/ClientConnectionEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientConnectionEventTests.cs
@@ -16,16 +16,17 @@ namespace Tester
 {
     public class ClientConnectionEventTests : TestClusterPerTest
     {
-        private readonly OutsideRuntimeClient runtimeClient;
-
-        public ClientConnectionEventTests()
-        {
-            this.runtimeClient = this.HostedCluster.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
-        }
+        private OutsideRuntimeClient runtimeClient;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             builder.AddClientBuilderConfigurator<Configurator>();
+        }
+
+        public override async Task InitializeAsync()
+        {
+           await base.InitializeAsync();
+           this.runtimeClient = this.HostedCluster.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
         }
 
         public class Configurator : IClientBuilderConfigurator

--- a/test/Tester/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
@@ -15,12 +15,13 @@ namespace Tester
 {
     public class ClientConnectionRegisteredServiceEventTests : TestClusterPerTest
     {
-        private readonly EventNotifier<EventArgs> clusterConnectionLostNotifier;
+        private EventNotifier<EventArgs> clusterConnectionLostNotifier;
 
-        private readonly EventNotifier<GatewayCountChangedEventArgs> gatewayCountChangedNotifier;
+        private EventNotifier<GatewayCountChangedEventArgs> gatewayCountChangedNotifier;
 
-        public ClientConnectionRegisteredServiceEventTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             this.clusterConnectionLostNotifier = this.HostedCluster.ServiceProvider.GetRequiredService<EventNotifier<EventArgs>>();
             this.gatewayCountChangedNotifier = this.HostedCluster.ServiceProvider.GetRequiredService<EventNotifier<GatewayCountChangedEventArgs>>();
         }

--- a/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
@@ -46,7 +46,7 @@ namespace Tester
 
     public class GatewayConnectionTests : TestClusterPerTest
     {
-        private readonly OutsideRuntimeClient runtimeClient;
+        private OutsideRuntimeClient runtimeClient;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -98,8 +98,9 @@ namespace Tester
             }
         }
 
-        public GatewayConnectionTests()
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             this.runtimeClient = this.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
         }
 

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -6,7 +6,6 @@ using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.StreamingTests;
@@ -20,11 +19,16 @@ namespace Tester.StreamingTests
         private const string SMSStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
         private const string StreamNamespace = "SMSDeactivationTestsNamespace";
         private readonly ITestOutputHelper output;
-        private readonly ClientStreamTestRunner runner;
+        private ClientStreamTestRunner runner;
 
         public SMSClientStreamTests(ITestOutputHelper output)
         {
             this.output = output;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             runner = new ClientStreamTestRunner(this.HostedCluster);
         }
 

--- a/test/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/test/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -17,10 +17,12 @@ namespace UnitTests.StreamingTests
     {
         private const string SMSStreamProviderName = "SMSProvider";
         private const string StreamNamespace = "SMSDeactivationTestsNamespace";
-        private readonly DeactivationTestRunner runner;
+        private DeactivationTestRunner runner;
         public static readonly TimeSpan CollectionAge = GrainCollectionOptions.DEFAULT_COLLECTION_QUANTUM + TimeSpan.FromSeconds(1);
-        public SMSDeactivationTests()
+
+        public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
             runner = new DeactivationTestRunner(SMSStreamProviderName, this.Client);
         }
 

--- a/test/TesterInternal/StorageTests/TestDataSets/StorageDataSetGeneric.cs
+++ b/test/TesterInternal/StorageTests/TestDataSets/StorageDataSetGeneric.cs
@@ -1,45 +1,26 @@
-﻿using System;
+using System;
 using Orleans;
-using System.Collections;
-using System.Collections.Generic;
 using Orleans.Runtime;
-
+using Xunit;
 
 namespace UnitTests.StorageTests.Relational.TestDataSets
 {
-    public sealed class StorageDataSetGeneric<TGrainKey, TStateData>: IEnumerable<object[]>
+    internal sealed class StorageDataSetGeneric<TGrainKey, TStateData> : TheoryData<TGrainKey, Func<IInternalGrainFactory, GrainReference>, GrainState<TestStateGeneric1<TStateData>>>
     {
-        private IEnumerable<object[]> DataSet { get; } = new[]
+        public StorageDataSetGeneric()
         {
-            new object[]
-            {
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data1", B = 1, C = 4 } }
-            },
-            new object[]
-            {
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data1", B = 1, C = 4 } });
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data2", B = 2, C = 5 } }
-            },
-            new object[]
-            {
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data2", B = 2, C = 5 } });
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data3", B = 3, C = 6 } }
-            }
-        };
-
-        public IEnumerator<object[]> GetEnumerator()
-        {
-            return DataSet.GetEnumerator();
-        }
-
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(), A = "Data3", B = 3, C = 6 } });
         }
     }
 }

--- a/test/TesterInternal/StorageTests/TestDataSets/StorageDateSetGenericHuge.cs
+++ b/test/TesterInternal/StorageTests/TestDataSets/StorageDateSetGenericHuge.cs
@@ -1,46 +1,28 @@
-﻿using Orleans;
+using Orleans;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Orleans.Runtime;
-
+using Xunit;
 
 namespace UnitTests.StorageTests.Relational.TestDataSets
 {
-    public sealed class StorageDataSetGenericHuge<TGrainKey, TStateData>: IEnumerable<object[]>
+    internal sealed class StorageDataSetGenericHuge<TGrainKey, TStateData> : TheoryData<TGrainKey, Func<IInternalGrainFactory, GrainReference>, GrainState<TestStateGeneric1<TStateData>>>
     {
         private static Range<long> CountOfCharacters { get; } = new Range<long>(1000000, 1000000);
 
-        private IEnumerable<object[]> DataSet { get; } = new[]
+        public StorageDataSetGenericHuge()
         {
-            new object[]
-            {
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data1", B = 1, C = 4 } }
-            },
-            new object[]
-            {
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data1", B = 1, C = 4 } });
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data2", B = 2, C = 5 } }
-            },
-            new object[]
-            {
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data2", B = 2, C = 5 } });
+            this.AddRow(
                 GrainTypeGenerator.GetGrainType<TGrainKey>(),
                 (Func<IInternalGrainFactory, GrainReference>)(grainFactory => RandomUtilities.GetRandomGrainReference<TGrainKey>(grainFactory)),
-                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data3", B = 3, C = 6 } }
-            }
-        };
-
-        public IEnumerator<object[]> GetEnumerator()
-        {
-            return DataSet.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
+                new GrainState<TestStateGeneric1<TStateData>> { State = new TestStateGeneric1<TStateData> { SomeData = RandomUtilities.GetRandom<TStateData>(CountOfCharacters), A = "Data3", B = 3, C = 6 } });
         }
     }
 }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
@@ -14,11 +14,18 @@ namespace Orleans.Transactions.AzureStorage.Tests
     [TestCategory("Azure"), TestCategory("Transactions"), TestCategory("Functional")]
     public class TransactionRecoveryTests : TestClusterPerTest
     {
-        private readonly TransactionRecoveryTestsRunnerxUnit testRunner;
+        private TransactionRecoveryTestsRunnerxUnit testRunner;
+        private ITestOutputHelper helper;
 
         public TransactionRecoveryTests(ITestOutputHelper helper)
         {
             this.EnsurePreconditionsMet();
+            this.helper = helper;
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
             this.testRunner = new TransactionRecoveryTestsRunnerxUnit(this.HostedCluster, helper);
         }
 


### PR DESCRIPTION
When disposing the client, we should not dispose the `IServiceProvider` if the client is not responsible for it. If the client was constructed using `ClientBuilder`, then it is responsible for disposal.

Adds support for `IAsyncDisposable`.