### PR TITLE
Port: Avoid race for stateless worker grains with activation limit #6795

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -511,6 +511,29 @@ namespace Orleans.Runtime
 
                 if (newPlacement && !SiloStatusOracle.CurrentStatus.IsTerminating())
                 {
+                    if (placement is StatelessWorkerPlacement st)
+                    {
+                        // Check if there is already enough StatelessWorker created
+                        if (LocalLookup(address.Grain, out var local) && local.Count > st.MaxLocal)
+                        {
+                            // Redirect directly to an already created StatelessWorker
+                            // It's a bit hacky since we will return an activation with a different
+                            // ActivationId than the one requested, but StatelessWorker are local only,
+                            // so no need to clear the cache. This will avoid unecessary and costly redirects.
+                            var redirect = StatelessWorkerDirector.PickRandom(local);
+                            if (logger.IsEnabled(LogLevel.Debug))
+                            {
+                                logger.LogDebug(
+                                    (int)ErrorCode.Catalog_DuplicateActivation,
+                                    "Trying to create too many {GrainType} activations on this silo. Redirecting to activation {RedirectActivation}",
+                                    result.Name,
+                                    redirect.ActivationId);
+                            }
+                            return redirect;
+                        }
+                        // The newly created StatelessWorker will be registered in RegisterMessageTarget()
+                    }
+
                     TimeSpan ageLimit = this.collectionOptions.Value.ClassSpecificCollectionAge.TryGetValue(grainType, out TimeSpan limit)
                         ? limit
                         : collectionOptions.Value.CollectionAge;
@@ -1155,16 +1178,8 @@ namespace Orleans.Runtime
             else if (activation.PlacedUsing is StatelessWorkerPlacement stPlacement)
             {
                 // Stateless workers are not registered in the directory and can have multiple local activations.
-                int maxNumLocalActivations = stPlacement.MaxLocal;
-                lock (activations)
-                {
-                    List<ActivationData> local;
-                    if (!LocalLookup(address.Grain, out local) || local.Count <= maxNumLocalActivations)
-                        return ActivationRegistrationResult.Success;
-
-                    var id = StatelessWorkerDirector.PickRandom(local).Address;
-                    return new ActivationRegistrationResult(existingActivationAddress: id);
-                }
+                // We already checked earlier that we didn't created too many instances of this worker
+                return ActivationRegistrationResult.Success;
             }
             else
             {

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -96,6 +96,20 @@ namespace DefaultCluster.Tests.General
             }
         }
 
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
+        public async Task ManyConcurrentInvocationsOnActivationLimitedStatelessWorkerDoesNotFail()
+        {
+            // Issue #6795: significantly more concurrent invocations than the local worker limit results in too many
+            // message forwards. When the issue occurs, this test will throw an exception.
+
+            // We are trying to trigger a race condition and need more than 1 attempt to reliably reproduce the issue.
+            for (var attempt = 0; attempt < 100; attempt ++)
+            {
+                var grain = this.GrainFactory.GetGrain<IStatelessWorkerGrain>(attempt);
+                await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => grain.DummyCall()));
+            }
+        }
+
         [SkippableFact(Skip = "Skipping test for now, since there seems to be a bug"), TestCategory("Functional"), TestCategory("StatelessWorker")]
         public async Task StatelessWorkerFastActivationsDontFailInMultiSiloDeployment()
         {

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerGrain.cs
@@ -9,5 +9,7 @@ namespace UnitTests.GrainInterfaces
     {
         Task LongCall();
         Task<Tuple<Guid, string, List<Tuple<DateTime, DateTime>>>> GetCallStats();
+
+        Task DummyCall();
     }
 }

--- a/test/Grains/TestGrains/StatelessWorkerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerGrain.cs
@@ -77,5 +77,7 @@ namespace UnitTests.Grains
             logger.Info($"# allActivationIds {ids.Count} for silo {silo}: {Utils.EnumerableToString(ids)}");
             return Task.FromResult(Tuple.Create(activationGuid, silo, calls));
         }
+
+        public Task DummyCall() => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
* Fix issue #6795

Co-authored-by: Benjamin Petit <bpetit@microsoft.com>