### PR TITLE
In GrainId.ToString(), display the grain type name and format the key properly

### DIFF
--- a/src/Orleans.Core.Abstractions/CodeGeneration/InvokeMethodRequest.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/InvokeMethodRequest.cs
@@ -9,6 +9,8 @@ namespace Orleans.CodeGeneration
     [Serializable]
     public sealed class InvokeMethodRequest
     {
+        internal static IInvokeMethodRequestLoggingHelper Helper { get; set; }
+
         /// <summary> InterfaceId for this Invoke request. </summary>
         public int InterfaceId { get; private set; }
         public ushort InterfaceVersion { get; private set; }
@@ -33,7 +35,20 @@ namespace Orleans.CodeGeneration
         /// </remarks>
         public override string ToString()
         {
-            return String.Format("InvokeMethodRequest {0}:{1}", InterfaceId, MethodId);
+            if (Helper != null)
+            {
+                Helper.GetInterfaceAndMethodName(this.InterfaceId, this.MethodId, out var interfaceName, out var methodName);
+                return $"InvokeMethodRequest {interfaceName}:{methodName}";
+            }
+            else
+            {
+                return $"InvokeMethodRequest {this.InterfaceId}:{this.MethodId}";
+            }
+        }
+
+        private void GetInterfaceAndMethodName()
+        {
+
         }
     }
 

--- a/src/Orleans.Core.Abstractions/CodeGeneration/InvokeMethodRequest.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/InvokeMethodRequest.cs
@@ -45,11 +45,6 @@ namespace Orleans.CodeGeneration
                 return $"InvokeMethodRequest {this.InterfaceId}:{this.MethodId}";
             }
         }
-
-        private void GetInterfaceAndMethodName()
-        {
-
-        }
     }
 
     /// <summary>

--- a/src/Orleans.Core.Abstractions/IDs/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/UniqueKey.cs
@@ -342,6 +342,22 @@ namespace Orleans.Runtime
             return s.ToString();
         }
 
+        internal string ToGrainKeyString()
+        {
+            string keyString;
+            if (HasKeyExt)
+            {
+                string extension;
+                keyString = IsLongKey ? PrimaryKeyToLong(out extension).ToString() : PrimaryKeyToGuid(out extension).ToString();
+                keyString = $"{keyString}+{extension}";
+            }
+            else
+            {
+                keyString = this.IsLongKey ? PrimaryKeyToLong().ToString() : this.PrimaryKeyToGuid().ToString();
+            }
+            return keyString;
+        }
+
         private static void ValidateKeyExt(string keyExt, UInt64 typeCodeData)
         {
             Category category = GetCategory(typeCodeData);

--- a/src/Orleans.Core.Abstractions/Logging/IdLoggingHelper.cs
+++ b/src/Orleans.Core.Abstractions/Logging/IdLoggingHelper.cs
@@ -11,4 +11,9 @@ namespace Orleans
 
         string GetSystemTargetName(GrainId grainId);
     }
+
+    internal interface IInvokeMethodRequestLoggingHelper
+    {
+        void GetInterfaceAndMethodName(int interfaceId, int methodId, out string interfaceName, out string methodName);
+    }
 }

--- a/src/Orleans.Core.Abstractions/Logging/IdLoggingHelper.cs
+++ b/src/Orleans.Core.Abstractions/Logging/IdLoggingHelper.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    internal interface IGrainIdLoggingHelper
+    {
+        string GetGrainTypeName(int typeCode);
+
+        string GetSystemTargetName(GrainId grainId);
+    }
+}

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -119,6 +119,7 @@ namespace Orleans
             services.AddSingleton<ClientLoggingHelper>();
             services.AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, ClientLoggingHelper>();
             services.AddFromExisting<IGrainIdLoggingHelper, ClientLoggingHelper>();
