### PR TITLE
Analyze running activations and report back status to callers for long-running and blocked requests

### DIFF
--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -18,6 +18,7 @@ namespace Orleans.Configuration
             get { return Debugger.IsAttached ? ResponseTimeoutWithDebugger : responseTimeout; }
             set { this.responseTimeout = value; }
         }
+
         public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = TimeSpan.FromSeconds(30);
         private TimeSpan responseTimeout = DEFAULT_RESPONSE_TIMEOUT;
 
@@ -83,6 +84,7 @@ namespace Orleans.Configuration
         /// if the body size is greater than this value.
         /// </summary>
         public int MaxMessageBodySize { get; set; } = DEFAULT_MAX_MESSAGE_BODY_SIZE;
+
         public const int DEFAULT_MAX_MESSAGE_BODY_SIZE = 104857600; // 100MB
     }
 }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -65,7 +65,8 @@ namespace Orleans.Runtime
         {
             Success,
             Error,
-            Rejection
+            Rejection,
+            Status
         }
 
         public enum RejectionTypes
@@ -424,6 +425,10 @@ namespace Orleans.Runtime
 
                     case ResponseTypes.Rejection:
                         response = string.Format("{0} Rejection (info: {1}) ", RejectionType, RejectionInfo);
+                        break;
+
+                    case ResponseTypes.Status:
+                        response = "Status ";
                         break;
 
                     default:

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
@@ -143,6 +144,17 @@ namespace Orleans.Runtime
             response.RejectionInfo = info;
             response.BodyObject = ex;
             if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
+            return response;
+        }
+
+        internal Message CreateDiagnosticResponseMessage(Message request, bool isExecuting, bool isWaiting, List<string> diagnostics)
+        {
+            var response = this.CreateResponseMessage(request);
+            response.Result = Message.ResponseTypes.Status;
+            response.BodyObject = new StatusResponse(isExecuting, isWaiting, diagnostics);
+
+            if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("Creating {RequestMesssage} status update with diagnostics {Diagnostics}", request, diagnostics);
+
             return response;
         }
     }

--- a/src/Orleans.Core/Messaging/StatusResponse.cs
+++ b/src/Orleans.Core/Messaging/StatusResponse.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Orleans.Concurrency;
+
+namespace Orleans.Runtime
+{
+    [Immutable]
+    [Serializable]
+    internal class StatusResponse
+    {
+        private readonly uint _statusFlags;
+
+        public StatusResponse(bool isExecuting, bool isWaiting, List<string> diagnostics)
+        {
+            if (isExecuting) _statusFlags |= 0x1;
+            if (isWaiting) _statusFlags |= 0x2;
+
+            Diagnostics = diagnostics;
+        }
+
+        public List<string> Diagnostics { get; }
+
+        public bool IsExecuting => (_statusFlags & 0x1) != 0;
+
+        public bool IsWaiting => (_statusFlags & 0x2) != 0;
+
+        public override string ToString() => $"IsExecuting: {IsExecuting}, IsWaiting: {IsWaiting}, Diagnostics: [{string.Join(", ", this.Diagnostics)}]";
+    }
+}

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -306,6 +306,38 @@ namespace Orleans
             {
                 return;
             }
+            else if (response.Result == Message.ResponseTypes.Status)
+            {
+                var status = (StatusResponse)response.BodyObject;
+                callbacks.TryGetValue(response.Id, out var callback);
+                var request = callback?.Message;
+                if (!(request is null))
+                {
+                    callback.OnStatusUpdate(status);
+
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Information))
+                    {
+                        var diagnosticsString = string.Join("\n", status.Diagnostics);
+                        using (request.SetThreadActivityId())
+                        {
+                            this.logger.LogInformation("Received status update for pending request, Request: {RequestMessage}. Status: {Diagnostics}", request, diagnosticsString);
+                        }
+                    }
+                }
+                else
+                {
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Information))
+                    {
+                        var diagnosticsString = string.Join("\n", status.Diagnostics);
+                        using (response.SetThreadActivityId())
+                        {
+                            this.logger.LogInformation("Received status update for unknown request. Message: {StatusMessage}. Status: {Diagnostics}", response, diagnosticsString);
+                        }
+                    }
+                }
+
+                return;
+            }
             
             CallbackData callbackData;
             var found = callbacks.TryRemove(response.Id, out callbackData);

