### PR TITLE
Try to limit forwarding when a grain activation throws an exception in OnActivateAsync()

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -242,6 +242,8 @@ namespace Orleans.Runtime
             var number = Interlocked.Increment(ref collectionNumber);
             long memBefore = GC.GetTotalMemory(false) / (1024 * 1024);
 
+            failedActivations.RemoveExpired();
+
             if (logger.IsEnabled(LogLevel.Debug))
             {
                 logger.LogDebug(

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -444,8 +444,7 @@ namespace Orleans.Runtime
                         msg.InterfaceType,
                         msg);
 
-                    var str = $"Error creating activation for grain {msg.TargetGrain} (interface: {msg.InterfaceType}). Message {msg}";
-                    this.RejectMessage(msg, Message.RejectionTypes.Transient, new OrleansException(str, ex));
+                    this.RejectMessage(msg, Message.RejectionTypes.Transient, ex);
                 }
             }
         }

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -86,6 +86,35 @@ namespace DefaultCluster.Tests.General
             if (!failed) Assert.True(false, "Should have failed, but instead returned " + key);
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("ErrorHandling"), TestCategory("GetGrain")]
+        public async Task BasicActivation_BurstFail()
+        {
+            bool failed;
+            long key = 0;
+            var tasks = new List<Task>();
+            try
+            {
+                // Key values of -2 are not allowed in this case
+                var fail = this.GrainFactory.GetGrain<ITestGrainLongOnActivateAsync>(-2);
+                for (int i = 0; i < 10000; i++)
+                {
+                    tasks.Add(fail.GetKey());
+                }
+                failed = false;
+                await Task.WhenAll(tasks);
+            }
+            catch (Exception)
+            {
+                failed = true;
+                foreach (var t in tasks)
+                {
+                    Assert.Equal(typeof(ArgumentException), t.Exception.InnerException.GetType());
+                }
+            }
+
+            if (!failed) Assert.True(false, "Should have failed, but instead returned " + key);
+        }
+
         [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_ULong_MaxValue()
         {

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -561,7 +561,7 @@ namespace DefaultCluster.Tests.General
 
             var id = Guid.NewGuid();
             var nonGenericFacet =  this.GrainFactory.GetGrain<INonGenericBase>(id, "UnitTests.Grains.Generic1ArgumentGrain");
-            await Assert.ThrowsAsync<OrleansException>(async () =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
                 try
                 {
@@ -583,7 +583,7 @@ namespace DefaultCluster.Tests.General
             var s2 = await grain.Ping(s1);
             Assert.Equal(s1, s2);
             var nonGenericFacet =  this.GrainFactory.GetGrain<INonGenericBase>(id, "UnitTests.Grains.Generic1ArgumentGrain");
-            await Assert.ThrowsAsync<OrleansException>(async () =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
                 try
                 {

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -34,7 +34,8 @@ namespace DefaultCluster.Tests.General
 
             for (int i=0; i<100; i++)
             {
-                await Assert.ThrowsAsync<OrleansException>(() => grain.Ping());
+                var ex = await Assert.ThrowsAsync<Exception>(() => grain.Ping());
+                Assert.Equal("oops", ex.Message);
             }
         }
 

--- a/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
+++ b/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
@@ -8,6 +8,7 @@ using UnitTests.Grains;
 using Xunit;
 using System.Linq;
 using Orleans.Hosting;
+using System;
 
 namespace DependencyInjection.Tests
 {
@@ -156,9 +157,8 @@ namespace DependencyInjection.Tests
         public async Task CannotGetExplictlyRegisteredGrain()
         {
             ISimpleDIGrain grain = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
-            var exception = await Assert.ThrowsAsync<OrleansException>(() => grain.GetLongValue());
-            Assert.Contains("Error creating activation for", exception.Message);
-            Assert.Contains("explicitly-registered", exception.Message);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.GetLongValue());
+            Assert.Contains("Unable to resolve service for type 'System.String' while attempting to activate 'UnitTests.Grains.ExplicitlyRegisteredSimpleDIGrain'", exception.Message);
         }
 
         [Fact]

--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -34,6 +34,9 @@ namespace UnitTests.GrainInterfaces
         Task DoLongAction(TimeSpan timespan, string str);
     }
 
+    public interface ITestGrainLongOnActivateAsync : ITestGrain
+    { }
+
     public interface IGuidTestGrain : IGrainWithGuidKey
     {
         // duplicate to verify identity

--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -34,8 +34,10 @@ namespace UnitTests.GrainInterfaces
         Task DoLongAction(TimeSpan timespan, string str);
     }
 
-    public interface ITestGrainLongOnActivateAsync : ITestGrain
-    { }
+    public interface ITestGrainLongOnActivateAsync : IGrainWithIntegerKey
+    {
+        Task<long> GetKey();
+    }
 
     public interface IGuidTestGrain : IGrainWithGuidKey
     {

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -134,6 +134,20 @@ namespace UnitTests.Grains
         }
     }
 
+    public class TestGrainLongActivateAsync : TestGrain, ITestGrainLongOnActivateAsync
+    {
+        public TestGrainLongActivateAsync(ILoggerFactory loggerFactory)
+            : base(loggerFactory)
+        {
+        }
+
+        public override async Task OnActivateAsync()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            await base.OnActivateAsync();
+        }
+    }
+
     internal class GuidTestGrain : Grain, IGuidTestGrain
     {
         private string label;

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -134,17 +134,25 @@ namespace UnitTests.Grains
         }
     }
 
-    public class TestGrainLongActivateAsync : TestGrain, ITestGrainLongOnActivateAsync
+    public class TestGrainLongActivateAsync : Grain, ITestGrainLongOnActivateAsync
     {
-        public TestGrainLongActivateAsync(ILoggerFactory loggerFactory)
-            : base(loggerFactory)
+        public TestGrainLongActivateAsync()
         {
         }
 
         public override async Task OnActivateAsync()
         {
             await Task.Delay(TimeSpan.FromSeconds(3));
+
+            if (this.GetPrimaryKeyLong() == -2)
+                throw new ArgumentException("Primary key cannot be -2 for this test case");
+
             await base.OnActivateAsync();
+        }
+
+        public Task<long> GetKey()
+        {
+            return Task.FromResult(this.GetPrimaryKeyLong());
         }
     }
 

--- a/test/NonSilo.Tests/General/LruTest.cs
+++ b/test/NonSilo.Tests/General/LruTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Orleans.Runtime;
 using Xunit;
 
@@ -87,6 +88,39 @@ namespace UnitTests
                 var s = i.ToString();
                 Assert.True(target.ContainsKey(s), "Recently used item " + s + " was incorrectly expelled");
             }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("LRU")]
