### PR TITLE
Catch potential exceptions in AddOnDeactivate calls

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -717,6 +717,10 @@ namespace Orleans.Runtime
                         {
                             await DestroyActivation(activationData, cts.Token);
                         }
+                        catch (Exception exception)
+                        {
+                            logger.LogError(exception, "Error deactivating activation {Activation}", activationData);
+                        }
                         finally
                         {
                             mtcs.SetOneResult();
@@ -763,7 +767,17 @@ namespace Orleans.Runtime
                     }
                     else // busy, so destroy later.
                     {
-                        data.AddOnInactive(() => _ = DestroyActivation(data, cts.Token));
+                        data.AddOnInactive(async () =>
+                        {
+                            try
+                            {
+                                await DestroyActivation(data, cts.Token);
+                            }
+                            catch (Exception exception)
+                            {
+                                logger.LogError(exception, "Error deactivating activation {Activation}", data);
+                            }
+                        });
                     }
                 }
                 else if (data.State == ActivationState.Create)
@@ -789,7 +803,7 @@ namespace Orleans.Runtime
             CounterStatistic.FindOrCreate(statisticName).Increment();
             if (promptly)
             {
-                _ = DestroyActivation(data, cts.Token); // Don't await or Ignore, since we are in this activation context and it may have alraedy been destroyed!
+                DestroyActivation(data, cts.Token).Ignore();
             }
         }
 
@@ -838,7 +852,7 @@ namespace Orleans.Runtime
             }
             catch (Exception ex)
             {
-                this.logger.Warn(ErrorCode.Catalog_DeactivateActivation_Exception, $"Exception when trying to deactivate {activationData}", ex);
+                this.logger.LogWarning((int)ErrorCode.Catalog_DeactivateActivation_Exception, ex, "Exception when trying to deactivate {Activation}", activationData);
             }
             finally
             {
@@ -846,11 +860,17 @@ namespace Orleans.Runtime
                 {
                     activationData.SetState(ActivationState.Invalid);
                 }
-                // Capture grainInstance since UnregisterMessageTarget will set it to null...
-                var grainInstance = activationData.GrainInstance;
-                UnregisterMessageTarget(activationData);
-                RerouteAllQueuedMessages(activationData, null, "Finished Destroy Activation");
-                await activationData.DisposeAsync();
+
+                try
+                {
+                    UnregisterMessageTarget(activationData);
+                    RerouteAllQueuedMessages(activationData, null, "Finished Destroy Activation");
+                    await activationData.DisposeAsync();
+                }
+                catch (Exception exception)
+                {
+                    this.logger.LogWarning(exception, "Exception disposing activation {Activation}", activationData);
+                }
             }
         }
 


### PR DESCRIPTION
Because the parameter to this method is coerced into an `Action`, we need to be careful about never throwing, or else the process will crash. There may be other instances of similar patterns (async delegate or task-returning method group being coerced into an Action)