--- a/src/Orleans.Core/Utils/ReferenceEqualsComparer.cs
+++ b/src/Orleans.Core/Utils/ReferenceEqualsComparer.cs
@@ -27,4 +27,29 @@ namespace Orleans
             return obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
         }
     }
+
+    internal class ReferenceEqualsComparer<T> : EqualityComparer<T> where T : class
+    {
+        /// <summary>
+        /// Gets an instance of this class.
+        /// </summary>
+        public static ReferenceEqualsComparer<T> Instance { get; } = new ReferenceEqualsComparer<T>();
+
+        /// <summary>
+        /// Defines object equality by reference equality (eq, in LISP).
+        /// </summary>
+        /// <returns>
+        /// true if the specified objects are equal; otherwise, false.
+        /// </returns>
+        /// <param name="x">The first object to compare.</param><param name="y">The second object to compare.</param>
+        public override bool Equals(T x, T y)
+        {
+            return object.ReferenceEquals(x, y);
+        }
+
+        public override int GetHashCode(T obj)
+        {
+            return obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
+        }
+    }
 }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -123,8 +123,6 @@ namespace Orleans.Runtime
             _components[typeof(TComponent)] = instance;
         }
 
-        public HashSet<ActivationId> RunningRequestsSenders { get; } = new HashSet<ActivationId>();
-
         internal void SetGrainInstance(Grain grainInstance)
         {
             GrainInstance = grainInstance;
@@ -257,10 +255,7 @@ namespace Orleans.Runtime
         internal bool IsUsingGrainDirectory => this.PlacedUsing.IsUsingGrainDirectory;
 
         public Message Blocking { get; private set; }
-
-        // the number of requests that are currently executing on this activation.
-        // includes reentrant and non-reentrant requests.
-        private int numRunning;
+        public Dictionary<Message, DateTime> RunningRequests { get; private set; } = new Dictionary<Message, DateTime>();
 
         private DateTime currentRequestStartTime;
         private DateTime becameIdle;
@@ -269,29 +264,23 @@ namespace Orleans.Runtime
         public void RecordRunning(Message message, bool isInterleavable)
         {
             // Note: This method is always called while holding lock on this activation, so no need for additional locks here
-
-            numRunning++;
-            if (message.Direction != Message.Directions.OneWay 
-                && !(message.SendingActivation is null)
-                && !message.SendingGrain.IsClient())
-            {
-                RunningRequestsSenders.Add(message.SendingActivation);
-            }
+            var now = DateTime.UtcNow;
+            RunningRequests.Add(message, now);
 
             if (this.Blocking != null || isInterleavable) return;
 
             // This logic only works for non-reentrant activations
             // Consider: Handle long request detection for reentrant activations.
             this.Blocking = message;
-            currentRequestStartTime = DateTime.UtcNow;
+            currentRequestStartTime = now;
         }
 
         public void ResetRunning(Message message)
         {
             // Note: This method is always called while holding lock on this activation, so no need for additional locks here
-            numRunning--;
-            RunningRequestsSenders.Remove(message.SendingActivation);
-            if (numRunning == 0)
+            RunningRequests.Remove(message);
+
+            if (RunningRequests.Count == 0)
             {
                 becameIdle = DateTime.UtcNow;
                 if (!IsExemptFromCollection)
@@ -380,7 +369,7 @@ namespace Orleans.Runtime
                     if (deactivatingTime > maxRequestProcessingTime)
                     {
                         logger.Error(ErrorCode.Dispatcher_StuckActivation,
-                            $"Current activation {ToDetailedString()} marked as Deactivating for {deactivatingTime}. Trying  to enqueue {message}.");
+                            $"Current activation {ToDetailedString()} marked as Deactivating for {deactivatingTime}. Trying to enqueue {message}.");
                         return EnqueueMessageResult.ErrorStuckActivation;
                     }
                 }
@@ -390,7 +379,7 @@ namespace Orleans.Runtime
                     if (currentRequestActiveTime > maxRequestProcessingTime)
                     {
                         logger.Error(ErrorCode.Dispatcher_StuckActivation,
-                            $"Current request has been active for {currentRequestActiveTime} for activation {ToDetailedString()}. Currently executing {this.Blocking}.  Trying  to enqueue {message}.");
+                            $"Current request has been active for {currentRequestActiveTime} for activation {ToDetailedString()}. Currently executing {this.Blocking}. Trying to enqueue {message}.");
                         return EnqueueMessageResult.ErrorStuckActivation;
                     }
                     // Consider: Handle long request detection for reentrant activations -- this logic only works for non-reentrant activations
