### PR TITLE
Adding analyzer to notify user classes that implement IGrain should inherit from Grain

### DIFF
--- a/src/Orleans.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Orleans.Analyzers/AnalyzerReleases.Shipped.md
@@ -6,3 +6,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 ORLEANS0001  | Usage   | Error  | [AlwaysInterleave] must only be used on the grain interface method and not the grain class method
 ORLEANS0002  | Usage   | Error  | Reference parameter modifiers are not allowed
+ORLEANS0003  | Usage   | Warning | Non-abstract classes that implement IGrain should derive from the base class Orleans.Grain

--- a/src/Orleans.Analyzers/InheritFromGrainBaseAnalyzer.cs
+++ b/src/Orleans.Analyzers/InheritFromGrainBaseAnalyzer.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using System.Linq;
 
-namespace TestOrleansAnalyzer
+namespace Orleans.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class InheritFromGrainBaseAnalyzer : DiagnosticAnalyzer

--- a/src/Orleans.Analyzers/InheritFromGrainBaseAnalyzer.cs
+++ b/src/Orleans.Analyzers/InheritFromGrainBaseAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace TestOrleansAnalyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InheritFromGrainBaseAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ORLEANS0003";
+        private const string BaseInterfaceName = "Orleans.IGrain";
+        private const string BaseClassName = "Orleans.Grain";
+        public const string Title = "Non-abstract classes that implement IGrain should derive from the base class Orleans.Grain";
+        public const string MessageFormat = Title;
+        private const string Category = "Usage";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var namedSymbol = context.Symbol as INamedTypeSymbol;
+
+            // continue if the class is not abstract.
+            if (namedSymbol == null || namedSymbol.IsAbstract) return;
+
+            // continue only if there is no issue inside the class.
+            var diagnostics = context.Compilation.GetDeclarationDiagnostics();
+            if (diagnostics.Any()) return;
+
+            // continue only if the class implements IGrain
+            var GrainInterfaceType = context.Compilation.GetTypeByMetadataName(BaseInterfaceName);
+            if (GrainInterfaceType == null || !namedSymbol.AllInterfaces.Contains(GrainInterfaceType)) return;
+
+            // Get the base type of the class
+            var GrainType = context.Compilation.GetTypeByMetadataName(BaseClassName);
+            var baseType = namedSymbol.BaseType;
+            
+            // Check equality with the base class
+            if (!SymbolEqualityComparer.Default.Equals(baseType, GrainType))
+            {
+                var location = namedSymbol.Locations.FirstOrDefault();
+
+                if (location != null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, location));
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Analyzers/InheritFromGrainBaseCodeFixProvider.cs
+++ b/src/Orleans.Analyzers/InheritFromGrainBaseCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace TestOrleansAnalyzer
+namespace Orleans.Analyzers
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InheritFromGrainBaseCodeFixProvider)), Shared]
     public class InheritFromGrainBaseCodeFixProvider : CodeFixProvider

