### PR TITLE
Perform self-health checks before suspecting other nodes

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -347,7 +347,6 @@ namespace Orleans.Runtime
             return CompareTo((SiloAddress)obj);
         }
 
-
         public int CompareTo(SiloAddress other)
         {
             if (other == null) return 1;

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -112,5 +112,10 @@ namespace Orleans.Configuration
         /// The period between self-tests to log local health degradation status.
         /// </summary>
         public TimeSpan LocalHealthDegradationMonitoringPeriod { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Whether to extend the effective <see cref="ProbeTimeout"/> value based upon current local health degradation.
+        /// </summary>
+        public bool ExtendProbeTimeoutDuringDegradation { get; set; } = false;
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -1,7 +1,6 @@
 
 using System;
 using Orleans.Internal;
-using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -108,5 +107,10 @@ namespace Orleans.Configuration
 
         internal TimeSpan AllowedIAmAliveMissPeriod => this.IAmAliveTablePublishTimeout.Multiply(this.NumMissedTableIAmAliveLimit);
         internal static TimeSpan ClusteringShutdownGracePeriod => TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// The period between self-tests to log local health degradation status.
+        /// </summary>
+        public TimeSpan LocalHealthDegradationMonitoringPeriod { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -83,6 +83,16 @@ namespace Orleans.Runtime.Messaging
             return false;
         }
 
+        public ImmutableArray<Connection> GetExistingConnections(SiloAddress endpoint)
+        {
+            if (this.connections.TryGetValue(endpoint, out var entry))
+            {
+                return entry.Connections;
+            }
+
+            return ImmutableArray<Connection>.Empty;
+        }
+
         private async Task<Connection> GetConnectionAsync(SiloAddress endpoint)
         {
             while (true)

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;

--- a/src/Orleans.Core/Runtime/IHealthCheckable.cs
+++ b/src/Orleans.Core/Runtime/IHealthCheckable.cs
@@ -8,7 +8,8 @@ namespace Orleans.Runtime
         /// Returns a value indicating the health of this instance.
         /// </summary>
         /// <param name="lastCheckTime">The last time which this instance health was checked.</param>
+        /// <param name="reason">If this method returns <see langword="false"/>, this parameter will describe the reason for that verdict.</param>
         /// <returns><see langword="true"/> if the instance is healthy, <see langword="false"/> otherwise.</returns>
-        bool CheckHealth(DateTime lastCheckTime);
+        bool CheckHealth(DateTime lastCheckTime, out string reason);
     }
 }

--- a/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
+++ b/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
@@ -72,6 +72,23 @@ namespace Orleans.Runtime
         public MembershipVersion Version { get; }
         public ImmutableDictionary<SiloAddress, MembershipEntry> Entries { get; }
 
+        public int ActiveNodeCount
+        {
+            get
+            {
+                var count = 0;
+                foreach (var entry in this.Entries)
+                {
+                    if (entry.Value.Status == SiloStatus.Active)
+                    {
+                        ++count;
+                    }
+                }
+
+                return count;
+            }
+        }
+
         public SiloStatus GetSiloStatus(SiloAddress silo)
         {
             var status = this.Entries.TryGetValue(silo, out var entry) ? entry.Status : SiloStatus.None;

--- a/src/Orleans.Core/Timers/ValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/ValueStopwatch.cs
@@ -108,6 +108,11 @@ namespace Orleans.Runtime
         public void Restart() => this.value = GetTimestamp();
 
         /// <summary>
+        /// Resets this stopwatch into a stopped state with no elapsed duration.
+        /// </summary>
+        public void Reset() => this.value = 0;
+
+        /// <summary>
         /// Stops this stopwatch.
         /// </summary>
         public void Stop()

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -225,7 +225,7 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exception)
                 {
-                    this.logger.LogError(exception, "Exception while collecting activations: {Exception}", exception);
+                    this.logger.LogError(exception, "Exception while collecting activations");
                 }
             }
         }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -1189,13 +1189,14 @@ namespace Orleans.Runtime
             }
         }
 
-        public bool CheckHealth(DateTime lastCheckTime)
+        public bool CheckHealth(DateTime lastCheckTime, out string reason)
         {
             if (this.gcTimer is IAsyncTimer timer)
             {
-                return timer.CheckHealth(lastCheckTime);
+                return timer.CheckHealth(lastCheckTime, out reason);
             }
 
+            reason = default;
             return true;
         }
     }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -172,6 +172,7 @@ namespace Orleans.Hosting
             services.AddSingleton<ClusterHealthMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, ClusterHealthMonitor>();
             services.AddFromExisting<IHealthCheckParticipant, ClusterHealthMonitor>();
+            services.AddSingleton<ProbeRequestMonitor>();
             services.AddSingleton<LocalSiloHealthMonitor>();
             services.AddFromExisting<ILocalSiloHealthMonitor, LocalSiloHealthMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, LocalSiloHealthMonitor>();

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -172,6 +172,9 @@ namespace Orleans.Hosting
             services.AddSingleton<ClusterHealthMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, ClusterHealthMonitor>();
             services.AddFromExisting<IHealthCheckParticipant, ClusterHealthMonitor>();
+            services.AddSingleton<LocalSiloHealthMonitor>();
+            services.AddFromExisting<ILocalSiloHealthMonitor, LocalSiloHealthMonitor>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, LocalSiloHealthMonitor>();
             services.AddSingleton<MembershipAgent>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, MembershipAgent>();
             services.AddFromExisting<IHealthCheckParticipant, MembershipAgent>();

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
-using Orleans.Runtime.Utilities;
+using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -21,15 +21,15 @@ namespace Orleans.Runtime.MembershipService
     {
         private readonly CancellationTokenSource shutdownCancellation = new CancellationTokenSource();
         private readonly ILocalSiloDetails localSiloDetails;
-        private readonly MembershipTableManager tableManager;
+        private readonly IServiceProvider serviceProvider;
+        private readonly MembershipTableManager membershipService;
         private readonly ILogger<ClusterHealthMonitor> log;
         private readonly IFatalErrorHandler fatalErrorHandler;
         private readonly ClusterMembershipOptions clusterMembershipOptions;
-        private readonly IAsyncTimer monitorClusterHealthTimer;
         private ImmutableDictionary<SiloAddress, SiloHealthMonitor> monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
         private MembershipVersion observedMembershipVersion;
         private Func<SiloAddress, SiloHealthMonitor> createMonitor;
-        private int probeNumber;
+        private Func<SiloHealthMonitor, ProbeResult, Task> onProbeResult;
 
         /// <summary>
         /// Exposes private members of <see cref="ClusterHealthMonitor"/> for test purposes.
@@ -39,80 +39,44 @@ namespace Orleans.Runtime.MembershipService
             ImmutableDictionary<SiloAddress, SiloHealthMonitor> MonitoredSilos { get; set; }
             Func<SiloAddress, SiloHealthMonitor> CreateMonitor { get; set; }
             MembershipVersion ObservedVersion { get; }
+            Func<SiloHealthMonitor, ProbeResult, Task> OnProbeResult { get; set; }
         }
 
         public ClusterHealthMonitor(
             ILocalSiloDetails localSiloDetails,
-            MembershipTableManager tableManager,
+            MembershipTableManager membershipService,
             ILogger<ClusterHealthMonitor> log,
             IOptions<ClusterMembershipOptions> clusterMembershipOptions,
             IFatalErrorHandler fatalErrorHandler,
-            IServiceProvider serviceProvider,
-            IAsyncTimerFactory timerFactory)
+            IServiceProvider serviceProvider)
         {
             this.localSiloDetails = localSiloDetails;
-            this.tableManager = tableManager;
+            this.serviceProvider = serviceProvider;
+            this.membershipService = membershipService;
             this.log = log;
             this.fatalErrorHandler = fatalErrorHandler;
             this.clusterMembershipOptions = clusterMembershipOptions.Value;
-            this.monitorClusterHealthTimer = timerFactory.Create(
-                this.clusterMembershipOptions.ProbeTimeout,
-                nameof(MonitorClusterHealth));
-            this.createMonitor = silo => ActivatorUtilities.CreateInstance<SiloHealthMonitor>(serviceProvider, silo);
+            this.onProbeResult = this.OnProbeResultInternal;
+            Func<SiloHealthMonitor, ProbeResult, Task> onProbeResultFunc = (siloHealthMonitor, probeResult) => this.onProbeResult(siloHealthMonitor, probeResult);
+            this.createMonitor = silo => ActivatorUtilities.CreateInstance<SiloHealthMonitor>(serviceProvider, silo, onProbeResultFunc);
         }
 
         ImmutableDictionary<SiloAddress, SiloHealthMonitor> ITestAccessor.MonitoredSilos { get => this.monitoredSilos; set => this.monitoredSilos = value; }
         Func<SiloAddress, SiloHealthMonitor> ITestAccessor.CreateMonitor { get => this.createMonitor; set => this.createMonitor = value; }
         MembershipVersion ITestAccessor.ObservedVersion => this.observedMembershipVersion;
