### PR TITLE
Reintroduce a simpler stream filter mechanism

### DIFF
--- a/src/Orleans.Core.Abstractions/Streams/Core/IAsyncObservable.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Core/IAsyncObservable.cs
@@ -31,12 +31,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="observer">The asynchronous observer to subscribe.</param>
         /// <param name="token">The stream sequence to be used as an offset to start the subscription from.</param>
+        /// <param name="filterData">Data object that will be passed in to the filter.</param>
         /// <returns>A promise for a StreamSubscriptionHandle that represents the subscription.
         /// The consumer may unsubscribe by using this handle.
         /// The subscription remains active for as long as it is not explicitly unsubscribed.
         /// </returns>
-        /// <exception cref="ArgumentException">Thrown if the supplied stream filter function is not suitable. 
-        /// Usually this is because it is not a static method. </exception>
-        Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncObserver<T> observer, StreamSequenceToken token);
+        Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncObserver<T> observer, StreamSequenceToken token, string filterData = null);
     }
 }

--- a/src/Orleans.Core/Streams/Core/StreamSubscriptionManager.cs
+++ b/src/Orleans.Core/Streams/Core/StreamSubscriptionManager.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streams.Core
             var consumer = grainRef.AsReference<IStreamConsumerExtension>();
             var internalStreamId = new InternalStreamId(streamProviderName, streamId);
             var subscriptionId = streamPubSub.CreateSubscriptionId(internalStreamId, consumer);
-            await streamPubSub.RegisterConsumer(subscriptionId, internalStreamId, consumer);
+            await streamPubSub.RegisterConsumer(subscriptionId, internalStreamId, consumer, null);
             var newSub = new StreamSubscription(subscriptionId.Guid, streamProviderName, streamId, grainRef.GrainId);
             return newSub;
         }

--- a/src/Orleans.Core/Streams/Filtering/IStreamFilter.cs
+++ b/src/Orleans.Core/Streams/Filtering/IStreamFilter.cs
@@ -10,7 +10,7 @@ namespace Orleans.Streams.Filtering
         bool ShouldDeliver(StreamId streamId, object item, string filterData);
     }
 
-    internal class NoOpStreamFilter : IStreamFilter
+    internal sealed class NoOpStreamFilter : IStreamFilter
     {
         public bool ShouldDeliver(StreamId streamId, object item, string filterData) => true;
     }

--- a/src/Orleans.Core/Streams/Filtering/IStreamFilter.cs
+++ b/src/Orleans.Core/Streams/Filtering/IStreamFilter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Orleans.Runtime;
+
+namespace Orleans.Streams.Filtering
+{
+    public interface IStreamFilter
+    {
+        bool ShouldDeliver(StreamId streamId, object item, string filterData);
+    }
+
+    internal class NoOpStreamFilter : IStreamFilter
+    {
+        public bool ShouldDeliver(StreamId streamId, object item, string filterData) => true;
+    }
+}

--- a/src/Orleans.Core/Streams/Internal/IStreamGrainExtensions.cs
+++ b/src/Orleans.Core/Streams/Internal/IStreamGrainExtensions.cs
@@ -20,7 +20,7 @@ namespace Orleans.Streams
     internal interface IStreamProducerExtension : IGrainExtension
     {
         [AlwaysInterleave]
-        Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer);
+        Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
         [AlwaysInterleave]
         Task RemoveSubscriber(GuidId subscriptionId, InternalStreamId streamId);

--- a/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
@@ -47,7 +47,13 @@ namespace Orleans.Streams
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
         }
 
-        internal StreamSubscriptionHandleImpl<T> SetObserver<T>(GuidId subscriptionId, StreamImpl<T> stream, IAsyncObserver<T> observer, IAsyncBatchObserver<T> batchObserver, StreamSequenceToken token)
+        internal StreamSubscriptionHandleImpl<T> SetObserver<T>(
+            GuidId subscriptionId,
+            StreamImpl<T> stream,
+            IAsyncObserver<T> observer,
+            IAsyncBatchObserver<T> batchObserver,
+            StreamSequenceToken token,
+            string filterData)
         {
             if (null == stream) throw new ArgumentNullException("stream");
 
@@ -56,7 +62,7 @@ namespace Orleans.Streams
                 if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("{0} AddObserver for stream {1}", providerRuntime.ExecutingEntityIdentity(), stream.InternalStreamId);
 
                 // Note: The caller [StreamConsumer] already handles locking for Add/Remove operations, so we don't need to repeat here.
-                var handle = new StreamSubscriptionHandleImpl<T>(subscriptionId, observer, batchObserver, stream, token);
+                var handle = new StreamSubscriptionHandleImpl<T>(subscriptionId, observer, batchObserver, stream, token, filterData);
                 return allStreamObservers.AddOrUpdate(subscriptionId, handle, (key, old) => handle) as StreamSubscriptionHandleImpl<T>;
             }
             catch (Exception exc)

--- a/src/Orleans.Core/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamImpl.cs
@@ -54,9 +54,9 @@ namespace Orleans.Streams
             return GetConsumerInterface().SubscribeAsync(observer, null);
         }
 
