### PR TITLE
Stop sending messages to a gateway that is shutting down

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -224,7 +224,7 @@ namespace Orleans.Messaging
         private ValueTask<Connection> GetGatewayConnection(Message msg)
         {
             // If there's a specific gateway specified, use it
-            if (msg.TargetSilo != null && gatewayManager.GetLiveGateways().Contains(msg.TargetSilo))
+            if (msg.TargetSilo != null && gatewayManager.IsGatewayAvailable(msg.TargetSilo))
             {
                 var siloAddress = SiloAddress.New(msg.TargetSilo.Endpoint, 0);
                 var connectionTask = this.connectionManager.GetConnection(siloAddress);
@@ -273,7 +273,7 @@ namespace Orleans.Messaging
             if (weakRef != null
                 && weakRef.TryGetTarget(out var existingConnection)
                 && existingConnection.IsValid
-                && gatewayManager.GetLiveGateways().Contains(msg.TargetSilo))
+                && gatewayManager.IsGatewayAvailable(msg.TargetSilo))
             {
                 return new ValueTask<Connection>(existingConnection);
             }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -256,6 +256,13 @@ namespace Orleans
 
         private void HandleMessage(Message message)
         {
+            if (message.CloseRequested)
+            {
+                this.logger.LogInformation("Gateway {Gateway} request us to stop sending message to it", message.SendingSilo);
+                this.MessageCenter.StopSendingMessageTo(message.SendingSilo);
+                return;
+            }
+
             switch (message.Direction)
             {
                 case Message.Directions.Response:

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly IConnectionListenerFactory listenerFactory;
         private readonly ConnectionManager connectionManager;
-        private readonly ConcurrentDictionary<Connection, Task> connections = new ConcurrentDictionary<Connection, Task>(ReferenceEqualsComparer.Instance);
+        protected readonly ConcurrentDictionary<Connection, Task> connections = new ConcurrentDictionary<Connection, Task>(ReferenceEqualsComparer.Instance);
         private readonly ConnectionCommon connectionShared;
         private TaskCompletionSource<object> acceptLoopTcs;
         private IConnectionListener listener;


### PR DESCRIPTION
When a silo shutdown, notify clients connected to the local gateway to stop sending messages.

While the current implementation is a bit hacky, we got very good results, and it shouldn't break backward compatibility, so we should be able to backport this fix to 3.2.x and potentially 3.1.x branches.