### PR TITLE
Fix LRU race conditions and remove dead code

### DIFF
--- a/src/Orleans.Core/Utils/LRU.cs
+++ b/src/Orleans.Core/Utils/LRU.cs
@@ -11,37 +11,12 @@ namespace Orleans.Runtime
     // flush "old" values 
     internal class LRU<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        // Delegate type for fetching the value associated with a given key.
-        public delegate TValue FetchValueDelegate(TKey key);
-
         // The following machinery is used to notify client objects when a key and its value 
         // is being flushed from the cache.
         // The client's event handler is called after the key has been removed from the cache,
         // but when the cache is in a consistent state so that other methods on the cache may freely
         // be invoked.
-        public class FlushEventArgs : EventArgs
-        {
-            private readonly TKey key;
-            private readonly TValue value;
-
-            public FlushEventArgs(TKey k, TValue v)
-            {
-                key = k;
-                value = v;
-            }
-
-            public TKey Key
-            {
-                get { return key; }
-            }
-
-            public TValue Value
-            {
-                get { return value; }
-            }
-        }
-
-        public event EventHandler<FlushEventArgs> RaiseFlushEvent;
+        public event Action RaiseFlushEvent;
 
         private long nextGeneration = 0;
         private long generationToFree = 0;
@@ -61,78 +36,78 @@ namespace Orleans.Runtime
                 WhenLoaded = DateTime.UtcNow;
             }
         }
-        private readonly ConcurrentDictionaryWithCount<TKey, TimestampedValue> cache;
-        readonly FetchValueDelegate fetcher;
+        private readonly ConcurrentDictionary<TKey, TimestampedValue> cache = new();
+        private int count;
 
-        public int Count { get { return cache.Count; } }
-        public int MaximumSize { get; private set; }
+        public int Count => count;
+        public int MaximumSize { get; }
 
         /// <summary>
         /// Creates a new LRU cache.
         /// </summary>
         /// <param name="maxSize">Maximum number of entries to allow.</param>
         /// <param name="maxAge">Maximum age of an entry.</param>
-        /// <param name="f"></param>
-        public LRU(int maxSize, TimeSpan maxAge, FetchValueDelegate f)
+        public LRU(int maxSize, TimeSpan maxAge)
         {
             if (maxSize <= 0)
             {
-                throw new ArgumentOutOfRangeException("maxSize", "LRU maxSize must be greater than 0");
+                throw new ArgumentOutOfRangeException(nameof(maxSize), "LRU maxSize must be greater than 0");
             }
             MaximumSize = maxSize;
             requiredFreshness = maxAge;
-            fetcher = f;
-            cache = new ConcurrentDictionaryWithCount<TKey, TimestampedValue>();
         }
 
         public void Add(TKey key, TValue value)
         {
-            AdjustSize();
             var result = new TimestampedValue(this, value);
-            cache[key] = result;
+            AdjustSize();
+
+            // add/update delegates can be called multiple times, but only the last result counts
+            var added = false;
+            cache.AddOrUpdate(key, _ =>
+            {
+                added = true;
+                return result;
+            }, (_, old) =>
+            {
+                added = false;
+                // if multiple values are added at once for the same key, take the newest one
+                return old.WhenLoaded >= result.WhenLoaded && old.Generation > result.Generation ? old : result;
+            });
+
+            if (added) Interlocked.Increment(ref count);
         }
 
         public bool ContainsKey(TKey key) => cache.ContainsKey(key);
 
-        public bool RemoveKey(TKey key, out TValue value)
+        public bool RemoveKey(TKey key)
         {
-            value = default(TValue);
-            if (!cache.TryRemove(key, out var tv)) return false;
+            if (!cache.TryRemove(key, out _)) return false;
 
-            value = tv.Value;
+            Interlocked.Decrement(ref count);
             return true;
         }
 
         public void Clear()
         {
-            foreach (var pair in cache)
+            if (RaiseFlushEvent is { } FlushEvent)
             {
-                var args = new FlushEventArgs(pair.Key, pair.Value.Value);
-                EventHandler<FlushEventArgs> handler = RaiseFlushEvent;
-                if (handler == null) continue;
-
-                handler(this, args);
+                foreach (var _ in cache) FlushEvent();
             }
+
+            // not thread-safe: if anything is added, or even removed after addition, between Clear and Count, count may be off
             cache.Clear();
+            Interlocked.Exchange(ref count, 0);
         }
 
         public bool TryGetValue(TKey key, out TValue value)
         {
-            TimestampedValue result;
-
-            value = default(TValue);
-
-            if (cache.TryGetValue(key, out result))
+            if (cache.TryGetValue(key, out var result))
             {
                 var age = DateTime.UtcNow.Subtract(result.WhenLoaded);
                 if (age > requiredFreshness)
                 {
-                    if (!cache.TryRemove(key, out result)) return false;
-                    if (RaiseFlushEvent == null) return false;
-
-                    var args = new FlushEventArgs(key, result.Value);
-                    RaiseFlushEvent(this, args);
-                    return false;
+                    if (RemoveKey(key)) RaiseFlushEvent?.Invoke();
                 }
                 else
                 {
@@ -141,19 +116,14 @@ namespace Orleans.Runtime
                     return true;
                 }
             }
-            else
-            {
-                return false;
-            }
+
+            value = default;
+            return false;
         }
 
         public TValue Get(TKey key)
         {
-            if (TryGetValue(key, out var value)) return value;
-            if (fetcher == null) return value;
-
-            value = fetcher(key);
-            Add(key, value);
+            TryGetValue(key, out var value);
             return value;
         }
 