--- a/src/Orleans.Analyzers/InheritFromGrainBaseCodeFixProvider.cs
+++ b/src/Orleans.Analyzers/InheritFromGrainBaseCodeFixProvider.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestOrleansAnalyzer
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InheritFromGrainBaseCodeFixProvider)), Shared]
+    public class InheritFromGrainBaseCodeFixProvider : CodeFixProvider
+    {
+        public const string CodeFixTitle = "Inherit from Orleans.Grain";
+        public const string AbstractCodeFixTitle = "Mark as Abstract";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(InheritFromGrainBaseAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the type declaration identified by the diagnostic.
+            var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().First();
+
+            // Register a code action to invoke the fix
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: CodeFixTitle,
+                    createChangedDocument: c => ApplyBaseClassAsync(context.Document, declaration, c),
+                    equivalenceKey: CodeFixTitle),
+                diagnostic);
+        }
+
+        private async Task<Document> ApplyBaseClassAsync(Document document, TypeDeclarationSyntax typeDeclaration, CancellationToken cancellationToken)
+        {
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+
+            // Add Grain as base case
+            var generator = SyntaxGenerator.GetGenerator(document);
+            var newNode = generator.AddBaseType(typeDeclaration, SyntaxFactory.ParseName("Orleans.Grain"));
+
+            // Format node
+            var formattedNewNode = newNode.WithAdditionalAnnotations(Formatter.Annotation);
+
+            // Replace node
+            var newRoot = oldRoot.ReplaceNode(typeDeclaration, formattedNewNode);
+
+            // Update Document
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/test/Analyzers.Tests/InheritFromGrainBaseAnalyzerTests.cs
+++ b/test/Analyzers.Tests/InheritFromGrainBaseAnalyzerTests.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Orleans.Analyzers;
+using Xunit;
+
+namespace Analyzers.Tests
+{
+    [TestCategory("BVT"), TestCategory("Analyzer")]
+    public class InheritFromGrainBaseAnalyzerTests : DiagnosticAnalyzerTestBase<InheritFromGrainBaseAnalyzer>
+    {
+        protected override Task<(Diagnostic[], string)> GetDiagnosticsAsync(string source, params string[] extraUsings)
+            => base.GetDiagnosticsAsync(source, extraUsings.Concat(new[] { "Orleans.Concurrency" }).ToArray());
+
+        [Fact]
+        public async Task InheritFromGrain_Analyzer_NoWarningsIfNotImplementingIGrain() => await this.AssertNoDiagnostics(@"
+class A
+{
+    Task M() => Task.CompletedTask;
+}
+");
+
+        [Fact]
+        public async Task InheritFromGrain_Analyzer_NoWarningsImplementingIGrain_AndInheritingFromGrain() => await this.AssertNoDiagnostics(@"
+class A : Grain, IGrain
+{
+    Task M() => Task.CompletedTask;
+}
+");
+
+        [Fact]
+        public async Task InheritFromGrain_Analyzer_WarningIfImplementingIGrain_AndNotInheritingFromGrain()
+        {
+            var (diagnostics, source) = await this.GetDiagnosticsAsync(@"
+public class A : IGrain
+{
+    Task M() => Task.CompletedTask;
+}
+");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(InheritFromGrainBaseAnalyzer.DiagnosticId, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(InheritFromGrainBaseAnalyzer.MessageFormat, diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task InheritFromGrain_Analyzer_WarningIfImplementingIGrainWithGuidCompoundKey_AndNotInheritingFromGrain()
+        {
+            var (diagnostics, source) = await this.GetDiagnosticsAsync(@"
+public class A : IGrainWithGuidCompoundKey
+{
+    Task M() => Task.CompletedTask;
+}
+");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(InheritFromGrainBaseAnalyzer.DiagnosticId, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(InheritFromGrainBaseAnalyzer.MessageFormat, diagnostic.GetMessage());
+        }
+    }
+}


### PR DESCRIPTION
Closing #6194

From the feedback, it might be helpful to have an analyzer check to see if a non-abstract class implements `IGrain`, but doesn't inherit from `Grain`.

Previously, there was no message from the compiler when a user forgets to derive an implementation from the base `Grain` class, so this analyzer will generate ORLEANS0003 and inform the user that "Non-abstract classes that implement IGrain should derive from the base class Orleans.Grain".

Example, using [HelloWorld](https://github.com/dotnet/orleans/tree/master/Samples/3.3/HelloWorld) from the Samples, where `HelloGrain` implements `IHello`, which implements the interface `IGrainWithIntegerKey`:

![image](https://user-images.githubusercontent.com/8077887/107138091-2399e180-68c7-11eb-9c8e-e5b54a4ef21c.png)

Another addition is the CodeFixProvider, which provides the user with a potential fix:

![image](https://user-images.githubusercontent.com/8077887/107138114-40ceb000-68c7-11eb-9c76-7ec03873a47e.png)

![image](https://user-images.githubusercontent.com/8077887/107138122-4f1ccc00-68c7-11eb-932f-0d9de1f11c05.png)

Also works on classes that derive from an abstract class that implements `IGrain`

![image](https://user-images.githubusercontent.com/8077887/107138253-3f51b780-68c8-11eb-80de-8a1b2549d27d.png)