### PR TITLE
Allow arbitrary A -> B -> C -> ... -> A call chain reentrancy

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
@@ -7,6 +7,8 @@ namespace Orleans.Runtime
     {
         public IGrainContext GrainContext { get; private set; }
 
+        public long? CallChainId { get; private set; }
+
         [ThreadStatic]
         private static RuntimeContext threadLocalContext;
 
@@ -14,19 +16,24 @@ namespace Orleans.Runtime
 
         internal static IGrainContext CurrentGrainContext { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => threadLocalContext?.GrainContext; }
 
+        internal static long? CurrentCallChainId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => threadLocalContext?.CallChainId; }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void SetExecutionContext(IGrainContext newContext)
+        internal static void SetExecutionContext(IGrainContext newContext, long? newCallChainId)
         {
             var ctx = threadLocalContext ??= new RuntimeContext();
             ctx.GrainContext = newContext;
+            ctx.CallChainId = newCallChainId;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void SetExecutionContext(IGrainContext newContext, out IGrainContext existingContext)
+        internal static void SetExecutionContext(IGrainContext newContext, long? newCallChainId, out IGrainContext existingContext, out long? existingCallChainId)
         {
             var ctx = threadLocalContext ??= new RuntimeContext();
             existingContext = ctx.GrainContext;
+            existingCallChainId = ctx.CallChainId;
             ctx.GrainContext = newContext;
+            ctx.CallChainId = newCallChainId;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Orleans.Core/Messaging/CorrelationId.cs
+++ b/src/Orleans.Core/Messaging/CorrelationId.cs
@@ -65,7 +65,7 @@ namespace Orleans.Runtime
 
         public static bool operator !=(CorrelationId lhs, CorrelationId rhs)
         {
-            return rhs.id != lhs.id;
+            return !(lhs == rhs);
         }
 
         public int CompareTo(CorrelationId other)

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
             this.messagingTrace = messagingTrace;
         }
 
-        public Message CreateMessage(InvokeMethodRequest request, InvokeMethodOptions options)
+        public Message CreateMessage(InvokeMethodRequest request, InvokeMethodOptions options, CorrelationId callChainId)
         {
             var message = new Message
             {
@@ -32,7 +32,8 @@ namespace Orleans.Runtime
                 IsUnordered = (options & InvokeMethodOptions.Unordered) != 0,
                 IsAlwaysInterleave = (options & InvokeMethodOptions.AlwaysInterleave) != 0,
                 BodyObject = request,
-                RequestContextData = RequestContextExtensions.Export(this.serializationManager)
+                RequestContextData = RequestContextExtensions.Export(this.serializationManager),
+                CallChainId = callChainId ?? CorrelationId.GetNext()
             };
 
             if (options.IsTransactional())

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -260,7 +260,7 @@ namespace Orleans
             Justification = "CallbackData is IDisposable but instances exist beyond lifetime of this method so cannot Dispose yet.")]
         public void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, InvokeMethodOptions options)
         {
-            var message = this.messageFactory.CreateMessage(request, options);
+            var message = this.messageFactory.CreateMessage(request, options, null);
             OrleansOutsideRuntimeClientEvent.Log.SendRequest(message);
             SendRequestMessage(target, message, context, options);
         }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -175,7 +175,7 @@ namespace Orleans.Runtime
                     _sharedComponents,
                     _activationMessageScheduler);
 
-                RuntimeContext.SetExecutionContext(context, out var existingContext);
+                RuntimeContext.SetExecutionContext(context, null, out var existingContext, out var existingCallChainId);
 
                 try
                 {
@@ -187,7 +187,7 @@ namespace Orleans.Runtime
                 }
                 finally
                 {
-                    RuntimeContext.SetExecutionContext(existingContext);
+                    RuntimeContext.SetExecutionContext(existingContext, existingCallChainId);
                 }
 
                 return context;

--- a/src/Orleans.Runtime/Core/ActivationMessageScheduler.cs
+++ b/src/Orleans.Runtime/Core/ActivationMessageScheduler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Orleans.Runtime.Scheduler;
 using Orleans.Runtime.Versions;
 using Orleans.Runtime.Versions.Compatibility;
@@ -234,6 +235,11 @@ namespace Orleans.Runtime
             }
 
             if (targetActivation.Blocking.IsReadOnly && incoming.IsReadOnly)
