### PR TITLE
Remove unnecessary variable assignments

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -209,7 +209,7 @@ namespace Orleans.Storage
                 fields.Add(GRAIN_REFERENCE_PROPERTY_NAME, new AttributeValue(record.GrainReference));
                 fields.Add(GRAIN_TYPE_PROPERTY_NAME, new AttributeValue(record.GrainType));
 
-                int currentEtag = 0;
+                int currentEtag;
                 int.TryParse(grainState.ETag, out currentEtag);
                 newEtag = currentEtag;
                 fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = newEtag++.ToString() });
@@ -231,7 +231,7 @@ namespace Orleans.Storage
                 keys.Add(GRAIN_REFERENCE_PROPERTY_NAME, new AttributeValue(record.GrainReference));
                 keys.Add(GRAIN_TYPE_PROPERTY_NAME, new AttributeValue(record.GrainType));
 
-                int currentEtag = 0;
+                int currentEtag;
                 int.TryParse(grainState.ETag, out currentEtag);
                 newEtag = currentEtag;
                 newEtag++;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
@@ -72,7 +72,7 @@ namespace Orleans.Configuration
                     throw new OrleansConfigurationException($"Configuration for AzureBlobStorageOptions {name} is invalid. {nameof(options.ServiceUri)} is required for {nameof(options.TokenCredential)}");
                 }
 
