### PR TITLE
Kubernetes hosting integration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,7 +62,7 @@
     <MicrosoftBuildVersion>16.4.0</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>3.4.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
-    <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
+    <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesVersion>
     <MicrosoftBclHashCodeVersion>1.0.0</MicrosoftBclHashCodeVersion>
 
@@ -76,6 +76,7 @@
     <MicrosoftExtensionsLoggingVersion>3.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsObjectPoolVersion>3.0.0</MicrosoftExtensionsObjectPoolVersion>
     <MicrosoftExtensionsOptionsVersion>3.0.0</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsHttpVersion>3.0.0</MicrosoftExtensionsHttpVersion>
     <MicrosoftExtensionsHostingAbstractionsVersion>3.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsHostingVersion>3.0.0</MicrosoftExtensionsHostingVersion>
 
@@ -107,6 +108,7 @@
     <NSubstituteAnalyzersCSharpVersion>1.0.10</NSubstituteAnalyzersCSharpVersion>
     <ZooKeeperNetExVersion>3.4.12.1</ZooKeeperNetExVersion>
     <StackExchangeRedis>2.0.601</StackExchangeRedis>
+    <KubernetesClientVersion>2.0.29</KubernetesClientVersion>
 
     <!-- Test related packages -->
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -196,9 +196,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Connections.Securit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.GrainDirectory.AzureStorage", "src\Azure\Orleans.GrainDirectory.AzureStorage\Orleans.GrainDirectory.AzureStorage.csproj", "{16B9B850-ED3B-4B45-B0F2-3F802D44F382}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orleans.GrainDirectory.Redis", "src\Orleans.GrainDirectory.Redis\Orleans.GrainDirectory.Redis.csproj", "{CCEF897C-F4F8-48F0-8F95-CC1487EE2936}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.GrainDirectory.Redis", "src\Orleans.GrainDirectory.Redis\Orleans.GrainDirectory.Redis.csproj", "{CCEF897C-F4F8-48F0-8F95-CC1487EE2936}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester.Redis", "test\Extensions\Tester.Redis\Tester.Redis.csproj", "{F13247A0-70C9-4200-9CB1-2002CB8105E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tester.Redis", "test\Extensions\Tester.Redis\Tester.Redis.csproj", "{F13247A0-70C9-4200-9CB1-2002CB8105E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Hosting.Kubernetes", "src\Orleans.Hosting.Kubernetes\Orleans.Hosting.Kubernetes.csproj", "{D1214CD3-EB99-4420-9E30-A50ACFD66A48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1206,6 +1208,18 @@ Global
 		{F13247A0-70C9-4200-9CB1-2002CB8105E0}.Release|x64.Build.0 = Release|Any CPU
 		{F13247A0-70C9-4200-9CB1-2002CB8105E0}.Release|x86.ActiveCfg = Release|Any CPU
 		{F13247A0-70C9-4200-9CB1-2002CB8105E0}.Release|x86.Build.0 = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Debug|x86.Build.0 = Debug|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|x64.Build.0 = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1307,6 +1321,7 @@ Global
 		{16B9B850-ED3B-4B45-B0F2-3F802D44F382} = {4C5D66BF-EE1C-4DD8-8551-D1B7F3768A34}
 		{CCEF897C-F4F8-48F0-8F95-CC1487EE2936} = {FE2E08C6-9C3B-4AEE-AE07-CCA387580D7A}
 		{F13247A0-70C9-4200-9CB1-2002CB8105E0} = {082D25DB-70CA-48F4-93E0-EC3455F494B8}
+		{D1214CD3-EB99-4420-9E30-A50ACFD66A48} = {FE2E08C6-9C3B-4AEE-AE07-CCA387580D7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
@@ -1,3 +1,4 @@
+using AutoMapper.Configuration.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -9,7 +10,7 @@ namespace Orleans.Hosting.Kubernetes
     internal class ConfigureKubernetesHostingOptions :
         IConfigureOptions<ClusterOptions>,
         IConfigureOptions<SiloOptions>,
-        IConfigureOptions<EndpointOptions>,
+        IPostConfigureOptions<EndpointOptions>,
         IConfigureOptions<KubernetesHostingOptions>
     {
         private readonly IServiceProvider _serviceProvider;
@@ -37,8 +38,10 @@ namespace Orleans.Hosting.Kubernetes
             options.SiloName = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable);
         }
 
-        public void Configure(EndpointOptions options)
+        public void PostConfigure(string name, EndpointOptions options)
         {
+            // Use PostConfigure to give the developer an opportunity to set SiloPort and GatewayPort using regular
+            // Configure methods without needing to worry about ordering with respect to the UseKubernetesHosting call.
             if (options.AdvertisedIPAddress is null)
             {
                 var hostingOptions = _serviceProvider.GetRequiredService<IOptions<KubernetesHostingOptions>>().Value;

--- a/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using System;
+using System.Net;
+
+namespace Orleans.Hosting.Kubernetes
+{
+    internal class ConfigureKubernetesHostingOptions :
+        IConfigureOptions<ClusterOptions>,
+        IConfigureOptions<SiloOptions>,
+        IConfigureOptions<EndpointOptions>,
+        IConfigureOptions<KubernetesHostingOptions>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ConfigureKubernetesHostingOptions(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void Configure(KubernetesHostingOptions options)
+        {
+            options.Namespace = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNamespaceEnvironmentVariable);
+            options.PodName = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable);
+            options.PodIP = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodIPEnvironmentVariable);
+        }
+
+        public void Configure(ClusterOptions options)
+        {
+            options.ServiceId = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ServiceIdEnvironmentVariable);
+            options.ClusterId = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ClusterIdEnvironmentVariable);
+        }
+
+        public void Configure(SiloOptions options)
+        {
+            options.SiloName = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable);
+        }
+
+        public void Configure(EndpointOptions options)
+        {
+            if (options.AdvertisedIPAddress is null)
+            {
+                var hostingOptions = _serviceProvider.GetRequiredService<IOptions<KubernetesHostingOptions>>().Value;
+                var podIp = IPAddress.Parse(hostingOptions.PodIP);
+                options.AdvertisedIPAddress = podIp;
+            }
+
+            if (options.SiloListeningEndpoint is null)
+            {
+                options.SiloListeningEndpoint = new IPEndPoint(IPAddress.Any, options.SiloPort);
+            }
+
+            if (options.GatewayListeningEndpoint is null && options.GatewayPort > 0)
+            {
+                options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, options.GatewayPort);
+            }
+        }
+    }
+}

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -1,0 +1,265 @@
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Orleans.Hosting.Kubernetes
+{
+    /// <summary>
+    /// Reflects cluster configuration changes between Orleans and Kubernetes.
+    /// </summary>
+    public sealed class KubernetesClusterAgent : ILifecycleParticipant<ISiloLifecycle>
+    {
+        private readonly IOptionsMonitor<KubernetesHostingOptions> _options;
+        private readonly ClusterOptions _clusterOptions;
+        private readonly IClusterMembershipService _clusterMembershipService;
+        private readonly KubernetesClientConfiguration _config;
+        private readonly k8s.Kubernetes _client;
+        private readonly string _podLabelSelector;
+        private readonly string _podNamespace;
+        private readonly string _podName;
+        private readonly ILogger<KubernetesClusterAgent> _logger;
+        private readonly CancellationTokenSource _shutdownToken;
+        private Task _runTask;
+
+        public KubernetesClusterAgent(
+            IClusterMembershipService clusterMembershipService,
+            ILogger<KubernetesClusterAgent> logger,
+            IOptionsMonitor<KubernetesHostingOptions> options,
+            IOptions<ClusterOptions> clusterOptions)
+        {
+            _logger = logger;
+            _shutdownToken = new CancellationTokenSource();
+            _options = options;
+            _clusterOptions = clusterOptions.Value;
+            _clusterMembershipService = clusterMembershipService;
+            _config = _options.CurrentValue.GetClientConfiguration?.Invoke() ?? throw new ArgumentNullException(nameof(KubernetesHostingOptions) + "." + nameof(KubernetesHostingOptions.GetClientConfiguration));
+            _client = new k8s.Kubernetes(_config);
+            _podLabelSelector = $"serviceId={_clusterOptions.ServiceId},clusterId={_clusterOptions.ClusterId}";
+            _podNamespace = _options.CurrentValue.Namespace;
+            _podName = _options.CurrentValue.PodName;
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(
+                nameof(KubernetesClusterAgent),
+                ServiceLifecycleStage.AfterRuntimeGrainServices,
+                OnRuntimeInitializeStart,
+                OnRuntimeInitializeStop);
+        }
+
+        private async Task OnRuntimeInitializeStart(CancellationToken cancellation)
+        {
+            // Find the currently known cluster members first, before interrogating Kubernetes
+            await _clusterMembershipService.Refresh();
+            var snapshot = _clusterMembershipService.CurrentSnapshot.Members;
+
+            // Find the pods which correspond to this cluster
+            var pods = await _client.ListNamespacedPodAsync(
+                namespaceParameter: _podNamespace,
+                labelSelector: _podLabelSelector,
+                cancellationToken: cancellation);
+            var clusterPods = new HashSet<string>();
+            clusterPods.Add(_podName);
+            foreach (var pod in pods.Items)
+            {
+                clusterPods.Add(pod.Metadata.Name);
+            }
+
+            HashSet<string> known = new HashSet<string>();
+            var knownMap = new Dictionary<string, ClusterMember>();
+            known.Add(_podName);
+            foreach (var member in snapshot.Values)
+            {
+                if (member.Status == SiloStatus.Dead)
+                {
+                    continue;
+                }
+
+                known.Add(member.Name);
+                knownMap[member.Name] = member;
+            }
+
+            var unknown = new List<string>(clusterPods.Except(known));
+            unknown.Sort();
+            foreach (var pod in unknown)
+            {
+                _logger.LogWarning("Pod {PodName} does not correspond to any known silos", pod);
+
+                // Delete the pod once it has been active long enough?
+            }
+
+            var unmatched = new List<string>(known.Except(clusterPods));
+            unmatched.Sort();
+            foreach (var pod in unmatched)
+            {
+                var siloAddress = knownMap[pod];
+                _logger.LogWarning("Silo {SiloAddress} does not correspond to any known pod. Marking it as dead.", siloAddress);
+                await _clusterMembershipService.TryKill(siloAddress.SiloAddress);
+            }
+
+            // Start monitoring loop
+            _runTask = Task.Run(Run);
+        }
+
+        public async Task OnRuntimeInitializeStop(CancellationToken cancellationToken)
+        {
+            _shutdownToken.Cancel();
+
+            if (_runTask is object)
+            {
+                await Task.WhenAny(_runTask, Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
+            }
+        }
+
+        private async Task Run()
+        {
+            var jsonSettings = new JsonSerializerSettings
+            {
+                DefaultValueHandling = DefaultValueHandling.Ignore,
+                Formatting = Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+            while (!_shutdownToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var pods = await _client.ListNamespacedPodWithHttpMessagesAsync(
+                        namespaceParameter: _podNamespace,
+                        labelSelector: _podLabelSelector,
+                        watch: true,
+                        cancellationToken: _shutdownToken.Token);
+
+                    await foreach (var (eventType, pod) in pods.WatchAsync<V1PodList, V1Pod>(_shutdownToken.Token))
+                    {
+#if false
+                        _logger.LogInformation(
+                            "Event: {Event} Pod: {Pod}",
+                            eventType.ToString(),
+                            JsonConvert.SerializeObject(pod, jsonSettings));
+#endif
+                        _logger.LogInformation(
+                            "Event: {Event} PodName: {PodName}",
+                            eventType.ToString(),
+                            pod.Metadata.Name);
+
+                        if (string.Equals(pod.Metadata.Name, _podName, StringComparison.Ordinal))
+                        {
+                            // Never declare ourselves dead this way.
+                            continue;
+                        }
+
+                        if (eventType == WatchEventType.Modified)
+                        {
+                            // TODO: Remember silo addresses for pods are restarting/terminating
+                        }
+                        
+                        if (eventType == WatchEventType.Deleted)
+                        {
+                            if (this.TryMatchSilo(pod, out var member) && member.Status != SiloStatus.Dead)
+                            {
+                                _logger.LogInformation("Declaring server {Silo} dead since its corresponding pod, {Pod}, has been deleted", member.SiloAddress, pod.Metadata.Name);
+                                await _clusterMembershipService.TryKill(member.SiloAddress);
+                            }
+                        }
+                    }
+
+                    if (!_shutdownToken.IsCancellationRequested)
+                    {
+                        _logger.LogDebug("Unexpected end of stream from Kubernetes API. Will try again.");
+                        await Task.Delay(1000);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogError(exception, "Error trying to watch pods");
+                    if (!_shutdownToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(1000);
+                    }
+                }
+            }
+        }
+
+        private bool TryMatchSilo(V1Pod pod, out ClusterMember server)
+        {
+            var snapshot = _clusterMembershipService.CurrentSnapshot;
+            foreach (var member in snapshot.Members)
+            {
+                if (string.Equals(member.Value.Name, pod.Metadata.Name, StringComparison.Ordinal))
+                {
+                    server = member.Value;
+                    return true;
+                }
+            }
+
+            server = default;
+            return false;
+        }
+    }
+
+    internal static class KubernetesExtensions
+    {
+        public static async IAsyncEnumerable<(WatchEventType EventType, TValue Value)> WatchAsync<TList, TValue>(this HttpOperationResponse<TList> watchList, [EnumeratorCancellation] CancellationToken cancellation)
+        {
+            Channel<(WatchEventType, TValue)> channel = Channel.CreateUnbounded<(WatchEventType, TValue)>(
+                new UnboundedChannelOptions
+                {
+                    AllowSynchronousContinuations = false,
+                    SingleReader = true,
+                    SingleWriter = true
+                });
+
+            var reader = channel.Reader;
+            Watcher<TValue>[] watcher = new Watcher<TValue>[] { default };
+            var cancellationRegistration = cancellation.Register(() =>
+            {
+                _ = channel.Writer.TryComplete();
+                watcher[0]?.Dispose();
+            });
+
+            watcher[0] = watchList.Watch<TValue, TList>((eventType, value) =>
+            {
+                _ = channel.Writer.TryWrite((eventType, value));
+            },
+            exception =>
+            {
+                _ = channel.Writer.TryComplete(exception);
+                cancellationRegistration.Dispose();
+            },
+            () =>
+            {
+                _ = channel.Writer.TryComplete();
+                cancellationRegistration.Dispose();
+            });
+
+            _ = Task.Run(async () =>
+            {
+                await channel.Reader.Completion.ConfigureAwait(false);
+                watcher[0].Dispose();
+                cancellationRegistration.Dispose();
+            });
+
+
+            while (await channel.Reader.WaitToReadAsync(cancellation))
+            {
+                while (reader.TryRead(out var item))
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -52,7 +52,7 @@ namespace Orleans.Hosting.Kubernetes
             _clusterMembershipService = clusterMembershipService;
             _config = _options.CurrentValue.GetClientConfiguration?.Invoke() ?? throw new ArgumentNullException(nameof(KubernetesHostingOptions) + "." + nameof(KubernetesHostingOptions.GetClientConfiguration));
             _client = new k8s.Kubernetes(_config);
-            _podLabelSelector = $"serviceId={_clusterOptions.ServiceId},clusterId={_clusterOptions.ClusterId}";
+            _podLabelSelector = $"{KubernetesHostingOptions.ServiceIdLabel}={_clusterOptions.ServiceId},{KubernetesHostingOptions.ClusterIdLabel}={_clusterOptions.ClusterId}";
             _podNamespace = _options.CurrentValue.Namespace;
             _podName = _options.CurrentValue.PodName;
         }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -1,0 +1,71 @@
+using k8s;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Hosting.Kubernetes;
+using Orleans.Runtime;
+using System;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extensions for hosting a silo in Kubernetes.
+    /// </summary>
+    public static class KubernetesHostingExtensions
+    {
+        /// <summary>
+        /// Adds Kubernetes hosting support.
+        /// </summary>
+        public static ISiloBuilder UseKubernetesHosting(this ISiloBuilder siloBuilder)
+        {
+            return siloBuilder.ConfigureServices(services => services.UseKubernetesHosting(configureOptions: null));
+        }
+
+        /// <summary>
+        /// Adds Kubernetes hosting support.
+        /// </summary>
+        public static ISiloBuilder UseKubernetesHosting(this ISiloBuilder siloBuilder, Action<OptionsBuilder<KubernetesHostingOptions>> configureOptions)
+        {
+            return siloBuilder.ConfigureServices(services => services.UseKubernetesHosting(configureOptions));
+        }
+
+        /// <summary>
+        /// Adds Kubernetes hosting support.
+        /// </summary>
+        public static IServiceCollection UseKubernetesHosting(this IServiceCollection services) => services.UseKubernetesHosting(configureOptions: null);
+
+        /// <summary>
+        /// Adds Kubernetes hosting support.
+        /// </summary>
+        public static IServiceCollection UseKubernetesHosting(this IServiceCollection services, Action<OptionsBuilder<KubernetesHostingOptions>> configureOptions)
+        {
+            configureOptions?.Invoke(services.AddOptions<KubernetesHostingOptions>());
+
+            // Configure defaults based on the current environment.
+            services.AddSingleton<IConfigureOptions<ClusterOptions>, ConfigureKubernetesHostingOptions>();
+            services.AddSingleton<IConfigureOptions<SiloOptions>, ConfigureKubernetesHostingOptions>();
+            services.AddSingleton<IConfigureOptions<EndpointOptions>, ConfigureKubernetesHostingOptions>();
+            services.AddSingleton<IConfigureOptions<KubernetesHostingOptions>, ConfigureKubernetesHostingOptions>();
+            services.AddSingleton<IValidateOptions<KubernetesHostingOptions>, KubernetesHostingOptionsValidator>();
+
+            services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, KubernetesClusterAgent>();
+
+            // Configure the Kubernetes client.
+            services.AddHttpClient("Orleans.Kubernetes.Agent")
+                .AddTypedClient<IKubernetes>((httpClient, serviceProvider) =>
+                {
+                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
+                    return new k8s.Kubernetes(
+                        config,
+                        httpClient);
+                }).ConfigurePrimaryHttpMessageHandler(serviceProvider =>
+                {
+                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
+                    return config.CreateDefaultHttpClientHandler();
+                })
+                .AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);
+
+            return services;
+        }
+    }
+}

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -44,7 +44,7 @@ namespace Orleans.Hosting
             // Configure defaults based on the current environment.
             services.AddSingleton<IConfigureOptions<ClusterOptions>, ConfigureKubernetesHostingOptions>();
             services.AddSingleton<IConfigureOptions<SiloOptions>, ConfigureKubernetesHostingOptions>();
-            services.AddSingleton<IConfigureOptions<EndpointOptions>, ConfigureKubernetesHostingOptions>();
+            services.AddSingleton<IPostConfigureOptions<EndpointOptions>, ConfigureKubernetesHostingOptions>();
             services.AddSingleton<IConfigureOptions<KubernetesHostingOptions>, ConfigureKubernetesHostingOptions>();
             services.AddSingleton<IValidateOptions<KubernetesHostingOptions>, KubernetesHostingOptionsValidator>();
 

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
@@ -51,6 +51,19 @@ namespace Orleans.Hosting.Kubernetes
         public Func<KubernetesClientConfiguration> GetClientConfiguration { get; set; } = KubernetesClientConfiguration.InClusterConfig;
 
         /// <summary>
+        /// The number of silos in the cluster which should monitor Kubernetes.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to a small number can reduce the load on the Kubernetes API server.
+        /// </remarks>
+        public int MaxAgents { get; set; } = 2;
+
+        /// <summary>
+        /// Whether or not to delete pods which correspond to silos which have become defunct since this silo became active.
+        /// </summary>
+        public bool DeleteDefunctSiloPods { get; set; } = false;
+
+        /// <summary>
         /// The Kubernetes namespace which this silo and all other silos belong to.
         /// </summary>
         internal string Namespace { get; set; }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
@@ -35,6 +35,16 @@ namespace Orleans.Hosting.Kubernetes
         /// </summary>
         public const string ServiceIdEnvironmentVariable = "ORLEANS_SERVICE_ID";
 
+        /// <summary>
+        /// The name of the <see cref="Orleans.Configuration.ClusterOptions.ServiceId"/> label on the pod.
+        /// </summary>
+        public const string ServiceIdLabel = "orleans/serviceId";
+
+        /// <summary>
+        /// The name of the <see cref="Orleans.Configuration.ClusterOptions.ClusterId"/> label on the pod.
+        /// </summary>
+        public const string ClusterIdLabel = "orleans/clusterId";
+
         public KubernetesHostingOptions()
         {
             _clientConfiguration = new Lazy<KubernetesClientConfiguration>(() => this.GetClientConfiguration());

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
@@ -1,0 +1,68 @@
+using k8s;
+using System;
+
+namespace Orleans.Hosting.Kubernetes
+{
+    /// <summary>
+    /// Options for hosting in Kubernetes.
+    /// </summary>
+    public sealed class KubernetesHostingOptions
+    {
+        private readonly Lazy<KubernetesClientConfiguration> _clientConfiguration;
+
+        /// <summary>
+        /// The environment variable for specifying the Kubernetes namespace which all silos in this cluster belong to.
+        /// </summary>
+        public const string PodNamespaceEnvironmentVariable = "POD_NAMESPACE";
+
+        /// <summary>
+        /// The environment variable for specifying the name of the Kubernetes pod which this silo is executing in.
+        /// </summary>
+        public const string PodNameEnvironmentVariable = "POD_NAME";
+
+        /// <summary>
+        /// The environment variable for specifying the IP address of this pod.
+        /// </summary>
+        public const string PodIPEnvironmentVariable = "POD_IP";
+
+        /// <summary>
+        /// The environment variable for specifying <see cref="Orleans.Configuration.ClusterOptions.ClusterId"/>.
+        /// </summary>
+        public const string ClusterIdEnvironmentVariable = "ORLEANS_CLUSTER_ID";
+
+        /// <summary>
+        /// The environment variable for specifying <see cref="Orleans.Configuration.ClusterOptions.ServiceId"/>.
+        /// </summary>
+        public const string ServiceIdEnvironmentVariable = "ORLEANS_SERVICE_ID";
+
+        public KubernetesHostingOptions()
+        {
+            _clientConfiguration = new Lazy<KubernetesClientConfiguration>(() => this.GetClientConfiguration());
+        }
+
+        /// <summary>
+        /// Gets the client configuration.
+        /// </summary>
+        internal KubernetesClientConfiguration ClientConfiguration => _clientConfiguration.Value;
+
+        /// <summary>
+        /// The delegate used to get an instance of <see cref="KubernetesClientConfiguration"/>.
+        /// </summary>
+        public Func<KubernetesClientConfiguration> GetClientConfiguration { get; set; } = KubernetesClientConfiguration.InClusterConfig;
+
+        /// <summary>
+        /// The Kubernetes namespace which this silo and all other silos belong to.
+        /// </summary>
+        internal string Namespace { get; set; }
+
+        /// <summary>
+        /// The name of the Kubernetes pod which this silo is executing in.
+        /// </summary>
+        internal string PodName { get; set; }
+
+        /// <summary>
+        /// The PodIP of the Kubernetes pod which this silo is executing in.
+        /// </summary>
+        internal string PodIP { get; set; }
+    }
+}

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptionsValidator.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptionsValidator.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Hosting.Kubernetes
+{
+    /// <summary>
+    /// Validates <see cref="KubernetesHostingOptions"/>.
+    /// </summary>
+    internal class KubernetesHostingOptionsValidator : IValidateOptions<KubernetesHostingOptions>
+    {
+        private readonly IOptions<SiloOptions> _siloOptions;
+
+        public KubernetesHostingOptionsValidator(IOptions<SiloOptions> siloOptions) => _siloOptions = siloOptions;
+
+        public ValidateOptionsResult Validate(string name, KubernetesHostingOptions options)
+        {
+            List<string> failures = default;
+            if (string.IsNullOrWhiteSpace(options.Namespace))
+            {
+                failures ??= new List<string>();
+                failures.Add($"{nameof(KubernetesHostingOptions)}.{nameof(KubernetesHostingOptions.Namespace)} is not set. Set it via the {KubernetesHostingOptions.PodNamespaceEnvironmentVariable} environment variable");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.PodName))
+            {
+                failures ??= new List<string>();
+                failures.Add($"{nameof(KubernetesHostingOptions)}.{nameof(KubernetesHostingOptions.PodName)} is not set. Set it via the {KubernetesHostingOptions.PodNameEnvironmentVariable} environment variable");
+            }
+
+            if (!string.Equals(_siloOptions.Value.SiloName, options.PodName, StringComparison.Ordinal))
+            {
+                failures ??= new List<string>();
+                failures.Add($"{nameof(SiloOptions)}.{nameof(SiloOptions.SiloName)} is not equal to the current pod name as defined by {nameof(KubernetesHostingOptions)}.{nameof(KubernetesHostingOptions.PodName)}");
+            }
+
+            if (failures is object) return ValidateOptionsResult.Fail(failures);
+
+            return ValidateOptionsResult.Success;
+        }
+    }
+}

--- a/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
+++ b/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Orleans.Hosting.Kubernetes</PackageId>
+    <Title>Microsoft Orleans Hosting for Kubernetes</Title>
+    <Description>Microsoft Orleans hosting support for Kubernetes</Description>
+    <PackageTags>$(PackageTags) Kubernetes k8s</PackageTags>
+    <TargetFrameworks>$(StandardTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
+    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
+++ b/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Hosting.Kubernetes</PackageId>
@@ -6,6 +6,7 @@
     <Description>Microsoft Orleans hosting support for Kubernetes</Description>
     <PackageTags>$(PackageTags) Kubernetes k8s</PackageTags>
     <TargetFrameworks>$(StandardTargetFrameworks)</TargetFrameworks>
+    <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Runtime/MembershipService/ClusterMember.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMember.cs
@@ -5,21 +5,26 @@ namespace Orleans.Runtime
     [Serializable]
     public sealed class ClusterMember : IEquatable<ClusterMember>
     {
-        public ClusterMember(SiloAddress siloAddress, SiloStatus status)
+        public ClusterMember(SiloAddress siloAddress, SiloStatus status, string name)
         {
             this.SiloAddress = siloAddress ?? throw new ArgumentNullException(nameof(siloAddress));
             this.Status = status;
+            this.Name = name;
         }
 
         public SiloAddress SiloAddress { get; }
         public SiloStatus Status { get; }
+        public string Name { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as ClusterMember);
 
-        public bool Equals(ClusterMember other) => other != null && this.SiloAddress.Equals(other.SiloAddress) && this.Status == other.Status;
+        public bool Equals(ClusterMember other) => other != null
+            && this.SiloAddress.Equals(other.SiloAddress)
+            && this.Status == other.Status
+            && string.Equals(this.Name, other.Name, StringComparison.Ordinal);
 
         public override int GetHashCode() => this.SiloAddress.GetConsistentHashCode();
 
-        public override string ToString() => $"{this.SiloAddress}/{this.Status}";
+        public override string ToString() => $"{this.SiloAddress}/{this.Name}/{this.Status}";
     }
 }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -62,6 +62,8 @@ namespace Orleans.Runtime
             }
         }
 
+        public async Task<bool> TryKill(SiloAddress siloAddress) => await this.membershipTableManager.TryKill(siloAddress);
+
         private async Task ProcessMembershipUpdates(CancellationToken ct)
         {
             try

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
@@ -63,9 +63,9 @@ namespace Orleans.Runtime
             // Handle entries which were removed entirely.
             foreach (var entry in previous.Members)
             {
-                if (!this.Members.TryGetValue(entry.Key, out var newEntry))
+                if (!this.Members.TryGetValue(entry.Key, out _))
                 {
-                    changes.Add(new ClusterMember(entry.Key, SiloStatus.Dead));
+                    changes.Add(new ClusterMember(entry.Key, SiloStatus.Dead, entry.Value.Name));
                 }
             }
 

--- a/src/Orleans.Runtime/MembershipService/IClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/IClusterMembershipService.cs
@@ -10,5 +10,10 @@ namespace Orleans.Runtime
         IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates { get; }
 
         ValueTask Refresh(MembershipVersion minimumVersion = default);
+
+        /// <summary>
+        /// Unilaterally declares the specified silo defunct.
+        /// </summary>
+        Task<bool> TryKill(SiloAddress siloAddress);
     }
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableSnapshotExtensions.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableSnapshotExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -10,7 +10,7 @@ namespace Orleans.Runtime.MembershipService
             foreach (var member in membership.Entries)
             {
                 var entry = member.Value;
-                memberBuilder[entry.SiloAddress] = new ClusterMember(entry.SiloAddress, entry.Status);
+                memberBuilder[entry.SiloAddress] = new ClusterMember(entry.SiloAddress, entry.Status, entry.SiloName);
             }
 
             return new ClusterMembershipSnapshot(memberBuilder.ToImmutable(), membership.Version);

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -111,8 +111,8 @@ namespace UnitTests.Directory
             var outdatedGrainAddr = outdatedAddr.ToGrainAddress();
 
             // Setup membership service
-            this.mockMembershipService.UpdateSiloStatus(expectedAddr.Silo, SiloStatus.Active);
-            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead);
+            this.mockMembershipService.UpdateSiloStatus(expectedAddr.Silo, SiloStatus.Active, "exp");
+            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead, "old");
             await this.lifecycle.OnStart();
             await WaitUntilClusterChangePropagated();
 