@@ -402,8 +391,14 @@ namespace Orleans.Runtime
                     }
                 }
 
-                waiting = waiting ?? new List<Message>();
+                if (!message.QueuedTime.HasValue)
+                {
+                    message.QueuedTime = DateTime.UtcNow;
+                }
+
+                waiting ??= new List<Message>();
                 waiting.Add(message);
+
                 return EnqueueMessageResult.Success;
             }
         }
@@ -495,7 +490,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                return numRunning > 0 ;
+                return RunningRequests.Count > 0;
             }
         }
 
@@ -632,15 +627,115 @@ namespace Orleans.Runtime
             }
         }
 
+        public void AnalyzeWorkload(DateTime now, IMessageCenter messageCenter, MessageFactory messageFactory, SiloMessagingOptions options)
+        {
+            var slowRunningRequestDuration = options.RequestProcessingWarningTime;
+            var longQueueTimeDuration = options.RequestQueueDelayWarningTime;
+
+            List<string> diagnostics = null;
+            lock (this)
+            {
+                if (State != ActivationState.Valid)
+                {
+                    return;
+                }
+
+                if (this.Blocking is object)
+                {
+                    var message = this.Blocking;
+                    var timeSinceQueued = now - message.QueuedTime;
+                    var executionTime = now - currentRequestStartTime;
+                    if (executionTime >= slowRunningRequestDuration)
+                    {
+                        GetStatusList(ref diagnostics);
+                        if (timeSinceQueued.HasValue)
+                        {
+                            diagnostics.Add($"Message {message} was enqueued {timeSinceQueued} ago and has now been executing for {executionTime}.");
+                        }
+                        else
+                        {
+                            diagnostics.Add($"Message {message} was has been executing for {executionTime}.");
+                        }
+
+                        var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, diagnostics);
+                        messageCenter.SendMessage(response);
+                    }
+                }
+
+                foreach (var running in RunningRequests)
+                {
+                    var message = running.Key;
+                    var startTime = running.Value;
+                    if (ReferenceEquals(message, this.Blocking)) continue;
+
+                    // Check how long they've been executing.
+                    var executionTime = now - startTime;
+                    if (executionTime >= slowRunningRequestDuration)
+                    {
+                        // Interleaving message X has been executing for a long time
+                        GetStatusList(ref diagnostics);
+                        var messageDiagnostics = new List<string>(diagnostics)
+                        {
+                            $"Interleaving message {message} has been executing for {executionTime}."
+                        };
+
+                        var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, messageDiagnostics);
+                        messageCenter.SendMessage(response);
+                    }
+                }
+
+                if (waiting is object)
+                {
+                    var queueLength = 1;
+                    foreach (var message in waiting)
+                    {
+                        var waitTime = now - message.QueuedTime;
+                        if (waitTime >= longQueueTimeDuration)
+                        {
+                            // Message X has been enqueued on the target grain for Y and is currently position QueueLength in queue for processing.
+                            GetStatusList(ref diagnostics); 
+                            var messageDiagnostics = new List<string>(diagnostics)
+                            {
+                               $"Message {message} has been enqueued on the target grain for {waitTime} and is currently position {queueLength} in queue for processing."
+                            };
+
+                            var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: false, isWaiting: true, messageDiagnostics);
+                            messageCenter.SendMessage(response);
+                        }
+
+                        queueLength++;
+                    }
+                }
+            }
+
+            void GetStatusList(ref List<string> diagnostics)
+            {
+                if (diagnostics is object) return;
+
+                diagnostics = new List<string>
+                {
+                    this.ToDetailedString(),
+                    $"TaskScheduler status: {this.WorkItemGroup.DumpStatus()}"
+                };
+            }
+        }
+
         public string DumpStatus()
         {
             var sb = new StringBuilder();
             lock (this)
             {
                 sb.AppendFormat("   {0}", ToDetailedString());
+
                 if (this.Blocking != null)
                 {
                     sb.AppendFormat("   Processing message: {0}", this.Blocking);
+                }
+
+                foreach (var msg in RunningRequests)
+                {
+                    if (ReferenceEquals(msg, this.Blocking)) continue;
+                    sb.AppendFormat("   Processing message: {0}", msg);
                 }
 
                 if (waiting!=null && waiting.Count > 0)
@@ -674,7 +769,7 @@ namespace Orleans.Runtime
                     WaitingCount,                   // 5 NonReentrancyQueueSize
                     EnqueuedOnDispatcherCount,      // 6 EnqueuedOnDispatcher
                     InFlightCount,                  // 7 InFlightCount
-                    numRunning,                     // 8 NumRunning
+                    RunningRequests.Count,          // 8 NumRunning
                     GetIdleness(DateTime.UtcNow),   // 9 IdlenessTimeSpan
                     CollectionAgeLimit,             // 10 CollectionAgeLimit
                     (includeExtraDetails && this.Blocking != null) ? " CurrentlyExecuting=" + this.Blocking : "");  // 11: Running

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Internal;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Monitors currently-active requests and sends status notifications to callers for long-running and blocked requests.
+    /// </summary>
+    internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>
+    {
+        private static readonly TimeSpan DefaultAnalysisPeriod = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan InactiveGrainIdleness = TimeSpan.FromMinutes(1);
+        private readonly IAsyncTimer _scanPeriodTimer;
+        private readonly IMessageCenter _messageCenter;
+        private readonly MessageFactory _messageFactory;
+        private readonly IOptionsMonitor<SiloMessagingOptions> _messagingOptions;
+        private readonly ConcurrentDictionary<ActivationData, ActivationData> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, ActivationData>(ReferenceEqualsComparer<ActivationData>.Instance);
+        private bool _enabled = true;
+        private Task _runTask;
+
+        public IncomingRequestMonitor(
+            IAsyncTimerFactory asyncTimerFactory,
+            IMessageCenter messageCenter,
+            MessageFactory messageFactory,
+            IOptionsMonitor<SiloMessagingOptions> siloMessagingOptions)
+        {
+            _scanPeriodTimer = asyncTimerFactory.Create(TimeSpan.FromSeconds(1), nameof(IncomingRequestMonitor));
+            _messageCenter = messageCenter;
+            _messageFactory = messageFactory;
+            _messagingOptions = siloMessagingOptions;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MarkRecentlyUsed(ActivationData activation)
+        {
+            if (!_enabled)
+            {
+                return;
+            }
+            
+            _recentlyUsedActivations.TryAdd(activation, activation);
+        }
+
+        void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(
+                nameof(IncomingRequestMonitor),
+                ServiceLifecycleStage.BecomeActive,
+                ct =>
+                {
+                    _runTask = Task.Run(this.Run);
+                    return Task.CompletedTask;
+                },
+                async ct =>
+                {
+                    _scanPeriodTimer.Dispose();
+                    if (_runTask is Task task) await Task.WhenAny(task, ct.WhenCancelled());
+                });
+        }
+
+        private async Task Run()
+        {
+            var options = _messagingOptions.CurrentValue;
+            var optionsPeriod = options.GrainWorkloadAnalysisPeriod;
+            TimeSpan nextDelay = optionsPeriod > TimeSpan.Zero ? optionsPeriod : DefaultAnalysisPeriod;
+
+            while (await _scanPeriodTimer.NextTick(nextDelay))
+            {
+                options = _messagingOptions.CurrentValue;
+                optionsPeriod = options.GrainWorkloadAnalysisPeriod;
+
+                if (optionsPeriod <= TimeSpan.Zero)
+                {
+                    // Scanning is disabled. Wake up and check again soon.
+                    nextDelay = DefaultAnalysisPeriod;
+                    if (_enabled)
+                    {
+                        _enabled = false;
+                    }
+
+                    _recentlyUsedActivations.Clear();
+                    continue;
+                }
+
+                nextDelay = optionsPeriod;
+                if (!_enabled)
+                {
+                    _enabled = true;
+                }
+
+                var iteration = 0;
+                var now = DateTime.UtcNow;
+                foreach (var activationEntry in _recentlyUsedActivations)
+                {
+                    var activation = activationEntry.Value;
+                    lock (activation)
+                    {
+                        if (activation.IsInactive && activation.GetIdleness(now) > InactiveGrainIdleness)
+                        {
+                            _recentlyUsedActivations.TryRemove(activation, out _);
+                            continue;
+                        }
+
+                        activation.AnalyzeWorkload(now, _messageCenter, _messageFactory, options);
+                    }
+
+                    // Yield execution frequently
+                    if (++iteration % 100 == 0)
+                    {
+                        await Task.Yield();
+                        now = DateTime.UtcNow;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -98,5 +98,20 @@ namespace Orleans.Configuration
             get { return Debugger.IsAttached ? ResponseTimeoutWithDebugger : this.systemResponseTimeout; }
             set { this.systemResponseTimeout = value; }
         }
+
+        /// <summary>
+        /// The period of time between analyzing currently executing activation workloads.
+        /// </summary>
+        public TimeSpan GrainWorkloadAnalysisPeriod { get; set; } = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// The period after which a currently executing request is deemed to be slow.
+        /// </summary>
+        public TimeSpan RequestProcessingWarningTime { get; set; } = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// The period after which an enqueued request is deemed to be delayed.
+        /// </summary>
+        public TimeSpan RequestQueueDelayWarningTime { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -568,6 +568,37 @@ namespace Orleans.Runtime
                         break;
                 }
             }
+            else if (message.Result == Message.ResponseTypes.Status)
+            {
+                var status = (StatusResponse)message.BodyObject;
+                callbacks.TryGetValue(message.Id, out var callback);
+                var request = callback?.Message;
+                if (!(request is null))
+                {
+                    callback.OnStatusUpdate(status);
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Information))
+                    {
+                        var diagnosticsString = string.Join("\n", status.Diagnostics);
+                        using (request.SetThreadActivityId())
+                        {
+                            this.logger.LogInformation("Received status update for pending request, Request: {RequestMessage}. Status: {Diagnostics}", request, diagnosticsString);
+                        }
+                    }
+                }
+                else
+                {
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Information))
+                    {
+                        var diagnosticsString = string.Join("\n", status.Diagnostics);
+                        using (message.SetThreadActivityId())
+                        {
+                            this.logger.LogInformation("Received status update for unknown request. Message: {StatusMessage}. Status: {Diagnostics}", message, diagnosticsString);
+                        }
+                    }
+                }
+
+                return;
+            }
 
             CallbackData callbackData;
             bool found = callbacks.TryRemove(message.Id, out callbackData);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -265,6 +265,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<GrainReferenceActivator>();
             services.TryAddSingleton<IGrainContextActivatorProvider, ActivationDataActivatorProvider>();
             services.TryAddSingleton<IGrainContextAccessor, GrainContextAccessor>();
