### PR TITLE
Probe silos indirectly before submitting a vote

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -117,5 +117,10 @@ namespace Orleans.Configuration
         /// Whether to extend the effective <see cref="ProbeTimeout"/> value based upon current local health degradation.
         /// </summary>
         public bool ExtendProbeTimeoutDuringDegradation { get; set; } = false;
+
+        /// <summary>
+        /// Whether to enable probing silos indirectly, via other silos.
+        /// </summary>
+        public bool EnableIndirectProbes { get; set; } = false;
     }
 }

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipService.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 
@@ -26,5 +27,37 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="pingNumber">A unique sequence number for ping message, to facilitate testing and debugging.</param>
         Task Ping(int pingNumber);
+
+        Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber);
+    }
+
+    /// <summary>
+    /// Represents the result of probing a node via an intermediary node.
+    /// </summary>
+    [Serializable]
+    public struct IndirectProbeResponse
+    {
+        /// <summary>
+        /// The health score of the intermediary node.
+        /// </summary>
+        public int IntermediaryHealthScore { get; set; }
+
+        /// <summary>
+        /// <see langword="true"/> if the probe succeeded; otherwise, <see langword="false"/>.
+        /// </summary>
+        public bool Succeeded { get; set; }
+
+        /// <summary>
+        /// The duration of the probe attempt.
+        /// </summary>
+        public TimeSpan ProbeResponseTime { get; set; }
+
+        /// <summary>
+        /// The failure message if the probe did not succeed.
+        /// </summary>
+        public string FailureMessage { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString() => $"IndirectProbeResponse {{ Succeeded: {Succeeded}, IntermediaryHealthScore: {IntermediaryHealthScore}, ProbeResponseTime: {ProbeResponseTime}, FailureMessage: {FailureMessage} }}";
     }
 }

--- a/src/Orleans.Runtime/Core/SystemTargetExtensions.cs
+++ b/src/Orleans.Runtime/Core/SystemTargetExtensions.cs
@@ -26,6 +26,17 @@ namespace Orleans.Runtime
         /// <param name="self">The <see cref="SystemTarget"/>.</param>
         /// <param name="action">The action.</param>
         /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
