### PR TITLE
Close connections asynchronously and improve gracefulness

### DIFF
--- a/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
@@ -9,48 +10,120 @@ namespace Orleans.Connections.Security
 {
     internal class DuplexPipeStream : Stream
     {
-        private readonly PipeReader _input;
-        private readonly PipeWriter _output;
-        private readonly bool _throwOnCancelled;
-        private volatile bool _cancelCalled;
-
-        public DuplexPipeStream(PipeReader input, PipeWriter output, bool throwOnCancelled = false)
-        {
-            _input = input;
-            _output = output;
-            _throwOnCancelled = throwOnCancelled;
-        }
-
-        public void CancelPendingRead()
-        {
-            _cancelCalled = true;
-            _input.CancelPendingRead();
-        }
+        private readonly PipeReader _reader;
+        private readonly PipeWriter _writer;
 
         public override bool CanRead => true;
-
         public override bool CanSeek => false;
-
         public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 
-        public override long Length
+        public DuplexPipeStream(IDuplexPipe pipe)
         {
-            get
-            {
-                throw new NotSupportedException();
-            }
+            _reader = pipe.Input;
+            _writer = pipe.Output;
         }
 
-        public override long Position
+        protected override void Dispose(bool disposing)
         {
-            get
+            if (disposing)
             {
-                throw new NotSupportedException();
+                _reader.Complete();
+                _writer.Complete();
             }
-            set
+            base.Dispose(disposing);
+        }
+
+#if NETCOREAPP
+        public override async ValueTask DisposeAsync()
+        {
+            await _reader.CompleteAsync().ConfigureAwait(false);
+            await _writer.CompleteAsync().ConfigureAwait(false);
+        }
+#endif
+
+        public override void Flush()
+        {
+            FlushAsync().GetAwaiter().GetResult();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            FlushResult r = await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            if (r.IsCanceled) throw new OperationCanceledException(cancellationToken);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArguments(buffer, offset, count);
+
+            ValueTask<int> t = ReadAsync(buffer.AsMemory(offset, count));
+            return
+                t.IsCompleted ? t.GetAwaiter().GetResult() :
+                t.AsTask().GetAwaiter().GetResult();
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateBufferArguments(buffer, offset, count);
+
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public
+#if NETCOREAPP
+        override
+#endif
+        async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ReadResult result = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            if (result.IsCanceled)
             {
-                throw new NotSupportedException();
+                throw new OperationCanceledException();
             }
+
+            ReadOnlySequence<byte> sequence = result.Buffer;
+            long bufferLength = sequence.Length;
+            SequencePosition consumed = sequence.Start;
+
+            try
+            {
+                if (bufferLength != 0)
+                {
+                    int actual = (int)Math.Min(bufferLength, buffer.Length);
+
+                    ReadOnlySequence<byte> slice = actual == bufferLength ? sequence : sequence.Slice(0, actual);
+                    consumed = slice.End;
+                    slice.CopyTo(buffer.Span);
+
+                    return actual;
+                }
+
+                if (result.IsCompleted)
+                {
+                    return 0;
+                }
+            }
+            finally
+            {
+                _reader.AdvanceTo(consumed);
+            }
+
+            // This is a buggy PipeReader implementation that returns 0 byte reads even though the PipeReader
+            // isn't completed or canceled.
+            throw new InvalidOperationException("Read zero bytes unexpectedly");
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return TaskToApm.End<int>(asyncResult);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -63,168 +136,169 @@ namespace Orleans.Connections.Security
             throw new NotSupportedException();
         }
 
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            // ValueTask uses .GetAwaiter().GetResult() if necessary
-            // https://github.com/dotnet/corefx/blob/f9da3b4af08214764a51b2331f3595ffaf162abe/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs#L156
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), CancellationToken.None).Result;
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
-        }
-
-#if NETCOREAPP
-        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
-        {
-            return ReadAsyncInternal(destination, cancellationToken);
-        }
-#endif
-
         public override void Write(byte[] buffer, int offset, int count)
         {
-            WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (buffer != null)
-            {
-                _output.Write(new ReadOnlySpan<byte>(buffer, offset, count));
-            }
+            ValidateBufferArguments(buffer, offset, count);
 
-            await _output.FlushAsync(cancellationToken);
+            return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
         }
 
+        public
 #if NETCOREAPP
-        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
-        {
-            _output.Write(source.Span);
-            await _output.FlushAsync(cancellationToken);
-        }
+            override
 #endif