-        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncObserver<T> observer, StreamSequenceToken token)
+        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncObserver<T> observer, StreamSequenceToken token, string filterData = null)
         {
-            return GetConsumerInterface().SubscribeAsync(observer, token);
+            return GetConsumerInterface().SubscribeAsync(observer, token, filterData);
         }
 
         public Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncBatchObserver<T> batchObserver)

--- a/src/Orleans.Core/Streams/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamSubscriptionHandleImpl.cs
@@ -10,6 +10,7 @@ namespace Orleans.Streams
     internal class StreamSubscriptionHandleImpl<T> : StreamSubscriptionHandle<T>, IStreamSubscriptionHandle 
     {
         private StreamImpl<T> streamImpl;
+        private readonly string filterData;
         private readonly GuidId subscriptionId;
         private readonly bool isRewindable;
 
@@ -28,16 +29,23 @@ namespace Orleans.Streams
         public override Guid HandleId { get { return subscriptionId.Guid; } }
 
         public StreamSubscriptionHandleImpl(GuidId subscriptionId, StreamImpl<T> streamImpl)
-            : this(subscriptionId, null, null, streamImpl, null)
+            : this(subscriptionId, null, null, streamImpl, null, null)
         {
         }
 
-        public StreamSubscriptionHandleImpl(GuidId subscriptionId, IAsyncObserver<T> observer, IAsyncBatchObserver<T> batchObserver, StreamImpl<T> streamImpl, StreamSequenceToken token)
+        public StreamSubscriptionHandleImpl(
+            GuidId subscriptionId,
+            IAsyncObserver<T> observer,
+            IAsyncBatchObserver<T> batchObserver,
+            StreamImpl<T> streamImpl,
+            StreamSequenceToken token,
+            string filterData)
         {
             this.subscriptionId = subscriptionId ?? throw new ArgumentNullException("subscriptionId");
             this.observer = observer;
             this.batchObserver = batchObserver;
             this.streamImpl = streamImpl ?? throw new ArgumentNullException("streamImpl");
+            this.filterData = filterData;
             this.isRewindable = streamImpl.IsRewindable;
             if (IsRewindable)
             {

--- a/src/Orleans.Core/Streams/PersistentStreams/QueueStreamDataStructures.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/QueueStreamDataStructures.cs
@@ -20,12 +20,14 @@ namespace Orleans.Streams
         public StreamConsumerDataState State = StreamConsumerDataState.Inactive;
         public IQueueCacheCursor Cursor;
         public StreamHandshakeToken LastToken;
+        public string FilterData;
 
-        public StreamConsumerData(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public StreamConsumerData(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             SubscriptionId = subscriptionId;
             StreamId = streamId;
             StreamConsumer = streamConsumer;
+            FilterData = filterData;
         }
 
         internal void SafeDisposeCursor(ILogger logger)

--- a/src/Orleans.Core/Streams/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/StreamConsumerCollection.cs
@@ -19,9 +19,9 @@ namespace Orleans.Streams
             lastActivityTime = now;
         }
 
-        public StreamConsumerData AddConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public StreamConsumerData AddConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
-            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer);
+            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData);
             queueData.Add(subscriptionId, consumerData);
             lastActivityTime = DateTime.UtcNow;
             return consumerData;

--- a/src/Orleans.Core/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans.Core/Streams/Providers/IStreamProviderRuntime.cs
@@ -66,7 +66,7 @@ namespace Orleans.Streams
 
         Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer);
+        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
         Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId);
 

--- a/src/Orleans.Core/Streams/PubSub/GrainBasedPubSubRuntime.cs
+++ b/src/Orleans.Core/Streams/PubSub/GrainBasedPubSubRuntime.cs
@@ -27,10 +27,10 @@ namespace Orleans.Streams
             return streamRendezvous.UnregisterProducer(streamId, streamProducer);
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
-            return streamRendezvous.RegisterConsumer(subscriptionId, streamId, streamConsumer);
+            return streamRendezvous.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData);
         }
 
         public Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)

--- a/src/Orleans.Core/Streams/PubSub/IPubSubRendezvousGrain.cs
+++ b/src/Orleans.Core/Streams/PubSub/IPubSubRendezvousGrain.cs
@@ -11,7 +11,7 @@ namespace Orleans.Streams
 
         Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer);
+        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
         Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId);
 

--- a/src/Orleans.Core/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Core/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -42,8 +42,9 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
+            // TODO BPETIT filter data?
             if (!IsImplicitSubscriber(streamConsumer, streamId))
             {
                 throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit subscriptions are supported.");

--- a/src/Orleans.Core/Streams/PubSub/PubSubSubscriptionState.cs
+++ b/src/Orleans.Core/Streams/PubSub/PubSubSubscriptionState.cs
@@ -27,7 +27,7 @@ namespace Orleans.Streams
         public GrainReference consumerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
 
         [JsonProperty]
-        public object filterWrapper; // Serialized func info
+        public string FilterData; // Serialized func info
 
         [JsonProperty]
         public SubscriptionStates state;
@@ -49,6 +49,11 @@ namespace Orleans.Streams
             Stream = streamId;
             consumerReference = streamConsumer as GrainReference;
             state = SubscriptionStates.Active;
+        }
+
+        public void AddFilter(string filterData)
+        {
+            this.FilterData = filterData;
         }
 
         public override bool Equals(object obj)

