### PR TITLE
Add GrainStorage.AdoNet benchmark along with concurency and larger payloads

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Benchmarks</RootNamespace>
     <AssemblyName>Benchmarks</AssemblyName>
@@ -16,11 +16,13 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" />
     <!-- Temporarily kept to resolve a conflict between Microsoft.Azure.DocumentDB.Core's dependencies -->
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
     <ProjectReference Include="..\..\src\Azure\Orleans.Transactions.AzureStorage\Orleans.Transactions.AzureStorage.csproj" />
+    <ProjectReference Include="..\..\src\AdoNet\Orleans.Persistence.AdoNet\Orleans.Persistence.AdoNet.csproj" />
     <ProjectReference Include="..\..\src\Serializers\Orleans.Serialization.ProtobufNet\Orleans.Serialization.ProtobufNet.csproj" />
     <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\Grains\BenchmarkGrains\BenchmarkGrains.csproj" />

--- a/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
+++ b/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
@@ -14,11 +14,13 @@ namespace Benchmarks.GrainStorage
     {
         private TestCluster host;
         private int concurrent;
+        private int payloadSize;
         private TimeSpan duration;
 
-        public GrainStorageBenchmark(int concurrent, TimeSpan duration)
+        public GrainStorageBenchmark(int concurrent, int payloadSize, TimeSpan duration)
         {
             this.concurrent = concurrent;
+            this.payloadSize = payloadSize;
             this.duration = duration;
         }
 
@@ -120,14 +122,14 @@ namespace Benchmarks.GrainStorage
         {
             var persistentGrain = this.host.Client.GetGrain<IPersistentGrain>(Guid.NewGuid());
             // activate grain
-            await persistentGrain.TrySet(0);
-            var state = instance;
+            await persistentGrain.Init(payloadSize);
+            var iteration = instance % payloadSize;
             var reports = new List<Report>(5000);
             while (running())
             {
-                var report = await persistentGrain.TrySet(state);
+                var report = await persistentGrain.TrySet(iteration);
                 reports.Add(report);
-                state++;
+                iteration = (iteration + 1) % payloadSize;
             }
 
             return reports;

--- a/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
+++ b/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
@@ -36,6 +36,14 @@ namespace Benchmarks.GrainStorage
             this.host.Deploy();
         }
 
+        public void AdoNetSetup()
+        {
+            var builder = new TestClusterBuilder();
+            builder.AddSiloBuilderConfigurator<SiloAdoNetStorageConfigurator>();
+            this.host = builder.Build();
+            this.host.Deploy();
+        }
+
         public class SiloMemoryStorageConfigurator : ISiloConfigurator
         {
             public void Configure(ISiloBuilder hostBuilder)
@@ -60,6 +68,17 @@ namespace Benchmarks.GrainStorage
             public void Configure(ISiloBuilder hostBuilder)
             {
                 hostBuilder.AddAzureBlobGrainStorageAsDefault(options =>
+                {
+                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                });
+            }
+        }
+
+        public class SiloAdoNetStorageConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder.AddAdoNetGrainStorageAsDefault(options =>
                 {
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                 });

--- a/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
+++ b/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
@@ -99,6 +99,7 @@ namespace Benchmarks.GrainStorage
 
         public async Task RunAsync()
         {
+            Stopwatch sw = Stopwatch.StartNew();
             bool running = true;
             Func<bool> isRunning = () => running;
             var runTask = Task.WhenAll(Enumerable.Range(0, concurrent).Select(i => RunAsync(i, isRunning)).ToList());
@@ -106,6 +107,7 @@ namespace Benchmarks.GrainStorage
             await Task.WhenAny(waitTasks);
             running = false;
             var runResults = await runTask;
+            sw.Stop(); 
             var reports = runResults.SelectMany(r => r).ToList();
 
             var stored = reports.Count(r => r.Success);
@@ -114,8 +116,9 @@ namespace Benchmarks.GrainStorage
             var calltime = calltimes.Sum();
             var maxCalltime = calltimes.Max();
             var averageCalltime = calltimes.Average();
-            Console.WriteLine($"Performed {stored} persist (read & write) operations with {failed} failures in {calltime}ms.");
+            Console.WriteLine($"Performed {stored} persist (read & write) operations with {failed} failures in {sw.ElapsedMilliseconds}ms.");
             Console.WriteLine($"Average time in ms per call was {averageCalltime}, with longest call taking {maxCalltime}ms.");
+            Console.WriteLine($"Total time waiting for the persistent store was {calltime}ms.");
         }
 
         public async Task<List<Report>> RunAsync(int instance, Func<bool> running)

--- a/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
+++ b/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
@@ -112,7 +112,7 @@ namespace Benchmarks.GrainStorage
             var calltime = calltimes.Sum();
             var maxCalltime = calltimes.Max();
             var averageCalltime = calltimes.Average();
-            Console.WriteLine($"Performed {stored} persist operations with {failed} failures in {calltime}ms.");
+            Console.WriteLine($"Performed {stored} persist (read & write) operations with {failed} failures in {calltime}ms.");
             Console.WriteLine($"Average time in ms per call was {averageCalltime}, with longest call taking {maxCalltime}ms.");
         }
 

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -169,7 +169,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against memory",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(10, TimeSpan.FromSeconds( 30 ));
                     benchmark.MemorySetup();
                     return benchmark;
                 },