+        Func<SiloHealthMonitor, ProbeResult, Task> ITestAccessor.OnProbeResult { get => this.onProbeResult; set => this.onProbeResult = value; }
 
         /// <summary>
-        /// Attempts to probe all active silos in the cluster, returning a list of silos with which connectivity could not be verified.
+        /// Gets the collection of monitored silos.
         /// </summary>
-        /// <returns>A list of silos with which connectivity could not be verified.</returns>
-        public async Task<List<SiloAddress>> CheckClusterConnectivity(SiloAddress[] members)
-        {
-            if (members.Length == 0) return new List<SiloAddress>();
-
-            var tasks = new List<Task<int>>(members.Length);
-
-            this.log.LogInformation(
-                (int)ErrorCode.MembershipSendingPreJoinPing,
-                "About to send pings to {Count} nodes in order to validate communication in the Joining state. Pinged nodes = {Nodes}",
-                members.Length,
-                Utils.EnumerableToString(members));
-
-            foreach (var silo in members)
-            {
-                tasks.Add(this.createMonitor(silo).Probe(Interlocked.Increment(ref this.probeNumber), CancellationToken.None));
-            }
-
-            try
-            {
-                await Task.WhenAll(tasks);
-            }
-            catch
-            {
-                // Ignore exceptions for now.
-            }
-
-            var failed = new List<SiloAddress>();
-            for (var i = 0; i < tasks.Count; i++)
-            {
-                if (tasks[i].Status != TaskStatus.RanToCompletion || tasks[i].GetAwaiter().GetResult() > 0)
-                {
-                    failed.Add(members[i]);
-                }
-            }
-
-            return failed;
-        }
+        public ImmutableDictionary<SiloAddress, SiloHealthMonitor> SiloMonitors => this.monitoredSilos;
 
         private async Task ProcessMembershipUpdates()
         {
             try
             {
                 if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug("Starting to process membership updates");
-                await foreach (var tableSnapshot in this.tableManager.MembershipTableUpdates.WithCancellation(this.shutdownCancellation.Token))
+                await foreach (var tableSnapshot in this.membershipService.MembershipTableUpdates.WithCancellation(this.shutdownCancellation.Token))
                 {
                     var newMonitoredSilos = this.UpdateMonitoredSilos(tableSnapshot, this.monitoredSilos, DateTime.UtcNow);
 
@@ -120,7 +84,8 @@ namespace Orleans.Runtime.MembershipService
                     {
                         if (!newMonitoredSilos.ContainsKey(pair.Key))
                         {
-                            pair.Value.Cancel();
+                            var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.ProbeTimeout).Token;
+                            await pair.Value.StopAsync(cancellation);
                         }
                     }
 
@@ -135,95 +100,6 @@ namespace Orleans.Runtime.MembershipService
             finally
             {
                 if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug("Stopped processing membership updates");
-            }
-        }
-
-        private async Task MonitorClusterHealth()
-        {
-            if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug("Starting cluster health monitor");
-            try
-            {
-                // Randomize the initial wait time before initiating probes.
-                var random = new SafeRandom();
-                TimeSpan? onceOffDelay = random.NextTimeSpan(this.clusterMembershipOptions.ProbeTimeout);
-
-                while (await this.monitorClusterHealthTimer.NextTick(onceOffDelay))
-                {
-                    if (onceOffDelay != default) onceOffDelay = default;
-
-                    _ = this.ProbeMonitoredSilos();
-                }
-            }
-            catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
-            {
-                this.fatalErrorHandler.OnFatalException(this, nameof(ProcessMembershipUpdates), exception);
-            }
-            finally
-            {
-                if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug("Stopped cluster health monitor");
-            }
-        }
-
-        private async Task ProbeMonitoredSilos()
-        {
-            try
-            {
-                using var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.ProbeTimeout);
-                var tasks = new List<Task>(this.monitoredSilos.Count);
-                foreach (var pair in this.monitoredSilos)
-                {
-                    var monitor = pair.Value;
-                    tasks.Add(PingSilo(monitor, cancellation.Token));
-                }
-
-                await Task.WhenAll(tasks);
-            }
-            catch (Exception exception)
-            {
-                this.log.LogError(
-                    (int)ErrorCode.MembershipUpdateIAmAliveFailure,
-                    "Exception while monitoring cluster members: {Exception}",
-                    exception);
-            }
-
-            async Task PingSilo(SiloHealthMonitor monitor, CancellationToken pingCancellation)
-            {
-                var failedProbes = await monitor.Probe(Interlocked.Increment(ref this.probeNumber), pingCancellation);
-
-                if (this.shutdownCancellation.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                if (failedProbes < this.clusterMembershipOptions.NumMissedProbesLimit)
-                {
-                    return;
-                }
-
-                if (monitor.IsCanceled || !this.monitoredSilos.ContainsKey(monitor.SiloAddress))
-                {
-                    if (this.log.IsEnabled(LogLevel.Debug))
-                    {
-                        this.log.LogDebug(
-                            (int)ErrorCode.MembershipPingedSiloNotInWatchList,
-                            "Ignoring probe failure from silo {Silo} since it is no longer being monitored.",
-                            monitor.SiloAddress,
-                            failedProbes);
-                    }
-
-                    return;
-                }
-
-                this.log.LogWarning("Silo {Silo} failed {FailedProbes} probes and is suspected of being dead. Publishing a death vote.", monitor.SiloAddress, failedProbes);
-
-                try
-                {
-                    await this.tableManager.TryToSuspectOrKill(monitor.SiloAddress);
-                }
-                catch (Exception exception)
-                {
-                    this.log.LogError((int)ErrorCode.MembershipFailedToSuspect, "Failed to register death vote for silo {Silo}: {Exception}", monitor.SiloAddress, exception);
-                }
             }
         }
 
@@ -292,6 +168,7 @@ namespace Orleans.Runtime.MembershipService
                 if (!monitoredSilos.TryGetValue(silo, out monitor))
                 {
                     monitor = this.createMonitor(silo);
+                    monitor.Start();
                 }
 
                 newProbedSilos[silo] = monitor;
@@ -306,12 +183,12 @@ namespace Orleans.Runtime.MembershipService
 
             return result;
 
-            bool AreTheSame<T>(ImmutableDictionary<SiloAddress, T> first, ImmutableDictionary<SiloAddress, T> second)
+            static bool AreTheSame<T>(ImmutableDictionary<SiloAddress, T> first, ImmutableDictionary<SiloAddress, T> second)
             {
                 return first.Count == second.Count && first.Count == first.Keys.Intersect(second.Keys).Count();
             }
 
-            bool IsFunctionalForMembership(SiloStatus status)
+            static bool IsFunctionalForMembership(SiloStatus status)
             {
                 return status == SiloStatus.Active || status == SiloStatus.ShuttingDown || status == SiloStatus.Stopping;
             }
@@ -326,31 +203,45 @@ namespace Orleans.Runtime.MembershipService
             Task OnActiveStart(CancellationToken ct)
             {
                 tasks.Add(Task.Run(() => this.ProcessMembershipUpdates()));
-                tasks.Add(Task.Run(() => this.MonitorClusterHealth()));
                 return Task.CompletedTask;
             }
 
-            Task OnActiveStop(CancellationToken ct)
+            async Task OnActiveStop(CancellationToken ct)
             {
-                this.monitorClusterHealthTimer.Dispose();
                 this.shutdownCancellation.Cancel(throwOnFirstException: false);
 
                 foreach (var monitor in this.monitoredSilos.Values)
                 {
-                    monitor.Cancel();
+                    tasks.Add(monitor.StopAsync(ct));
                 }
 
-                this.monitoredSilos = this.monitoredSilos.Clear();
+                this.monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
 
                 // Allow some minimum time for graceful shutdown.
                 var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
-                return Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
+                await Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
+            }
+        }
+
+        /// <summary>
+        /// Performs the default action when a new probe result is created.
+        /// </summary>
+        private async Task OnProbeResultInternal(SiloHealthMonitor monitor, ProbeResult probeResult)
+        {
+            if (probeResult.Status == ProbeResultStatus.Failed && probeResult.FailedProbeCount >= this.clusterMembershipOptions.NumMissedProbesLimit)
+            {
+                await this.membershipService.TryToSuspectOrKill(monitor.SiloAddress);
             }
         }
 
         bool IHealthCheckable.CheckHealth(DateTime lastCheckTime)
         {
-            var ok = this.monitorClusterHealthTimer.CheckHealth(lastCheckTime);
+            var ok = true;
+            foreach (var monitor in this.monitoredSilos.Values)
+            {
+                ok &= monitor.CheckHealth(lastCheckTime);
+            }
+
             return ok;
         }
     }

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -234,12 +234,25 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime)
+        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, out string reason)
         {
             var ok = true;
+            reason = default;
             foreach (var monitor in this.monitoredSilos.Values)
             {
-                ok &= monitor.CheckHealth(lastCheckTime);
+                ok &= monitor.CheckHealth(lastCheckTime, out var monitorReason);
+                if (!string.IsNullOrWhiteSpace(monitorReason))
+                {
+                    var siloReason = $"Monitor for {monitor.SiloAddress} is degraded with: {monitorReason}.";
+                    if (string.IsNullOrWhiteSpace(reason))
+                    {
+                        reason = siloReason;
+                    }
+                    else
+                    {
+                        reason = reason + " " + siloReason;
+                    }
+                }
             }
 
             return ok;

--- a/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
+++ b/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Orleans.Runtime.MembershipService

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Internal;
+using Orleans.Runtime.Messaging;
+
+namespace Orleans.Runtime.MembershipService
+{
+    internal interface ILocalSiloHealthMonitor
+    {
+        int GetLocalHealthDegradationScore(DateTime checkTime);
+    }
+
+    /// <summary>
+    /// Monitors the health of the local node using a combination of heuristics to create a health degradation score which
+    /// is exposed as a boolean value: whether or not the local node's health is degraded.
+    /// </summary>
+    /// <remarks>
+    /// The primary goal of this functionality is to passify degraded nodes so that they do not evict healthy nodes.
+    /// This functionality is inspired by the Lifeguard paper (https://arxiv.org/abs/1707.00788), which is a set of extensions
+    /// to the SWIM membership algorithm (https://research.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf). Orleans
+    /// uses a strong consistency membership algorithm, and not all of the Lifeguard extensions to SWIM apply to Orleans'
+    /// membership algorithm (refutation, for example).
+    /// The monitor implements the following heuristics:
+    /// <list type="bullet">
+    ///   <item>Check that this silos is marked as active in membership.</item>
+    ///   <item>Check that no other silo suspects this silo.</item>
+    ///   <item>Check for recently received successful ping responses.</item>
+    ///   <item>Check for recently received ping requests.</item>
+    ///   <item>Check that the .NET Thread Pool is able to process work items within one second.</item>
+    ///   <item>Check that local async timers have been firing on-time (within 3 seconds of their due time).</item>
+    /// </list>
+    /// </remarks>
+    internal class LocalSiloHealthMonitor : ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver, ILocalSiloHealthMonitor
+    {
+        private const int MaxScore = 8;
+        private readonly List<IHealthCheckParticipant> _healthCheckParticipants;
+        private readonly MembershipTableManager _membershipTableManager;
+        private readonly ConnectionManager _connectionManager;
+        private readonly ClusterHealthMonitor _clusterHealthMonitor;
+        private readonly ILocalSiloDetails _localSiloDetails;
+        private readonly ILogger<LocalSiloHealthMonitor> _log;
+        private readonly ClusterMembershipOptions _clusterMembershipOptions;
+        private readonly IAsyncTimer _degradationCheckTimer;
+        private readonly ThreadPoolMonitor _threadPoolMonitor;
+        private ValueStopwatch _runTime;
+        private Task _runTask;
+        private DateTime _lastHealthCheckTime;
+
+        public LocalSiloHealthMonitor(
+            IEnumerable<IHealthCheckParticipant> healthCheckParticipants,
+            MembershipTableManager membershipTableManager,
+            ConnectionManager connectionManager,
+            ClusterHealthMonitor clusterHealthMonitor,
+            ILocalSiloDetails localSiloDetails,
+            ILogger<LocalSiloHealthMonitor> log,
+            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
+            IAsyncTimerFactory timerFactory,
+            ILoggerFactory loggerFactory)
+        {
+            _healthCheckParticipants = healthCheckParticipants.ToList();
+            _membershipTableManager = membershipTableManager;
+            _connectionManager = connectionManager;
+            _clusterHealthMonitor = clusterHealthMonitor;
+            _localSiloDetails = localSiloDetails;
+            _log = log;
+            _clusterMembershipOptions = clusterMembershipOptions.Value;
+            _degradationCheckTimer = timerFactory.Create(
+                _clusterMembershipOptions.LocalHealthDegradationMonitoringPeriod,
+                nameof(LocalSiloHealthMonitor));
+            _threadPoolMonitor = new ThreadPoolMonitor(loggerFactory.CreateLogger<ThreadPoolMonitor>());
+            _runTime = ValueStopwatch.StartNew();
+        }
+
+        /// <summary>
+        /// Returns the local health degradation score, which is a value between 0 (healthy) and <see cref="MaxScore"/> (unhealthy).
+        /// </summary>
+        /// <param name="checkTime">The time which the check is taking place.</param>
+        /// <returns>The local health degradation score, which is a value between 0 (healthy) and <see cref="MaxScore"/> (unhealthy).</returns>
+        public int GetLocalHealthDegradationScore(DateTime checkTime)
+        {
+            var score = 0;
+            score += CheckSuspectingNodes(checkTime);
+            score += CheckReceivedProbeResponses(checkTime);
+            score += CheckReceivedProbeRequests(checkTime);
+            score += CheckLocalHealthCheckParticipants(checkTime);
+            score += CheckThreadPoolQueueDelay(checkTime);
+
+            // Clamp the score between 0 and the maximum allowed score.
+            score = Math.Max(0, Math.Min(MaxScore, score));
+            return score;
+        }
+
+        private int CheckThreadPoolQueueDelay(DateTime checkTime)
+        {
+            var threadPoolDelaySeconds = _threadPoolMonitor.MeasureQueueDelay().TotalSeconds;
+
+            if (threadPoolDelaySeconds > 1)
+            {
+                _log.LogWarning(
+                    ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",
+                    threadPoolDelaySeconds);
+            }
+
+            // Each second of delay contributes to the score.
+            return (int)threadPoolDelaySeconds;
+        }
+
+        private int CheckSuspectingNodes(DateTime now)
+        {
+            var score = 0;
+            var membershipSnapshot = _membershipTableManager.MembershipTableSnapshot;
+            if (membershipSnapshot.Entries.TryGetValue(_localSiloDetails.SiloAddress, out var membershipEntry))
+            {
+                if (membershipEntry.Status != SiloStatus.Active)
+                {
+                    if (_log.IsEnabled(LogLevel.Warning))
+                    {
+                        _log.LogWarning("This silo is not active (Status: {Status}) and is therefore not healthy.", membershipEntry.Status);
+                    }
+
+                    score = MaxScore;
+                }
+
+                // Check if there are valid votes against this node.
+                var expiration = _clusterMembershipOptions.DeathVoteExpirationTimeout;
+                var freshVotes = membershipEntry.GetFreshVotes(now, expiration);
+                foreach (var vote in freshVotes)
+                {
+                    if (membershipSnapshot.GetSiloStatus(vote.Item1) == SiloStatus.Active)
+                    {
+                        if (_log.IsEnabled(LogLevel.Warning))
+                        {
+                            _log.LogWarning("Silo {Silo} recently suspected for node at {SuspectingTime}.", vote.Item1, vote.Item2);
+                        }
+
+                        ++score;
+                    }
+                }
+            }
+            else
+            {
+                // If our entry is not found, this node is not healthy.
+                if (_log.IsEnabled(LogLevel.Error))
+                {
+                    _log.LogError("Could not find a membership entry for this silo");
+                }
+
+                score = MaxScore;
+            }
+
+            return score;
+        }
+
+        private int CheckReceivedProbeRequests(DateTime now)
+        {
+            // Have we received ping REQUESTS from other nodes?
+            var score = 0;
+
+            if (_runTime.Elapsed < TimeSpan.FromSeconds(30))
+            {
+                return 0;
+            }
+
+            var lastProbeRequest = default(DateTime);
+            var membershipSnapshot = _membershipTableManager.MembershipTableSnapshot;
+            foreach (var entry in membershipSnapshot.Entries)
+            {
+                if (entry.Key.Equals(_localSiloDetails.SiloAddress))
+                {
+                    continue;
+                }
+
+                if (entry.Value.Status == SiloStatus.Active)
+                {
+                    foreach (var connection in _connectionManager.GetExistingConnections(entry.Key))
+                    {
+                        if (!connection.IsValid) continue;
+                        if (connection is SiloConnection siloConnection)
+                        {
+                            var siloLastProbeRequest = siloConnection.LastReceivedProbeRequest;
+                            if (siloLastProbeRequest > lastProbeRequest)
+                            {
+                                lastProbeRequest = siloLastProbeRequest;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Only consider recency of the last received probe request if there is more than one other node.
+            // Otherwise, it may fail to vote another node dead in a one or two node cluster.
+            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+            if (lastProbeRequest < now - recencyWindow && membershipSnapshot.ActiveNodeCount > 2)
+            {
+                // This node has not received a successful ping response since the window began.
+                if (_log.IsEnabled(LogLevel.Warning))
+                {
+                    if (lastProbeRequest == default)
+                    {
+                        _log.LogWarning("This silo has not received any probe requests from currently valid connections");
+                    }
+                    else
+                    {
+                        _log.LogWarning("This silo has not received a probe request since {LastProbeRequest}", lastProbeRequest);
+                    }
+                }
+
+                ++score;
+            }
+
+            return score;
+        }
+
+        private int CheckLocalHealthCheckParticipants(DateTime now)
+        {
+            // Check for execution delays and other local health warning signs.
+            var score = 0;
+            foreach (var participant in _healthCheckParticipants)
+            {
+                try
+                {
+                    if (!participant.CheckHealth(_lastHealthCheckTime))
+                    {
+                        if (_log.IsEnabled(LogLevel.Warning))
+                        {
+                            _log.LogWarning("Health check participant {Participant} is reporting that it is unhealthy", participant?.GetType().ToString());
+                        }
+
+                        ++score;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _log.LogError(exception, "Error checking health for {Participant}", participant?.GetType().ToString());
+                }
+            }
+
+            _lastHealthCheckTime = now;
+            return score;
+        }
+
+        private int CheckReceivedProbeResponses(DateTime now)
+        {
+            if (_runTime.Elapsed < TimeSpan.FromSeconds(30))
+            {
+                // If the silo has not been live for long enough, 
+                return 0;
+            }
+
+            // Determine how recently the latest successful ping response was received.
+            var score = 0;
+            var siloMonitors = _clusterHealthMonitor.SiloMonitors;
+            var lastSuccessfulResponse = default(DateTime);
+            var shortestRoundTripTime = TimeSpan.MaxValue;
+            foreach (var monitor in siloMonitors.Values)
+            {
+                var current = monitor.LastResponse;
+                if (current > lastSuccessfulResponse)
+                {
+                    lastSuccessfulResponse = current;
+                }
+
+                if (monitor.LastRoundTripTime < shortestRoundTripTime)
+                {
+                    shortestRoundTripTime = monitor.LastRoundTripTime;
+                }
+            }
+
+            // Only consider recency of the last successful ping if this node is monitoring more than one other node.
+            // Otherwise, it may fail to vote another node dead in a one or two node cluster.
+            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+            if (lastSuccessfulResponse < now - recencyWindow && siloMonitors.Count > 1)
+            {
+                // This node has not received a successful ping response since the window began.
+                if (_log.IsEnabled(LogLevel.Warning))
+                {
+                    if (lastSuccessfulResponse == default)
+                    {
+                        _log.LogWarning("This silo has not received any successful probe responses");
+                    }
+                    else
+                    {
+                        _log.LogWarning("This silo has not received a successful probe response since {LastSuccessfulResponse}", lastSuccessfulResponse);
+                    }
+                }
+
+                ++score;
+            }
+
+            return score;
+        }
+
+        private async Task Run()
+        {
+            while (await _degradationCheckTimer.NextTick())
+            {
+                try
+                {
+                    var now = DateTime.UtcNow;
+                    var score = GetLocalHealthDegradationScore(now);
+                    if (score > 0 && _log.IsEnabled(LogLevel.Warning))
+                    {
+                        _log.LogWarning("Self-monitoring determined that local health is degraded. Degradation score is {Score}/{MaxScore} (lower is better)", score, MaxScore);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _log.LogError(exception, "Error while monitoring local silo health");
+                }
+            }
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(ServiceLifecycleStage.Active, this);
+        }
+
+        public Task OnStart(CancellationToken ct)
+        {
+            _runTask = Task.Run(this.Run);
+            _runTime.Restart();
+            return Task.CompletedTask;
+        }
+
+        public async Task OnStop(CancellationToken ct)
+        {
+            _degradationCheckTimer.Dispose();
+
+            if (_runTask is Task task)
+            {
+                await Task.WhenAny(task, ct.WhenCancelled()).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Measures queue delay on the .NET <see cref="ThreadPool"/>.
+        /// </summary>
+        private class ThreadPoolMonitor
+        {
+            private static readonly WaitCallback Callback = state => ((ThreadPoolMonitor)state).Execute();
+            private readonly object _lockObj = new object();
+            private readonly ILogger<ThreadPoolMonitor> _log;
+            private bool _scheduled;
+            private TimeSpan _lastQueueDelay;
+            private ValueStopwatch _queueDelay;
+
+            public ThreadPoolMonitor(ILogger<ThreadPoolMonitor> log)
+            {
+                _log = log;
+            }
+
+            public TimeSpan MeasureQueueDelay()
+            {
+                bool shouldSchedule;
+                TimeSpan delay;
+                lock (_lockObj)
+                {
+                    var currentQueueDelay = _queueDelay.Elapsed;
+                    delay = currentQueueDelay > _lastQueueDelay ? currentQueueDelay : _lastQueueDelay;
+
+                    if (!_scheduled)
+                    {
+                        _scheduled = true;
+                        shouldSchedule = true;
+                        _queueDelay.Restart();
+                    }
+                    else
+                    {
+                        shouldSchedule = false;
+                    }
+                }
+
+                if (shouldSchedule)
+                {
+                    _ = ThreadPool.UnsafeQueueUserWorkItem(Callback, this);
+                }
+
+                return delay;
+            }
+
+            private void Execute()
+            {
+                try
+                {
+                    lock (_lockObj)
+                    {
+                        _scheduled = false;
+                        _queueDelay.Stop();
+                        _lastQueueDelay = _queueDelay.Elapsed;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _log.LogError(exception, "Exception monitoring .NET thread pool delay");
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -100,7 +100,14 @@ namespace Orleans.Runtime.MembershipService
         {
             var threadPoolDelaySeconds = _threadPoolMonitor.MeasureQueueDelay().TotalSeconds;
 
-            if (threadPoolDelaySeconds > 1)
+            if (threadPoolDelaySeconds > 10)
+            {
+                // Log as an error if the delay is massive.
+                _log.LogError(
+                    ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",
+                    threadPoolDelaySeconds);
+            }
+            else if (threadPoolDelaySeconds > 1)
             {
                 _log.LogWarning(
                     ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -167,9 +167,10 @@ namespace Orleans.Runtime.MembershipService
         private int CheckReceivedProbeRequests(DateTime now)
         {
             // Have we received ping REQUESTS from other nodes?
+            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
             var score = 0;
 
-            if (_runTime.Elapsed < TimeSpan.FromSeconds(30))
+            if (_runTime.Elapsed < recencyWindow)
             {
                 return 0;
             }
@@ -202,7 +203,6 @@ namespace Orleans.Runtime.MembershipService
 
             // Only consider recency of the last received probe request if there is more than one other node.
             // Otherwise, it may fail to vote another node dead in a one or two node cluster.
-            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
             if (lastProbeRequest < now - recencyWindow && membershipSnapshot.ActiveNodeCount > 2)
             {
                 // This node has not received a successful ping response since the window began.
@@ -254,9 +254,10 @@ namespace Orleans.Runtime.MembershipService
 
         private int CheckReceivedProbeResponses(DateTime now)
         {
-            if (_runTime.Elapsed < TimeSpan.FromSeconds(30))
+            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+            if (_runTime.Elapsed < recencyWindow)
             {
-                // If the silo has not been live for long enough, 
+                // If the silo has not been live for long enough.
                 return 0;
             }
 
@@ -281,7 +282,6 @@ namespace Orleans.Runtime.MembershipService
 
             // Only consider recency of the last successful ping if this node is monitoring more than one other node.
             // Otherwise, it may fail to vote another node dead in a one or two node cluster.
-            var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
             if (lastSuccessfulResponse < now - recencyWindow && siloMonitors.Count > 1)
             {
                 // This node has not received a successful ping response since the window began.

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.Extensions.Options;
 using System.Linq;
 using Orleans.Internal;
+using System.Runtime.CompilerServices;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -17,29 +18,29 @@ namespace Orleans.Runtime.MembershipService
     {
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
         private readonly MembershipTableManager tableManager;
-        private readonly ClusterHealthMonitor clusterHealthMonitor;
         private readonly ILocalSiloDetails localSilo;
         private readonly IFatalErrorHandler fatalErrorHandler;
         private readonly ClusterMembershipOptions clusterMembershipOptions;
         private readonly ILogger<MembershipAgent> log;
+        private readonly IRemoteSiloProber siloProber;
         private readonly IAsyncTimer iAmAliveTimer;
         private Func<DateTime> getUtcDateTime = () => DateTime.UtcNow;
 
         public MembershipAgent(
             MembershipTableManager tableManager,
-            ClusterHealthMonitor clusterHealthMonitor,
             ILocalSiloDetails localSilo,
             IFatalErrorHandler fatalErrorHandler,
             IOptions<ClusterMembershipOptions> options,
             ILogger<MembershipAgent> log,
-            IAsyncTimerFactory timerFactory)
+            IAsyncTimerFactory timerFactory,
+            IRemoteSiloProber siloProber)
         {
             this.tableManager = tableManager;
-            this.clusterHealthMonitor = clusterHealthMonitor;
             this.localSilo = localSilo;
             this.fatalErrorHandler = fatalErrorHandler;
             this.clusterMembershipOptions = options.Value;
             this.log = log;
+            this.siloProber = siloProber;
             this.iAmAliveTimer = timerFactory.Create(
                 this.clusterMembershipOptions.IAmAliveTablePublishTimeout,
                 nameof(UpdateIAmAlive));
@@ -152,7 +153,7 @@ namespace Orleans.Runtime.MembershipService
                         activeSilos.Add(entry.SiloAddress);
                     }
 
-                    var failedSilos = await this.clusterHealthMonitor.CheckClusterConnectivity(activeSilos.ToArray());
+                    var failedSilos = await CheckClusterConnectivity(activeSilos.ToArray());
                     var successfulSilos = activeSilos.Where(s => !failedSilos.Contains(s)).ToList();
 
                     // If there were no failures, terminate the loop and return without error.
@@ -192,6 +193,85 @@ namespace Orleans.Runtime.MembershipService
 
                 ++attemptNumber;
                 now = this.getUtcDateTime();
+            }
+
+            async Task<List<SiloAddress>> CheckClusterConnectivity(SiloAddress[] members)
+            {
+                if (members.Length == 0) return new List<SiloAddress>();
+
+                var tasks = new List<Task<bool>>(members.Length);
+
+                this.log.LogInformation(
+                    (int)ErrorCode.MembershipSendingPreJoinPing,
+                    "About to send pings to {Count} nodes in order to validate communication in the Joining state. Pinged nodes = {Nodes}",
+                    members.Length,
+                    Utils.EnumerableToString(members));
+
+                var timeout = this.clusterMembershipOptions.ProbeTimeout;
+                foreach (var silo in members)
+                {
+                    tasks.Add(ProbeSilo(this.siloProber, silo, timeout, this.log));
+                }
+
+                try
+                {
+                    await Task.WhenAll(tasks);
+                }
+                catch
+                {
+                    // Ignore exceptions for now.
+                }
+
+                var failed = new List<SiloAddress>();
+                for (var i = 0; i < tasks.Count; i++)
+                {
+                    if (tasks[i].Status != TaskStatus.RanToCompletion || !tasks[i].GetAwaiter().GetResult())
+                    {
+                        failed.Add(members[i]);
+                    }
+                }
+
+                return failed;
+            }
+
+            static async Task<bool> ProbeSilo(IRemoteSiloProber siloProber, SiloAddress silo, TimeSpan timeout, ILogger log)
+            {
+                Exception exception;
+                try
+                {
+                    using var cancellation = new CancellationTokenSource(timeout);
+                    var probeTask = siloProber.Probe(silo, 0);
+                    var cancellationTask = cancellation.Token.WhenCancelled();
+                    var completedTask = await Task.WhenAny(probeTask, cancellationTask).ConfigureAwait(false);
+
+                    if (ReferenceEquals(completedTask, probeTask))
+                    {
+                        cancellation.Cancel();
+                        if (probeTask.IsFaulted)
+                        {
+                            exception = probeTask.Exception;
+                        }
+                        else if (probeTask.Status == TaskStatus.RanToCompletion)
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            exception = null;
+                        }
+                    }
+                    else
+                    {
+                        exception = null;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                log.LogWarning(exception, "Did not receive a probe response from silo {SiloAddress} in timeout {Timeout}", silo.ToString(), timeout);
+                return false;
             }
         }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -427,10 +427,6 @@ namespace Orleans.Runtime.MembershipService
             this.iAmAliveTimer.Dispose();
         }
 
-        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime)
-        {
-            var ok = this.iAmAliveTimer.CheckHealth(lastCheckTime);
-            return ok;
-        }
+        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, out string reason) => this.iAmAliveTimer.CheckHealth(lastCheckTime, out reason);
     }
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.MembershipService
             if (gossipPartners.Count == 0) return Task.CompletedTask;
 
             this.log.LogInformation(
-                "Gossiping {Silo} status change to {Status} to {NumPartners} partners",
+                "Gossiping {Silo} status {Status} to {NumPartners} partners",
                 updatedSilo,
                 updatedStatus,
                 gossipPartners.Count);

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -109,10 +109,15 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime)
+        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, out string reason)
         {
-            var ok = this.cleanupDefunctSilosTimer?.CheckHealth(lastCheckTime) ?? true;
-            return ok;
+            if (cleanupDefunctSilosTimer is IAsyncTimer timer)
+            {
+                return timer.CheckHealth(lastCheckTime, out reason);
+            }
+
+            reason = default;
+            return true;
         }
     }
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -843,11 +843,7 @@ namespace Orleans.Runtime.MembershipService
             return true;
         }
 
-        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime)
-        {
-            var ok = this.membershipUpdateTimer.CheckHealth(lastCheckTime);
-            return ok;
-        }
+        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, out string reason) => this.membershipUpdateTimer.CheckHealth(lastCheckTime, out reason);
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {

--- a/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
+++ b/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// Monitors incoming cluster health probe requests
+    /// </summary>
+    internal sealed class ProbeRequestMonitor
+    {
+        private readonly object _lock = new object();
+        private ValueStopwatch _probeRequestStopwatch;
+
+        public ProbeRequestMonitor()
+        {
+            _probeRequestStopwatch = ValueStopwatch.StartNew();
+        }
+
+        /// <summary>
+        /// Called when this silo receives a health probe request.
+        /// </summary>
+        public void OnReceivedProbeRequest()
+        {
+            lock (_lock)
+            {
+                _probeRequestStopwatch.Restart();
+            }
+        }
+
+        /// <summary>
+        /// The duration which has elapsed since the most recently received health probe request.
+        /// </summary>
+        public TimeSpan ElapsedSinceLastProbeRequest => _probeRequestStopwatch.Elapsed;
+    }
+}

--- a/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
+++ b/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
@@ -10,11 +10,6 @@ namespace Orleans.Runtime.Messaging
         private readonly object _lock = new object();
         private ValueStopwatch _probeRequestStopwatch;
 
-        public ProbeRequestMonitor()
-        {
-            _probeRequestStopwatch = ValueStopwatch.StartNew();
-        }
-
         /// <summary>
         /// Called when this silo receives a health probe request.
         /// </summary>
@@ -29,6 +24,6 @@ namespace Orleans.Runtime.Messaging
         /// <summary>
         /// The duration which has elapsed since the most recently received health probe request.
         /// </summary>
-        public TimeSpan ElapsedSinceLastProbeRequest => _probeRequestStopwatch.Elapsed;
+        public TimeSpan? ElapsedSinceLastProbeRequest => _probeRequestStopwatch.IsRunning ? (Nullable<TimeSpan>)_probeRequestStopwatch.Elapsed : null;
     }
 }

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -45,6 +45,8 @@ namespace Orleans.Runtime.Messaging
 
         public NetworkProtocolVersion RemoteProtocolVersion { get; private set; }
 
+        public DateTime LastReceivedProbeRequest { get; private set; }
+
         protected override void OnReceivedMessage(Message msg)
         {
             // See it's a Ping message, and if so, short-circuit it
@@ -154,6 +156,7 @@ namespace Orleans.Runtime.Messaging
             }
             else
             {
+                this.LastReceivedProbeRequest = DateTime.UtcNow;
                 var response = this.MessageFactory.CreateResponseMessage(msg);
                 response.BodyObject = PingResponse;
                 this.Send(response);

--- a/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.Messaging
         internal static readonly object ServicesKey = new object();
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly ConnectionCommon connectionShared;
+        private readonly ProbeRequestMonitor probeRequestMonitor;
         private readonly IServiceProvider serviceProvider;
         private readonly SiloConnectionOptions siloConnectionOptions;
         private readonly object initializationLock = new object();
@@ -26,13 +27,15 @@ namespace Orleans.Runtime.Messaging
             IOptions<ConnectionOptions> connectionOptions,
             IOptions<SiloConnectionOptions> siloConnectionOptions,
             ILocalSiloDetails localSiloDetails,
-            ConnectionCommon connectionShared)
+            ConnectionCommon connectionShared,
+            ProbeRequestMonitor probeRequestMonitor)
             : base(serviceProvider.GetRequiredServiceByKey<object, IConnectionFactory>(ServicesKey), serviceProvider, connectionOptions)
         {
             this.serviceProvider = serviceProvider;
             this.siloConnectionOptions = siloConnectionOptions.Value;
             this.localSiloDetails = localSiloDetails;
             this.connectionShared = connectionShared;
+            this.probeRequestMonitor = probeRequestMonitor;
         }
 
         public override ValueTask<Connection> ConnectAsync(SiloAddress address, CancellationToken cancellationToken)
@@ -59,7 +62,8 @@ namespace Orleans.Runtime.Messaging
                 this.localSiloDetails,
                 this.connectionManager,
                 this.ConnectionOptions,
-                this.connectionShared);
+                this.connectionShared,
+                this.probeRequestMonitor);
         }
 
         protected override void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder)

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -18,6 +18,7 @@ namespace Orleans.Runtime.Messaging
         private readonly EndpointOptions endpointOptions;
         private readonly ConnectionManager connectionManager;
         private readonly ConnectionCommon connectionShared;
+        private readonly ProbeRequestMonitor probeRequestMonitor;
 
         public SiloConnectionListener(
             IServiceProvider serviceProvider,
@@ -27,7 +28,8 @@ namespace Orleans.Runtime.Messaging
             IOptions<EndpointOptions> endpointOptions,
             ILocalSiloDetails localSiloDetails,
             ConnectionManager connectionManager,
-            ConnectionCommon connectionShared)
+            ConnectionCommon connectionShared,
+            ProbeRequestMonitor probeRequestMonitor)
             : base(serviceProvider.GetRequiredServiceByKey<object, IConnectionListenerFactory>(ServicesKey), connectionOptions, connectionManager, connectionShared)
         {
             this.siloConnectionOptions = siloConnectionOptions.Value;
@@ -35,6 +37,7 @@ namespace Orleans.Runtime.Messaging
             this.localSiloDetails = localSiloDetails;
             this.connectionManager = connectionManager;
             this.connectionShared = connectionShared;
+            this.probeRequestMonitor = probeRequestMonitor;
             this.endpointOptions = endpointOptions.Value;
         }
 
@@ -50,7 +53,8 @@ namespace Orleans.Runtime.Messaging
                 this.localSiloDetails,
                 this.connectionManager,
                 this.ConnectionOptions,
-                this.connectionShared);
+                this.connectionShared,
+                this.probeRequestMonitor);
         }
 
         protected override void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder)

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -6,7 +6,6 @@ using Orleans.Internal;
 
 namespace Orleans.Runtime
 {
-
     internal class Watchdog
     {
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
@@ -54,7 +53,7 @@ namespace Orleans.Runtime
             {
                 try
                 {
-                    WatchdogHeartbeatTick(null);
+                    WatchdogHeartbeatTick();
                     Thread.Sleep(heartbeatPeriod);
                 }
                 catch (ThreadAbortException)
@@ -68,7 +67,7 @@ namespace Orleans.Runtime
             }
         }
 
-        private void WatchdogHeartbeatTick(object state)
+        private void WatchdogHeartbeatTick()
         {
             try
             {

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
@@ -62,7 +63,7 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exc)
                 {
-                    logger.Error(ErrorCode.Watchdog_InternalError, "Watchdog Internal Error.", exc);
+                    logger.LogError((int)ErrorCode.Watchdog_InternalError, exc, "Watchdog encountered an internal error");
                 }
             }
         }
