### PR TITLE
Fix handling of requests to invalid activation

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -905,11 +905,14 @@ namespace Orleans.Runtime
             var msg = (Message)message;
             lock (this)
             {
+                // Get the activation's scheduler or the default task scheduler if the activation is not valid.
+                // Requests to an invalid activation are handled later.
+                var scheduler = this.WorkItemGroup?.TaskScheduler ?? TaskScheduler.Default;
                 this.IncrementEnqueuedOnDispatcherCount();
 
                 // Enqueue the handler on the activation's scheduler
                 var task = new Task(_receiveMessageInScheduler, msg);
-                task.Start(this.WorkItemGroup.TaskScheduler);
+                task.Start(scheduler);
             }
         }
 


### PR DESCRIPTION
#6621 introduced a race in the handling of scheduling messages against an invalid (terminating) activation