-
-        public override void Flush()
+        async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            FlushAsync(CancellationToken.None).GetAwaiter().GetResult();
-        }
-
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            return WriteAsync(null, 0, 0, cancellationToken);
-        }
-
-        private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                var result = await _input.ReadAsync(cancellationToken);
-                var readableBuffer = result.Buffer;
-                try
-                {
-                    if (_throwOnCancelled && result.IsCanceled && _cancelCalled)
-                    {
-                        // Reset the bool
-                        _cancelCalled = false;
-                        throw new OperationCanceledException();
-                    }
-
-                    if (!readableBuffer.IsEmpty)
-                    {
-                        // buffer.Count is int
-                        var count = (int)Math.Min(readableBuffer.Length, destination.Length);
-                        readableBuffer = readableBuffer.Slice(0, count);
-                        readableBuffer.CopyTo(destination.Span);
-                        return count;
-                    }
-
-                    if (result.IsCompleted)
-                    {
-                        return 0;
-                    }
-                }
-                finally
-                {
-                    _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
-                }
-            }
-        }
-
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            var task = ReadAsync(buffer, offset, count, CancellationToken.None, state);
-            if (callback != null)
-            {
-                task.ContinueWith(t => callback.Invoke(t));
-            }
-            return task;
-        }
-
-        public override int EndRead(IAsyncResult asyncResult)
-        {
-            return ((Task<int>)asyncResult).GetAwaiter().GetResult();
-        }
-
-        private Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
-        {
-            var tcs = new TaskCompletionSource<int>(state);
-            var task = ReadAsync(buffer, offset, count, cancellationToken);
-            task.ContinueWith((task2, state2) =>
-            {
-                var tcs2 = (TaskCompletionSource<int>)state2;
-                if (task2.IsCanceled)
-                {
-                    tcs2.SetCanceled();
-                }
-                else if (task2.IsFaulted)
-                {
-                    tcs2.SetException(task2.Exception);
-                }
-                else
-                {
-                    tcs2.SetResult(task2.Result);
-                }
-            }, tcs, cancellationToken);
-            return tcs.Task;
+            FlushResult r = await _writer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (r.IsCanceled) throw new OperationCanceledException(cancellationToken);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
-            var task = WriteAsync(buffer, offset, count, CancellationToken.None, state);
-            if (callback != null)
-            {
-                task.ContinueWith(t => callback.Invoke(t));
-            }
-            return task;
+            return TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
         }
 
         public override void EndWrite(IAsyncResult asyncResult)
         {
-            ((Task<object>)asyncResult).GetAwaiter().GetResult();
+            TaskToApm.End(asyncResult);
         }
 