@@ -141,7 +141,7 @@ namespace UnitTests.Directory
             this.grainDirectory.Lookup(grainAddress.GrainId).Returns(grainAddress);
 
             // Cache should be empty
-            Assert.False(this.grainLocator.TryLocalLookup(expected.Grain, out var unused));
+            Assert.False(this.grainLocator.TryLocalLookup(expected.Grain, out _));
 
             // Do a remote lookup
             var results = await this.grainLocator.Lookup(expected.Grain);
@@ -161,7 +161,7 @@ namespace UnitTests.Directory
             var outdatedGrainAddr = outdatedAddr.ToGrainAddress();
 
             // Setup membership service
-            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead);
+            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead, "old");
             await this.lifecycle.OnStart();
             await WaitUntilClusterChangePropagated();
 
@@ -172,8 +172,7 @@ namespace UnitTests.Directory
 
             await this.grainDirectory.Received(1).Lookup(outdatedGrainAddr.GrainId);
             await this.grainDirectory.Received(1).Unregister(outdatedGrainAddr);
-
-            Assert.False(this.grainLocator.TryLocalLookup(outdatedAddr.Grain, out var unused));
+            Assert.False(this.grainLocator.TryLocalLookup(outdatedAddr.Grain, out _));
 
             await this.lifecycle.OnStop();
         }