@@ -83,18 +84,31 @@ namespace Orleans.Runtime
 
             watchdogChecks.Increment();
             int numFailedChecks = 0;
+            StringBuilder reasons = null;
             foreach (IHealthCheckParticipant participant in participants)
             {
                 try
                 {
-                    bool ok = participant.CheckHealth(lastWatchdogCheck);
+                    bool ok = participant.CheckHealth(lastWatchdogCheck, out var reason);
                     if (!ok)
+                    {
+                        reasons ??= new StringBuilder();
+                        if (reasons.Length > 0)
+                        {
+                            reasons.Append(" ");
+                        }
+
+                        reasons.Append($"{participant.GetType()} failed health check with reason \"{reason}\".");
                         numFailedChecks++;
+                    }
                 }
                 catch (Exception exc) 
                 {
-                    logger.Warn(ErrorCode.Watchdog_ParticipantThrownException, 
-                        String.Format("HealthCheckParticipant {0} has thrown an exception from its CheckHealth method.", participant.ToString()), exc); 
+                    logger.LogWarning(
+                        (int)ErrorCode.Watchdog_ParticipantThrownException,
+                        exc,
+                        "Health check participant {Participant} has thrown an exception from its CheckHealth method.",
+                        participant?.GetType());
                 }
             }
             if (numFailedChecks > 0)