-        private Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<object>(state);
-            var task = WriteAsync(buffer, offset, count, cancellationToken);
-            task.ContinueWith((task2, state2) =>
+            return _reader.CopyToAsync(destination, cancellationToken);
+        }
+
+        private static void ValidateBufferArguments(byte[] buffer, int offset, int size)
+        {
+            if (buffer == null)
             {
-                var tcs2 = (TaskCompletionSource<object>)state2;
-                if (task2.IsCanceled)
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if ((uint)offset > (uint)buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if ((uint)size > (uint)(buffer.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(size));
+            }
+        }
+
+        /// <summary>
+        /// Provides support for efficiently using Tasks to implement the APM (Begin/End) pattern.
+        /// </summary>
+        internal static class TaskToApm
+        {
+            /// <summary>
+            /// Marshals the Task as an IAsyncResult, using the supplied callback and state
+            /// to implement the APM pattern.
+            /// </summary>
+            /// <param name="task">The Task to be marshaled.</param>
+            /// <param name="callback">The callback to be invoked upon completion.</param>
+            /// <param name="state">The state to be stored in the IAsyncResult.</param>
+            /// <returns>An IAsyncResult to represent the task's asynchronous operation.</returns>
+            public static IAsyncResult Begin(Task task, AsyncCallback callback, object state) =>
+                new TaskAsyncResult(task, state, callback);
+
+            /// <summary>Processes an IAsyncResult returned by Begin.</summary>
+            /// <param name="asyncResult">The IAsyncResult to unwrap.</param>
+            public static void End(IAsyncResult asyncResult)
+            {
+                if (GetTask(asyncResult) is Task t)
                 {
-                    tcs2.SetCanceled();
+                    t.GetAwaiter().GetResult();
+                    return;
                 }
-                else if (task2.IsFaulted)
+
+                ThrowArgumentException(asyncResult);
+            }
+
+            /// <summary>Processes an IAsyncResult returned by Begin.</summary>
+            /// <param name="asyncResult">The IAsyncResult to unwrap.</param>
+            public static TResult End<TResult>(IAsyncResult asyncResult)
+            {
+                if (GetTask(asyncResult) is Task<TResult> task)
                 {
-                    tcs2.SetException(task2.Exception);
+                    return task.GetAwaiter().GetResult();
                 }
-                else
+
+                ThrowArgumentException(asyncResult);
+                return default!; // unreachable
+            }
+
+            /// <summary>Gets the task represented by the IAsyncResult.</summary>
+            public static Task GetTask(IAsyncResult asyncResult) => (asyncResult as TaskAsyncResult)?._task;
+
+            /// <summary>Throws an argument exception for the invalid <paramref name="asyncResult"/>.</summary>
+            private static void ThrowArgumentException(IAsyncResult asyncResult) =>
+                throw (asyncResult is null ?
+                    new ArgumentNullException(nameof(asyncResult)) :
+                    new ArgumentException(null, nameof(asyncResult)));
+
+            /// <summary>Provides a simple IAsyncResult that wraps a Task.</summary>
+            /// <remarks>
+            /// We could use the Task as the IAsyncResult if the Task's AsyncState is the same as the object state,
+            /// but that's very rare, in particular in a situation where someone cares about allocation, and always
+            /// using TaskAsyncResult simplifies things and enables additional optimizations.
+            /// </remarks>
+            internal sealed class TaskAsyncResult : IAsyncResult
+            {
+                /// <summary>The wrapped Task.</summary>
+                internal readonly Task _task;
+                /// <summary>Callback to invoke when the wrapped task completes.</summary>
+                private readonly AsyncCallback _callback;
+
+                /// <summary>Initializes the IAsyncResult with the Task to wrap and the associated object state.</summary>
+                /// <param name="task">The Task to wrap.</param>
+                /// <param name="state">The new AsyncState value.</param>
+                /// <param name="callback">Callback to invoke when the wrapped task completes.</param>
+                internal TaskAsyncResult(Task task, object state, AsyncCallback callback)
                 {
-                    tcs2.SetResult(null);
+                    Debug.Assert(task != null);
+                    _task = task;
+                    AsyncState = state;
+
+                    if (task.IsCompleted)
+                    {
+                        // Synchronous completion.  Invoke the callback.  No need to store it.
+                        CompletedSynchronously = true;
+                        callback?.Invoke(this);
+                    }
+                    else if (callback != null)
+                    {
+                        // Asynchronous completion, and we have a callback; schedule it. We use OnCompleted rather than ContinueWith in
+                        // order to avoid running synchronously if the task has already completed by the time we get here but still run
+                        // synchronously as part of the task's completion if the task completes after (the more common case).
+                        _callback = callback;
+                        _task.ConfigureAwait(continueOnCapturedContext: false)
+                             .GetAwaiter()
+                             .OnCompleted(InvokeCallback); // allocates a delegate, but avoids a closure
+                    }
                 }
-            }, tcs, cancellationToken);
-            return tcs.Task;
+
+                /// <summary>Invokes the callback.</summary>
+                private void InvokeCallback()
+                {
+                    Debug.Assert(!CompletedSynchronously);
+                    Debug.Assert(_callback != null);
+                    _callback.Invoke(this);
+                }
+
+                /// <summary>Gets a user-defined object that qualifies or contains information about an asynchronous operation.</summary>
+                public object AsyncState { get; }
+                /// <summary>Gets a value that indicates whether the asynchronous operation completed synchronously.</summary>
+                /// <remarks>This is set lazily based on whether the <see cref="_task"/> has completed by the time this object is created.</remarks>
+                public bool CompletedSynchronously { get; }
+                /// <summary>Gets a value that indicates whether the asynchronous operation has completed.</summary>
+                public bool IsCompleted => _task.IsCompleted;
+                /// <summary>Gets a <see cref="WaitHandle"/> that is used to wait for an asynchronous operation to complete.</summary>
+                public WaitHandle AsyncWaitHandle => ((IAsyncResult)_task).AsyncWaitHandle;
+            }
         }
     }
 }