@@ -182,7 +182,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Table",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(100, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureTableSetup();
                     return benchmark;
                 },
@@ -195,7 +195,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Blob",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(10, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureBlobSetup();
                     return benchmark;
                 },
@@ -208,7 +208,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against AdoNet",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(100, TimeSpan.FromSeconds( 30 ));
                     benchmark.AdoNetSetup();
                     return benchmark;
                 },

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -169,7 +169,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against memory",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(10, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(10, 10000, TimeSpan.FromSeconds( 30 ));
                     benchmark.MemorySetup();
                     return benchmark;
                 },
@@ -182,7 +182,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Table",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(100, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(100, 10000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureTableSetup();
                     return benchmark;
                 },
@@ -195,7 +195,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Blob",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(10, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(10, 10000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureBlobSetup();
                     return benchmark;
                 },
@@ -208,7 +208,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against AdoNet",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark(100, TimeSpan.FromSeconds( 30 ));
+                    var benchmark = new GrainStorageBenchmark(100, 10000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AdoNetSetup();
                     return benchmark;
                 },

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -202,6 +202,19 @@ namespace Benchmarks
                 benchmark => benchmark.RunAsync().GetAwaiter().GetResult(),
                 benchmark => benchmark.Teardown());
             },
+            ["GrainStorage.AdoNet"] = () =>
+            {
+                RunBenchmark(
+                "Running grain storage benchmark against AdoNet",
+                () =>
+                {
+                    var benchmark = new GrainStorageBenchmark();
+                    benchmark.AdoNetSetup();
+                    return benchmark;
+                },
+                benchmark => benchmark.RunAsync().GetAwaiter().GetResult(),
+                benchmark => benchmark.Teardown());
+            },
         };
 
         // requires benchmark name or 'All' word as first parameter

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -169,7 +169,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against memory",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark();
+                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
                     benchmark.MemorySetup();
                     return benchmark;
                 },
@@ -182,7 +182,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Table",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark();
+                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureTableSetup();
                     return benchmark;
                 },
@@ -195,7 +195,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against Azure Blob",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark();
+                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AzureBlobSetup();
                     return benchmark;
                 },
@@ -208,7 +208,7 @@ namespace Benchmarks
                 "Running grain storage benchmark against AdoNet",
                 () =>
                 {
-                    var benchmark = new GrainStorageBenchmark();
+                    var benchmark = new GrainStorageBenchmark(15000, TimeSpan.FromSeconds( 30 ));
                     benchmark.AdoNetSetup();
                     return benchmark;
                 },

--- a/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
@@ -1,10 +1,18 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using Orleans;
 
 namespace BenchmarkGrainInterfaces.GrainStorage
 {
+    public class Report
+    {
+        public bool Success { get; set; }
+        public int State { get; set; }
+        public TimeSpan Elapsed { get; set; }
+    }
+
     public interface IPersistentGrain : IGrainWithGuidKey
     {
-        Task<int> Set(int value);
+        Task<Report> TrySet(int value);
     }
 }

