### PR TITLE
[Backport] Probe silos indirectly before submitting a vote (#6800)

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -117,5 +117,10 @@ namespace Orleans.Configuration
         /// Whether to extend the effective <see cref="ProbeTimeout"/> value based upon current local health degradation.
         /// </summary>
         public bool ExtendProbeTimeoutDuringDegradation { get; set; } = false;
+
+        /// <summary>
+        /// Whether to enable probing silos indirectly, via other silos.
+        /// </summary>
+        public bool EnableIndirectProbes { get; set; } = false;
     }
 }

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipService.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 
@@ -26,5 +27,37 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="pingNumber">A unique sequence number for ping message, to facilitate testing and debugging.</param>
         Task Ping(int pingNumber);
+
+        Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber);
+    }
+
+    /// <summary>
+    /// Represents the result of probing a node via an intermediary node.
+    /// </summary>
+    [Serializable]
+    public struct IndirectProbeResponse
+    {
+        /// <summary>
+        /// The health score of the intermediary node.
+        /// </summary>
+        public int IntermediaryHealthScore { get; set; }
+
+        /// <summary>
+        /// <see langword="true"/> if the probe succeeded; otherwise, <see langword="false"/>.
+        /// </summary>
+        public bool Succeeded { get; set; }
+
+        /// <summary>
+        /// The duration of the probe attempt.
+        /// </summary>
+        public TimeSpan ProbeResponseTime { get; set; }
+
+        /// <summary>
+        /// The failure message if the probe did not succeed.
+        /// </summary>
+        public string FailureMessage { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString() => $"IndirectProbeResponse {{ Succeeded: {Succeeded}, IntermediaryHealthScore: {IntermediaryHealthScore}, ProbeResponseTime: {ProbeResponseTime}, FailureMessage: {FailureMessage} }}";
     }
 }

--- a/src/Orleans.Runtime/Core/SystemTargetExtensions.cs
+++ b/src/Orleans.Runtime/Core/SystemTargetExtensions.cs
@@ -26,6 +26,17 @@ namespace Orleans.Runtime
         /// <param name="self">The <see cref="SystemTarget"/>.</param>
         /// <param name="action">The action.</param>
         /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
+        public static Task<T> ScheduleTask<T>(this SystemTarget self, Func<Task<T>> action)
+        {
+            return self.RuntimeClient.Scheduler.RunOrQueueTask(action, self);
+        }
+
+        /// <summary>
+        /// Schedules the provided <paramref name="action"/> on the <see cref="SystemTarget"/>.
+        /// </summary>
+        /// <param name="self">The <see cref="SystemTarget"/>.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
         public static Task ScheduleTask(this SystemTarget self, Action action)
         {
             return self.RuntimeClient.Scheduler.RunOrQueueAction(action, self);

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly MembershipTableManager membershipService;
         private readonly ILogger<ClusterHealthMonitor> log;
         private readonly IFatalErrorHandler fatalErrorHandler;
-        private readonly ClusterMembershipOptions clusterMembershipOptions;
+        private readonly IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions;
         private ImmutableDictionary<SiloAddress, SiloHealthMonitor> monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
         private MembershipVersion observedMembershipVersion;
         private Func<SiloAddress, SiloHealthMonitor> createMonitor;
@@ -46,7 +46,7 @@ namespace Orleans.Runtime.MembershipService
             ILocalSiloDetails localSiloDetails,
             MembershipTableManager membershipService,
             ILogger<ClusterHealthMonitor> log,
-            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
+            IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions,
             IFatalErrorHandler fatalErrorHandler,
             IServiceProvider serviceProvider)
         {
@@ -55,7 +55,7 @@ namespace Orleans.Runtime.MembershipService
             this.membershipService = membershipService;
             this.log = log;
             this.fatalErrorHandler = fatalErrorHandler;
-            this.clusterMembershipOptions = clusterMembershipOptions.Value;
+            this.clusterMembershipOptions = clusterMembershipOptions;
             this.onProbeResult = this.OnProbeResultInternal;
             Func<SiloHealthMonitor, ProbeResult, Task> onProbeResultFunc = (siloHealthMonitor, probeResult) => this.onProbeResult(siloHealthMonitor, probeResult);
             this.createMonitor = silo => ActivatorUtilities.CreateInstance<SiloHealthMonitor>(serviceProvider, silo, onProbeResultFunc);
@@ -84,7 +84,7 @@ namespace Orleans.Runtime.MembershipService
                     {
                         if (!newMonitoredSilos.ContainsKey(pair.Key))
                         {
-                            var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.ProbeTimeout).Token;
+                            var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.CurrentValue.ProbeTimeout).Token;
                             await pair.Value.StopAsync(cancellation);
                         }
                     }
@@ -142,14 +142,14 @@ namespace Orleans.Runtime.MembershipService
             var silosToWatch = new List<SiloAddress>();
             var additionalSilos = new List<SiloAddress>();
 