+            services.AddFromExisting<IInvokeMethodRequestLoggingHelper, ClientLoggingHelper>();
         }
     }
 }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -114,6 +114,11 @@ namespace Orleans
             services.AddSingleton<GatewayManager>();
             services.AddSingleton<NetworkingTrace>();
             services.AddSingleton<MessagingTrace>();
+
+            // Logging helpers
+            services.AddSingleton<ClientLoggingHelper>();
+            services.AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, ClientLoggingHelper>();
+            services.AddFromExisting<IGrainIdLoggingHelper, ClientLoggingHelper>();
         }
     }
 }

--- a/src/Orleans.Core/Logging/BaseLoggingHelper.cs
+++ b/src/Orleans.Core/Logging/BaseLoggingHelper.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.ApplicationParts;
+using Orleans.CodeGeneration;
+using Orleans.Metadata;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    internal abstract class BaseLoggingHelper<T> : IGrainIdLoggingHelper, IInvokeMethodRequestLoggingHelper, ILifecycleParticipant<T>
+        where T : ILifecycleObservable
+    {
+        protected readonly IRuntimeClient runtimeClient;
+        protected readonly Dictionary<int, (string InterfaceName, Dictionary<int, string> Methods)> interfaceMethodMap
+            = new Dictionary<int, (string Name, Dictionary<int, string> Methods)>();
+
+        public BaseLoggingHelper(IRuntimeClient runtimeClient, IApplicationPartManager applicationPartManager)
+        {
+            this.runtimeClient = runtimeClient;
+
+            var interfaceFeature = applicationPartManager.CreateAndPopulateFeature<GrainInterfaceFeature>();
+            foreach (var grainInterface in interfaceFeature.Interfaces)
+            {
+                var interfaceType = grainInterface.InterfaceType;
+                var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(interfaceType);
+                var methodMap = new Dictionary<int, string>();
+                foreach (var interfaceMethod in GrainInterfaceUtils.GetMethods(interfaceType))
+                {
+                    methodMap[GrainInterfaceUtils.ComputeMethodId(interfaceMethod)] = interfaceMethod.Name;
+                }
+                this.interfaceMethodMap[interfaceId] = (interfaceType.FullName, methodMap);
+            }
+        }
+
+        public string GetGrainTypeName(int typeCode) => this.runtimeClient.GrainTypeResolver.GetGrainTypeName(typeCode);
+
+        public abstract string GetSystemTargetName(GrainId grainId);
+
+        public void GetInterfaceAndMethodName(int interfaceId, int methodId, out string interfaceName, out string methodName)
+        {
+            if (this.interfaceMethodMap.TryGetValue(interfaceId, out var interfaceInfo))
+            {
+                interfaceName = interfaceInfo.InterfaceName;
+                if (!interfaceInfo.Methods.TryGetValue(methodId, out methodName))
+                {
+                    methodName = methodId.ToString();
+                }
+            }
+            else
+            {
+                interfaceName = interfaceId.ToString();
+                methodName = methodId.ToString();
+            }
+        }
+
+        public void Participate(T lifecycle)
+        {
+            Task Setup(CancellationToken ct)
+            {
+                GrainId.GrainTypeNameMapper = this;
+                InvokeMethodRequest.Helper = this;
+                return Task.CompletedTask;
+            }
+
+            lifecycle.Subscribe<ClientLoggingHelper>(ServiceLifecycleStage.BecomeActive, Setup);
+        }
+    }
+}