--- a/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
@@ -20,7 +20,7 @@ namespace Orleans.Connections.Security
         }
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) :
-            base(duplexPipe.Input, duplexPipe.Output)
+            base(duplexPipe)
         {
             var stream = createStream(this);
             Stream = stream;

--- a/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
@@ -143,7 +143,7 @@ namespace Orleans.Connections.Security
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogWarning(1, ex, "Authentication failed: {Exception}", ex);
+                    _logger?.LogWarning(1, ex, "Authentication failed");
 #if NETCOREAPP
                     await sslStream.DisposeAsync();
 #else

--- a/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
@@ -186,7 +186,7 @@ namespace Orleans.Connections.Security
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogWarning(1, ex, "Authentication failed: {Exception}", ex);
+                    _logger?.LogWarning(1, ex, "Authentication failed");
 #if NETCOREAPP
                     await sslStream.DisposeAsync();
 #else

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -238,7 +238,7 @@ namespace Orleans.Messaging
         {
             try
             {
-                UpdateLiveGatewaysSnapshot(gateways.Select(gw => gw.ToGatewayAddress()), gatewayListProvider.MaxStaleness);
+                UpdateLiveGatewaysSnapshot(gateways.Select(gw => gw.ToGatewayAddress()), gatewayListProvider.MaxStaleness).Ignore();
             }
             catch (Exception exc)
             {
@@ -261,8 +261,7 @@ namespace Orleans.Messaging
                     logger.LogDebug("Discovered {GatewayCount} gateways: {Gateways}", refreshedGateways.Count, Utils.EnumerableToString(refreshedGateways));
                 }
 
-                // the next one will grab the lock.
-                UpdateLiveGatewaysSnapshot(refreshedGateways, gatewayListProvider.MaxStaleness);
+                await UpdateLiveGatewaysSnapshot(refreshedGateways, gatewayListProvider.MaxStaleness);
             }
             catch (Exception exc)
             {
@@ -271,13 +270,14 @@ namespace Orleans.Messaging
         }
 
         // This function is called asynchronously from gateway refresh timer.
-        private void UpdateLiveGatewaysSnapshot(IEnumerable<SiloAddress> refreshedGateways, TimeSpan maxStaleness)
+        private async Task UpdateLiveGatewaysSnapshot(IEnumerable<SiloAddress> refreshedGateways, TimeSpan maxStaleness)
         {
-            // this is a short lock, protecting the access to knownDead, knownMasked and cachedLiveGateways.
+            List<SiloAddress> connectionsToKeepAlive;
+
+            // This is a short lock, protecting the access to knownDead, knownMasked and cachedLiveGateways.
             lock (lockable)
             {
                 // now take whatever listProvider gave us and exclude those we think are dead.
-
                 var live = new List<SiloAddress>();
                 var now = DateTime.UtcNow;
 
@@ -340,8 +340,8 @@ namespace Orleans.Messaging
                 if (logger.IsEnabled(LogLevel.Information))
                 {
                     logger.Info(ErrorCode.GatewayManager_FoundKnownGateways,
-                            "Refreshed the live Gateway list. Found {0} gateways from Gateway listProvider: {1}. Picked only known live out of them. Now has {2} live Gateways: {3}. Previous refresh time was = {4}",
-                                knownGateways.Count,
+                            "Refreshed the live gateway list. Found {0} gateways from gateway list provider: {1}. Picked only known live out of them. Now has {2} live gateways: {3}. Previous refresh time was = {4}",
+                            knownGateways.Count,
                             Utils.EnumerableToString(knownGateways),
                             cachedLiveGateways.Count,
                             Utils.EnumerableToString(cachedLiveGateways),
@@ -351,13 +351,14 @@ namespace Orleans.Messaging
                 // Close connections to known dead connections, but keep the "masked" ones.
                 // Client will not send any new request to the "masked" connections, but might still
                 // receive responses
-                var connectionsToKeepAlive = new List<SiloAddress>(live);
+                connectionsToKeepAlive = new List<SiloAddress>(live);
                 connectionsToKeepAlive.AddRange(knownMasked.Select(e => e.Key));
-                this.CloseEvictedGatewayConnections(connectionsToKeepAlive);
             }
+
+            await this.CloseEvictedGatewayConnections(connectionsToKeepAlive);
         }
 
-        private void CloseEvictedGatewayConnections(List<SiloAddress> liveGateways)
+        private async Task CloseEvictedGatewayConnections(List<SiloAddress> liveGateways)
         {
             if (this.connectionManager == null) return;
 
@@ -381,7 +382,7 @@ namespace Orleans.Messaging
                         this.logger.LogInformation("Closing connection to {Endpoint} because it has been marked as dead", address);
                     }
 
-                    this.connectionManager.Close(address);
+                    await this.connectionManager.CloseAsync(address);
                 }
             }
         }

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -17,10 +17,20 @@ using Microsoft.Extensions.ObjectPool;
 
 namespace Orleans.Runtime.Messaging
 {
+    internal interface IUnderlyingTransportFeature
+    {
+        IDuplexPipe OriginalTransport { get; }
+    }
+
+    internal class OriginalConnectionTransportFeature : IUnderlyingTransportFeature
+    {
+        public IDuplexPipe OriginalTransport { get; set; }
+    }
+
     internal abstract class Connection
     {
         private static readonly Func<ConnectionContext, Task> OnConnectedDelegate = context => OnConnectedAsync(context);
-        private static readonly Action<object> OnConnectionClosedDelegate = state => ((Connection)state).CloseInternal(new ConnectionAbortedException("Connection closed"));
+        private static readonly Action<object> OnConnectionClosedDelegate = state => ((Connection)state).OnTransportConnectionClosed();
         private static readonly UnboundedChannelOptions OutgoingMessageChannelOptions = new UnboundedChannelOptions
         {
             SingleReader = true,
@@ -37,10 +47,13 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionDelegate middleware;
         private readonly Channel<Message> outgoingMessages;
         private readonly ChannelWriter<Message> outgoingMessageWriter;
-        private readonly object lockObj = new object();
+        private readonly object _closeLock = new object();
         private readonly List<Message> inflight = new List<Message>(4);
+        private readonly TaskCompletionSource<int> _transportConnectionClosed = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private IDuplexPipe _transport;
         private Task _processIncomingTask;
         private Task _processOutgoingTask;
+        private Task _closeTask;
 
         protected Connection(
             ConnectionContext connection,
@@ -61,7 +74,6 @@ namespace Orleans.Runtime.Messaging
 
             this.RemoteEndPoint = NormalizeEndpoint(this.Context.RemoteEndPoint);
             this.LocalEndPoint = NormalizeEndpoint(this.Context.LocalEndPoint);
-            this.IsValid = true;
         }
 
         public string ConnectionId => this.Context?.ConnectionId;
@@ -76,7 +88,7 @@ namespace Orleans.Runtime.Messaging
         protected MessageFactory MessageFactory => this.shared.MessageFactory;
         protected abstract IMessageCenter MessageCenter { get; }
 
-        public bool IsValid { get; private set; }
+        public bool IsValid => _closeTask is null;
 
         public static void ConfigureBuilder(ConnectionBuilder builder) => builder.Run(OnConnectedDelegate);
 
@@ -98,9 +110,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                this.CloseInternal(error);
-                this.RerouteMessages().Ignore();
-                await this.Context.DisposeAsync();
+                await this.CloseAsync(error);
             }
         }
 
@@ -115,12 +125,11 @@ namespace Orleans.Runtime.Messaging
 
         protected virtual async Task RunInternal()
         {
+            _transport = this.Context.Transport;
             _processIncomingTask = this.ProcessIncoming();
             _processOutgoingTask = this.ProcessOutgoing();
             await Task.WhenAll(_processIncomingTask, _processOutgoingTask);
         }
-
-        public void Abort(ConnectionAbortedException exception) => this.CloseInternal(exception);
 
         /// <summary>
         /// Called immediately prior to transporting a message.
@@ -131,103 +140,157 @@ namespace Orleans.Runtime.Messaging
 
         protected abstract void RetryMessage(Message msg, Exception ex = null);
 
-        public void Close()
+        public async Task CloseAsync(Exception exception)
         {
-            if (!this.IsValid) return;
-
-            // Stop processing incoming messages first.
-            // This signals the outgoing message processor to exit gracefully and terminate the connection.
-            this.outgoingMessageWriter.TryComplete();
-
-            lock (this.lockObj)
+            StartClosing(exception);
+            if (_closeTask is Task task && !task.IsCompleted)
             {
-                if (_processIncomingTask is null || _processOutgoingTask is null)
+                await _closeTask;
+            }
+        }
+
+        private void OnTransportConnectionClosed()
+        {
+            StartClosing(new ConnectionAbortedException("Underlying connection closed"));
+            _transportConnectionClosed.SetResult(0);
+        }
+
+        private void StartClosing(Exception exception)
+        {
+            if (_closeTask is object)
+            {
+                return;
+            }
+
+            TaskCompletionSource<int> completion;
+            lock (_closeLock)
+            {
+                if (_closeTask is object)
                 {
-                    // Connection has not started processing yet and may be stuck in a preparatory stage (eg, due to a misbehaved client).
-                    // This is not yet a functioning connection, so we should close it ungracefully.
-                    this.CloseInternal(new ConnectionAbortedException("Connection is being closed before handshake has completed"));
+                    return;
+                }
+
+                completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _closeTask = completion.Task;
+            }
+
+
+            if (this.Log.IsEnabled(LogLevel.Information))
+            {
+                this.Log.LogInformation(
+                    exception,
+                    "Closing connection {Connection}",
+                    this);
+            }
+
+            _ = WrapCloseAsync(this, completion);
+
+            // Propagate the result of the close method to the task completion source.
+            static async Task WrapCloseAsync(Connection self, TaskCompletionSource<int> completion)
+            {
+                try
+                {
+                    await Task.Yield();
+                    await self.FinishClosing().ConfigureAwait(false);
+                    completion.SetResult(0);
+                }
+                catch (Exception closeException)
+                {
+                    completion.SetException(closeException);
                 }
             }
         }
 
-        private void CloseInternal(Exception exception)
+        /// <summary>
+        /// Close the connection. This method should only be called by <see cref="StartClosing(Exception)"/>.
+        /// </summary>
+        private async Task FinishClosing()
         {
-            if (!this.IsValid) return;
+            NetworkingStatisticsGroup.OnClosedSocket(this.ConnectionDirection);
 
-            lock (this.lockObj)
+            // Signal the outgoing message processor to exit gracefully.
+            this.outgoingMessageWriter.TryComplete();
+
+            var transportFeature = Context.Features.Get<IUnderlyingTransportFeature>();
+            var transport = transportFeature?.OriginalTransport ?? _transport;
+
+            //transport.Input.CancelPendingRead();
+            //transport.Output.CancelPendingFlush();
+            await transport.Input.CompleteAsync();
+            await transport.Output.CompleteAsync();
+
+            // Try to gracefully stop the reader/writer loops, if they are running.
+            try
             {
-                try
+                if (_processIncomingTask is Task task && !task.IsCompleted)
                 {
-                    if (!this.IsValid) return;
-                    this.IsValid = false;
-                    NetworkingStatisticsGroup.OnClosedSocket(this.ConnectionDirection);
+                    await task.ConfigureAwait(false);
+                }
+            }
+            catch (Exception processIncomingException)
+            {
+                // Swallow any exceptions here.
+                this.Log.LogWarning(processIncomingException, "Exception processing incoming messages on connection {Connection}", this);
+            }
 
+            try
+            {
+                if (_processOutgoingTask is Task task && !task.IsCompleted)
+                {
+                    await task.ConfigureAwait(false);
+                }
+            }
+            catch (Exception processOutgoingException)
+            {
+                // Swallow any exceptions here.
+                this.Log.LogWarning(processOutgoingException, "Exception processing outgoing messages on connection {Connection}", this);
+            }
+
+            // Wait for the transport to signal that it's closed before disposing it.
+            await _transportConnectionClosed.Task;
+
+            try
+            {
+                await this.Context.DisposeAsync();
+            }
+            catch (Exception abortException)
+            {
+                // Swallow any exceptions here.
+                this.Log.LogWarning(abortException, "Exception terminating connection {Connection}", this);
+            }
+
+            // Reject in-flight messages.
+            foreach (var message in this.inflight)
+            {
+                this.OnSendMessageFailure(message, "Connection terminated");
+            }
+
+            this.inflight.Clear();
+
+            // Reroute enqueued messages.
+            var i = 0;
+            while (this.outgoingMessages.Reader.TryRead(out var message))
+            {
+                if (i == 0)
+                {
                     if (this.Log.IsEnabled(LogLevel.Information))
                     {
-                        if (exception is null)
-                        {
-                            this.Log.LogInformation(
-                                "Closing connection with remote endpoint {EndPoint}",
-                                this.RemoteEndPoint);
-                        }
-                        else
-                        {
-                            this.Log.LogInformation(
-                                exception,
-                                "Closing connection with remote endpoint {EndPoint}. Exception: {Exception}",
-                                this.RemoteEndPoint,
-                                exception);
-                        }
-                    }
-
-                    // Try to gracefully stop the reader/writer loops, if they are running.
-                    try
-                    {
-                        if (_processIncomingTask is Task task && !task.IsCompleted)
-                        {
-                            this.Context.Transport.Input.CancelPendingRead();
-                        }
-                    }
-                    catch (Exception cancelException)
-                    {
-                        // Swallow any exceptions here.
-                        this.Log.LogWarning(cancelException, "Exception canceling pending read with remote endpoint {EndPoint}: {Exception}", this.RemoteEndPoint, cancelException);
-                    }
-
-                    try
-                    {
-                        if (_processOutgoingTask is Task task && !task.IsCompleted)
-                        {
-                            this.Context.Transport.Output.CancelPendingFlush();
-                        }
-                    }
-                    catch (Exception cancelException)
-                    {
-                        // Swallow any exceptions here.
-                        this.Log.LogWarning(cancelException, "Exception canceling pending flush with remote endpoint {EndPoint}: {Exception}", this.RemoteEndPoint, cancelException);
-                    }
-
-                    this.outgoingMessageWriter.TryComplete();
-
-                    if (exception is null)
-                    {
-                        this.Context.Abort();
-                    }
-                    else
-                    {
-                        var abortedException = exception as ConnectionAbortedException
-                            ?? new ConnectionAbortedException(
-                                    $"Connection closed. See {nameof(Exception.InnerException)}",
-                                    exception);
-
-                        this.Context.Abort(abortedException);
+                        this.Log.LogInformation(
+                            "Rerouting messages for remote endpoint {EndPoint}",
+                            this.RemoteEndPoint?.ToString() ?? "(never connected)");
                     }
                 }
-                catch (Exception innerException)
-                {
-                    // Swallow any exceptions here.
-                    this.Log.LogWarning(innerException, "Exception closing connection with remote endpoint {EndPoint}: {Exception}", this.RemoteEndPoint, innerException);
-                }
+
+                ++i;
+                this.RetryMessage(message);
+            }
+
+            if (i > 0 && this.Log.IsEnabled(LogLevel.Information))
+            {
+                this.Log.LogInformation(
+                    "Rerouted {Count} messages for remote endpoint {EndPoint}",
+                    i,
+                    this.RemoteEndPoint?.ToString() ?? "(never connected)");
             }
         }
 
@@ -239,7 +302,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        public override string ToString() => $"Local: {this.LocalEndPoint}, Remote: {this.RemoteEndPoint}, ConnectionId: {this.Context.ConnectionId}";
+        public override string ToString() => $"[Local: {this.LocalEndPoint}, Remote: {this.RemoteEndPoint}, ConnectionId: {this.Context.ConnectionId}]";
 
         protected abstract void OnReceivedMessage(Message message);
 
@@ -250,11 +313,10 @@ namespace Orleans.Runtime.Messaging
             await Task.Yield();
 
             Exception error = default;
-            PipeReader input = default;
             var serializer = this.shared.ServiceProvider.GetRequiredService<IMessageSerializer>();
             try
             {
-                input = this.Context.Transport.Input;
+                var input = this._transport.Input;
                 var requiredBytes = 0;
                 Message message = default;
                 while (true)
@@ -295,17 +357,19 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exception)
             {
-                this.Log.LogWarning(
-                    exception,
-                    "Exception while processing messages from remote endpoint {EndPoint}: {Exception}",
-                    this.RemoteEndPoint,
-                    exception);
+                if (IsValid)
+                {
+                    this.Log.LogWarning(
+                        exception,
+                        "Exception while processing messages from remote endpoint {EndPoint}",
+                        this.RemoteEndPoint);
+                }
+
                 error = exception;
             }
             finally
             {
-                input?.Complete();
-                this.CloseInternal(error);
+                this.StartClosing(error);
             }
         }
 
