### PR TITLE
Set longer timeout for ASP.NET core example to match modern versions

### DIFF
--- a/Samples/3.0/AspNetCoreCohosting/API/Program.cs
+++ b/Samples/3.0/AspNetCoreCohosting/API/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -40,6 +41,7 @@ namespace AspNetCoreCohosting
                 {
                     siloBuilder
                     .UseLocalhostClustering()
+                    .Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromMinutes(1))
                     .Configure<ClusterOptions>(opts =>
                     {
                         opts.ClusterId = "dev";


### PR DESCRIPTION
Fixes #6688 by extending timeout (Only matters in more modern versions, but samples are copy/pasted.