@@ -185,13 +184,12 @@ namespace UnitTests.Directory
             var outdatedGrainAddr = outdatedAddr.ToGrainAddress();
 
             // Setup membership service
-            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead);
+            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead, "old");
             await this.lifecycle.OnStart();
             await WaitUntilClusterChangePropagated();
 
             this.grainDirectory.Lookup(outdatedGrainAddr.GrainId).Returns(outdatedGrainAddr);
-
-            Assert.False(this.grainLocator.TryLocalLookup(outdatedAddr.Grain, out var unused));
+            Assert.False(this.grainLocator.TryLocalLookup(outdatedAddr.Grain, out _));
 
             // Local lookup should never call the directory
             await this.grainDirectory.DidNotReceive().Lookup(outdatedGrainAddr.GrainId);
@@ -209,8 +207,8 @@ namespace UnitTests.Directory
             var outdatedGrainAddr = outdatedAddr.ToGrainAddress();
 
             // Setup membership service
-            this.mockMembershipService.UpdateSiloStatus(expectedAddr.Silo, SiloStatus.Active);
-            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Active);
+            this.mockMembershipService.UpdateSiloStatus(expectedAddr.Silo, SiloStatus.Active, "exp");
+            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Active, "old");
             await this.lifecycle.OnStart();
             await WaitUntilClusterChangePropagated();
 