@@ -103,7 +117,7 @@ namespace Orleans.Runtime
                     watchdogFailedChecks = CounterStatistic.FindOrCreate(StatisticNames.WATCHDOG_NUM_FAILED_HEALTH_CHECKS);
                 
                 watchdogFailedChecks.Increment();
-                logger.Warn(ErrorCode.Watchdog_HealthCheckFailure, String.Format("Watchdog had {0} Health Check Failure(s) out of {1} Health Check Participants.", numFailedChecks, participants.Count)); 
+                logger.LogWarning((int)ErrorCode.Watchdog_HealthCheckFailure, "Watchdog had {FailedChecks} health Check failure(s) out of {ParticipantCount} health Check participants: {Reasons}", numFailedChecks, participants.Count, reasons.ToString()); 
             }
             lastWatchdogCheck = DateTime.UtcNow;
         }
@@ -114,8 +128,9 @@ namespace Orleans.Runtime
             if (timeSinceLastTick > heartbeatPeriod.Multiply(2))
             {
                 var gc = new[] { GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2) };
-                logger.Warn(ErrorCode.SiloHeartbeatTimerStalled,
-                    ".NET Runtime Platform stalled for {0} - possibly GC? We are now using total of {1}MB memory. gc={2}, {3}, {4}",
+                logger.LogWarning(
+                    (int)ErrorCode.SiloHeartbeatTimerStalled,
+                    ".NET Runtime Platform stalled for {TimeSinceLastTick} - possibly GC? We are now using total of {TotalMemory}MB memory. gc={GCGen0Count}, {GCGen1Count}, {GCGen2Count}",
                     timeSinceLastTick,
                     GC.GetTotalMemory(false) / (1024 * 1024),
                     gc[0],

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -14,14 +14,16 @@ namespace Orleans.Runtime
 
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
         private readonly TimeSpan period;
+        private readonly string name;
         private readonly ILogger log;
         private DateTime lastFired = DateTime.MinValue;
         private DateTime? expected;
 
-        public AsyncTimer(TimeSpan period, ILogger log)
+        public AsyncTimer(TimeSpan period, string name, ILogger log)
         {
             this.log = log;
             this.period = period;
+            this.name = name;
         }
 
         /// <summary>
@@ -101,20 +103,18 @@ namespace Orleans.Runtime
             return TimeSpan.Zero;
         }
 
-        public bool CheckHealth(DateTime lastCheckTime)
+        public bool CheckHealth(DateTime lastCheckTime, out string reason)
         {
             var now = DateTime.UtcNow;
             var dueTime = this.expected.GetValueOrDefault();
             var overshoot = GetOvershootDelay(now, dueTime);
             if (overshoot > TimeSpan.Zero)
             {
-                this.log?.LogWarning(
-                    "Timer should have fired at {DueTime}, which is {Overshoot} ago",
-                    dueTime,
-                    overshoot);
+                reason = $"{this.name} timer should have fired at {dueTime}, which is {overshoot} ago";
                 return false;
             }
 
+            reason = default;
             return true;
         }
 

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
                 {
                     // for backwards compatibility, support timers with periods up to ReminderRegistry.MaxSupportedTimeout
                     var maxDelay = TimeSpan.FromMilliseconds(int.MaxValue);
-                    if (delay > maxDelay)
+                    while (delay > maxDelay)
                     {
                         delay -= maxDelay;
                         await Task.Delay(maxDelay, cancellation.Token).ConfigureAwait(false);

--- a/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimerFactory.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
         public IAsyncTimer Create(TimeSpan period, string name)
         {
             var log = this.loggerFactory.CreateLogger($"{typeof(AsyncTimer).FullName}.{name}");
-            return new AsyncTimer(period, log);
+            return new AsyncTimer(period, name, log);
         }
     }
 }

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,7 @@ namespace NonSilo.Tests.Membership
         private readonly List<DelegateAsyncTimer> timers;
         private readonly ConcurrentQueue<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)> timerCalls;
         private readonly DelegateAsyncTimerFactory timerFactory;
