### PR TITLE
Prevent source generator from running during design time

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,6 +33,7 @@
     </ProjectReference>
   </ItemGroup>
 
+  <Import Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' " Project="$(MSBuildThisFileDirectory)src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props" />
   <Import Condition=" '$(OrleansBuildTimeCodeGen)' == 'msbuild' " Project="$(MSBuildThisFileDirectory)src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets" />
 
   <ItemGroup>
@@ -43,4 +44,5 @@
       OutputItemType="Analyzer"
       Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' "/>
   </ItemGroup>
+
 </Project>

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -3,20 +3,45 @@
     <AssemblyName>Orleans.CodeGenerator</AssemblyName>
     <RootNamespace>Orleans.CodeGenerator</RootNamespace>
     <PackageId>Microsoft.Orleans.CodeGenerator</PackageId>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
   </PropertyGroup>
+  
   <ItemGroup>
     <None Remove="AnalyzerReleases.Shipped.md" />
     <None Remove="AnalyzerReleases.Unshipped.md" />
+    <None Remove="buildMultiTargeting\Microsoft.Orleans.CodeGenerator.props" />
+    <None Remove="build\Microsoft.Orleans.CodeGenerator.props" />
   </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="buildMultiTargeting\Microsoft.Orleans.CodeGenerator.props">
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="build\Microsoft.Orleans.CodeGenerator.props">
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+      <Pack>true</Pack>
+    </Content>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).xml" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
+
 </Project>

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -44,6 +44,18 @@ namespace Orleans.CodeGenerator
 
         public void Execute(GeneratorExecutionContext context)
         {
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_debugsourcegenerator", out var attachDebuggerValue)
+                && string.Equals("true", attachDebuggerValue, StringComparison.OrdinalIgnoreCase))
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
+
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_designtimebuild", out var isDesignTimeBuild)
+                && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
             try
             {
                 ExecuteInner(context);

--- a/src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props
+++ b/src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="Orleans_DebugSourceGenerator" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="Orleans_DesignTimeBuild" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Orleans_DesignTimeBuild>$(DesignTimeBuild)</Orleans_DesignTimeBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/Orleans.CodeGenerator/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.props
+++ b/src/Orleans.CodeGenerator/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.CodeGenerator.props" />
+</Project>


### PR DESCRIPTION
The first part of #6999 is simply to not run the C# Source Generator during IDE-builds. This also requires correctly packaging the source generator.