@@ -162,22 +132,12 @@ namespace Orleans.Runtime
         /// </summary>
         public void RemoveExpired()
         {
-            var now = DateTime.UtcNow;
-            var toRemove = new List<TKey>();
+            var frestTime = DateTime.UtcNow - requiredFreshness;
             foreach (var entry in this.cache)
             {
-                var age = DateTime.UtcNow.Subtract(entry.Value.WhenLoaded);
-                if (age > requiredFreshness)
+                if (entry.Value.WhenLoaded < frestTime)
                 {
-                    toRemove.Add(entry.Key);
-                }
-            }
-            foreach (var key in toRemove)
-            {
-                if (cache.TryRemove(key, out var result) && RaiseFlushEvent != null)
-                {
-                    var args = new FlushEventArgs(key, result.Value);
-                    RaiseFlushEvent(this, args);
+                    if (RemoveKey(entry.Key)) RaiseFlushEvent?.Invoke();
                 }
             }
         }
@@ -187,16 +147,14 @@ namespace Orleans.Runtime
             while (cache.Count >= MaximumSize)
             {
                 long generationToDelete = Interlocked.Increment(ref generationToFree);
-                KeyValuePair<TKey, TimestampedValue> entryToFree =
-                    cache.FirstOrDefault(kvp => kvp.Value.Generation == generationToDelete);
-
-                if (entryToFree.Key == null) continue;
-                TKey keyToFree = entryToFree.Key;
-                if (!cache.TryRemove(keyToFree, out var old)) continue;
-                if (RaiseFlushEvent == null) continue;
-
-                var args = new FlushEventArgs(keyToFree, old.Value);
-                RaiseFlushEvent(this, args);
+                foreach (var e in cache)
+                {
+                    if (e.Value.Generation <= generationToDelete)
+                    {
+                        if (RemoveKey(e.Key)) RaiseFlushEvent?.Invoke();
+                        break;
+                    }
+                }
             }
         }
 
