### PR TITLE
Reduce global lock use for ConcurrentDictionary

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -11,43 +11,21 @@ namespace Orleans.Runtime
     {
         private readonly ILogger logger;
 
-        private readonly ConcurrentDictionary<ActivationId, ActivationData> activations;                // Activation data (app grains) only.
-        private readonly ConcurrentDictionary<ActivationId, SystemTarget> systemTargets;                // SystemTarget only.
-        private readonly ConcurrentDictionary<GrainId, List<ActivationData>> grainToActivationsMap;     // Activation data (app grains) only.
-        private readonly ConcurrentDictionary<string, CounterStatistic> grainCounts;                    // simple statistics type->count
-        private readonly ConcurrentDictionary<string, CounterStatistic> systemTargetCounts;             // simple statistics systemTargetTypeName->count
+        private readonly ConcurrentDictionary<ActivationId, ActivationData> activations = new();                // Activation data (app grains) only.
+        private readonly ConcurrentDictionary<ActivationId, SystemTarget> systemTargets = new();                // SystemTarget only.
+        private readonly ConcurrentDictionary<GrainId, List<ActivationData>> grainToActivationsMap = new();     // Activation data (app grains) only.
+        private readonly ConcurrentDictionary<string, CounterStatistic> grainCounts = new();                    // simple statistics type->count
+        private readonly ConcurrentDictionary<string, CounterStatistic> systemTargetCounts = new();             // simple statistics systemTargetTypeName->count
 
-        public ActivationDirectory(ILogger<ActivationDirectory> logger)
-        {
-            activations = new ConcurrentDictionary<ActivationId, ActivationData>();
-            systemTargets = new ConcurrentDictionary<ActivationId, SystemTarget>();
-            grainToActivationsMap = new ConcurrentDictionary<GrainId, List<ActivationData>>();
-            grainCounts = new ConcurrentDictionary<string, CounterStatistic>();
-            systemTargetCounts = new ConcurrentDictionary<string, CounterStatistic>();
-            this.logger = logger;
-        }
+        public ActivationDirectory(ILogger<ActivationDirectory> logger) => this.logger = logger;
 
-        public int Count
-        {
-            get { return activations.Count; }
-        }
+        public int Count => activations.Count;
 
-        public IEnumerable<SystemTarget> AllSystemTargets()
-        {
-            return systemTargets.Values;
-        }
+        public IEnumerable<SystemTarget> AllSystemTargets() => systemTargets.Select(i => i.Value);
 
-        public ActivationData FindTarget(ActivationId key)
-        {
-            ActivationData target;
-            return activations.TryGetValue(key, out target) ? target : null;
-        }
+        public ActivationData FindTarget(ActivationId key) => activations.TryGetValue(key, out var v) ? v : null;
 
-        public SystemTarget FindSystemTarget(ActivationId key)
-        {
-            SystemTarget target;
-            return systemTargets.TryGetValue(key, out target) ? target : null;
-        }
+        public SystemTarget FindSystemTarget(ActivationId key) => systemTargets.TryGetValue(key, out var v) ? v : null;
 
         internal void IncrementGrainCounter(string grainTypeName)
         {
@@ -65,31 +43,34 @@ namespace Orleans.Runtime
 
         private CounterStatistic FindGrainCounter(string grainTypeName)
         {
-            CounterStatistic ctr;
-            if (grainCounts.TryGetValue(grainTypeName, out ctr)) return ctr;
+            if (grainCounts.TryGetValue(grainTypeName, out var ctr)) return ctr;
 
             var counterName = new StatisticName(StatisticNames.GRAIN_COUNTS_PER_GRAIN, grainTypeName);
-            ctr = grainCounts[grainTypeName] = CounterStatistic.FindOrCreate(counterName, false);
-            return ctr;
+            return grainCounts.GetOrAdd(grainTypeName, CounterStatistic.FindOrCreate(counterName, false));
         }
 
         private CounterStatistic FindSystemTargetCounter(string systemTargetTypeName)
         {
-            CounterStatistic ctr;
-            if (systemTargetCounts.TryGetValue(systemTargetTypeName, out ctr)) return ctr;
+            if (systemTargetCounts.TryGetValue(systemTargetTypeName, out var ctr)) return ctr;
 
             var counterName = new StatisticName(StatisticNames.SYSTEM_TARGET_COUNTS, systemTargetTypeName);
-            ctr = systemTargetCounts[systemTargetTypeName] = CounterStatistic.FindOrCreate(counterName, false);
-            return ctr;
+            return systemTargetCounts.GetOrAdd(systemTargetTypeName, CounterStatistic.FindOrCreate(counterName, false));
         }
 
         public void RecordNewTarget(ActivationData target)
         {
             if (!activations.TryAdd(target.ActivationId, target))
                 return;
+
+#if NETCOREAPP
             grainToActivationsMap.AddOrUpdate(target.GrainId,
-                g => new List<ActivationData> { target },
-                (g, list) => { lock (list) { list.Add(target); } return list; });
+                (_, t) => new() { t },
+                (_, list, t) => { lock (list) list.Add(t); return list; }, target);
+#else
+            grainToActivationsMap.AddOrUpdate(target.GrainId,
+                new List<ActivationData> { target },
+                (g, list) => { lock (list) list.Add(target); return list; });
+#endif
         }
 
         public void RecordNewSystemTarget(SystemTarget target)
@@ -114,11 +95,10 @@ namespace Orleans.Runtime
 
         public void RemoveTarget(ActivationData target)
         {
-            ActivationData ignore;
-            if (!activations.TryRemove(target.ActivationId, out ignore))
+            if (!activations.TryRemove(target.ActivationId, out _))
                 return;
-            List<ActivationData> list;
-            if (grainToActivationsMap.TryGetValue(target.GrainId, out list))
+
+            if (grainToActivationsMap.TryGetValue(target.GrainId, out var list))
             {
                 lock (list)
                 {
@@ -133,8 +113,8 @@ namespace Orleans.Runtime
                                 if (list2.Count > 0)
                                 {
                                     grainToActivationsMap.AddOrUpdate(target.GrainId,
-                                        g => list2,
-                                        (g, list3) => { lock (list3) { list3.AddRange(list2); } return list3; });
+                                        list2,
+                                        (g, list3) => { lock (list3) list3.AddRange(list2); return list3; });
                                 }
                             }
                         }
@@ -170,22 +150,17 @@ namespace Orleans.Runtime
         {
             if (logger.IsEnabled(LogLevel.Information))
             {
-                string stats = Utils.EnumerableToString(activations.Values.OrderBy(act => act.Name), act => string.Format("++{0}", act.DumpStatus()), Environment.NewLine);
+                var all = activations.ToList();
+                string stats = Utils.EnumerableToString(all.Select(i => i.Value).OrderBy(act => act.Name), act => string.Format("++{0}", act.DumpStatus()), Environment.NewLine);
                 if (stats.Length > 0)
                 {
-                    logger.Info(ErrorCode.Catalog_ActivationDirectory_Statistics, $"ActivationDirectory.PrintActivationDirectory(): Size = { activations.Count}, Directory:{Environment.NewLine}{stats}");
+                    logger.Info(ErrorCode.Catalog_ActivationDirectory_Statistics, $"ActivationDirectory.PrintActivationDirectory(): Size = { all.Count}, Directory:{Environment.NewLine}{stats}");
                 }
             }
         }
 
-        public IEnumerator<KeyValuePair<ActivationId, ActivationData>> GetEnumerator()
-        {
-            return activations.GetEnumerator();
-        }
+        public IEnumerator<KeyValuePair<ActivationId, ActivationData>> GetEnumerator() => activations.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
@@ -187,7 +187,7 @@ namespace Orleans.Providers.Streams.Generator
         {
             var dimensions = new ReceiverMonitorDimensions(queueId.ToString());
             var receiverMonitor = this.ReceiverMonitorFactory(dimensions, this.telemetryProducer);
-            Receiver receiver = receivers.GetOrAdd(queueId, qid => new Receiver(receiverMonitor));
+            var receiver = receivers.GetOrAdd(queueId, new Receiver(receiverMonitor));
             SetGeneratorOnReceiver(receiver);
             return receiver;
         }
@@ -210,9 +210,9 @@ namespace Orleans.Providers.Streams.Generator
             }
 
             // update generator on receivers
