### PR TITLE
Update Newtonsoft.Json to 11.0.1 and remove redundant/unused dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,6 @@
     <!-- System packages -->
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <SystemDiagnosticsEventLogVersion>4.7.0</SystemDiagnosticsEventLogVersion>
-    <SystemConfigurationConfigurationManagerVersion>4.7.0</SystemConfigurationConfigurationManagerVersion>
     <SystemCollectionsImmutableVersion>1.7.0</SystemCollectionsImmutableVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.7.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemDiagnosticsPerformanceCounterVersion>4.7.0</SystemDiagnosticsPerformanceCounterVersion>
@@ -53,20 +52,16 @@
     <SystemReflectionMetadataVersion>1.8.0</SystemReflectionMetadataVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
-    <SystemThreadingTasksExtensionsVersion>4.5.3</SystemThreadingTasksExtensionsVersion>
     <SystemThreadingChannelsVersion>4.7.0</SystemThreadingChannelsVersion>
-    <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
-    <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
     <SystemIOPipelinesVersion>4.7.0</SystemIOPipelinesVersion>
     <SystemCodeDomVersion>4.7.0</SystemCodeDomVersion>
-    <SystemSecurityPermissionsVersion>4.7.0</SystemSecurityPermissionsVersion>
     <SystemDiagnosticsDiagnosticsSourceVersion>4.7.0</SystemDiagnosticsDiagnosticsSourceVersion>
     <SystemSecurityCryptographyVersion>4.7.0</SystemSecurityCryptographyVersion>
 
     <!-- Microsoft packages -->
     <MicrosoftBuildVersion>16.4.0</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>3.4.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftWin32RegistryVersion>4.7.0</MicrosoftWin32RegistryVersion>
+    <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesVersion>
     <MicrosoftBclHashCodeVersion>1.0.0</MicrosoftBclHashCodeVersion>
@@ -80,7 +75,6 @@
     <MicrosoftExtensionsDependencyModelVersion>3.0.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsLoggingVersion>3.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsObjectPoolVersion>3.0.0</MicrosoftExtensionsObjectPoolVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsVersion>3.0.0</MicrosoftExtensionsOptionsConfigurationExtensionsVersion>
     <MicrosoftExtensionsOptionsVersion>3.0.0</MicrosoftExtensionsOptionsVersion>
     <MicrosoftExtensionsHostingAbstractionsVersion>3.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsHostingVersion>3.0.0</MicrosoftExtensionsHostingVersion>
@@ -107,7 +101,7 @@
     <ProtobufNetVersion>2.3.7</ProtobufNetVersion>
     <MySqlDataVersion>8.0.18</MySqlDataVersion>
     <NewRelicAgentApiVersion>8.0.0.0</NewRelicAgentApiVersion>
-    <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>11.0.1</NewtonsoftJsonVersion>
     <NpgsqlVersion>3.1.9</NpgsqlVersion>
     <NSubstituteVersion>4.2.0</NSubstituteVersion>
     <NSubstituteAnalyzersCSharpVersion>1.0.10</NSubstituteAnalyzersCSharpVersion>

--- a/src/AWS/Directory.Build.props
+++ b/src/AWS/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAWSVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAWSVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Persistence.DynamoDB</PackageId>
     <Title>Microsoft Orleans Persistence DynamoDB</Title>
@@ -20,9 +20,5 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="$(AWSSDKDynamoDBv2Version)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
   </ItemGroup>
 </Project>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
@@ -22,8 +22,4 @@
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="$(AWSSDKDynamoDBv2Version)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Storage" />
-  </ItemGroup>
-
 </Project>