-                if (!CloudStorageAccount.TryParse(this.options.ConnectionString, out var ignore))
+                if (!CloudStorageAccount.TryParse(this.options.ConnectionString, out _))
                     throw new OrleansConfigurationException(
                         $"Configuration for AzureBlobStorageOptions {name} is invalid. {nameof(this.options.ConnectionString)} is not valid.");
             }

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -824,8 +824,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         private void CheckAlertWriteError(string operation, object data1, string data2, Exception exc)
         {
             HttpStatusCode httpStatusCode;
-            string restStatus;
-            if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus) && AzureTableUtils.IsContentionError(httpStatusCode))
+            if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out _) && AzureTableUtils.IsContentionError(httpStatusCode))
             {
                 // log at Verbose, since failure on conditional is not not an error. Will analyze and warn later, if required.
                 if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug((int)Utilities.ErrorCode.AzureTable_13,

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
@@ -153,7 +153,7 @@ namespace Orleans.Runtime
         internal string GetPrimaryKeyString()
         {
             string key;
-            var tmp = GetPrimaryKey(out key);
+            _ = GetPrimaryKey(out key);
             return key;
         }
 
@@ -308,7 +308,7 @@ namespace Orleans.Runtime
                     idString = keyString.Substring(24, 8);
             }
 
-            string fullString = null;
+            string fullString;
             switch (Category)
             {
                 case UniqueKey.Category.Grain:

--- a/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
@@ -286,8 +286,7 @@ namespace Orleans.Runtime
 
         private static bool InterpretFileLoadException(string asmPathName, out string[] complaints)
         {
-            var matched = default(Assembly);
-
+            Assembly matched;
             try
             {
                 matched = MatchWithLoadedAssembly(AssemblyName.GetAssemblyName(asmPathName));

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -167,7 +167,7 @@ namespace Orleans.Internal
             }
             catch (Exception exc)
             {
-                var ignored = task.Exception; // Observe exception
+                _ = task.Exception; // Observe exception
                 logger.Error(errorCode, message, exc);
                 throw;
             }

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -431,8 +431,7 @@ namespace Orleans.Runtime
 
         public static bool IsConcreteGrainClass(Type type)
         {
-            IEnumerable<string> complaints;
-            return IsConcreteGrainClass(type, out complaints, complain: false);
+            return IsConcreteGrainClass(type, out _, complain: false);
         }
 
         public static bool IsGeneratedType(Type type)

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -361,8 +361,7 @@ namespace Orleans
 
         private void UnregisterCallback(CorrelationId id)
         {
-            CallbackData ignore;
-            callbacks.TryRemove(id, out ignore);
+            callbacks.TryRemove(id, out _);
         }
 
         public void Reset(bool cleanup)

--- a/src/Orleans.Core/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans.Core/Serialization/BinaryTokenStreamReader.cs
@@ -609,14 +609,13 @@ namespace Orleans.Serialization
 
         private byte[] CheckLength(int n, out int offset)
         {
-            bool ignore;
             byte[] res;
-            if (TryCheckLengthFast(n, out res, out offset, out ignore))
+            if (TryCheckLengthFast(n, out res, out offset, out _))
             {
                 return res;
             }
 
-            return CheckLength(n, out offset, out ignore);
+            return CheckLength(n, out offset, out _);
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -639,8 +638,6 @@ namespace Orleans.Serialization
 
         private byte[] CheckLength(int n, out int offset, out bool safeToUse)
         {
-            safeToUse = false;
-            offset = 0;
             if (currentOffset == currentSegmentOffsetPlusCount)
             {
                 StartNextSegment();

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1158,10 +1158,8 @@ namespace Orleans.Serialization
                 timer.Start();
                 context.SerializationManager.serializationStatistics.Deserializations.Increment();
             }
-            object result = null;
 
-            result = DeserializeInner(t, context);
-
+            var result = DeserializeInner(t, context);
             if (timer != null)
             {
                 timer.Stop();

--- a/src/Orleans.Core/Streams/Core/StreamSubscriptionManagerAdmin.cs
+++ b/src/Orleans.Core/Streams/Core/StreamSubscriptionManagerAdmin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,7 +21,7 @@ namespace Orleans.Streams.Core
 
         public IStreamSubscriptionManager GetStreamSubscriptionManager(string managerType)
         {
-            IStreamSubscriptionManager manager = null;
+            IStreamSubscriptionManager manager;
             if (this.managerStore.TryGetValue(managerType, out manager))
             {
                 return manager;

--- a/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Core/Streams/Internal/StreamConsumerExtension.cs
@@ -75,8 +75,7 @@ namespace Orleans.Streams
 
         public bool RemoveObserver(GuidId subscriptionId)
         {
-            IStreamSubscriptionHandle ignore;
-            return allStreamObservers.TryRemove(subscriptionId, out ignore);
+            return allStreamObservers.TryRemove(subscriptionId, out _);
         }
 
         public Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, InternalStreamId streamId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -42,12 +42,11 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         internal void AddStream(InternalStreamId streamId)
         {
-            StreamConsumerExtensionCollection obs;
             // no need to lock on _remoteConsumers, since on the client we have one extension per stream (per StreamProducer)
             // so this call is only made once, when StreamProducer is created.
-            if (remoteConsumers.TryGetValue(streamId, out obs)) return;
+            if (remoteConsumers.TryGetValue(streamId, out _)) return;
 
-            obs = new StreamConsumerExtensionCollection(streamPubSub, this.logger);
+            var obs = new StreamConsumerExtensionCollection(streamPubSub, this.logger);
             remoteConsumers.Add(streamId, obs);
         }
 

--- a/src/Orleans.Core/Telemetry/TelemetryManager.cs
+++ b/src/Orleans.Core/Telemetry/TelemetryManager.cs
@@ -37,9 +37,8 @@ namespace Orleans.Runtime
 
         private static ITelemetryConsumer GetTelemetryConsumer(IServiceProvider serviceProvider, Type consumerType)
         {
-            ITelemetryConsumer consumer = null;
             // first check whether it is registered in the container already
-            consumer = (ITelemetryConsumer)serviceProvider.GetService(consumerType);
+            var consumer = (ITelemetryConsumer)serviceProvider.GetService(consumerType);
             if (consumer == null)
             {
                 consumer = (ITelemetryConsumer)ActivatorUtilities.CreateInstance(serviceProvider, consumerType);

--- a/src/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -90,7 +90,6 @@ namespace Orleans.GrainDirectory.Redis
 
         public async Task Unregister(GrainAddress address)
         {
-            var key = GetKey(address.GrainId);
             var value = JsonConvert.SerializeObject(address);
 
             try

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -418,8 +418,7 @@ namespace Orleans.Runtime
             public bool TryRemove(ActivationData item)
             {
                 if (!item.TrySetCollectionCancelledFlag()) return false;
-
-                return items.TryRemove(item.ActivationId, out ActivationData unused);
+                return items.TryRemove(item.ActivationId, out _);
             }
 
             public IEnumerable<ActivationData> CancelAll()

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -106,8 +106,7 @@ namespace Orleans.Runtime
         public void RemoveSystemTarget(SystemTarget target)
         {
             var systemTarget = (ISystemTargetBase) target;
-            SystemTarget ignore;
-            systemTargets.TryRemove(target.ActivationId, out ignore);
+            systemTargets.TryRemove(target.ActivationId, out _);
             if (!Constants.IsSingletonSystemTarget(systemTarget.GrainId.Type))
             {
                 FindSystemTargetCounter(Constants.SystemTargetName(systemTarget.GrainId.Type)).DecrementBy(1);

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -211,8 +211,7 @@ namespace Orleans.Runtime
         /// <param name="id"></param>
         private void UnregisterCallback(CorrelationId id)
         {
-            CallbackData ignore;
-            callbacks.TryRemove(id, out ignore);
+            callbacks.TryRemove(id, out _);
         }
 
         public void SniffIncomingMessage(Message message)

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
@@ -82,8 +82,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool Remove(GrainId key)
         {
-            GrainDirectoryCacheEntry tmp;
-            return cache.RemoveKey(key, out tmp);
+            return cache.RemoveKey(key, out _);
         }
 
         public void Clear()

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -126,7 +126,6 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool RemoveActivation(ActivationId act, UnregistrationCause cause, TimeSpan lazyDeregistrationDelay, out IActivationInfo info, out bool wasRemoved)
         {
-            info = null;
             wasRemoved = false;
             if (Instances.TryGetValue(act, out info) && info.OkToRemove(cause, lazyDeregistrationDelay))
             {
@@ -335,9 +334,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="cause">reason for removing the activation</param>
         internal void RemoveActivation(GrainId grain, ActivationId activation, UnregistrationCause cause = UnregistrationCause.Force)
         {
-            IActivationInfo ignore1;
-            bool ignore2;
-            RemoveActivation(grain, activation, cause, out ignore1, out ignore2);
+            RemoveActivation(grain, activation, cause, out _, out _);
         }
 
 

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryCache.cs
@@ -54,8 +54,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns>true if the given key is in the cache</returns>
         public static bool LookUp(this IGrainDirectoryCache cache, GrainId key, out IReadOnlyList<Tuple<SiloAddress, ActivationId>> result)
         {
-            int version;
-            return cache.LookUp(key, out result, out version);
+            return cache.LookUp(key, out result, out _);
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
@@ -21,8 +21,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool Remove(GrainId key)
         {
-            IReadOnlyList<Tuple<SiloAddress, ActivationId>> tmp;
-            return cache.RemoveKey(key, out tmp);
+            return cache.RemoveKey(key, out _);
         }
 
         public void Clear()

--- a/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
@@ -187,8 +187,7 @@ namespace Orleans.Runtime.Placement
 
         public void RemoveSilo(SiloAddress removedSilo)
         {
-            CachedLocalStat ignore;
-            localCache.TryRemove(removedSilo, out ignore);
+            localCache.TryRemove(removedSilo, out _);
         }
     }
 }

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -223,9 +223,7 @@ namespace Orleans.Runtime
 
             if (Equals(updatedSilo, this.Silo))
                 this.publishTimer.Dispose();
-
-            SiloRuntimeStatistics ignore;
-            periodicStats.TryRemove(updatedSilo, out ignore);
+            periodicStats.TryRemove(updatedSilo, out _);
             NotifyAllStatisticsChangeEventsSubscribers(updatedSilo, null);
         }
     }

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -149,11 +149,10 @@ namespace Orleans.Core
 
         private string MakeErrorMsg(string what, Exception exc)
         {
-            HttpStatusCode httpStatusCode;
             string errorCode = string.Empty;
 
             var decoder = store as IRestExceptionDecoder;
-            decoder?.DecodeException(exc, out httpStatusCode, out errorCode, true);
+            decoder?.DecodeException(exc, out _, out errorCode, true);
 
             return string.Format("Error from storage provider {0} during {1} for grain Type={2} Pk={3} Id={4} Error={5}" + Environment.NewLine + " {6}",
                 $"{this.store.GetType().Name}.{this.name}", what, name, grainRef.GrainId.ToString(), grainRef, errorCode, LogFormatter.PrintException(exc));

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -612,18 +612,15 @@ namespace Orleans.Streams
         {
             if (this.options.BatchContainerBatchSize <= 1)
             {
-                Exception ignore;
-
                 if (!cursor.MoveNext())
                 {
                     return null;
                 }
 
-                return cursor.GetCurrent(out ignore);
+                return cursor.GetCurrent(out _);
             }
             else if (this.options.BatchContainerBatchSize > 1)
             {
-                Exception ignore;
                 int i = 0;
                 var batchContainers = new List<IBatchContainer>();
 
@@ -634,7 +631,7 @@ namespace Orleans.Streams
                         break;
                     }
 
-                    var batchContainer = cursor.GetCurrent(out ignore);
+                    var batchContainer = cursor.GetCurrent(out _);
 
                     if (!ShouldDeliverBatch(streamId, batchContainer, filterData))
                         continue;

--- a/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
+++ b/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
         internal static void InitializeSiloUnobservedExceptionsHandler(this IServiceProvider services)
         {
             //resolve handler from DI to initialize it
-            var ignore = services.GetService<SiloUnobservedExceptionsHandler>();
+            _ = services.GetService<SiloUnobservedExceptionsHandler>();
         }
 
         /// <summary>

--- a/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestHarness.cs
@@ -76,7 +76,6 @@ namespace Orleans.Transactions.TestKit.Consistency
 
             for (int i = 0; i < count; i++)
             {
-                string id = null;
                 var target = localRandom.Next(options.NumGrains);
                 output($"({partition},{i}) g{target}");
 
@@ -88,7 +87,7 @@ namespace Orleans.Transactions.TestKit.Consistency
 
                     if (result.Length > 0)
                     {
-                        id = result[0].ExecutingTx;
+                        var id = result[0].ExecutingTx;
 
                         lock (succeeded)
                             succeeded.Add(id);                           

--- a/src/Orleans.Transactions.TestKitBase/Grains/TransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/Grains/TransactionCoordinatorGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,7 +28,7 @@ namespace Orleans.Transactions.TestKit
 
         public Task OrphanCallTransaction(ITransactionTestGrain grain)
         {
-            Task t = grain.Add(1000);
+            _ = grain.Add(1000);
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionalStateStorageTestRunner.cs
@@ -200,11 +200,11 @@ namespace Orleans.Transactions.TestKit
 
             var expectedState = this.stateFactory(123);
             var pendingstate = MakePendingState(1, expectedState, false);
-            etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, null, null);
+            _ = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, null, null);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -231,16 +231,16 @@ namespace Orleans.Transactions.TestKit
             if (useTwoSteps)
             {
                 etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, null, null);
-                etag = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, null);
+                _ = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, null);
             }
             else
             {
-                etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, 1, null);
+                _ = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, 1, null);
             }
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -262,11 +262,11 @@ namespace Orleans.Transactions.TestKit
             var pendingstate = MakePendingState(1, this.stateFactory(123), false);
 
             etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate }, null, null);
-            etag = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 0);
+            _ = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 0);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -291,11 +291,11 @@ namespace Orleans.Transactions.TestKit
             var pendingstate2 = MakePendingState(1, expectedState2, false);
 
             etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate1 }, null, null);
-            etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate2 }, null, null);
+            _ = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate2 }, null, null);
       
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -328,22 +328,22 @@ namespace Orleans.Transactions.TestKit
                 if (reverseOrder)
                 {
                     etag = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, null);