-            foreach (Receiver receiver in receivers.Values)
+            foreach (var receiver in receivers)
             {
-                SetGeneratorOnReceiver(receiver);
+                SetGeneratorOnReceiver(receiver.Value);
             }
 
             return Task.FromResult<object>(true);
@@ -221,7 +221,7 @@ namespace Orleans.Providers.Streams.Generator
         private class Receiver : IQueueAdapterReceiver
         {
             const int MaxDelayMs = 20;
-            private IQueueAdapterReceiverMonitor receiverMonitor;
+            private readonly IQueueAdapterReceiverMonitor receiverMonitor;
             public IStreamGenerator QueueGenerator { private get; set; }
 
             public Receiver(IQueueAdapterReceiverMonitor receiverMonitor)

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -183,10 +183,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             internal void RemoveRemoteSubscriber(GuidId subscriptionId)
             {
                 consumers.TryRemove(subscriptionId, out _);
-                //if (consumers.IsEmpty)
-                //{
-                //    // Unsubscribe from PubSub?
-                //}
+                
+                // Unsubscribe from PubSub if the consumers collection is empty?
             }
 
             internal Task DeliverItem(InternalStreamId streamId, IStreamFilter streamFilter, object item, bool fireAndForgetDelivery, bool optimizeForImmutableData)

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -165,7 +165,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         [Serializable]
         internal class StreamConsumerExtensionCollection
         {
-            private readonly ConcurrentDictionary<GuidId, (IStreamConsumerExtension StreamConsumer, string FilterData)> consumers;
+            private readonly ConcurrentDictionary<GuidId, (IStreamConsumerExtension StreamConsumer, string FilterData)> consumers = new();
             private readonly IStreamPubSub streamPubSub;
             private readonly ILogger logger;
 
@@ -173,7 +173,6 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             {
                 this.streamPubSub = pubSub;
                 this.logger = logger;
-                this.consumers = new ConcurrentDictionary<GuidId, (IStreamConsumerExtension StreamConsumer, string FilterData)>();
             }
 
             internal void AddRemoteSubscriber(GuidId subscriptionId, IStreamConsumerExtension streamConsumer, string filterData)
@@ -184,10 +183,10 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             internal void RemoveRemoteSubscriber(GuidId subscriptionId)
             {
                 consumers.TryRemove(subscriptionId, out _);
-                if (consumers.Count == 0)
-                {
-                    // Unsubscribe from PubSub?
-                }
+                //if (consumers.IsEmpty)
+                //{
+                //    // Unsubscribe from PubSub?
+                //}
             }
 
             internal Task DeliverItem(InternalStreamId streamId, IStreamFilter streamFilter, object item, bool fireAndForgetDelivery, bool optimizeForImmutableData)

--- a/src/Serializers/Orleans.Serialization.ProtobufNet/ProtobufNetSerializer.cs
+++ b/src/Serializers/Orleans.Serialization.ProtobufNet/ProtobufNetSerializer.cs
@@ -1,8 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.IO;
-using Orleans.Concurrency;
-using ProtoBuf;
 
 namespace Orleans.Serialization.ProtobufNet
 {
@@ -11,7 +9,7 @@ namespace Orleans.Serialization.ProtobufNet
     /// </summary>
     public class ProtobufNetSerializer : IExternalSerializer
     {
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, ProtobufTypeCacheItem> Cache = new ConcurrentDictionary<RuntimeTypeHandle, ProtobufTypeCacheItem>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, ProtobufTypeCacheItem> Cache = new();
 
         /// <summary>
         /// Determines whether this serializer has the ability to serialize a particular type.
@@ -24,9 +22,7 @@ namespace Orleans.Serialization.ProtobufNet
             {
                 return cacheItem.IsSupported;
             }
-            cacheItem = new ProtobufTypeCacheItem(itemType);
-            Cache.AddOrUpdate(itemType.TypeHandle, cacheItem, (type, val) => cacheItem);
-            return cacheItem.IsSupported;
+            return Cache.GetOrAdd(itemType.TypeHandle, new ProtobufTypeCacheItem(itemType)).IsSupported;
         }
 
         /// <inheritdoc />

--- a/src/Serializers/Orleans.Serialization.ProtobufNet/ProtobufTypeCacheItem.cs
+++ b/src/Serializers/Orleans.Serialization.ProtobufNet/ProtobufTypeCacheItem.cs
@@ -1,8 +1,6 @@
-﻿using Orleans.Concurrency;
-using ProtoBuf;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using Orleans.Concurrency;
+using ProtoBuf;
 
 namespace Orleans.Serialization.ProtobufNet
 {
@@ -13,8 +11,8 @@ namespace Orleans.Serialization.ProtobufNet
 
         public ProtobufTypeCacheItem(Type type)
         {
-            IsSupported = Attribute.GetCustomAttribute(type, typeof(ProtoContractAttribute), false) != null;
-            IsImmutable = Attribute.GetCustomAttribute(type, typeof(ImmutableAttribute), false) != null;
+            IsSupported = type.IsDefined(typeof(ProtoContractAttribute), false);
+            IsImmutable = type.IsDefined(typeof(ImmutableAttribute), false);
         }
     }
 }

--- a/test/NonSilo.Tests/TestInternalHelper.cs
+++ b/test/NonSilo.Tests/TestInternalHelper.cs
@@ -30,7 +30,7 @@ namespace UnitTests.TesterInternal
             var serviceProvider = services.BuildServiceProvider();
 
             var scheduler = ActivatorUtilities.CreateInstance<OrleansTaskScheduler>(serviceProvider);
-            WorkItemGroup ignore = scheduler.RegisterWorkContext(context);
+            scheduler.RegisterWorkContext(context);
             return scheduler;
         }
     }


### PR DESCRIPTION
* Reduce global locking when accessing `ConcurrentDictionary` by reducing use of `Keys/Values/Count/IsEmpty`.
* Remove some dead code.

Inspider by #6870.