--- a/src/AdoNet/Directory.Build.props
+++ b/src/AdoNet/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAdoNetVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAdoNetVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -14,20 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
-    <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
-    <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
-    <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
-    <Compile Include="..\Shared\Storage\DbConstantsStore.cs" Link="Storage\DbConstantsStore.cs" />
-    <Compile Include="..\Shared\Storage\DbStoredQueries.cs" Link="Storage\DbStoredQueries.cs" />
-    <Compile Include="..\Shared\Storage\ICommandInterceptor.cs" Link="Storage\ICommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\IRelationalStorage.cs" Link="Storage\IRelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\NoOpDatabaseCommandInterceptor.cs" Link="Storage\NoOpDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OracleDatabaseCommandInterceptor.cs" Link="Storage\OracleDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OrleansRelationalDownloadStream.cs" Link="Storage\OrleansRelationalDownloadStream.cs" />
-    <Compile Include="..\Shared\Storage\RelationalOrleansQueries.cs" Link="Storage\RelationalOrleansQueries.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
+    <Compile Include="..\Shared\Storage\*.cs" LinkBase="Storage" />
   </ItemGroup>
 
 </Project>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -14,20 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
-    <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
-    <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
-    <Compile Include="..\Shared\Storage\DbConstantsStore.cs" Link="Storage\DbConstantsStore.cs" />
-    <Compile Include="..\Shared\Storage\DbStoredQueries.cs" Link="Storage\DbStoredQueries.cs" />
-    <Compile Include="..\Shared\Storage\ICommandInterceptor.cs" Link="Storage\ICommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\IRelationalStorage.cs" Link="Storage\IRelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\NoOpDatabaseCommandInterceptor.cs" Link="Storage\NoOpDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OracleDatabaseCommandInterceptor.cs" Link="Storage\OracleDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OrleansRelationalDownloadStream.cs" Link="Storage\OrleansRelationalDownloadStream.cs" />
-    <Compile Include="..\Shared\Storage\RelationalOrleansQueries.cs" Link="Storage\RelationalOrleansQueries.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
-    <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
+    <Compile Include="..\Shared\Storage\*.cs" LinkBase="Storage" />
   </ItemGroup>
 
 </Project>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -14,24 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
-    <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
-    <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
-    <Compile Include="..\Shared\Storage\DbConstantsStore.cs" Link="Storage\DbConstantsStore.cs" />
-    <Compile Include="..\Shared\Storage\DbStoredQueries.cs" Link="Storage\DbStoredQueries.cs" />
-    <Compile Include="..\Shared\Storage\ICommandInterceptor.cs" Link="Storage\ICommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\IRelationalStorage.cs" Link="Storage\IRelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\NoOpDatabaseCommandInterceptor.cs" Link="Storage\NoOpDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OracleDatabaseCommandInterceptor.cs" Link="Storage\OracleDatabaseCommandInterceptor.cs" />
-    <Compile Include="..\Shared\Storage\OrleansRelationalDownloadStream.cs" Link="Storage\OrleansRelationalDownloadStream.cs" />
-    <Compile Include="..\Shared\Storage\RelationalOrleansQueries.cs" Link="Storage\RelationalOrleansQueries.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
-    <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
-    <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <Compile Include="..\Shared\Storage\*.cs" LinkBase="Storage" />
   </ItemGroup>
 
 </Project>

--- a/src/Azure/Orleans.Clustering.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Directory.Build.props
@@ -10,19 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzureClusteringVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureClusteringVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -26,9 +26,4 @@
     <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.csproj
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.csproj
@@ -28,8 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Orleans.Hosting.AzureCloudServices.csproj
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Orleans.Hosting.AzureCloudServices.csproj
@@ -13,4 +13,8 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Directory.Build.props
@@ -10,19 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzurePersistenceVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzurePersistenceVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -28,9 +28,4 @@
     <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Reminders.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Directory.Build.props
@@ -10,19 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzureRemindersVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureRemindersVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
@@ -26,9 +26,4 @@
     <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Directory.Build.props
@@ -10,19 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansAzureStreamingVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansAzureStreamingVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -29,9 +29,4 @@
     <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Streaming.EventHubs/Directory.Build.props
+++ b/src/Azure/Orleans.Streaming.EventHubs/Directory.Build.props
@@ -10,19 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansEventHubProviderVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansEventHubProviderVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
+++ b/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
@@ -27,9 +27,4 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="$(MicrosoftAzureEventHubsVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Transactions.AzureStorage/Directory.Build.props
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Directory.Build.props
@@ -27,19 +27,6 @@
   </Choose>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansTransactionsVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansTransactionsVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