-                    etag = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 1);
+                    _ = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 1);
                 }
                 else
                 {
                     etag = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, null);
-                    etag = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 1);
+                    _ = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 1);
                 }
             }
             else
             {
-                etag = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, 1);
+                _ = await stateStorage.Store(etag, metadata, emptyPendingStates, 1, 1);
             }
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -373,11 +373,11 @@ namespace Orleans.Transactions.TestKit
             {
                 pendingstates.Add(MakePendingState(i + 1, expectedStates[i], false));
             }
-            etag = await stateStorage.Store(etag, metadata, pendingstates, null, null);
+            _ = await stateStorage.Store(etag, metadata, pendingstates, null, null);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -416,16 +416,16 @@ namespace Orleans.Transactions.TestKit
             if (useTwoSteps)
             {
                 etag = await stateStorage.Store(etag, metadata, pendingstates, null, null);
-                etag = await stateStorage.Store(etag, metadata, emptyPendingStates, count, null);
+                _ = await stateStorage.Store(etag, metadata, emptyPendingStates, count, null);
             }
             else
             {
-                etag = await stateStorage.Store(etag, metadata, pendingstates, count, null);
+                _ = await stateStorage.Store(etag, metadata, pendingstates, count, null);
             }
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -457,11 +457,11 @@ namespace Orleans.Transactions.TestKit
             }
 
             etag = await stateStorage.Store(etag, metadata, pendingstates, null, null);
-            etag = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 0);
+            _ = await stateStorage.Store(etag, metadata, emptyPendingStates, null, 0);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -504,11 +504,11 @@ namespace Orleans.Transactions.TestKit
             }
 
             etag = await stateStorage.Store(etag, metadata, pendingstates1, null, null);
-            etag = await stateStorage.Store(etag, metadata, pendingstates2, null, null);
+            _ = await stateStorage.Store(etag, metadata, pendingstates2, null, null);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -554,11 +554,11 @@ namespace Orleans.Transactions.TestKit
             etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate1, pendingstate2, pendingstate3a, pendingstate4a}, null, null);
 
             // replace 3b,4b, prepare 5, 6, 7, 8 confirm 1, 2, 3b, 4b, 5, 6
-            etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate3b, pendingstate4b, pendingstate5, pendingstate6, pendingstate7, pendingstate8 }, 6, null);
+            _ = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate3b, pendingstate4b, pendingstate5, pendingstate6, pendingstate7, pendingstate8 }, 6, null);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
@@ -605,11 +605,11 @@ namespace Orleans.Transactions.TestKit
             etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate1, pendingstate2, pendingstate3a, pendingstate4a, pendingstate5, pendingstate6, pendingstate7, pendingstate8 }, null, null);
 
             // replace 3b,4b, confirm 1, 2, 3b, cancel 5, 6, 7, 8
-            etag = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate3b, pendingstate4b }, 3, 4);
+            _ = await stateStorage.Store(etag, metadata, new List<PendingTransactionState<TState>>() { pendingstate3b, pendingstate4b }, 3, 4);
 
             loadresponse = await stateStorage.Load();
-            etag = loadresponse.ETag;
-            metadata = loadresponse.Metadata;
+            _ = loadresponse.ETag;
+            _ = loadresponse.Metadata;
 
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
@@ -60,9 +60,10 @@ namespace Orleans.Transactions
                 return (TransactionalStatus.Ok, null);
             }
 
-            List<ParticipantId> writeParticipants = null;
-            List<KeyValuePair<ParticipantId, AccessCounter>> resources = null;
             KeyValuePair<ParticipantId, AccessCounter>? manager;
