### PR TITLE
Added ability to configure reminder period

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 
 namespace Orleans.Configuration
@@ -6,8 +8,34 @@ namespace Orleans.Configuration
     public class ReminderOptions
     {
         /// <summary>
-        /// Minimal Interval for Reminders. High-frequency reminders are dangerous for production systems.
+        /// Minimum period for reminders. High-frequency reminders are dangerous for production systems.
         /// </summary>
-        public TimeSpan MinimalReminderInterval { get; set; } = Constants.MinReminderPeriod;
+        public TimeSpan MinimumReminderPeriod { get; set; } = Constants.MinReminderPeriod;
+    }
+
+    internal class ReminderOptionsValidator : IConfigurationValidator
+    {
+        private readonly ILogger<ReminderOptionsValidator> _logger;
+        private readonly ReminderOptions _options;
+
+        public ReminderOptionsValidator(ILogger<ReminderOptionsValidator> logger, IOptions<ReminderOptions> reminderOptions)
+        {
+            _logger = logger;
+            _options = reminderOptions.Value;
+        }
+
+        public void ValidateConfiguration()
+        {
+            if (_options.MinimumReminderPeriod < TimeSpan.Zero)
+            {
+                throw new OrleansConfigurationException($"{nameof(ReminderOptions)}.{nameof(ReminderOptions.MinimumReminderPeriod)} must not be less than {TimeSpan.Zero}");
+            }
+
+            if (_options.MinimumReminderPeriod < Constants.MinReminderPeriod)
+            {
+                _logger.LogWarning((int)ErrorCode.RS_FastReminderInterval,
+                        $"{nameof(ReminderOptions)}.{nameof(ReminderOptions.MinimumReminderPeriod)} is {_options.MinimumReminderPeriod:g} (default {Constants.MinReminderPeriod:g}. High-Frequency reminders are unsuitable for production use.");
+            }
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using Orleans.Runtime;
+
+namespace Orleans.Configuration
+{
+    public class ReminderOptions
+    {
+        /// <summary>
+        /// Minimal Interval for Reminders. High-frequency reminders are dangerous for production systems.
+        /// </summary>
+        public TimeSpan MinimalReminderInterval { get; set; } = Constants.MinReminderPeriod;
+    }
+}

--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -338,7 +338,7 @@ namespace Orleans
         Runtime_Error_100329 = Runtime + 329,
         Runtime_Error_100330 = Runtime + 330,
         Runtime_Error_100331 = Runtime + 331,
-        
+
         SiloBase                        = Runtime + 400,
         SiloStarting                    = SiloBase + 1,
         SiloStarted                     = SiloBase + 2,
@@ -555,7 +555,7 @@ namespace Orleans
         PerfCounterCategoryCheckError   = PerfCounterBase + 18,
         PerfCounterConnectError         = PerfCounterBase + 19,
         PerfCounterFailedToInitialize   = PerfCounterBase + 20,
-        
+
         ProxyClientBase                             = Runtime + 900,
         ProxyClient_ReceiveError                    = Runtime_Error_100021, // Backward compatability
         ProxyClient_SerializationError              = Runtime_Error_100159, // Backward compatability
@@ -897,8 +897,9 @@ namespace Orleans
         RS_Started                              = ReminderServiceBase + 36,
         RS_ServiceInitialLoadFailing            = ReminderServiceBase + 37,
         RS_ServiceInitialLoadFailed             = ReminderServiceBase + 38,
+        RS_FastReminderInterval                 = ReminderServiceBase + 39,
 
-        
+
         // Codes for the Consistent Ring Provider
         ConsistentRingProviderBase                  = Runtime + 3000,
         CRP_Local_Subscriber_Exception              = ConsistentRingProviderBase + 1,
@@ -999,7 +1000,7 @@ namespace Orleans
         PersistentStreamPullingManager_AlreadyStarted   = PersistentStreamPullingManagerBase + 21,
         PersistentStreamPullingManager_AlreadyStopped   = PersistentStreamPullingManagerBase + 22,
         PersistentStreamPullingManager_PeriodicPrint    = PersistentStreamPullingManagerBase + 23,
-        
+
         AzureServiceRuntimeWrapper          = Runtime + 3700,
         AzureServiceRuntime_NotLoaded       = AzureServiceRuntimeWrapper +1,
         AzureServiceRuntime_FailedToLoad    = AzureServiceRuntimeWrapper + 2,
@@ -1040,7 +1041,7 @@ namespace Orleans
         LogConsistency_CaughtException = LogConsistencyBase + 2,
         LogConsistency_ProtocolError = LogConsistencyBase + 3,
         LogConsistency_ProtocolFatalError = LogConsistencyBase + 4,
-        
+
         // Note: individual Service Fabric error codes are defined in
         // Microsoft.Orleans.ServiceFabric.Utilities.ErrorCode.
         ServiceFabricBase = Runtime + 4400,

--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -186,11 +186,6 @@ namespace Orleans.Runtime
             logger.LogInformation(LoggingUtils.CreateEventId(logCode), message);
         }
 
-        public static void Warn(this ILogger logger, string message, params object[] args)
-        {
-            logger.LogWarning(message, args);
-        }
-
         /// <summary>
         /// Writes a log entry at the Warning level
         /// </summary>

--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -72,7 +72,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Writes a log entry at the Info logLevel 
+        /// Writes a log entry at the Info logLevel
         /// </summary>
         /// <param name="logger">Target logger.</param>
         /// <param name="message">The log message.</param>
@@ -184,6 +184,11 @@ namespace Orleans.Runtime
         public static void Info(this ILogger logger, ErrorCode logCode, string message)
         {
             logger.LogInformation(LoggingUtils.CreateEventId(logCode), message);
+        }
+
+        public static void Warn(this ILogger logger, string message, params object[] args)
+        {
+            logger.LogWarning(message, args);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -104,6 +104,7 @@ namespace Orleans.Hosting
             services.AddLogging();
             services.TryAddSingleton<ITimerRegistry, TimerRegistry>();
             services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
+            services.AddTransient<IConfigurationValidator, ReminderOptionsValidator>();
             services.TryAddSingleton<GrainRuntime>();
             services.TryAddSingleton<IGrainRuntime, GrainRuntime>();
             services.TryAddSingleton<IGrainCancellationTokenRuntime, GrainCancellationTokenRuntime>();

--- a/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime.ReminderService
                         "Cannot register reminder {0} as requested period ({1}) is less than minimum allowed reminder period ({2})",
                         reminderName,
                         period,
-                        Constants.MinReminderPeriod);
+                        minReminderPeriod);
                 throw new ArgumentException(msg);
             }
             if (string.IsNullOrEmpty(reminderName))

