### PR TITLE
Avoid disposing uncompleted task in LinuxEnvironmentStatistics

### DIFF
--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
@@ -50,8 +50,10 @@ namespace Orleans.Statistics
 
         public void Dispose()
         {
-            _cts?.Dispose();
-            _monitorTask?.Dispose();
+            if (_cts != null && !_cts.IsCancellationRequested)
+            {
+                _cts.Cancel();
+            }
         }
 
         public void Participate(ISiloLifecycle lifecycle)


### PR DESCRIPTION
Avoid exceptions when shutdown a silo where the monitoring task wasn't completed yet.