+
+            List<ParticipantId> writeParticipants;
+            List<KeyValuePair<ParticipantId, AccessCounter>> resources;
             CollateParticipants(transactionInfo.Participants, out writeParticipants, out resources, out manager);
             try
             {

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -414,7 +414,7 @@ namespace Orleans.Transactions.State
                     // if we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
                     if (group == null
                         && pos.FillCount < this.options.MaxLockGroupSize
-                        && !HasConflict(isRead, DateTime.MaxValue, guid, pos, out var resolvable))
+                        && !HasConflict(isRead, DateTime.MaxValue, guid, pos, out _))
                     {
                         group = pos;
                     }

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -114,7 +114,6 @@ namespace Orleans.Providers.Streams.Common
             {
                 var newestMessage = this.Newest.Value;
                 var oldestMessage = this.Oldest.Value;
-                var now = DateTime.UtcNow;
                 var newestMessageEnqueueTime = newestMessage.EnqueueTimeUtc;
                 var oldestMessageEnqueueTime = oldestMessage.EnqueueTimeUtc;
                 var oldestMessageDequeueTime = oldestMessage.DequeueTimeUtc;

--- a/src/Serializers/Orleans.Serialization.Protobuf/ProtobufSerializer.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ProtobufSerializer.cs
@@ -101,7 +101,7 @@ namespace Orleans.Serialization
             }
 
             var typeHandle = expectedType.TypeHandle;
