### PR TITLE
Configure grain state serializer per storage provider 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,6 +47,7 @@
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.6</MicrosoftDotNetPlatformAbstractionsVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
     <SystemIoPipelinesVersion>5.0.0</SystemIoPipelinesVersion>
+    <SystemMemoryData>1.0.1</SystemMemoryData>
 
     <!-- Microsoft packages -->
     <MicrosoftBuildVersion>16.9.0</MicrosoftBuildVersion>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureTableSiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureTableSiloBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloBuilder AddAzureTableGrainStorage(this ISiloBuilder builder, string name, Action<AzureTableStorageOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.AddAzureTableGrainStorage(name, ob => ob.Configure(configureOptions)));
+            return builder.AddAzureTableGrainStorage(name, ob => ob.Configure(configureOptions));
         }
 
         /// <summary>
@@ -40,18 +40,34 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloBuilder AddAzureTableGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureTableStorageOptions>> configureOptions = null)
         {
-            return builder.ConfigureServices(services => services.AddAzureTableGrainStorage(name, configureOptions));
+            return builder.AddGrainStorage(name, configure =>
+            {
+                configure.UseOrleansSerializer();
+                configure.UseAzureTable(configureOptions);
+            });
         }
 
-        internal static IServiceCollection AddAzureTableGrainStorage(this IServiceCollection services, string name,
-            Action<OptionsBuilder<AzureTableStorageOptions>> configureOptions = null)
+        /// <summary>
+        /// Use Azure Table as grain storage
+        /// </summary>
+        public static void UseAzureTable(this IGrainStorageProviderConfigurator configurator, Action<AzureTableStorageOptions> options)
         {
-            configureOptions?.Invoke(services.AddOptions<AzureTableStorageOptions>(name));
-            services.AddTransient<IConfigurationValidator>(sp => new AzureTableGrainStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableStorageOptions>>().Get(name), name));
-            services.ConfigureNamedOptionForLogging<AzureTableStorageOptions>(name);
-            services.TryAddSingleton<IGrainStorage>(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
-            return services.AddSingletonNamedService<IGrainStorage>(name, AzureTableGrainStorageFactory.Create)
-                           .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+            configurator.UseAzureTable(builder => builder.Configure(options));
+        }
+
+        /// <summary>
+        /// Use Azure Table as grain storage
+        /// </summary>
+        public static void UseAzureTable(this IGrainStorageProviderConfigurator configurator, Action<OptionsBuilder<AzureTableStorageOptions>> configureOptions)
+        {
+            configurator.ConfigureStorage(AzureTableGrainStorageFactory.Create, configureOptions);
+            configurator.ConfigureDelegate.Invoke(services =>
+            {
+                services.AddSingletonNamedService(
+                  configurator.Name,
+                  (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+                services.AddTransient<IConfigurationValidator>(sp => new AzureTableGrainStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableStorageOptions>>().Get(configurator.Name), configurator.Name));
+            });
         }
     }
 }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/GrainStorageProviderConfigurator.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/GrainStorageProviderConfigurator.cs