@@ -314,11 +378,10 @@ namespace Orleans.Runtime.Messaging
             await Task.Yield();
 
             Exception error = default;   
-            PipeWriter output = default;
             var serializer = this.shared.ServiceProvider.GetRequiredService<IMessageSerializer>();
             try
             {
-                output = this.Context.Transport.Output;
+                var output = this._transport.Output;
                 var reader = this.outgoingMessages.Reader;
 
                 while (true)
@@ -355,58 +418,19 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exception)
             {
-                this.Log.LogWarning(
-                    exception,
-                    "Exception while processing messages to remote endpoint {EndPoint}: {Exception}",
-                    this.RemoteEndPoint,
-                    exception);
+                if (IsValid)
+                {
+                    this.Log.LogWarning(
+                        exception,
+                        "Exception while processing messages to remote endpoint {EndPoint}",
+                        this.RemoteEndPoint);
+                }
+
                 error = exception;
             }
             finally
             {
-                output?.Complete();
-                this.CloseInternal(error);
-            }
-        }
-
-        private async Task RerouteMessages()
-        {
-            lock (this.lockObj)
-            {
-                foreach (var message in this.inflight)
-                {
-                    this.OnSendMessageFailure(message, "Connection terminated");
-                }
-
-                this.inflight.Clear();
-            }
-
-            var i = 0;
-            while (this.outgoingMessages.Reader.TryRead(out var message))
-            {
-                if (i == 0)
-                {
-                    if (this.Log.IsEnabled(LogLevel.Information))
-                    {
-                        this.Log.LogInformation(
-                            "Rerouting messages for remote endpoint {EndPoint}",
-                            this.RemoteEndPoint?.ToString() ?? "(never connected)");
-                    }
-
-                    // Wait some time before re-sending the first time around.
-                    await Task.Delay(TimeSpan.FromSeconds(2));
-                }
-
-                ++i;
-                this.RetryMessage(message);
-            }
-
-            if (i > 0 && this.Log.IsEnabled(LogLevel.Information))
-            {
-                this.Log.LogInformation(
-                    "Rerouted {Count} messages for remote endpoint {EndPoint}",
-                    i,
-                    this.RemoteEndPoint?.ToString() ?? "(never connected)");
+                this.StartClosing(error);
             }
         }
 
