### PR TITLE
Fix for half and nested generics.

### DIFF
--- a/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
@@ -85,7 +85,7 @@ namespace Orleans.CodeGeneration
             if (t.IsGenericType)
             {
                 var typeName = t.GetGenericTypeDefinition().FullName;
-                return typeName == "System.Threading.Tasks.Task`1" 
+                return typeName == "System.Threading.Tasks.Task`1"
                        || typeName == "System.Threading.Tasks.ValueTask`1";
             }
 
@@ -145,14 +145,14 @@ namespace Orleans.CodeGeneration
 
             if (IsGrainInterface(type))
                 dict.Add(GetGrainInterfaceId(type), type);
-            
+
             Type[] interfaces = type.GetInterfaces();
             foreach (Type interfaceType in interfaces.Where(i => !checkIsGrainInterface || IsGrainInterface(i)))
                 dict.Add(GetGrainInterfaceId(interfaceType), interfaceType);
 
             return dict;
         }
-        
+
         public static int ComputeMethodId(MethodInfo methodInfo)
         {
             var attr = methodInfo.GetCustomAttribute<MethodIdAttribute>(true);
@@ -390,7 +390,7 @@ namespace Orleans.CodeGeneration
             foreach (Type iType in iTypes)
             {
                 var mapping = new InterfaceMapping();
-                
+
                 if (grainType.IsClass)
                     mapping = grainType.GetTypeInfo().GetRuntimeInterfaceMap(iType);
 
@@ -422,12 +422,17 @@ namespace Orleans.CodeGeneration
             var attr = grainInterfaceOrClass.GetCustomAttributes<TypeCodeOverrideAttribute>(false).FirstOrDefault();
             if (attr != null) return attr.TypeCode;
 
-            var fullName = TypeUtils.GetTemplatedName(
-                TypeUtils.GetFullName(grainInterfaceOrClass), 
-                grainInterfaceOrClass,
-                grainInterfaceOrClass.GetGenericArguments(),
-                t => false);
+            var fullName = GetFullName(grainInterfaceOrClass);
             return Utils.CalculateIdHash(fullName);
+        }
+
+        public static string GetFullName(Type grainInterfaceOrClass)
+        {
+            return TypeUtils.GetTemplatedName(
+                TypeUtils.GetFullName(grainInterfaceOrClass),
+                grainInterfaceOrClass,
+                grainInterfaceOrClass.GetGenericArgumentsSafe(),
+                t => false);
         }
     }
 }

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
                     return GetTemplatedName(
                         GetUntemplatedTypeName(type.DeclaringType.Name),
                         type.DeclaringType,
-                        type.GetGenericArguments(),
+                        type.GetGenericArgumentsSafe(),
                         _ => true) + "." + GetUntemplatedTypeName(type.Name);
                 }
 
@@ -99,7 +99,7 @@ namespace Orleans.Runtime
             if (fullName == null)
                 fullName = _ => true; // default to full type names
 
-            if (t.IsGenericType) return GetTemplatedName(GetSimpleTypeName(t, fullName), t, t.GetGenericArguments(), fullName);
+            if (t.IsGenericType) return GetTemplatedName(GetSimpleTypeName(t, fullName), t, t.GetGenericArgumentsSafe(), fullName);
 
             if (t.IsArray)
             {
@@ -117,18 +117,42 @@ namespace Orleans.Runtime
             if (!t.IsGenericType || (t.DeclaringType != null && t.DeclaringType.IsGenericType)) return baseName;
             string s = baseName;
             s += "<";
-            s += GetGenericTypeArgs(t, genericArguments, fullName);
+            s += GetGenericTypeArgs(genericArguments, fullName);
             s += ">";
             return s;
         }
 
