### PR TITLE
Use stable hash in GrainId

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -124,10 +124,21 @@ namespace Orleans.Runtime
         public bool Equals(GrainId other) => this.Type.Equals(other.Type) && this.Key.Equals(other.Key);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => HashCode.Combine(Type, Key);
+        public override int GetHashCode() => HashCode.Combine(this.Type, this.Key);
 
         /// <inheritdoc/>
-        public uint GetUniformHashCode() => unchecked((uint)this.GetHashCode());
+        public uint GetUniformHashCode()
+        {
+            // This value must be stable for a given id and equal for all nodes in a cluster.
+            // HashCode.Combine does not currently offer stability with respect to its inputs.
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 31 + Type.GetHashCode();
+                hash = hash * 31 + Key.GetHashCode();
+                return (uint)hash;
+            }
+        }
 
         /// <inheritdoc/>
         public void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -1,4 +1,5 @@
 using System;
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -534,7 +535,7 @@ namespace Orleans.Runtime.GrainDirectory
             if (hopCount >= HOP_LIMIT)
             {
                 // we are not forwarding because there were too many hops already
-                throw new OrleansException(string.Format("Silo {0} is not owner of {1}, cannot forward {2} to owner {3} because hop limit is reached", MyAddress, grainId, operationDescription, owner));
+                throw new OrleansException($"Silo {MyAddress} is not owner of {grainId}, cannot forward {operationDescription} to owner {owner} because hop limit is reached");
             }
 
             // forward to the silo that we think is the owner
@@ -559,7 +560,11 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(address.Grain, hopCount, "RegisterAsync");
-                this.log.LogWarning($"RegisterAsync - It seems we are not the owner of activation {address}, trying to forward it to {forwardAddress} (hopCount={hopCount})");
+                if (forwardAddress is object)
+                {
+                    int hash = unchecked((int)address.Grain.GetUniformHashCode());
+                    this.log.LogWarning($"RegisterAsync - It seems we are not the owner of activation {address} (hash: {hash:X}), trying to forward it to {forwardAddress} (hopCount={hopCount})");
+                }
             }
 
             if (forwardAddress == null)
@@ -824,7 +829,11 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
-                this.log.LogWarning($"LookupAsync - It seems we are not the owner of grain {grainId}, trying to forward it to {forwardAddress} (hopCount={hopCount})");
+                if (forwardAddress is object)
+                {
+                    int hash = unchecked((int)grainId.GetUniformHashCode());
+                    this.log.LogWarning($"LookupAsync - It seems we are not the owner of grain {grainId} (hash: {hash:X}), trying to forward it to {forwardAddress} (hopCount={hopCount})");
+                }
             }
 
             if (forwardAddress == null)

--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -35,26 +35,6 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact]
-        public void ReubensGenericGrainIdTest()
-        {
-            var genericType = GrainType.Create("foo`1");
-            var services = ((InProcessSiloHandle)this.Fixture.HostedCluster.Primary).SiloHost.Services;
-            var resolver = services.GetRequiredService<PlacementStrategyResolver>();
-
-            var t = resolver.GetPlacementStrategy(genericType);
-            Assert.NotNull(t);
-
-            Assert.True(GenericGrainType.TryParse(genericType, out var g));
-            Assert.False(g.IsConstructed);
-
-            var formatter = services.GetRequiredService<TypeConverter>();
-            var c = g.Construct(formatter, typeof(int));
-
-            var t2 = resolver.GetPlacementStrategy(c.GrainType);
-            Assert.NotNull(t2);
-        }
-
-        [Fact]
         public void GrainReferenceComparison_DifferentReference()
         {
             ISimpleGrain ref1 = this.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), UnitTests.Grains.SimpleGrain.SimpleGrainNamePrefix);

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 namespace UnitTests.General
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
-    public class Identifiertests
+    public class IdentifierTests
     {
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture environment;
@@ -23,10 +23,18 @@ namespace UnitTests.General
         class A { }
         class B : A { }
         
-        public Identifiertests(ITestOutputHelper output, TestEnvironmentFixture fixture)
+        public IdentifierTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
             this.environment = fixture;
+        }
+
+        [Fact]
+        public void GrainIdUniformHashCodeIsStable()
+        {
+            var id = GrainId.Create("type", "key");
+            var hashCode = id.GetUniformHashCode();
+            Assert.Equal((uint)2618661990, hashCode);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Identifiers")]


### PR DESCRIPTION
Fixes an issue with GrainId.GetUniformHashCode which was causing distributed tests to fail.