@@ -1,0 +1,100 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Orleans.Storage;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Base interface for configuring the grain storage providers
+    /// </summary>
+    public interface IGrainStorageProviderConfigurator : INamedServiceConfigurator
+    {
+    }
+
+    /// <summary>
+    /// Class used to  configuring the grain storage providers
+    /// </summary>
+    public class GrainStorageProviderConfigurator : NamedServiceConfigurator, IGrainStorageProviderConfigurator
+    {
+        public GrainStorageProviderConfigurator(
+            string name,
+            Action<Action<IServiceCollection>> configureDelegate)
+            : base(name, configureDelegate)
+        {
+        }
+    }
+
+    public static class GrainStorageProviderConfiguratorExtensions
+    {
+        /// <summary>
+        /// Set the serializer to use
+        /// </summary>
+        public static void ConfigureSerializer(
+            this IGrainStorageProviderConfigurator self,
+            Func<IServiceProvider, string, IGrainStorageSerializer> factory)
+        {
+            self.ConfigureComponent(factory);
+        }
+
+        /// <summary>
+        /// Configure the storage to use
+        /// </summary>
+        public static void ConfigureStorage<T>(
+            this IGrainStorageProviderConfigurator self,
+            Func<IServiceProvider, string, IGrainStorage> grainStorageFactory,
+            Action<OptionsBuilder<T>> configureOptions)
+             where T : class, new()
+        {
+            self.ConfigureComponent(grainStorageFactory, configureOptions);
+        }
+
+        /// <summary>
+        /// Use the Orleans built-in serializer.
+        /// Fast, but not backward compatible, and hard to use outside Orleans
+        /// </summary>
+        public static void UseOrleansSerializer(this IGrainStorageProviderConfigurator self, bool useJsonAsFallback = true)
+        {
+            self.ConfigureDelegate.Invoke(sp => sp.TryAddSingleton<OrleansGrainStorageSerializer>());
+            if (useJsonAsFallback)
+            {
+                self.ConfigureDelegate.Invoke(sp => sp.TryAddSingleton<JsonGrainStorageSerializer>());
+                self.ConfigureSerializer((sp, name) => new GrainStorageSerializer(sp.GetService<OrleansGrainStorageSerializer>(), sp.GetService<JsonGrainStorageSerializer>()));
+            }
+            else
+            {
+                self.ConfigureSerializer((sp, name) => sp.GetService<OrleansGrainStorageSerializer>());
+            }
+        }
+
+        /// <summary>
+        /// Use the Orleans built-in serializer.
+        /// Fast, but not backward compatible, and hard to use outside Orleans
+        /// </summary>
+        public static void UseJsonSerializer(this IGrainStorageProviderConfigurator self, bool useOrleansBinaryAsFallback = true)
+        {
+            self.ConfigureDelegate.Invoke(sp => sp.TryAddSingleton<JsonGrainStorageSerializer>());
+            self.ConfigureSerializer((sp, name) => sp.GetService<JsonGrainStorageSerializer>());
+            if (useOrleansBinaryAsFallback)
+            {
+                self.ConfigureDelegate.Invoke(sp => sp.TryAddSingleton<OrleansGrainStorageSerializer>());
+                self.ConfigureSerializer((sp, name) => new GrainStorageSerializer(sp.GetService<JsonGrainStorageSerializer>(), sp.GetService<OrleansGrainStorageSerializer>()));
+            }
+            else
+            {
+                self.ConfigureSerializer((sp, name) => sp.GetService<OrleansGrainStorageSerializer>());
+            }
+        }
+
+        /// <summary>
+        /// Add a grain storage provider
+        /// </summary>
+        public static ISiloBuilder AddGrainStorage(this ISiloBuilder self, string name, Action<IGrainStorageProviderConfigurator> configure)
+        {
+            var configurator = new GrainStorageProviderConfigurator(name, configureDelegate => self.ConfigureServices(configureDelegate));
+            configure.Invoke(configurator);
+            return self;
+        }
+    }
+}

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
@@ -1,9 +1,11 @@
 using System;
 using Azure.Core;
 using Microsoft.Azure.Cosmos.Table;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Orleans.Persistence.AzureStorage;
 using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Orleans.Configuration
 {

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -29,12 +29,11 @@ namespace Orleans.Storage
     {
         private readonly AzureTableStorageOptions options;
         private readonly ClusterOptions clusterOptions;
-        private readonly Serializer serializer;
+        private readonly IGrainStorageSerializer storageSerializer;
         private readonly IServiceProvider services;
         private readonly ILogger logger;
 
         private GrainStateTableDataManager tableDataManager;
-        private JsonSerializerSettings JsonSettings;
 
         // each property can hold 64KB of data and each entity can take 1MB in total, so 15 full properties take
         // 15 * 64 = 960 KB leaving room for the primary key, timestamp etc
@@ -51,14 +50,14 @@ namespace Orleans.Storage
             string name,
             AzureTableStorageOptions options,
             IOptions<ClusterOptions> clusterOptions,
-            Serializer serializer,
+            IGrainStorageSerializer storageSerializer,
             IServiceProvider services,
             ILogger<AzureTableGrainStorage> logger)
         {
             this.options = options;
             this.clusterOptions = clusterOptions.Value;
             this.name = name;
-            this.serializer = serializer;
+            this.storageSerializer = storageSerializer;
             this.services = services;
             this.logger = logger;
         }
@@ -185,10 +184,13 @@ namespace Orleans.Storage
             IEnumerable<EntityProperty> properties;
             string basePropertyName;
 
-            if (this.options.UseJson)
+            // Convert to binary format
+            var tag = this.storageSerializer.Serialize(grainState.GetType(), grainState, out var output);
+            basePropertyName = ConvertTagToPropertyName(tag);
+
+            if (basePropertyName.Equals(STRING_DATA_PROPERTY_NAME))
             {
-                // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
-                string data = Newtonsoft.Json.JsonConvert.SerializeObject(grainState, this.JsonSettings);
+                var data = output.ToString();
 
                 if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
                     data.Length, entity.PartitionKey, entity.RowKey);
@@ -196,22 +198,20 @@ namespace Orleans.Storage
                 // each Unicode character takes 2 bytes
                 dataSize = data.Length * 2;
 
-                properties = SplitStringData(data).Select(t => new EntityProperty(t));
-                basePropertyName = STRING_DATA_PROPERTY_NAME;
+                properties = SplitStringData(data.AsMemory()).Select(t => new EntityProperty(t.ToString()));
             }
             else
             {
                 // Convert to binary format
+                var (tag, output) = this.storageSerializer.Serialize(grainState.GetType(), grainState);
+                var data = output.ToArray();
 
-                byte[] data = this.serializer.SerializeToArray(grainState);
-
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
-                    data.Length, entity.PartitionKey, entity.RowKey);
+                if (logger.IsEnabled(LogLevel.Trace))
+                    logger.Trace("Writing data size = {0} for grain id = Partition={1} / Row={2}", data.Length, entity.PartitionKey, entity.RowKey);
 
                 dataSize = data.Length;
 
