### PR TITLE
Implement ISerializable fallback serializer

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -90,7 +90,6 @@ namespace Orleans
             services.AddSingleton<BinaryFormatterSerializer>();
             services.AddSingleton<BinaryFormatterISerializableSerializer>();
             services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
-
 #pragma warning disable CS0618 // Type or member is obsolete
             services.TryAddSingleton<ILBasedSerializer>();
             services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -82,9 +82,15 @@ namespace Orleans
                 sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
+
+            // Register the ISerializable serializer first, so that it takes precedence
+            services.AddSingleton<DotNetSerializableSerializer>();
+            services.AddFromExisting<IKeyedSerializer, DotNetSerializableSerializer>();
+
             services.AddSingleton<BinaryFormatterSerializer>();
             services.AddSingleton<BinaryFormatterISerializableSerializer>();
             services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
+
 #pragma warning disable CS0618 // Type or member is obsolete
             services.TryAddSingleton<ILBasedSerializer>();
             services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();

--- a/src/Orleans.Core/Serialization/DotNetSerializableSerializer.cs
+++ b/src/Orleans.Core/Serialization/DotNetSerializableSerializer.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Serialization;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// Serializer for types which implement <see cref="ISerializable"/>, including the required constructor.
+    /// </summary>
+    internal sealed class DotNetSerializableSerializer : IKeyedSerializer
+    {
+        private readonly IFormatterConverter _formatterConverter = new FormatterConverter();
+        private readonly TypeInfo _serializableType = typeof(ISerializable).GetTypeInfo();
+        private readonly SerializationConstructorFactory _constructorFactory = new SerializationConstructorFactory();
+        private readonly SerializationCallbacksFactory _serializationCallbacks = new SerializationCallbacksFactory();
+        private readonly ValueTypeSerializerFactory _valueTypeSerializerFactory;
+        private readonly ObjectSerializer _objectSerializer;
+
+        public DotNetSerializableSerializer()
+        {
+            _objectSerializer = new ObjectSerializer(_constructorFactory, _serializationCallbacks, _formatterConverter);
+            _valueTypeSerializerFactory = new ValueTypeSerializerFactory(_constructorFactory, _serializationCallbacks, _formatterConverter);
+        }
+
+        /// <inheritdoc />
+        public KeyedSerializerId SerializerId => KeyedSerializerId.ISerializableSerializer;
+        
+        /// <inheritdoc />
+        public bool IsSupportedType(Type itemType) => _serializableType.IsAssignableFrom(itemType) && itemType.IsSerializable &&
+                                                      _constructorFactory.GetSerializationConstructor(itemType) != null;
+
+        /// <inheritdoc />
+        public object DeepCopy(object source, ICopyContext context)
+        {
+            var type = source.GetType();
+            if (type.IsValueType)
+            {
+                var serializer = _valueTypeSerializerFactory.GetSerializer(type);
+                return serializer.DeepCopy(source, context);
+            }
+
+            return _objectSerializer.DeepCopy(source, context);
+        }
+
+        /// <inheritdoc />
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
+        {
+            var type = item.GetType();
+            if (type.IsValueType)
+            {
+                var serializer = _valueTypeSerializerFactory.GetSerializer(type);
+                serializer.Serialize(item, context);
+            }
+            else
+            {
+                _objectSerializer.Serialize(item, context);
+            }
+        }
+
+        /// <inheritdoc />
+        public object Deserialize(Type expectedType, IDeserializationContext context)
+        {
+            var startOffset = context.CurrentObjectOffset;
+            var type = SerializationManager.DeserializeInner<Type>(context);
+            if (type.IsValueType)
+            {
+                var serializer = _valueTypeSerializerFactory.GetSerializer(type);
+                return serializer.Deserialize(type, startOffset, context);
+            }
+
+            return _objectSerializer.Deserialize(type, startOffset, context);
+        }
+
+        /// <summary>
+        /// Serializer for ISerializable reference types.
+        /// </summary>
+        internal class ObjectSerializer
+        {
+            private readonly IFormatterConverter _formatterConverter;
+            private readonly SerializationConstructorFactory _constructorFactory;
+            private readonly SerializationCallbacksFactory _serializationCallbacks;
+
+            public ObjectSerializer(
+                SerializationConstructorFactory constructorFactory,
+                SerializationCallbacksFactory serializationCallbacks,
+                IFormatterConverter formatterConverter)
+            {
+                _constructorFactory = constructorFactory;
+                _serializationCallbacks = serializationCallbacks;
+                _formatterConverter = formatterConverter;
+            }
+
+            /// <inheritdoc />
+            public object DeepCopy(object source, ICopyContext context)
+            {
+                var type = source.GetType();
+                var callbacks = _serializationCallbacks.GetReferenceTypeCallbacks(type);
+                var serializable = (ISerializable)source;
+                var result = FormatterServices.GetUninitializedObject(type);
+                context.RecordCopy(source, result);
+
+                // Shallow-copy the object into the serialization info.
+                var originalInfo = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                callbacks.OnSerializing?.Invoke(source, streamingContext);
+                serializable.GetObjectData(originalInfo, streamingContext);
+
+                // Deep-copy the serialization info.
+                var copyInfo = new SerializationInfo(type, _formatterConverter);
+                foreach (var item in originalInfo)
+                {
+                    copyInfo.AddValue(item.Name, SerializationManager.DeepCopyInner(item.Value, context));
+                }
+                callbacks.OnSerialized?.Invoke(source, streamingContext);
+                callbacks.OnDeserializing?.Invoke(result, streamingContext);
+
+                // Shallow-copy the serialization info into the result.
+                var constructor = _constructorFactory.GetSerializationConstructorDelegate(type);
+                constructor(result, copyInfo, streamingContext);
+                callbacks.OnDeserialized?.Invoke(result, streamingContext);
+                if (result is IDeserializationCallback callback)
+                {
+                    callback.OnDeserialization(context);
+                }
+
+                return result;
+            }
+
+            /// <inheritdoc />
+            public void Serialize(object item, ISerializationContext context)
+            {
+                var type = item.GetType();
+                var callbacks = _serializationCallbacks.GetReferenceTypeCallbacks(type);
+                var info = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                callbacks.OnSerializing?.Invoke(item, streamingContext);
+                ((ISerializable)item).GetObjectData(info, streamingContext);
+
+                SerializationManager.SerializeInner(type, context);
+                SerializationManager.SerializeInner(info.MemberCount, context);
+                foreach (var entry in info)
+                {
+                    SerializationManager.SerializeInner(entry.Name, context);
+                    var fieldType = entry.Value?.GetType();
+                    SerializationManager.SerializeInner(fieldType, context);
+                    SerializationManager.SerializeInner(entry.Value, context, fieldType);
+                }
+
+                callbacks.OnSerialized?.Invoke(item, streamingContext);
+            }
+
+            /// <inheritdoc />
+            public object Deserialize(Type type, int startOffset, IDeserializationContext context)
+            {
+                var callbacks = _serializationCallbacks.GetReferenceTypeCallbacks(type);
+                var result = FormatterServices.GetUninitializedObject(type);
+                context.RecordObject(result, startOffset);
+
+                var memberCount = SerializationManager.DeserializeInner<int>(context);
+
+                var info = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                callbacks.OnDeserializing?.Invoke(result, streamingContext);
+
+                for (var i = 0; i < memberCount; i++)
+                {
+                    var name = SerializationManager.DeserializeInner<string>(context);
+                    var fieldType = SerializationManager.DeserializeInner<Type>(context);
+                    var value = SerializationManager.DeserializeInner(fieldType, context);
+                    info.AddValue(name, value);
+                }
+
+                var constructor = _constructorFactory.GetSerializationConstructorDelegate(type);
+                constructor(result, info, streamingContext);
+                callbacks.OnDeserialized?.Invoke(result, streamingContext);
+                if (result is IDeserializationCallback callback)
+                {
+                    callback.OnDeserialization(context);
+                }
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Serializer for ISerializable value types.
+        /// </summary>
+        internal abstract class ValueTypeSerializer
+        {
+            public abstract object Deserialize(Type type, int startOffset, IDeserializationContext context);
+            public abstract void Serialize(object item, ISerializationContext context);
+            public abstract object DeepCopy(object source, ICopyContext context);
+        }
+
+        /// <summary>
+        /// Serializer for ISerializable value types.
+        /// </summary>
+        /// <typeparam name="T">The type which this serializer can serialize.</typeparam>
+        internal class ValueTypeSerializer<T> : ValueTypeSerializer where T : struct
+        {
+            public delegate void ValueConstructor(ref T value, SerializationInfo info, StreamingContext context);
+            public delegate void SerializationCallback(ref T value, StreamingContext context);
+
+            private readonly ValueConstructor _constructor;
+            private readonly SerializationCallbacksFactory.SerializationCallbacks<SerializationCallback> _callbacks;
+            private readonly IFormatterConverter _formatterConverter;
+
+            public ValueTypeSerializer(
+                ValueConstructor constructor,
+                SerializationCallbacksFactory.SerializationCallbacks<SerializationCallback> callbacks,
+                IFormatterConverter formatterConverter)
+            {
+                _constructor = constructor;
+                _callbacks = callbacks;
+                _formatterConverter = formatterConverter;
+            }
+
+            public override object Deserialize(Type type, int startOffset, IDeserializationContext context)
+            {
+                var result = default(T);
+                var memberCount = SerializationManager.DeserializeInner<int>(context);
+
+                var info = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                _callbacks.OnDeserializing?.Invoke(ref result, streamingContext);
+
+                for (var i = 0; i < memberCount; i++)
+                {
+                    var name = SerializationManager.DeserializeInner<string>(context);
+                    var fieldType = SerializationManager.DeserializeInner<Type>(context);
+                    var value = SerializationManager.DeserializeInner(fieldType, context);
+                    info.AddValue(name, value);
+                }
+
+                _constructor(ref result, info, streamingContext);
+                _callbacks.OnDeserialized?.Invoke(ref result, streamingContext);
+                if (result is IDeserializationCallback callback)
+                {
+                    callback.OnDeserialization(context);
+                }
+
+                return result;
+            }
+
+            public override void Serialize(object item, ISerializationContext context)
+            {
+                var localItem = (T) item;
+                var type = item.GetType();
+                var info = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                _callbacks.OnSerializing?.Invoke(ref localItem, streamingContext);
+                ((ISerializable)item).GetObjectData(info, streamingContext);
+
+                SerializationManager.SerializeInner(type, context);
+                SerializationManager.SerializeInner(info.MemberCount, context);
+                foreach (var entry in info)
+                {
+                    SerializationManager.SerializeInner(entry.Name, context);
+                    var fieldType = entry.Value?.GetType();
+                    SerializationManager.SerializeInner(fieldType, context);
+                    SerializationManager.SerializeInner(entry.Value, context, fieldType);
+                }
+
+                _callbacks.OnSerialized?.Invoke(ref localItem, streamingContext);
+            }
+
+            public override object DeepCopy(object source, ICopyContext context)
+            {
+                var localSource = (T) source;
+                var type = source.GetType();
+                var serializable = (ISerializable)source;
+                var result = default(T);
+
+                // Shallow-copy the object into the serialization info.
+                var originalInfo = new SerializationInfo(type, _formatterConverter);
+                var streamingContext = new StreamingContext(StreamingContextStates.All, context);
+                _callbacks.OnSerializing?.Invoke(ref localSource, streamingContext);
+                serializable.GetObjectData(originalInfo, streamingContext);
+
+                // Deep-copy the serialization info.
+                var copyInfo = new SerializationInfo(type, _formatterConverter);
+                foreach (var item in originalInfo)
+                {
+                    copyInfo.AddValue(item.Name, SerializationManager.DeepCopyInner(item.Value, context));
+                }
+
+                _callbacks.OnSerialized?.Invoke(ref localSource, streamingContext);
+                _callbacks.OnDeserializing?.Invoke(ref localSource, streamingContext);
+
+                // Shallow-copy the serialization info into the result.
+                _constructor(ref result, copyInfo, streamingContext);
+                _callbacks.OnDeserialized?.Invoke(ref result, streamingContext);
+                if (result is IDeserializationCallback callback)
+                {
+                    callback.OnDeserialization(context);
+                }
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Creates <see cref="ValueTypeSerializer"/> instances for value types.
+        /// </summary>
+        internal class ValueTypeSerializerFactory
+        {
+            private readonly SerializationConstructorFactory _constructorFactory;
+            private readonly SerializationCallbacksFactory _callbacksFactory;
+            private readonly IFormatterConverter _formatterConverter;
+            private readonly Func<Type, ValueTypeSerializer> _createSerializerDelegate;
+
+            private readonly ConcurrentDictionary<Type, ValueTypeSerializer> _serializers = new ConcurrentDictionary<Type, ValueTypeSerializer>();
+
+            private readonly MethodInfo _createTypedSerializerMethodInfo = typeof(ValueTypeSerializerFactory).GetMethod(
+                nameof(CreateTypedSerializer),
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            public ValueTypeSerializerFactory(
+                SerializationConstructorFactory constructorFactory,
+                SerializationCallbacksFactory callbacksFactory,
+                IFormatterConverter formatterConverter)
+            {
+                _constructorFactory = constructorFactory;
+                _callbacksFactory = callbacksFactory;
+                _formatterConverter = formatterConverter;
+                _createSerializerDelegate = type => (ValueTypeSerializer) 
+                    _createTypedSerializerMethodInfo.MakeGenericMethod(type).Invoke(this, null);
+            }
+
+            public ValueTypeSerializer GetSerializer(Type type)
+            {
+                return _serializers.GetOrAdd(type, _createSerializerDelegate);
+            }
+
+            private ValueTypeSerializer CreateTypedSerializer<T>() where T : struct
+            {
+                var constructor = _constructorFactory.GetSerializationConstructorDelegate<T, ValueTypeSerializer<T>.ValueConstructor>();
+                var callbacks =
+                    _callbacksFactory.GetValueTypeCallbacks<T, ValueTypeSerializer<T>.SerializationCallback>(typeof(T));
+                return new ValueTypeSerializer<T>(constructor, callbacks, _formatterConverter);
+            }
+        }
+
+        /// <summary>
+        /// Creates delegates for calling ISerializable-conformant constructors.
+        /// </summary>
+        internal class SerializationConstructorFactory
+        {
+            private static readonly Type[] SerializationConstructorParameterTypes = { typeof(SerializationInfo), typeof(StreamingContext) };
+
+            private readonly Func<Type, object> _createConstructorDelegate;
+
+            private readonly ConcurrentDictionary<Type, object> _constructors = new ConcurrentDictionary<Type, object>();
+
+            public SerializationConstructorFactory()
+            {
+                _createConstructorDelegate = 
+                    GetSerializationConstructorInvoker<object, Action<object, SerializationInfo, StreamingContext>>;
+            }
+
+            public Action<object, SerializationInfo, StreamingContext> GetSerializationConstructorDelegate(Type type)
+            {
+                return (Action<object, SerializationInfo, StreamingContext>)_constructors.GetOrAdd(
+                    type,
+                    _createConstructorDelegate);
+            }
+
+            public TConstructor GetSerializationConstructorDelegate<TOwner, TConstructor>()
+            {
+                return (TConstructor) _constructors.GetOrAdd(
+                    typeof(TOwner),
+                    type => (object) GetSerializationConstructorInvoker<TOwner, TConstructor>(type));
+            }
+
+            public ConstructorInfo GetSerializationConstructor(Type type)
+            {
+                return type.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    SerializationConstructorParameterTypes,
+                    null);
+            }
+
+            private TConstructor GetSerializationConstructorInvoker<TOwner, TConstructor>(Type type)
+            {
+                var constructor = GetSerializationConstructor(type);
+                if (constructor == null) throw new SerializationException($"{nameof(ISerializable)} constructor not found on type {type}.");
+
+                Type[] parameterTypes;
+                if (typeof(TOwner).IsValueType)
+                {
+                    parameterTypes = new[] { typeof(TOwner).MakeByRefType(), typeof(SerializationInfo), typeof(StreamingContext) };
+                }
+                else
+                {
+                    parameterTypes = new[] { typeof(object), typeof(SerializationInfo), typeof(StreamingContext) };
+                }
+                
+                var method = new DynamicMethod($"{type}_serialization_ctor", null, parameterTypes, typeof(TOwner), skipVisibility: true);
+                var il = method.GetILGenerator();
+
+                il.Emit(OpCodes.Ldarg_0);
+                if (type != typeof(TOwner))
+                {
+                    il.Emit(OpCodes.Castclass, type);
+                }
+
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldarg_2);
+                il.Emit(OpCodes.Call, constructor);
+                il.Emit(OpCodes.Ret);
+
+                object result = method.CreateDelegate(typeof(TConstructor));
+                return (TConstructor)result;
+            }
+        }
+
+        /// <summary>
+        /// Creates delegates for calling methods marked with serialization attributes.
+        /// </summary>
+        internal class SerializationCallbacksFactory
+        {
+            private readonly ConcurrentDictionary<Type, object> _cache = new ConcurrentDictionary<Type, object>();
+            private readonly Func<Type, object> _factory;
+            
+            public SerializationCallbacksFactory()
+            {
+                _factory = CreateTypedCallbacks<object, Action<object, StreamingContext>>;
+            }
+
+            public SerializationCallbacks<Action<object, StreamingContext>> GetReferenceTypeCallbacks(Type type) => (
+                SerializationCallbacks<Action<object, StreamingContext>>)_cache.GetOrAdd(type, _factory);
+
+            public SerializationCallbacks<TDelegate> GetValueTypeCallbacks<TOwner, TDelegate>(Type type) => (
+                SerializationCallbacks<TDelegate>) _cache.GetOrAdd(type, t => (object) CreateTypedCallbacks<TOwner, TDelegate>(type));
+
+            private SerializationCallbacks<TDelegate> CreateTypedCallbacks<TOwner, TDelegate>(Type type)
+            {
+                var typeInfo = type.GetTypeInfo();
+                var onDeserializing = default(TDelegate);
+                var onDeserialized = default(TDelegate);
+                var onSerializing = default(TDelegate);
+                var onSerialized = default(TDelegate);
+                foreach (var method in typeInfo.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    var parameterInfos = method.GetParameters();
+                    if (parameterInfos.Length != 1) continue;
+                    if (parameterInfos[0].ParameterType != typeof(StreamingContext)) continue;
+
+                    if (method.GetCustomAttribute<OnDeserializingAttribute>() != null)
+                    {
+                        onDeserializing = GetSerializationMethod<TOwner, TDelegate>(typeInfo, method);
+                    }
+
+                    if (method.GetCustomAttribute<OnDeserializedAttribute>() != null)
+                    {
+                        onDeserialized = GetSerializationMethod<TOwner, TDelegate>(typeInfo, method);
+                    }
+
+                    if (method.GetCustomAttribute<OnSerializingAttribute>() != null)
+                    {
+                        onSerializing = GetSerializationMethod<TOwner, TDelegate>(typeInfo, method);
+                    }
+
+                    if (method.GetCustomAttribute<OnSerializedAttribute>() != null)
+                    {
+                        onSerialized = GetSerializationMethod<TOwner, TDelegate>(typeInfo, method);
+                    }
+                }
+
+                return new SerializationCallbacks<TDelegate>(onDeserializing, onDeserialized, onSerializing, onSerialized);
+            }
+
+            private static TDelegate GetSerializationMethod<TOwner, TDelegate>(Type type, MethodInfo callbackMethod)
+            {
+                Type[] callbackParameterTypes;
+                if (typeof(TOwner).IsValueType)
+                {
+                    callbackParameterTypes = new[] { typeof(TOwner).MakeByRefType(), typeof(StreamingContext) };
+                }
+                else
+                {
+                    callbackParameterTypes = new[] { typeof(object), typeof(StreamingContext) };
+                }
+
+                var method = new DynamicMethod($"{callbackMethod.Name}_Trampoline", null, callbackParameterTypes, type, skipVisibility: true);
+                var il = method.GetILGenerator();
+
+                il.Emit(OpCodes.Ldarg_0);
+                if (type != typeof(TOwner))
+                {
+                    il.Emit(OpCodes.Castclass, type);
+                }
+
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Callvirt, callbackMethod);
+                il.Emit(OpCodes.Ret);
+
+                object result = method.CreateDelegate(typeof(TDelegate));
+                return (TDelegate)result;
+            }
+
+            public class SerializationCallbacks<TDelegate>
+            {
+                public SerializationCallbacks(
+                    TDelegate onDeserializing,
+                    TDelegate onDeserialized,
+                    TDelegate onSerializing,
+                    TDelegate onSerialized)
+                {
+                    OnDeserializing = onDeserializing;
+                    OnDeserialized = onDeserialized;
+                    OnSerializing = onSerializing;
+                    OnSerialized = onSerialized;
+                }
+
+                public TDelegate OnDeserializing { get; }
+                public TDelegate OnDeserialized { get; }
+                public TDelegate OnSerializing { get; }
+                public TDelegate OnSerialized { get; }
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans.Core/Serialization/ILBasedExceptionSerializer.cs
@@ -1,12 +1,11 @@
 using System.Runtime.Serialization;
 using Orleans.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace Orleans.Serialization
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
-
     /// <summary>
     /// Methods for serializing instances of <see cref="Exception"/> and its subclasses.
     /// </summary>

--- a/src/Orleans.Core/Serialization/KeyedSerializerId.cs
+++ b/src/Orleans.Core/Serialization/KeyedSerializerId.cs
@@ -1,4 +1,6 @@
-﻿namespace Orleans.Serialization
+using System;
+
+namespace Orleans.Serialization
 {
     /// <summary>
     /// Values for identifying <see cref="IKeyedSerializer"/> serializers.
@@ -14,6 +16,11 @@
         /// <see cref="Orleans.Serialization.BinaryFormatterISerializableSerializer"/>
         /// </summary>
         BinaryFormatterISerializable = 2,
+
+        /// <summary>
+        /// <see cref="DotNetSerializableSerializer"/>
+        /// </summary>
+        ISerializableSerializer = 3,
 
         /// <summary>
         /// The maximum reserved value.

--- a/src/Orleans.Core/Serialization/UnavailableExceptionFallbackException.cs
+++ b/src/Orleans.Core/Serialization/UnavailableExceptionFallbackException.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// Represents an exception which has a type which is unavailable during deserialization.
+    /// </summary>
+    [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
+    public sealed class UnavailableExceptionFallbackException : Exception
+    {
+        /// <inheritdoc />
+        public UnavailableExceptionFallbackException()
+        {
+        }
+
+        /// <inheritdoc />
+        public UnavailableExceptionFallbackException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            foreach (var pair in info)
+            {
+                Properties[pair.Name] = pair.Value;
+            }
+        }
+
+        /// <inheritdoc />
+        public UnavailableExceptionFallbackException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Gets the serialized properties of the exception.
+        /// </summary>
+        public Dictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets the exception type name.
+        /// </summary>
+        public string ExceptionType { get; internal set; }
+
+        /// <inheritdoc />
+        public override string ToString() => string.IsNullOrWhiteSpace(ExceptionType) ? $"Unknown exception: {base.ToString()}" : $"Unknown exception of type {ExceptionType}: {base.ToString()}";
+
+        private string GetDebuggerDisplay() => ToString();
+    }
+}

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -300,9 +300,15 @@ namespace Orleans.Hosting
                 sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value.LargeMessageWarningThreshold));
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
+
+            // Register the ISerializable serializer first, so that it takes precedence
+            services.AddSingleton<DotNetSerializableSerializer>();
+            services.AddFromExisting<IKeyedSerializer, DotNetSerializableSerializer>();
+
             services.AddSingleton<BinaryFormatterSerializer>();
             services.AddSingleton<BinaryFormatterISerializableSerializer>();
             services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
+
 #pragma warning disable CS0618 // Type or member is obsolete
             services.AddSingleton<ILBasedSerializer>();
             services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();

--- a/test/Grains/TestInternalGrains/SerializationTestTypes.cs
+++ b/test/Grains/TestInternalGrains/SerializationTestTypes.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
 using Orleans.Serialization;

--- a/test/NonSilo.Tests/Serialization/DotNetSerializableTests.cs
+++ b/test/NonSilo.Tests/Serialization/DotNetSerializableTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Orleans.Serialization;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Serialization
+{
+    [TestCategory("BVT"), TestCategory("Serialization")]
+    public class DotNetSerializableTests
+    {
+        private readonly SerializationTestEnvironment environment;
+
+        public DotNetSerializableTests()
+        {
+            this.environment = SerializationTestEnvironment.Initialize();
+        }
+
+        /// <summary>
+        /// Tests that <see cref="DotNetSerializableSerializer"/> can correctly serialize objects.
+        /// </summary>
+        /// <param name="serializerToUse"></param>
+        [Fact]
+        public void DotNetSerializableSerializerSerializesObjectWithCallbacks()
+        {
+            var input = new SimpleISerializableObject
+            {
+                Payload = "pyjamas"
+            };
+
+            // Verify that our behavior conforms to our expected behavior.
+            var result = (SimpleISerializableObject) BuiltInSerializerTests.OrleansSerializationLoop(this.environment.SerializationManager, input);
+            Assert.Equal(
+                new[]
+                {
+                    "default_ctor",
+                    "serializing",
+                    "serialized"
+                },
+                input.History);
+            Assert.Equal(3, input.Contexts.Count);
+            Assert.All(input.Contexts, ctx => Assert.True(ctx.Context is ICopyContext || ctx.Context is ISerializationContext));
+
+            Assert.Equal(
+                new[]
+                {
+                    "deserializing",
+                    "serialization_ctor",
+                    "deserialized",
+                    "deserialization"
+                },
+                result.History);
+            Assert.Equal(input.Payload, result.Payload, StringComparer.Ordinal);
+            Assert.Equal(3, result.Contexts.Count);
+            Assert.All(result.Contexts, ctx => Assert.True(ctx.Context is IDeserializationContext));
+
+            // Verify that our behavior conforms to the behavior of BinaryFormatter.
+            var input2 = new SimpleISerializableObject
+            {
+                Payload = "pyjamas"
+            };
+
+            var result2 = (SimpleISerializableObject) BuiltInSerializerTests.DotNetSerializationLoop(
+                input2,
+                this.environment.SerializationManager);
+
+            Assert.Equal(input2.History, input.History);
+            Assert.Equal(result2.History, result.History);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="DotNetSerializableSerializer"/> can correctly serialize structs.
+        /// </summary>
+        /// <param name="serializerToUse"></param>
+        [Fact]
+        public void DotNetSerializableSerializerSerializesStructWithCallbacks()
+        {
+            var input = new SimpleISerializableStruct
+            {
+                Payload = "pyjamas"
+            };
+
+            // Verify that our behavior conforms to our expected behavior.
+            var result = (SimpleISerializableStruct) BuiltInSerializerTests.OrleansSerializationLoop(this.environment.SerializationManager, input);
+            Assert.Equal(
+                new[]
+                {
+                    "serialization_ctor",
+                    "deserialized",
+                    "deserialization"
+                },
+                result.History);
+            Assert.Equal(input.Payload, result.Payload, StringComparer.Ordinal);
+            Assert.Equal(2, result.Contexts.Count);
+            Assert.All(result.Contexts, ctx => Assert.True(ctx.Context is IDeserializationContext));
+
+            // Verify that our behavior conforms to the behavior of BinaryFormatter.
+            var input2 = new SimpleISerializableStruct
+            {
+                Payload = "pyjamas"
+            };
+
+            var result2 = (SimpleISerializableStruct) BuiltInSerializerTests.DotNetSerializationLoop(
+                input2,
+                this.environment.SerializationManager);
+
+            Assert.Equal(input2.History, input.History);
+            Assert.Equal(result2.History, result.History);
+        }
+
+        [Serializable]
+        public class SimpleISerializableObject : ISerializable, IDeserializationCallback
+        {
+            private List<string> history;
+            private List<StreamingContext> contexts;
+
+            public SimpleISerializableObject()
+            {
+                this.History.Add("default_ctor");
+            }
+
+            public SimpleISerializableObject(SerializationInfo info, StreamingContext context)
+            {
+                this.History.Add("serialization_ctor");
+                this.Contexts.Add(context);
+                this.Payload = info.GetString(nameof(this.Payload));
+            }
+
+            public List<string> History => this.history ?? (this.history = new List<string>());
+            public List<StreamingContext> Contexts => this.contexts ?? (this.contexts = new List<StreamingContext>());
+
+            public string Payload { get; set; }
+
+            public void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                this.Contexts.Add(context);
+                info.AddValue(nameof(this.Payload), this.Payload);
+            }
+
+            [OnSerializing]
+            internal void OnSerializingMethod(StreamingContext context)
+            {
+                this.History.Add("serializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnSerialized]
+            internal void OnSerializedMethod(StreamingContext context)
+            {
+                this.History.Add("serialized");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserializing]
+            internal void OnDeserializingMethod(StreamingContext context)
+            {
+                this.History.Add("deserializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserialized]
+            internal void OnDeserializedMethod(StreamingContext context)
+            {
+                this.History.Add("deserialized");
+                this.Contexts.Add(context);
+            }
+
+            void IDeserializationCallback.OnDeserialization(object sender)
+            {
+                this.History.Add("deserialization");
+            }
+        }
+
+        [Serializable]
+        public struct SimpleISerializableStruct : ISerializable, IDeserializationCallback
+        {
+            private List<string> history;
+            private List<StreamingContext> contexts;
+
+            public SimpleISerializableStruct(SerializationInfo info, StreamingContext context)
+            {
+                this.history = null;
+                this.contexts = null;
+                this.Payload = info.GetString(nameof(this.Payload));
+                this.History.Add("serialization_ctor");
+                this.Contexts.Add(context);
+            }
+
+            public List<string> History => this.history ?? (this.history = new List<string>());
+            public List<StreamingContext> Contexts => this.contexts ?? (this.contexts = new List<StreamingContext>());
+
+            public string Payload { get; set; }
+
+            public void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                this.Contexts.Add(context);
+                info.AddValue(nameof(this.Payload), this.Payload);
+            }
+
+            [OnSerializing]
+            internal void OnSerializingMethod(StreamingContext context)
+            {
+                this.History.Add("serializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnSerialized]
+            internal void OnSerializedMethod(StreamingContext context)
+            {
+                this.History.Add("serialized");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserializing]
+            internal void OnDeserializingMethod(StreamingContext context)
+            {
+                this.History.Add("deserializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserialized]
+            internal void OnDeserializedMethod(StreamingContext context)
+            {
+                this.History.Add("deserialized");
+                this.Contexts.Add(context);
+            }
+
+            void IDeserializationCallback.OnDeserialization(object sender)
+            {
+                this.History.Add("deserialization");
+            }
+        }
+    }
+}

--- a/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -212,7 +213,20 @@ namespace UnitTests.Serialization
 
         private class BaseException : Exception
         {
+            public BaseException() { }
+
+            protected BaseException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+                BaseField = (SomeFunObject)info.GetValue("BaseField", typeof(SomeFunObject));
+            }
+
             public SomeFunObject BaseField { get; set; }
+
+            public override void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                base.GetObjectData(info, context);
+                info.AddValue("BaseField", BaseField, typeof(SomeFunObject));
+            }
         }
 
         [Serializable]
@@ -221,6 +235,23 @@ namespace UnitTests.Serialization
             public string SubClassField { get; set; }
             public SomeFunObject OtherField { get; set; }
             public object SomeObject { get; set; }
+
+            public ILExceptionSerializerTestException() : base() { }
+
+            protected ILExceptionSerializerTestException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+                SubClassField = info.GetString("SubClassField");
+                SomeObject = info.GetValue("SomeObject", typeof(object));
+                OtherField = (SomeFunObject)info.GetValue("OtherField", typeof(SomeFunObject));
+            }
+
+            public override void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                base.GetObjectData(info, context);
+                info.AddValue("SubClassField", SubClassField);
+                info.AddValue("SomeObject", SomeObject, typeof(object));
+                info.AddValue("OtherField", OtherField, typeof(SomeFunObject));
+            }
         }
 
         private class TestTypeSerializer : TypeSerializer


### PR DESCRIPTION
Implements a new serializer specifically for conforming `ISerializable` implementations. This is intended to replace most of the use case that we currently have for `BinaryFormatter`, which is blocked in .NET 5

This also adds fallback exception serialization so that exception types which are unknown by the deserializing party (eg, the caller of a method which throws) can be deserialized into a special type, maintaining the stack.

Additionally, this supports deserializing exception types which do not expose a protected deserialization constructor (because they did not correctly implement the `ISerializable` pattern)