+        public async Task LruRemoveExpired()
+        {
+            const int n = 10;
+            const int maxSize = n*2;
+            var maxAge = TimeSpan.FromMilliseconds(500);
+            LRU<string, string>.FetchValueDelegate f = null;
+            var flushCounter = 0;
+
+            var target = new LRU<string, string>(maxSize, maxAge, f);
+            target.RaiseFlushEvent += (object o, LRU<string, string>.FlushEventArgs args) => flushCounter++;
+
+            for (int i = 0; i < n; i++)
+            {
+                var s = i.ToString();
+                target.Add(s, $"item {s}");
+            }
+
+            target.RemoveExpired();
+            Assert.Equal(0, flushCounter);
+            Assert.Equal(n, target.Count);
+
+            await Task.Delay(maxAge.Add(maxAge));
+
+            target.Add("expected", "value");
+            target.RemoveExpired();
+
+            Assert.Equal(n, flushCounter);
+            Assert.Equal(1, target.Count);
+            Assert.True(target.TryGetValue("expected", out var value));
+            Assert.Equal("value", value);
         }
     }
 }


### PR DESCRIPTION
The goal of this PR is to reduce the occurrence of forwarding failure because a grain cannot be activated due to a failure in `OnActivateAsync()`.

When a grain has no activation, it's possible that multiple silos will _try_ to create multiple activations for the same grain identity at the same time. But only one activation will win the race, and all other silos will then forward the requests to the winning activation.

If this winning activation throws during `OnActivateAsync()`, it might trigger another potential race for activation creation, and additional forwarding. As a result, the user might see several "Forwarding failed" exceptions instead of the exception that was thrown during the activation process.