### PR TITLE
Throw an exception when trying to register an activation on an invalid silo

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -276,7 +276,10 @@ namespace Orleans.Runtime.GrainDirectory
             AddressAndTag result = new AddressAndTag();
 
             if (!IsValidSilo(silo))
-                return result;
+            {
+                var siloStatus = this.siloStatusOracle.GetApproximateSiloStatus(silo);
+                throw new OrleansException($"Trying to register {grain} on invalid silo: {silo}. Known status: {siloStatus}");
+            }
 
             IGrainInfo grainInfo;
             lock (lockable)


### PR DESCRIPTION
In `GrainDirectoryPartition` we return `null` if we are trying to register a grain on an invalid silo". Instead, we should throw an exception that clearly says the reason of the rejection.

Related issue: #6894