+        public static Task<T> ScheduleTask<T>(this SystemTarget self, Func<Task<T>> action)
+        {
+            return self.RuntimeClient.Scheduler.RunOrQueueTask(action, self);
+        }
+
+        /// <summary>
+        /// Schedules the provided <paramref name="action"/> on the <see cref="SystemTarget"/>.
+        /// </summary>
+        /// <param name="self">The <see cref="SystemTarget"/>.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
         public static Task ScheduleTask(this SystemTarget self, Action action)
         {
             return self.RuntimeClient.Scheduler.RunOrQueueAction(action, self);

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -228,6 +228,12 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         private async Task OnProbeResultInternal(SiloHealthMonitor monitor, ProbeResult probeResult)
         {
+            // Do not act on probe results if shutdown is in progress.
+            if (this.shutdownCancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (probeResult.IsDirectProbe)
             {
                 if (probeResult.Status == ProbeResultStatus.Failed && probeResult.FailedProbeCount >= this.clusterMembershipOptions.CurrentValue.NumMissedProbesLimit)

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -35,7 +35,20 @@ namespace Orleans.Runtime
             this.fatalErrorHandler = fatalErrorHandler;
         }
 
-        public ClusterMembershipSnapshot CurrentSnapshot => this.snapshot;
+        public ClusterMembershipSnapshot CurrentSnapshot
+        {
+            get
+            {
+                var tableSnapshot = this.membershipTableManager.MembershipTableSnapshot;
+                if (this.snapshot.Version == tableSnapshot.Version)
+                {
+                    return this.snapshot;
+                }
+
+                this.updates.TryPublish(tableSnapshot.CreateClusterMembershipSnapshot());
+                return this.snapshot;
+            }
+        }
 
         public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => this.updates;
 

--- a/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
+++ b/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
@@ -17,5 +17,14 @@ namespace Orleans.Runtime.MembershipService
         /// A <see cref="Task"/> which completes when the probe returns successfully and faults when the probe fails.
         /// </returns>
         Task Probe(SiloAddress silo, int probeNumber);
+
+        /// <summary>
+        /// Probes the specified <paramref name="target"/> indirectly, via <paramref name="intermediary"/>.
+        /// </summary>
+        /// <param name="intermediary">The silo which will perform a direct probe.</param>
+        /// <param name="target">The silo which will be probed.</param>
+        /// <param name="probeTimeout">The timeout which the <paramref name="intermediary" /> should apply to the probe.</param>
+        /// <param name="probeNumber">The probe number for diagnostic purposes.</param>
+        Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber);
     }
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -63,6 +63,57 @@ namespace Orleans.Runtime.MembershipService
         /// <returns>The result of pinging the remote silo.</returns>
         public Task ProbeRemoteSilo(SiloAddress remoteSilo, int probeNumber) => this.ScheduleTask(() => ProbeInternal(remoteSilo, probeNumber));
 
+        /// <summary>
+        /// Send a ping to a remote silo via an intermediary silo. This is intended to be called from a <see cref="SiloHealthMonitor"/>
+        /// in order to initiate the call from the <see cref="MembershipSystemTarget"/>'s context
+        /// </summary>
+        /// <param name="intermediary">The intermediary which will directly probe the target.</param>
+        /// <param name="target">The target which will be probed.</param>
+        /// <param name="probeTimeout">The timeout for the eventual direct probe request.</param>
+        /// <param name="probeNumber">The probe number, for diagnostic purposes.</param>
+        /// <returns>The result of pinging the remote silo.</returns>
+        public Task<IndirectProbeResponse> ProbeRemoteSiloIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            Task<IndirectProbeResponse> ProbeIndirectly()
+            {
+                var remoteOracle = this.grainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleType, intermediary);
+                return remoteOracle.ProbeIndirectly(target, probeTimeout, probeNumber);
+            }
+
+            return this.ScheduleTask(ProbeIndirectly);
+        }
+
+        public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            IndirectProbeResponse result;
+            var healthScore = this.ActivationServices.GetRequiredService<LocalSiloHealthMonitor>().GetLocalHealthDegradationScore(DateTime.UtcNow);
+            var probeResponseTimer = ValueStopwatch.StartNew();
+            try
+            {
+                var probeTask = this.ProbeInternal(target, probeNumber);
+                await probeTask.WithTimeout(probeTimeout, exceptionMessage: $"Requested probe timeout {probeTimeout} exceeded");
+
+                result = new IndirectProbeResponse
+                {
+                    Succeeded = true,
+                    IntermediaryHealthScore = healthScore,
+                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                };
+            }
+            catch (Exception exception)
+            {
+                result = new IndirectProbeResponse
+                {
+                    Succeeded = false,
+                    IntermediaryHealthScore = healthScore,
+                    FailureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}",
+                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                };
+            }
+
+            return result;
+        }
+
         public Task GossipToRemoteSilos(
             List<SiloAddress> gossipPartners,
             MembershipTableSnapshot snapshot,

--- a/src/Orleans.Runtime/MembershipService/RemoteSiloProber.cs
+++ b/src/Orleans.Runtime/MembershipService/RemoteSiloProber.cs
@@ -20,5 +20,12 @@ namespace Orleans.Runtime.MembershipService
             var systemTarget = this.serviceProvider.GetRequiredService<MembershipSystemTarget>();
             return systemTarget.ProbeRemoteSilo(remoteSilo, probeNumber);
         }
+
+        /// <inheritdoc />
+        public Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            var systemTarget = this.serviceProvider.GetRequiredService<MembershipSystemTarget>();
+            return systemTarget.ProbeRemoteSiloIndirectly(intermediary, target, probeTimeout, probeNumber);
+        }
     }
 }

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -116,7 +116,9 @@ namespace NonSilo.Tests.Membership
                 this.loggerFactory,
                 this.prober,
                 this.timerFactory,
-                this.localSiloHealthMonitor);
+                this.localSiloHealthMonitor,
+                this.manager,
+                this.localSiloDetails);
 
             await this.lifecycle.OnStart();
             Assert.Empty(testAccessor.MonitoredSilos);

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
+++ b/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
@@ -39,6 +39,8 @@ namespace NonSilo.Tests.Membership
         private readonly Func<SiloHealthMonitor, SiloHealthMonitor.ProbeResult, Task> onProbeResult;
         private readonly MembershipAgent agent;
         private readonly ILocalSiloHealthMonitor localSiloHealthMonitor;
+        private readonly IOptionsMonitor<ClusterMembershipOptions> optionsMonitor;
+        private readonly IClusterMembershipService membershipService;
 
         public MembershipAgentTests(ITestOutputHelper output)
         {
@@ -85,11 +87,13 @@ namespace NonSilo.Tests.Membership
                 this.lifecycle);
             ((ILifecycleParticipant<ISiloLifecycle>)this.manager).Participate(this.lifecycle);
 