-                properties = SplitBinaryData(data).Select(t => new EntityProperty(t));
-                basePropertyName = BINARY_DATA_PROPERTY_NAME;
+                properties = SplitBinaryData(data).Select(t => new EntityProperty(t.ToArray()));
             }
 
             CheckMaxDataSize(dataSize, MAX_DATA_CHUNK_SIZE * MAX_DATA_CHUNKS_COUNT);
@@ -233,29 +233,27 @@ namespace Orleans.Storage
             }
         }
 
-        private static IEnumerable<string> SplitStringData(string stringData)
+        private static IEnumerable<ReadOnlyMemory<char>> SplitStringData(ReadOnlyMemory<char> stringData)
         {
             var startIndex = 0;
             while (startIndex < stringData.Length)
             {
                 var chunkSize = Math.Min(MAX_STRING_PROPERTY_LENGTH, stringData.Length - startIndex);
 
-                yield return stringData.Substring(startIndex, chunkSize);
+                yield return stringData.Slice(startIndex, chunkSize);
 
                 startIndex += chunkSize;
             }
         }
 
-        private static IEnumerable<byte[]> SplitBinaryData(byte[] binaryData)
+        private static IEnumerable<ReadOnlyMemory<byte>> SplitBinaryData(ReadOnlyMemory<byte> binaryData)
         {
             var startIndex = 0;
             while (startIndex < binaryData.Length)
             {
                 var chunkSize = Math.Min(MAX_DATA_CHUNK_SIZE, binaryData.Length - startIndex);
 
-                var chunk = new byte[chunkSize];
-                Array.Copy(binaryData, startIndex, chunk, 0, chunkSize);
-                yield return chunk;
+                yield return binaryData.Slice(startIndex, chunkSize);
 
                 startIndex += chunkSize;
             }
@@ -352,11 +350,11 @@ namespace Orleans.Storage
                 if (binaryData.Length > 0)
                 {
                     // Rehydrate
-                    dataValue = this.serializer.Deserialize<object>(binaryData);
+                    dataValue = this.storageSerializer.Deserialize<object>(binaryData, ConvertPropertyNameToTag(BINARY_DATA_PROPERTY_NAME));
                 }
                 else if (!string.IsNullOrEmpty(stringData))
                 {
-                    dataValue = Newtonsoft.Json.JsonConvert.DeserializeObject(stringData, stateType, this.JsonSettings);
+                    dataValue = this.storageSerializer.Deserialize(stateType, new BinaryData(stringData), ConvertPropertyNameToTag(STRING_DATA_PROPERTY_NAME));
                 }
 
                 // Else, no data found
@@ -480,8 +478,6 @@ namespace Orleans.Storage
             {
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"AzureTableGrainStorage {name} initializing: {this.options.ToString()}");
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, $"AzureTableGrainStorage {name} is using DataConnectionString: {ConfigUtilities.RedactConnectionStringInfo(this.options.ConnectionString)}");
-                this.JsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.services), this.options.UseFullAssemblyNames, this.options.IndentJson, this.options.TypeNameHandling);
-                this.options.ConfigureJsonSerializerSettings?.Invoke(this.JsonSettings);
                 this.tableDataManager = new GrainStateTableDataManager(this.options, this.logger);
                 await this.tableDataManager.InitTableAsync();
                 stopWatch.Stop();
