### PR TITLE
Improve error message for OpenConnectionTimeout

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -129,10 +129,10 @@ namespace Orleans.Runtime.Messaging
 
         protected abstract void RetryMessage(Message msg, Exception ex = null);
 
-        public async Task CloseAsync(Exception exception)
+        public Task CloseAsync(Exception exception)
         {
             StartClosing(exception);
-            await _closeTask;
+            return _closeTask;
         }
 
         private void OnTransportConnectionClosed()
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            var task = new Task<Task>(FinishClosing);
+            var task = new Task<Task>(CloseAsync);
             if (Interlocked.CompareExchange(ref _closeTask, task.Unwrap(), null) is object)
             {
                 return;
@@ -162,13 +162,13 @@ namespace Orleans.Runtime.Messaging
                     this);
             }
 
-            task.Start();
+            task.Start(TaskScheduler.Default);
         }
 
         /// <summary>
         /// Close the connection. This method should only be called by <see cref="StartClosing(Exception)"/>.
         /// </summary>
-        private async Task FinishClosing()
+        private async Task CloseAsync()
         {
             NetworkingStatisticsGroup.OnClosedSocket(this.ConnectionDirection);
 
@@ -181,31 +181,27 @@ namespace Orleans.Runtime.Messaging
             await transport.Output.CompleteAsync();
 
             // Try to gracefully stop the reader/writer loops, if they are running.
-            try
-            {
-                if (_processIncomingTask is Task task && !task.IsCompleted)
+            if (_processIncomingTask is { IsCompleted: false } incoming)
+                try
                 {
-                    await task.ConfigureAwait(false);
+                    await incoming;
                 }
-            }
-            catch (Exception processIncomingException)
-            {
-                // Swallow any exceptions here.
-                this.Log.LogWarning(processIncomingException, "Exception processing incoming messages on connection {Connection}", this);
-            }
+                catch (Exception processIncomingException)
+                {
+                    // Swallow any exceptions here.
+                    this.Log.LogWarning(processIncomingException, "Exception processing incoming messages on connection {Connection}", this);
+                }
 
-            try
-            {
-                if (_processOutgoingTask is Task task && !task.IsCompleted)
+            if (_processOutgoingTask is { IsCompleted: false } outgoing)
+                try
                 {
-                    await task.ConfigureAwait(false);
+                    await outgoing;
                 }
-            }
-            catch (Exception processOutgoingException)
-            {
-                // Swallow any exceptions here.
-                this.Log.LogWarning(processOutgoingException, "Exception processing outgoing messages on connection {Connection}", this);
-            }
+                catch (Exception processOutgoingException)
+                {
+                    // Swallow any exceptions here.
+                    this.Log.LogWarning(processOutgoingException, "Exception processing outgoing messages on connection {Connection}", this);
+                }
 
             // Wait for the transport to signal that it's closed before disposing it.
             await _transportConnectionClosed.Task;
@@ -232,14 +228,11 @@ namespace Orleans.Runtime.Messaging
             var i = 0;
             while (this.outgoingMessages.Reader.TryRead(out var message))
             {
-                if (i == 0)
+                if (i == 0 && Log.IsEnabled(LogLevel.Information))
                 {
-                    if (this.Log.IsEnabled(LogLevel.Information))
-                    {
-                        this.Log.LogInformation(
-                            "Rerouting messages for remote endpoint {EndPoint}",
-                            this.RemoteEndPoint?.ToString() ?? "(never connected)");
-                    }
+                    this.Log.LogInformation(
+                        "Rerouting messages for remote endpoint {EndPoint}",
+                        this.RemoteEndPoint?.ToString() ?? "(never connected)");
                 }
 
                 ++i;

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -112,12 +112,12 @@ namespace Orleans.Runtime.Messaging
             return connection.RunInternal();
         }
 
-        protected virtual Task RunInternal()
+        protected virtual async Task RunInternal()
         {
             _transport = this.Context.Transport;
             _processIncomingTask = this.ProcessIncoming();
             _processOutgoingTask = this.ProcessOutgoing();
-            return Task.WhenAll(_processIncomingTask, _processOutgoingTask);
+            await Task.WhenAll(_processIncomingTask, _processOutgoingTask);
         }
 
         /// <summary>
@@ -129,10 +129,10 @@ namespace Orleans.Runtime.Messaging
 
         protected abstract void RetryMessage(Message msg, Exception ex = null);
 
-        public Task CloseAsync(Exception exception)
+        public async Task CloseAsync(Exception exception)
         {
             StartClosing(exception);
-            return _closeTask;
+            await _closeTask;
         }
 
         private void OnTransportConnectionClosed()
@@ -338,7 +338,7 @@ namespace Orleans.Runtime.Messaging
         {
             await Task.Yield();
 
-            Exception error = default;   
+            Exception error = default;
             var serializer = this.shared.ServiceProvider.GetRequiredService<IMessageSerializer>();
             try
             {

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -293,14 +293,14 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        public Task CloseAsync(SiloAddress endpoint)
+        public async Task CloseAsync(SiloAddress endpoint)
         {
             ConnectionEntry entry;
             lock (this.lockObj)
             {
                 if (!this.connections.TryGetValue(endpoint, out entry))
                 {
-                    return Task.CompletedTask;
+                    return;
                 }
 
                 if (entry.PendingConnection is null)
@@ -323,9 +323,8 @@ namespace Orleans.Runtime.Messaging
                     }
                 }
 
-                return Task.WhenAll(closeTasks);
+                await Task.WhenAll(closeTasks);
             }
-            return Task.CompletedTask;
         }
 
         public async Task Close(CancellationToken ct)


### PR DESCRIPTION
This improves the error message for connection opening timeouts.
Also updated `SocketConnectionFactory.ConnectAsync` to properly support cancellation (mostly copied from dotnet/runtime repo).

Message diff for OrleansMessageRejectionException looks similar to this:
```diff
+Exception while sending message: Orleans.Runtime.Messaging.ConnectionFailedException: Connection attempt to endpoint S10.0.0.4:11111:332519906 timed out after 00:00:03
-Exception while sending message: Orleans.Runtime.Messaging.ConnectionFailedException: Unable to connect to endpoint S10.0.0.4:11111:332519906. See InnerException ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
-   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
-   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
-   at Orleans.Internal.OrleansTaskExtentions.<MakeCancellable>d__25`1.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Core\Async\TaskExtensions.cs:line 409
---- End of stack trace from previous location where exception was thrown ---
-   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
-   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
-   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
-   at Orleans.Runtime.Messaging.ConnectionManager.<ConnectAsync>d__20.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Core\Networking\ConnectionManager.cs:line 239
---- End of inner exception stack trace ---
   at Orleans.Runtime.Messaging.ConnectionManager.<ConnectAsync>d__20.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Core\Networking\ConnectionManager.cs:line 263
 --- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
 --- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Orleans.Runtime.Messaging.ConnectionManager.<GetConnectionAsync>d__15.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Core\Networking\ConnectionManager.cs:line 114
   at Orleans.Runtime.Messaging.ConnectionManager.<GetConnectionAsync>d__15.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Core\Networking\ConnectionManager.cs:line 114
 --- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Orleans.Runtime.Messaging.OutboundMessageQueue.<<SendMessage>g__SendAsync|10_0>d.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Runtime\Messaging\OutboundMessageQueue.cs:line 121
 --- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Orleans.Runtime.Messaging.OutboundMessageQueue.<<SendMessage>g__SendAsync|10_0>d.MoveNext() in D:\build\agent\_work\25\s\src\Orleans.Runtime\Messaging\OutboundMessageQueue.cs:line 121