+        private readonly ILocalSiloHealthMonitor localSiloHealthMonitor;
         private readonly IRemoteSiloProber prober;
         private readonly InMemoryMembershipTable membershipTable;
         private readonly MembershipTableManager manager;
@@ -66,6 +68,9 @@ namespace NonSilo.Tests.Membership
                     return t;
                 });
 
+            this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
+            this.localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+
             this.prober = Substitute.For<IRemoteSiloProber>();
             this.membershipTable = new InMemoryMembershipTable(new TableVersion(1, "1"));
             this.manager = new MembershipTableManager(
@@ -94,20 +99,26 @@ namespace NonSilo.Tests.Membership
             });
 
             var clusterMembershipOptions = new ClusterMembershipOptions();
+            var options = Options.Create(clusterMembershipOptions);
             var monitor = new ClusterHealthMonitor(
                 this.localSiloDetails,
                 this.manager,
                 this.loggerFactory.CreateLogger<ClusterHealthMonitor>(),
-                Options.Create(clusterMembershipOptions),
+                options,
                 this.fatalErrorHandler,
-                null,
-                this.timerFactory);
+                null);
             ((ILifecycleParticipant<ISiloLifecycle>)monitor).Participate(this.lifecycle);
             var testAccessor = (ClusterHealthMonitor.ITestAccessor)monitor;