@@ -505,6 +501,26 @@ namespace Orleans.Storage
         {
             lifecycle.Subscribe(OptionFormattingUtilities.Name<AzureTableGrainStorage>(this.name), this.options.InitStage, Init, Close);
         }
+
+        private static string ConvertTagToPropertyName(string tag)
+        {
+            // TODO handle xml?
+            return tag switch
+            {
+                WellKnownSerializerTag.Json => STRING_DATA_PROPERTY_NAME,
+                _ => BINARY_DATA_PROPERTY_NAME
+            };
+        }
+
+        private static string ConvertPropertyNameToTag(string propertyName)
+        {
+            // TODO handle xml?
+            return propertyName switch
+            {
+                STRING_DATA_PROPERTY_NAME => WellKnownSerializerTag.Json,
+                _ => WellKnownSerializerTag.Binary
+            };
+        }
     }
 
     public static class AzureTableGrainStorageFactory
@@ -513,7 +529,8 @@ namespace Orleans.Storage
         {
             var optionsSnapshot = services.GetRequiredService<IOptionsMonitor<AzureTableStorageOptions>>();
             var clusterOptions = services.GetProviderClusterOptions(name);
-            return ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(services, name, optionsSnapshot.Get(name), clusterOptions);
+            var storageSerializer = services.GetRequiredServiceByName<IGrainStorageSerializer>(name);
+            return ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(services, name, optionsSnapshot.Get(name), clusterOptions, storageSerializer);
         }
     }
 }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
@@ -1,6 +1,8 @@
 using System;
 using Newtonsoft.Json;
 using Orleans.Persistence.AzureStorage;
+using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Orleans.Configuration
 {
@@ -25,13 +27,8 @@ namespace Orleans.Configuration
         /// </summary>
         public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
         public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
-
-        public bool UseJson { get; set; }
-        public bool UseFullAssemblyNames { get; set; }
-        public bool IndentJson { get; set; }
-        public TypeNameHandling? TypeNameHandling { get; set; }
-        public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
     }