+            {
+                return true;
+            }
+
+            if (incoming.CallChainId != null && targetActivation.RunningRequests.Keys.Any(message => incoming.CallChainId.Equals(message.CallChainId)))
             {
                 return true;
             }

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -38,7 +38,7 @@ namespace Orleans.Runtime.Scheduler
 
         public void RunTask(Task task)
         {
-            RuntimeContext.SetExecutionContext(workerGroup.GrainContext);
+            RuntimeContext.SetExecutionContext(workerGroup.GrainContext, null);
             bool done = TryExecuteTask(task);
             if (!done)
                 logger.Warn(ErrorCode.SchedulerTaskExecuteIncomplete4, "RunTask: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",

--- a/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
+                RuntimeContext.SetExecutionContext(this.GrainContext, null);
                 RequestContext.Clear();
                 await this.continuation();
                 this.completion.TrySetResult(true);
@@ -85,7 +85,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
+                RuntimeContext.SetExecutionContext(this.GrainContext, null);
                 RequestContext.Clear();
                 var result = await this.continuation();
                 this.completion.TrySetResult(result);

--- a/src/Orleans.Runtime/Scheduler/InvokeWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/InvokeWorkItem.cs
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.activation);
+                RuntimeContext.SetExecutionContext(this.activation, message.CallChainId?.ToInt64());
                 Task task = this.runtimeClient.Invoke(this.activation, this.message);
 
                 // Note: This runs for all outcomes of resultPromiseTask - both Success or Fault

--- a/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.target);
+                RuntimeContext.SetExecutionContext(this.target, request.CallChainId?.ToInt64());
                 target.HandleNewRequest(request);
             }
             finally

--- a/src/Orleans.Runtime/Scheduler/ResponseWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ResponseWorkItem.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.target);
+                RuntimeContext.SetExecutionContext(this.target, response.CallChainId?.ToInt64());
                 target.HandleResponse(response);
             }
             finally

--- a/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
+++ b/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(todo.GrainContext);
+                RuntimeContext.SetExecutionContext(todo.GrainContext, null);
                 todo.Execute();
             }
             finally

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -347,7 +347,7 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
+                RuntimeContext.SetExecutionContext(this.GrainContext, null);
 
                 // Process multiple items -- drain the applicationMessageQueue (up to max items) for this physical activation
                 int count = 0;

--- a/test/DefaultCluster.Tests/CallChainTests.cs
+++ b/test/DefaultCluster.Tests/CallChainTests.cs
@@ -18,7 +18,7 @@ namespace DefaultCluster.Tests
         }
 
         [Fact, TestCategory("Functional")]
-        public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
+        public async Task CallChainTests_CircularCallChainWithThreeGrains()
         {
             var grain = GrainFactory.GetGrain<ICallChainGrain1>(0);
             var result = await grain.Run(10);

--- a/test/DefaultCluster.Tests/CallChainTests.cs
+++ b/test/DefaultCluster.Tests/CallChainTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests
+{
+    /// <summary>
+    /// Unit tests for circular call chains involving multiple grains
+    /// </summary>
+    public class CallChainTests : HostedTestClusterEnsureDefaultStarted
+    {
+        public CallChainTests(DefaultClusterFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
+        {
+            var grain = GrainFactory.GetGrain<ICallChainGrain1>(0);
+            var result = await grain.Run(10);
+
+            Assert.Equal(10, result);
+        }
+    }
+}

--- a/test/Grains/TestGrainInterfaces/ICallChainGrains.cs
+++ b/test/Grains/TestGrainInterfaces/ICallChainGrains.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface ICallChainGrain1 : IGrainWithIntegerKey
+    {
+        Task<int> Run(int v);
+    }
+
+    public interface ICallChainGrain2 : IGrainWithIntegerKey
+    {
+        Task<int> Run(int v);
+    }
+
+    public interface ICallChainGrain3 : IGrainWithIntegerKey
+    {
+        Task<int> Run(int v);
+    }
+}

--- a/test/Grains/TestGrains/CallChainGrains.cs
+++ b/test/Grains/TestGrains/CallChainGrains.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class CallChainGrain1 : Grain, ICallChainGrain1
+    {
+        public async Task<int> Run(int v)
+        {
+            if (v == 0)
+                return 0;
+
+            var res = await GrainFactory.GetGrain<ICallChainGrain2>(this.GetPrimaryKeyLong()).Run(v - 1);
+            return res + 1;
+        }
+    }
+
+    class CallChainGrain2 : Grain, ICallChainGrain2
+    {
+        public async Task<int> Run(int v)
+        {
+            if (v == 0)
+                return 0;
+
+            var res = await GrainFactory.GetGrain<ICallChainGrain3>(this.GetPrimaryKeyLong()).Run(v - 1);
+            return res + 1;
+        }
+    }
+
+    class CallChainGrain3 : Grain, ICallChainGrain3
+    {
+        public async Task<int> Run(int v)
+        {
+            if (v == 0)
+                return 0;
+
+            var res = await GrainFactory.GetGrain<ICallChainGrain1>(this.GetPrimaryKeyLong()).Run(v - 1);
+            return res + 1;
+        }
+    }
+}

