### PR TITLE
Return zero elapsed time for unstarted Messages

### DIFF
--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -500,10 +500,7 @@ namespace Orleans.Runtime
             timeInterval.Restart();
         }
 
-        public TimeSpan Elapsed
-        {
-            get { return timeInterval.Elapsed; }
-        }
+        public TimeSpan Elapsed => timeInterval == null ? TimeSpan.Zero : timeInterval.Elapsed;
 
         public static Message CreatePromptExceptionResponse(Message request, Exception exception)
         {

--- a/test/NonSilo.Tests/General/MessageTests.cs
+++ b/test/NonSilo.Tests/General/MessageTests.cs
@@ -12,6 +12,5 @@ namespace UnitTests.General
             var m = new Message();
             Assert.Equal(TimeSpan.Zero, m.Elapsed);
         }
-
     }
 }

--- a/test/NonSilo.Tests/General/MessageTests.cs
+++ b/test/NonSilo.Tests/General/MessageTests.cs
@@ -1,0 +1,17 @@
+using System;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests.General
+{
+    public class MessageTests
+    {
+        [Fact, TestCategory("Functional")]
+        public void Message_ElapsedZeroIfNeverStarted()
+        {
+            var m = new Message();
+            Assert.Equal(TimeSpan.Zero, m.Elapsed);
+        }
+
+    }
+}


### PR DESCRIPTION
If `Message.Start()` is never called, `Message.Elapsed` throws a
`NullReferenceException` because `timeInterval` is never set.

Return `TimeSpan.Zero` if `timeInterval` is null.

I discovered this when the logging framework we use attempted to
serialize the Message object that is included in some log messages, like
the one emitted from /src/Orleans.Runtime/Core/Dispatcher.cs line 445 as
of commit cd8fcd745 (Implement C# Source Generator (#6925), 2021-02-18):

    logger.LogError(
        (int)ErrorCode.Dispatcher_ErrorCreatingActivation,
        ex,
        "Error creating activation for grain {TargetGrain} (interface: {InterfaceType}). Message {Message}",
        msg.TargetGrain,
        msg.InterfaceType,
        msg);

Yes, the logging framework we're using is trying to serialize too much.

----------------

A different approach: the timing code in Message doesn't appear to be used. Could the timing code&mdash;`Start()`, `Stop()`, `Reset()`, and `Elapsed`&mdash;be deleted entirely?