+
     /// <summary>
     /// Configuration validator for AzureTableStorageOptions
     /// </summary>

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.Memory.Data" Version="$(SystemMemoryData)" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Core/Providers/IGrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/IGrainStorageSerializer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Common interface for grain state serializers
+    /// </summary>
+    public interface IGrainStorageSerializer
+    {
+        /// <summary>
+        /// Returns the list of supported tags by the implementation
+        /// </summary>
+        List<string> SupportedTags { get; }
+
+        /// <summary>
+        /// Serialize the object in input
+        /// </summary>
+        /// <param name="input">Object to serialize</param>
+        /// <param name="output">The serialized object will be written to this output</param>
+        /// <returns>The tag used for serialization</returns>
+        string Serialize<T>(T input, out BinaryData output);
+
+        /// <summary>
+        /// Deserialize the data in input
+        /// </summary>
+        /// <param name="input">Data to deserialize</param>
+        /// <param name="tag">Tag returned during serialization</param>
+        /// <returns>The deserialized object</returns>
+        T Deserialize<T>(BinaryData input, string tag);
+    }
+
+    public static class WellKnownSerializerTag
+    {
+        public const string Binary = "binary";
+        public const string Json = "json";
+        public const string Xml = "xml";
+        public const string Text = "text";
+    }
+
+    public static class GrainStateSerializerExtensions
+    {
+        /// <summary>
+        /// Serialize the object in input
+        /// </summary>
+        /// <param name="self">Serializer to use</param>
+        /// <param name="input">Object to serialize</param>
+        /// <returns>The serializer tag and the srialized output</returns>
+        public static (string tag, ReadOnlyMemory<byte> output) Serialize<T>(this IGrainStorageSerializer self, T input)
+        {
+            var tag = self.Serialize(input, out var output);
+            return (tag, output.ToMemory());
+        }
+
+        /// <summary>
+        /// Serialize the object in input
+        /// </summary>
+        /// <param name="self">Serializer to use</param>
+        /// <param name="input">Data to deserialize</param>
+        /// <param name="tag">Tag returned during serialization</param>
+        /// <returns>The deserialized object</returns>
+        public static T Deserialize<T>(this IGrainStorageSerializer self, ReadOnlyMemory<byte> input, string tag)
+        {
+            return self.Deserialize<T>(new BinaryData(input), tag);
+        }
+    }
+}

--- a/src/Orleans.Core/Providers/StorageSerializer/GrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/GrainStorageSerializer.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Grain storage serializer that use a primary serializer and can deserialize from other serializers
+    /// </summary>
+    public class GrainStorageSerializer : IGrainStorageSerializer
+    {
+        private readonly IGrainStorageSerializer serializer;
+        private readonly Dictionary<string, IGrainStorageSerializer> deserializers = new Dictionary<string, IGrainStorageSerializer>();
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public List<string> SupportedTags => this.deserializers.Keys.ToList();
+
+        public GrainStorageSerializer(IGrainStorageSerializer serializer, params IGrainStorageSerializer[] fallbackDeserializers)
+        {
+            this.serializer = serializer;
+            InsertDeserializer(serializer);
+
+            foreach (var deserializer in fallbackDeserializers)
+            {
+                InsertDeserializer(deserializer);
+            }
+
+            void InsertDeserializer(IGrainStorageSerializer deserializer)
+            {
+                foreach (var tag in deserializer.SupportedTags)
+                {
+                    this.deserializers[tag] = deserializer;
+                }
+            }
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string Serialize<T>(T value, out BinaryData output) => this.serializer.Serialize(value, out output);
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public T Deserialize<T>(BinaryData input, string tag)
+        {
+            if (!this.deserializers.TryGetValue(tag, out var deserializer))
+            {
+                throw new ArgumentException($"Unsupported tag '{tag}'", nameof(tag));
+            }
+
+            return deserializer.Deserialize<T>( input, tag);
+        }
+    }
+}