+            this.optionsMonitor = Substitute.For<IOptionsMonitor<ClusterMembershipOptions>>();
+            this.optionsMonitor.CurrentValue.ReturnsForAnyArgs(this.clusterMembershipOptions.Value);
             this.clusterHealthMonitor = new ClusterHealthMonitor(
                 this.localSiloDetails,
                 this.manager,
                 this.loggerFactory.CreateLogger<ClusterHealthMonitor>(),
-                this.clusterMembershipOptions,
+                optionsMonitor,
                 this.fatalErrorHandler,
                 null);
             ((ILifecycleParticipant<ISiloLifecycle>)this.clusterHealthMonitor).Participate(this.lifecycle);
@@ -111,6 +115,9 @@ namespace NonSilo.Tests.Membership
                 this.timerFactory,
                 this.remoteSiloProber);
             ((ILifecycleParticipant<ISiloLifecycle>)this.agent).Participate(this.lifecycle);
+
+            this.membershipService = Substitute.For<IClusterMembershipService>();
+            this.membershipService.CurrentSnapshot.ReturnsForAnyArgs(info => this.manager.MembershipTableSnapshot.CreateClusterMembershipSnapshot());
         }
 
         [Fact]
@@ -268,7 +275,16 @@ namespace NonSilo.Tests.Membership
             Func<SiloHealthMonitor, SiloHealthMonitor.ProbeResult, Task> onProbeResult = (siloHealthMonitor, probeResult) => Task.CompletedTask;
 
             var clusterHealthMonitorTestAccessor = (ClusterHealthMonitor.ITestAccessor)this.clusterHealthMonitor;
-            clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(silo, onProbeResult, this.clusterMembershipOptions, this.loggerFactory, remoteSiloProber, this.timerFactory, this.localSiloHealthMonitor, this.manager, this.localSiloDetails);
+            clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(
+                silo,
+                onProbeResult,
+                this.optionsMonitor,
+                this.loggerFactory,
+                remoteSiloProber,
+                this.timerFactory,
+                this.localSiloHealthMonitor,
+                this.membershipService,
+                this.localSiloDetails);
             var started = this.lifecycle.OnStart();
 
             await Until(() => remoteSiloProber.ReceivedCalls().Count() < otherSilos.Length);
@@ -317,12 +333,12 @@ namespace NonSilo.Tests.Membership
             clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(
                 silo,
                 this.onProbeResult,
-                Options.Create(new ClusterMembershipOptions()),
+                this.optionsMonitor,
                 this.loggerFactory,
                 this.remoteSiloProber,
                 this.timerFactory,
                 this.localSiloHealthMonitor,
-                this.manager,
+                this.membershipService,
                 this.localSiloDetails);
             var started = this.lifecycle.OnStart();
 

--- a/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
+++ b/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
@@ -268,7 +268,7 @@ namespace NonSilo.Tests.Membership
             Func<SiloHealthMonitor, SiloHealthMonitor.ProbeResult, Task> onProbeResult = (siloHealthMonitor, probeResult) => Task.CompletedTask;
 
             var clusterHealthMonitorTestAccessor = (ClusterHealthMonitor.ITestAccessor)this.clusterHealthMonitor;
-            clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(silo, onProbeResult, this.clusterMembershipOptions, this.loggerFactory, remoteSiloProber, this.timerFactory, this.localSiloHealthMonitor);
+            clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(silo, onProbeResult, this.clusterMembershipOptions, this.loggerFactory, remoteSiloProber, this.timerFactory, this.localSiloHealthMonitor, this.manager, this.localSiloDetails);
             var started = this.lifecycle.OnStart();
 
             await Until(() => remoteSiloProber.ReceivedCalls().Count() < otherSilos.Length);
@@ -321,7 +321,9 @@ namespace NonSilo.Tests.Membership
                 this.loggerFactory,
                 this.remoteSiloProber,
                 this.timerFactory,
-                this.localSiloHealthMonitor);
+                this.localSiloHealthMonitor,
+                this.manager,
+                this.localSiloDetails);
             var started = this.lifecycle.OnStart();
 
             await Until(() => this.remoteSiloProber.ReceivedCalls().Count() < otherSilos.Length);