--- a/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
+++ b/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
@@ -41,11 +41,11 @@ namespace Orleans.Streams
             return explicitPubSub.UnregisterProducer(streamId, streamProducer);
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             return implicitPubSub.IsImplicitSubscriber(streamConsumer, streamId)
-                ? implicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer)
-                : explicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer);
+                ? implicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData)
+                : explicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData);
         }
 
         public Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -6,6 +6,7 @@ using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
 using Microsoft.Extensions.Logging;
+using Orleans.Streams.Filtering;
 
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
@@ -19,7 +20,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         [NonSerialized]
         private readonly IStreamPubSub                  pubSub;
-
+        private readonly IStreamFilter streamFilter;
         [NonSerialized]
         private readonly IStreamProviderRuntime         providerRuntime;
         private SimpleMessageStreamProducerExtension    myExtension;
@@ -42,6 +43,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             bool fireAndForgetDelivery,
             bool optimizeForImmutableData,
             IStreamPubSub pubSub,
+            IStreamFilter streamFilter,
             bool isRewindable,
             SerializationManager serializationManager,
             ILogger<SimpleMessageStreamProducer<T>> logger)
@@ -50,6 +52,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             this.streamProviderName = streamProviderName;
             providerRuntime = providerUtilities;
             this.pubSub = pubSub;
+            this.streamFilter = streamFilter;
             this.serializationManager = serializationManager;
             connectedToRendezvous = false;
             this.fireAndForgetDelivery = fireAndForgetDelivery;
@@ -64,7 +67,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private async Task<ISet<PubSubSubscriptionState>> RegisterProducer()
         {
             (myExtension, myGrainReference) = providerRuntime.BindExtension<SimpleMessageStreamProducerExtension, IStreamProducerExtension>(
-                () => new SimpleMessageStreamProducerExtension(providerRuntime, pubSub, this.logger, fireAndForgetDelivery, optimizeForImmutableData));
+                () => new SimpleMessageStreamProducerExtension(providerRuntime, pubSub, this.streamFilter, this.logger, fireAndForgetDelivery, optimizeForImmutableData));
 
             myExtension.AddStream(stream.InternalStreamId);
 

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -7,6 +7,8 @@ using Orleans.Streams;
 using Orleans.Streams.Core;
 using Orleans.Serialization;
 using Orleans.Configuration;
+using Orleans.Streams.Filtering;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
@@ -21,15 +23,23 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private ILoggerFactory              loggerFactory;
         private SerializationManager        serializationManager;
         private SimpleMessageStreamProviderOptions options;
+        private readonly IStreamFilter streamFilter;
+
         public bool IsRewindable { get { return false; } }
 
-        public SimpleMessageStreamProvider(string name, SimpleMessageStreamProviderOptions options,
-            ILoggerFactory loggerFactory, IProviderRuntime providerRuntime, SerializationManager serializationManager)
+        public SimpleMessageStreamProvider(
+            string name,
+            SimpleMessageStreamProviderOptions options,
+            IStreamFilter streamFilter,
+            ILoggerFactory loggerFactory,
+            IProviderRuntime providerRuntime,
+            SerializationManager serializationManager)
         {
             this.loggerFactory = loggerFactory;
             this.Name = name;
             this.logger = loggerFactory.CreateLogger<SimpleMessageStreamProvider>();
             this.options = options;
+            this.streamFilter = streamFilter;
             this.providerRuntime = providerRuntime as IStreamProviderRuntime;
             this.runtimeClient = providerRuntime.ServiceProvider.GetService<IRuntimeClient>();
             this.serializationManager = serializationManager;
@@ -68,6 +78,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 this.options.FireAndForgetDelivery,
                 this.options.OptimizeForImmutableData,
                 providerRuntime.PubSub(this.options.PubSubType),
+                this.streamFilter,
                 IsRewindable,
                 this.serializationManager,
                 this.loggerFactory.CreateLogger<SimpleMessageStreamProducer<T>>());
@@ -86,8 +97,11 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         public static IStreamProvider Create(IServiceProvider services, string name)
         {
-            return ActivatorUtilities.CreateInstance<SimpleMessageStreamProvider>(services, name,
-                services.GetRequiredService<IOptionsMonitor<SimpleMessageStreamProviderOptions>>().Get(name));
+            return ActivatorUtilities.CreateInstance<SimpleMessageStreamProvider>(
+                services,
+                name,
+                services.GetRequiredService<IOptionsMonitor<SimpleMessageStreamProviderOptions>>().Get(name),
+                services.GetServiceByName<IStreamFilter>(name) ?? new NoOpStreamFilter());
         }
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
@@ -4,6 +4,9 @@ using Microsoft.Extensions.Options;
 using Orleans.Hosting;
 using Orleans.Streams;
 using Orleans.Configuration;
