### PR TITLE
TickStatus constructor access modifier changed to public

### DIFF
--- a/src/Orleans.Core.Abstractions/Timers/IRemindable.cs
+++ b/src/Orleans.Core.Abstractions/Timers/IRemindable.cs
@@ -55,7 +55,7 @@ namespace Orleans
             /// </summary>
             public DateTime CurrentTickTime { get; private set; }
 
-            internal static TickStatus NewStruct(DateTime firstTickTime, TimeSpan period, DateTime timeStamp)
+            public static TickStatus NewStruct(DateTime firstTickTime, TimeSpan period, DateTime timeStamp)
             {
                 return
                     new TickStatus


### PR DESCRIPTION
Reminder functionality is not unit tests friendly because TickStatus has only internal constructor.

Changing accessing modifier to `public` will allow to cover Reminder functionality of grain with unit tests without hacks like using reflection to access constructor or creating virtual methods for deconstruction of tick status in grain.