### PR TITLE
Avoid race for stateless worker grains with activation limit #6795

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -462,7 +462,16 @@ namespace Orleans.Runtime
                             // It's a bit hacky since we will return an activation with a different
                             // ActivationId than the one requested, but StatelessWorker are local only,
                             // so no need to clear the cache. This will avoid unecessary and costly redirects.
-                            return StatelessWorkerDirector.PickRandom(local);
+                            var redirect = StatelessWorkerDirector.PickRandom(local);
+                            if (logger.IsEnabled(LogLevel.Debug))
+                            {
+                                logger.LogDebug(
+                                    (int)ErrorCode.Catalog_DuplicateActivation,
+                                    "Trying to create too many {GrainType} activations on this silo. Redirecting to activation {RedirectActivation}",
+                                    result.Name,
+                                    redirect.ActivationId);
+                            }
+                            return redirect;
                         }
                         // The newly created StatelessWorker will be registered in RegisterMessageTarget()
                     }

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -96,6 +96,20 @@ namespace DefaultCluster.Tests.General
             }
         }
 
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
+        public async Task ManyConcurrentInvocationsOnActivationLimitedStatelessWorkerDoesNotFail()
+        {
+            // Issue #6795: significantly more concurrent invocations than the local worker limit results in too many
+            // message forwards. When the issue occurs, this test will throw an exception.
+
+            // We are trying to trigger a race condition and need more than 1 attempt to reliably reproduce the issue.
+            for (var attempt = 0; attempt < 100; attempt ++)
+            {
+                var grain = this.GrainFactory.GetGrain<IStatelessWorkerGrain>(attempt);
+                await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => grain.DummyCall()));
+            }
+        }
+
         [SkippableFact(Skip = "Skipping test for now, since there seems to be a bug"), TestCategory("Functional"), TestCategory("StatelessWorker")]
         public async Task StatelessWorkerFastActivationsDontFailInMultiSiloDeployment()
         {

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerGrain.cs
@@ -9,5 +9,7 @@ namespace UnitTests.GrainInterfaces
     {
         Task LongCall();
         Task<Tuple<Guid, string, List<Tuple<DateTime, DateTime>>>> GetCallStats();
+
+        Task DummyCall();
     }
 }

--- a/test/Grains/TestGrains/StatelessWorkerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerGrain.cs
@@ -77,5 +77,7 @@ namespace UnitTests.Grains
             logger.Info($"# allActivationIds {ids.Count} for silo {silo}: {Utils.EnumerableToString(ids)}");
             return Task.FromResult(Tuple.Create(activationGuid, silo, calls));
         }
+
+        public Task DummyCall() => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
When too many activations of a stateless worker grain are created due to many concurrent invocations on a not-yet-activated grain that has a small activation limit, redirect messages from surplus activations to random valid activations, and not to any random activation. The latter would result in redirecting to another invalid activation too many times, triggering message redirect limit exceeded exceptions.