--- a/src/Orleans.Core/Logging/ClientLoggingHelper.cs
+++ b/src/Orleans.Core/Logging/ClientLoggingHelper.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    internal class ClientLoggingHelper : IGrainIdLoggingHelper, ILifecycleParticipant<IClusterClientLifecycle>
+    {
+        private readonly IRuntimeClient runtimeClient;
+
+        public ClientLoggingHelper(IRuntimeClient runtimeClient)
+        {
+            this.runtimeClient = runtimeClient;
+        }
+
+        public string GetGrainTypeName(int typeCode) => this.runtimeClient.GrainTypeResolver.GetGrainTypeName(typeCode);
+
+        public string GetSystemTargetName(GrainId grainId) => Constants.SystemTargetName(grainId);
+
+        public void Participate(IClusterClientLifecycle lifecycle)
+        {
+            Task Setup(CancellationToken ct)
+            {
+                GrainId.GrainTypeNameMapper = this;
+                return Task.CompletedTask;
+            }
+
+            lifecycle.Subscribe<ClientLoggingHelper>(ServiceLifecycleStage.BecomeActive, Setup);
+        }
+    }
+}

--- a/src/Orleans.Core/Logging/ClientLoggingHelper.cs
+++ b/src/Orleans.Core/Logging/ClientLoggingHelper.cs
@@ -1,34 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Orleans.ApplicationParts;
 using Orleans.Runtime;
 
 namespace Orleans
 {
-    internal class ClientLoggingHelper : IGrainIdLoggingHelper, ILifecycleParticipant<IClusterClientLifecycle>
+
+    internal sealed class ClientLoggingHelper : BaseLoggingHelper<IClusterClientLifecycle>
     {
-        private readonly IRuntimeClient runtimeClient;
-
-        public ClientLoggingHelper(IRuntimeClient runtimeClient)
+        public ClientLoggingHelper(IRuntimeClient runtimeClient, IApplicationPartManager applicationPartManager)
+            : base(runtimeClient, applicationPartManager)
         {
-            this.runtimeClient = runtimeClient;
         }
 
-        public string GetGrainTypeName(int typeCode) => this.runtimeClient.GrainTypeResolver.GetGrainTypeName(typeCode);
-
-        public string GetSystemTargetName(GrainId grainId) => Constants.SystemTargetName(grainId);
-
-        public void Participate(IClusterClientLifecycle lifecycle)
-        {
-            Task Setup(CancellationToken ct)
-            {
-                GrainId.GrainTypeNameMapper = this;
-                return Task.CompletedTask;
-            }
-
-            lifecycle.Subscribe<ClientLoggingHelper>(ServiceLifecycleStage.BecomeActive, Setup);
-        }
+        public override string GetSystemTargetName(GrainId grainId) => Constants.SystemTargetName(grainId);
     }
 }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -458,7 +458,7 @@ namespace Orleans.Runtime
                         break;
                 }
             }
-            return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}",
+            return String.Format("{0}{1}{2}{3}{4} {5}->{6}{7} #{8}{9}",
                 IsReadOnly ? "ReadOnly " : "", //0
                 IsAlwaysInterleave ? "IsAlwaysInterleave " : "", //1
                 IsNewPlacement ? "NewPlacement " : "", // 2
@@ -466,8 +466,9 @@ namespace Orleans.Runtime
                 Direction, //4
                 String.Format("{0}{1}{2}", SendingSilo, SendingGrain, SendingActivation), //5
                 String.Format("{0}{1}{2}{3}", TargetSilo, TargetGrain, TargetActivation, TargetObserverId), //6
-                Id, //7
-                ForwardCount > 0 ? "[ForwardCount=" + ForwardCount + "]" : ""); //8
+                BodyObject is InvokeMethodRequest request ? $" {request.ToString()}" : string.Empty, // 7
+                Id, //8
+                ForwardCount > 0 ? "[ForwardCount=" + ForwardCount + "]" : ""); //9
         }
 
         internal void SetTargetPlacement(PlacementResult value)

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.CodeGeneration;
 using Orleans.Transactions;
 
 namespace Orleans.Runtime

--- a/src/Orleans.Core/Runtime/Constants.cs
+++ b/src/Orleans.Core/Runtime/Constants.cs
@@ -74,11 +74,17 @@ namespace Orleans.Runtime
             {ClientObserverRegistrarId,"ClientObserverRegistrar"},
             {CatalogId,"Catalog"},
             {MembershipOracleId,"MembershipOracle"},