+using Orleans.Streams.Filtering;
+using Orleans.Runtime;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Orleans.Hosting
 {
@@ -103,6 +106,28 @@ namespace Orleans.Hosting
 
         {
             return AddSimpleMessageStreamProvider(builder, name, b => b.Configure(configureOptions));
+        }
+
+        public static ISiloBuilder AddStreamFilter<T>(this ISiloBuilder builder, string name) where T : class, IStreamFilter
+        {
+            return builder.ConfigureServices(svc => svc.AddStreamFilter<T>(name));
+        }
+
+        public static ISiloHostBuilder AddStreamFilter<T>(this ISiloHostBuilder builder, string name) where T : class, IStreamFilter
+        {
+            return builder.ConfigureServices(svc => svc.AddStreamFilter<T>(name));
+        }
+
+        public static IClientBuilder AddStreamFilter<T>(this IClientBuilder builder, string name) where T : class, IStreamFilter
+        {
+            return builder.ConfigureServices(svc => svc.AddStreamFilter<T>(name));
+        }
+
+
+        public static IServiceCollection AddStreamFilter<T>(this IServiceCollection services, string name) where T : class, IStreamFilter
+        {
+            //services.TryAddSingleton<T>();
+            return services.AddSingletonNamedService<IStreamFilter, T>(name);
         }
     }
 }

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -8,6 +8,8 @@ using Orleans.Streams;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
+using Orleans.Streams.Filtering;
+using System.IO;
 
 namespace Orleans.Runtime.Providers
 {
@@ -97,6 +99,7 @@ namespace Orleans.Runtime.Providers
             var managerId = SystemTargetGrainId.Create(Constants.StreamPullingAgentManagerType, this.siloDetails.SiloAddress, streamProviderName);
             var pubsubOptions = this.ServiceProvider.GetOptionsByName<StreamPubSubOptions>(streamProviderName);
             var pullingAgentOptions = this.ServiceProvider.GetOptionsByName<StreamPullingAgentOptions>(streamProviderName);
+            var filter = this.ServiceProvider.GetServiceByName<IStreamFilter>(streamProviderName) ?? new NoOpStreamFilter();
             var manager = new PersistentStreamPullingManager(
                 managerId,
                 streamProviderName,
@@ -104,6 +107,7 @@ namespace Orleans.Runtime.Providers
                 this.PubSub(pubsubOptions.PubSubType),
                 adapterFactory,
                 queueBalancer,
+                filter,
                 pullingAgentOptions,
                 this.loggerFactory,
                 this.siloDetails.SiloAddress);

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -809,6 +809,9 @@ namespace Orleans.Streams
 
         private bool ShouldDeliverBatch(StreamId streamId, IBatchContainer batchContainer, string filterData)
         {
+            if (this.streamFilter is NoOpStreamFilter)
+                return true;
+
             try
             {
                 foreach (var evt in batchContainer.GetEvents<object>())

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -8,6 +8,7 @@ using Orleans.Concurrency;
 using Orleans.Configuration;
 using Orleans.Internal;
 using Orleans.Runtime;
+using Orleans.Streams.Filtering;
 
 namespace Orleans.Streams
 {
@@ -20,6 +21,7 @@ namespace Orleans.Streams
         private const int StreamInactivityCheckFrequency = 10;
         private readonly string streamProviderName;
         private readonly IStreamPubSub pubSub;
+        private readonly IStreamFilter streamFilter;
         private readonly Dictionary<InternalStreamId, StreamConsumerCollection> pubSubCache;
         private readonly SafeRandom safeRandom;
         private readonly StreamPullingAgentOptions options;
@@ -46,6 +48,7 @@ namespace Orleans.Streams
             IStreamProviderRuntime runtime,
             ILoggerFactory loggerFactory,
             IStreamPubSub streamPubSub,
+            IStreamFilter streamFilter,
             QueueId queueId,
             StreamPullingAgentOptions options,
             SiloAddress siloAddress)
@@ -57,6 +60,7 @@ namespace Orleans.Streams
             QueueId = queueId;
             streamProviderName = strProviderName;
             pubSub = streamPubSub;
+            this.streamFilter = streamFilter;
             pubSubCache = new Dictionary<InternalStreamId, StreamConsumerCollection>();
             safeRandom = new SafeRandom();
             this.options = options;
@@ -221,11 +225,12 @@ namespace Orleans.Streams
         public Task AddSubscriber(
             GuidId subscriptionId,
             InternalStreamId streamId,
-            IStreamConsumerExtension streamConsumer)
+            IStreamConsumerExtension streamConsumer,
+            string filterData)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.PersistentStreamPullingAgent_09, "AddSubscriber: Stream={0} Subscriber={1}.", streamId, streamConsumer);
             // cannot await here because explicit consumers trigger this call, so it could cause a deadlock.
-            AddSubscriber_Impl(subscriptionId, streamId, streamConsumer, null)
+            AddSubscriber_Impl(subscriptionId, streamId, streamConsumer, filterData, null)
                 .LogException(logger, ErrorCode.PersistentStreamPullingAgent_26,
                     $"Failed to add subscription for stream {streamId}.")
                 .Ignore();
@@ -237,6 +242,7 @@ namespace Orleans.Streams
             GuidId subscriptionId,
             InternalStreamId streamId,
             IStreamConsumerExtension streamConsumer,
+            string filterData,
             StreamSequenceToken cacheToken)
         {
             if (IsShutdown) return;
@@ -250,7 +256,7 @@ namespace Orleans.Streams
 
             StreamConsumerData data;
             if (!streamDataCollection.TryGetConsumer(subscriptionId, out data))
-                data = streamDataCollection.AddConsumer(subscriptionId, streamId, streamConsumer);
+                data = streamDataCollection.AddConsumer(subscriptionId, streamId, streamConsumer, filterData);
 
             if (await DoHandshakeWithConsumer(data, cacheToken))
             {
@@ -535,7 +541,7 @@ namespace Orleans.Streams
                     Exception exceptionOccured = null;
                     try
                     {
-                        batch = GetBatchForConsumer(consumerData.Cursor, consumerData.StreamId);
+                        batch = GetBatchForConsumer(consumerData.Cursor, consumerData.StreamId, consumerData.FilterData);
                         if (batch == null)
                         {
                             break;
@@ -546,6 +552,12 @@ namespace Orleans.Streams
                         exceptionOccured = exc;
                         consumerData.SafeDisposeCursor(logger);
                         consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, null);
+                    }
+
+                    if (batch != null)
+                    {
+                        if (!ShouldDeliverBatch(consumerData.StreamId, batch, consumerData.FilterData))
+                            continue;
                     }
 
                     try
@@ -596,7 +608,7 @@ namespace Orleans.Streams
             }
         }
 