--- a/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
@@ -43,18 +43,27 @@ namespace UnitTests.Serialization
         public async Task MessageTest_TtlUpdatedOnAccess()
         {
             var request = new InvokeMethodRequest(0, 0, null);
-            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
+            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
 
             message.TimeToLive = TimeSpan.FromSeconds(1);
             await Task.Delay(TimeSpan.FromMilliseconds(500));
             Assert.InRange(message.TimeToLive.Value, TimeSpan.FromMilliseconds(-1000), TimeSpan.FromMilliseconds(900));
         }
 
+        [Fact, TestCategory("Functional")]
+        public void MessageTest_CallChainIdGeneratedIfNotProvided()
+        {
+            var request = new InvokeMethodRequest(0, 0, null);
+            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
+
+            Assert.NotNull(message.CallChainId);
+        }
+
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public async Task MessageTest_TtlUpdatedOnSerialization()
         {
             var request = new InvokeMethodRequest(0, 0, null);
-            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
+            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
 
             message.TimeToLive = TimeSpan.FromSeconds(1);
             await Task.Delay(TimeSpan.FromMilliseconds(500));
@@ -74,7 +83,7 @@ namespace UnitTests.Serialization
                 RequestContext.Set("big_object", new byte[maxHeaderSize + 1]);
 
                 var request = new InvokeMethodRequest(0, 0, null);
-                var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
+                var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
 
                 var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
                 var writer = pipe.Writer;
@@ -94,7 +103,7 @@ namespace UnitTests.Serialization
             // Create a request with a ridiculously big argument
             var arg = new byte[maxBodySize + 1];
             var request = new InvokeMethodRequest(0, 0, new[] { arg });
-            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
+            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
 
             var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
             var writer = pipe.Writer;
@@ -152,7 +161,7 @@ namespace UnitTests.Serialization
         private void RunTest(int numItems)
         {
             InvokeMethodRequest request = new InvokeMethodRequest(0, 2, null);
-            Message resp = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
+            Message resp = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
             resp.Id = new CorrelationId();
             resp.SendingSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 200), 0);
             resp.TargetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 300), 0);

--- a/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
@@ -50,15 +50,6 @@ namespace UnitTests.Serialization
             Assert.InRange(message.TimeToLive.Value, TimeSpan.FromMilliseconds(-1000), TimeSpan.FromMilliseconds(900));
         }
 
-        [Fact, TestCategory("Functional")]
-        public void MessageTest_CallChainIdGeneratedIfNotProvided()
-        {
-            var request = new InvokeMethodRequest(0, 0, null);
-            var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None, null);
-
-            Assert.NotNull(message.CallChainId);
-        }
-
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public async Task MessageTest_TtlUpdatedOnSerialization()
         {


### PR DESCRIPTION
This PR is supposed to allow arbitrary A -> B -> C -> ... -> A call chain reentrancy.

I just took the discussion in #5456 and tried to turn it into working code. I'm not very familiar with how Orleans works internally, so I don't even know if I broke anything by mistake, or if this is a valid way to implement the feature. What I do know is that it *seems* to work, according to a simple test I wrote for it.

One thing that has me worried is that `CorrelationId`s generated by different silos *could* be duplicates. It's a very highly unlikely scenario for two call chains that originated on different silos to have the same ID and somehow both end up calling the same activation, but it's not impossible. However, the implementation of `CallChainId` was already there and I just used that. I believe changing its type will introduce a breaking change in the messaging protocol.

I used `RuntimeContext` to store the current call chain ID, since that's where a call's context seems to live. I'm not sure if it was the right choice.

It'd be awesome if someone could take a look at the code.