--- a/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
@@ -7,12 +7,12 @@ namespace BenchmarkGrainInterfaces.GrainStorage
     public class Report
     {
         public bool Success { get; set; }
-        public int State { get; set; }
         public TimeSpan Elapsed { get; set; }
     }
 
     public interface IPersistentGrain : IGrainWithGuidKey
     {
-        Task<Report> TrySet(int value);
+        Task Init(int payloadSize);
+        Task<Report> TrySet(int index);
     }
 }

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -1,40 +1,53 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Orleans;
 using BenchmarkGrainInterfaces.GrainStorage;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
 
 namespace BenchmarkGrains.GrainStorage
 {
-    public class PersistentGrain : Grain<int>, IPersistentGrain
+    public class PersistentGrain : Grain, IPersistentGrain
     {
         private readonly ILogger<PersistentGrain> logger;
+        private readonly IPersistentState<int> persistentState;
 
-        public PersistentGrain(ILogger<PersistentGrain> logger)
+        public PersistentGrain(
+            ILogger<PersistentGrain> logger,
+            [PersistentState("state")]
+            IPersistentState<int> persistentState)
         {
             this.logger = logger;
+            this.persistentState = persistentState;
         }
 
-        public async Task<int> Set(int value)
+        public async Task<Report> TrySet(int value)
         {
             Stopwatch sw = Stopwatch.StartNew();
+            bool success;
             try
             {
-                this.State = value;
-                await this.WriteStateAsync();
+                this.persistentState.State = value;
+                await this.persistentState.WriteStateAsync();
                 sw.Stop();
                 object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
                 logger.LogInformation("Grain {GrainId} took {WriteTimeMs}ms to set state.", args);
+                success = true;
             } catch(Exception ex)
             {
                 sw.Stop();
                 object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
                 this.logger.LogError(ex, "Grain {GrainId} failed to set state in {WriteTimeMs}ms to set state.", args);
-                throw;
+                success = false;
             }
 
-            return this.State;
+            return new Report
+            {
+                Success = success,
+                Elapsed = sw.Elapsed,
+                State = this.persistentState.State,
+            };
         }
     }
 }

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -28,6 +28,7 @@ namespace BenchmarkGrains.GrainStorage
             bool success;
             try
             {
+                await this.persistentState.ReadStateAsync();
                 this.persistentState.State = value;
                 await this.persistentState.WriteStateAsync();
                 sw.Stop();

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -5,31 +5,44 @@ using Orleans;
 using BenchmarkGrainInterfaces.GrainStorage;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
+using System.Linq;
 
 namespace BenchmarkGrains.GrainStorage
 {
+    [Serializable]
+    public class PersistentGrainState
+    {
+        public byte[] Payload { get; set; }
+    }
+
     public class PersistentGrain : Grain, IPersistentGrain
     {
         private readonly ILogger<PersistentGrain> logger;
-        private readonly IPersistentState<int> persistentState;
+        private readonly IPersistentState<PersistentGrainState> persistentState;
 
         public PersistentGrain(
             ILogger<PersistentGrain> logger,
             [PersistentState("state")]
-            IPersistentState<int> persistentState)
+            IPersistentState<PersistentGrainState> persistentState)
         {
             this.logger = logger;
             this.persistentState = persistentState;
         }
 
-        public async Task<Report> TrySet(int value)
+        public async Task Init(int payloadSize)
+        {
+            this.persistentState.State.Payload = Enumerable.Range(0, payloadSize).Select(i => (byte)i).ToArray();
+            await this.persistentState.WriteStateAsync();
+        }
+
+        public async Task<Report> TrySet(int index)
         {
             Stopwatch sw = Stopwatch.StartNew();
             bool success;
             try
             {
                 await this.persistentState.ReadStateAsync();
-                this.persistentState.State = value;
+                this.persistentState.State.Payload[index] = (byte)(this.persistentState.State.Payload[index] + 1);
                 await this.persistentState.WriteStateAsync();
                 sw.Stop();
                 object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
@@ -47,7 +60,6 @@ namespace BenchmarkGrains.GrainStorage
             {
                 Success = success,
                 Elapsed = sw.Elapsed,
-                State = this.persistentState.State,
             };
         }
     }


### PR DESCRIPTION
I wanted a better benchmark for AdoNet to compare concurrent read/writes and payloads that exceed maximum column sizes for various datastores. 

1. Add GrainStorage.AdoNet benchmark
2. Add concurrency to all GrainStorageBenchmark
3. Add configurable payload to PersistentGrain
4. Accurately time PersistentStore by isolating it's Read/Write call separate of Orleans overhead
5. Force Read and Write and avoid etag/cache.

Please advise for concurrency number and payload sizes. I just guessed at either 10 or 100 concurrent requests, and 10000 byte payloads.