-        private IBatchContainer GetBatchForConsumer(IQueueCacheCursor cursor, StreamId streamId)
+        private IBatchContainer GetBatchForConsumer(IQueueCacheCursor cursor, StreamId streamId, string filterData)
         {
             if (this.options.BatchContainerBatchSize <= 1)
             {
@@ -623,6 +635,9 @@ namespace Orleans.Streams
                     }
 
                     var batchContainer = cursor.GetCurrent(out ignore);
+
+                    if (!ShouldDeliverBatch(streamId, batchContainer, filterData))
+                        continue;
 
                     batchContainers.Add(batchContainer);
                     i++;
@@ -780,7 +795,7 @@ namespace Orleans.Streams
                 var addSubscriptionTasks = new List<Task>(streamData.Count);
                 foreach (PubSubSubscriptionState item in streamData)
                 {
-                    addSubscriptionTasks.Add(AddSubscriber_Impl(item.SubscriptionId, item.Stream, item.Consumer, streamStartToken));
+                    addSubscriptionTasks.Add(AddSubscriber_Impl(item.SubscriptionId, item.Stream, item.Consumer, item.FilterData, streamStartToken));
                 }
                 await Task.WhenAll(addSubscriptionTasks);
             }
@@ -790,6 +805,25 @@ namespace Orleans.Streams
                 logger.Error(ErrorCode.PersistentStreamPullingAgent_17, "Ignored RegisterAsStreamProducer Error", exc);
                 throw;
             }
+        }
+
+        private bool ShouldDeliverBatch(StreamId streamId, IBatchContainer batchContainer, string filterData)
+        {
+            try
+            {
+                foreach (var evt in batchContainer.GetEvents<object>())
+                {
+                    if (this.streamFilter.ShouldDeliver(streamId, evt.Item1, filterData))
+                        return true;
+                }
+                return false;
+            }
+            catch (Exception exc)
+            {
+                var message = $"Ignoring exception while trying to evaluate subscription filter '{this.streamFilter.GetType().Name}' with data '{filterData}' on stream {streamId}";
+                logger.Warn((int)ErrorCode.PersistentStreamPullingAgent_13, message, exc);
+            }
+            return true;
         }
     }
 }

--- a/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -112,7 +112,8 @@ namespace Orleans.Streams
         public async Task RegisterConsumer(
             GuidId subscriptionId,
             InternalStreamId streamId,
-            IStreamConsumerExtension streamConsumer)
+            IStreamConsumerExtension streamConsumer,
+            string filterData)
         {
             counterConsumersAdded.Increment();
             PubSubSubscriptionState pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
@@ -125,6 +126,9 @@ namespace Orleans.Streams
                     pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer);
                     State.Consumers.Add(pubSubState);
                 }
+
+                if (!string.IsNullOrWhiteSpace(filterData))
+                    pubSubState.AddFilter(filterData);
 
                 LogPubSubCounts("RegisterConsumer {0}", streamConsumer);
                 await WriteStateAsync();
@@ -155,7 +159,7 @@ namespace Orleans.Streams
             {
                 foreach (PubSubPublisherState producerState in producers)
                 {
-                    tasks.Add(ExecuteProducerTask(producerState, producerState.Producer.AddSubscriber(subscriptionId, streamId, streamConsumer)));
+                    tasks.Add(ExecuteProducerTask(producerState, producerState.Producer.AddSubscriber(subscriptionId, streamId, streamConsumer, filterData)));
                 }
 
                 Exception exception = null;

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -21,6 +21,7 @@ namespace Tester.AzureUtils.Streaming
 
         public AQStreamFilteringTests(Fixture fixture) : base(fixture)
         {
+            fixture.EnsurePreconditionsMet();
         }
 
         public class Fixture : BaseAzureTestClusterFixture
@@ -63,19 +64,24 @@ namespace Tester.AzureUtils.Streaming
                         .AddStreamFilter<CustomStreamFilter>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME);
                 }
             }
+
+            protected override void CheckPreconditionsOrThrow()
+            {
+                TestUtils.CheckForEventHub();
+            }
         }
 
         protected override string ProviderName => StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
 
         protected override TimeSpan WaitTime => TimeSpan.FromSeconds(2);
 