-            MessageParser parser = null;
+            MessageParser parser;
             if (!Parsers.TryGetValue(typeHandle, out parser))
             {
                 throw new ArgumentException("No parser found for the expected type " + expectedType, nameof(expectedType));

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -189,7 +189,6 @@ namespace DefaultCluster.Tests.General
         public void BasicActivation_Reentrant_RecoveryAfterExpiredMessage()
         {
             List<Task> promises = new List<Task>();
-            var client = (IInternalClusterClient) this.Client;
             TimeSpan prevTimeout = this.GetResponseTimeout();
             try
             {

--- a/test/DefaultCluster.Tests/CodeGenTests/IRuntimeCodeGenGrain.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/IRuntimeCodeGenGrain.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 namespace Tester.CodeGenTests
 {
     using System;
@@ -280,8 +280,6 @@ namespace Tester.CodeGenTests
 
             public int GetHashCode(@event obj)
             {
-                var x = typeof(NestedGeneric<int>.Nested);
-
                 return obj.GetHashCode();
             }
         }

--- a/test/DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/DefaultCluster.Tests/ErrorGrainTest.cs
@@ -31,7 +31,7 @@ namespace DefaultCluster.Tests
         {
             var grainFullName = typeof(ErrorGrain).FullName;
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName);
-            int ignored = await grain.GetA();
+            _ = await grain.GetA();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -660,7 +660,7 @@ namespace DefaultCluster.Tests.General
         {
             var grainId = Guid.NewGuid();
             var grain =  this.GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
-            var c1 = await grain.GetState();
+            _ = await grain.GetState();
         }
                 
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
@@ -965,7 +965,7 @@ namespace DefaultCluster.Tests.General
 
                 await grain.Hello();
 
-                var castRef = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
 
                 var response = await grain.Hello();
 
@@ -977,7 +977,7 @@ namespace DefaultCluster.Tests.General
             public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating() {
                 var grain =  this.GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
 
-                var castRef = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
 
                 var response = await grain.Hello();
 
@@ -1014,8 +1014,7 @@ namespace DefaultCluster.Tests.General
                 var grain =  this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
 
                 await grain.Hello();
-
-                var castRef = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
+                _ = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
 
                 var response = await grain.Hello();
 
@@ -1026,8 +1025,7 @@ namespace DefaultCluster.Tests.General
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating() {
                 var grain =  this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
-
-                var castRef = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
+                _ = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
 
                 var response = await grain.Hello();
 

--- a/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
@@ -149,7 +149,6 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastInternalCastFromMyType()
         {
-            var serviceName = typeof(SimpleGrain).FullName;
             GrainReference grain = (GrainReference)this.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), SimpleGrain.SimpleGrainNamePrefix);
             
             // This cast should be a no-op, since the interface matches the initial reference's exactly.

--- a/test/DefaultCluster.Tests/SimpleGrainTests.cs
+++ b/test/DefaultCluster.Tests/SimpleGrainTests.cs
@@ -24,7 +24,7 @@ namespace DefaultCluster.Tests.General
         public async Task SimpleGrainGetGrain()
         {
             ISimpleGrain grain = GetSimpleGrain();
-            int ignored = await grain.GetAxB();
+            _ = await grain.GetAxB();
         }
 
         [Fact, TestCategory("BVT")]

--- a/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
+++ b/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
@@ -48,7 +48,7 @@ namespace DependencyInjection.Tests
         public async Task CanGetGrainWithInjectedDependencies()
         {
             IDIGrainWithInjectedServices grain = this.fixture.GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
-            long ignored = await grain.GetLongValue();
+            var _ = await grain.GetLongValue();
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace DependencyInjection.Tests
             // please don't inject your implemetation of IGrainFactory to DI container in Startup Class, 
             // since we are currently not supporting replacing IGrainFactory 
             IDIGrainWithInjectedServices grain = this.fixture.GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
-            long ignored = await grain.GetGrainFactoryId();
+            _ = await grain.GetGrainFactoryId();
         }
 
         [Fact]

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -141,8 +141,7 @@ namespace AWSUtils.Tests.StorageTests
             var storage = await InitDynamoDBTableStorageProvider(
                 this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
-            var convertedState = new GrainStateContainingGrainReferences();
-            convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
+            var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
             Assert.NotNull(convertedState); // Converted state
             Assert.Equal(initialState.Grain, convertedState.Grain);  // "Grain"
         }

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -74,11 +74,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             this.cachePressureInjectionMonitor.isUnderPressure = true;
             //set purgePredicate to be ShouldPurge
             this.purgePredicate.ShouldPurge = true;
-
-            //perform purge
-            IList<IBatchContainer> ignore;
-            this.receiver1.TryPurgeFromCache(out ignore);
-            this.receiver2.TryPurgeFromCache(out ignore);
+            this.receiver1.TryPurgeFromCache(out _);
+            this.receiver2.TryPurgeFromCache(out _);
 
             //Assert
             int expectedItemCountInCacheList = itemAddToCache + itemAddToCache;
@@ -102,9 +99,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             this.purgePredicate.ShouldPurge = false;
 
             //perform purge
-            IList<IBatchContainer> ignore;
-            this.receiver1.TryPurgeFromCache(out ignore);
-            this.receiver2.TryPurgeFromCache(out ignore);
+            this.receiver1.TryPurgeFromCache(out _);
+            this.receiver2.TryPurgeFromCache(out _);
 
             //Assert
             int expectedItemCountInCacheList = itemAddToCache + itemAddToCache;
@@ -128,9 +124,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             this.purgePredicate.ShouldPurge = true;
 
             //perform purge
-            IList<IBatchContainer> ignore;
-            this.receiver1.TryPurgeFromCache(out ignore);
-            this.receiver2.TryPurgeFromCache(out ignore);
+            this.receiver1.TryPurgeFromCache(out _);
+            this.receiver2.TryPurgeFromCache(out _);
 
             //Assert
             int expectedItemCountInCaches = 0;

--- a/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -75,7 +75,7 @@ namespace ServiceBus.Tests.MonitorTests
             var streamId = new FullStreamIdentity(Guid.NewGuid(), StreamNamespace, StreamProviderName);
             //set up 30 healthy consumer grain to show how much we favor slow consumer 
             int healthyConsumerCount = 30;
-            var healthyConsumers = await EHSlowConsumingTests.SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamId.Guid, StreamNamespace, StreamProviderName, healthyConsumerCount);
+            _ = await EHSlowConsumingTests.SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamId.Guid, StreamNamespace, StreamProviderName, healthyConsumerCount);
 
             //configure data generator for stream and start producing
             var mgmtGrain = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
@@ -159,7 +159,7 @@ namespace UnitTests.General
             var splitScripts = ConvertToExecutableBatches(setupScript, dataBaseName);
             foreach (var script in splitScripts)
             {
-                var res1 = await Storage.ExecuteAsync(script);
+                _ = await Storage.ExecuteAsync(script);
             }
         }
 

--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/CommonFixture.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/CommonFixture.cs
@@ -60,7 +60,7 @@ namespace UnitTests.StorageTests.Relational
         /// </summary>
         public CommonFixture()
         {
-            var clusterOptions = this.Services.GetRequiredService<IOptions<ClusterOptions>>();
+            _ = this.Services.GetRequiredService<IOptions<ClusterOptions>>();
             DefaultProviderRuntime = new ClientProviderRuntime(
                 this.InternalGrainFactory,
                 this.Services,

--- a/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
@@ -102,7 +102,7 @@ namespace Tester.AzureUtils
 
             var data3 = data.Clone();
             data3.StringData = "EvenNewerData";
-            string ignoredETag = await manager.UpdateTableEntryAsync(data3, eTag1);
+            _ = await manager.UpdateTableEntryAsync(data3, eTag1);
             tuple = await manager.ReadSingleTableEntryAsync(data3.PartitionKey, data3.RowKey);
             Assert.Equal(data3.StringData, tuple.Item1.StringData);
 
@@ -293,7 +293,7 @@ namespace Tester.AzureUtils
 
             string etag = await manager.CreateTableEntryAsync(data2.Clone());
             var tuple1 = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag);
-            var tuple2 = await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
+            _ = await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
 
             try
             {

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -567,7 +567,7 @@ namespace UnitTests.StreamingTests
             for (int i = 0; i < numStreams; i++)
             {
                 var streamId = new InternalStreamId(streamProviderName, streamIds[i]);
-                string extKey = streamProviderName + "_" + this.StreamNamespace;
+                _ = streamProviderName + "_" + this.StreamNamespace;
 
                 IPubSubRendezvousGrain pubsub = this.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
 
@@ -645,8 +645,7 @@ namespace UnitTests.StreamingTests
         {
             var consumers = new List<IStreamLifecycleConsumerGrain>();
             var promises = new List<Task>();
-
-            long consumerIdStart = random.Next();
+            _ = random.Next();
             for (int loopCount = 0; loopCount < numConsumers; loopCount++)
             {
                 var grain = this.GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
@@ -794,13 +793,10 @@ namespace UnitTests.StreamingTests
             List<IStreamLifecycleProducerGrain> producers, List<IStreamLifecycleConsumerGrain> consumers,
             bool useFanOut)
         {
-            long nextGrainId = random.Next();
-
             //var promises = new List<Task>();
             AsyncPipeline pipeline = new AsyncPipeline(InitPipelineSize);
 
             // Consumers
-            long consumerIdStart = nextGrainId;
             for (int loopCount = 0; loopCount < numConsumers; loopCount++)
             {
                 var grain = this.GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
@@ -833,10 +829,8 @@ namespace UnitTests.StreamingTests
                 //output.WriteLine("InitializeTopology: Waiting for {0} consumers to initialize", pipeline.Count);
                 pipeline.Wait();
             }
-            nextGrainId += numConsumers;
 
             // Producers
-            long producerIdStart = nextGrainId;
             pipeline = new AsyncPipeline(InitPipelineSize);
             for (int loopCount = 0; loopCount < numProducers; loopCount++)
             {

--- a/test/Grains/TestGrains/ObserverManager.cs
+++ b/test/Grains/TestGrains/ObserverManager.cs
@@ -134,9 +134,8 @@ namespace UnitTests.Grains
         /// </param>
         public void Unsubscribe(TAddress subscriber)
         {
-            ObserverEntry removed;
             this.log.LogDebug(this.logPrefix + ": Removed entry for {0}. {1} total subscribers after remove.", subscriber, this.observers.Count);
-            this.observers.TryRemove(subscriber, out removed);
+            this.observers.TryRemove(subscriber, out _);
         }
 
         /// <summary>
@@ -188,8 +187,7 @@ namespace UnitTests.Grains
             {
                 foreach (var observer in defunct)
                 {
-                    ObserverEntry removed;
-                    this.observers.TryRemove(observer, out removed);
+                    this.observers.TryRemove(observer, out _);
                     if (this.log.IsEnabled(LogLevel.Debug))
                     {
                         this.log.LogDebug(this.logPrefix + ": Removing defunct entry for {0}. {1} total subscribers after remove.", observer, this.observers.Count);
@@ -244,8 +242,7 @@ namespace UnitTests.Grains
             {
                 foreach (var observer in defunct)
                 {
-                    ObserverEntry removed;
-                    this.observers.TryRemove(observer, out removed);
+                    this.observers.TryRemove(observer, out _);
                     if (this.log.IsEnabled(LogLevel.Debug))
                     {
                         this.log.LogDebug(this.logPrefix + ": Removing defunct entry for {0}. {1} total subscribers after remove.", observer, this.observers.Count);
@@ -277,8 +274,7 @@ namespace UnitTests.Grains
                 this.log.Info(this.logPrefix + ": Removing {0} defunct observers entries.", defunct.Count);
                 foreach (var observer in defunct)
                 {
-                    ObserverEntry removed;
-                    this.observers.TryRemove(observer, out removed);
+                    this.observers.TryRemove(observer, out _);
                 }
             }
         }

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
@@ -20,8 +20,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
     {
         public Task<bool> CanGetSubscriptionManager(string providerName)
         {
-            IStreamSubscriptionManager manager;
-            return Task.FromResult(this.ServiceProvider.GetServiceByName<IStreamProvider>(providerName).TryGetStreamSubscrptionManager(out manager));
+            return Task.FromResult(this.ServiceProvider.GetServiceByName<IStreamProvider>(providerName).TryGetStreamSubscrptionManager(out _));
         }
     }
 

--- a/test/Grains/TestGrains/SimpleDIGrain.cs
+++ b/test/Grains/TestGrains/SimpleDIGrain.cs
@@ -24,11 +24,10 @@ namespace UnitTests.Grains
             this.injectedService = injectedService;
             this.injectedGrainFactory = injectedGrainFactory;
             this.injectedScopedService = injectedScopedService;
-            bool set;
             // get the object Id for injected GrainFactory, 
             // object Id will be the same if the underlying object is the same,
             // this is one way to prove that this GrainFactory is injected from DI
-            this.grainFactoryId = ObjectIdGenerator.GetId(this.injectedGrainFactory, out set);
+            this.grainFactoryId = ObjectIdGenerator.GetId(this.injectedGrainFactory, out _);
             this.grainContextAccessor = grainContextAccessor;
         }
 

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -399,7 +399,7 @@ namespace UnitTests.Grains
         public Task<string> GetExtendedKeyValue()
         {
             string extKey;
-            var pk = this.GetPrimaryKey(out extKey);
+            _ = this.GetPrimaryKey(out extKey);
             return Task.FromResult(extKey);
         }
 
@@ -504,7 +504,7 @@ namespace UnitTests.Grains
         public Task<string> GetExtendedKeyValue()
         {
             string extKey;
-            var pk = this.GetPrimaryKey(out extKey);
+            _ = this.GetPrimaryKey(out extKey);
             return Task.FromResult(extKey);
         }
 

--- a/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
@@ -65,7 +65,7 @@ namespace UnitTests.PersistentState.Grains
         public Task<string> GetExtendedKeyValue()
         {
             string extKey;
-            var pk = this.GetPrimaryKey(out extKey);
+            _ = this.GetPrimaryKey(out extKey);
             return Task.FromResult(extKey);
         }
 

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -67,12 +67,12 @@ namespace UnitTests.Grains
         {
             TimeSpan usePeriod = p ?? this.period;
             this.logger.Info("Starting reminder {0}.", reminderName);
-            IGrainReminder r = null;
             TimeSpan dueTime;
             if (reminderOptions.Value.MinimumReminderPeriod < TimeSpan.FromSeconds(2))
                 dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimumReminderPeriod;
             else dueTime = usePeriod - TimeSpan.FromSeconds(2);
 
+            IGrainReminder r;
             if (validate)
                 r = await RegisterOrUpdateReminder(reminderName, dueTime, usePeriod);
             else
@@ -135,7 +135,7 @@ namespace UnitTests.Grains
             this.logger.Info("Stopping reminder {0}.", reminderName);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             //return UnregisterReminder(allReminders[reminderName]);
-            IGrainReminder reminder = null;
+            IGrainReminder reminder;
             if (this.allReminders.TryGetValue(reminderName, out reminder))
             {
                 await UnregisterReminder(reminder);
@@ -265,7 +265,7 @@ namespace UnitTests.Grains
         {
             TimeSpan usePeriod = p ?? this.period;
             this.logger.Info("Starting reminder {0} for {1}", reminderName, this.GrainId);
-            IGrainReminder r = null;
+            IGrainReminder r;
             if (validate)
                 r = await RegisterOrUpdateReminder(reminderName, /*TimeSpan.FromSeconds(3)*/usePeriod - TimeSpan.FromSeconds(2), usePeriod);
             else
@@ -335,7 +335,7 @@ namespace UnitTests.Grains
             this.logger.Info("Stopping reminder {0}.", reminderName);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             //return UnregisterReminder(allReminders[reminderName]);
-            IGrainReminder reminder = null;
+            IGrainReminder reminder;
             if (this.allReminders.TryGetValue(reminderName, out reminder))
             {
                 await UnregisterReminder(reminder);

--- a/test/Grains/TestInternalGrains/StressTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StressTestGrain.cs
@@ -241,7 +241,7 @@ namespace UnitTests.Grains
                 Func<Task> func = (async () =>
                 {
                     await Task.Delay(random.NextTimeSpan(delay));
-                    string fileMetadata = fileMetadatas[fileId];
+                    _ = fileMetadatas[fileId];
                 });
                 tagPromises.Add(func());
             }

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -54,7 +54,7 @@ namespace UnitTestGrains
                 logger.Error((int)ErrorCode.Runtime_Error_100146, "grain not running in the right activation context");
 
             string name = (string)data;
-            IDisposable timer = null;
+            IDisposable timer;
             if (name == DefaultTimerName)
             {
                 timer = defaultTimer;

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -86,7 +86,6 @@ namespace UnitTests.General
                 var sw = new BinaryTokenStreamWriter();
                 sw.Write(siloAddress);
                 sw.Write(i);
-                var tmp = sw.ToByteArray();
                 var expected = JenkinsHash.ComputeHash(sw.ToByteArray());
 
                 Assert.Equal(expected, result[i]);

--- a/test/NonSilo.Tests/General/LruTest.cs
+++ b/test/NonSilo.Tests/General/LruTest.cs
@@ -72,8 +72,7 @@ namespace UnitTests
             for (var i = maxSize; i >= 1; i--)
             {
                 var s = i.ToString();
-                string val;
-                target.TryGetValue(s, out val);
+                target.TryGetValue(s, out _);
             }
             
             // Add a new item to push the least recently used out -- which should be item "10"

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -824,7 +824,7 @@ namespace UnitTests.Serialization
         [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ValidateBuildSegmentListWithLengthLimit(SerializerToUse serializerToUse)
         {
-            var environment = InitializeSerializer(serializerToUse);
+            _ = InitializeSerializer(serializerToUse);
             byte[] array1 = { 1 };
             byte[] array2 = { 2, 3 };
             byte[] array3 = { 4, 5, 6 };

--- a/test/NonSilo.Tests/Serialization/CustomSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/CustomSerializerTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Serialization
         public void Serialize_CustomCopier()
         {
             var original = new ClassWithCustomCopier() {IntProperty = 5, StringProperty = "Hello"};
-            var copy = this.fixture.SerializationManager.DeepCopy(original);
+            _ = this.fixture.SerializationManager.DeepCopy(original);
             Assert.Equal(1, ClassWithCustomCopier.CopyCounter); //Custom copier was not called
         }
 
@@ -33,7 +33,7 @@ namespace UnitTests.Serialization
             Assert.Equal(1, ClassWithCustomSerializer.SerializeCounter); //Custom serializer was not called
 
             var readStream = new BinaryTokenStreamReader(writeStream.ToBytes());
-            var obj = this.fixture.SerializationManager.Deserialize(readStream);
+            _ = this.fixture.SerializationManager.Deserialize(readStream);
             Assert.Equal(1, ClassWithCustomSerializer.DeserializeCounter); //Custom deserializer was not called
         }
 

--- a/test/NonSilo.Tests/Serialization/SerializationTests.DifferentTypes.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationTests.DifferentTypes.cs
@@ -121,10 +121,8 @@ namespace UnitTests.Serialization
             TestTypeA input = new TestTypeA();
             input.Collection = new HashSet<TestTypeA>();
             input.Collection.Add(input);
-
-            TestTypeA output1 = Orleans.TestingHost.Utils.TestingUtils.RoundTripDotNetSerializer(input, this.fixture.GrainFactory, this.fixture.SerializationManager);
-
-            TestTypeA output2 = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
+            _ = Orleans.TestingHost.Utils.TestingUtils.RoundTripDotNetSerializer(input, this.fixture.GrainFactory, this.fixture.SerializationManager);
+            _ = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Serialization")]

--- a/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
@@ -28,8 +28,6 @@ namespace UnitTests.Serialization
         [Fact]
         public void SerializationTests_TypeWithInternalNestedClass()
         {
-            var v = new MyTypeWithAnInternalTypeField();
-
             Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(MyTypeWithAnInternalTypeField)));
             Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(MyTypeWithAnInternalTypeField.MyInternalDependency)));
         }

--- a/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHandle.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.AppDomain/AppDomainSiloHandle.cs
@@ -179,7 +179,7 @@ namespace Orleans.TestingHost
 
         private static void ReportUnobservedException(object sender, System.UnhandledExceptionEventArgs eventArgs)
         {
-            Exception exception = (Exception)eventArgs.ExceptionObject;
+            _ = (Exception)eventArgs.ExceptionObject;
             // WriteLog("Unobserved exception: {0}", exception);
         }
     }

--- a/test/TestInfrastructure/TestExtensions/TestUtils.cs
+++ b/test/TestInfrastructure/TestExtensions/TestUtils.cs
@@ -57,11 +57,9 @@ namespace Tester
         {
             const int NumLoops = 10000;
             TimeSpan baseline = TimeSpan.FromTicks(80); // Baseline from jthelin03D
-            int n;
             var sw = Stopwatch.StartNew();
             for (int i = 0; i < NumLoops; i++)
             {
-                n = i;
             }
             sw.Stop();
             double multiple = 1.0 * sw.ElapsedTicks / baseline.Ticks;

--- a/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
@@ -121,7 +121,7 @@ namespace UnitTests.CancellationTests
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
             var tcs = new GrainCancellationTokenSource();
-            var grainTask = grain.CancellationTokenCallbackThrow(tcs.Token);
+            _ = grain.CancellationTokenCallbackThrow(tcs.Token);
             await Task.Delay(TimeSpan.FromMilliseconds(100));
             try
             {

--- a/test/Tester/Forwarding/ShutdownSiloTests.cs
+++ b/test/Tester/Forwarding/ShutdownSiloTests.cs
@@ -107,8 +107,7 @@ namespace Tester.Forwarding
         public async Task SiloGracefulShutdown_StuckActivation()
         {
             var grain = await GetTimerRequestGrainOnSecondary();
-
-            var promise = grain.StartAndWaitTimerTick(TimeSpan.FromMinutes(2));
+            _ = grain.StartAndWaitTimerTick(TimeSpan.FromMinutes(2));
 
             await Task.Delay(500);
             var stopwatch = Stopwatch.StartNew();

--- a/test/Tester/MinimalReminderTests.cs
+++ b/test/Tester/MinimalReminderTests.cs
@@ -44,8 +44,7 @@ namespace UnitTests.CatalogTests
             const string reminderName = "minimal_reminder";
 
             var reminderGrain = this.fixture.GrainFactory.GetGrain<IReminderTestGrain2>(grainGuid);
-
-            IGrainReminder o1 = await reminderGrain.StartReminder(reminderName, TimeSpan.FromMilliseconds(100), true);
+            _ = await reminderGrain.StartReminder(reminderName, TimeSpan.FromMilliseconds(100), true);
 
             var r = await reminderGrain.GetReminderObject(reminderName);
             await reminderGrain.StopReminder(r);

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -266,6 +266,7 @@ namespace UnitTests.General
             // lookup for 'key' should return 'truth' on all silos
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos()) // do this for each silo
             {
+                testHooks = this.Client.GetTestHooks(siloHandle);
                 SiloAddress s = testHooks.GetConsistentRingPrimaryTargetSilo((uint)key).Result;
                 Assert.Equal(truth, s);
             }
@@ -274,7 +275,7 @@ namespace UnitTests.General
         private async Task<List<SiloHandle>> getSilosToFail(Fail fail, int numOfFailures)
         {
             List<SiloHandle> failures = new List<SiloHandle>();
-            int count = 0, index = 0;
+            int count = 0;
 
             // Figure out the primary directory partition and the silo hosting the ReminderTableGrain.
             var tableGrain = this.GrainFactory.GetGrain<IReminderTableGrain>(InMemoryReminderTable.ReminderTableGrainId);
@@ -304,6 +305,7 @@ namespace UnitTests.General
                 ids.Add(siloHandle.SiloAddress.GetConsistentHashCode(), siloHandle);
             }
 
+            int index;
             // we should not fail the primary!
             // we can't guarantee semantics of 'Fail' if it evalutes to the primary's address
             switch (fail)

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -116,7 +116,7 @@ namespace UnitTests.LivenessTests
             var options = new HashRingStreamQueueMapperOptions();
             options.TotalQueueCount = totalNumQueues;
             HashRingBasedStreamQueueMapper queueMapper = new HashRingBasedStreamQueueMapper(options, "AzureQueues");
-            var allQueues = queueMapper.GetAllQueues();
+            _ = queueMapper.GetAllQueues();
 
             Dictionary<SiloAddress, List<int>> queueHistogram = new Dictionary<SiloAddress, List<int>>();
             foreach (var siloRange in siloRanges)

--- a/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
+++ b/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
@@ -59,8 +59,7 @@ namespace UnitTests.StorageTests
             data.Add(ValueName1, testName);
 
             var store = new HierarchicalKeyStore(1);
-
-            string eTag = store.WriteRow(keys, data, null);
+            _ = store.WriteRow(keys, data, null);
 
             var result = store.ReadRow(keys);
 
@@ -89,8 +88,7 @@ namespace UnitTests.StorageTests
             data.Add(ValueName1, testName);
 
             var store = new HierarchicalKeyStore(2);
-
-            string eTag = store.WriteRow(keys, data, null);
+            _ = store.WriteRow(keys, data, null);
 
             var result = store.ReadRow(keys);
 
@@ -123,8 +121,7 @@ namespace UnitTests.StorageTests
             data[ValueName3] = testName + 3;
 
             var store = new HierarchicalKeyStore(3);
-
-            string eTag = store.WriteRow(keys, data, null);
+            _ = store.WriteRow(keys, data, null);
 
             var result = store.ReadRow(keys);
 
@@ -158,7 +155,7 @@ namespace UnitTests.StorageTests
             data[ValueName3] = "Three";
 
             // Write #2
-            string newEtag = store.WriteRow(keys, data, eTag);
+            _ = store.WriteRow(keys, data, eTag);
 
             var result = store.ReadRow(keys);
 
@@ -229,8 +226,7 @@ namespace UnitTests.StorageTests
             data[ValueName3] = testName + 3;
 
             var store = new HierarchicalKeyStore(keys.Count);
-
-            string eTag = store.WriteRow(keys, data, null);
+            _ = store.WriteRow(keys, data, null);
 
             var readKeys = new List<Tuple<string, string>>();
             readKeys.Add(keys.First());
@@ -252,7 +248,7 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("MemoryStore")]
         public void HKS_KeyNotFound()
         {
-            string testName = Guid.NewGuid().ToString(); //TestContext.TestName;
+            _ = Guid.NewGuid().ToString(); //TestContext.TestName;
 
             int key1 = _keyCounter++;
             int key2 = _keyCounter++;

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -141,7 +141,7 @@ namespace UnitTests.StorageTests
             const string providerName = MockStorageProviderName1;
             string grainType = typeof(PersistenceTestGrain).FullName;
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
 
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(guid);
 
@@ -159,7 +159,7 @@ namespace UnitTests.StorageTests
             const string providerName = MockStorageProviderName1;
             string grainType = typeof(PersistenceTestGenericGrain<int>).FullName;
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
 
             var grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGenericGrain<int>>(guid);
 
@@ -236,7 +236,7 @@ namespace UnitTests.StorageTests
             string grainType = typeof(PersistenceTestGrain).FullName;
 
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(guid);
 
             await grain.DoSomething();
@@ -259,7 +259,7 @@ namespace UnitTests.StorageTests
         public async Task MemoryStore_Read_Write()
         {
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
             IMemoryStorageTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IMemoryStorageTestGrain>(guid);
 
             int val = await grain.GetValue();
@@ -389,8 +389,7 @@ namespace UnitTests.StorageTests
             const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceErrorGrain>(id);
-
-            var val = await grain.GetValue();
+            _ = await grain.GetValue();
 
             var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
@@ -528,10 +527,9 @@ namespace UnitTests.StorageTests
             string grainType = typeof(PersistenceErrorGrain).FullName;
 
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
             IPersistenceErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceErrorGrain>(guid);
-
-            var val = await grain.GetValue();
+            _ = await grain.GetValue();
 
             var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
@@ -865,16 +863,15 @@ namespace UnitTests.StorageTests
             string grainType = typeof(PersistenceUserHandledErrorGrain).FullName;
             string providerName = ErrorInjectorProviderName;
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
             IPersistenceUserHandledErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceUserHandledErrorGrain>(guid);
-
-            var val = await grain.GetValue(); // Activate grain
+            _ = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
             SetErrorInjection(providerName, ErrorInjectionPoint.None);
             SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
 
-            val = await grain.DoRead(false);
+            var val = await grain.DoRead(false);
 
             Assert.Equal(expectedVal, val); // Returned value
 
@@ -898,16 +895,15 @@ namespace UnitTests.StorageTests
             string grainType = typeof(PersistenceUserHandledErrorGrain).FullName;
             string providerName = ErrorInjectorProviderName;
             Guid guid = Guid.NewGuid();
-            string id = guid.ToString("N");
+            _ = guid.ToString("N");
             IPersistenceUserHandledErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceUserHandledErrorGrain>(guid);
-
-            var val = await grain.GetValue(); // Activate grain
+            _ = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
             SetErrorInjection(providerName, ErrorInjectionPoint.None);
             SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
 
-            val = await grain.DoRead(false);
+            var val = await grain.DoRead(false);
 
             Assert.Equal(expectedVal, val); // Returned value
 
@@ -977,7 +973,7 @@ namespace UnitTests.StorageTests
                 int expectedVal = i;
                 IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(Guid.NewGuid());
                 Guid guid = grain.GetPrimaryKey();
-                string id = guid.ToString("N");
+                _ = guid.ToString("N");
 
                 SetStoredValue(MockStorageProviderName1, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", expectedVal); // Update state data behind grain
                 promises[i] = grain.DoRead();
@@ -1305,7 +1301,7 @@ namespace UnitTests.StorageTests
                 {
                     if (!this.HostedCluster.Client.GetTestHooks(siloHandle).HasStorageProvider(providerName).Result) continue;
                     IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
-                    object[] replies = mgmtGrain.SendControlCommandToProvider(typeof(MockStorageProvider).FullName,
+                    _ = mgmtGrain.SendControlCommandToProvider(typeof(MockStorageProvider).FullName,
                        providerName, (int)MockStorageProvider.Commands.ResetHistory, null).Result;
                 }
             }

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -463,7 +463,7 @@ namespace UnitTests.StreamingTests
         {
             var consumerCount = await consumer.ConsumerCount;
             Assert.NotEqual(0,  consumerCount);  // "no consumers were detected."
-            var producerCount = await producer.ProducerCount;
+            _ = await producer.ProducerCount;
             var numProduced = await producer.ExpectedItemsProduced;
             var expectConsumed = numProduced * consumerCount;
             var numConsumed = await consumer.ItemsConsumed;

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -83,10 +83,10 @@ namespace UnitTests.TimerTests
             log.Info("Removed reminder2 successfully");
 
             // trying to see if readreminder works
-            IGrainReminder o1 = await grain.StartReminder(DR);
-            IGrainReminder o2 = await grain.StartReminder(DR);
-            IGrainReminder o3 = await grain.StartReminder(DR);
-            IGrainReminder o4 = await grain.StartReminder(DR);
+            _ = await grain.StartReminder(DR);
+            _ = await grain.StartReminder(DR);
+            _ = await grain.StartReminder(DR);
+            _ = await grain.StartReminder(DR);
 
             IGrainReminder r = await grain.GetReminderObject(DR);
             await grain.StopReminder(r);


### PR DESCRIPTION
These show up as errors in VS for me, so they're getting in the way.

I tried to retain semantics where reasonable. In one place in test code ([VerifyKey](https://github.com/dotnet/orleans/compare/master...ReubenBond:cleanup/unnecessary-assignment?expand=1#diff-9fc919426fa34679ae8bcd6f1e31eb3e5858d333a39bf67c96b4cd4761373222R269), I think the existing code was wrong, so I've changed it slightly.