@@ -222,7 +220,7 @@ namespace UnitTests.Directory
             await this.grainLocator.Register(outdatedAddr);
 
             // Simulate a dead silo
-            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead);
+            this.mockMembershipService.UpdateSiloStatus(outdatedAddr.Silo, SiloStatus.Dead, "old");
 
             // Wait a bit for the update to be processed
             await WaitUntilClusterChangePropagated();
@@ -256,7 +254,7 @@ namespace UnitTests.Directory
 
             // Unregister and check if cache was cleaned
             await this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
-            Assert.False(this.grainLocator.TryLocalLookup(expectedAddr.Grain, out var unused));
+            Assert.False(this.grainLocator.TryLocalLookup(expectedAddr.Grain, out _));
         }
 
 

--- a/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
+++ b/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
@@ -11,7 +11,7 @@ namespace UnitTests.Directory
     internal class MockClusterMembershipService : IClusterMembershipService
     {
         private long version = 0;
-        private Dictionary<SiloAddress, SiloStatus> statuses;
+        private Dictionary<SiloAddress, (SiloStatus Status, string Name)> statuses;
         private ClusterMembershipSnapshot snapshot;
         private readonly AsyncEnumerable<ClusterMembershipSnapshot> updates;
 
@@ -23,9 +23,9 @@ namespace UnitTests.Directory
 
         public IClusterMembershipService Target => this;
 
-        public MockClusterMembershipService(Dictionary<SiloAddress, SiloStatus> initialStatuses = null)
+        public MockClusterMembershipService(Dictionary<SiloAddress, (SiloStatus Status, string Name)> initialStatuses = null)
         {
-            this.statuses = initialStatuses ?? new Dictionary<SiloAddress, SiloStatus>();
+            this.statuses = initialStatuses ?? new Dictionary<SiloAddress, (SiloStatus Status, string Name)>();
             this.snapshot = ToSnapshot(this.statuses, ++version);
             this.updates = this.updates = new AsyncEnumerable<ClusterMembershipSnapshot>(
                 (previous, proposed) => proposed.Version == MembershipVersion.MinValue || proposed.Version > previous.Version,
@@ -35,17 +35,17 @@ namespace UnitTests.Directory
             };
         }
 
-        public void UpdateSiloStatus(SiloAddress siloAddress, SiloStatus siloStatus)
+        public void UpdateSiloStatus(SiloAddress siloAddress, SiloStatus siloStatus, string name)
         {
-            this.statuses[siloAddress] = siloStatus;
+            this.statuses[siloAddress] = (siloStatus, name);
             this.updates.Publish(ToSnapshot(this.statuses, ++version));
         }
 
-        internal static ClusterMembershipSnapshot ToSnapshot(Dictionary<SiloAddress, SiloStatus> statuses, long version)
+        internal static ClusterMembershipSnapshot ToSnapshot(Dictionary<SiloAddress, (SiloStatus Status, string Name)> statuses, long version)
         {
             var dictBuilder = ImmutableDictionary.CreateBuilder<SiloAddress, ClusterMember>();
             foreach (var kvp in statuses)
-                dictBuilder.Add(kvp.Key, new ClusterMember(kvp.Key, kvp.Value));
+                dictBuilder.Add(kvp.Key, new ClusterMember(kvp.Key, kvp.Value.Status, kvp.Value.Name));
 
             return new ClusterMembershipSnapshot(dictBuilder.ToImmutable(), new MembershipVersion(version));
         }

--- a/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
+++ b/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Utilities;
 
@@ -53,5 +51,7 @@ namespace UnitTests.Directory
         }
 
         public ValueTask Refresh(MembershipVersion minimumVersion = default) => new ValueTask();
