### PR TITLE
Remove IGatewayListListener and IGatewayListObservable

### DIFF
--- a/src/Orleans.Core/Messaging/IGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/IGatewayListProvider.cs
@@ -13,6 +13,7 @@ namespace Orleans.Messaging
         /// Initializes the provider, will be called before all other methods
         /// </summary>
         Task InitializeGatewayListProvider();
+
         /// <summary>
         /// Returns the list of gateways (silos) that can be used by a client to connect to Orleans cluster.
         /// The Uri is in the form of: "gwy.tcp://IP:port/Generation". See Utils.ToGatewayUri and Utils.ToSiloAddress for more details about Uri format.
@@ -29,26 +30,5 @@ namespace Orleans.Messaging
         /// </summary>
         [Obsolete("This attribute is no longer used and all providers are considered updatable")]
         bool IsUpdatable { get; }
-    }
-
-    /// <summary>
-    /// A listener interface for optional GatewayList notifications provided by the IGatewayListObservable interface.
-    /// </summary>
-    public interface IGatewayListListener
-    {
-        void GatewayListNotification(IEnumerable<Uri> gateways);
-    }
-
-    /// <summary>
-    /// An optional interface that GatewayListProvider may implement if it support out of band gw update notifications.
-    /// By default GatewayListProvider should support pull based queries (GetGateways).
-    /// Optionally, some GatewayListProviders may be able to notify a listener if an updated gw information is available.
-    /// This is optional and not required.
-    /// </summary>
-    public interface IGatewayListObservable
-    {
-        bool SubscribeToGatewayNotificationEvents(IGatewayListListener listener);
-
-        bool UnSubscribeFromGatewayNotificationEvents(IGatewayListListener listener);
     }
 }


### PR DESCRIPTION
Fixes #6869

I see no strong need to deprecate the functionality first, since it is likely unused. Thankfully, `IGatewayListObservable` was an optional interface, with no implementers.