@@ -29,9 +29,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Orleans.Transactions\Orleans.Transactions.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
-    <Folder Include="Utilities\" />
-  </ItemGroup>
 </Project>

--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
@@ -16,6 +16,7 @@
     <PublishDir>$(PublishRoot)$(TargetFramework)</PublishDir>
     <SourceDir>$(MSBuildThisFileDirectory)..\..\Orleans.CodeGenerator.MSBuild\</SourceDir>
     <OrleansBuildTimeCodeGen>false</OrleansBuildTimeCodeGen>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
   </PropertyGroup>
   
   <ItemGroup>
@@ -25,25 +26,14 @@
       <Visible>false</Visible>
     </Compile>
     <ProjectReference Include="..\..\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\Orleans.CodeGenerator.MSBuild.Tasks\Orleans.CodeGenerator.MSBuild.Tasks.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\Orleans.CodeGenerator.MSBuild.Tasks\Orleans.CodeGenerator.MSBuild.Tasks.csproj" PrivateAssets="all" ExcludeAssets="compile" />
   </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-  </ItemGroup>
-
-  <!-- Packages included explicitly to prevent build warnings about inconsistent versions -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
   </ItemGroup>
 
 

--- a/src/Orleans.CodeGenerator.MSBuild.Tasks/Orleans.CodeGenerator.MSBuild.Tasks.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild.Tasks/Orleans.CodeGenerator.MSBuild.Tasks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -8,12 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-  </ItemGroup>
-
-  <!-- Packages included explicitly to prevent build warnings about inconsistent versions -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -41,22 +41,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
-  <!-- Packages included explicitly to prevent build warnings about inconsistent versions -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
-  </ItemGroup>
-  
   <ItemGroup>
     <!-- This must come after all other PackageReference elements -->
     <PackageReference Update="@(PackageReference)" PrivateAssets="All" Publish="true" />
@@ -64,7 +53,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" PrivateAssets="all" Publish="true" />
-    <ProjectReference Include="..\Orleans.CodeGenerator.MSBuild.Tasks\Orleans.CodeGenerator.MSBuild.Tasks.csproj" PrivateAssets="all" Publish="true" />
+    <ProjectReference Include="..\Orleans.CodeGenerator.MSBuild.Tasks\Orleans.CodeGenerator.MSBuild.Tasks.csproj" PrivateAssets="all" ExcludeAssets="compile" Publish="true" />
   </ItemGroup>
 
   <Target Name="PostBuildPublish" AfterTargets="Build">

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <AssemblyName>Orleans.CodeGenerator</AssemblyName>
     <RootNamespace>Orleans.CodeGenerator</RootNamespace>
     <PackageId>Microsoft.Orleans.CodeGenerator</PackageId>
-    <TargetFrameworks>$(StandardTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/src/Orleans.Connections.Security/Directory.Build.props
+++ b/src/Orleans.Connections.Security/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansCodegenVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansExtensionsVersion)">
       <ItemGroup>
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />

--- a/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
+++ b/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
@@ -14,9 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
   

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsOptionsConfigurationExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsOptionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
@@ -33,10 +33,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticsSourceVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />

--- a/src/Orleans.EventSourcing/Directory.Build.props
+++ b/src/Orleans.EventSourcing/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansEventSourcingVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansEventSourcingVersion)">
       <ItemGroup>
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />

--- a/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
+++ b/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.EventSourcing</PackageId>
     <Title>Microsoft Orleans Event-Sourcing</Title>
@@ -11,4 +11,8 @@
     <AssemblyName>Orleans.EventSourcing</AssemblyName>
     <RootNamespace>OrleansEventSourcing</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
+++ b/src/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
@@ -11,13 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeRedis)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Runtime.Abstractions/Orleans.Runtime.Abstractions.csproj
+++ b/src/Orleans.Runtime.Abstractions/Orleans.Runtime.Abstractions.csproj
@@ -13,11 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
   </ItemGroup>
 