@@ -205,74 +163,6 @@ namespace Orleans.Runtime
             return cache.Select(p => new KeyValuePair<TKey, TValue>(p.Key, p.Value.Value)).GetEnumerator();
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        private class ConcurrentDictionaryWithCount<K, V> : IEnumerable<KeyValuePair<K, V>>
-        {
-            private int count;
-
-            private ConcurrentDictionary<K, V> dictionary;
-
-
-            public ConcurrentDictionaryWithCount()
-            {
-                dictionary = new ConcurrentDictionary<K, V>();
-            }
-
-            public int Count => count;
-
-            public V this[K key] 
-            { 
-                get => dictionary[key]; 
-                set 
-                {
-                    // if the value is to be added, increment count, otherwise just replace
-                    dictionary.AddOrUpdate(key, k => { Interlocked.Increment(ref count); return value; }, (k, _) => value);
-                }
-            }
-
-            public bool TryRemove(K key, out V value)
-            {
-                if (dictionary.TryRemove(key, out value))
-                {
-                    Interlocked.Decrement(ref count);
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-
-            public bool ContainsKey(K key)
-            {
-                return dictionary.ContainsKey(key);
-            }
-
-            public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
-            {
-                return dictionary.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return dictionary.GetEnumerator();
-            }
-
-            public bool TryGetValue(K key, out V value)
-            {
-                return dictionary.TryGetValue(key, out value);
-            }
-
-            // not thread-safe: if anything is added, or even removed after addition, between Clear and Count, count may be off
-            public void Clear()
-            {
-                dictionary.Clear();
-                count = dictionary.Count;
-            }
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Orleans.Core/Utils/LRU.cs
+++ b/src/Orleans.Core/Utils/LRU.cs
@@ -144,7 +144,7 @@ namespace Orleans.Runtime
 
         private void AdjustSize()
         {
-            while (cache.Count >= MaximumSize)
+            while (Count >= MaximumSize)
             {
                 long generationToDelete = Interlocked.Increment(ref generationToFree);
                 foreach (var e in cache)

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public AdaptiveGrainDirectoryCache(TimeSpan initialExpirationTimer, TimeSpan maxExpirationTimer, double exponentialTimerGrowth, int maxCacheSize)
         {
-            cache = new LRU<GrainId, GrainDirectoryCacheEntry>(maxCacheSize, TimeSpan.MaxValue, null);
+            cache = new(maxCacheSize, TimeSpan.MaxValue);
 
             this.initialExpirationTimer = initialExpirationTimer;
             this.maxExpirationTimer = maxExpirationTimer;
@@ -80,15 +80,9 @@ namespace Orleans.Runtime.GrainDirectory
             cache.Add(key, entry);
         }
 
-        public bool Remove(GrainId key)
-        {
-            return cache.RemoveKey(key, out _);
-        }
+        public bool Remove(GrainId key) => cache.RemoveKey(key);
 
-        public void Clear()
-        {
-            cache.Clear();
-        }
+        public void Clear() => cache.Clear();
 
         public bool LookUp(GrainId key, out IReadOnlyList<Tuple<SiloAddress, ActivationId>> result, out int version)
         {

--- a/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
@@ -8,10 +8,7 @@ namespace Orleans.Runtime.GrainDirectory
     {
         private readonly LRU<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>> cache;
 
-        public LRUBasedGrainDirectoryCache(int maxCacheSize, TimeSpan maxEntryAge)
-        {
-            cache = new LRU<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>>(maxCacheSize, maxEntryAge, null);
-        }
+        public LRUBasedGrainDirectoryCache(int maxCacheSize, TimeSpan maxEntryAge) => cache = new(maxCacheSize, maxEntryAge);
 
         public void AddOrUpdate(GrainId key, IReadOnlyList<Tuple<SiloAddress, ActivationId>> value, int version)
         {
@@ -19,15 +16,9 @@ namespace Orleans.Runtime.GrainDirectory
             cache.Add(key, value);
         }
 
-        public bool Remove(GrainId key)
-        {
-            return cache.RemoveKey(key, out _);
-        }
+        public bool Remove(GrainId key) => cache.RemoveKey(key);
 
-        public void Clear()
-        {
-            cache.Clear();
-        }
+        public void Clear() => cache.Clear();
 
         public bool LookUp(GrainId key, out IReadOnlyList<Tuple<SiloAddress, ActivationId>> result, out int version)
         {
@@ -40,11 +31,11 @@ namespace Orleans.Runtime.GrainDirectory
             get
             {
                 var result = new List<Tuple<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>, int>>();
-                IEnumerator<KeyValuePair<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>>> enumerator = cache.GetEnumerator();
+                var enumerator = cache.GetEnumerator();
                 while (enumerator.MoveNext())
                 {
                     var current = enumerator.Current;
-                    result.Add(new Tuple<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>, int>(current.Key, current.Value, -1));
+                    result.Add(new(current.Key, current.Value, -1));
                 }
                 return result;
             }

--- a/test/NonSilo.Tests/General/LruTest.cs
+++ b/test/NonSilo.Tests/General/LruTest.cs
@@ -17,9 +17,8 @@ namespace UnitTests
         {
             const int maxSize = 10;
             var maxAge = new TimeSpan(0, 1, 0, 0);
-            LRU<string, string>.FetchValueDelegate f = null;
 
-            var target = new LRU<string, string>(maxSize, maxAge, f);
+            var target = new LRU<string, string>(maxSize, maxAge);
             Assert.Equal(0, target.Count);  // "Count wrong after construction"
 
             target.Add("1", "one");
@@ -34,9 +33,8 @@ namespace UnitTests
         {
             const int maxSize = 10;
             var maxAge = new TimeSpan(0, 1, 0, 0);
-            LRU<string, string>.FetchValueDelegate f = null;
 
-            var target = new LRU<string, string>(maxSize, maxAge, f);
+            var target = new LRU<string, string>(maxSize, maxAge);
             for (var i = 1; i <= maxSize + 5; i++)
             {
                 var s = i.ToString();
@@ -57,9 +55,8 @@ namespace UnitTests
         {
             const int maxSize = 10;
             var maxAge = new TimeSpan(0, 1, 0, 0);
-            LRU<string, string>.FetchValueDelegate f = null;
 
-            var target = new LRU<string, string>(maxSize, maxAge, f);
+            var target = new LRU<string, string>(maxSize, maxAge);
 
             // Fill the LRU with "1" through "10"
             for (var i = 1; i <= maxSize; i++)
@@ -96,11 +93,10 @@ namespace UnitTests
             const int n = 10;
             const int maxSize = n*2;
             var maxAge = TimeSpan.FromMilliseconds(500);
-            LRU<string, string>.FetchValueDelegate f = null;
             var flushCounter = 0;
 
-            var target = new LRU<string, string>(maxSize, maxAge, f);
-            target.RaiseFlushEvent += (object o, LRU<string, string>.FlushEventArgs args) => flushCounter++;
+            var target = new LRU<string, string>(maxSize, maxAge);
+            target.RaiseFlushEvent += () => flushCounter++;
 
             for (int i = 0; i < n; i++)
             {


### PR DESCRIPTION
* Fix race condition in `AddOrUpdate` use from #6870.
* Remove dictionary wrapper that had redundant (4) generic type arguments.
* Trim `RaiseFlushEvent` overhead (only used by tests).
* Remove unused `fetcher` logic.