### PR TITLE
Ensure DynamoDB options are consistent. Add EndpointDiscovery option to DDB options.

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -35,13 +35,7 @@ namespace Orleans.Clustering.DynamoDB
 
         public Task InitializeGatewayListProvider()
         {
-            this.storage = new DynamoDBStorage(
-                this.logger,
-                this.options.Service,
-                this.options.AccessKey,
-                this.options.SecretKey,
-                this.options.ReadCapacityUnits,
-                this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(this.logger, this.options);
 
             return this.storage.InitializeTable(this.options.TableName,
                 new List<KeySchemaElement>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -39,8 +39,7 @@ namespace Orleans.Clustering.DynamoDB
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(this.logger, this.options);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
@@ -1,36 +1,9 @@
-﻿using Orleans.Clustering.DynamoDB;
+using Orleans.Clustering.DynamoDB;
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBClusteringOptions
+    public class DynamoDBClusteringOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
-        /// <summary>
-        /// Read capacity unit for DynamoDB storage
-        /// </summary>
-        public int ReadCapacityUnits { get; set; } = DynamoDBStorage.DefaultReadCapacityUnits;
-
-        /// <summary>
-        /// Write capacity unit for DynamoDB storage
-        /// </summary>
-        public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
-
         /// <summary>
         /// DynamoDB table name.
         /// Defaults to 'OrleansSilos'.

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
@@ -1,34 +1,9 @@
-﻿using Orleans.Clustering.DynamoDB;
+using Orleans.Clustering.DynamoDB;
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBGatewayOptions
+    public class DynamoDBGatewayOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
-        /// <summary>
-        /// Read capacity unit for DynamoDB storage
-        /// </summary>
-        public int ReadCapacityUnits { get; set; } = DynamoDBStorage.DefaultReadCapacityUnits;
-
-        /// <summary>
-        /// Write capacity unit for DynamoDB storage
-        /// </summary>
-        public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
-
         /// <summary>
         /// DynamoDB table name.
         /// Defaults to 'OrleansSilos'.

--- a/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
   </ItemGroup>
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -5,44 +5,12 @@ using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBStorageOptions
+    public class DynamoDBStorageOptions : DynamoDBClientOptions
     {
         /// <summary>
         /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment.
         /// </summary>
         public string ServiceId { get; set; } = string.Empty;
-
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name
-        /// </summary>
-        public string Service { get; set; }
-
-        /// <summary>
-        /// Use Provisioned Throughput for tables
-        /// </summary>
-        public bool UseProvisionedThroughput { get; set; } = true;
-
-        /// <summary>
-        /// Read capacity unit for DynamoDB storage
-        /// </summary>
-        public int ReadCapacityUnits { get; set; } = DynamoDBStorage.DefaultReadCapacityUnits;
-
-        /// <summary>
-        /// Write capacity unit for DynamoDB storage
-        /// </summary>
-        public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
 
         /// <summary>
         /// DynamoDB table name.

--- a/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -84,8 +84,7 @@ namespace Orleans.Storage
 
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
-                this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
+                this.storage = new DynamoDBStorage(this.logger, this.options);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
   </ItemGroup>
 

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -54,8 +54,7 @@ namespace Orleans.Reminders.DynamoDB
         /// <summary>Initialize current instance with specific global configuration and logger</summary>
         public Task Init()
         {
-            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(this.logger, this.options);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
@@ -5,35 +5,8 @@ namespace Orleans.Configuration
     /// <summary>
     /// Configuration for Amazon DynamoDB reminder storage.
     /// </summary>
-    public class DynamoDBReminderStorageOptions
+    public class DynamoDBReminderStorageOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
-        /// <summary>
-        /// Read capacity unit for DynamoDB storage
-        /// </summary>
-        public int ReadCapacityUnits { get; set; } = DynamoDBStorage.DefaultReadCapacityUnits;
-
-        /// <summary>
-        /// Write capacity unit for DynamoDB storage
-        /// </summary>
-        public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
-
         /// <summary>
         /// DynamoDB table name.
         /// Defaults to 'OrleansReminders'.

--- a/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
+++ b/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
@@ -1,0 +1,47 @@
+#if CLUSTERING_DYNAMODB
+namespace Orleans.Clustering.DynamoDB
+#elif PERSISTENCE_DYNAMODB
+namespace Orleans.Persistence.DynamoDB
+#elif REMINDERS_DYNAMODB
+namespace Orleans.Reminders.DynamoDB
+#elif AWSUTILS_TESTS
+namespace Orleans.AWSUtils.Tests
+#elif TRANSACTIONS_DYNAMODB
+namespace Orleans.Transactions.DynamoDB
+#else
+// No default namespace intentionally to cause compile errors if something is not defined
+#endif
+{
+    /// <summary>
+    ///     Options for configuring the DynamoDB behaviour
+    /// </summary>
+    public class DynamoDBClientOptions
+    {
+        /// <summary>
+        ///     The DynamoDB implementation to use. Can either be the service url, eg: http://localstack:4566 or a region endpoint, eg: eu-west-1.
+        /// </summary>
+        public string Service { get; set; }
+        /// <summary>
+        ///     The access key of the IAM principal to use. Must be used with <see cref="SecretKey"/>
+        /// </summary>
+        [Redact]
+        public string AccessKey { get; set; } = "";
+        /// <summary>
+        ///     The secret key of the IAM principal to use. Must be used with <see cref="AccessKey"/>
+        /// </summary>
+        [Redact]
+        public string SecretKey { get; set; } = "";
+        /// <summary>
+        ///     If a table is uninitialized and <see cref="UseProvisionedThroughput"/> is set to true, then the table will have its ReadCapacityUnits set to this value. Defaults to: 10
+        /// </summary>
+        public int ReadCapacityUnits { get; set; } = 10;
+        /// <summary>
+        ///     If a table is uninitialized and <see cref="UseProvisionedThroughput"/> is set to true, then the table will have its WriteCapacityUnits set to this value. Defaults to: 5
+        /// </summary>
+        public int WriteCapacityUnits { get; set; } = 5;
+        /// <summary>
+        ///     If a table is uninitialized, the table will be initialized with provisioned throughput guided by <see cref="ReadCapacityUnits"/> and <see cref="WriteCapacityUnits"/>, otherwise the PayPerRequest model is used for table initialization.
+        /// </summary>
+        public bool UseProvisionedThroughput { get; set; } = true;
+    }
+}

--- a/test/Extensions/AWSUtils.Tests/AWSUtils.Tests.csproj
+++ b/test/Extensions/AWSUtils.Tests/AWSUtils.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="$(SourceRoot)src\AWS\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
     <Compile Include="$(SourceRoot)src\AWS\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="$(SourceRoot)src\AWS\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Extensions/AWSUtils.Tests/LivenessTests.cs
+++ b/test/Extensions/AWSUtils.Tests/LivenessTests.cs
@@ -26,7 +26,7 @@ namespace AWSUtils.Tests.Liveness
                 Orleans.AWSUtils.Tests.DynamoDBStorage storage;
                 try
                 {
-                    storage = new Orleans.AWSUtils.Tests.DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), "http://localhost:8000");
+                    storage = new Orleans.AWSUtils.Tests.DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), new Orleans.AWSUtils.Tests.DynamoDBClientOptions { Service = "http://localhost:8000" });
                 }
                 catch (AmazonServiceException)
                 {

--- a/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
@@ -18,7 +18,7 @@ namespace AWSUtils.Tests.StorageTests
                 DynamoDBStorage storage;
                 try
                 {
-                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), Service);
+                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), new DynamoDBClientOptions { Service = Service });
                 }
                 catch (AmazonServiceException)
                 {

--- a/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
@@ -88,7 +88,7 @@ namespace AWSUtils.Tests.StorageTests
         public const string INSTANCE_TABLE_NAME = "UnitTestDDBTableData";
 
         public UnitTestDynamoDBStorage()
-            : base(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), AWSTestConstants.Service)
+            : base(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), new DynamoDBClientOptions { Service = AWSTestConstants.Service })
         {
             if (AWSTestConstants.IsDynamoDbAvailable)
             {


### PR DESCRIPTION
Two main parts behind this PR:
- Allow the ability to set `ClientConfig.EndpointDiscoveryEnabled` on the AWS config in a backwards compatible way
- Ensure that DynamoDB options are consistent across all storage engines by refactoring into a options class rather than passing a ton of parameters

The desire to set the EndpointDiscoveryEnabled flag is driven from this issue: https://github.com/aws/aws-sdk-net/issues/1270

Notes:
- Currently a draft PR whilst I get some real world performance numbers
- Thought that the refactoring would be beneficial even without the additional option
- Working on getting all the tests to run locally (probably missing a pre-req), though all the changes should be backwards compatible