-        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        [SkippableFact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async override Task IgnoreBadFilter() => await base.IgnoreBadFilter();
 
-        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        [SkippableFact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async override Task OnlyEvenItems() => await base.OnlyEvenItems();
 
-        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        [SkippableFact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
         public async override Task MultipleSubscriptionsDifferentFilterData() => await base.MultipleSubscriptionsDifferentFilterData();
 
         public Task InitializeAsync() => Task.CompletedTask;

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.TestingHost;
+using Tester.StreamingTests.Filtering;
+using TestExtensions;
+using UnitTests.StreamingTests;
+using Xunit;
+
+namespace Tester.AzureUtils.Streaming
+{
+    public class AQStreamFilteringTests : StreamFilteringTestsBase, IClassFixture<AQStreamFilteringTests.Fixture>, IAsyncLifetime
+    {
+        private const int queueCount = 1;
+
+        public AQStreamFilteringTests(Fixture fixture) : base(fixture)
+        {
+        }
+
+        public class Fixture : BaseAzureTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                TestUtils.CheckForAzureStorage();
+                builder.AddClientBuilderConfigurator<ClientConfigurator>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+
+            public class SiloConfigurator : ISiloConfigurator
+            {
+                public void Configure(ISiloBuilder hostBuilder)
+                {
+                    hostBuilder
+                        .AddAzureQueueStreams(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME, ob => ob.Configure<IOptions<ClusterOptions>>(
+                            (options, dep) =>
+                            {
+                                options.ConfigureTestDefaults();
+                                options.QueueNames = AzureQueueUtilities.GenerateQueueNames(dep.Value.ClusterId, queueCount);
+                            }))
+                        .AddMemoryGrainStorage("MemoryStore")
+                        .AddMemoryGrainStorage("PubSubStore")
+                        .AddStreamFilter<CustomStreamFilter>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME);
+                }
+            }
+
+            public class ClientConfigurator : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder
+                        .AddAzureQueueStreams(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME, ob => ob.Configure<IOptions<ClusterOptions>>(
+                            (options, dep) =>
+                            {
+                                options.ConfigureTestDefaults();
+                                options.QueueNames = AzureQueueUtilities.GenerateQueueNames(dep.Value.ClusterId, queueCount);
+                            }))
+                        .AddStreamFilter<CustomStreamFilter>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME);
+                }
+            }
+        }
+
+        protected override string ProviderName => StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+        protected override TimeSpan WaitTime => TimeSpan.FromSeconds(2);
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task IgnoreBadFilter() => await base.IgnoreBadFilter();
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task OnlyEvenItems() => await base.OnlyEvenItems();
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task MultipleSubscriptionsDifferentFilterData() => await base.MultipleSubscriptionsDifferentFilterData();
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            if (!string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
+            {
+                await AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(
+                  NullLoggerFactory.Instance,
+                  AzureQueueUtilities.GenerateQueueNames(this.fixture.HostedCluster.Options.ClusterId, queueCount),
+                  new AzureQueueOptions().ConfigureTestDefaults());
+            }
+        }
+    }
+}

--- a/test/Grains/TestGrainInterfaces/IStreamingHistoryGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStreamingHistoryGrain.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IStreamingHistoryGrain : IGrainWithStringKey
+    {
+        Task BecomeConsumer(StreamId streamId, string provider, string filterData = null);
+
+        Task StopBeingConsumer();
+
+        Task<List<int>> GetReceivedItems();
+    }
+}

--- a/test/Grains/TestGrains/StreamingHistoryGrain.cs
+++ b/test/Grains/TestGrains/StreamingHistoryGrain.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    public class StreamingHistoryGrain : Grain, IStreamingHistoryGrain, IAsyncObserver<int>
+    {
+        private List<int> receivedItems = new List<int>();
+        private List<StreamSubscriptionHandle<int>> subscriptionHandles = new List<StreamSubscriptionHandle<int>>();
+
+        public async Task BecomeConsumer(StreamId streamId, string provider, string filterData = null)
+        {
+            var stream = base.GetStreamProvider(provider).GetStream<int>(streamId);
+            this.subscriptionHandles.Add(await stream.SubscribeAsync(this, null, filterData));
+        }
+
+        public Task<List<int>> GetReceivedItems() => Task.FromResult(this.receivedItems);
+
+        public async Task StopBeingConsumer()
+        {
+            foreach (var sub in this.subscriptionHandles)
+            {
+                await sub.UnsubscribeAsync();
+            }
+        }
+
+        public Task OnCompletedAsync() => Task.CompletedTask;
+
+        public Task OnErrorAsync(Exception ex) => Task.CompletedTask;
+
+        public Task OnNextAsync(int item, StreamSequenceToken token = null)
+        {
+            this.receivedItems.Add(item);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -244,9 +244,9 @@ namespace UnitTests.Grains
             var id = new InternalStreamId(providerName, streamId);
             IPubSubRendezvousGrain pubsub = GrainFactory.GetGrain<IPubSubRendezvousGrain>(id.ToString());
             GuidId subscriptionId = GuidId.GetNewGuidId();
-            await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference);
+            await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference, null);
 
