### PR TITLE
SocketConnectionListener: allow address reuse

### DIFF
--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -43,7 +43,13 @@ namespace Orleans.Networking.Shared
                 throw new InvalidOperationException("Transport already bound");
             }
 
-            var listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            var listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            {
+                LingerState = new LingerOption(true, 0),
+                NoDelay = true
+            };
+
+            listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             listenSocket.EnableFastPath();
 
             // Kestrel expects IPv6Any to bind to both IPv6 and IPv4


### PR DESCRIPTION
This behavior changed with the move to Bedrock, but it causes issues for some users upon fast restart.
This PR reintroduces allowing address reuse for listen sockets