+
+        public Task<bool> TryKill(SiloAddress siloAddress) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This PR adds experimental support for integrating more deeply with Kubernetes.

Users make a call to `siloBuilder.UseKubernetesHosting()` to enable the following:

* Early in the startup process and at runtime, the silo will probe Kubernetes to find which silos do not have corresponding pods and mark those silos as dead
* Configure `ClusterOptions.ServiceId` and `ClusterOptions.ClusterId` based on labels set on the pod in Kubernetes
* Configure `SiloOptions.SiloName` based on the pod name
* Configure `EndpointOptions.AdvertisedIPAddress`, `EndpointOptions.SiloListeningEndpoint`, and `EndpointOptions.GatewayListeningEndpoint` based upon the pod's PodIP and the configured SiloPort and GatewayPort (default values 11111, 30000)

In a future update, we could consider optionally instructing Kubernetes to delete pods which correspond to dead silos (eg, because the pod is not responding - perhaps the process has become a zombie).

To reduce load on Kubernetes' API server (which is apparently a big issue), only a subset of silos will monitor Kubernetes. The default value is 2 silos per cluster, and to reduce churn, the two oldest silos in the cluster are chosen.

There are some requirements on how Orleans is deployed into Kubernetes when using this plugin. For example:

* Silo names must match pod names (the abovementioned method will configure that)
* Pods must have a `serviceId` and `clusterId` label which corresponds to the silo's ServiceId and ClusterId. The abovementioned method will propagate those labels into the corresponding options in Orleans from Env vars.
* Pods must have environment variables set for ServiceId, ClusterId, PodName, and PodNamespace (see example below)