-            myExtension.SetObserver(subscriptionId, ((StreamImpl<int>)State.Stream), observer, null, null);
+            myExtension.SetObserver(subscriptionId, ((StreamImpl<int>)State.Stream), observer, null, null, null);
         }
 
         public async Task RemoveConsumer(StreamId streamId, string providerName, StreamSubscriptionHandle<int> subsHandle)

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
@@ -80,9 +80,9 @@ namespace UnitTests.Grains
             var id = new InternalStreamId(providerName, streamId);
             IPubSubRendezvousGrain pubsub = GrainFactory.GetGrain<IPubSubRendezvousGrain>(id.ToString());
             GuidId subscriptionId = GuidId.GetNewGuidId();
-            await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference);
+            await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference, null);
 
-            myExtension.SetObserver(subscriptionId, ((StreamImpl<int>)State.Stream), observer, null, null);
+            myExtension.SetObserver(subscriptionId, ((StreamImpl<int>)State.Stream), observer, null, null, null);
         }
     }
 }

--- a/test/Tester/StreamingTests/Filtering/SmsStreamFilteringTests.cs
+++ b/test/Tester/StreamingTests/Filtering/SmsStreamFilteringTests.cs
@@ -1,0 +1,60 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.StreamingTests;
+using Xunit;
+
+namespace Tester.StreamingTests.Filtering
+{
+    public class SmsStreamFilteringTests : StreamFilteringTestsBase, IClassFixture<SmsStreamFilteringTests.Fixture>
+    {
+        public SmsStreamFilteringTests(Fixture fixture) : base(fixture)
+        {
+        }
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddClientBuilderConfigurator<ClientConfigurator>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+
+            public class SiloConfigurator : ISiloConfigurator
+            {
+                public void Configure(ISiloBuilder hostBuilder)
+                {
+                    hostBuilder
+                        .AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME)
+                        .AddStreamFilter<CustomStreamFilter>(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME)
+                        .AddMemoryGrainStorage("MemoryStore")
+                        .AddMemoryGrainStorage("PubSubStore");
+                }
+            }
+
+            public class ClientConfigurator : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder
+                        .AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME)
+                        .AddStreamFilter<CustomStreamFilter>(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
+                }
+            }
+        }
+
+        protected override string ProviderName => StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task IgnoreBadFilter() => await base.IgnoreBadFilter();
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task OnlyEvenItems() => await base.OnlyEvenItems();
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async override Task MultipleSubscriptionsDifferentFilterData() => await base.MultipleSubscriptionsDifferentFilterData();
+    }
+}