+            services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, IncomingRequestMonitor>();
 
             services.TryAddSingleton<IStreamSubscriptionManagerAdmin>(sp => new StreamSubscriptionManagerAdmin(sp.GetRequiredService<IStreamProviderRuntime>()));
             services.TryAddSingleton<IConsistentRingProvider>(

--- a/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
+++ b/src/Orleans.Runtime/Messaging/OutboundMessageQueue.cs
@@ -60,11 +60,6 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            if (!msg.QueuedTime.HasValue)
-            {
-                msg.QueuedTime = DateTime.UtcNow;
-            }
-
             // First check to see if it's really destined for a proxied client, instead of a local grain.
             if (messageCenter.TryDeliverToProxy(msg))
             {

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -469,7 +469,7 @@ namespace Orleans.Runtime.Scheduler
             {
                 var sb = new StringBuilder();
                 sb.Append(this);
-                sb.AppendFormat(". Currently QueuedWorkItems={0}; Total EnQueued={1}; Total processed={2}; Quantum expirations={3}; ",
+                sb.AppendFormat(". Currently QueuedWorkItems={0}; Total Enqueued={1}; Total processed={2}; Quantum expirations={3}; ",
                     WorkItemCount, totalItemsEnQueued, totalItemsProcessed, quantumExpirations);
                 if (CurrentTask is Task task)
                 {


### PR DESCRIPTION
Adds a new `ActivationWorkloadMonitor` type that periodically scans active activations to analyze running and blocked requests. Requests which have been running or blocked for a configurable period of time are responded to with a status update message that is printed as a warning. Eventual timeout exceptions also include the latest status messages.

The hope is that this will improve debuggability for some users and make persistent issues more apparent.

Also adds the ability to tier timeouts based upon the most recent status update. Eg, for messages with no response, we can timeout early. For messages which are running, we can allow them to keep running past the usual 30s timeout (although we would need to also consider this when performing message expiry).