-            testAccessor.CreateMonitor = s => new SiloHealthMonitor(s, this.loggerFactory, this.prober);
+            testAccessor.CreateMonitor = s => new SiloHealthMonitor(
+                s,
+                testAccessor.OnProbeResult,
+                options,
+                this.loggerFactory,
+                this.prober,
+                this.timerFactory,
+                this.localSiloHealthMonitor);
 
             await this.lifecycle.OnStart();
-            Assert.NotEmpty(this.timers);
             Assert.Empty(testAccessor.MonitoredSilos);
 
             var otherSilos = new[]
@@ -133,9 +144,6 @@ namespace NonSilo.Tests.Membership
             }
 
             await this.manager.Refresh();
-            (TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion) timer = (default, default);
-            while (!this.timerCalls.TryDequeue(out timer)) await Task.Delay(1);
-            timer.Completion.TrySetResult(true);
 
             await Until(() => testAccessor.ObservedVersion > lastVersion);
             lastVersion = testAccessor.ObservedVersion;
@@ -150,20 +158,27 @@ namespace NonSilo.Tests.Membership
 
             // Now that this silo is active, it should be monitoring some fraction of the other active silos
             Assert.NotEmpty(testAccessor.MonitoredSilos);
+            Assert.NotEmpty(this.timers);
             Assert.DoesNotContain(testAccessor.MonitoredSilos, s => s.Key.Equals(this.localSilo));
             Assert.Equal(clusterMembershipOptions.NumProbedSilos, testAccessor.MonitoredSilos.Count);
             Assert.All(testAccessor.MonitoredSilos, m => m.Key.Equals(m.Value.SiloAddress));
             Assert.Empty(probeCalls);
 
             // Check that those silos are actually being probed periodically
