### PR TITLE
Event Hubs: Update to the latest GA package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,10 +85,7 @@
     <MicrosoftAzureCosmosTableVersion>1.0.5</MicrosoftAzureCosmosTableVersion>
     <AzureCoreVersion>1.3.0</AzureCoreVersion>
     <AzureIdentityVersion>1.1.1</AzureIdentityVersion>
-    <AzureMessagingEventHubs>5.1.0</AzureMessagingEventHubs>
-    <!-- BEGIN Should not be needed donce AzureMessagingEventHubs is upgraded to 5.3.0 -->
-    <MicrosoftAzureAmqp>2.4.9</MicrosoftAzureAmqp>
-    <!-- END Should not be needed donce AzureMessagingEventHubs is upgraded to 5.3.0 -->
+    <AzureMessagingEventHubs>5.3.0</AzureMessagingEventHubs>
     <AzureStorageBlobsVersion>12.4.4</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.3.2</AzureStorageQueuesVersion>
     <MicrosoftDataSqliteVersion>5.0.2</MicrosoftDataSqliteVersion>

--- a/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
+++ b/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
@@ -27,7 +27,5 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
     <PackageReference Include="System.Net.NameResolution" Version="$(SystemNetNameResolutionVersion)" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="$(AzureMessagingEventHubs)" />
-    <!-- Should not be needed donce AzureMessagingEventHubs is upgraded to 5.3.0 -->
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="$(MicrosoftAzureAmqp)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updating the Event Hubs client library to v5.3.0 (GA) which resolves the AMQP dependency issue with .NET 5.  Removing the direct reference to `Microsoft.Azure.Amqp`, as it was needed only as a workaround to the .NET 5 compatibility issue.