+            {TypeManagerId,"TypeManager"},
+            {FallbackSystemTargetId, "Fallback"},
+            {LifecycleSchedulingSystemTargetId, "LifecycleScheduling"},
+            {DeploymentLoadPublisherSystemTargetId, "DeploymentLoadPublisher"},
             {MultiClusterOracleId,"MultiClusterOracle"},
-            {TypeManagerId,"TypeManagerId"},
+            {ClusterDirectoryServiceId,"ClusterDirectoryService"},
+            {StreamProviderManagerAgentSystemTargetId,"StreamProviderManagerAgent"},
+            {TestHooksSystemTargetId,"TestHooks"},
             {ProtocolGatewayId,"ProtocolGateway"},
-            {FallbackSystemTargetId, "FallbackSystemTarget"},
-            {DeploymentLoadPublisherSystemTargetId, "DeploymentLoadPublisherSystemTarget"},
+            {TransactionAgentSystemTargetId,"TransactionAgent"},
+            {SystemMembershipTableId,"SystemMembershipTable"},
         };
 
         private static readonly Dictionary<int, string> nonSingletonSystemTargetNames = new Dictionary<int, string>

--- a/src/Orleans.Core/Runtime/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Runtime/GrainTypeResolver.cs
@@ -11,6 +11,7 @@ namespace Orleans.Runtime
         bool TryGetGrainClassData(Type grainInterfaceType, out GrainClassData implementation, string grainClassNamePrefix);
         bool TryGetGrainClassData(int grainInterfaceId, out GrainClassData implementation, string grainClassNamePrefix);
         bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation);
+        bool TryGetInterfaceData(int grainInterfaceId, out GrainInterfaceData interfaceData);
         bool IsUnordered(int grainTypeCode);
         string GetLoadedGrainAssemblies();
         string GetGrainTypeName(int typeCode);
@@ -92,6 +93,17 @@ namespace Orleans.Runtime
             }
             return false;
         }
+
+        public bool TryGetInterfaceData(int grainInterfaceId, out GrainInterfaceData interfaceData)
+        {
+            if (table.TryGetValue(grainInterfaceId, out interfaceData))
+            {
+                return true;
+            }
+            interfaceData = null;
+            return false;
+        }
+
 
         public string GetLoadedGrainAssemblies()
         {

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -377,6 +377,11 @@ namespace Orleans.Hosting
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, GatewayConnectionListener>();
             services.AddSingleton<SocketSchedulers>();
             services.AddSingleton<SharedMemoryPool>();
+
+            // Logging helpers
+            services.AddSingleton<SiloLoggingHelper>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, SiloLoggingHelper>();
+            services.AddFromExisting<IGrainIdLoggingHelper, SiloLoggingHelper>();
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -382,6 +382,7 @@ namespace Orleans.Hosting
             services.AddSingleton<SiloLoggingHelper>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, SiloLoggingHelper>();
             services.AddFromExisting<IGrainIdLoggingHelper, SiloLoggingHelper>();
+            services.AddFromExisting<IInvokeMethodRequestLoggingHelper, SiloLoggingHelper>();
         }
     }
 }