-            for (int i = 0; i < tmpList.Count - 1 && silosToWatch.Count < this.clusterMembershipOptions.NumProbedSilos; i++)
+            for (int i = 0; i < tmpList.Count - 1 && silosToWatch.Count < this.clusterMembershipOptions.CurrentValue.NumProbedSilos; i++)
             {
                 var candidate = tmpList[(myIndex + i + 1) % tmpList.Count];
                 var candidateEntry = membership.Entries[candidate];
 
                 if (candidate.IsSameLogicalSilo(this.localSiloDetails.SiloAddress)) continue;
 
-                bool isSuspected = candidateEntry.GetFreshVotes(now, this.clusterMembershipOptions.DeathVoteExpirationTimeout).Count > 0;
+                bool isSuspected = candidateEntry.GetFreshVotes(now, this.clusterMembershipOptions.CurrentValue.DeathVoteExpirationTimeout).Count > 0;
                 if (isSuspected)
                 {
                     additionalSilos.Add(candidate);
@@ -228,9 +228,30 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         private async Task OnProbeResultInternal(SiloHealthMonitor monitor, ProbeResult probeResult)
         {
-            if (probeResult.Status == ProbeResultStatus.Failed && probeResult.FailedProbeCount >= this.clusterMembershipOptions.NumMissedProbesLimit)
+            // Do not act on probe results if shutdown is in progress.
+            if (this.shutdownCancellation.IsCancellationRequested)
             {
-                await this.membershipService.TryToSuspectOrKill(monitor.SiloAddress);
+                return;
+            }
+
+            if (probeResult.IsDirectProbe)
+            {
+                if (probeResult.Status == ProbeResultStatus.Failed && probeResult.FailedProbeCount >= this.clusterMembershipOptions.CurrentValue.NumMissedProbesLimit)
+                {
+                    await this.membershipService.TryToSuspectOrKill(monitor.SiloAddress).ConfigureAwait(false);
+                }
+            }
+            else if (probeResult.Status == ProbeResultStatus.Failed)
+            {
+                if (this.clusterMembershipOptions.CurrentValue.NumVotesForDeathDeclaration <= 2)
+                {
+                    // Since both this silo and another silo were unable to probe the target silo, we declare it dead.
+                    await this.membershipService.TryKill(monitor.SiloAddress).ConfigureAwait(false);
+                }
+                else
+                {
+                    await this.membershipService.TryToSuspectOrKill(monitor.SiloAddress).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -35,7 +35,20 @@ namespace Orleans.Runtime
             this.fatalErrorHandler = fatalErrorHandler;
         }
 
-        public ClusterMembershipSnapshot CurrentSnapshot => this.snapshot;
+        public ClusterMembershipSnapshot CurrentSnapshot
+        {
+            get
+            {
+                var tableSnapshot = this.membershipTableManager.MembershipTableSnapshot;
+                if (this.snapshot.Version == tableSnapshot.Version)
+                {
+                    return this.snapshot;
+                }
+
+                this.updates.TryPublish(tableSnapshot.CreateClusterMembershipSnapshot());
+                return this.snapshot;
+            }
+        }
 
         public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => this.updates;
 

--- a/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
+++ b/src/Orleans.Runtime/MembershipService/IRemoteSiloProber.cs
@@ -17,5 +17,14 @@ namespace Orleans.Runtime.MembershipService
         /// A <see cref="Task"/> which completes when the probe returns successfully and faults when the probe fails.
         /// </returns>
         Task Probe(SiloAddress silo, int probeNumber);
+
+        /// <summary>
+        /// Probes the specified <paramref name="target"/> indirectly, via <paramref name="intermediary"/>.
+        /// </summary>
+        /// <param name="intermediary">The silo which will perform a direct probe.</param>
+        /// <param name="target">The silo which will be probed.</param>
+        /// <param name="probeTimeout">The timeout which the <paramref name="intermediary" /> should apply to the probe.</param>
+        /// <param name="probeNumber">The probe number for diagnostic purposes.</param>
+        Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber);
     }
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -63,6 +63,57 @@ namespace Orleans.Runtime.MembershipService
         /// <returns>The result of pinging the remote silo.</returns>
         public Task ProbeRemoteSilo(SiloAddress remoteSilo, int probeNumber) => this.ScheduleTask(() => ProbeInternal(remoteSilo, probeNumber));
 
+        /// <summary>
+        /// Send a ping to a remote silo via an intermediary silo. This is intended to be called from a <see cref="SiloHealthMonitor"/>
+        /// in order to initiate the call from the <see cref="MembershipSystemTarget"/>'s context
+        /// </summary>
+        /// <param name="intermediary">The intermediary which will directly probe the target.</param>
+        /// <param name="target">The target which will be probed.</param>
+        /// <param name="probeTimeout">The timeout for the eventual direct probe request.</param>
+        /// <param name="probeNumber">The probe number, for diagnostic purposes.</param>
+        /// <returns>The result of pinging the remote silo.</returns>
+        public Task<IndirectProbeResponse> ProbeRemoteSiloIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            Task<IndirectProbeResponse> ProbeIndirectly()
+            {
+                var remoteOracle = this.grainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleType, intermediary);
+                return remoteOracle.ProbeIndirectly(target, probeTimeout, probeNumber);
+            }
+
+            return this.ScheduleTask(ProbeIndirectly);
+        }
+
+        public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            IndirectProbeResponse result;
+            var healthScore = this.ActivationServices.GetRequiredService<LocalSiloHealthMonitor>().GetLocalHealthDegradationScore(DateTime.UtcNow);
+            var probeResponseTimer = ValueStopwatch.StartNew();
+            try
+            {
+                var probeTask = this.ProbeInternal(target, probeNumber);
+                await probeTask.WithTimeout(probeTimeout, exceptionMessage: $"Requested probe timeout {probeTimeout} exceeded");
+
+                result = new IndirectProbeResponse
+                {
+                    Succeeded = true,
+                    IntermediaryHealthScore = healthScore,
+                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                };
+            }
+            catch (Exception exception)
+            {
+                result = new IndirectProbeResponse
+                {
+                    Succeeded = false,
+                    IntermediaryHealthScore = healthScore,
+                    FailureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}",
+                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                };
+            }
+
+            return result;
+        }
+
         public Task GossipToRemoteSilos(
             List<SiloAddress> gossipPartners,
             MembershipTableSnapshot snapshot,

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -76,7 +76,7 @@ namespace Orleans.Runtime.MembershipService
         {
             Task<IndirectProbeResponse> ProbeIndirectly()
             {
-                var remoteOracle = this.grainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleType, intermediary);
+                var remoteOracle = this.grainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleId, intermediary);
                 return remoteOracle.ProbeIndirectly(target, probeTimeout, probeNumber);
             }
 
