### PR TITLE
Do not hand off grain directory during shutdown

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IRemoteGrainDirectory.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IRemoteGrainDirectory.cs
@@ -56,16 +56,6 @@ namespace Orleans.Runtime
         Task<List<Tuple<GrainId, int, List<ActivationAddress>>>> LookUpMany(List<Tuple<GrainId, int>> grainAndETagList);
 
         /// <summary>
-        /// Handoffs the directory partition from source silo to the destination silo.
-        /// </summary>
-        /// <param name="source">The address of the owner of the partition.</param>
-        /// <param name="partition">The (full or partial) copy of the directory partition to be Haded off.</param>
-        /// <param name="isFullCopy">Flag specifying whether it is a full copy of the directory partition (and thus any old copy should be just replaced) or the
-        /// a delta copy (and thus the old copy should be updated by delta changes) </param>
-        /// <returns></returns>
-        Task AcceptHandoffPartition(SiloAddress source, Dictionary<GrainId, IGrainInfo> partition, bool isFullCopy);
-
-        /// <summary>
         /// Removes the handed off directory partition from source silo on the destination silo.
         /// </summary>
         /// <param name="source">The address of the owner of the partition.</param>

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -15,8 +15,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <summary>
         /// Stops the local portion of the directory service.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Stop")]
-        Task Stop(bool doOnStopHandoff);
+        void Stop();
 
         RemoteGrainDirectory RemoteGrainDirectory { get; }
         RemoteGrainDirectory CacheValidator { get; }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -208,7 +208,7 @@ namespace Orleans.Runtime.GrainDirectory
         // The alternative would be to allow the silo to process requests after it has handed off its partition, in which case those changes 
         // would receive successful responses but would not be reflected in the eventual state of the directory. 
         // It's easy to change this, if we think the trade-off is better the other way.
-        public async Task Stop(bool doOnStopHandoff)
+        public void Stop()
         {
             // This will cause remote write requests to be forwarded to the silo that will become the new owner.
             // Requests might bounce back and forth for a while as membership stabilizes, but they will either be served by the
@@ -223,17 +223,6 @@ namespace Orleans.Runtime.GrainDirectory
                 maintainer.Stop();
             }
 
-            if (doOnStopHandoff)
-            {
-                try
-                {
-                    await HandoffManager.ProcessSiloStoppingEvent();
-                }
-                catch (Exception exc)
-                {
-                    this.log.LogWarning($"GrainDirectoryHandOffManager failed ProcessSiloStoppingEvent due to exception {exc}");
-                }
-            }
             DirectoryPartition.Clear();
             DirectoryCache.Clear();
         }
@@ -928,43 +917,6 @@ namespace Orleans.Runtime.GrainDirectory
         public SiloAddress GetPrimaryForGrain(GrainId grain)
         {
             return CalculateGrainDirectoryPartition(grain);
-        }
-
-        /// <summary>
-        /// For testing purposes only.
-        /// Returns the silos that this silo thinks hold copies of the directory information for
-        /// the provided grain ID.
-        /// </summary>
-        /// <param name="grain"></param>
-        /// <returns></returns>
-        public List<SiloAddress> GetSilosHoldingDirectoryInformationForGrain(GrainId grain)
-        {
-            var primary = CalculateGrainDirectoryPartition(grain);
-            return FindPredecessors(primary, 1);
-        }
-
-        /// <summary>
-        /// For testing purposes only.
-        /// Returns the directory information held by the local silo for the provided grain ID.
-        /// The result will be null if no information is held.
-        /// </summary>
-        /// <param name="grain"></param>
-        /// <param name="isPrimary"></param>
-        /// <returns></returns>
-        public List<ActivationAddress> GetLocalDataForGrain(GrainId grain, out bool isPrimary)
-        {
-            var primary = CalculateGrainDirectoryPartition(grain);
-            List<ActivationAddress> backupData = HandoffManager.GetHandedOffInfo(grain);
-            if (MyAddress.Equals(primary))
-            {
-                log.Assert(ErrorCode.DirectoryBothPrimaryAndBackupForGrain, backupData == null,
-                    "Silo contains both primary and backup directory data for grain " + grain);
-                isPrimary = true;
-                return GetLocalDirectoryData(grain).Addresses;
-            }
-
-            isPrimary = false;
-            return backupData;
         }
 
         public override string ToString()

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -95,12 +95,6 @@ namespace Orleans.Runtime.GrainDirectory
             return Task.FromResult(result);
         }
 
-        public Task AcceptHandoffPartition(SiloAddress source, Dictionary<GrainId, IGrainInfo> partition, bool isFullCopy)
-        {
-            router.HandoffManager.AcceptHandoffPartition(source, partition, isFullCopy);
-            return Task.CompletedTask;
-        }
-
         public Task RemoveHandoffPartition(SiloAddress source)
         {
             router.HandoffManager.RemoveHandoffPartition(source);

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -621,8 +621,7 @@ namespace Orleans.Runtime
                 if (gracefully)
                 {
                     // Stop LocalGrainDirectory
-                    await LocalScheduler.QueueTask(() => localGrainDirectory.Stop(true), localGrainDirectory.CacheValidator)
-                        .WithCancellation(ct, "Failed to stop local grain directory gracefully before cancellation");
+                    await LocalScheduler.QueueActionAsync(() => localGrainDirectory.Stop(), localGrainDirectory.CacheValidator);
 
                     SafeExecute(() => catalog.DeactivateAllActivations().Wait(ct));
 

--- a/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
+++ b/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
@@ -105,7 +105,7 @@ namespace UnitTests.Directory
             throw new NotImplementedException();
         }
 
-        public Task Stop(bool doOnStopHandoff)
+        public void Stop()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
The in-cluster directory has a mechanism for handing off partition segments during graceful shutdown. This functionality does not prevent grains which were registered on the now-dead silo from being destroyed, however, because there are no guarantees which are strong enough to maintain the desired invariants (every activation is registered, at most one activation is registered for each grain).

Therefore, this PR removes that functionality. We can consider other options to reduce the impact of silo shutdown in future, such as directory replication. Note that external grain directories do not have this attribute.