-        public static string GetGenericTypeArgs(Type originalType, IEnumerable<Type> args, Predicate<Type> fullName)
+        public static Type[] GetGenericArgumentsSafe(this Type type)
+        {
+            var result = type.GetGenericArguments();
+
+            if (type.ContainsGenericParameters)
+            {
+                // Get generic parameter from generic type definition to have consistent naming for inherited interfaces
+                // Example: interface IA<TName>, class A<TOtherName>: IA<OtherName>
+                // in this case generic parameter name of IA interface from class A is OtherName instead of TName.
+                // To avoid this situation use generic parameter from generic type definition.
+                // Matching by position in array, because GenericParameterPosition is number across generic parameters.
+                // For half open generic types (IA<int,T>) T will have position 0.
+                var originalGenericArguments = type.GetGenericTypeDefinition().GetGenericArguments();
+                if (result.Length != originalGenericArguments.Length) // this check may be redunant
+                    return result;
+
+                for (int i = 0; i < result.Length; i++)
+                {
+                    if (result[i].IsGenericParameter)
+                        result[i] = originalGenericArguments[i];
+                }
+            }
+            return result;
+        }
+
+        public static string GetGenericTypeArgs(IEnumerable<Type> args, Predicate<Type> fullName)
         {
             string s = string.Empty;
 
             bool first = true;
-            var genericTypeDefinition = originalType.GetGenericTypeDefinition();
-            var originalGenericArguments = genericTypeDefinition.GetGenericArguments();
+
             foreach (var genericParameter in args)
             {
                 if (!first)
@@ -138,18 +162,7 @@ namespace Orleans.Runtime
 
                 if (!genericParameter.IsGenericType)
                 {
-                    var nonGenericType = genericParameter;
-                    
-                    // get generic parameter from generic type definition to have consistent naming for inherited interfaces
-                    // Example: interface IA<TName>, class A<TOtherName>: IA<OtherName>
-                    // in this case generic parameter name of IA interface from class A is OtherName instead of TName.
-                    // To avoid this situation use generic parameter from generic type definition.
-                    if (genericParameter.IsGenericParameter)
-                    {
-                        nonGenericType = originalGenericArguments[genericParameter.GenericParameterPosition];
-                    }
-
-                    s += GetSimpleTypeName(nonGenericType, fullName);
+                    s += GetSimpleTypeName(genericParameter, fullName);
                 }
                 else
                 {

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -350,6 +350,11 @@ namespace Orleans.Runtime
                        + new string(',', t.GetArrayRank() - 1)
                        + "]";
             }
+
+            // using of t.FullName breaks interop with core and full .net in one cluster, because
+            // FullName of types from corelib is different.
+            // .net core int: [System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]
+            // full .net int: [System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]
             return t.FullName ?? (t.IsGenericParameter ? t.Name : t.Namespace + "." + t.Name);
         }
 

--- a/test/CodeGeneration/CodeGenerator.Tests/RoslynTypeNameFormatterTests.cs
+++ b/test/CodeGeneration/CodeGenerator.Tests/RoslynTypeNameFormatterTests.cs
@@ -180,7 +180,7 @@ namespace CodeGenerator.Tests
                     var expected = TypeUtils.GetTemplatedName(
                         TypeUtils.GetFullName(type),
                         type,
-                        type.GetGenericArguments(),
+                        type.GetGenericArgumentsSafe(),
                         t => false);
                     var named = Assert.IsAssignableFrom<INamedTypeSymbol>(symbol);
                     var actual = OrleansLegacyCompat.FormatTypeForIdComputation(named);

--- a/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
+++ b/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
@@ -5,7 +5,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
+    public class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
     {
         protected int T { get; set; }
 
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
         }
     }
 
-    class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
+    public class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
     {
         protected float T { get; set; }
 
@@ -37,7 +37,7 @@ namespace UnitTests.Grains
         }
     }
 
-    class ConcreteGrainWith2GenericInterfaces: Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
+    public class ConcreteGrainWith2GenericInterfaces : Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
     {
         // IGenericGrain<int, string> methods:
 
@@ -72,7 +72,7 @@ namespace UnitTests.Grains
             return Task.FromResult(T);
         }
 