--- a/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NonSilo.Tests.Utilities;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT")]
+    public class SiloHealthMonitorTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly LoggerFactory _loggerFactory;
+        private readonly ILocalSiloDetails _localSiloDetails;
+        private readonly SiloAddress _localSilo;
+        private readonly List<DelegateAsyncTimer> _timers;
+        private readonly Channel<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)> _timerCalls;
+        private readonly DelegateAsyncTimerFactory _timerFactory;
+        private readonly ILocalSiloHealthMonitor _localSiloHealthMonitor;
+        private readonly IRemoteSiloProber _prober;
+        private readonly IClusterMembershipService _membershipService;
+        private ClusterMembershipOptions _clusterMembershipOptions;
+        private readonly IOptionsMonitor<ClusterMembershipOptions> _optionsMonitor;
+        private readonly Channel<ProbeResult> _probeResults;
+        private readonly SiloHealthMonitor _monitor;
+        private ClusterMembershipSnapshot _membershipSnapshot;
+
+        public SiloHealthMonitorTests(ITestOutputHelper output)
+        {
+            MessagingStatisticsGroup.Init();
+            _output = output;
+            _loggerFactory = new LoggerFactory(new[] { new XunitLoggerProvider(_output) });
+
+            _localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            _localSilo = Silo("127.0.0.1:100@100");
+            _localSiloDetails.SiloAddress.Returns(_localSilo);
+            _localSiloDetails.DnsHostName.Returns("MyServer11");
+            _localSiloDetails.Name.Returns(Guid.NewGuid().ToString("N"));
+
+            _timers = new List<DelegateAsyncTimer>();
+            _timerCalls = Channel.CreateUnbounded<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)>();
+            _timerFactory = new DelegateAsyncTimerFactory(
+                (period, name) =>
+                {
+                    var t = new DelegateAsyncTimer(
+                        overridePeriod =>
+                        {
+                            var task = new TaskCompletionSource<bool>();
+                            _timerCalls.Writer.TryWrite((overridePeriod, task));
+                            return task.Task;
+                        });
+                    _timers.Add(t);
+                    return t;
+                });
+
+            _localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
+            _localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+
+            _prober = Substitute.For<IRemoteSiloProber>();
+
+            _membershipService = Substitute.For<IClusterMembershipService>();
+
+            _clusterMembershipOptions = new ClusterMembershipOptions();
+            _optionsMonitor = Substitute.For<IOptionsMonitor<ClusterMembershipOptions>>();
+            _optionsMonitor.CurrentValue.ReturnsForAnyArgs(info => _clusterMembershipOptions);
+
+            _probeResults = Channel.CreateBounded<ProbeResult>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.Wait });
+            Func<SiloHealthMonitor, ProbeResult, Task> onProbeResult = (mon, res) => _probeResults.Writer.WriteAsync(res).AsTask();
+
+            _membershipSnapshot = Snapshot(
+                1,
+                Member(_localSilo, SiloStatus.Active),
+                Member(Silo("127.0.0.200:100@100"), SiloStatus.Active));
+            _membershipService.CurrentSnapshot.ReturnsForAnyArgs(info => _membershipSnapshot);
+
+            _monitor = new SiloHealthMonitor(
+                Silo("127.0.0.200:100@100"),
+                onProbeResult,
+                _optionsMonitor,
+                _loggerFactory,
+                _prober,
+                _timerFactory,
+                _localSiloHealthMonitor,
+                _membershipService,
+                _localSiloDetails);
+        }
+
+        private async Task Shutdown()
+        {
+            var stopTask = _monitor.StopAsync(CancellationToken.None);
+
+            Task.Run(async () =>
+            {
+                while (!stopTask.IsCompleted && await _timerCalls.Reader.WaitToReadAsync())
+                {
+                    while (_timerCalls.Reader.TryRead(out var timerCall))
+                    {
+                        timerCall.Completion.TrySetResult(false);
+                    }
+                }
+            }).Ignore();
+
+            await stopTask;
+            _timerCalls.Writer.TryComplete();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_SuccessfulProbe()
+        {
+            _prober.Probe(default, default).ReturnsForAnyArgs(Task.CompletedTask);
+            _prober.ProbeIndirectly(default, default, default, default).ThrowsForAnyArgs(new InvalidOperationException("No"));
+
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // Check the resulting probe result.
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
+            Assert.Equal(0, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            await Shutdown();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_FailedProbe()
+        {
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+
+            _prober.Probe(default, default).ReturnsForAnyArgs(info => Task.Delay(TimeSpan.FromSeconds(3)));
+            _prober.ProbeIndirectly(default, default, default, default).ThrowsForAnyArgs(new InvalidOperationException("No"));
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(1, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Throw directly, instead of timing out the probe
+            _prober.Probe(default, default).ThrowsForAnyArgs(new Exception("nope"));
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(2, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            await Shutdown();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_Indirect_FailedProbe()
+        {
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.EnableIndirectProbes = true;
+
+            _prober.Probe(default, default).ThrowsForAnyArgs(info => new Exception("nonono!"));
+            _prober.ProbeIndirectly(default, default, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            {
+                FailureMessage = "fail",
+                IntermediaryHealthScore = 0,
+                ProbeResponseTime = TimeSpan.FromSeconds(1),
+                Succeeded = false
+            });
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(1, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var otherSilo = Silo("127.0.0.1:1234@1234");
+            _membershipSnapshot = Snapshot(2, Member(_localSilo, SiloStatus.Active), Member(_monitor.SiloAddress, SiloStatus.Active), Member(otherSilo, SiloStatus.Joining));
+
+            // There is only one other active silo (the target silo), so an indirect probe cannot be performed.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(2, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Make the other silo active so that there is an intermediary to use for an indirect probe.
+            _membershipSnapshot = Snapshot(3, Member(_localSilo, SiloStatus.Active), Member(_monitor.SiloAddress, SiloStatus.Active), Member(otherSilo, SiloStatus.Active));
+
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // Since there is another active silo, an indirect probe will be performed.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(3, probeResult.FailedProbeCount);
+            Assert.False(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that the correct intermediary was selected.
+            var probeCall = _prober.ReceivedCalls().Single();
+            var args = probeCall.GetArguments();
+            var intermediary = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(otherSilo, intermediary);
+
+            // Ensure that negative results from unhealthy intermediaries are not considered.
+            _prober.ProbeIndirectly(default, default, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            {
+                FailureMessage = "fail",
+                IntermediaryHealthScore = 1,
+                ProbeResponseTime = TimeSpan.FromSeconds(1),
+                Succeeded = false
+            });
+
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // The number of failed probes should not be incremented, the status should be "unknown", and the health score should be 1.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Unknown, probeResult.Status);
+            Assert.Equal(3, probeResult.FailedProbeCount);
+            Assert.False(probeResult.IsDirectProbe);
+            Assert.Equal(1, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that the correct intermediary was selected.
+            probeCall = _prober.ReceivedCalls().Single();
+            args = probeCall.GetArguments();
+            intermediary = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(otherSilo, intermediary);
+
+            // After seeing that the chosen intermediary is unhealthy, a subsequent probe should be
+            // performed directly (since there are no other silos to use as an intermediary).
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(4, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that it was the target that was probed directly.
+            probeCall = _prober.ReceivedCalls().Single();
+            args = probeCall.GetArguments();
+            var target = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(_monitor.SiloAddress, target);
+
+            await Shutdown();
+        }
+
+        private static ClusterMembershipSnapshot Snapshot(long version, params ClusterMember[] members)
+            => new ClusterMembershipSnapshot(
+                ImmutableDictionary.CreateRange(
+                    members.Select(m => new KeyValuePair<SiloAddress, ClusterMember>(m.SiloAddress, m))),
+                new MembershipVersion(version));
+
+        private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
+
+        private static ClusterMember Member(SiloAddress address, SiloStatus status) => new ClusterMember(address, status, address.ToString());
+    }
+}

--- a/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
@@ -22,7 +22,7 @@ using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
 
 namespace NonSilo.Tests.Membership
 {
-    [TestCategory("BVT")]
+    [TestCategory("BVT"), TestCategory("Membership")]
     public class SiloHealthMonitorTests
     {
         private readonly ITestOutputHelper _output;


### PR DESCRIPTION
This is part 2 of the Lifeguard-inspired changes to cluster membership management. For the original PR and discussion: #6745

This PR adds support for indirectly pinging silos before suspecting/declaring them dead.
When a silo is one missed probe away from being voted, the monitoring silo switches to indirect pings. In this mode, the silo picks a random other silo and sends it a request to probe the target silo. If that silo responds promptly with a negative acknowledgement (after waiting for a specified timeout), then the silo will be suspected/declared dead.

Additionally, when the vote limit to declare a silo dead is 2 silos, a negative acknowledgement counts for both required votes and the silos is unilaterally declared dead.

The feature is disabled by default - only direct probes are used by-default - but could be enabled in a later release, or by users by setting `ClusterMembershipOptions.EnableIndirectProbes` to `true`.