Here is an example YAML file to deploy such a silo:

``` yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dictionary-app
  labels:
    serviceId: dictionary-app
spec:
  selector:
    matchLabels:
      serviceId: dictionary-app
  replicas: 3
  template:
    metadata:
      labels:
        # The serviceId label is used to identify the service to Orleans
        serviceId: dictionary-app

        # The clusterId label is used to identify an instance of a cluster to Orleans.
        # Typically, this will be the same value as serviceId or any fixed value.
        # In cases where you are not using rolling deployments (for example, blue/green deployments),
        # this value can allow for distinct clusters which do not communicate directly with each others,
        # but which still share the same storage and other resources.
        clusterId: dictionary-app
    spec:
      containers:
        - name: main
          image: reuben.azurecr.io/dictionary-app
          imagePullPolicy: Always
          ports:
          # Define the ports which Orleans uses
          - containerPort: 11111
          - containerPort: 30000
          env:
          # The Azure Storage connection string for clustering is injected as an environment variable
          # It must be created separately using a command such as:
          # > kubectl create secret generic az-storage-acct --from-file=key=./az-storage-acct.txt
          - name: STORAGE_CONNECTION_STRING
            valueFrom:
              secretKeyRef:
                name: az-storage-acct
                key: key
          # Configure settings to let Orleans know which cluster it belongs to and which pod it is running in
          - name: ORLEANS_SERVICE_ID
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['serviceId']
          - name: ORLEANS_CLUSTER_ID
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['clusterId']
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_IP
            valueFrom:
              fieldRef:
                fieldPath: status.podIP
          - name: DOTNET_SHUTDOWNTIMEOUTSECONDS
            value: "120"
          request:
            # Set resource requests
      terminationGracePeriodSeconds: 180
      imagePullSecrets:
        - name: reuben-acr
  minReadySeconds: 60
  strategy:
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
```

A minimal, do-nothing program then looks like this:

``` C#
using Microsoft.Extensions.Hosting;
using Orleans.Hosting;
using System;

var storageConnectionString = Environment.GetEnvironmentVariable("STORAGE_CONNECTION_STRING");

await Host.CreateDefaultBuilder()
    .UseOrleans(siloBuilder =>
    {
        siloBuilder.UseKubernetesHosting();
        siloBuilder.UseAzureStorageClustering(options => options.ConnectionString = storageConnectionString);
    })
    .RunConsoleAsync();
```