### PR TITLE
Fix race in shutdown WorkItemGroups

### DIFF
--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -440,7 +440,7 @@ namespace Orleans.Runtime.Scheduler
                 // If our run list is empty, then we're waiting.
                 lock (lockable)
                 {
-                    if (WorkItemCount > 0 && !this.IsShutdown)
+                    if (WorkItemCount > 0)
                     {
                         state = WorkGroupStatus.Runnable;
                         ScheduleExecution(this);


### PR DESCRIPTION
There is a minute chance of hitting a race in `WorkItemGroup` when a task is enqueued between the time the dequeue lock in `Enqueue` is exited and the time the `finally` lock is entered, if the `WorkItemGroup` is in a shutdown state. 

Found by inspection. I'm not sure that this has ever been hit, it's a very minor case.

The bug was introduced when I changed `WorkItemGroup` from denying execution after shutdown to allowing it (with a warning/error log).