### PR TITLE
Delete old Joining records as part of cleanup of defunct entries

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -567,7 +567,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             return DateTimeOffset.TryParse(silo.IAmAliveTime, out var iAmAliveTime)
                     && iAmAliveTime < beforeDate
-                    && silo.Status == (int)SiloStatus.Dead;
+                    && silo.Status != (int)SiloStatus.Active;
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -21,6 +21,7 @@ namespace Orleans.AzureUtils
         private readonly string INSTANCE_STATUS_CREATED = SiloStatus.Created.ToString();  //"Created";
         private readonly string INSTANCE_STATUS_ACTIVE = SiloStatus.Active.ToString();    //"Active";
         private readonly string INSTANCE_STATUS_DEAD = SiloStatus.Dead.ToString();        //"Dead";
+        private readonly string INSTANCE_STATUS_JOINING = SiloStatus.Joining.ToString();        //"Joining";
 
         private readonly AzureTableDataManager<SiloInstanceTableEntry> storage;
         private readonly ILogger logger;
@@ -198,7 +199,7 @@ namespace Orleans.AzureUtils
         public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             var entriesList = (await FindAllSiloEntries())
-                .Where(entry => entry.Item1.Status == INSTANCE_STATUS_DEAD && entry.Item1.Timestamp < beforeDate)
+                .Where(entry => (entry.Item1.Status == INSTANCE_STATUS_DEAD || entry.Item1.Status == INSTANCE_STATUS_JOINING) && entry.Item1.Timestamp < beforeDate)
                 .ToList();
 
             await DeleteEntriesBatch(entriesList);

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -21,7 +21,6 @@ namespace Orleans.AzureUtils
         private readonly string INSTANCE_STATUS_CREATED = SiloStatus.Created.ToString();  //"Created";
         private readonly string INSTANCE_STATUS_ACTIVE = SiloStatus.Active.ToString();    //"Active";
         private readonly string INSTANCE_STATUS_DEAD = SiloStatus.Dead.ToString();        //"Dead";
-        private readonly string INSTANCE_STATUS_JOINING = SiloStatus.Joining.ToString();        //"Joining";
 
         private readonly AzureTableDataManager<SiloInstanceTableEntry> storage;
         private readonly ILogger logger;
@@ -199,7 +198,7 @@ namespace Orleans.AzureUtils
         public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             var entriesList = (await FindAllSiloEntries())
-                .Where(entry => (entry.Item1.Status == INSTANCE_STATUS_DEAD || entry.Item1.Status == INSTANCE_STATUS_JOINING) && entry.Item1.Timestamp < beforeDate)
+                .Where(entry => (entry.Item1.Status != INSTANCE_STATUS_ACTIVE) && entry.Item1.Timestamp < beforeDate)
                 .ToList();
 
             await DeleteEntriesBatch(entriesList);

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -418,15 +418,17 @@ namespace UnitTests.MembershipTests
             oldEntryDead.StartTime = oldEntryDead.StartTime.AddDays(-10);
             oldEntryDead.Status = SiloStatus.Dead;
             bool ok = await membershipTable.InsertRow(oldEntryDead, newTableVersion);
-            
+            var table = await membershipTable.ReadAll();
+
             Assert.True(ok, "InsertRow Dead failed");
 
+            newTableVersion = table.Version.Next();
             var oldEntryJoining = CreateMembershipEntryForTest();
             oldEntryJoining.IAmAliveTime = oldEntryJoining.IAmAliveTime.AddDays(-10);
             oldEntryJoining.StartTime = oldEntryJoining.StartTime.AddDays(-10);
             oldEntryJoining.Status = SiloStatus.Joining;
             ok = await membershipTable.InsertRow(oldEntryJoining, newTableVersion);
-            var table = await membershipTable.ReadAll();
+            table = await membershipTable.ReadAll();
 
             Assert.True(ok, "InsertRow Joining failed");
 

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -413,17 +413,25 @@ namespace UnitTests.MembershipTests
 
             TableVersion newTableVersion = data.Version.Next();
 
-            MembershipEntry oldEntry = CreateMembershipEntryForTest();
-            oldEntry.IAmAliveTime = oldEntry.IAmAliveTime.AddDays(-10);
-            oldEntry.StartTime = oldEntry.StartTime.AddDays(-10);
-            oldEntry.Status = SiloStatus.Dead;
-            bool ok = await membershipTable.InsertRow(oldEntry, newTableVersion);
+            var oldEntryDead = CreateMembershipEntryForTest();
+            oldEntryDead.IAmAliveTime = oldEntryDead.IAmAliveTime.AddDays(-10);
+            oldEntryDead.StartTime = oldEntryDead.StartTime.AddDays(-10);
+            oldEntryDead.Status = SiloStatus.Dead;
+            bool ok = await membershipTable.InsertRow(oldEntryDead, newTableVersion);
+            
+            Assert.True(ok, "InsertRow Dead failed");
+
+            var oldEntryJoining = CreateMembershipEntryForTest();
+            oldEntryJoining.IAmAliveTime = oldEntryJoining.IAmAliveTime.AddDays(-10);
+            oldEntryJoining.StartTime = oldEntryJoining.StartTime.AddDays(-10);
+            oldEntryJoining.Status = SiloStatus.Joining;
+            ok = await membershipTable.InsertRow(oldEntryJoining, newTableVersion);
             var table = await membershipTable.ReadAll();
 
-            Assert.True(ok, "InsertRow failed");
+            Assert.True(ok, "InsertRow Joining failed");
 
             newTableVersion = table.Version.Next();
-            MembershipEntry newEntry = CreateMembershipEntryForTest();
+            var  newEntry = CreateMembershipEntryForTest();
             ok = await membershipTable.InsertRow(newEntry, newTableVersion);
 
             Assert.True(ok, "InsertRow failed");
@@ -431,10 +439,10 @@ namespace UnitTests.MembershipTests
             data = await membershipTable.ReadAll();
             logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
-            Assert.Equal(2, data.Members.Count);
+            Assert.Equal(3, data.Members.Count);
 
 
-            await membershipTable.CleanupDefunctSiloEntries(oldEntry.IAmAliveTime.AddDays(3));
+            await membershipTable.CleanupDefunctSiloEntries(oldEntryDead.IAmAliveTime.AddDays(3));
 
             data = await membershipTable.ReadAll();
             logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);


### PR DESCRIPTION
In environments like Kubernetes, if a silo fails to join cluster, its `Joining` records stays in the table even if cleanup of old records is enabled because the cleanup logic only deletes `Dead` entries. This change makes it include `Joining` records as well.

I didn't find an easy way to add an Azure Table tests because the cleanup logic uses `Timestamp` field to select old entries, and the test code doesn't have a way to override it.