--- a/src/Orleans.Runtime/Logging/SiloLoggingHelper.cs
+++ b/src/Orleans.Runtime/Logging/SiloLoggingHelper.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+using Orleans.Services;
+
+namespace Orleans
+{
+    internal class SiloLoggingHelper : IGrainIdLoggingHelper, ILifecycleParticipant<ISiloLifecycle>
+    {
+        private readonly IRuntimeClient runtimeClient;
+        private readonly Dictionary<int, string> grainServicesNames = new Dictionary<int, string>();
+
+        public SiloLoggingHelper(IRuntimeClient runtimeClient)
+        {
+            this.runtimeClient = runtimeClient;
+        }
+
+        public string GetGrainTypeName(int typeCode) => this.runtimeClient.GrainTypeResolver.GetGrainTypeName(typeCode);
+
+        public string GetSystemTargetName(GrainId grainId)
+        {
+            // "SystemTarget" can be either a real SystemTarget, or a GrainService
+            var name = Constants.SystemTargetName(grainId);
+            if (!string.IsNullOrEmpty(name))
+            {
+                // It was a real SystemTarget
+                return name;
+            }
+            else
+            {
+                // It should be a grain service
+                if (this.grainServicesNames.TryGetValue(grainId.TypeCode, out name))
+                    return name;
+            }
+
+            return null;
+        }
+
+        public void RegisterGrainService(IGrainService service)
+        {
+            var typeCode = ((ISystemTargetBase)service).GrainId.TypeCode;
+            var name = service.GetType().FullName;
+            this.grainServicesNames.Add(typeCode, name);
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            Task Setup(CancellationToken ct)
+            {
+                GrainId.GrainTypeNameMapper = this;
+                return Task.CompletedTask;
+            }
+
+            lifecycle.Subscribe<SiloLoggingHelper>(ServiceLifecycleStage.BecomeActive, Setup);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Logging/SiloLoggingHelper.cs
+++ b/src/Orleans.Runtime/Logging/SiloLoggingHelper.cs
@@ -1,28 +1,20 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Orleans.CodeGeneration;
+using Orleans.ApplicationParts;
 using Orleans.Runtime;
-using Orleans.Runtime.ReminderService;
 using Orleans.Services;
 
 namespace Orleans
 {
-    internal class SiloLoggingHelper : IGrainIdLoggingHelper, ILifecycleParticipant<ISiloLifecycle>
+    internal class SiloLoggingHelper : BaseLoggingHelper<ISiloLifecycle>
     {
-        private readonly IRuntimeClient runtimeClient;
         private readonly Dictionary<int, string> grainServicesNames = new Dictionary<int, string>();
 
-        public SiloLoggingHelper(IRuntimeClient runtimeClient)
+        public SiloLoggingHelper(IRuntimeClient runtimeClient, IApplicationPartManager applicationPartManager)
+            : base(runtimeClient, applicationPartManager)
         {
-            this.runtimeClient = runtimeClient;
         }
 
-        public string GetGrainTypeName(int typeCode) => this.runtimeClient.GrainTypeResolver.GetGrainTypeName(typeCode);
-
-        public string GetSystemTargetName(GrainId grainId)
+        public override string GetSystemTargetName(GrainId grainId)
         {
             // "SystemTarget" can be either a real SystemTarget, or a GrainService
             var name = Constants.SystemTargetName(grainId);
@@ -46,17 +38,6 @@ namespace Orleans
             var typeCode = ((ISystemTargetBase)service).GrainId.TypeCode;
             var name = service.GetType().FullName;
             this.grainServicesNames.Add(typeCode, name);
-        }
-
-        public void Participate(ISiloLifecycle lifecycle)
-        {
-            Task Setup(CancellationToken ct)
-            {
-                GrainId.GrainTypeNameMapper = this;
-                return Task.CompletedTask;
-            }
-
-            lifecycle.Subscribe<SiloLoggingHelper>(ServiceLifecycleStage.BecomeActive, Setup);
         }
     }
 }


### PR DESCRIPTION
Currently, when we log a `GrainId`, you see this in your logs:

`[...] Request *cli/2cea48bd@c0bcfeac->S127.0.0.1:40960:0*grn/1688AE7A/bdcdc9a6 [...]`

With this PR, it will be

`[...] Request *cli/cb9755b0@3437749e->S127.0.0.1:40406:0*grn/UnitTests.Grains.EchoTaskGrain/7aef23f0-713b-451c-97de-ac0dbc629f71 [...]`

It should greatly improve the logging/debugging experience.

Related issue: #3852