### PR TITLE
fix name of MySqlConnector DbProviderFactory

### DIFF
--- a/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
+++ b/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
@@ -68,6 +68,6 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// An open source implementation of the MySQL connector library.
         /// </summary>
-        public const string InvariantNameMySqlConnector = "MySql.Data.MySqlConnector";
+        public const string InvariantNameMySqlConnector = "MySqlConnector";
     }
 }

--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -32,7 +32,7 @@ namespace Orleans.Tests.SqlUtils
                 { AdoNetInvariants.InvariantNamePostgreSql, new Tuple<string, string>("Npgsql", "Npgsql.NpgsqlFactory") },
                 { AdoNetInvariants.InvariantNameSqlLite, new Tuple<string, string>("Microsoft.Data.SQLite", "Microsoft.Data.SQLite.SqliteFactory") },
                 { AdoNetInvariants.InvariantNameSqlServerDotnetCore, new Tuple<string, string>("Microsoft.Data.SqlClient", "Microsoft.Data.SqlClient.SqlClientFactory") },
-                { AdoNetInvariants.InvariantNameMySqlConnector, new Tuple<string, string>("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory") },
+                { AdoNetInvariants.InvariantNameMySqlConnector, new Tuple<string, string>("MySqlConnector", "MySqlConnector.MySqlConnectorFactory") },
             };
 
         private static CachedFactory GetFactory(string invariantName)


### PR DESCRIPTION
see https://mysqlconnector.net/overview/dbproviderfactories/

the invariant name should probably be changed here too: https://github.com/chillitom/orleans/blob/patch-1/src/AdoNet/Shared/Storage/AdoNetInvariants.cs#L71

Would mean a breaking change, but then this is currently not working so presumably wouldn't affect anyone.