--- a/src/Orleans.Runtime/Directory.Build.props
+++ b/src/Orleans.Runtime/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansRuntimeVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansRuntimeVersion)">
       <ItemGroup>
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />

--- a/src/Orleans.Runtime/Orleans.Runtime.csproj
+++ b/src/Orleans.Runtime/Orleans.Runtime.csproj
@@ -12,16 +12,4 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
-    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Orleans.Streaming.GCP/Directory.Build.props
+++ b/src/Orleans.Streaming.GCP/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansGoogleCloudProviderVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansGoogleCloudProviderVersion)">
       <ItemGroup>
         <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Orleans.TestingHost/Directory.Build.props
+++ b/src/Orleans.TestingHost/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansTestingHostVersion)">
-      <ItemGroup>
-        <ProjectReference Include="$(SourceRoot)src\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansRuntimeAbstractionsVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansProvidersVersion) == $(VersionPrefix) AND $(OrleansProvidersVersion) == $(OrleansTestingHostVersion)">
       <ItemGroup>
         <ProjectReference Include="$(SourceRoot)src\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Orleans.TestingHost/Orleans.TestingHost.csproj
+++ b/src/Orleans.TestingHost/Orleans.TestingHost.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
   </ItemGroup>
 </Project>

--- a/src/OrleansProviders/Directory.Build.props
+++ b/src/OrleansProviders/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansProvidersVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansProvidersVersion)">
       <ItemGroup>
         <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />

--- a/src/Serializers/Orleans.Serialization.Protobuf/Orleans.Serialization.Protobuf.csproj
+++ b/src/Serializers/Orleans.Serialization.Protobuf/Orleans.Serialization.Protobuf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.OrleansGoogleUtils</PackageId>
     <Title>Microsoft Orleans Google Utilities</Title>
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
+    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/TelemetryConsumers/Directory.Build.props
+++ b/src/TelemetryConsumers/Directory.Build.props
@@ -14,19 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(OrleansCoreVersion) == $(VersionPrefix) AND $(OrleansCoreVersion) == $(OrleansTelemetryConsumersVersion)">
-      <ItemGroup>
-        <ProjectReference Include="..\..\Orleans.Core\Orleans.Core.csproj" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansCoreVersion)"/>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
-  <Choose>
     <When Condition="$(OrleansRuntimeAbstractionsVersion) == $(VersionPrefix) AND $(OrleansRuntimeAbstractionsVersion) == $(OrleansTelemetryConsumersVersion)">
       <ItemGroup>
         <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Benchmarks</RootNamespace>
     <AssemblyName>Benchmarks</AssemblyName>
@@ -13,8 +13,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" />
     <!-- Temporarily kept to resolve a conflict between Microsoft.Azure.DocumentDB.Core's dependencies -->
     <PackageReference Include="System.Net.NameResolution" Version="$(SystemNetNameResolutionVersion)" />

--- a/test/CodeGeneration/CodeGenerator.Tests/CodeGenerator.Tests.csproj
+++ b/test/CodeGeneration/CodeGenerator.Tests/CodeGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\Orleans.Core\Orleans.Core.csproj" />
   </ItemGroup>
 

--- a/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
+++ b/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>DefaultCluster.Tests</RootNamespace>
     <AssemblyName>DefaultCluster.Tests</AssemblyName>
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />

--- a/test/Extensions/AWSUtils.Tests/AWSUtils.Tests.csproj
+++ b/test/Extensions/AWSUtils.Tests/AWSUtils.Tests.csproj
@@ -44,7 +44,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Storage\" />
-  </ItemGroup>
 </Project>

