### PR TITLE
AdoNet - be more explicit when extracting DateTime from IDataRecord

### DIFF
--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -139,6 +139,20 @@ namespace Orleans.Tests.SqlUtils
             }
         }
 
+        public static DateTime? GetDateTimeValueOrDefault(this IDataRecord record, string fieldName, DateTime @default = default)
+        {
+
+            try
+            {
+                var ordinal = record.GetOrdinal(fieldName);
+                return record.IsDBNull(ordinal) ? @default : record.GetDateTime(ordinal);
+            }
+            catch (IndexOutOfRangeException e)
+            {
+                throw new DataException($"Field '{fieldName}' not found in data record.", e);
+            }
+        }
+
         /// <summary>
         /// Returns a value if it is not <see cref="System.DBNull"/>, <em>default(TValue)</em> otherwise.
         /// </summary>
@@ -211,6 +225,19 @@ namespace Orleans.Tests.SqlUtils
             {
                 var ordinal = record.GetOrdinal(fieldName);
                 return (TValue)record.GetValue(ordinal);
+            }
+            catch (IndexOutOfRangeException e)
+            {
+                throw new DataException($"Field '{fieldName}' not found in data record.", e);
+            }
+        }
+
+        public static DateTime GetDateTimeValue(this IDataRecord record, string fieldName)
+        {
+            try
+            {
+                var ordinal = record.GetOrdinal(fieldName);
+                return record.GetDateTime(ordinal);
             }
             catch (IndexOutOfRangeException e)
             {

--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -139,7 +139,7 @@ namespace Orleans.Tests.SqlUtils
             }
         }
 
-        public static DateTime? GetDateTimeValueOrDefault(this IDataRecord record, string fieldName, DateTime @default = default)
+        public static DateTime? GetDateTimeValueOrDefault(this IDataRecord record, string fieldName, DateTime? @default = default)
         {
 
             try

--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -138,7 +138,17 @@ namespace Orleans.Tests.SqlUtils
                 throw new DataException($"Field '{fieldName}' not found in data record.", e);
             }
         }
-
+        /// <summary>
+        /// Returns a value if it is not <see cref="System.DBNull"/>, <em>default</em>  otherwise.
+        /// </summary>
+        /// <param name="record">The record from which to retrieve the value.</param>
+        /// <param name="fieldName">The name of the field to retrieve.</param>
+        /// <param name="default">The default value if value in position is <see cref="System.DBNull"/>.</param>
+        /// <returns>Either the given value or the default for <see cref="System.DateTime"/>?.</returns>
+        /// <exception cref="DataException"/>
+        /// <remarks>An explicit function like this is needed in cases where to connector infers a type that is undesirable.
+        /// An example here is Npgsql.NodaTime, which makes Npgsql return Noda type and consequently Orleans is not able to
+        /// use it since it expects .NET <see cref="System.DateTime"/>. This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>
         public static DateTime? GetDateTimeValueOrDefault(this IDataRecord record, string fieldName, DateTime? @default = default)
         {
 

--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -241,7 +241,16 @@ namespace Orleans.Tests.SqlUtils
                 throw new DataException($"Field '{fieldName}' not found in data record.", e);
             }
         }
-
+        /// <summary>
+        /// Returns a <see cref="System.DateTime"/> value with the given <see paramref="fieldName"/>.
+        /// </summary>
+        /// <param name="record">The record from which to retrieve the value.</param>
+        /// <param name="fieldName">The name of the field.</param>
+        /// <returns>DateTime Value in the given field.</returns>
+        /// <exception cref="DataException"/>
+        /// <remarks>An explicit function like this is needed in cases where to connector infers a type that is undesirable.
+        /// An example here is Npgsql.NodaTime, which makes Npgsql return Noda type and consequently Orleans is not able to
+        /// use it since it expects .NET <see cref="System.DateTime"/>. This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>
         public static DateTime GetDateTimeValue(this IDataRecord record, string fieldName)
         {
             try

--- a/src/AdoNet/Shared/Storage/DbStoredQueries.cs
+++ b/src/AdoNet/Shared/Storage/DbStoredQueries.cs
@@ -146,7 +146,7 @@ namespace Orleans.Tests.SqlUtils
                     {
                         GrainRef = grainReferenceConverter.FromKeyString(grainId),
                         ReminderName = record.GetValue<string>(nameof(Columns.ReminderName)),
-                        StartAt = record.GetValue<DateTime>(nameof(Columns.StartTime)),
+                        StartAt = record.GetDateTimeValue(nameof(Columns.StartTime)),
 
                         //Use the GetInt64 method instead of the generic GetValue<TValue> version to retrieve the value from the data record
                         //GetValue<int> causes an InvalidCastException with oracle data provider. See https://github.com/dotnet/orleans/issues/3561
@@ -160,7 +160,7 @@ namespace Orleans.Tests.SqlUtils
             internal static Tuple<MembershipEntry, int> GetMembershipEntry(IDataRecord record)
             {
                 //TODO: This is a bit of hack way to check in the current version if there's membership data or not, but if there's a start time, there's member.            
-                DateTime? startTime = record.GetValueOrDefault<DateTime?>(nameof(Columns.StartTime));
+                DateTime? startTime = record.GetDateTimeValueOrDefault(nameof(Columns.StartTime));
                 MembershipEntry entry = null;
                 if (startTime.HasValue)
                 {
@@ -172,7 +172,7 @@ namespace Orleans.Tests.SqlUtils
                         Status = (SiloStatus)Enum.Parse(typeof(SiloStatus), record.GetInt32(nameof(Columns.Status)).ToString()),
                         ProxyPort = record.GetInt32(nameof(Columns.ProxyPort)),
                         StartTime = startTime.Value,
-                        IAmAliveTime = record.GetValue<DateTime>(nameof(Columns.IAmAliveTime))
+                        IAmAliveTime = record.GetDateTimeValue(nameof(Columns.IAmAliveTime))
                     };
 
                     string suspectingSilos = record.GetValueOrDefault<string>(nameof(Columns.SuspectTimes));


### PR DESCRIPTION
Context:
In my project, we are using Npgsql, NodaTime and Npgsql.NodaTime. As a result of this combination, the postgres date/time types (such as those used in the AdoNet membership table) get mapped to NodaTime types instead of BCL types by default, unless you explicitly request the column as DateTime via `IDataRecord.GetDateTime(...)` or similar. 

Without the changes here, I am getting an invalid cast exception at runtime because the Instant type returned by Npgsql is being cast to DateTime by the Orleans AdoNet code.