--- a/test/Tester/StreamingTests/Filtering/StreamFilteringTestsBase.cs
+++ b/test/Tester/StreamingTests/Filtering/StreamFilteringTestsBase.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams.Filtering;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Tester.StreamingTests.Filtering
+{
+    public class CustomStreamFilter : IStreamFilter
+    {
+        private ILogger<CustomStreamFilter> logger;
+
+        public CustomStreamFilter(ILogger<CustomStreamFilter> logger)
+        {
+            this.logger = logger;
+        }
+
+        public bool ShouldDeliver(StreamId streamId, object item, string filterData)
+        {
+            try
+            {
+                var result = ShouldDeliverImpl(streamId, item, filterData);
+                logger.LogInformation("Filter -> StreamId {StreamId}, Item: {Item}, FilterData: {FilterData} -> Result: {Result}", streamId, item, filterData, result);
+
+                return result;
+            }
+            catch (Exception)
+            {
+                logger.LogInformation("Filter -> StreamId {StreamId}, Item: {Item}, FilterData: {FilterData} -> Result: exception", streamId, item, filterData);
+                throw;
+            }
+        }
+
+        private bool ShouldDeliverImpl(StreamId streamId, object item, string filterData)
+        {
+            if (filterData.Equals("throw"))
+                throw new Exception("throw");
+
+            if (string.IsNullOrWhiteSpace(filterData))
+                return true;
+
+            if (filterData.Equals("even"))
+            {
+                var value = (int)item;
+                return value % 2 == 0;
+            }
+
+            if (filterData.Equals("only3"))
+            {
+                var value = (int)item;
+                return value == 3;
+            }
+
+            if (filterData.Equals("only7"))
+            {
+                var value = (int)item;
+                return value == 7;
+            }
+
+            return true;
+        }
+    }
+
+    public abstract class StreamFilteringTestsBase : OrleansTestingBase
+    {
+        protected readonly BaseTestClusterFixture fixture;
+        private IClusterClient clusterClient => this.fixture.Client;
+        private CustomStreamFilter streamFilter => this.fixture.HostedCluster.ServiceProvider.GetServiceByName<IStreamFilter>(ProviderName) as CustomStreamFilter;
+
+        protected ILogger logger => fixture.Logger;
+
+        protected abstract string ProviderName { get; }
+
+        protected virtual TimeSpan WaitTime => TimeSpan.Zero;
+
+        protected StreamFilteringTestsBase(BaseTestClusterFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        public virtual async Task IgnoreBadFilter()
+        {
+            EnsureStreamFilterIsRegistered();
+
+            const int numberOfEvents = 10;
+            var streamId = StreamId.Create("IgnoreBadFilter", "my-stream");
+            var grain = this.clusterClient.GetGrain<IStreamingHistoryGrain>("IgnoreBadFilter");
+
+            try
+            {
+                await grain.BecomeConsumer(streamId, ProviderName, "throw");
+
+                var stream = this.clusterClient.GetStreamProvider(ProviderName).GetStream<int>(streamId);
+
+                for (var i = 0; i < numberOfEvents; i++)
+                {
+                    await stream.OnNextAsync(i);
+                }
+
+                await Task.Delay(WaitTime);
+
+                var history = await grain.GetReceivedItems();
+
+                Assert.Equal(numberOfEvents, history.Count);
+                for (var i = 0; i < numberOfEvents; i++)
+                {
+                    Assert.Equal(i, history[i]);
+                }
+            }
+            finally
+            {
+                await grain.StopBeingConsumer();
+            }
+        }
+
+        public virtual async Task OnlyEvenItems()
+        {
+            EnsureStreamFilterIsRegistered();
+
+            const int numberOfEvents = 10;
+            var streamId = StreamId.Create("OnlyEvenItems", "my-stream");
+            var grain = this.clusterClient.GetGrain<IStreamingHistoryGrain>("OnlyEvenItems");
+
+            try
+            {
+                await grain.BecomeConsumer(streamId, ProviderName, "even");
+
+                var stream = this.clusterClient.GetStreamProvider(ProviderName).GetStream<int>(streamId);
+
+                for (var i = 0; i < numberOfEvents; i++)
+                {
+                    await stream.OnNextAsync(i);
+                }
+
+                await Task.Delay(WaitTime);
+
+                var history = await grain.GetReceivedItems();
+
+                var idx = 0;
+                for (var i = 0; i < numberOfEvents; i++)
+                {
+                    if (i % 2 == 0)
+                    {
+                        Assert.Equal(i, history[idx]);
+                        idx++;
+                    }
+                }
+            }
+            finally
+            {
+                await grain.StopBeingConsumer();
+            }
+        }
+
+        public virtual async Task MultipleSubscriptionsDifferentFilterData()
+        {
+            EnsureStreamFilterIsRegistered();
+
+            const int numberOfEvents = 10;
+            var streamId = StreamId.Create("MultipleSubscriptionsDifferentFilterData", "my-stream");
+            var grain = this.clusterClient.GetGrain<IStreamingHistoryGrain>("MultipleSubscriptionsDifferentFilterData");
+
+            try
+            {
+                await grain.BecomeConsumer(streamId, ProviderName, "only3");
+                await grain.BecomeConsumer(streamId, ProviderName, "only7");
+
+                var stream = this.clusterClient.GetStreamProvider(ProviderName).GetStream<int>(streamId);
+
+                for (var i = 0; i < numberOfEvents; i++)
+                {
+                    await stream.OnNextAsync(i);
+                }
+
+                await Task.Delay(WaitTime);
+
+                var history = await grain.GetReceivedItems();
+
+                Assert.Equal(2, history.Count);
+                Assert.Contains(3, history);
+                Assert.Contains(7, history);
+
+            }
+            finally
+            {
+                await grain.StopBeingConsumer();
+            }
+        }
+
+        private void EnsureStreamFilterIsRegistered()
+        {
+            if (this.streamFilter == null)
+            {
+                throw new XunitException("CustomStreamFilter not registered as a filter!");
+            }
+        }
+    }
+}

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -46,7 +46,7 @@ namespace UnitTests.StreamingTests
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
 
             // clean call, to make sure everything is happy and pubsub has state.
-            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null);
+            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null);
             int consumers = await pubSubGrain.ConsumerCount(streamId);
             Assert.Equal(1, consumers);
 
@@ -55,10 +55,10 @@ namespace UnitTests.StreamingTests
 
             // expect exception when registering a new consumer
             await Assert.ThrowsAsync<OrleansException>(
-                    () => pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null));
+                    () => pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null));
 
             // pubsub grain should recover and still function
-            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null);
+            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null);
             consumers = await pubSubGrain.ConsumerCount(streamId);
             Assert.Equal(2, consumers);
         }
@@ -74,8 +74,8 @@ namespace UnitTests.StreamingTests
             // Add two consumers so when we remove the first it does a storage write, not a storage clear.
             GuidId subscriptionId1 = GuidId.GetGuidId(Guid.NewGuid());
             GuidId subscriptionId2 = GuidId.GetGuidId(Guid.NewGuid());
-            await pubSubGrain.RegisterConsumer(subscriptionId1, streamId, null);
-            await pubSubGrain.RegisterConsumer(subscriptionId2, streamId, null);
+            await pubSubGrain.RegisterConsumer(subscriptionId1, streamId, null, null);
+            await pubSubGrain.RegisterConsumer(subscriptionId2, streamId, null, null);
             int consumers = await pubSubGrain.ConsumerCount(streamId);
             Assert.Equal(2, consumers);
 
@@ -190,7 +190,7 @@ namespace UnitTests.StreamingTests
                 id = Guid.NewGuid();
             }
 
-            public Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+            public Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
             {
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
Usage of this new filter:

- Filters are now configured on a per provider basis. Only one filter per provider is supported for now, but since you can implement whatever logic you want...
- At subscription, consummer can attach a `string` data that will be passed to the filter whenit will be evaluated
- The filters have to implement the new `IStreamFilter` interface