@@ -445,11 +469,11 @@ namespace Orleans.Runtime.Messaging
         private bool HandleReceiveMessageFailure(Message message, Exception exception)
         {
             this.Log.LogWarning(
-                "Exception reading message {Message} from remote endpoint {Remote} to local endpoint {Local}: {Exception}",
+                exception,
+                "Exception reading message {Message} from remote endpoint {Remote} to local endpoint {Local}",
                 message,
                 this.RemoteEndPoint,
-                this.LocalEndPoint,
-                exception);
+                this.LocalEndPoint);
 
             // If deserialization completely failed, rethrow the exception so that it can be handled at another level.
             if (message?.Headers is null)
@@ -490,9 +514,9 @@ namespace Orleans.Runtime.Messaging
             // Response msg fails to serialize on the responding silo, so we try to send an error response back.
             this.Log.LogWarning(
                 (int)ErrorCode.Messaging_SerializationError,
-                "Unexpected error serializing message {Message}: {Exception}",
-                message,
-                exception);
+                exception,
+                "Unexpected error serializing message {Message}",
+                message);
 
             MessagingStatisticsGroup.OnFailedSentMessage(message);
 
@@ -518,9 +542,9 @@ namespace Orleans.Runtime.Messaging
             {
                 this.Log.LogWarning(
                     (int)ErrorCode.Messaging_OutgoingMS_DroppingMessage,
-                    "Dropping message which failed during serialization: {Message}. Exception = {Exception}",
-                    message,
-                    exception);
+                    exception,
+                    "Dropping message which failed during serialization: {Message}",
+                    message);
 
                 MessagingStatisticsGroup.OnDroppedSentMessage(message);
             }

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -37,6 +37,14 @@ namespace Orleans.Runtime.Messaging
 
                     // Configure the connection builder using the user-defined options.
                     var connectionBuilder = new ConnectionBuilder(this.serviceProvider);
