### PR TITLE
In PooledQueueCache, avoid cache miss if we know that we didn't missed any event

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -31,7 +31,6 @@ namespace Orleans.ServiceBus.Providers
         private readonly ILogger logger;
         private readonly AggregatedCachePressureMonitor cachePressureMonitor;
         private readonly ICacheMonitor cacheMonitor;
-
         private FixedSizeBuffer currentBuffer;
 
         /// <summary>
@@ -46,6 +45,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="logger"></param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval"></param>
+        /// <param name="metadataMinTimeInCache"></param>
         public EventHubQueueCache(
             string partition,
             int defaultMaxAddCount,
@@ -55,14 +55,15 @@ namespace Orleans.ServiceBus.Providers
             IStreamQueueCheckpointer<string> checkpointer,
             ILogger logger,
             ICacheMonitor cacheMonitor,
-            TimeSpan? cacheMonitorWriteInterval)
+            TimeSpan? cacheMonitorWriteInterval,
+            TimeSpan? metadataMinTimeInCache)
         {
             this.Partition = partition;
             this.defaultMaxAddCount = defaultMaxAddCount;
             this.bufferPool = bufferPool;
             this.dataAdapter = dataAdapter;
             this.checkpointer = checkpointer;
-            this.cache = new PooledQueueCache(dataAdapter, logger, cacheMonitor, cacheMonitorWriteInterval);
+            this.cache = new PooledQueueCache(dataAdapter, logger, cacheMonitor, cacheMonitorWriteInterval, metadataMinTimeInCache);
             this.cacheMonitor = cacheMonitor;
             this.evictionStrategy = evictionStrategy;
             this.evictionStrategy.OnPurged = this.OnPurge;

--- a/src/Orleans.Core/Streams/Core/StreamIdentity.cs
+++ b/src/Orleans.Core/Streams/Core/StreamIdentity.cs
@@ -1,5 +1,6 @@
-﻿
+
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Streams
 {
@@ -25,5 +26,15 @@ namespace Orleans.Streams
         /// Stream namespace.
         /// </summary>
         public string Namespace { get; }
+
+        public override bool Equals(object obj) => obj is StreamIdentity identity && this.Guid.Equals(identity.Guid) && this.Namespace == identity.Namespace;
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1455462324;
+            hashCode = hashCode * -1521134295 + this.Guid.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Namespace);
+            return hashCode;
+        }
     }
 }