-            while (!this.timerCalls.TryDequeue(out timer)) await Task.Delay(1);
-            timer.Completion.TrySetResult(true);
+            await UntilEqual(clusterMembershipOptions.NumProbedSilos, () =>
+            {
+                if (this.timerCalls.TryDequeue(out var timer))
+                {
+                    timer.Completion.TrySetResult(true);
+                }
 
-            await Until(() => probeCalls.Count == clusterMembershipOptions.NumProbedSilos);
+                return probeCalls.Count;
+            });
             Assert.Equal(clusterMembershipOptions.NumProbedSilos, probeCalls.Count);
             while (probeCalls.TryDequeue(out var call)) Assert.Contains(testAccessor.MonitoredSilos, k => k.Key.Equals(call.Item1));
 
-            foreach (var siloMonitor in testAccessor.MonitoredSilos.Values)
+            var monitoredSilos = testAccessor.MonitoredSilos.Values.ToList();
+            foreach (var siloMonitor in monitoredSilos)
             {
                 Assert.Equal(0, ((SiloHealthMonitor.ITestAccessor)siloMonitor).MissedProbes);
             }
@@ -177,22 +192,28 @@ namespace NonSilo.Tests.Membership
 
             // The above call to specify the probe behaviour also enqueued a value, so clear it here.
             while (probeCalls.TryDequeue(out _)) ;