--- a/test/Extensions/TestServiceFabric/TestServiceFabric.csproj
+++ b/test/Extensions/TestServiceFabric/TestServiceFabric.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(MicrosoftServiceFabricServicesVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
   </ItemGroup>

--- a/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
+++ b/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
@@ -17,27 +17,12 @@
     <PackageReference Include="Microsoft.Data.SQLite" Version="$(MicrosoftDataSQLiteVersion)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="MySql.Data" Version="$(MySqlDataVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\DbConstantsStore.cs" Link="Storage\DbConstantsStore.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\DbStoredQueries.cs" Link="Storage\DbStoredQueries.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\ICommandInterceptor.cs" Link="Storage\ICommandInterceptor.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\IRelationalStorage.cs" Link="Storage\IRelationalStorage.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\NoOpDatabaseCommandInterceptor.cs" Link="Storage\NoOpDatabaseCommandInterceptor.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\OracleDatabaseCommandInterceptor.cs" Link="Storage\OracleDatabaseCommandInterceptor.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\OrleansRelationalDownloadStream.cs" Link="Storage\OrleansRelationalDownloadStream.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\RelationalOrleansQueries.cs" Link="Storage\RelationalOrleansQueries.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
-    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
+    <Compile Include="$(SourceRoot)src\AdoNet\Shared\Storage\*.cs" LinkBase="Storage" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,58 +49,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SourceRoot)src\AdoNet\Shared\MySQL-Main.sql" Link="MySQL-Main.sql">
+    <None Include="$(SourceRoot)src\AdoNet\Shared\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(SourceRoot)src\AdoNet\Shared\Oracle-Main.sql" Link="Oracle-Main.sql">
+    <None Include="$(SourceRoot)src\AdoNet\Orleans.Clustering.AdoNet\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(SourceRoot)src\AdoNet\Shared\PostgreSQL-Main.sql" Link="PostgreSQL-Main.sql">
+    <None Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(SourceRoot)src\AdoNet\Shared\SQLServer-Main.sql" Link="SQLServer-Main.sql">
+    <None Include="$(SourceRoot)src\AdoNet\Orleans.Reminders.AdoNet\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Clustering.AdoNet\MySQL-Clustering.sql" Link="MySQL-Clustering.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Clustering.AdoNet\Oracle-Clustering.sql" Link="Oracle-Clustering.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Clustering.AdoNet\PostgreSQL-Clustering.sql" Link="PostgreSQL-Clustering.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Clustering.AdoNet\SQLServer-Clustering.sql" Link="SQLServer-Clustering.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\MySQL-Persistence.sql" Link="MySQL-Persistence.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\Oracle-Persistence.sql" Link="Oracle-Persistence.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\PostgreSQL-Persistence.sql" Link="PostgreSQL-Persistence.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\SQLServer-Persistence.sql" Link="SQLServer-Persistence.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Reminders.AdoNet\MySQL-Reminders.sql" Link="MySQL-Reminders.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Reminders.AdoNet\Oracle-Reminders.sql" Link="Oracle-Reminders.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Reminders.AdoNet\PostgreSQL-Reminders.sql" Link="PostgreSQL-Reminders.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(SourceRoot)src\AdoNet\Orleans.Reminders.AdoNet\SQLServer-Reminders.sql" Link="SQLServer-Reminders.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Storage\" />
   </ItemGroup>
 
 </Project>

--- a/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <AssemblyName>TestGrainInterfaces</AssemblyName>
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/test/TestInfrastructure/Orleans.TestingHost.AppDomain/Orleans.TestingHost.AppDomain.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.AppDomain/Orleans.TestingHost.AppDomain.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.TestingHost.AppDomain</PackageId>
     <Title>Microsoft Orleans Testing Host Library AppDomain support</Title>
@@ -16,8 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" />
   </ItemGroup>
 

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />


### PR DESCRIPTION
* Update Newtonsoft.Json to 11.0.1 (first version with proper netstandard2.0 packaging)
* Clean-up and simplify shared files inclusion in some provider projects
* Add `ExcludeAssets="compile"` attribute to CodeGenerator.MSBuild.Tasks references
* Change Orleans.CodeGenerator TFM to `netcoreapp3.1` (also for CodeGenerator.Tests)
* Remove some more redundant/unused dependencies