--- a/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
@@ -52,7 +52,7 @@ namespace Orleans.Runtime.ReminderService
                     $"Cannot use value larger than {MaxSupportedTimeout}ms for period when creating a reminder");
 
             var reminderOptions = serviceProvider.GetService<IOptions<ReminderOptions>>();
-            var minReminderPeriod = reminderOptions.Value.MinimalReminderInterval;
+            var minReminderPeriod = reminderOptions.Value.MinimumReminderPeriod;
 
             if (period < minReminderPeriod)
             {

--- a/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime.Services;
 using Orleans.Timers;
 
@@ -49,7 +51,10 @@ namespace Orleans.Runtime.ReminderService
                     nameof(period),
                     $"Cannot use value larger than {MaxSupportedTimeout}ms for period when creating a reminder");
 
-            if (period < Constants.MinReminderPeriod)
+            var reminderOptions = serviceProvider.GetService<IOptions<ReminderOptions>>();
+            var minReminderPeriod = reminderOptions.Value.MinimalReminderInterval;
+
+            if (period < minReminderPeriod)
             {
                 var msg =
                     string.Format(

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -410,13 +410,6 @@ namespace Orleans.Runtime
             {
                 await StartAsyncTaskWithPerfAnalysis("Start reminder service", StartReminderService, stopWatch);
 
-                var reminderOptions = Services.GetService<IOptions<ReminderOptions>>();
-                var minReminderInterval = reminderOptions.Value.MinimalReminderInterval;
-
-                if (reminderOptions.Value.MinimalReminderInterval < Constants.MinReminderPeriod)
-                    this.logger.Warn(ErrorCode.RS_FastReminderInterval,
-                        $"A Minimal Reminder Interval of {minReminderInterval:g} has been set. High-Frequency reminders are dangerous for production use.");
-
                 async Task StartReminderService()
                 {
                     // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -414,7 +414,7 @@ namespace Orleans.Runtime
                 var minReminderInterval = reminderOptions.Value.MinimalReminderInterval;
 
                 if (reminderOptions.Value.MinimalReminderInterval < Constants.MinReminderPeriod)
-                    this.logger.Warn(
+                    this.logger.Warn(ErrorCode.RS_FastReminderInterval,
                         $"A Minimal Reminder Interval of {minReminderInterval:g} has been set. High-Frequency reminders are dangerous for production use.");
 
                 async Task StartReminderService()

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime
 
         private readonly ILoggerFactory loggerFactory;
         /// <summary>
-        /// Gets the type of this 
+        /// Gets the type of this
         /// </summary>
         internal string Name => this.siloDetails.Name;
         internal OrleansTaskScheduler LocalScheduler { get; private set; }
@@ -242,7 +242,7 @@ namespace Orleans.Runtime
 
             logger.Debug("Creating {0} System Target", "DeploymentLoadPublisher");
             RegisterSystemTarget(Services.GetRequiredService<DeploymentLoadPublisher>());
-            
+
             logger.Debug("Creating {0} System Target", "RemoteGrainDirectory + CacheValidator");
             RegisterSystemTarget(LocalGrainDirectory.RemoteGrainDirectory);
             RegisterSystemTarget(LocalGrainDirectory.CacheValidator);
@@ -336,7 +336,7 @@ namespace Orleans.Runtime
             StartTaskWithPerfAnalysis("Start local grain directory", LocalGrainDirectory.Start, stopWatch);
 
             this.runtimeClient.CurrentStreamProviderRuntime = this.Services.GetRequiredService<SiloProviderRuntime>();
-            
+
             // This has to follow the above steps that start the runtime components
             await StartAsyncTaskWithPerfAnalysis("Create system targets and inject dependencies", () =>
             {
@@ -356,7 +356,7 @@ namespace Orleans.Runtime
             // Load and init grain services before silo becomes active.
             await StartAsyncTaskWithPerfAnalysis("Init grain services",
                 () => CreateGrainServices(), stopWatch);
-            
+
             try
             {
                 StatisticsOptions statisticsOptions = Services.GetRequiredService<IOptions<StatisticsOptions>>().Value;
@@ -409,6 +409,14 @@ namespace Orleans.Runtime
             if (this.reminderService != null)
             {
                 await StartAsyncTaskWithPerfAnalysis("Start reminder service", StartReminderService, stopWatch);
+
+                var reminderOptions = Services.GetService<IOptions<ReminderOptions>>();
+                var minReminderInterval = reminderOptions.Value.MinimalReminderInterval;
+
+                if (reminderOptions.Value.MinimalReminderInterval < Constants.MinReminderPeriod)
+                    this.logger.Warn(
+                        $"A Minimal Reminder Interval of {minReminderInterval:g} has been set. High-Frequency reminders are dangerous for production use.");
+
                 async Task StartReminderService()
                 {
                     // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service
@@ -492,7 +500,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Gracefully stop the run time system only, but not the application. 
+        /// Gracefully stop the run time system only, but not the application.
         /// Applications requests would be abruptly terminated, while the internal system state gracefully stopped and saved as much as possible.
         /// Grains are not deactivated.
         /// </summary>
@@ -504,7 +512,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Gracefully stop the run time system and the application. 
+        /// Gracefully stop the run time system and the application.
         /// All grains will be properly deactivated.
         /// All in-flight applications requests would be awaited and finished gracefully.
         /// </summary>
@@ -515,7 +523,7 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Gracefully stop the run time system only, but not the application. 
+        /// Gracefully stop the run time system only, but not the application.
         /// Applications requests would be abruptly terminated, while the internal system state gracefully stopped and saved as much as possible.
         /// </summary>
         public async Task StopAsync(CancellationToken cancellationToken)
@@ -593,7 +601,7 @@ namespace Orleans.Runtime
             logger.Info(ErrorCode.SiloStopped, "Silo is Stopped()");
 
             // timers
-            if (platformWatchdog != null) 
+            if (platformWatchdog != null)
                 SafeExecute(platformWatchdog.Stop); // Silo may be dying before platformWatchdog was set up
 
             if (!ct.IsCancellationRequested)
@@ -624,7 +632,7 @@ namespace Orleans.Runtime
                     await LocalScheduler.QueueTask(()=>localGrainDirectory.Stop(true), localGrainDirectory.CacheValidator)
                         .WithCancellation(ct, "localGrainDirectory Stop failed because the task was cancelled");
                     SafeExecute(() => catalog.DeactivateAllActivations().Wait(ct));
-                    //wait for all queued message sent to OutboundMessageQueue before MessageCenter stop and OutboundMessageQueue stop. 
+                    //wait for all queued message sent to OutboundMessageQueue before MessageCenter stop and OutboundMessageQueue stop.
                     await Task.Delay(WaitForMessageToBeQueuedForOutbound);
                 }
             }
@@ -669,8 +677,8 @@ namespace Orleans.Runtime
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {
                     logger.Debug(
-                        "{GrainServiceType} Grain Service with Id {GrainServiceId} stopped successfully.", 
-                        grainService.GetType().FullName, 
+                        "{GrainServiceType} Grain Service with Id {GrainServiceId} stopped successfully.",
+                        grainService.GetType().FullName,
                         grainService.GetPrimaryKeyLong(out string ignored));
                 }
             }
@@ -700,10 +708,10 @@ namespace Orleans.Runtime
         /// <returns>Debug data for this silo.</returns>
         public string GetDebugDump(bool all = true)
         {
-            var sb = new StringBuilder();            
+            var sb = new StringBuilder();
             foreach (var systemTarget in activationDirectory.AllSystemTargets())
-                sb.AppendFormat("System target {0}:", ((ISystemTargetBase)systemTarget).GrainId.ToString()).AppendLine();               
-            
+                sb.AppendFormat("System target {0}:", ((ISystemTargetBase)systemTarget).GrainId.ToString()).AppendLine();
+
             var enumerator = activationDirectory.GetEnumerator();
             while(enumerator.MoveNext())
             {

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -69,8 +69,8 @@ namespace UnitTests.Grains
             this.logger.Info("Starting reminder {0}.", reminderName);
             IGrainReminder r = null;
             TimeSpan dueTime;
-            if (reminderOptions.Value.MinimalReminderInterval < TimeSpan.FromSeconds(2))
-                dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimalReminderInterval;
+            if (reminderOptions.Value.MinimumReminderPeriod < TimeSpan.FromSeconds(2))
+                dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimumReminderPeriod;
             else dueTime = usePeriod - TimeSpan.FromSeconds(2);
 
             if (validate)

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ReminderService;
@@ -28,6 +31,8 @@ namespace UnitTests.Grains
 
         private static long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
 
+        private IOptions<ReminderOptions> reminderOptions;
+
         private ILogger logger;
         private string myId; // used to distinguish during debugging between multiple activations of the same grain
 
@@ -38,6 +43,7 @@ namespace UnitTests.Grains
             this.reminderTable = reminderTable;
             this.unvalidatedReminderRegistry = new UnvalidatedReminderRegistry(services);
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+            this.reminderOptions = services.GetService<IOptions<ReminderOptions>>();
         }
 
         public override Task OnActivateAsync()
@@ -62,10 +68,15 @@ namespace UnitTests.Grains
             TimeSpan usePeriod = p ?? this.period;
             this.logger.Info("Starting reminder {0}.", reminderName);
             IGrainReminder r = null;
+            TimeSpan dueTime;
+            if (reminderOptions.Value.MinimalReminderInterval < TimeSpan.FromSeconds(2))
+                dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimalReminderInterval;
+            else dueTime = usePeriod - TimeSpan.FromSeconds(2);
+
             if (validate)
-                r = await RegisterOrUpdateReminder(reminderName, usePeriod - TimeSpan.FromSeconds(2), usePeriod);
+                r = await RegisterOrUpdateReminder(reminderName, dueTime, usePeriod);
             else
-                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(reminderName, usePeriod - TimeSpan.FromSeconds(2), usePeriod);
+                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(reminderName, dueTime, usePeriod);
 
             this.allReminders[reminderName] = r;
             this.sequence[reminderName] = 0;
@@ -78,7 +89,7 @@ namespace UnitTests.Grains
 
         public Task ReceiveReminder(string reminderName, TickStatus status)
         {
-            // it can happen that due to failure, when a new activation is created, 
+            // it can happen that due to failure, when a new activation is created,
             // it doesn't know which reminders were registered against the grain
             // hence, this activation may receive a reminder that it didn't register itself, but
             // the previous activation (incarnation of the grain) registered... so, play it safe
@@ -132,7 +143,7 @@ namespace UnitTests.Grains
             else
             {
                 // during failures, there may be reminders registered by an earlier activation that we dont have cached locally
-                // therefore, we need to update our local cache 
+                // therefore, we need to update our local cache
                 await GetMissingReminders();
                 if (this.allReminders.TryGetValue(reminderName, out reminder))
                 {
@@ -280,7 +291,7 @@ namespace UnitTests.Grains
 
         public Task ReceiveReminder(string reminderName, TickStatus status)
         {
-            // it can happen that due to failure, when a new activation is created, 
+            // it can happen that due to failure, when a new activation is created,
             // it doesn't know which reminders were registered against the grain
             // hence, this activation may receive a reminder that it didn't register itself, but
             // the previous activation (incarnation of the grain) registered... so, play it safe
@@ -332,7 +343,7 @@ namespace UnitTests.Grains
             else
             {
                 // during failures, there may be reminders registered by an earlier activation that we dont have cached locally
-                // therefore, we need to update our local cache 
+                // therefore, we need to update our local cache
                 await GetMissingReminders();
                 await UnregisterReminder(this.allReminders[reminderName]);
             }

--- a/test/Tester/MinimalReminderTests.cs
+++ b/test/Tester/MinimalReminderTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.CatalogTests
             public void Configure(ISiloBuilder siloBuilder)
             {
                 siloBuilder.Configure<ReminderOptions>(options =>
-                        options.MinimalReminderInterval = TimeSpan.FromMilliseconds(100))
+                        options.MinimumReminderPeriod = TimeSpan.FromMilliseconds(100))
                     .UseInMemoryReminderService();
             }
         }

--- a/test/Tester/MinimalReminderTests.cs
+++ b/test/Tester/MinimalReminderTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.CatalogTests
+{
+    public class MinimalReminderTests : IClassFixture<MinimalReminderTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<SiloConfiguration>();
+            }
+        }
+
+        public class SiloConfiguration : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder siloBuilder)
+            {
+                siloBuilder.Configure<ReminderOptions>(options =>
+                        options.MinimalReminderInterval = TimeSpan.FromMilliseconds(100))
+                    .UseInMemoryReminderService();
+            }
+        }
+
+        public MinimalReminderTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact, TestCategory("Catalog"), TestCategory("Functional")]
+        public async Task MinimalReminderInterval()
+        {
+            var grainGuid = Guid.NewGuid();
+            const string reminderName = "minimal_reminder";
+
+            var reminderGrain = this.fixture.GrainFactory.GetGrain<IReminderTestGrain2>(grainGuid);
+
+            IGrainReminder o1 = await reminderGrain.StartReminder(reminderName, TimeSpan.FromMilliseconds(100), true);
+
+            var r = await reminderGrain.GetReminderObject(reminderName);
+            await reminderGrain.StopReminder(r);
+
+        }
+    }
+}


### PR DESCRIPTION
One minute minimum restriction on Reminder period
- Added configurable options via ISiloHostBuilder
- Added Unit Tests to verify smaller reminder period no longer causes Silo to not start
- Resolved Tests to allow for new smaller interval
Fixes #4218 

**Log Entry**
[2020-12-09 16:50:11.014 GMT 11	Warning	0	Orleans.Runtime.Silo]	A Minimal Reminder Interval of 0:00:00.1 has been set. High-Frequency reminders are dangerous for production use.	