@@ -86,7 +86,7 @@ namespace Orleans.Runtime.MembershipService
         public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
         {
             IndirectProbeResponse result;
-            var healthScore = this.ActivationServices.GetRequiredService<LocalSiloHealthMonitor>().GetLocalHealthDegradationScore(DateTime.UtcNow);
+            var healthScore = this.RuntimeClient.ServiceProvider.GetRequiredService<LocalSiloHealthMonitor>().GetLocalHealthDegradationScore(DateTime.UtcNow);
             var probeResponseTimer = ValueStopwatch.StartNew();
             try
             {

--- a/src/Orleans.Runtime/MembershipService/RemoteSiloProber.cs
+++ b/src/Orleans.Runtime/MembershipService/RemoteSiloProber.cs
@@ -20,5 +20,12 @@ namespace Orleans.Runtime.MembershipService
             var systemTarget = this.serviceProvider.GetRequiredService<MembershipSystemTarget>();
             return systemTarget.ProbeRemoteSilo(remoteSilo, probeNumber);
         }
+
+        /// <inheritdoc />
+        public Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress intermediary, SiloAddress target, TimeSpan probeTimeout, int probeNumber)
+        {
+            var systemTarget = this.serviceProvider.GetRequiredService<MembershipSystemTarget>();
+            return systemTarget.ProbeRemoteSiloIndirectly(intermediary, target, probeTimeout, probeNumber);
+        }
     }
 }

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -15,9 +16,11 @@ namespace Orleans.Runtime.MembershipService
     internal class SiloHealthMonitor : ITestAccessor, IHealthCheckable
     {
         private readonly ILogger _log;
-        private readonly ClusterMembershipOptions _clusterMembershipOptions;
+        private readonly IOptionsMonitor<ClusterMembershipOptions> _clusterMembershipOptions;
         private readonly IRemoteSiloProber _prober;
         private readonly ILocalSiloHealthMonitor _localSiloHealthMonitor;
+        private readonly IClusterMembershipService _membershipService;
+        private readonly ILocalSiloDetails _localSiloDetails;
         private readonly CancellationTokenSource _stoppingCancellation = new CancellationTokenSource();
         private readonly object _lockObj = new object();
         private readonly IAsyncTimer _pingTimer;
@@ -28,12 +31,7 @@ namespace Orleans.Runtime.MembershipService
         /// <summary>
         /// The id of the next probe.
         /// </summary>
-        private long _nextProbeId;
-
-        /// <summary>
-        /// The highest internal probe number which has completed.
-        /// </summary>
-        private long _highestCompletedProbeId = -1;
+        private int _nextProbeId;
 
         /// <summary>
         /// The number of failed probes since the last successful probe.
@@ -53,19 +51,23 @@ namespace Orleans.Runtime.MembershipService
         public SiloHealthMonitor(
             SiloAddress siloAddress,
             Func<SiloHealthMonitor, ProbeResult, Task> onProbeResult,
-            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
+            IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions,
             ILoggerFactory loggerFactory,
             IRemoteSiloProber remoteSiloProber,
             IAsyncTimerFactory asyncTimerFactory,
-            ILocalSiloHealthMonitor localSiloHealthMonitor)
+            ILocalSiloHealthMonitor localSiloHealthMonitor,
+            IClusterMembershipService membershipService,
+            ILocalSiloDetails localSiloDetails)
         {
             SiloAddress = siloAddress;
-            _clusterMembershipOptions = clusterMembershipOptions.Value;
+            _clusterMembershipOptions = clusterMembershipOptions;
             _prober = remoteSiloProber;
             _localSiloHealthMonitor = localSiloHealthMonitor;
+            _membershipService = membershipService;
+            _localSiloDetails = localSiloDetails;
             _log = loggerFactory.CreateLogger<SiloHealthMonitor>();
             _pingTimer = asyncTimerFactory.Create(
-                _clusterMembershipOptions.ProbeTimeout,
+                _clusterMembershipOptions.CurrentValue.ProbeTimeout,
                 nameof(SiloHealthMonitor));
             _onProbeResult = onProbeResult;
             _elapsedSinceLastSuccessfulResponse = ValueStopwatch.StartNew();
@@ -74,7 +76,6 @@ namespace Orleans.Runtime.MembershipService
         internal interface ITestAccessor
         {
             int MissedProbes { get; }
-            Func<SiloHealthMonitor, ProbeResult, Task> OnProbeResult { get; set; }
         }
 
         /// <summary>
@@ -88,8 +89,6 @@ namespace Orleans.Runtime.MembershipService
         public bool IsCanceled => _stoppingCancellation.IsCancellationRequested;
 
         int ITestAccessor.MissedProbes => _failedProbes;
-
-        Func<SiloHealthMonitor, ProbeResult, Task> ITestAccessor.OnProbeResult { get => _onProbeResult; set => _onProbeResult = value; }
 
         /// <summary>
         /// Start the monitor.
@@ -137,36 +136,85 @@ namespace Orleans.Runtime.MembershipService
         private async Task Run()
         {
             var random = new SafeRandom();
-            TimeSpan? overrideDelay = random.NextTimeSpan(_clusterMembershipOptions.ProbeTimeout);
+            ClusterMembershipSnapshot activeMembersSnapshot = default;
+            SiloAddress[] otherNodes = default;
+            TimeSpan? overrideDelay = random.NextTimeSpan(_clusterMembershipOptions.CurrentValue.ProbeTimeout);
             while (await _pingTimer.NextTick(overrideDelay))
             {
+                ProbeResult probeResult;
                 overrideDelay = default;
-            
+
                 try
                 {
-                    TimeSpan timeout;
-                    if (_clusterMembershipOptions.ExtendProbeTimeoutDuringDegradation)
+                    // Discover the other active nodes in the cluster, if there are any.
+                    var membershipSnapshot = _membershipService.CurrentSnapshot;
+                    if (otherNodes is null || !object.ReferenceEquals(activeMembersSnapshot, membershipSnapshot))
                     {
-                        var localDegradationScore = _localSiloHealthMonitor.GetLocalHealthDegradationScore(DateTime.UtcNow);
+                        activeMembersSnapshot = membershipSnapshot;
+                        otherNodes = membershipSnapshot.Members.Values
+                            .Where(v => v.Status == SiloStatus.Active && v.SiloAddress != this.SiloAddress && v.SiloAddress != _localSiloDetails.SiloAddress)
+                            .Select(s => s.SiloAddress)
+                            .ToArray();
+                    }
 
+                    var isDirectProbe = !_clusterMembershipOptions.CurrentValue.EnableIndirectProbes || _failedProbes < _clusterMembershipOptions.CurrentValue.NumMissedProbesLimit - 1 || otherNodes.Length == 0;
+                    var timeout = GetTimeout(isDirectProbe);
+                    var cancellation = new CancellationTokenSource(timeout);
+
+                    if (isDirectProbe)
+                    {
                         // Probe the silo directly.
-                        // Attempt to account for local health degradation by extending the timeout period.
-                        timeout = _clusterMembershipOptions.ProbeTimeout.Multiply(1 + localDegradationScore);
+                        probeResult = await this.ProbeDirectly(cancellation.Token).ConfigureAwait(false);
                     }
                     else
                     {
-                        timeout = _clusterMembershipOptions.ProbeTimeout;
+                        // Pick a random other node and probe the target indirectly, using the selected node as an intermediary.
+                        var intermediary = otherNodes[random.Next(0, otherNodes.Length - 1)];
+
+                        // Select a timeout which will allow the intermediary node to attempt to probe the target node and still respond to this node
+                        // if the remote node does not respond in time.
+                        // Attempt to account for local health degradation by extending the timeout period.
+                        probeResult = await this.ProbeIndirectly(intermediary, timeout, cancellation.Token).ConfigureAwait(false);
+
+                        // If the intermediary is not entirely healthy, remove it from consideration and continue to probe.
+                        // Note that all recused silos will be included in the consideration set the next time cluster membership changes.
+                        if (probeResult.Status != ProbeResultStatus.Succeeded && probeResult.IntermediaryHealthDegradationScore > 0)
+                        {
+                            _log.LogInformation("Recusing unhealthy intermediary {Intermediary} and trying again with remaining nodes", intermediary);
+                            otherNodes = otherNodes.Where(node => !node.Equals(intermediary)).ToArray();
+                            overrideDelay = TimeSpan.FromMilliseconds(250);
+                        }
                     }
 
-                    var cancellation = new CancellationTokenSource(timeout);
-                    var probeResult = await this.ProbeDirectly(cancellation.Token).ConfigureAwait(false);
-
-                    await _onProbeResult(this, probeResult).ConfigureAwait(false);
+                    if (!_stoppingCancellation.IsCancellationRequested)
+                    {
+                        await _onProbeResult(this, probeResult).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception exception)
                 {
                     _log.LogError(exception, "Exception monitoring silo {SiloAddress}", SiloAddress);
                 }
+            }
+
+            TimeSpan GetTimeout(bool isDirectProbe)
+            {
+                var additionalTimeout = 0;
+
+                if (_clusterMembershipOptions.CurrentValue.ExtendProbeTimeoutDuringDegradation)
+                {
+                    // Attempt to account for local health degradation by extending the timeout period.
+                    var localDegradationScore = _localSiloHealthMonitor.GetLocalHealthDegradationScore(DateTime.UtcNow);
+                    additionalTimeout += localDegradationScore;
+                }
+
+                if (!isDirectProbe)
+                {
+                    // Indirect probes need extra time to account for the additional hop.
+                    additionalTimeout += 1;
+                }
+
+                return _clusterMembershipOptions.CurrentValue.ProbeTimeout.Multiply(1 + additionalTimeout);
             }
         }
 
@@ -177,8 +225,7 @@ namespace Orleans.Runtime.MembershipService
         /// <returns>The number of failed probes since the last successful probe.</returns>
         private async Task<ProbeResult> ProbeDirectly(CancellationToken cancellation)
         {
-            var id = (int)Interlocked.Increment(ref _nextProbeId);
-
+            var id = ++_nextProbeId;
             if (_log.IsEnabled(LogLevel.Trace))
             {
                 _log.LogTrace("Going to send Ping #{Id} to probe silo {Silo}", id, SiloAddress);
@@ -193,7 +240,7 @@ namespace Orleans.Runtime.MembershipService
                 var probeTask = _prober.Probe(SiloAddress, id);
                 var task = await Task.WhenAny(probeCancellation, probeTask);
 
-                if (ReferenceEquals(task, probeCancellation))
+                if (ReferenceEquals(task, probeCancellation) && probeTask.Status != TaskStatus.RanToCompletion)
                 {
                     probeTask.Ignore();
                     failureException = new OperationCanceledException($"The ping attempt was cancelled after {roundTripTimer.Elapsed}. Ping #{id}");
@@ -217,89 +264,129 @@ namespace Orleans.Runtime.MembershipService
             {
                 MessagingStatisticsGroup.OnPingReplyReceived(SiloAddress);
 
-                lock (_lockObj)
+                if (_log.IsEnabled(LogLevel.Trace))
                 {
-                    if (id <= _highestCompletedProbeId)
-                    {
-                        _log.LogInformation(
-                            "Ignoring success result for ping #{Id} from {Silo} in {RoundTripTime} since a later probe has already completed. Highest ({HighestCompletedProbeId}) > Current ({CurrentProbeId})",
-                            id,
-                            SiloAddress,
-                            roundTripTimer.Elapsed,
-                            _highestCompletedProbeId,
-                            id);
-                        probeResult = new ProbeResult(_failedProbes, ProbeResultStatus.Unknown);
-                    }
-                    else if (_stoppingCancellation.IsCancellationRequested)
-                    {
-                        _log.LogInformation(
-                            "Ignoring success result for ping #{Id} from {Silo} in {RoundTripTime} since this monitor has been stopped",
-                            id,
-                            SiloAddress,
-                            roundTripTimer.Elapsed);
-                        probeResult = new ProbeResult(_failedProbes, ProbeResultStatus.Unknown);
-                    }
-                    else
-                    {
-                        if (_log.IsEnabled(LogLevel.Trace))
-                        {
-                            _log.LogTrace(
-                                "Got successful ping response for ping #{Id} from {Silo} with round trip time of {RoundTripTime}",
-                                id,
-                                SiloAddress,
-                                roundTripTimer.Elapsed);
-                        }
-
-                        _highestCompletedProbeId = id;
-                        Interlocked.Exchange(ref _failedProbes, 0);
-                        _elapsedSinceLastSuccessfulResponse.Restart();
-                        LastRoundTripTime = roundTripTimer.Elapsed;
-                        probeResult = new ProbeResult(0, ProbeResultStatus.Succeeded);
-                    }
+                    _log.LogTrace(
+                        "Got successful ping response for ping #{Id} from {Silo} with round trip time of {RoundTripTime}",
+                        id,
+                        SiloAddress,
+                        roundTripTimer.Elapsed);
                 }
+
+                _failedProbes = 0;
+                _elapsedSinceLastSuccessfulResponse.Restart();
+                LastRoundTripTime = roundTripTimer.Elapsed;
+                probeResult = ProbeResult.CreateDirect(0, ProbeResultStatus.Succeeded);
             }
             else
             {
                 MessagingStatisticsGroup.OnPingReplyMissed(SiloAddress);
 
-                lock (_lockObj)
+                var failedProbes = ++_failedProbes;
+                _log.LogWarning(
+                    (int)ErrorCode.MembershipMissedPing,
+                    failureException,
+                    "Did not get response for probe #{Id} to silo {Silo} after {Elapsed}. Current number of consecutive failed probes is {FailedProbeCount}",
+                    id,
+                    SiloAddress,
+                    roundTripTimer.Elapsed,
+                    failedProbes);
+
+                probeResult = ProbeResult.CreateDirect(failedProbes, ProbeResultStatus.Failed);
+            }
+
+            return probeResult;
+        }
+
+        /// <summary>
+        /// Probes the remote node via an intermediary silo.
+        /// </summary>
+        /// <param name="intermediary">The node to probe the target with.</param>
+        /// <param name="directProbeTimeout">The amount of time which the intermediary should allow for the target to respond.</param>
+        /// <param name="cancellation">A token to cancel and fail the probe attempt.</param>
+        /// <returns>The number of failed probes since the last successful probe.</returns>
+        private async Task<ProbeResult> ProbeIndirectly(SiloAddress intermediary, TimeSpan directProbeTimeout, CancellationToken cancellation)
+        {
+            var id = ++_nextProbeId;
+            if (_log.IsEnabled(LogLevel.Trace))
+            {
+                _log.LogTrace("Going to send indirect ping #{Id} to probe silo {Silo} via {Intermediary}", id, SiloAddress, intermediary);
+            }
+
+            var roundTripTimer = ValueStopwatch.StartNew();
+            ProbeResult probeResult;
+            try
+            {
+                using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _stoppingCancellation.Token);
+                var cancellationTask = cancellationSource.Token.WhenCancelled();
+                var probeTask = _prober.ProbeIndirectly(intermediary, SiloAddress, directProbeTimeout, id);
+                var task = await Task.WhenAny(cancellationTask, probeTask);
+
+                if (ReferenceEquals(task, cancellationTask) && probeTask.Status != TaskStatus.RanToCompletion)
                 {
-                    if (id <= _highestCompletedProbeId)
+                    probeTask.Ignore();
+                    probeResult = ProbeResult.CreateIndirect(_failedProbes, ProbeResultStatus.Unknown, default);
+                }
+                else
+                {
+                    var indirectResult = await probeTask;
+                    roundTripTimer.Stop();
+                    var roundTripTime = roundTripTimer.Elapsed - indirectResult.ProbeResponseTime;
+
+                    // Record timing regardless of the result.
+                    _elapsedSinceLastSuccessfulResponse.Restart();
+                    LastRoundTripTime = roundTripTimer.Elapsed - indirectResult.ProbeResponseTime;
+
+                    if (indirectResult.Succeeded)
                     {
                         _log.LogInformation(
-                            failureException,
-                            "Ignoring failure result for probe #{Id} to {Silo} since a later probe has already completed. Highest completed probe id is {HighestCompletedProbeId}",
+                            "Indirect probe request #{Id} to silo {SiloAddress} via silo {IntermediarySiloAddress} succeeded after {RoundTripTime} with a direct probe response time of {ProbeResponseTime}.",
                             id,
                             SiloAddress,
-                            _highestCompletedProbeId);
-                        probeResult = new ProbeResult(_failedProbes, ProbeResultStatus.Unknown);
-                    }
-                    else if (_stoppingCancellation.IsCancellationRequested)
-                    {
-                        _log.LogInformation(
-                            failureException,
-                            "Ignoring failure result for probe #{Id} to {Silo} since this monitor has been stopped",
-                            id,
-                            SiloAddress);
-                        probeResult = new ProbeResult(_failedProbes, ProbeResultStatus.Unknown);
+                            intermediary,
+                            roundTripTimer.Elapsed,
+                            indirectResult.ProbeResponseTime);
+
+                        MessagingStatisticsGroup.OnPingReplyReceived(SiloAddress);
+
+                        _failedProbes = 0;
+                        probeResult = ProbeResult.CreateIndirect(0, ProbeResultStatus.Succeeded, indirectResult);
                     }
                     else
                     {
-                        _highestCompletedProbeId = id;
-                        var failedProbes = Interlocked.Increment(ref _failedProbes);
+                        MessagingStatisticsGroup.OnPingReplyMissed(SiloAddress);
 
-                        _log.LogWarning(
-                            (int)ErrorCode.MembershipMissedPing,
-                            failureException,
-                            "Did not get response for probe #{Id} to silo {Silo} after {Elapsed}. Current number of consecutive failed probes is {FailedProbeCount}",
-                            id,
-                            SiloAddress,
-                            roundTripTimer.Elapsed,
-                            failedProbes);
+                        if (indirectResult.IntermediaryHealthScore > 0)
+                        {
+                            _log.LogInformation(
+                                "Ignoring failure result for ping #{Id} from {Silo} since the intermediary used to probe the silo is not healthy. Intermediary health degradation score: {IntermediaryHealthScore}",
+                                id,
+                                SiloAddress,
+                                indirectResult.IntermediaryHealthScore);
+                            probeResult = ProbeResult.CreateIndirect(_failedProbes, ProbeResultStatus.Unknown, indirectResult);
+                        }
+                        else
+                        {
+                            _log.LogWarning(
+                                "Indirect probe request #{Id} to silo {SiloAddress} via silo {IntermediarySiloAddress} failed after {RoundTripTime} with a direct probe response time of {ProbeResponseTime}. Failure message: {FailureMessage}. Intermediary health score: {IntermediaryHealthScore}",
+                                id,
+                                SiloAddress,
+                                intermediary,
+                                roundTripTimer.Elapsed,
+                                indirectResult.ProbeResponseTime,
+                                indirectResult.FailureMessage,
+                                indirectResult.IntermediaryHealthScore);
 
-                        probeResult = new ProbeResult(failedProbes, ProbeResultStatus.Failed);
+                            var missed = ++_failedProbes;
+                            probeResult = ProbeResult.CreateIndirect(missed, ProbeResultStatus.Failed, indirectResult);
+                        }
                     }
                 }
+            }
+            catch (Exception exception)
+            {
+                _log.LogWarning(exception, "Indirect probe request failed");
+                probeResult = ProbeResult.CreateIndirect(_failedProbes, ProbeResultStatus.Unknown, default);
             }
 
             return probeResult;
@@ -313,15 +400,27 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         public readonly struct ProbeResult
         {
-            public ProbeResult(int failedProbeCount, ProbeResultStatus status)
+            private ProbeResult(int failedProbeCount, ProbeResultStatus status, bool isDirectProbe, int intermediaryHealthDegradationScore)
             {
-                this.FailedProbeCount = failedProbeCount;
-                this.Status = status;
+                FailedProbeCount = failedProbeCount;
+                Status = status;
+                IsDirectProbe = isDirectProbe;
+                IntermediaryHealthDegradationScore = intermediaryHealthDegradationScore;
             }
+
+            public static ProbeResult CreateDirect(int failedProbeCount, ProbeResultStatus status)
+                => new ProbeResult(failedProbeCount, status, isDirectProbe: true, 0);
+
+            public static ProbeResult CreateIndirect(int failedProbeCount, ProbeResultStatus status, IndirectProbeResponse indirectProbeResponse)
+                => new ProbeResult(failedProbeCount, status, isDirectProbe: false, indirectProbeResponse.IntermediaryHealthScore);
 
             public int FailedProbeCount { get; }
 
             public ProbeResultStatus Status { get; }
+
+            public bool IsDirectProbe { get; }
+
+            public int IntermediaryHealthDegradationScore { get; }
         }
 
         public enum ProbeResultStatus

--- a/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NonSilo.Tests.Utilities;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT"), TestCategory("Membership")]
+    public class SiloHealthMonitorTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly LoggerFactory _loggerFactory;
+        private readonly ILocalSiloDetails _localSiloDetails;
+        private readonly SiloAddress _localSilo;
+        private readonly List<DelegateAsyncTimer> _timers;
+        private readonly Channel<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)> _timerCalls;
+        private readonly DelegateAsyncTimerFactory _timerFactory;
+        private readonly ILocalSiloHealthMonitor _localSiloHealthMonitor;
+        private readonly IRemoteSiloProber _prober;
+        private readonly IClusterMembershipService _membershipService;
+        private ClusterMembershipOptions _clusterMembershipOptions;
+        private readonly IOptionsMonitor<ClusterMembershipOptions> _optionsMonitor;
+        private readonly Channel<ProbeResult> _probeResults;
+        private readonly SiloHealthMonitor _monitor;
+        private ClusterMembershipSnapshot _membershipSnapshot;
+
+        public SiloHealthMonitorTests(ITestOutputHelper output)
+        {
+            MessagingStatisticsGroup.Init();
+            _output = output;
+            _loggerFactory = new LoggerFactory(new[] { new XunitLoggerProvider(_output) });
+
+            _localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            _localSilo = Silo("127.0.0.1:100@100");
+            _localSiloDetails.SiloAddress.Returns(_localSilo);
+            _localSiloDetails.DnsHostName.Returns("MyServer11");
+            _localSiloDetails.Name.Returns(Guid.NewGuid().ToString("N"));
+
+            _timers = new List<DelegateAsyncTimer>();
+            _timerCalls = Channel.CreateUnbounded<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)>();
+            _timerFactory = new DelegateAsyncTimerFactory(
+                (period, name) =>
+                {
+                    var t = new DelegateAsyncTimer(
+                        overridePeriod =>
+                        {
+                            var task = new TaskCompletionSource<bool>();
+                            _timerCalls.Writer.TryWrite((overridePeriod, task));
+                            return task.Task;
+                        });
+                    _timers.Add(t);
+                    return t;
+                });
+
+            _localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
+            _localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+
+            _prober = Substitute.For<IRemoteSiloProber>();
+
+            _membershipService = Substitute.For<IClusterMembershipService>();
+
+            _clusterMembershipOptions = new ClusterMembershipOptions();
+            _optionsMonitor = Substitute.For<IOptionsMonitor<ClusterMembershipOptions>>();
+            _optionsMonitor.CurrentValue.ReturnsForAnyArgs(info => _clusterMembershipOptions);
+
+            _probeResults = Channel.CreateBounded<ProbeResult>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.Wait });
+            Func<SiloHealthMonitor, ProbeResult, Task> onProbeResult = (mon, res) => _probeResults.Writer.WriteAsync(res).AsTask();
+
+            _membershipSnapshot = Snapshot(
+                1,
+                Member(_localSilo, SiloStatus.Active),
+                Member(Silo("127.0.0.200:100@100"), SiloStatus.Active));
+            _membershipService.CurrentSnapshot.ReturnsForAnyArgs(info => _membershipSnapshot);
+
+            _monitor = new SiloHealthMonitor(
+                Silo("127.0.0.200:100@100"),
+                onProbeResult,
+                _optionsMonitor,
+                _loggerFactory,
+                _prober,
+                _timerFactory,
+                _localSiloHealthMonitor,
+                _membershipService,
+                _localSiloDetails);
+        }
+
+        private async Task Shutdown()
+        {
+            var stopTask = _monitor.StopAsync(CancellationToken.None);
+
+            Task.Run(async () =>
+            {
+                while (!stopTask.IsCompleted && await _timerCalls.Reader.WaitToReadAsync())
+                {
+                    while (_timerCalls.Reader.TryRead(out var timerCall))
+                    {
+                        timerCall.Completion.TrySetResult(false);
+                    }
+                }
+            }).Ignore();
+
+            await stopTask;
+            _timerCalls.Writer.TryComplete();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_SuccessfulProbe()
+        {
+            _prober.Probe(default, default).ReturnsForAnyArgs(Task.CompletedTask);
+            _prober.ProbeIndirectly(default, default, default, default).ThrowsForAnyArgs(new InvalidOperationException("No"));
+
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // Check the resulting probe result.
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
+            Assert.Equal(0, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            await Shutdown();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_FailedProbe()
+        {
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+
+            _prober.Probe(default, default).ReturnsForAnyArgs(info => Task.Delay(TimeSpan.FromSeconds(3)));
+            _prober.ProbeIndirectly(default, default, default, default).ThrowsForAnyArgs(new InvalidOperationException("No"));
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(1, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Throw directly, instead of timing out the probe
+            _prober.Probe(default, default).ThrowsForAnyArgs(new Exception("nope"));
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(2, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            await Shutdown();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_Indirect_FailedProbe()
+        {
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.EnableIndirectProbes = true;
+
+            _prober.Probe(default, default).ThrowsForAnyArgs(info => new Exception("nonono!"));
+            _prober.ProbeIndirectly(default, default, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            {
+                FailureMessage = "fail",
+                IntermediaryHealthScore = 0,
+                ProbeResponseTime = TimeSpan.FromSeconds(1),
+                Succeeded = false
+            });
+            _monitor.Start();
+
+            // Let a timer complete
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(1, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            var otherSilo = Silo("127.0.0.1:1234@1234");
+            _membershipSnapshot = Snapshot(2, Member(_localSilo, SiloStatus.Active), Member(_monitor.SiloAddress, SiloStatus.Active), Member(otherSilo, SiloStatus.Joining));
+
+            // There is only one other active silo (the target silo), so an indirect probe cannot be performed.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(2, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Make the other silo active so that there is an intermediary to use for an indirect probe.
+            _membershipSnapshot = Snapshot(3, Member(_localSilo, SiloStatus.Active), Member(_monitor.SiloAddress, SiloStatus.Active), Member(otherSilo, SiloStatus.Active));
+
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // Since there is another active silo, an indirect probe will be performed.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(3, probeResult.FailedProbeCount);
+            Assert.False(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that the correct intermediary was selected.
+            var probeCall = _prober.ReceivedCalls().Single();
+            var args = probeCall.GetArguments();
+            var intermediary = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(otherSilo, intermediary);
+
+            // Ensure that negative results from unhealthy intermediaries are not considered.
+            _prober.ProbeIndirectly(default, default, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            {
+                FailureMessage = "fail",
+                IntermediaryHealthScore = 1,
+                ProbeResponseTime = TimeSpan.FromSeconds(1),
+                Succeeded = false
+            });
+
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            // The number of failed probes should not be incremented, the status should be "unknown", and the health score should be 1.
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Unknown, probeResult.Status);
+            Assert.Equal(3, probeResult.FailedProbeCount);
+            Assert.False(probeResult.IsDirectProbe);
+            Assert.Equal(1, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that the correct intermediary was selected.
+            probeCall = _prober.ReceivedCalls().Single();
+            args = probeCall.GetArguments();
+            intermediary = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(otherSilo, intermediary);
+
+            // After seeing that the chosen intermediary is unhealthy, a subsequent probe should be
+            // performed directly (since there are no other silos to use as an intermediary).
+            _prober.ClearReceivedCalls();
+            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+
+            probeResult = await _probeResults.Reader.ReadAsync();
+            Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
+            Assert.Equal(4, probeResult.FailedProbeCount);
+            Assert.True(probeResult.IsDirectProbe);
+            Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+
+            // Ensure that it was the target that was probed directly.
+            probeCall = _prober.ReceivedCalls().Single();
+            args = probeCall.GetArguments();
+            var target = Assert.IsType<SiloAddress>(args[0]);
+            Assert.Equal(_monitor.SiloAddress, target);
+
+            await Shutdown();
+        }
+
+        private static ClusterMembershipSnapshot Snapshot(long version, params ClusterMember[] members)
+            => new ClusterMembershipSnapshot(
+                ImmutableDictionary.CreateRange(
+                    members.Select(m => new KeyValuePair<SiloAddress, ClusterMember>(m.SiloAddress, m))),
+                new MembershipVersion(version));
+
+        private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
+
+        private static ClusterMember Member(SiloAddress address, SiloStatus status) => new ClusterMember(address, status, address.ToString());
+    }
+}


### PR DESCRIPTION
* Probe silos indirectly before submitting a vote

* Improve tests

* Remove no-longer necessary cases in SiloHealthMonitor, since concurrency has been removed.