+                    connectionBuilder.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            context.Features.Set<IUnderlyingTransportFeature>(new OriginalConnectionTransportFeature { OriginalTransport = context.Transport });
+                            await next(context);
+                        };
+                    });
                     this.ConfigureConnectionBuilder(connectionBuilder);
                     Connection.ConfigureBuilder(connectionBuilder);
                     return this.connectionDelegate = connectionBuilder.Build();

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -188,8 +188,14 @@ namespace Orleans.Runtime.Messaging
         // There is NO need to acquire individual ClientState lock, since we only access client Id (immutable) and close an older socket.
         private void DropClient(ClientState client)
         {
-            logger.Info(ErrorCode.GatewayDroppingClient, "Dropping client {0}, {1} after disconnect with no reconnect", 
-                client.Id, DateTime.UtcNow.Subtract(client.DisconnectedSince));
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                logger.LogInformation(
+                    (int)ErrorCode.GatewayDroppingClient,
+                    "Dropping client {ClientId}, {IdleDuration} after disconnect with no reconnect",
+                    client.Id,
+                    DateTime.UtcNow.Subtract(client.DisconnectedSince));
+            }
             
             clients.TryRemove(client.Id, out _);
             clientRegistrar.ClientDropped(client.Id);
@@ -200,7 +206,8 @@ namespace Orleans.Runtime.Messaging
                 // this will not happen, since we drop only already disconnected clients, for socket is already null. But leave this code just to be sure.
                 client.RecordDisconnection();
                 clientConnections.TryRemove(oldConnection, out _);