--- a/src/Orleans.Core/Streams/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/StreamConsumerCollection.cs
@@ -11,6 +11,7 @@ namespace Orleans.Streams
     {
         private readonly Dictionary<GuidId, StreamConsumerData> queueData; // map of consumers for one stream: from Guid ConsumerId to StreamConsumerData
         private DateTime lastActivityTime;
+
         public bool StreamRegistered { get; set; }
 
         public StreamConsumerCollection(DateTime now)

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -412,7 +412,7 @@ namespace Orleans.Streams
             if (queueCache != null)
             {
                 IList<IBatchContainer> purgedItems;
-                if (queueCache.TryPurgeFromCache(out purgedItems))
+                 if (queueCache.TryPurgeFromCache(out purgedItems))
                 {
                     try
                     {

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -412,7 +412,7 @@ namespace Orleans.Streams
             if (queueCache != null)
             {
                 IList<IBatchContainer> purgedItems;
-                 if (queueCache.TryPurgeFromCache(out purgedItems))
+                if (queueCache.TryPurgeFromCache(out purgedItems))
                 {
                     try
                     {

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Orleans.Internal;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
@@ -29,7 +30,11 @@ namespace Orleans.Providers.Streams.Common
         private readonly ICacheDataAdapter cacheDataAdapter;
         private readonly ILogger logger;
         private readonly ICacheMonitor cacheMonitor;
+        private readonly TimeSpan purgeMetadataInterval;
         private readonly PeriodicAction periodicMonitoring;
+        private readonly PeriodicAction periodicMetadaPurging;
+
+        private readonly Dictionary<IStreamIdentity, (DateTime TimeStamp, StreamSequenceToken Token)> lastPurgedToken = new Dictionary<IStreamIdentity, (DateTime TimeStamp, StreamSequenceToken Token)>();
 
         /// <summary>
         /// Cached message most recently added
@@ -69,7 +74,13 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="logger"></param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval">cache monitor write interval.  Only triggered for active caches.</param>
-        public PooledQueueCache(ICacheDataAdapter cacheDataAdapter, ILogger logger, ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
+        /// <param name="purgeMetadataInterval"></param>
+        public PooledQueueCache(
+            ICacheDataAdapter cacheDataAdapter,
+            ILogger logger,
+            ICacheMonitor cacheMonitor,
+            TimeSpan? cacheMonitorWriteInterval,
+            TimeSpan? purgeMetadataInterval = null)
         {
             this.cacheDataAdapter = cacheDataAdapter ?? throw new ArgumentNullException("cacheDataAdapter");
             this.logger = logger ?? throw new ArgumentNullException("logger");
@@ -77,10 +88,15 @@ namespace Orleans.Providers.Streams.Common
             pool = new CachedMessagePool(cacheDataAdapter);
             messageBlocks = new LinkedList<CachedMessageBlock>();
             this.cacheMonitor = cacheMonitor;
-
             if (this.cacheMonitor != null && cacheMonitorWriteInterval.HasValue)
             {
                 this.periodicMonitoring = new PeriodicAction(cacheMonitorWriteInterval.Value, this.ReportCacheMessageStatistics);
+            }
+
+            if (purgeMetadataInterval.HasValue)
+            {
+                this.purgeMetadataInterval = purgeMetadataInterval.Value;
+                this.periodicMetadaPurging = new PeriodicAction(purgeMetadataInterval.Value.Divide(5), this.PurgeMetadata);
             }
         }
 
@@ -121,6 +137,41 @@ namespace Orleans.Providers.Streams.Common
             }
         }
 
+        private void PurgeMetadata()
+        {
+            var now = DateTime.UtcNow;
+            var keys = new List<IStreamIdentity>();
+
+            // Get all keys older than this.purgeMetadataInterval
+            foreach (var kvp in this.lastPurgedToken)
+            {
+                if (kvp.Value.TimeStamp + this.purgeMetadataInterval < now)
+                {
+                    keys.Add(kvp.Key);
+                }
+            }
+
+            // Remove the expired entries
+            foreach (var key in keys)
+            {
+                this.lastPurgedToken.Remove(key);
+            }
+        }
+
+        private void TrackAndPurgeMetadata(CachedMessage messageToRemove)
+        {
+            // If tracking of evicted message metadata is disabled, do nothing
+            if (this.periodicMetadaPurging == null)
+                return;
+
+            var now = DateTime.UtcNow;
+            var streamId = new StreamIdentity(messageToRemove.StreamGuid, messageToRemove.StreamNamespace);
+            var token = this.cacheDataAdapter.GetSequenceToken(ref messageToRemove);
+            this.lastPurgedToken[streamId] = (now, token);
+
+            this.periodicMetadaPurging.TryAction(now);
+        }
+
         private void SetCursor(Cursor cursor, StreamSequenceToken sequenceToken)
         {
             // If nothing in cache, unset token, and wait for more data.
@@ -153,13 +204,27 @@ namespace Orleans.Providers.Streams.Common
             }
 
             // Check to see if sequenceToken is too old to be in cache
-            CachedMessage oldestMessage = messageBlocks.Last.Value.OldestMessage;
+            var oldestBlock = messageBlocks.Last;
+            var oldestMessage = oldestBlock.Value.OldestMessage;
             if (oldestMessage.Compare(sequenceToken) > 0)
             {
-                // throw cache miss exception
-                throw new QueueCacheMissException(sequenceToken,
-                    messageBlocks.Last.Value.GetOldestSequenceToken(cacheDataAdapter),
-                    messageBlocks.First.Value.GetNewestSequenceToken(cacheDataAdapter));
+                // Check if the sequenceToken correspond to the last message purged from cache
+                var streamIdentity = new StreamIdentity(cursor.StreamIdentity.Guid, cursor.StreamIdentity.Namespace);
+                if (this.lastPurgedToken.TryGetValue(streamIdentity, out var entry) && sequenceToken.Equals(entry.Token))
+                {
+                    // If it maches, then we didn't lose anything. Start from the oldest message in cache
+                    cursor.State = CursorStates.Set;
+                    cursor.CurrentBlock = oldestBlock;
+                    cursor.Index = oldestBlock.Value.OldestMessageIndex;
+                    cursor.SequenceToken = oldestBlock.Value.GetOldestSequenceToken(cacheDataAdapter);
+                    return;
+                }
+                else
+                {
+                    throw new QueueCacheMissException(cursor.SequenceToken,
+                        messageBlocks.Last.Value.GetOldestSequenceToken(cacheDataAdapter),
+                        messageBlocks.First.Value.GetNewestSequenceToken(cacheDataAdapter));
+                }
             }
 
             // Find block containing sequence number, starting from the newest and working back to oldest
@@ -312,6 +377,8 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         public void RemoveOldestMessage()
         {
+            TrackAndPurgeMetadata(this.messageBlocks.Last.Value.OldestMessage);
+
             this.messageBlocks.Last.Value.Remove();
             this.ItemCount--;
             CachedMessageBlock lastCachedMessageBlock = this.messageBlocks.Last.Value;

--- a/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
+++ b/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Internal;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -25,6 +26,17 @@ namespace Orleans.Configuration
         /// Default DataMaxAgeInCache
         /// </summary>
         public static readonly TimeSpan DefaultDataMaxAgeInCache = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Minimum time message metadata (<see cref="StreamSequenceToken"/>) will stay in cache before it is available for time based purge.
+        /// Used to avoid cache miss if the full message was purged.
+        /// Set to null to disable this tracking.
+        /// </summary>
+        public TimeSpan? MetadataMinTimeInCache { get; set; } = DefaultMetadataMinTimeInCache;
+        /// <summary>
+        /// Default MetadataMinTimeInCache
+        /// </summary>
+        public static readonly TimeSpan DefaultMetadataMinTimeInCache = DefaultDataMinTimeInCache.Multiply(2);
     }
 
     public class StreamStatisticOptions

--- a/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
+++ b/src/OrleansProviders/Streams/Common/RecoverableStreamOptions.cs
@@ -33,6 +33,7 @@ namespace Orleans.Configuration
         /// Set to null to disable this tracking.
         /// </summary>
         public TimeSpan? MetadataMinTimeInCache { get; set; } = DefaultMetadataMinTimeInCache;
+
         /// <summary>
         /// Default MetadataMinTimeInCache
         /// </summary>

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
@@ -13,7 +13,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
     {
         public EventHubQueueCacheForTesting(IObjectPool<FixedSizeBuffer> bufferPool, IEventHubDataAdapter dataAdapter, IEvictionStrategy evictionStrategy, IStreamQueueCheckpointer<string> checkpointer,
             ILogger logger)
-            :base("test", EventHubAdapterReceiver.MaxMessagesPerRead, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, null, null)
+            :base("test", EventHubAdapterReceiver.MaxMessagesPerRead, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, null, null, null)
             { }
 
         public int ItemCount => this.cache.ItemCount;

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
@@ -102,8 +102,6 @@ namespace ServiceBus.Tests.StreamingTests
 
             protected override IBatchContainer GetBatchContainer(EventHubMessage eventHubMessage)
                 => new CustomBatchContainer(base.GetBatchContainer(eventHubMessage));
-
-            //public override string GetPartitionKey(Guid streamGuid, string streamNamespace) => Guid.Empty.ToString();
         }
 
         #endregion

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
@@ -1,0 +1,110 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Orleans.Hosting;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.TestingHost;
+using ServiceBus.Tests.TestStreamProviders.EventHub;
+using TestExtensions;
+using Xunit.Abstractions;
+using Orleans.Streams;
+using Orleans.ServiceBus.Providers;
+using Tester;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Serialization;
+using Orleans.Providers.Streams.Common;
+using System.Collections.Generic;
+using Xunit;
+using System.Threading.Tasks;
+using UnitTests.GrainInterfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Tester.StreamingTests;
+
+namespace ServiceBus.Tests.StreamingTests
+{
+    [TestCategory("EventHub"), TestCategory("Streaming"), TestCategory("Functional"), TestCategory("StreamingCacheMiss")]
+    public class EHCustomBatchContainerTests : StreamingCacheMissTests
+    {
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+
+        public EHCustomBatchContainerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            TestUtils.CheckForEventHub();
+            builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
+            builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
+        }
+
+        #region Configuration stuff
+
+        private class MySiloBuilderConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder
+                    .AddMemoryGrainStorage("PubSubStore")
+                    .AddEventHubStreams(StreamProviderName, b =>
+                    {
+                        b.ConfigureCacheEviction(ob => ob.Configure(options =>
+                        {
+                            options.DataMaxAgeInCache = TimeSpan.FromSeconds(5);
+                            options.DataMinTimeInCache = TimeSpan.FromSeconds(0);
+                        }));
+                        b.ConfigureEventHub(ob => ob.Configure(options =>
+                        {
+                            options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
+                            options.ConsumerGroup = EHConsumerGroup;
+                            options.Path = EHPath;
+                        }));
+                        b.UseAzureTableCheckpointer(ob => ob.Configure(options =>
+                        {
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.PersistInterval = TimeSpan.FromSeconds(10);
+                        }));
+                        b.UseDataAdapter((sp, n) => ActivatorUtilities.CreateInstance<CustomDataAdapter>(sp));
+                    });
+            }
+        }
+
+        private class MyClientBuilderConfigurator : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder
+                    .AddEventHubStreams(StreamProviderName, b =>
+                    {
+                        b.ConfigureEventHub(ob => ob.Configure(options =>
+                        {
+                            options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
+                            options.ConsumerGroup = EHConsumerGroup;
+                            options.Path = EHPath;
+                        }));
+                        b.UseDataAdapter((sp, n) => ActivatorUtilities.CreateInstance<CustomDataAdapter>(sp));
+                    });
+            }
+        }
+
+        private class CustomDataAdapter : EventHubDataAdapter
+        {
+            public CustomDataAdapter(SerializationManager serializationManager)
+                : base(serializationManager)
+            {
+            }
+
+            public override IBatchContainer GetBatchContainer(ref CachedMessage cachedMessage)
+                => new CustomBatchContainer(base.GetBatchContainer(ref cachedMessage));
+
+            protected override IBatchContainer GetBatchContainer(EventHubMessage eventHubMessage)
+                => new CustomBatchContainer(base.GetBatchContainer(eventHubMessage));
+
+            //public override string GetPartitionKey(Guid streamGuid, string streamNamespace) => Guid.Empty.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHCustomBatchContainerTests.cs
@@ -54,6 +54,7 @@ namespace ServiceBus.Tests.StreamingTests
                         {
                             options.DataMaxAgeInCache = TimeSpan.FromSeconds(5);
                             options.DataMinTimeInCache = TimeSpan.FromSeconds(0);
+                            options.MetadataMinTimeInCache = TimeSpan.FromMinutes(1);
                         }));
                         b.ConfigureEventHub(ob => ob.Configure(options =>
                         {

--- a/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -66,7 +66,7 @@ namespace ServiceBus.Tests.TestStreamProviders
             }
 
             private const int DefaultMaxAddCount = 10;
-            protected override IEventHubQueueCache CreateCache(string partition, IEventHubDataAdapter dataAdatper, StreamStatisticOptions options, IStreamQueueCheckpointer<string> checkpointer,
+            protected override IEventHubQueueCache CreateCache(string partition, IEventHubDataAdapter dataAdatper, StreamStatisticOptions options, StreamCacheEvictionOptions evictionOptions, IStreamQueueCheckpointer<string> checkpointer,
                 ILoggerFactory loggerFactory, IObjectPool<FixedSizeBuffer> bufferPool, string blockPoolId,  TimePurgePredicate timePurge,
                 SerializationManager serializationManager, EventHubMonitorAggregationDimensions sharedDimensions, ITelemetryProducer telemetryProducer)
             {
@@ -88,7 +88,7 @@ namespace ServiceBus.Tests.TestStreamProviders
 
             public QueueCacheForTesting(int defaultMaxAddCount, IObjectPool<FixedSizeBuffer> bufferPool, IEventHubDataAdapter dataAdapter, IEvictionStrategy evictionStrategy, IStreamQueueCheckpointer<string> checkpointer, ILogger logger,
                 ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
-                : base("test", defaultMaxAddCount, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, cacheMonitor, cacheMonitorWriteInterval)
+                : base("test", defaultMaxAddCount, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, cacheMonitor, cacheMonitorWriteInterval, null)
             {
             }
 

--- a/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
@@ -1,0 +1,14 @@
+using Orleans;
+using System.Threading.Tasks;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IImplicitSubscriptionCounterGrain : IGrainWithGuidKey
+    {
+        Task<int> GetEventCounter();
+
+        Task<int> GetErrorCounter();
+
+        Task Deactivate();
+    }
+}

--- a/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Streams;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    [ImplicitStreamSubscription(nameof(IImplicitSubscriptionCounterGrain))]
+    public class ImplicitSubscriptionCounterGrain : Grain, IImplicitSubscriptionCounterGrain
+    {
+        private readonly ILogger logger;
+        private int eventCounter = 0;
+        private int errorCounter = 0;
+
+        public ImplicitSubscriptionCounterGrain(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger($"{nameof(ImplicitSubscriptionCounterGrain)} {this.IdentityString}");
+        }
+
+        public override async Task OnActivateAsync()
+        {
+            this.logger.LogInformation("OnActivateAsync");
+
+            var stream = this
+                .GetStreamProvider("StreamingCacheMissTests")
+                .GetStream<byte[]>(this.GetPrimaryKey(), nameof(IImplicitSubscriptionCounterGrain));
+            await stream.SubscribeAsync(OnNext, OnError, OnCompleted);
+
+            Task OnNext(byte[] value, StreamSequenceToken token)
+            {
+                this.logger.LogInformation("Received: [{Value} {Token}]", value, token);
+                this.eventCounter++;
+                return Task.CompletedTask;
+            }
+
+            Task OnError(Exception ex)
+            {
+                this.logger.LogError("Error: {Exception}", ex);
+                this.errorCounter++;
+                return Task.CompletedTask;
+            }
+
+            Task OnCompleted() => Task.CompletedTask;
+        }
+
+        public Task<int> GetErrorCounter() => Task.FromResult(this.errorCounter);
+
+        public Task<int> GetEventCounter() => Task.FromResult(this.eventCounter);
+
+        public Task Deactivate()
+        {
+            this.DeactivateOnIdle();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Tester/StreamingTests/MemoryStreamCacheMissTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamCacheMissTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.TestingHost;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.StreamingTests
+{
+    [TestCategory("Functional"), TestCategory("Streaming"), TestCategory("StreamingCacheMiss")]
+    public class MemoryStreamCacheMissTests : StreamingCacheMissTests
+    {
+        public MemoryStreamCacheMissTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
+            builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
+        }
+
+        #region Configuration stuff
+
+        private class MySiloBuilderConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder
+                    .AddMemoryGrainStorage("PubSubStore")
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b =>
+                    {
+                        b.ConfigureCacheEviction(ob => ob.Configure(options =>
+                        {
+                            options.DataMaxAgeInCache = TimeSpan.FromSeconds(5);
+                            options.DataMinTimeInCache = TimeSpan.FromSeconds(0);
+                        }));
+                    });
+            }
+        }
+
+        private class MyClientBuilderConfigurator : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName);
+            }
+        }
+
+        public override Task PreviousEventEvictedFromCacheWithFilterTest()
+            => throw new SkipException("Custom batch container not supported using MemoryStream");
+
+        #endregion
+
+
+    }
+}

--- a/test/Tester/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Tester/StreamingTests/StreamingCacheMissTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Streams;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.StreamingTests
+{
+    public abstract class StreamingCacheMissTests : TestClusterPerTest
+    {
+        protected static readonly TimeSpan DataMaxAgeInCache = TimeSpan.FromSeconds(5);
+        protected static readonly TimeSpan DataMinTimeInCache = TimeSpan.FromSeconds(0);
+        protected const string StreamProviderName = "StreamingCacheMissTests";
+
+        private readonly ITestOutputHelper output;
+
+        // Custom batch container that enable filtering for all provider
+        protected class CustomBatchContainer : IBatchContainer
+        {
+            private IBatchContainer batchContainer;
+
+            public CustomBatchContainer(IBatchContainer batchContainer)
+            {
+                this.batchContainer = batchContainer;
+            }
+
+            public Guid StreamGuid => this.batchContainer.StreamGuid;
+
+            public string StreamNamespace => this.batchContainer.StreamNamespace;
+
+            public StreamSequenceToken SequenceToken => this.batchContainer.SequenceToken;
+
+            public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => this.batchContainer.GetEvents<T>();
+
+            public bool ImportRequestContext() => this.batchContainer.ImportRequestContext();
+
+            public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc)
+            {
+                var events = this.GetEvents<byte[]>();
+
+                foreach (var evt in events)
+                {
+                    if (evt.Item1[0] == 1)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        public StreamingCacheMissTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [SkippableFact]
+        public virtual async Task PreviousEventEvictedFromCacheTest()
+        {
+            var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
+
+            // Tested stream and corresponding grain
+            var key = Guid.NewGuid();
+            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
+
+            // We need multiple streams, so at least another one will be handled by the same PullingAgent than "stream"
+            var otherStreams = new List<IAsyncStream<byte[]>>();
+            for (var i = 0; i < 20; i++)
+                otherStreams.Add(streamProvider.GetStream<byte[]>(Guid.NewGuid(), nameof(IImplicitSubscriptionCounterGrain)));
+
+            // Data that will be sent to the grains
+            var interestingData = new byte[1024];
+            interestingData[0] = 1;
+
+            // Should be delivered
+            await stream.OnNextAsync(interestingData);
+
+            // Wait a bit so cache expire, and launch a bunch of events to trigger the cleaning
+            await Task.Delay(TimeSpan.FromSeconds(6));
+            otherStreams.ForEach(s => s.OnNextAsync(interestingData));
+
+            // Should be delivered
+            await stream.OnNextAsync(interestingData);
+
+            await Task.Delay(1000);
+
+            Assert.Equal(0, await grain.GetErrorCounter());
+            Assert.Equal(2, await grain.GetEventCounter());
+        }
+
+        [SkippableFact]
+        public virtual async Task PreviousEventEvictedFromCacheWithFilterTest()
+        {
+            var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
+
+            // Tested stream and corresponding grain
+            var key = Guid.NewGuid();
+            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
+
+            // We need multiple streams, so at least another one will be handled by the same PullingAgent than "stream"
+            var otherStreams = new List<IAsyncStream<byte[]>>();
+            for (var i = 0; i < 20; i++)
+                otherStreams.Add(streamProvider.GetStream<byte[]>(Guid.NewGuid(), nameof(IImplicitSubscriptionCounterGrain)));
+
+            // Data that will always be filtered
+            var skippedData = new byte[1024];
+            skippedData[0] = 2;
+
+            // Data that will be sent to the grains
+            var interestingData = new byte[1024];
+            interestingData[0] = 1;
+
+            // Should not reach the grain
+            await stream.OnNextAsync(skippedData);
+
+            // Wait a bit so cache expire, and launch a bunch of events to trigger the cleaning
+            await Task.Delay(TimeSpan.FromSeconds(6));
+            otherStreams.ForEach(s => s.OnNextAsync(skippedData));
+
+            // Should be delivered
+            await stream.OnNextAsync(interestingData);
+
+            await Task.Delay(1000);
+
+            Assert.Equal(0, await grain.GetErrorCounter());
+            Assert.Equal(1, await grain.GetEventCounter());
+        }
+    }
+}

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Providers.Streams.Common;
@@ -176,6 +177,129 @@ namespace UnitTests.OrleansRuntime.Streams
             int startSequenceNuber = 222;
             startSequenceNuber = RunGoldenPath(cache, converter, startSequenceNuber);
             RunGoldenPath(cache, converter, startSequenceNuber);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void AvoidCacheMissNotEmptyCache()
+        {
+            AvoidCacheMiss(false);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void AvoidCacheMissEmptyCache()
+        {
+            AvoidCacheMiss(true);
+        }
+
+        private void AvoidCacheMiss(bool emptyCache)
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null, TimeSpan.FromSeconds(30));
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            var seqNumber = 123;
+            var stream = new StreamIdentity(Guid.NewGuid(), TestStreamNamespace);
+
+            // Enqueue a message for stream
+            var firstSequenceNumber = EnqueueMessage(stream.Guid);
+
+            // Consume first event
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(firstSequenceNumber));
+            Assert.True(cache.TryGetNextMessage(cursor, out var firstContainer));
+            Assert.Equal(stream.Guid, firstContainer.StreamGuid);
+            Assert.Equal(stream.Namespace, firstContainer.StreamNamespace);
+            Assert.Equal(firstSequenceNumber, firstContainer.SequenceToken.SequenceNumber);
+
+            // Remove first message, that was consumed
+            cache.RemoveOldestMessage();
+
+            if (!emptyCache)
+            {
+                // Enqueue something not related to the stream
+                // so the cache isn't empty
+                EnqueueMessage(Guid.NewGuid());
+                EnqueueMessage(Guid.NewGuid());
+                EnqueueMessage(Guid.NewGuid());
+                EnqueueMessage(Guid.NewGuid());
+                EnqueueMessage(Guid.NewGuid());
+                EnqueueMessage(Guid.NewGuid());
+            }
+
+            // Enqueue another message for stream
+            var lastSequenceNumber = EnqueueMessage(stream.Guid);
+
+            // Should be able to consume the event just pushed
+            Assert.True(cache.TryGetNextMessage(cursor, out var lastContainer));
+            Assert.Equal(stream.Guid, lastContainer.StreamGuid);
+            Assert.Equal(stream.Namespace, lastContainer.StreamNamespace);
+            Assert.Equal(lastSequenceNumber, lastContainer.SequenceToken.SequenceNumber);
+
+            long EnqueueMessage(Guid streamId)
+            {
+                var now = DateTime.UtcNow;
+                var msg = new TestQueueMessage
+                {
+                    StreamGuid = streamId,
+                    StreamNamespace = stream.Namespace,
+                    SequenceNumber = seqNumber,
+                };
+                cache.Add(new List<CachedMessage>() { converter.ToCachedMessage(msg, now) }, now);
+                seqNumber++;
+                return msg.SequenceNumber;
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void SimpleCacheMiss()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null, TimeSpan.FromSeconds(10));
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            int idx;
+            var seqNumber = 123;
+            var stream = new StreamIdentity(Guid.NewGuid(), TestStreamNamespace);
+
+            // First and last messages destined for stream, following messages
+            // destined for other streams
+            for (idx = 0; idx < 20; idx++)
+            {
+                var now = DateTime.UtcNow;
+                var msg = new TestQueueMessage
+                {
+                    StreamGuid = (idx == 0) ? stream.Guid : Guid.NewGuid(),
+                    StreamNamespace = stream.Namespace,
+                    SequenceNumber = seqNumber + idx,
+                };
+                cache.Add(new List<CachedMessage>() { converter.ToCachedMessage(msg, now) }, now);
+            }
+
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(seqNumber));
+
+            // Remove first message
+            cache.RemoveOldestMessage();
+
+            // Enqueue a new message for stream
+            {
+                idx++;
+                var now = DateTime.UtcNow;
+                var msg = new TestQueueMessage
+                {
+                    StreamGuid = stream.Guid,
+                    StreamNamespace = stream.Namespace,
+                    SequenceNumber = seqNumber + idx,
+                };
+                cache.Add(new List<CachedMessage>() { converter.ToCachedMessage(msg, now) }, now);
+            }
+
+            // Should throw since we missed the first message
+            Assert.Throws<QueueCacheMissException>(() => cache.TryGetNextMessage(cursor, out _));
         }
 
         private int RunGoldenPath(PooledQueueCache cache, CachedMessageConverter converter, int startOfCache)


### PR DESCRIPTION
## Current issue

In the current implementation of `PooledQueueCache` (the cache used notably by the EventHub streaming provider), in order to advance a cursor from event `N` to event `N+1`, both events need to be in cache, to ensure that nothing was missed between the two.

That means that if event `N` was evicted, trying to move the cursor will throw a `QueueCacheMissException`, even if the subscriber already consumed this event and is waiting for event `N+1`. This behavior can be really confusing for streaming users.

## Proposed change

In this PR, the `PooledQueueCache` keeps a dictionary of `StreamId` -> `StreamSequenceToken` to keep track of the token from the last evicted event for a given stream. 

If the consumer already processed event `N` and this event is not in cache:

- If event `N` was the last evicted event for this stream, we didn't missed anything. We restart the cursor from the oldest message in the cache
- If event `N` is older than the last evicted event from this stream: we know for sure we missed some events, so we will throw an exception

It is possible to opt-out by setting `StreamCacheEvictionOptions.MetadataMinTimeInCache` to `null`