-            
+
             for (var expectedMissedProbes = 1; expectedMissedProbes <= clusterMembershipOptions.NumMissedProbesLimit; expectedMissedProbes++)
             {
                 var now = DateTime.UtcNow;
                 this.membershipTable.ClearCalls();
 
-                while (!this.timerCalls.TryDequeue(out timer)) await Task.Delay(1);
-                timer.Completion.TrySetResult(true);
-
                 // Wait for probes to be fired
-                await Until(() => probeCalls.Count == clusterMembershipOptions.NumProbedSilos);
+                await UntilEqual(clusterMembershipOptions.NumProbedSilos, () =>
+                {
+                    if (this.timerCalls.TryDequeue(out var timer))
+                    {
+                        timer.Completion.TrySetResult(true);
+                    }
+
+                    return probeCalls.Count;
+                });
+
                 while (probeCalls.TryDequeue(out var call)) ;
 
                 // Check that probes match the expected missed probes
                 var table = await this.membershipTable.ReadAll();
-                foreach (var siloMonitor in testAccessor.MonitoredSilos.Values)
+                foreach (var siloMonitor in monitoredSilos)
                 {
                     Assert.Equal(expectedMissedProbes, ((SiloHealthMonitor.ITestAccessor)siloMonitor).MissedProbes);
 
@@ -220,11 +241,16 @@ namespace NonSilo.Tests.Membership
             // The above call to specify the probe behaviour also enqueued a value, so clear it here.
             while (probeCalls.TryDequeue(out _)) ;
 
-            while (!this.timerCalls.TryDequeue(out timer)) await Task.Delay(1);
-            timer.Completion.TrySetResult(true);
-
             // Wait for probes to be fired
-            await Until(() => probeCalls.Count == clusterMembershipOptions.NumProbedSilos);
+            await UntilEqual(testAccessor.MonitoredSilos.Count, () =>
+            {
+                if (this.timerCalls.TryDequeue(out var timer))
+                {
+                    timer.Completion.TrySetResult(true);
+                }
+
+                return probeCalls.Count;
+            });
             while (probeCalls.TryDequeue(out var call)) ;
             foreach (var siloMonitor in testAccessor.MonitoredSilos.Values)
             {
@@ -237,6 +263,21 @@ namespace NonSilo.Tests.Membership
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
         private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new MembershipEntry { SiloAddress = address, Status = status };
+
+        private static async Task UntilEqual<T>(T expected, Func<T> getActual)
+        {
+            var maxTimeout = 40_000;
+            var equalityComparer = EqualityComparer<T>.Default;
+            var actual = getActual();
+            while (!equalityComparer.Equals(expected, actual) && (maxTimeout -= 10) > 0)
+            {
+                await Task.Delay(10);
+                actual = getActual();
+            }
+
+            Assert.Equal(expected, actual);
+            Assert.True(maxTimeout > 0);
+        }
 
         private static async Task Until(Func<bool> condition)
         {

--- a/test/NonSilo.Tests/Utilities/DelegateAsyncTimer.cs
+++ b/test/NonSilo.Tests/Utilities/DelegateAsyncTimer.cs
@@ -17,7 +17,11 @@ namespace NonSilo.Tests.Utilities
 
         public Task<bool> NextTick(TimeSpan? overrideDelay = null) => this.nextTick(overrideDelay);
 
-        public bool CheckHealth(DateTime lastCheckTime) => true;
+        public bool CheckHealth(DateTime lastCheckTime, out string reason)
+        {
+            reason = default;
+            return true;
+        }
 
         public void Dispose() => ++this.DisposedCounter;
     }


### PR DESCRIPTION
This PR implements some of the ideas from Lifeguard ([paper](https://arxiv.org/abs/1707.00788), [talk](https://www.youtube.com/watch?v=u-a7rVJ6jZY), [blog](https://www.hashicorp.com/blog/making-gossip-more-robust-with-lifeguard)) which can help during times of catastrophe, where a large portion of a cluster is in a state of partial failure. One cause for these kinds of partial failures is large scale thread pool starvation, which can cause a node to run slowly enough to not process messages in a timely manner. Slow nodes can therefore suspect healthy nodes simply because the slow node is not able to process the healthy node's timely response. If a sufficiently proportion of nodes in a cluster are slow (eg, due to an application bug), then healthy nodes may have trouble joining and remaining in the cluster, since the slow nodes can evict them. In this scenario, slow nodes will also be evicting each other. The intention is to improve cluster stability in these scenarios.

This PR introduces `LocalSiloHealthMonitor` which uses heuristics to score the local silo's health. A low score (0) represents a healthy node and a high score (1 to 8) represents an unhealthy node.

`LocalSiloHealthMonitor` implements the following heuristics:
 
* Check that this silos is marked as `Active` in membership
* Check that no other silo suspects this silo
* Check for recently received successful ping responses
* Check for recently received ping requests
* Check that the .NET Thread Pool is able to execute work items within 1 second from enqueue time
* Check that local async timers have been firing on-time (within 3 seconds of their due time)

Failing heuristics contribute to increased probe timeouts, which has two effects:
* Improves the chance of a successful probe to a healthy node
* Increases the time taken for an unhealthy node to vote a healthy node dead, giving the cluster a larger chance of voting the unhealthy node dead first (Nodes marked as dead are pacified and cannot vote others)

A subsequent PR will add indirect probes which greatly reduce the ability of unhealthy nodes to vote healthy nodes dead by service as a positive indicator that the local node is healthy (via a NACK).