-                oldConnection.Close();
+
+                oldConnection.CloseAsync(exception: null).Ignore();
             }
             
             MessagingStatisticsGroup.ConnectedClientCount.DecrementBy(1);
@@ -475,7 +482,7 @@ namespace Orleans.Runtime.Messaging
                 catch (Exception exception)
                 {
                     gateway.RecordClosedConnection(connection);
-                    connection.Abort(new ConnectionAbortedException("Exception posting a message to sender. See InnerException for details.", exception));
+                    connection.CloseAsync(new ConnectionAbortedException("Exception posting a message to sender. See InnerException for details.", exception)).Ignore();
                     return false;
                 }
             }

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Internal;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -57,6 +59,14 @@ namespace Orleans.Runtime.Messaging
 
                     // Configure the connection builder using the user-defined options.
                     var connectionBuilder = new ConnectionBuilder(this.ServiceProvider);
+                    connectionBuilder.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            context.Features.Set<IUnderlyingTransportFeature>(new OriginalConnectionTransportFeature { OriginalTransport = context.Transport });
+                            await next(context);
+                        };
+                    });
                     this.ConfigureConnectionBuilder(connectionBuilder);
                     Connection.ConfigureBuilder(connectionBuilder);
                     return this.connectionDelegate = connectionBuilder.Build();
@@ -121,20 +131,17 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 var cycles = 0;
+                var closeTasks = new List<Task>();
+                var cancellationTask = cancellationToken.WhenCancelled();
                 while (this.ConnectionCount > 0)
                 {
+                    closeTasks.Clear();
                     foreach (var connection in this.connections.Keys.ToImmutableList())
                     {
-                        try
-                        {
-                            connection.Close();
-                        }
-                        catch
-                        {
-                        }
+                        closeTasks.Add(connection.CloseAsync(exception: null));
                     }
 
-                    await Task.Delay(10);
+                    await Task.WhenAny(Task.WhenAll(closeTasks), cancellationTask);
 
                     if (cancellationToken.IsCancellationRequested) break;
 

--- a/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
@@ -53,7 +53,7 @@ namespace Orleans.Runtime.Messaging
                 // Allow a short grace period to complete sending pending messages (eg, gossip responses)
                 await Task.Delay(TimeSpan.FromSeconds(10));
 
-                this.connectionManager.Close(silo);
+                await this.connectionManager.CloseAsync(silo);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
This is more involved than I would have liked.

* Add `Connection.CloseAsync(Exception)` method, which closes the connection asynchronously, completing the returned task once it has
* Clean up logging around expected termination cases
* Migrate to newer version of DuplexPipeStream.cs from dotnet/aspnetcore codebase (we are still running a fork until Bedrock is upstreamed into .NET itself or forked into a standalone lib)