-        public Task CompareGrainReferences(ISimpleGenericGrain<int> clientReference) 
+        public Task CompareGrainReferences(ISimpleGenericGrain<int> clientReference)
         {
             throw new NotImplementedException();
         }

--- a/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
+++ b/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
@@ -5,7 +5,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    public class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
+    class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
     {
         protected int T { get; set; }
 
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
         }
     }
 
-    public class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
+    class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
     {
         protected float T { get; set; }
 
@@ -37,7 +37,7 @@ namespace UnitTests.Grains
         }
     }
 
-    public class ConcreteGrainWith2GenericInterfaces : Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
+    class ConcreteGrainWith2GenericInterfaces : Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
     {
         // IGenericGrain<int, string> methods:
 

--- a/test/Grains/TestGrains/SpecializedSimpleGenericGrain.cs
+++ b/test/Grains/TestGrains/SpecializedSimpleGenericGrain.cs
@@ -3,7 +3,7 @@ using Orleans;
 
 namespace UnitTests.Grains
 {
-    class SpecializedSimpleGenericGrain : SimpleGenericGrain<double>
+    public class SpecializedSimpleGenericGrain : SimpleGenericGrain<double>
     {
         public override Task Transform()
         {

--- a/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
+++ b/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
@@ -7,12 +7,20 @@ using Orleans.CodeGeneration;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NonSilo.Tests.General
 {
     [TestCategory("BVT")]
     public class GrainInterfaceUtilsTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public GrainInterfaceUtilsTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void Override_MethodId_Test()
         {
@@ -90,6 +98,7 @@ namespace NonSilo.Tests.General
             "UnitTests.GrainInterfaces.IGenericReader3`3<TOne,TTwo,TThree>",
             "UnitTests.GrainInterfaces.IGenericReader2`2<TOne,TTwo>")]
 
+        [InlineData(typeof(OpenGeneric<,>), "NonSilo.Tests.General.IHalfOpenGrain`2<T1,T2>")]
         [InlineData(typeof(HalfOpenGrain1<>), "NonSilo.Tests.General.IHalfOpenGrain`2<T1,Int32>")]
         [InlineData(typeof(HalfOpenGrain2<>), "NonSilo.Tests.General.IHalfOpenGrain`2<Int32,T2>")]
         [InlineData(typeof(Root<>.G<,,>), "NonSilo.Tests.General.IG`1<Root<TRoot,T1,T2,T3>.IA>")]
@@ -105,6 +114,9 @@ namespace NonSilo.Tests.General
                 .Select(p => GrainInterfaceUtils.GetFullName(p))
                 .ToArray();
 
+            _testOutputHelper.WriteLine("Expected: " + string.Join(";", expected));
+            _testOutputHelper.WriteLine("Actual: " + string.Join(";", expected));
+
             Assert.Equal(expected, actual);
         }
     }
@@ -115,6 +127,9 @@ namespace NonSilo.Tests.General
     public class HalfOpenGrain1<T> : IHalfOpenGrain<T, int>
     { }
     public class HalfOpenGrain2<T> : IHalfOpenGrain<int, T>
+    { }
+
+    public class OpenGeneric<T2, T1> : IHalfOpenGrain<T2, T1>
     { }
 
     public interface IG<T> : IGrain

--- a/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
+++ b/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Linq;
+using Orleans;
 using Orleans.CodeGeneration;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
@@ -40,6 +41,99 @@ namespace NonSilo.Tests.General
             var expected = GrainInterfaceUtils.GetGrainInterfaceId(typeof(ISimpleGenericGrain<>));
             IDictionary<int, Type> actual = GrainInterfaceUtils.GetRemoteInterfaces(typeof(SimpleGenericGrain<>));
             Assert.Contains(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(typeof(ISimpleGrain), "UnitTests.GrainInterfaces.ISimpleGrain")]
+        [InlineData(typeof(ISimpleGenericGrain<>), "UnitTests.GrainInterfaces.ISimpleGenericGrain`1<T>")]
+        [InlineData(typeof(IGenericGrain<,>), "UnitTests.GrainInterfaces.IGenericGrain`2<T,U>")]
+
+        [InlineData(typeof(IGenericGrainWithGenericState<,,>),
+            "UnitTests.GrainInterfaces.IGenericGrainWithGenericState`3<TFirstTypeParam,TStateType,TLastTypeParam>")]
+
+        [InlineData(typeof(Root<>.IA<,,>), "NonSilo.Tests.General.Root`1.IA`3")]
+        public void GetFullName_Interface(Type interfaceType, string expected)
+        {
+            var actual = GrainInterfaceUtils.GetFullName(interfaceType);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(typeof(SimpleGrain), "UnitTests.GrainInterfaces.ISimpleGrain")]
+        [InlineData(typeof(SimpleGenericGrain<>), "UnitTests.GrainInterfaces.ISimpleGenericGrain`1<T>")]
+        [InlineData(typeof(SimpleGenericGrain2<,>), "UnitTests.GrainInterfaces.ISimpleGenericGrain2`2<T,U>")]
+
+        [InlineData(typeof(SpecializedSimpleGenericGrain),
+            "UnitTests.GrainInterfaces.ISimpleGenericGrain`1[[System.Double, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Double>")]
+
+        [InlineData(typeof(ConcreteGrainWithGenericInterfaceOfIntFloat),
+            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Single, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32,Single>")]
+
+        [InlineData(typeof(ConcreteGrainWithGenericInterfaceOfFloatString),
+            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Single, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Single,String>")]
+        [InlineData(typeof(ConcreteGrainWith2GenericInterfaces),
+            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32,String>",
+            "UnitTests.GrainInterfaces.ISimpleGenericGrain`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32>")]
+
+        [InlineData(typeof(GenericGrainWithGenericState<,,>),
+            "UnitTests.GrainInterfaces.IGenericGrainWithGenericState`3<TFirstTypeParam,TStateType,TLastTypeParam>")]
+
+        [InlineData(typeof(GenericReaderWriterGrain1<>),
+            "UnitTests.GrainInterfaces.IGenericReaderWriterGrain1`1<T>",
+            "UnitTests.GrainInterfaces.IGenericWriter1`1<T>",
+            "UnitTests.GrainInterfaces.IGenericReader1`1<T>")]
+
+        [InlineData(typeof(GenericReaderWriterGrain3<,,>),
+            "UnitTests.GrainInterfaces.IGenericReaderWriterGrain3`3<TOne,TTwo,TThree>",
+            "UnitTests.GrainInterfaces.IGenericWriter3`3<TOne,TTwo,TThree>",
+            "UnitTests.GrainInterfaces.IGenericWriter2`2<TOne,TTwo>",
+            "UnitTests.GrainInterfaces.IGenericReader3`3<TOne,TTwo,TThree>",
+            "UnitTests.GrainInterfaces.IGenericReader2`2<TOne,TTwo>")]
+
+        [InlineData(typeof(HalfOpenGrain1<>), "NonSilo.Tests.General.IHalfOpenGrain`2<T1,Int32>")]
+        [InlineData(typeof(HalfOpenGrain2<>), "NonSilo.Tests.General.IHalfOpenGrain`2<Int32,T2>")]
+        [InlineData(typeof(Root<>.G<,,>), "NonSilo.Tests.General.IG`1<Root<TRoot,T1,T2,T3>.IA>")]
+        [InlineData(typeof(G1<,,,>), "NonSilo.Tests.General.Root`1.IA`3")]
+
+        // broken logic for nested closed generic interfaces in generic class matching
+        [InlineData(typeof(G1<bool, int, string, decimal>), "NonSilo.Tests.General.Root`1.IA`3")]
+        public void GetFullName_ClassInterfaces(Type classType, params string[] expected)
+        {
+            var actual = classType
+                .GetInterfaces()
+                .Where(p => GrainInterfaceUtils.IsGrainInterface(p))
+                .Select(p => GrainInterfaceUtils.GetFullName(p))
+                .ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    public interface IHalfOpenGrain<T1, T2> : IGrainWithGuidKey
+    { }
+
+    public class HalfOpenGrain1<T> : IHalfOpenGrain<T, int>
+    { }
+    public class HalfOpenGrain2<T> : IHalfOpenGrain<int, T>
+    { }
+
+    public interface IG<T> : IGrain
+    {
+    }
+
+    public class G1<T1, T2, T3, T4> : Grain, Root<T1>.IA<T2, T3, T4>
+    {
+    }
+
+    public class Root<TRoot>
+    {
+        public interface IA<T1, T2, T3> : IGrainWithIntegerKey
+        {
+
+        }
+
+        public class G<T1, T2, T3> : Grain, IG<IA<T1, T2, T3>>
+        {
         }
     }
 }

--- a/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
+++ b/test/NonSilo.Tests/General/GrainInterfaceUtilsTests.cs
@@ -71,20 +71,14 @@ namespace NonSilo.Tests.General
         [InlineData(typeof(SimpleGenericGrain<>), "UnitTests.GrainInterfaces.ISimpleGenericGrain`1<T>")]
         [InlineData(typeof(SimpleGenericGrain2<,>), "UnitTests.GrainInterfaces.ISimpleGenericGrain2`2<T,U>")]
 
-        [InlineData(typeof(SpecializedSimpleGenericGrain),
-            "UnitTests.GrainInterfaces.ISimpleGenericGrain`1[[System.Double, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Double>")]
+        [InlineData(typeof(ClosedGeneric),
+            "NonSilo.Tests.General.IG2`2[[NonSilo.Tests.General.Dummy1, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null],[NonSilo.Tests.General.Dummy2, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]<Dummy1,Dummy2>")]
 
-        [InlineData(typeof(ConcreteGrainWithGenericInterfaceOfIntFloat),
-            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Single, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32,Single>")]
+        [InlineData(typeof(ClosedGenericWithManyInterfaces),
+            "NonSilo.Tests.General.IG2`2[[NonSilo.Tests.General.Dummy1, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null],[NonSilo.Tests.General.Dummy2, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]<Dummy1,Dummy2>",
+            "NonSilo.Tests.General.IG2`2[[NonSilo.Tests.General.Dummy2, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null],[NonSilo.Tests.General.Dummy1, NonSilo.Tests, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]<Dummy2,Dummy1>")]
 
-        [InlineData(typeof(ConcreteGrainWithGenericInterfaceOfFloatString),
-            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Single, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Single,String>")]
-        [InlineData(typeof(ConcreteGrainWith2GenericInterfaces),
-            "UnitTests.GrainInterfaces.IGenericGrain`2[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32,String>",
-            "UnitTests.GrainInterfaces.ISimpleGenericGrain`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]<Int32>")]
-
-        [InlineData(typeof(GenericGrainWithGenericState<,,>),
-            "UnitTests.GrainInterfaces.IGenericGrainWithGenericState`3<TFirstTypeParam,TStateType,TLastTypeParam>")]
+        [InlineData(typeof(GenericGrainWithGenericState<,,>), "UnitTests.GrainInterfaces.IGenericGrainWithGenericState`3<TFirstTypeParam,TStateType,TLastTypeParam>")]
 
         [InlineData(typeof(GenericReaderWriterGrain1<>),
             "UnitTests.GrainInterfaces.IGenericReaderWriterGrain1`1<T>",
@@ -98,9 +92,9 @@ namespace NonSilo.Tests.General
             "UnitTests.GrainInterfaces.IGenericReader3`3<TOne,TTwo,TThree>",
             "UnitTests.GrainInterfaces.IGenericReader2`2<TOne,TTwo>")]
 
-        [InlineData(typeof(OpenGeneric<,>), "NonSilo.Tests.General.IHalfOpenGrain`2<T1,T2>")]
-        [InlineData(typeof(HalfOpenGrain1<>), "NonSilo.Tests.General.IHalfOpenGrain`2<T1,Int32>")]
-        [InlineData(typeof(HalfOpenGrain2<>), "NonSilo.Tests.General.IHalfOpenGrain`2<Int32,T2>")]
+        [InlineData(typeof(OpenGeneric<,>), "NonSilo.Tests.General.IG2`2<T1,T2>")]
+        [InlineData(typeof(HalfOpenGrain1<>), "NonSilo.Tests.General.IG2`2<T1,Int32>")]
+        [InlineData(typeof(HalfOpenGrain2<>), "NonSilo.Tests.General.IG2`2<Int32,T2>")]
         [InlineData(typeof(Root<>.G<,,>), "NonSilo.Tests.General.IG`1<Root<TRoot,T1,T2,T3>.IA>")]
         [InlineData(typeof(G1<,,,>), "NonSilo.Tests.General.Root`1.IA`3")]
 
@@ -115,22 +109,32 @@ namespace NonSilo.Tests.General
                 .ToArray();
 
             _testOutputHelper.WriteLine("Expected: " + string.Join(";", expected));
-            _testOutputHelper.WriteLine("Actual: " + string.Join(";", expected));
+            _testOutputHelper.WriteLine("Actual: " + string.Join(";", actual));
 
             Assert.Equal(expected, actual);
         }
     }
 
-    public interface IHalfOpenGrain<T1, T2> : IGrainWithGuidKey
+    public interface IG2<T1, T2> : IGrainWithGuidKey
     { }
 
-    public class HalfOpenGrain1<T> : IHalfOpenGrain<T, int>
+    public class HalfOpenGrain1<T> : IG2<T, int>
     { }
-    public class HalfOpenGrain2<T> : IHalfOpenGrain<int, T>
+    public class HalfOpenGrain2<T> : IG2<int, T>
     { }
 
-    public class OpenGeneric<T2, T1> : IHalfOpenGrain<T2, T1>
+    public class OpenGeneric<T2, T1> : IG2<T2, T1>
     { }
+
+    public class ClosedGeneric : IG2<Dummy1, Dummy2>
+    { }
+
+    public class ClosedGenericWithManyInterfaces : IG2<Dummy1, Dummy2>, IG2<Dummy2, Dummy1>
+    { }
+
+    public class Dummy1 { }
+
+    public class Dummy2 { }
 
     public interface IG<T> : IGrain
     {


### PR DESCRIPTION
Fixed half generic naming and nested generic naming. Related to #6766 and #6777.

The correct name for half-open generic: `IHalfOpenGrain<T1,int>` for  `HalfOpenGrain1` and `IHalfOpenGrain<int,T2>` for `HalfOpenGrain2`.

``` //C#
public interface IHalfOpenGrain<T1, T2> : IGrainWithGuidKey
{ }
public class HalfOpenGrain1<T> : IHalfOpenGrain<T, int>
{ }
public class HalfOpenGrain2<T> : IHalfOpenGrain<int, T>
{ }
``` 

Fixed ArgumentOutOfRange for `Root<>.G<,,,>`. Also, I strongly recommend avoiding the usage of grains in generic types.

```//C#

public interface IG<T> : IGrain
{
}
public class G1<T1, T2, T3, T4> : Grain, Root<T1>.IA<T2, T3, T4>
{
}
public class Root<TRoot>
{
    public interface IA<T1, T2, T3> : IGrainWithIntegerKey
    {
     }
     public class G<T1, T2, T3> : Grain, IG<IA<T1, T2, T3>>
     {
     }
}

```