--- a/src/Orleans.Core/Providers/StorageSerializer/JsonGrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/JsonGrainStorageSerializer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Orleans.Serialization;
+
+namespace Orleans.Storage
+{
+    public class JsonGrainStorageSerializerOptions
+    {
+        public bool UseFullAssemblyNames { get; set; }
+        public bool IndentJson { get; set; }
+        public TypeNameHandling? TypeNameHandling { get; set; }
+        public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+    }
+
+    /// <summary>
+    /// Grain storage serializer that uses Newtonsoft.Json
+    /// </summary>
+    public class JsonGrainStorageSerializer : IGrainStorageSerializer
+    {
+        private static List<string> supportedTags => new List<string> { WellKnownSerializerTag.Json };
+
+        private JsonSerializerSettings jsonSettings;
+
+        public JsonGrainStorageSerializer(IOptions<JsonGrainStorageSerializerOptions> options, IServiceProvider services)
+        {
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(
+                OrleansJsonSerializer.GetDefaultSerializerSettings(services),
+                options.Value.UseFullAssemblyNames,
+                options.Value.IndentJson,
+                options.Value.TypeNameHandling);
+
+            options.Value.ConfigureJsonSerializerSettings?.Invoke(this.jsonSettings);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public List<string> SupportedTags => supportedTags;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string Serialize<T>(T value, out BinaryData output)
+        {
+            var data = JsonConvert.SerializeObject(value, this.jsonSettings);
+            output = new BinaryData(data);
+            return WellKnownSerializerTag.Json;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public T Deserialize<T>(BinaryData input, string tag)
+        {
+            if (!tag.Equals(WellKnownSerializerTag.Json, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new ArgumentException($"Unsupported tag '{tag}'", nameof(tag));
+            }
+
+            return JsonConvert.DeserializeObject(input.ToString(), expected, this.jsonSettings);
+        }
+    }
+}

--- a/src/Orleans.Core/Providers/StorageSerializer/OrleansGrainStateSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/OrleansGrainStateSerializer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Orleans.Serialization;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Grain storage serializer that uses the Orleans <see cref="Serializer"/>
+    /// </summary>
+    public class OrleansGrainStorageSerializer : IGrainStorageSerializer
+    {
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        private static List<string> supportedTags => new List<string> { WellKnownSerializerTag.Binary };
+
+        private readonly Serializer serializer;
+
+        public List<string> SupportedTags => supportedTags;
+
+        public OrleansGrainStorageSerializer(Serializer serializer)
+        {
+            this.serializer = serializer;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string Serialize<T>(T value, out BinaryData output)
+        {
+            var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+            this.serializer.Serialize(value, buffer);
+            output = new BinaryData(buffer.WrittenMemory);
+            return WellKnownSerializerTag.Binary;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public T Deserialize<T>(BinaryData input, string tag)
+        {
+            if (!tag.Equals(WellKnownSerializerTag.Binary, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new ArgumentException($"Unsupported tag '{tag}'", nameof(tag));
+            }
+
+            return this.serializer.Deserialize<T>(input.ToMemory());
+        }
+    }
+}

--- a/src/Orleans.Core/Serialization/ArrayBufferWriter.cs
+++ b/src/Orleans.Core/Serialization/ArrayBufferWriter.cs
@@ -1,0 +1,213 @@
+#if !NETCOREAPP
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Buffers;
+using System.Diagnostics;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// Represents a heap-based, array-backed output sink into which <typeparam name="T"/> data can be written.
+    /// </summary>
+    internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+    {
+        // Copy of Array.MaxArrayLength. For byte arrays the limit is slightly larger
+        private const int MaxArrayLength = 0X7FEFFFFF;
+
+        private const int DefaultInitialBufferSize = 256;
+
+        private T[] _buffer;
+        private int _index;
+
+
+        /// <summary>
+        /// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+        /// with the default initial capacity.
+        /// </summary>
+        public ArrayBufferWriter()
+        {
+            _buffer = Array.Empty<T>();
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+        /// with an initial capacity specified.
+        /// </summary>
+        /// <param name="initialCapacity">The minimum capacity with which to initialize the underlying buffer.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="initialCapacity"/> is not positive (i.e. less than or equal to 0).
+        /// </exception>
+        public ArrayBufferWriter(int initialCapacity)
+        {
+            if (initialCapacity <= 0)
+                throw new ArgumentException(null, nameof(initialCapacity));
+
+            _buffer = new T[initialCapacity];
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlyMemory{T}"/>.
+        /// </summary>
+        public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, _index);
+
+        /// <summary>
+        /// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, _index);
+
+        /// <summary>
+        /// Returns the amount of data written to the underlying buffer so far.
+        /// </summary>
+        public int WrittenCount => _index;
+
+        /// <summary>
+        /// Returns the total amount of space within the underlying buffer.
+        /// </summary>
+        public int Capacity => _buffer.Length;
+
+        /// <summary>
+        /// Returns the amount of space available that can still be written into without forcing the underlying buffer to grow.
+        /// </summary>
+        public int FreeCapacity => _buffer.Length - _index;
+
+        /// <summary>
+        /// Clears the data written to the underlying buffer.
+        /// </summary>
+        /// <remarks>
+        /// You must clear the <see cref="ArrayBufferWriter{T}"/> before trying to re-use it.
+        /// </remarks>
+        public void Clear()
+        {
+            Debug.Assert(_buffer.Length >= _index);
+            _buffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Notifies <see cref="IBufferWriter{T}"/> that <paramref name="count"/> amount of data was written to the output <see cref="Span{T}"/>/<see cref="Memory{T}"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="count"/> is negative.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when attempting to advance past the end of the underlying buffer.
+        /// </exception>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public void Advance(int count)
+        {
+            if (count < 0)
+                throw new ArgumentException(null, nameof(count));
+
+            if (_index > _buffer.Length - count)
+                ThrowInvalidOperationException_AdvancedTooFar(_buffer.Length);
+
+            _index += count;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Memory{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="sizeHint"/> is negative.
+        /// </exception>
+        /// <remarks>
+        /// This will never return an empty <see cref="Memory{T}"/>.
+        /// </remarks>
+        /// <remarks>
+        /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+        /// </remarks>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            Debug.Assert(_buffer.Length > _index);
+            return _buffer.AsMemory(_index);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Span{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="sizeHint"/> is negative.
+        /// </exception>
+        /// <remarks>
+        /// This will never return an empty <see cref="Span{T}"/>.
+        /// </remarks>
+        /// <remarks>
+        /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+        /// </remarks>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            Debug.Assert(_buffer.Length > _index);
+            return _buffer.AsSpan(_index);
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            if (sizeHint < 0)
+                throw new ArgumentException(nameof(sizeHint));
+
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (sizeHint > FreeCapacity)
+            {
+                int currentLength = _buffer.Length;
+
+                // Attempt to grow by the larger of the sizeHint and double the current size.
+                int growBy = Math.Max(sizeHint, currentLength);
+
+                if (currentLength == 0)
+                {
+                    growBy = Math.Max(growBy, DefaultInitialBufferSize);
+                }
+
+                int newSize = currentLength + growBy;
+
+                if ((uint)newSize > int.MaxValue)
+                {
+                    // Attempt to grow to MaxArrayLength.
+                    uint needed = (uint)(currentLength - FreeCapacity + sizeHint);
+                    Debug.Assert(needed > currentLength);
+
+                    if (needed > MaxArrayLength)
+                    {
+                        ThrowOutOfMemoryException(needed);
+                    }
+
+                    newSize = MaxArrayLength;
+                }
+
+                Array.Resize(ref _buffer, newSize);
+            }
+
+            Debug.Assert(FreeCapacity > 0 && FreeCapacity >= sizeHint);
+        }
+
+        private static void ThrowInvalidOperationException_AdvancedTooFar(int capacity)
+        {
+            throw new InvalidOperationException($"Cannot advance past the end of the buffer, which has a size of {capacity}");
+        }
+
+        private static void ThrowOutOfMemoryException(uint capacity)
+        {
+            throw new OutOfMemoryException($"Cannot allocate a buffer of size {capacity}");
+        }
+    }
+}
+#endif

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -36,6 +36,7 @@ using Orleans.Networking.Shared;
 using Orleans.Configuration.Internal;
 using Orleans.Runtime.Metadata;
 using Orleans.GrainReferences;
+using Orleans.Storage;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.Cloning;

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -1,10 +1,13 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.Hosting;
 using Orleans.TestingHost;
+using TestExtensions;
+using Orleans.Storage;
 
 namespace Tester.AzureUtils.Persistence
 {

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -12,6 +12,7 @@ using Orleans.Configuration;
 using Orleans.Internal;
 using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Serialization;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Storage;
 using Samples.StorageProviders;
@@ -255,22 +256,34 @@ namespace Tester.AzureUtils.Persistence
 
         private async Task<AzureTableGrainStorage> InitAzureTableGrainStorage(AzureTableStorageOptions options)
         {
-            AzureTableGrainStorage store = ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(this.providerRuntime.ServiceProvider, options, "TestStorage");
+            // TODO change test to include more serializer?
+            var serializer = new OrleansGrainStorageSerializer(this.providerRuntime.ServiceProvider.GetRequiredService<Serializer>());
+            AzureTableGrainStorage store = ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(this.providerRuntime.ServiceProvider, options, serializer, "TestStorage");
             ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(this.providerRuntime.ServiceProvider);
             store.Participate(lifecycle);
             await lifecycle.OnStart();
             return store;
         }
 
-        private Task<AzureTableGrainStorage> InitAzureTableGrainStorage(bool useJson = false, TypeNameHandling? typeNameHandling = null)
+        private async Task<AzureTableGrainStorage> InitAzureTableGrainStorage(bool useJson = false, TypeNameHandling? typeNameHandling = null)
         {
-            var options = new AzureTableStorageOptions
-            {
-                UseJson = useJson,
-                TypeNameHandling = typeNameHandling
-            };
+            var options = new AzureTableStorageOptions();
+            var jsonOptions = new JsonGrainStorageSerializerOptions { TypeNameHandling = typeNameHandling };
+
             options.ConfigureTestDefaults();
-            return InitAzureTableGrainStorage(options);
+
+            // TODO change test to include more serializer?
+            var binarySerializer = new OrleansGrainStorageSerializer(this.providerRuntime.ServiceProvider.GetRequiredService<SerializationManager>());
+            var jsonSerializer = new JsonGrainStorageSerializer(Options.Create(jsonOptions), this.providerRuntime.ServiceProvider);
+            var serializer = useJson
+                ? new GrainStorageSerializer(jsonSerializer, binarySerializer)
+                : new GrainStorageSerializer(binarySerializer, jsonSerializer);
+
+            AzureTableGrainStorage store = ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(this.providerRuntime.ServiceProvider, options, serializer, "TestStorage");
+            ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(this.providerRuntime.ServiceProvider);
+            store.Participate(lifecycle);
+            await lifecycle.OnStart();
+            return store;
         }
 
         private async Task Test_PersistenceProvider_Read(string grainTypeName, IGrainStorage store,


### PR DESCRIPTION
Right now, for the Azure providers at least, it's not possible to use a custom serializer: you only have the choice between Newtonsoft.Json or the Orleans `SerializationManager`.

Users can configure the `SerializationManager` to use a custom serializer for certains types, but this method has two main limitations:

- The custom serializer will be used for wire-transmission
- The output is still padded by some binary content from `SerializationManager`.

This PR enable configuration of custom serializer for grain state per storage provider. 

The base interface for these serializer is `IGrainStorageSerializer`. In this PR I included 3 implementations:

- `JsonGrainStorageSerializer`: an implementation that uses Newtonsoft.Json
- `OrleansGrainStorageSerializer`: an implementation that uses the Orleans `SerializationManager`
- `GrainStorageSerializer`: an implementation that use a primary Serializer, but capable of deserialize multiple formats.

The idea of this interface is that it's easy to compose. The `Serialize` method will return a `tag`, that will be used to identify the type of the serializer when calling `Deserialize`.

It should be easy to add custom implementation that read from a config, or from class Attributes for example.

Here is the new way to configure the Azure table storage provider:

``` csharp
siloBuilder.AddGrainStorage(name, configure =>
{
    configure.UseOrleansSerializer(); // Configure the serializer here
    configure.UseAzureTable(options => options.ConnectionString = "xxx");
});
```

For now, old configuration method are still available, and the `GrainStorageSerializer` will be used by default. I think for 4.0 we should remove this and ask the user to configure explicitely a serializer.

The configuration may seems more complicated, but maybe we can add some configuration helper methods like that:

``` csharp
siloBuilder.UseAzureTable<JsonGrainStorageSerializer>(options => options.ConnectionString = "xxx")
``` 

for serialization implementation that requires none or few configuration steps.

