### PR TITLE
[Logging] Use Microsoft.Logging.Extensions directly

### DIFF
--- a/Samples/1.x/ReplicatedEventSample/ReplicatedEventSample.Grains/EventGrain.cs
+++ b/Samples/1.x/ReplicatedEventSample/ReplicatedEventSample.Grains/EventGrain.cs
@@ -31,7 +31,7 @@ namespace ReplicatedEventSample.Grains
 
         public async Task NewOutcome(Outcome outcome)
         {
-            logger.Info("{3} new outcome {0} {1} {2}", outcome.When, outcome.Name, outcome.Score, EventName);
+            logger.LogInformation("{3} new outcome {0} {1} {2}", outcome.When, outcome.Name, outcome.Score, EventName);
 
             RaiseEvent(outcome);
 
@@ -138,7 +138,7 @@ namespace ReplicatedEventSample.Grains
             catch (Exception e)
             {
                 // we will log this for diagnostic purposes
-                logger.Info("Store Operation Failed: {0}", e);
+                logger.LogInformation("Store Operation Failed: {0}", e);
 
                 // there is no need to distinguish between exception types.
                 return false;

--- a/Samples/2.0/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
+++ b/Samples/2.0/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
@@ -36,7 +36,7 @@ namespace StatelessCalculatorService
                         }
                         catch (Exception exception)
                         {
-                            logger.Warn(exception.HResult, "Exception in bootstrap provider. Ignoring.", exception);
+                            logger.LogWarning(exception.HResult, "Exception in bootstrap provider. Ignoring.", exception);
                         }
                     }
                 }).Ignore();

--- a/Samples/2.0/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
+++ b/Samples/2.0/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
@@ -31,7 +31,7 @@ namespace StatelessCalculatorService
                         try
                         {
                             var value = await grain.Add(1);
-                            logger.Info($"{value - 1} + 1 = {value}");
+                            logger.LogInformation($"{value - 1} + 1 = {value}");
                             await Task.Delay(TimeSpan.FromSeconds(4));
                         }
                         catch (Exception exception)

--- a/Samples/2.1/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
+++ b/Samples/2.1/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
@@ -36,7 +36,7 @@ namespace StatelessCalculatorService
                         }
                         catch (Exception exception)
                         {
-                            logger.Warn(exception.HResult, "Exception in bootstrap provider. Ignoring.", exception);
+                            logger.LogWarning(exception.HResult, "Exception in bootstrap provider. Ignoring.", exception);
                         }
                     }
                 }).Ignore();

--- a/Samples/2.1/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
+++ b/Samples/2.1/ServiceFabric/Stateless/StatelessCalculatorService/StartupTask.cs
@@ -31,7 +31,7 @@ namespace StatelessCalculatorService
                         try
                         {
                             var value = await grain.Add(1);
-                            logger.Info($"{value - 1} + 1 = {value}");
+                            logger.LogInformation($"{value - 1} + 1 = {value}");
                             await Task.Delay(TimeSpan.FromSeconds(4));
                         }
                         catch (Exception exception)

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -179,8 +179,8 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.MembershipBase,
-                    $"Intermediate error reading silo entry for key {siloAddress.ToLongString()} from the table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.MembershipBase, exc,
+                    $"Intermediate error reading silo entry for key {siloAddress.ToLongString()} from the table {this.options.TableName}.");
                 throw;
             }
         }
@@ -207,7 +207,7 @@ namespace Orleans.Clustering.DynamoDB
 
                 if (records.Any(record => record.MembershipVersion > versionRow.MembershipVersion))
                 {
-                    this.logger.Warn(ErrorCode.MembershipBase, "Found an inconsistency while reading all silo entries");
+                    this.logger.LogWarning((int)ErrorCode.MembershipBase, "Found an inconsistency while reading all silo entries");
                     //not expecting this to hit often, but if it does, should put in a limit
                     return await this.ReadAll();
                 }
@@ -219,8 +219,8 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.MembershipBase,
-                    $"Intermediate error reading all silo entries {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.MembershipBase, exc,
+                    $"Intermediate error reading all silo entries {this.options.TableName}.");
                 throw;
             }
         }
@@ -234,7 +234,7 @@ namespace Orleans.Clustering.DynamoDB
 
                 if (!TryCreateTableVersionRecord(tableVersion.Version, tableVersion.VersionEtag, out var versionEntry))
                 {
-                    this.logger.Warn(ErrorCode.MembershipBase,
+                    this.logger.LogWarning((int)ErrorCode.MembershipBase,
                         $"Insert failed. Invalid ETag value. Will retry. Entry {entry.ToFullString()}, eTag {tableVersion.VersionEtag}");
                     return false;
                 }
@@ -274,7 +274,7 @@ namespace Orleans.Clustering.DynamoDB
                     if (canceledException.Message.Contains("ConditionalCheckFailed")) //not a good way to check for this currently
                     {
                         result = false;
-                        this.logger.Warn(ErrorCode.MembershipBase,
+                        this.logger.LogWarning((int)ErrorCode.MembershipBase,
                             $"Insert failed due to contention on the table. Will retry. Entry {entry.ToFullString()}");
                     }
                     else
@@ -287,8 +287,8 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.MembershipBase,
-                    $"Intermediate error inserting entry {entry.ToFullString()} to the table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.MembershipBase, exc,
+                    $"Intermediate error inserting entry {entry.ToFullString()} to the table {this.options.TableName}.");
                 throw;
             }
         }
@@ -301,7 +301,7 @@ namespace Orleans.Clustering.DynamoDB
                 var siloEntry = Convert(entry, tableVersion);
                 if (!int.TryParse(etag, out var currentEtag))
                 {
-                    this.logger.Warn(ErrorCode.MembershipBase,
+                    this.logger.LogWarning((int)ErrorCode.MembershipBase,
                         $"Update failed. Invalid ETag value. Will retry. Entry {entry.ToFullString()}, eTag {etag}");
                     return false;
                 }
@@ -310,7 +310,7 @@ namespace Orleans.Clustering.DynamoDB
 
                 if (!TryCreateTableVersionRecord(tableVersion.Version, tableVersion.VersionEtag, out var versionEntry))
                 {
-                    this.logger.Warn(ErrorCode.MembershipBase,
+                    this.logger.LogWarning((int)ErrorCode.MembershipBase,
                         $"Update failed. Invalid ETag value. Will retry. Entry {entry.ToFullString()}, eTag {tableVersion.VersionEtag}");
                     return false;
                 }
@@ -352,7 +352,7 @@ namespace Orleans.Clustering.DynamoDB
                     if (canceledException.Message.Contains("ConditionalCheckFailed")) //not a good way to check for this currently
                     {
                         result = false;
-                        this.logger.Warn(ErrorCode.MembershipBase,
+                        this.logger.LogWarning((int)ErrorCode.MembershipBase,
                             $"Update failed due to contention on the table. Will retry. Entry {entry.ToFullString()}, eTag {etag}");
                     }
                     else
@@ -365,8 +365,8 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.MembershipBase,
-                    $"Intermediate error updating entry {entry.ToFullString()} to the table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.MembershipBase, exc,
+                    $"Intermediate error updating entry {entry.ToFullString()} to the table {this.options.TableName}.");
                 throw;
             }
         }
@@ -383,8 +383,8 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.MembershipBase,
-                    $"Intermediate error updating IAmAlive field for entry {entry.ToFullString()} to the table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.MembershipBase, exc,
+                    $"Intermediate error updating IAmAlive field for entry {entry.ToFullString()} to the table {this.options.TableName}.");
                 throw;
             }
         }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -42,7 +42,7 @@ namespace Orleans.Clustering.DynamoDB
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
                   this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
-            logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
+            logger.LogInformation((int)ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,
                 new List<KeySchemaElement>
                 {
@@ -62,7 +62,7 @@ namespace Orleans.Clustering.DynamoDB
             {
                 // ignore return value, since we don't care if I inserted it or not, as long as it is in there.
                 bool created = await TryCreateTableVersionEntryAsync();
-                if(created) logger.Info("Created new table version row.");
+                if(created) logger.LogInformation("Created new table version row.");
             }
         }
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -174,7 +174,7 @@ namespace Orleans.Clustering.DynamoDB
                     new[] {siloEntryKeys, versionEntryKeys}, fields => new SiloInstanceRecord(fields));
 
                 MembershipTableData data = Convert(entries.ToList());
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("Read my entry {0} Table=" + Environment.NewLine + "{1}", siloAddress.ToLongString(), data.ToString());
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("Read my entry {0} Table=" + Environment.NewLine + "{1}", siloAddress.ToLongString(), data.ToString());
                 return data;
             }
             catch (Exception exc)
@@ -213,7 +213,7 @@ namespace Orleans.Clustering.DynamoDB
                 }
 
                 MembershipTableData data = Convert(records);
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("ReadAll Table=" + Environment.NewLine + "{0}", data.ToString());
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("ReadAll Table=" + Environment.NewLine + "{0}", data.ToString());
 
                 return data;
             }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -229,7 +229,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("InsertRow entry = {0}", entry.ToFullString());
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("InsertRow entry = {0}", entry.ToFullString());
                 var tableEntry = Convert(entry, tableVersion);
 
                 if (!TryCreateTableVersionRecord(tableVersion.Version, tableVersion.VersionEtag, out var versionEntry))
@@ -297,7 +297,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("UpdateRow entry = {0}, etag = {1}", entry.ToFullString(), etag);
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("UpdateRow entry = {0}, etag = {1}", entry.ToFullString(), etag);
                 var siloEntry = Convert(entry, tableVersion);
                 if (!int.TryParse(etag, out var currentEtag))
                 {
@@ -375,7 +375,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("Merge entry = {0}", entry.ToFullString());
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("Merge entry = {0}", entry.ToFullString());
                 var siloEntry = ConvertPartial(entry);
                 var fields = new Dictionary<string, AttributeValue> { { SiloInstanceRecord.I_AM_ALIVE_TIME_PROPERTY_NAME, new AttributeValue(siloEntry.IAmAliveTime) } };
                 var expression = $"attribute_exists({SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}) AND attribute_exists({SiloInstanceRecord.SILO_IDENTITY_PROPERTY_NAME})";

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -148,7 +148,7 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Error(ErrorCode.MembershipBase, string.Format("Unable to delete membership records on table {0} for clusterId {1}: Exception={2}",
+                this.logger.LogError((int)ErrorCode.MembershipBase, string.Format("Unable to delete membership records on table {0} for clusterId {1}: Exception={2}",
                     this.options.TableName, clusterId, exc));
                 throw;
             }
@@ -411,9 +411,8 @@ namespace Orleans.Clustering.DynamoDB
                         }
                         catch (Exception exc)
                         {
-                            this.logger.Error(ErrorCode.MembershipBase,
-                                $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {tableEntry}. Ignoring this entry.",
-                                exc);
+                            this.logger.LogError((int)ErrorCode.MembershipBase,
+                                exc, $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {tableEntry}. Ignoring this entry.");
                         }
                     }
                 }
@@ -422,8 +421,7 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Error(ErrorCode.MembershipBase,
-                    $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {Utils.EnumerableToString(entries, e => e.ToString())}.", exc);
+                this.logger.LogError((int)ErrorCode.MembershipBase, exc, $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {Utils.EnumerableToString(entries, e => e.ToString())}.");
                 throw;
             }
         }
@@ -558,7 +556,7 @@ namespace Orleans.Clustering.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Error(ErrorCode.MembershipBase, $"Unable to clean up defunct membership records on table {this.options.TableName} for clusterId {this.clusterId}", exc);
+                this.logger.LogError((int)ErrorCode.MembershipBase, exc, $"Unable to clean up defunct membership records on table {this.options.TableName} for clusterId {this.clusterId}");
                 throw;
             }
         }

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -107,7 +107,7 @@ namespace Orleans.Storage
             catch (Exception exc)
             {
                 stopWatch.Stop();
-                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.", exc);
+                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, exc, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.");
                 throw;
             }
         }
@@ -179,9 +179,8 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                this.logger.Error(ErrorCode.StorageProviderBase,
-                    string.Format("Error Writing: GrainType={0} Grainid={1} ETag={2} to Table={3} Exception={4}",
-                    grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message), exc);
+                this.logger.LogError((int)ErrorCode.StorageProviderBase, exc, string.Format("Error Writing: GrainType={0} Grainid={1} ETag={2} to Table={3} Exception={4}",
+                    grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message));
                 throw;
             }
         }
@@ -287,8 +286,8 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                this.logger.Error(ErrorCode.StorageProviderBase, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
-                    operation, grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message), exc);
+                this.logger.LogError((int)ErrorCode.StorageProviderBase, exc, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
+                    operation, grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message));
                 throw;
             }
         }
@@ -344,7 +343,7 @@ namespace Orleans.Storage
                     sb.AppendFormat("Data Value={0} Type={1}", dataValue, dataValue.GetType());
                 }
 
-                this.logger.Error(0, sb.ToString(), exc);
+                this.logger.LogError(0, exc, sb.ToString());
                 throw new AggregateException(sb.ToString(), exc);
             }
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -122,7 +122,7 @@ namespace Orleans.Storage
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string partitionKey = GetKeyString(grainReference);
-            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace(ErrorCode.StorageProviderBase,
+            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)ErrorCode.StorageProviderBase,
                 "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}",
                 grainType, partitionKey, grainReference, this.options.TableName);
 
@@ -260,7 +260,7 @@ namespace Orleans.Storage
             string partitionKey = GetKeyString(grainReference);
             if (this.logger.IsEnabled(LogLevel.Trace))
             {
-                this.logger.Trace(ErrorCode.StorageProviderBase,
+                this.logger.LogTrace((int)ErrorCode.StorageProviderBase,
                     "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}",
                     grainType, partitionKey, grainReference, grainState.ETag, this.options.DeleteStateOnClear, this.options.TableName);
             }
@@ -360,7 +360,7 @@ namespace Orleans.Storage
                 entity.StringState = JsonConvert.SerializeObject(grainState, this.jsonSettings);
                 dataSize = STRING_STATE_PROPERTY_NAME.Length + entity.StringState.Length;
 
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
                     dataSize, entity.GrainReference, entity.GrainType);
             }
             else
@@ -369,7 +369,7 @@ namespace Orleans.Storage
                 entity.BinaryState = this.serializationManager.SerializeToByteArray(grainState);
                 dataSize = BINARY_STATE_PROPERTY_NAME.Length + entity.BinaryState.Length;
 
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
                     dataSize, entity.GrainReference, entity.GrainType);
             }
 

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -57,7 +57,7 @@ namespace Orleans.Reminders.DynamoDB
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
-            this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
+            this.logger.LogInformation((int)ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 
             var secondaryIndex = new GlobalSecondaryIndex
             {

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -108,8 +108,8 @@ namespace Orleans.Reminders.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.ReminderServiceBase,
-                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(keys)} from table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.ReminderServiceBase, exc,
+                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(keys)} from table {this.options.TableName}.");
                 throw;
             }
         }
@@ -136,8 +136,8 @@ namespace Orleans.Reminders.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.ReminderServiceBase,
-                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.ReminderServiceBase, exc,
+                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.");
                 throw;
             }
         }
@@ -175,8 +175,8 @@ namespace Orleans.Reminders.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.ReminderServiceBase,
-                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.ReminderServiceBase, exc,
+                    $"Intermediate error reading reminder entry {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.");
                 throw;
             }
         }
@@ -261,8 +261,8 @@ namespace Orleans.Reminders.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.ReminderServiceBase,
-                    $"Intermediate error removing reminder entries {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.ReminderServiceBase, exc,
+                    $"Intermediate error removing reminder entries {Utils.DictionaryToString(expressionValues)} from table {this.options.TableName}.");
                 throw;
             }
         }
@@ -299,8 +299,8 @@ namespace Orleans.Reminders.DynamoDB
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.ReminderServiceBase,
-                    $"Intermediate error updating entry {entry.ToString()} to the table {this.options.TableName}.", exc);
+                this.logger.LogWarning((int)ErrorCode.ReminderServiceBase, exc,
+                    $"Intermediate error updating entry {entry.ToString()} to the table {this.options.TableName}.");
                 throw;
             }
         }

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -290,7 +290,7 @@ namespace Orleans.Reminders.DynamoDB
 
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("UpsertRow entry = {0}, etag = {1}", entry.ToString(), entry.ETag);
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("UpsertRow entry = {0}, etag = {1}", entry.ToString(), entry.ETag);
 
                 await this.storage.PutEntryAsync(this.options.TableName, fields);
                 

--- a/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
@@ -236,7 +236,7 @@ namespace OrleansAWSUtils.Storage
             var errMsg = String.Format(
                 "Error doing {0} for SQS queue {1} " + Environment.NewLine
                 + "Exception = {2}", operation, QueueName, exc);
-            Logger.Error(errorCode, errMsg, exc);
+            Logger.LogError((int)errorCode, exc, errMsg);
             throw new AggregateException(errMsg, exc);
         }
     }

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -444,7 +444,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception)
             {
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to find table entry for Keys = {0}", Utils.DictionaryToString(keys));
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Unable to find table entry for Keys = {0}", Utils.DictionaryToString(keys));
                 throw;
             }
         }
@@ -492,7 +492,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception)
             {
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to find table entry for Keys = {0}", Utils.DictionaryToString(keys));
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Unable to find table entry for Keys = {0}", Utils.DictionaryToString(keys));
                 throw;
             }
         }
@@ -663,7 +663,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception)
             {
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to find table entry for Keys = {0}", Utils.EnumerableToString(keys, d => Utils.DictionaryToString(d)));
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Unable to find table entry for Keys = {0}", Utils.EnumerableToString(keys, d => Utils.DictionaryToString(d)));
                 throw;
             }
         }
@@ -707,7 +707,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception)
             {
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Unable to write tx");
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Unable to write tx");
                 throw;
             }
         }

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -219,7 +219,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <returns></returns>
         public Task PutEntryAsync(string tableName, Dictionary<string, AttributeValue> fields, string conditionExpression = "", Dictionary<string, AttributeValue> conditionValues = null)
         {
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Creating {0} table entry: {1}", tableName, Utils.DictionaryToString(fields));
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Creating {0} table entry: {1}", tableName, Utils.DictionaryToString(fields));
 
             try
             {
@@ -255,7 +255,7 @@ namespace Orleans.Transactions.DynamoDB
             string conditionExpression = "", Dictionary<string, AttributeValue> conditionValues = null, string extraExpression = "",
             Dictionary<string, AttributeValue> extraExpressionValues = null)
         {
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Upserting entry {0} with key(s) {1} into table {2}", Utils.DictionaryToString(fields), Utils.DictionaryToString(keys), tableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Upserting entry {0} with key(s) {1} into table {2}", Utils.DictionaryToString(fields), Utils.DictionaryToString(keys), tableName);
 
             try
             {
@@ -347,7 +347,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <returns></returns>
         public Task DeleteEntryAsync(string tableName, Dictionary<string, AttributeValue> keys, string conditionExpression = "", Dictionary<string, AttributeValue> conditionValues = null)
         {
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Deleting table {0}  entry with key(s) {1}", tableName, Utils.DictionaryToString(keys));
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Deleting table {0}  entry with key(s) {1}", tableName, Utils.DictionaryToString(keys));
 
             try
             {
@@ -381,7 +381,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <returns></returns>
         public Task DeleteEntriesAsync(string tableName, IReadOnlyCollection<Dictionary<string, AttributeValue>> toDelete)
         {
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Deleting {0} table entries", tableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Deleting {0} table entries", tableName);
 
             if (toDelete == null) throw new ArgumentNullException("collection");
 
@@ -602,7 +602,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <returns></returns>
         public Task PutEntriesAsync(string tableName, IReadOnlyCollection<Dictionary<string, AttributeValue>> toCreate)
         {
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Put entries {0} table", tableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Put entries {0} table", tableName);
 
             if (toCreate == null) throw new ArgumentNullException("collection");
 

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -90,7 +90,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Error(ErrorCode.StorageProviderBase, $"Could not initialize connection to storage table {tableName}", exc);
+                Logger.LogError((int)ErrorCode.StorageProviderBase, exc, $"Could not initialize connection to storage table {tableName}");
                 throw;
             }
         }
@@ -186,7 +186,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Error(ErrorCode.StorageProviderBase, $"Could not create table {tableName}", exc);
+                Logger.LogError((int)ErrorCode.StorageProviderBase, exc, $"Could not create table {tableName}");
                 throw;
             }
         }
@@ -204,7 +204,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Error(ErrorCode.StorageProviderBase, $"Could not delete table {tableName}", exc);
+                Logger.LogError((int)ErrorCode.StorageProviderBase, exc, $"Could not delete table {tableName}");
                 throw;
             }
         }
@@ -234,7 +234,7 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Error(ErrorCode.StorageProviderBase, $"Unable to create item to table '{tableName}'", exc);
+                Logger.LogError((int)ErrorCode.StorageProviderBase, exc, $"Unable to create item to table '{tableName}'");
                 throw;
             }
         }

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -288,8 +288,8 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Warn(ErrorCode.StorageProviderBase,
-                    $"Intermediate error upserting to the table {tableName}", exc);
+                Logger.LogWarning((int)ErrorCode.StorageProviderBase, exc,
+                    $"Intermediate error upserting to the table {tableName}");
                 throw;
             }
         }
@@ -367,8 +367,8 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Warn(ErrorCode.StorageProviderBase,
-                    $"Intermediate error deleting entry from the table {tableName}.", exc);
+                Logger.LogWarning((int)ErrorCode.StorageProviderBase, exc,
+                    $"Intermediate error deleting entry from the table {tableName}.");
                 throw;
             }
         }
@@ -406,8 +406,8 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Warn(ErrorCode.StorageProviderBase,
-                    $"Intermediate error deleting entries from the table {tableName}.", exc);
+                Logger.LogWarning((int)ErrorCode.StorageProviderBase, exc,
+                    $"Intermediate error deleting entries from the table {tableName}.");
                 throw;
             }
         }
@@ -589,7 +589,7 @@ namespace Orleans.Transactions.DynamoDB
             catch (Exception exc)
             {
                 var errorMsg = $"Failed to read table {tableName}: {exc.Message}";
-                Logger.Warn(ErrorCode.StorageProviderBase, errorMsg, exc);
+                Logger.LogWarning((int)ErrorCode.StorageProviderBase, exc, errorMsg);
                 throw new OrleansException(errorMsg, exc);
             }
         }
@@ -627,8 +627,8 @@ namespace Orleans.Transactions.DynamoDB
             }
             catch (Exception exc)
             {
-                Logger.Warn(ErrorCode.StorageProviderBase,
-                    $"Intermediate error bulk inserting entries to table {tableName}.", exc);
+                Logger.LogWarning((int)ErrorCode.StorageProviderBase, exc,
+                    $"Intermediate error bulk inserting entries to table {tableName}.");
                 throw;
             }
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -58,7 +58,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.ReadRow failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.ReadRow failed");
                 throw;
             }
         }
@@ -73,7 +73,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.ReadAll failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.ReadAll failed");
                 throw;
             }
         }
@@ -90,12 +90,12 @@ namespace Orleans.Runtime.MembershipService
             //Likewise, no update can be done without membership entry.
             if (entry == null)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.InsertRow aborted due to null check. MembershipEntry is null.");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. MembershipEntry is null.");
                 throw new ArgumentNullException("entry");
             }
             if (tableVersion == null)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.InsertRow aborted due to null check. TableVersion is null ");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. TableVersion is null ");
                 throw new ArgumentNullException("tableVersion");
             }
 
@@ -105,7 +105,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.InsertRow failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.InsertRow failed");
                 throw;
             }            
         }
@@ -122,12 +122,12 @@ namespace Orleans.Runtime.MembershipService
             //Likewise, no update can be done without membership entry or an etag.
             if (entry == null)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.UpdateRow aborted due to null check. MembershipEntry is null.");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. MembershipEntry is null.");
                 throw new ArgumentNullException("entry");
             }
             if (tableVersion == null)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.UpdateRow aborted due to null check. TableVersion is null ");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. TableVersion is null ");
                 throw new ArgumentNullException("tableVersion");
             }
 
@@ -137,7 +137,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.UpdateRow failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.UpdateRow failed");
                 throw;
             }
         }
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.MembershipService
             if(logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.UpdateIAmAlive called with entry {0}.", entry));
             if (entry == null)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.UpdateIAmAlive aborted due to null check. MembershipEntry is null.");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateIAmAlive aborted due to null check. MembershipEntry is null.");
                 throw new ArgumentNullException("entry");
             }
             try
@@ -157,7 +157,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.UpdateIAmAlive failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.UpdateIAmAlive failed");
                 throw;
             }
         }
@@ -172,7 +172,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.DeleteMembershipTableEntries failed: {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.DeleteMembershipTableEntries failed");
                 throw;
             }
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.MembershipService
                 var wasCreated = await InitTableAsync();
                 if(wasCreated)
                 {
-                    logger.Info("Created new table version row.");
+                    logger.LogInformation("Created new table version row.");
                 }
             }
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -29,7 +29,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("AdoNetClusteringTable.InitializeMembershipTable called.");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.InitializeMembershipTable called.");
 
             //This initializes all of Orleans operational queries from the database using a well known view
             //and assumes the database with appropriate definitions exists already.
@@ -51,7 +51,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<MembershipTableData> ReadRow(SiloAddress key)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("AdoNetClusteringTable.ReadRow called with key: {0}.", key));
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(string.Format("AdoNetClusteringTable.ReadRow called with key: {0}.", key));
             try
             {
                 return await orleansQueries.MembershipReadRowAsync(this.clusterId, key);                
@@ -66,7 +66,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<MembershipTableData> ReadAll()
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("AdoNetClusteringTable.ReadAll called.");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.ReadAll called.");
             try
             {
                 return await orleansQueries.MembershipReadAllAsync(this.clusterId);                
@@ -81,7 +81,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace($"AdoNetClusteringTable.InsertRow called with entry {entry} and tableVersion {tableVersion}.");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace($"AdoNetClusteringTable.InsertRow called with entry {entry} and tableVersion {tableVersion}.");
 
             //The "tableVersion" parameter should always exist when inserting a row as Init should
             //have been called and membership version created and read. This is an optimization to
@@ -113,7 +113,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.UpdateRow called with entry {0}, etag {1} and tableVersion {2}.", entry, etag, tableVersion));
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(string.Format("IMembershipTable.UpdateRow called with entry {0}, etag {1} and tableVersion {2}.", entry, etag, tableVersion));
 
             //The "tableVersion" parameter should always exist when updating a row as Init should
             //have been called and membership version created and read. This is an optimization to
@@ -145,7 +145,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task UpdateIAmAlive(MembershipEntry entry)
         {
-            if(logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.UpdateIAmAlive called with entry {0}.", entry));
+            if(logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(string.Format("IMembershipTable.UpdateIAmAlive called with entry {0}.", entry));
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateIAmAlive aborted due to null check. MembershipEntry is null.");
@@ -165,7 +165,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task DeleteMembershipTableEntries(string clusterId)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.DeleteMembershipTableEntries called with clusterId {0}.", clusterId));
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(string.Format("IMembershipTable.DeleteMembershipTableEntries called with clusterId {0}.", clusterId));
             try
             {
                 await orleansQueries.DeleteMembershipTableEntriesAsync(clusterId);
@@ -186,7 +186,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch(Exception ex)
             {
-                if(logger.IsEnabled(LogLevel.Trace)) logger.Trace("Insert silo membership version failed: {0}", ex.ToString());
+                if(logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Insert silo membership version failed: {0}", ex.ToString());
                 throw;
             }
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime.Membership
             }
             catch (Exception ex)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("AdoNetClusteringTable.Gateways failed {0}", ex);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(ex, "AdoNetClusteringTable.Gateways failed");
                 throw;
             }
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -43,13 +43,13 @@ namespace Orleans.Runtime.Membership
 
         public async Task InitializeGatewayListProvider()
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("AdoNetClusteringTable.InitializeGatewayListProvider called.");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.InitializeGatewayListProvider called.");
             orleansQueries = await RelationalOrleansQueries.CreateInstance(options.Invariant, options.ConnectionString, this.grainReferenceConverter);
         }
 
         public async Task<IList<Uri>> GetGateways()
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("AdoNetClusteringTable.GetGateways called.");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.GetGateways called.");
             try
             {
                 return await orleansQueries.ActiveGatewaysAsync(this.clusterId);

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -163,7 +163,7 @@ namespace Orleans.Storage
             var baseGrainType = ExtractBaseClass(grainType);
             if(logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderClearing, LogString("Clearing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderClearing, LogString("Clearing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
             }
 
             string storageVersion = null;
@@ -202,7 +202,7 @@ namespace Orleans.Storage
             grainState.RecordExists = false;
             if(logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderCleared, LogString("Cleared grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderCleared, LogString("Cleared grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
             }
         }
 
@@ -217,7 +217,7 @@ namespace Orleans.Storage
             var baseGrainType = ExtractBaseClass(grainType);
             if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderReading, LogString("Reading grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderReading, LogString("Reading grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
             }
 
             try
@@ -322,7 +322,7 @@ namespace Orleans.Storage
                 grainState.RecordExists = recordExists;
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderRead, LogString("Read grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                    logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderRead, LogString("Read grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
                 }
             }
             catch(Exception ex)
@@ -344,7 +344,7 @@ namespace Orleans.Storage
             var baseGrainType = ExtractBaseClass(grainType);
             if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderWriting, LogString("Writing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderWriting, LogString("Writing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
             }
 
             string storageVersion = null;
@@ -390,7 +390,7 @@ namespace Orleans.Storage
 
             if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace((int)RelationalStorageProviderCodes.RelationalProviderWrote, LogString("Wrote grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                logger.LogTrace((int)RelationalStorageProviderCodes.RelationalProviderWrote, LogString("Wrote grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
             }
         }
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -186,7 +186,7 @@ namespace Orleans.Storage
             }
             catch(Exception ex)
             {
-                logger.Error((int)RelationalStorageProviderCodes.RelationalProviderDeleteError, LogString("Error clearing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message), ex);
+                logger.LogError((int)RelationalStorageProviderCodes.RelationalProviderDeleteError, ex, LogString("Error clearing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message));
                 throw;
             }
 
@@ -226,7 +226,7 @@ namespace Orleans.Storage
                 if(choice.Deserializer == null)
                 {
                     var errorString = LogString("No deserializer found", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString());
-                    logger.Error((int)RelationalStorageProviderCodes.RelationalProviderNoDeserializer, errorString);
+                    logger.LogError((int)RelationalStorageProviderCodes.RelationalProviderNoDeserializer, errorString);
                     throw new InvalidOperationException(errorString);
                 }
 
@@ -327,7 +327,7 @@ namespace Orleans.Storage
             }
             catch(Exception ex)
             {
-                logger.Error((int)RelationalStorageProviderCodes.RelationalProviderReadError, LogString("Error reading grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message), ex);
+                logger.LogError((int)RelationalStorageProviderCodes.RelationalProviderReadError, ex, LogString("Error reading grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message));
                 throw;
             }
         }
@@ -373,7 +373,7 @@ namespace Orleans.Storage
             }
             catch(Exception ex)
             {
-                logger.Error((int)RelationalStorageProviderCodes.RelationalProviderWriteError, LogString("Error writing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message), ex);
+                logger.LogError((int)RelationalStorageProviderCodes.RelationalProviderWriteError, ex, LogString("Error writing grain state", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString(), ex.Message));
                 throw;
             }
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -313,7 +313,7 @@ namespace Orleans.Storage
                 bool recordExists = readRecords != null;
                 if(state == null)
                 {
-                    logger.Info((int)RelationalStorageProviderCodes.RelationalProviderNoStateFound, LogString("Null grain state read (default will be instantiated)", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
+                    logger.LogInformation((int)RelationalStorageProviderCodes.RelationalProviderNoStateFound, LogString("Null grain state read (default will be instantiated)", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
                     state = Activator.CreateInstance(grainState.Type);
                 }
 
@@ -415,7 +415,7 @@ namespace Orleans.Storage
                 queries.Single(i => i.Item1 == "ReadFromStorageKey").Item2,
                 queries.Single(i => i.Item1 == "ClearStorageKey").Item2);
 
-            logger.Info(
+            logger.LogInformation(
                 (int)RelationalStorageProviderCodes.RelationalProviderInitProvider,
                 $"Initialized storage provider: ServiceId={serviceId} ProviderName={this.name} Invariant={Storage.InvariantName} ConnectionString={ConfigUtilities.RedactConnectionStringInfo(Storage.ConnectionString)}.");
         }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -75,8 +75,8 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                logger.Warn((int)TableStorageErrorCode.AzureTable_20,
-                    $"Intermediate error reading silo entry for key {key.ToLongString()} from the table {tableManager.TableName}.", exc);
+                logger.LogWarning((int)TableStorageErrorCode.AzureTable_20, exc,
+                    $"Intermediate error reading silo entry for key {key.ToLongString()} from the table {tableManager.TableName}.");
                 throw;
             }
         }
@@ -93,8 +93,8 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                logger.Warn((int)TableStorageErrorCode.AzureTable_21,
-                    $"Intermediate error reading all silo entries {tableManager.TableName}.", exc);
+                logger.LogWarning((int)TableStorageErrorCode.AzureTable_21, exc,
+                    $"Intermediate error reading all silo entries {tableManager.TableName}.");
                 throw;
             }
         }
@@ -111,14 +111,14 @@ namespace Orleans.Runtime.MembershipService
                     tableEntry, versionEntry, tableVersion.VersionEtag);
 
                 if (result == false)
-                    logger.Warn((int)TableStorageErrorCode.AzureTable_22,
+                    logger.LogWarning((int)TableStorageErrorCode.AzureTable_22,
                         $"Insert failed due to contention on the table. Will retry. Entry {entry.ToFullString()}, table version = {tableVersion}");
                 return result;
             }
             catch (Exception exc)
             {
-                logger.Warn((int)TableStorageErrorCode.AzureTable_23,
-                    $"Intermediate error inserting entry {entry.ToFullString()} tableVersion {(tableVersion == null ? "null" : tableVersion.ToString())} to the table {tableManager.TableName}.", exc);
+                logger.LogWarning((int)TableStorageErrorCode.AzureTable_23, exc,
+                    $"Intermediate error inserting entry {entry.ToFullString()} tableVersion {(tableVersion == null ? "null" : tableVersion.ToString())} to the table {tableManager.TableName}.");
                 throw;
             }
         }
@@ -133,14 +133,14 @@ namespace Orleans.Runtime.MembershipService
 
                 bool result = await tableManager.UpdateSiloEntryConditionally(siloEntry, etag, versionEntry, tableVersion.VersionEtag);
                 if (result == false)
-                    logger.Warn((int)TableStorageErrorCode.AzureTable_24,
+                    logger.LogWarning((int)TableStorageErrorCode.AzureTable_24,
                         $"Update failed due to contention on the table. Will retry. Entry {entry.ToFullString()}, eTag {etag}, table version = {tableVersion} ");
                 return result;
             }
             catch (Exception exc)
             {
-                logger.Warn((int)TableStorageErrorCode.AzureTable_25,
-                    $"Intermediate error updating entry {entry.ToFullString()} tableVersion {(tableVersion == null ? "null" : tableVersion.ToString())} to the table {tableManager.TableName}.", exc);
+                logger.LogWarning((int)TableStorageErrorCode.AzureTable_25, exc,
+                    $"Intermediate error updating entry {entry.ToFullString()} tableVersion {(tableVersion == null ? "null" : tableVersion.ToString())} to the table {tableManager.TableName}.");
                 throw;
             }
         }
@@ -155,8 +155,8 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                logger.Warn((int)TableStorageErrorCode.AzureTable_26,
-                    $"Intermediate error updating IAmAlive field for entry {entry.ToFullString()} to the table {tableManager.TableName}.", exc);
+                logger.LogWarning((int)TableStorageErrorCode.AzureTable_26, exc,
+                    $"Intermediate error updating IAmAlive field for entry {entry.ToFullString()} to the table {tableManager.TableName}.");
                 throw;
             }
         }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -87,7 +87,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 var entries = await tableManager.FindAllSiloEntries();
                 MembershipTableData data = Convert(entries);
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("ReadAll Table=" + Environment.NewLine + "{0}", data.ToString());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("ReadAll Table=" + Environment.NewLine + "{0}", data.ToString());
 
                 return data;
             }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 var entries = await tableManager.FindSiloEntryAndTableVersionRow(key);
                 MembershipTableData data = Convert(entries);
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Read my entry {0} Table=" + Environment.NewLine + "{1}", key.ToLongString(), data.ToString());
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Read my entry {0} Table=" + Environment.NewLine + "{1}", key.ToLongString(), data.ToString());
                 return data;
             }
             catch (Exception exc)
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("InsertRow entry = {0}, table version = {1}", entry.ToFullString(), tableVersion);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("InsertRow entry = {0}, table version = {1}", entry.ToFullString(), tableVersion);
                 var tableEntry = Convert(entry, tableManager.DeploymentId);
                 var versionEntry = tableManager.CreateTableVersionEntry(tableVersion.Version);
 
@@ -127,7 +127,7 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("UpdateRow entry = {0}, etag = {1}, table version = {2}", entry.ToFullString(), etag, tableVersion);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("UpdateRow entry = {0}, etag = {1}, table version = {2}", entry.ToFullString(), etag, tableVersion);
                 var siloEntry = Convert(entry, tableManager.DeploymentId);
                 var versionEntry = tableManager.CreateTableVersionEntry(tableVersion.Version);
 
@@ -149,7 +149,7 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Merge entry = {0}", entry.ToFullString());
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Merge entry = {0}", entry.ToFullString());
                 var siloEntry = ConvertPartial(entry, tableManager.DeploymentId);
                 await tableManager.MergeTableEntryAsync(siloEntry);
             }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -184,8 +184,7 @@ namespace Orleans.Runtime.MembershipService
                         }
                         catch (Exception exc)
                         {
-                            logger.Error((int)TableStorageErrorCode.AzureTable_61,
-                                $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {tableEntry}. Ignoring this entry.", exc);
+                            logger.LogError((int)TableStorageErrorCode.AzureTable_61, exc, $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {tableEntry}. Ignoring this entry.");
                         }
                     }
                 }
@@ -194,8 +193,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                logger.Error((int)TableStorageErrorCode.AzureTable_60,
-                    $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {Utils.EnumerableToString(entries, tuple => tuple.Item1.ToString())}.", exc);
+                logger.LogError((int)TableStorageErrorCode.AzureTable_60, exc, $"Intermediate error parsing SiloInstanceTableEntry to MembershipTableData: {Utils.EnumerableToString(entries, tuple => tuple.Item1.ToString())}.");
                 throw;
             }
         }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 // ignore return value, since we don't care if I inserted it or not, as long as it is in there.
                 bool created = await tableManager.TryCreateTableVersionEntryAsync();
-                if(created) logger.Info("Created new table version row.");
+                if(created) logger.LogInformation("Created new table version row.");
             }
         }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -75,20 +75,20 @@ namespace Orleans.AzureUtils
         public void RegisterSiloInstance(SiloInstanceTableEntry entry)
         {
             entry.Status = INSTANCE_STATUS_CREATED;
-            logger.Info(ErrorCode.Runtime_Error_100270, "Registering silo instance: {0}", entry.ToString());
+            logger.LogInformation((int)ErrorCode.Runtime_Error_100270, "Registering silo instance: {0}", entry.ToString());
             Task.WaitAll(new Task[] { storage.UpsertTableEntryAsync(entry) });
         }
 
         public Task<string> UnregisterSiloInstance(SiloInstanceTableEntry entry)
         {
             entry.Status = INSTANCE_STATUS_DEAD;
-            logger.Info(ErrorCode.Runtime_Error_100271, "Unregistering silo instance: {0}", entry.ToString());
+            logger.LogInformation((int)ErrorCode.Runtime_Error_100271, "Unregistering silo instance: {0}", entry.ToString());
             return storage.UpsertTableEntryAsync(entry);
         }
 
         public Task<string> ActivateSiloInstance(SiloInstanceTableEntry entry)
         {
-            logger.Info(ErrorCode.Runtime_Error_100272, "Activating silo instance: {0}", entry.ToString());
+            logger.LogInformation((int)ErrorCode.Runtime_Error_100272, "Activating silo instance: {0}", entry.ToString());
             entry.Status = INSTANCE_STATUS_ACTIVE;
             return storage.UpsertTableEntryAsync(entry);
         }
@@ -129,7 +129,7 @@ namespace Orleans.AzureUtils
 
                 var gatewaySiloInstances = queryResults.Select(entity => ConvertToGatewayUri(entity.Item1)).ToList();
 
-                logger.Info(ErrorCode.Runtime_Error_100278, "Found {0} active Gateway Silos for deployment {1}.", gatewaySiloInstances.Count, this.DeploymentId);
+                logger.LogInformation((int)ErrorCode.Runtime_Error_100278, "Found {0} active Gateway Silos for deployment {1}.", gatewaySiloInstances.Count, this.DeploymentId);
                 return gatewaySiloInstances;
             }catch(Exception exc)
             {

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -281,7 +281,7 @@ namespace Orleans.AzureUtils
                 string restStatus;
                 if (!AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus)) throw;
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("InsertSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("InsertSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                 if (AzureTableUtils.IsContentionError(httpStatusCode)) return false;
 
                 throw;
@@ -307,7 +307,7 @@ namespace Orleans.AzureUtils
                 string restStatus;
                 if (!AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus)) throw;
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("InsertSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("InsertSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                 if (AzureTableUtils.IsContentionError(httpStatusCode)) return false;
 
                 throw;
@@ -335,7 +335,7 @@ namespace Orleans.AzureUtils
                 string restStatus;
                 if (!AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus)) throw;
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("UpdateSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("UpdateSiloEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                 if (AzureTableUtils.IsContentionError(httpStatusCode)) return false;
 
                 throw;

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -114,7 +114,7 @@ namespace Orleans.AzureUtils
 
         public async Task<IList<Uri>> FindAllGatewayProxyEndpoints()
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Runtime_Error_100277, "Searching for active gateway silos for deployment {0}.", this.DeploymentId);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Runtime_Error_100277, "Searching for active gateway silos for deployment {0}.", this.DeploymentId);
             const string zeroPort = "0";
 
             try

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -55,7 +55,7 @@ namespace Orleans.AzureUtils
             catch (Exception ex)
             {
                 string errorMsg = string.Format("Exception trying to create or connect to the Azure table: {0}", ex.Message);
-                instance.logger.Error((int)TableStorageErrorCode.AzureTable_33, errorMsg, ex);
+                instance.logger.LogError((int)TableStorageErrorCode.AzureTable_33, ex, errorMsg);
                 throw new OrleansException(errorMsg, ex);
             }
             return instance;
@@ -133,7 +133,7 @@ namespace Orleans.AzureUtils
                 return gatewaySiloInstances;
             }catch(Exception exc)
             {
-                logger.Error(ErrorCode.Runtime_Error_100331, string.Format("Error searching for active gateway silos for deployment {0} ", this.DeploymentId), exc);
+                logger.LogError((int)ErrorCode.Runtime_Error_100331, exc, string.Format("Error searching for active gateway silos for deployment {0} ", this.DeploymentId));
                 throw;
             }
         }

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
@@ -181,7 +181,7 @@ namespace Orleans.Runtime.Host
             if (assembly == null)
             {
                 const string msg1 = "Microsoft.WindowsAzure.ServiceRuntime is not loaded. Trying to load it with Assembly.LoadWithPartialName().";
-                logger.Warn(ErrorCode.AzureServiceRuntime_NotLoaded, msg1);
+                logger.LogWarning((int)ErrorCode.AzureServiceRuntime_NotLoaded, msg1);
 
                 // Microsoft.WindowsAzure.ServiceRuntime isn't loaded. We may be running within a web role or not in Azure.
 #pragma warning disable 618

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.Host
                 string errorMsg = string.Format("Unable to obtain endpoint info for role {0} from role config parameter {1} -- Endpoints defined = [{2}]",
                     RoleName, endpointName, string.Join(", ", instanceEndpoints));
 
-                logger.Error(ErrorCode.SiloEndpointConfigError, errorMsg, exc);
+                logger.LogError((int)ErrorCode.SiloEndpointConfigError, exc, errorMsg);
                 throw new OrleansException(errorMsg, exc);
             }
         }
@@ -190,7 +190,7 @@ namespace Orleans.Runtime.Host
                 if (assembly == null)
                 {
                     const string msg2 = "Failed to find or load Microsoft.WindowsAzure.ServiceRuntime.";
-                    logger.Error(ErrorCode.AzureServiceRuntime_FailedToLoad, msg2);
+                    logger.LogError((int)ErrorCode.AzureServiceRuntime_FailedToLoad, msg2);
                     throw new OrleansException(msg2);
                 }
             }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -102,9 +102,8 @@ namespace Orleans.Storage
             }
             catch (Exception ex)
             {
-                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_ReadError,
-                    string.Format("Error reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
-                    ex);
+                logger.LogError((int)AzureProviderErrorCode.AzureBlobProvider_ReadError,
+                    ex, string.Format("Error reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message));
 
                 throw;
             }
@@ -134,9 +133,8 @@ namespace Orleans.Storage
             }
             catch (Exception ex)
             {
-                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_WriteError,
-                    string.Format("Error writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
-                    ex);
+                logger.LogError((int)AzureProviderErrorCode.AzureBlobProvider_WriteError,
+                    ex, string.Format("Error writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message));
 
                 throw;
             }
@@ -167,9 +165,8 @@ namespace Orleans.Storage
             }
             catch (Exception ex)
             {
-                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_ClearError,
-                  string.Format("Error clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
-                  ex);
+                logger.LogError((int)AzureProviderErrorCode.AzureBlobProvider_ClearError,
+                  ex, string.Format("Error clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message));
 
                 throw;
             }
@@ -237,7 +234,7 @@ namespace Orleans.Storage
             catch (Exception ex)
             {
                 stopWatch.Stop();
-                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.", ex);
+                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, ex, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.");
                 throw;
             }
         }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -60,7 +60,7 @@ namespace Orleans.Storage
         public async Task ReadStateAsync(string grainType, GrainReference grainId, IGrainState grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading, "Reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading, "Reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
             try
             {
@@ -76,18 +76,18 @@ namespace Orleans.Storage
                 }
                 catch (RequestFailedException exception) when (exception.IsBlobNotFound())
                 {
-                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     return;
                 }
                 catch (RequestFailedException exception) when (exception.IsContainerNotFound())
                 {
-                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     return;
                 }
 
                 if (contents == null || contents.Length == 0)
                 {
-                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_BlobEmpty, "BlobEmpty reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_BlobEmpty, "BlobEmpty reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     grainState.RecordExists = false;
                     return;
                 }
@@ -98,7 +98,7 @@ namespace Orleans.Storage
 
                 grainState.State = this.ConvertFromStorageFormat(contents);
 
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
             catch (Exception ex)
             {
@@ -122,7 +122,7 @@ namespace Orleans.Storage
             var blobName = GetBlobName(grainType, grainId);
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Writing, "Writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Writing, "Writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
                 var (contents, mimeType) = ConvertToStorageFormat(grainState.State);
 
@@ -130,7 +130,7 @@ namespace Orleans.Storage
 
                 await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, contents, mimeType, blob);
 
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Written: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Written: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
             catch (Exception ex)
             {
@@ -149,7 +149,7 @@ namespace Orleans.Storage
             var blobName = GetBlobName(grainType, grainId);
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ClearingData, "Clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_ClearingData, "Clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
                 var blob = container.GetBlobClient(blobName);
 
@@ -162,7 +162,7 @@ namespace Orleans.Storage
                 if (this.logger.IsEnabled(LogLevel.Trace))
                 {
                     var properties = await blob.GetPropertiesAsync();
-                    this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Cleared, "Cleared: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, properties.Value.ETag, blobName, container.Name);
+                    this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Cleared, "Cleared: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, properties.Value.ETag, blobName, container.Name);
                 }
             }
             catch (Exception ex)
@@ -191,7 +191,7 @@ namespace Orleans.Storage
             catch (RequestFailedException exception) when (exception.IsContainerNotFound())
             {
                 // if the container does not exist, create it, and make another attempt
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blob.Name, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blob.Name, container.Name);
                 await container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
                 await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, contents, mimeType, blob).ConfigureAwait(false);

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -70,7 +70,7 @@ namespace Orleans.Storage
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
-            if(logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_ReadingData, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, pk, grainReference, this.options.TableName);
+            if(logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_ReadingData, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, pk, grainReference, this.options.TableName);
             string partitionKey = pk;
             string rowKey = AzureTableUtils.SanitizeTableProperty(grainType);
             GrainStateRecord record = await tableDataManager.Read(partitionKey, rowKey).ConfigureAwait(false);
@@ -97,7 +97,7 @@ namespace Orleans.Storage
 
             string pk = GetKeyString(grainReference);
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Writing: GrainType={0} Pk={1} Grainid={2} ETag={3} to Table={4}", grainType, pk, grainReference, grainState.ETag, this.options.TableName);
+                logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Writing: GrainType={0} Pk={1} Grainid={2} ETag={3} to Table={4}", grainType, pk, grainReference, grainState.ETag, this.options.TableName);
 
             var rowKey = AzureTableUtils.SanitizeTableProperty(grainType);
             var entity = new DynamicTableEntity(pk, rowKey);
@@ -129,7 +129,7 @@ namespace Orleans.Storage
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, pk, grainReference, grainState.ETag, this.options.DeleteStateOnClear, this.options.TableName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, pk, grainReference, grainState.ETag, this.options.DeleteStateOnClear, this.options.TableName);
             var rowKey = AzureTableUtils.SanitizeTableProperty(grainType);
             var entity = new DynamicTableEntity(pk, rowKey);
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.ETag };
@@ -190,7 +190,7 @@ namespace Orleans.Storage
                 // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
                 string data = Newtonsoft.Json.JsonConvert.SerializeObject(grainState, this.JsonSettings);
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
                     data.Length, entity.PartitionKey, entity.RowKey);
 
                 // each Unicode character takes 2 bytes
@@ -205,7 +205,7 @@ namespace Orleans.Storage
 
                 byte[] data = this.serializationManager.SerializeToByteArray(grainState);
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
                     data.Length, entity.PartitionKey, entity.RowKey);
 
                 dataSize = data.Length;
@@ -416,25 +416,25 @@ namespace Orleans.Storage
 
             public async Task<GrainStateRecord> Read(string partitionKey, string rowKey)
             {
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Reading, "Reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Reading, "Reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
                 try
                 {
                     Tuple<DynamicTableEntity, string> data = await tableManager.ReadSingleTableEntryAsync(partitionKey, rowKey).ConfigureAwait(false);
                     if (data == null || data.Item1 == null)
                     {
-                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
                         return null;
                     }
                     DynamicTableEntity stateEntity = data.Item1;
                     var record = new GrainStateRecord { Entity = stateEntity, ETag = data.Item2 };
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_DataRead, "Read: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", stateEntity.PartitionKey, stateEntity.RowKey, TableName, record.ETag);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_Storage_DataRead, "Read: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", stateEntity.PartitionKey, stateEntity.RowKey, TableName, record.ETag);
                     return record;
                 }
                 catch (Exception exc)
                 {
                     if (AzureTableUtils.TableStorageDataNotFound(exc))
                     {
-                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading (exception): PartitionKey={0} RowKey={1} from Table={2} Exception={3}", partitionKey, rowKey, TableName, LogFormatter.PrintException(exc));
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading (exception): PartitionKey={0} RowKey={1} from Table={2} Exception={3}", partitionKey, rowKey, TableName, LogFormatter.PrintException(exc));
                         return null;  // No data
                     }
                     throw;
@@ -444,7 +444,7 @@ namespace Orleans.Storage
             public async Task Write(GrainStateRecord record)
             {
                 var entity = record.Entity;
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Writing: PartitionKey={0} RowKey={1} to Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Writing: PartitionKey={0} RowKey={1} to Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
                 string eTag = String.IsNullOrEmpty(record.ETag) ?
                     await tableManager.CreateTableEntryAsync(entity).ConfigureAwait(false) :
                     await tableManager.UpdateTableEntryAsync(entity, record.ETag).ConfigureAwait(false);
@@ -457,11 +457,11 @@ namespace Orleans.Storage
 
                 if (record.ETag == null)
                 {
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "Not attempting to delete non-existent persistent state: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "Not attempting to delete non-existent persistent state: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
                     return;
                 }
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Deleting: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Deleting: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
                 await tableManager.DeleteTableEntryAsync(entity, record.ETag).ConfigureAwait(false);
                 record.ETag = null;
             }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -111,8 +111,7 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                logger.Error((int)AzureProviderErrorCode.AzureTableProvider_WriteError,
-                    $"Error Writing: GrainType={grainType} GrainId={grainReference.GrainId} ETag={grainState.ETag} to Table={this.options.TableName} Exception={exc.Message}", exc);
+                logger.LogError((int)AzureProviderErrorCode.AzureTableProvider_WriteError, exc, $"Error Writing: GrainType={grainType} GrainId={grainReference.GrainId} ETag={grainState.ETag} to Table={this.options.TableName} Exception={exc.Message}");
                 throw;
             }
         }
@@ -151,8 +150,8 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                logger.Error((int)AzureProviderErrorCode.AzureTableProvider_DeleteError, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
-                    operation, grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message), exc);
+                logger.LogError((int)AzureProviderErrorCode.AzureTableProvider_DeleteError, exc, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
+                    operation, grainType, grainReference, grainState.ETag, this.options.TableName, exc.Message));
                 throw;
             }
         }
@@ -228,7 +227,7 @@ namespace Orleans.Storage
             if (dataSize > maxDataSize)
             {
                 var msg = string.Format("Data too large to write to Azure table. Size={0} MaxSize={1}", dataSize, maxDataSize);
-                logger.Error(0, msg);
+                logger.LogError(0, msg);
                 throw new ArgumentOutOfRangeException("GrainState.Size", msg);
             }
         }
@@ -377,7 +376,7 @@ namespace Orleans.Storage
                     sb.AppendFormat("Data Value={0} Type={1}", dataValue, dataValue.GetType());
                 }
 
-                logger.Error(0, sb.ToString(), exc);
+                logger.LogError(0, exc, sb.ToString());
                 throw new AggregateException(sb.ToString(), exc);
             }
 
@@ -490,7 +489,7 @@ namespace Orleans.Storage
             catch (Exception ex)
             {
                 stopWatch.Stop();
-                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.", ex);
+                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, ex, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.");
                 throw;
             }
         }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -75,7 +75,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 var error =
                     $"Failed to parse ReminderTableEntry: {tableEntry}. This entry is corrupt, going to ignore it.";
-                this.logger.Error((int)AzureReminderErrorCode.AzureTable_49, error, exc);
+                this.logger.LogError((int)AzureReminderErrorCode.AzureTable_49, exc, error);
                 throw;
             }
             finally

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -127,7 +127,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 var entries = await this.remTableManager.FindReminderEntries(key);
                 ReminderTableData data = ConvertFromTableEntryList(entries);
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("Read for grain {0} Table=" + Environment.NewLine + "{1}", key, data.ToString());
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("Read for grain {0} Table=" + Environment.NewLine + "{1}", key, data.ToString());
                 return data;
             }
             catch (Exception exc)
@@ -144,7 +144,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 var entries = await this.remTableManager.FindReminderEntries(begin, end);
                 ReminderTableData data = ConvertFromTableEntryList(entries);
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("Read in {0} Table=" + Environment.NewLine + "{1}", RangeFactory.CreateRange(begin, end), data);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("Read in {0} Table=" + Environment.NewLine + "{1}", RangeFactory.CreateRange(begin, end), data);
                 return data;
             }
             catch (Exception exc)
@@ -204,7 +204,7 @@ namespace Orleans.Runtime.ReminderService
             };
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace("RemoveRow entry = {0}", entry.ToString());
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace("RemoveRow entry = {0}", entry.ToString());
 
                 bool result = await this.remTableManager.DeleteReminderEntryConditionally(entry, eTag);
                 if (result == false)

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -159,7 +159,7 @@ namespace Orleans.Runtime.ReminderService
         {
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("ReadRow grainRef = {0} reminderName = {1}", grainRef, reminderName);
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("ReadRow grainRef = {0} reminderName = {1}", grainRef, reminderName);
                 var result = await this.remTableManager.FindReminderEntry(grainRef, reminderName);
                 return result == null ? null : ConvertFromTableEntry(result.Item1, result.Item2);
             }
@@ -175,7 +175,7 @@ namespace Orleans.Runtime.ReminderService
         {
             try
             {
-                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("UpsertRow entry = {0}", entry.ToString());
+                if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("UpsertRow entry = {0}", entry.ToString());
                 ReminderTableEntry remTableEntry = ConvertToTableEntry(entry, this.remTableManager.ServiceId, this.remTableManager.ClusterId);
 
                 string result = await this.remTableManager.UpsertRow(remTableEntry);

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -85,7 +85,7 @@ namespace Orleans.Runtime.ReminderService
                 {
                     var error =
                         $"Read a reminder entry for wrong Service id. Read {tableEntry}, but my service id is {serviceIdStr}. Going to discard it.";
-                    this.logger.Warn((int)AzureReminderErrorCode.AzureTable_ReadWrongReminder, error);
+                    this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_ReadWrongReminder, error);
                     throw new OrleansException(error);
                 }
             }
@@ -132,8 +132,8 @@ namespace Orleans.Runtime.ReminderService
             }
             catch (Exception exc)
             {
-                this.logger.Warn((int)AzureReminderErrorCode.AzureTable_47,
-                    $"Intermediate error reading reminders for grain {key} in table {this.remTableManager.TableName}.", exc);
+                this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_47, exc,
+                    $"Intermediate error reading reminders for grain {key} in table {this.remTableManager.TableName}.");
                 throw;
             }
         }
@@ -149,8 +149,8 @@ namespace Orleans.Runtime.ReminderService
             }
             catch (Exception exc)
             {
-                this.logger.Warn((int)AzureReminderErrorCode.AzureTable_40,
-                    $"Intermediate error reading reminders in range {RangeFactory.CreateRange(begin, end)} for table {this.remTableManager.TableName}.", exc);
+                this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_40, exc,
+                    $"Intermediate error reading reminders in range {RangeFactory.CreateRange(begin, end)} for table {this.remTableManager.TableName}.");
                 throw;
             }
         }
@@ -165,8 +165,8 @@ namespace Orleans.Runtime.ReminderService
             }
             catch (Exception exc)
             {
-                this.logger.Warn((int)AzureReminderErrorCode.AzureTable_46,
-                    $"Intermediate error reading row with grainId = {grainRef} reminderName = {reminderName} from table {this.remTableManager.TableName}.", exc);
+                this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_46, exc,
+                    $"Intermediate error reading row with grainId = {grainRef} reminderName = {reminderName} from table {this.remTableManager.TableName}.");
                 throw;
             }
         }
@@ -181,15 +181,15 @@ namespace Orleans.Runtime.ReminderService
                 string result = await this.remTableManager.UpsertRow(remTableEntry);
                 if (result == null)
                 {
-                    this.logger.Warn((int)AzureReminderErrorCode.AzureTable_45,
+                    this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_45,
                         $"Upsert failed on the reminder table. Will retry. Entry = {entry.ToString()}");
                 }
                 return result;
             }
             catch (Exception exc)
             {
-                this.logger.Warn((int)AzureReminderErrorCode.AzureTable_42,
-                    $"Intermediate error upserting reminder entry {entry.ToString()} to the table {this.remTableManager.TableName}.", exc);
+                this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_42, exc,
+                    $"Intermediate error upserting reminder entry {entry.ToString()} to the table {this.remTableManager.TableName}.");
                 throw;
             }
         }
@@ -209,15 +209,15 @@ namespace Orleans.Runtime.ReminderService
                 bool result = await this.remTableManager.DeleteReminderEntryConditionally(entry, eTag);
                 if (result == false)
                 {
-                    this.logger.Warn((int)AzureReminderErrorCode.AzureTable_43,
+                    this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_43,
                         $"Delete failed on the reminder table. Will retry. Entry = {entry}");
                 }
                 return result;
             }
             catch (Exception exc)
             {
-                this.logger.Warn((int)AzureReminderErrorCode.AzureTable_44,
-                    $"Intermediate error when deleting reminder entry {entry} to the table {this.remTableManager.TableName}.", exc);
+                this.logger.LogWarning((int)AzureReminderErrorCode.AzureTable_44, exc,
+                    $"Intermediate error when deleting reminder entry {entry} to the table {this.remTableManager.TableName}.");
                 throw;
             }
         }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -200,7 +200,7 @@ namespace Orleans.Runtime.ReminderService
                 string restStatus;
                 if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus))
                 {
-                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("UpsertRow failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("UpsertRow failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                     if (AzureTableUtils.IsContentionError(httpStatusCode)) return null; // false;
                 }
                 throw;
@@ -220,7 +220,7 @@ namespace Orleans.Runtime.ReminderService
                 string restStatus;
                 if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus))
                 {
-                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("DeleteReminderEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("DeleteReminderEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                     if (AzureTableUtils.IsContentionError(httpStatusCode)) return false;
                 }
                 throw;

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -96,7 +96,7 @@ namespace Orleans.Runtime.ReminderService
             catch (Exception ex)
             {
                 string errorMsg = $"Exception trying to create or connect to the Azure table: {ex.Message}";
-                singleton.Logger.Error((int)AzureReminderErrorCode.AzureTable_39, errorMsg, ex);
+                singleton.Logger.LogError((int)AzureReminderErrorCode.AzureTable_39, ex, errorMsg);
                 throw new OrleansException(errorMsg, ex);
             }
             return singleton;

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -90,7 +90,7 @@ namespace Orleans.Runtime.ReminderService
             var singleton = new RemindersTableManager(serviceId, clusterId, options, loggerFactory);
             try
             {
-                singleton.Logger.Info("Creating RemindersTableManager for service id {0} and clusterId {1}.", serviceId, clusterId);
+                singleton.Logger.LogInformation("Creating RemindersTableManager for service id {0} and clusterId {1}.", serviceId, clusterId);
                 await singleton.InitTableAsync();
             }
             catch (Exception ex)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -136,8 +136,8 @@ namespace Orleans.Providers.Streams.AzureQueue
                 }
                 catch (Exception exc)
                 {
-                    logger.Warn((int)AzureQueueErrorCode.AzureQueue_15,
-                        $"Exception upon DeleteQueueMessage on queue {this.azureQueueName}. Ignoring.", exc);
+                    logger.LogWarning((int)AzureQueueErrorCode.AzureQueue_15, exc,
+                        $"Exception upon DeleteQueueMessage on queue {this.azureQueueName}. Ignoring.");
                 }
             }
             finally

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -98,7 +98,7 @@ namespace Orleans.AzureUtils
             {
                 // Create the queue if it doesn't already exist.
                 var response = await queueClient.CreateIfNotExistsAsync();
-                logger.Info((int)AzureQueueErrorCode.AzureQueue_01, "Connected to Azure storage queue {0}", QueueName);
+                logger.LogInformation((int)AzureQueueErrorCode.AzureQueue_01, "Connected to Azure storage queue {0}", QueueName);
             }
             catch (Exception exc)
             {
@@ -122,7 +122,7 @@ namespace Orleans.AzureUtils
                 // that way we don't have first to create the queue to be able later to delete it.
                 if (await queueClient.DeleteIfExistsAsync())
                 {
-                    logger.Info((int)AzureQueueErrorCode.AzureQueue_03, "Deleted Azure Queue {0}", QueueName);
+                    logger.LogInformation((int)AzureQueueErrorCode.AzureQueue_03, "Deleted Azure Queue {0}", QueueName);
                 }
             }
             catch (Exception exc)
@@ -146,7 +146,7 @@ namespace Orleans.AzureUtils
             {
                 // that way we don't have first to create the queue to be able later to delete it.
                 await queueClient.ClearMessagesAsync();
-                logger.Info((int)AzureQueueErrorCode.AzureQueue_05, "Cleared Azure Queue {0}", QueueName);
+                logger.LogInformation((int)AzureQueueErrorCode.AzureQueue_05, "Cleared Azure Queue {0}", QueueName);
             }
             catch (RequestFailedException exc)
             {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -325,7 +325,7 @@ namespace Orleans.AzureUtils
             var timeSpan = DateTime.UtcNow - startOperation;
             if (timeSpan > AzureQueueDefaultPolicies.QueueOperationTimeout)
             {
-                logger.Warn((int)AzureQueueErrorCode.AzureQueue_13, "Slow access to Azure queue {0} for {1}, which took {2}.", QueueName, operation, timeSpan);
+                logger.LogWarning((int)AzureQueueErrorCode.AzureQueue_13, "Slow access to Azure queue {0} for {1}, which took {2}.", QueueName, operation, timeSpan);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -334,7 +334,7 @@ namespace Orleans.AzureUtils
             var errMsg = String.Format(
                 "Error doing {0} for Azure storage queue {1} " + Environment.NewLine
                 + "Exception = {2}", operation, QueueName, exc);
-            logger.Error((int)errorCode, errMsg, exc);
+            logger.LogError((int)errorCode, exc, errMsg);
             throw new AggregateException(errMsg, exc);
         }
 
@@ -360,7 +360,7 @@ namespace Orleans.AzureUtils
             }
             catch (Exception exc)
             {
-                logger.Error((int)AzureQueueErrorCode.AzureQueue_14, String.Format("Error creating GetCloudQueueOperationsClient."), exc);
+                logger.LogError((int)AzureQueueErrorCode.AzureQueue_14, exc, String.Format("Error creating GetCloudQueueOperationsClient."));
                 throw;
             }
         }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -116,7 +116,7 @@ namespace Orleans.AzureUtils
         public async Task DeleteQueue()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Deleting queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Deleting queue: {0}", QueueName);
             try
             {
                 // that way we don't have first to create the queue to be able later to delete it.
@@ -141,7 +141,7 @@ namespace Orleans.AzureUtils
         public async Task ClearQueue()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Clearing a queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Clearing a queue: {0}", QueueName);
             try
             {
                 // that way we don't have first to create the queue to be able later to delete it.
@@ -172,7 +172,7 @@ namespace Orleans.AzureUtils
         public async Task AddQueueMessage(string message)
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Adding message {0} to queue: {1}", message, QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Adding message {0} to queue: {1}", message, QueueName);
             try
             {
                 await queueClient.SendMessageAsync(message);
@@ -193,7 +193,7 @@ namespace Orleans.AzureUtils
         public async Task<PeekedMessage> PeekQueueMessage()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Peeking a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Peeking a message from queue: {0}", QueueName);
             try
             {
                 var messages = await queueClient.PeekMessagesAsync(maxMessages: 1);
@@ -218,7 +218,7 @@ namespace Orleans.AzureUtils
         public async Task<QueueMessage> GetQueueMessage()
         {
                var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Getting a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Getting a message from queue: {0}", QueueName);
             try
             {
                 //BeginGetMessage and EndGetMessage is not supported in netstandard, may be use GetMessageAsync
@@ -250,7 +250,7 @@ namespace Orleans.AzureUtils
                 count = null;
             }
 
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Getting up to {0} messages from queue: {1}", count, QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Getting up to {0} messages from queue: {1}", count, QueueName);
             try
             {
                 var messages = await queueClient.ReceiveMessagesAsync(count, messageVisibilityTimeout);
@@ -274,7 +274,7 @@ namespace Orleans.AzureUtils
         public async Task DeleteQueueMessage(QueueMessage message)
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Deleting a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Deleting a message from queue: {0}", QueueName);
             try
             {
                 await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt);
@@ -302,7 +302,7 @@ namespace Orleans.AzureUtils
         public async Task<int> GetApproximateMessageCount()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("GetApproximateMessageCount a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("GetApproximateMessageCount a message from queue: {0}", QueueName);
             try
             {
                 var properties = await queueClient.GetPropertiesAsync();

--- a/src/Azure/Orleans.Streaming.EventHubs/OrleansServiceBusErrorCode.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/OrleansServiceBusErrorCode.cs
@@ -17,37 +17,4 @@ namespace Orleans.ServiceBus
         FailedPartitionRead = ServiceBus + 1,
         RetryReceiverInit   = ServiceBus + 2,
     }
-
-    internal static class LoggerExtensions
-    {
-        internal static void Debug(this ILogger logger, OrleansServiceBusErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogDebug((int) errorCode, format, args);
-        }
-
-        internal static void Trace(this ILogger logger, OrleansServiceBusErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogTrace((int) errorCode, format, args);
-        }
-
-        internal static void Info(this ILogger logger, OrleansServiceBusErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogInformation((int) errorCode, format, args);
-        }
-
-        internal static void Warn(this ILogger logger, OrleansServiceBusErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogWarning((int) errorCode, format, args);
-        }
-
-        internal static void Warn(this ILogger logger, OrleansServiceBusErrorCode errorCode, string message, Exception exception)
-        {
-            logger.LogWarning((int) errorCode, exception, message);
-        }
-
-        internal static void Error(this ILogger logger, OrleansServiceBusErrorCode errorCode, string message, Exception exception = null)
-        {
-            logger.LogError((int) errorCode, exception, message);
-        }
-    }
 }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorAdapterFactory.cs
@@ -85,12 +85,12 @@ namespace Orleans.ServiceBus.Providers.Testing
                 if (this.EventHubReceivers.TryGetValue(queueToAssign, out receiverToAssign))
                 {
                     receiverToAssign.ConfigureDataGeneratorForStream(streamId);
-                    logger.Info($"Stream {streamId} is assigned to queue {queueToAssign.ToString()}");
+                    logger.LogInformation($"Stream {streamId} is assigned to queue {queueToAssign.ToString()}");
                 }
             }
             else
             {
-                logger.Info("Cannot get queues in the cluster, current streamQueueMapper is not EventHubQueueMapper");
+                logger.LogInformation("Cannot get queues in the cluster, current streamQueueMapper is not EventHubQueueMapper");
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
@@ -71,7 +71,7 @@ namespace Orleans.ServiceBus.Providers.Testing
 
                 eventDataList.Add(wrapper);
 
-                this.logger.Info($"Generate data of SequemceNumber {SequenceNumberCounter.Value} for stream {this.StreamId}");
+                this.logger.LogInformation($"Generate data of SequemceNumber {SequenceNumberCounter.Value} for stream {this.StreamId}");
             }
 
             events = eventDataList;
@@ -129,7 +129,7 @@ namespace Orleans.ServiceBus.Providers.Testing
         {
             var generator =  this.generatorFactory(streamId);
             generator.SequenceNumberCounter = sequenceNumberCounter;
-            this.logger.Info($"Data generator set up on stream {streamId}.");
+            this.logger.LogInformation($"Data generator set up on stream {streamId}.");
             this.generators.Add(generator);
         }
         /// <inheritdoc />
@@ -139,7 +139,7 @@ namespace Orleans.ServiceBus.Providers.Testing
                 if (generator.StreamId.Equals(streamId))
                 {
                     generator.ShouldProduce = false;
-                    this.logger.Info($"Stop producing data on stream {streamId}.");
+                    this.logger.LogInformation($"Stop producing data on stream {streamId}.");
                 }
             });
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AggregatedCachePressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AggregatedCachePressureMonitor.cs
@@ -64,7 +64,7 @@ namespace Orleans.ServiceBus.Providers
             {
                 this.isUnderPressure = underPressure;
                 this.CacheMonitor?.TrackCachePressureMonitorStatusChange(this.GetType().Name, this.isUnderPressure, null, null, null);
-                logger.Info(this.isUnderPressure
+                logger.LogInformation(this.isUnderPressure
                     ? $"Ingesting messages too fast. Throttling message reading."
                     : $"Message ingestion is healthy.");
             }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
@@ -88,9 +88,9 @@ namespace Orleans.ServiceBus.Providers
             {
                 this.CacheMonitor?.TrackCachePressureMonitorStatusChange(this.GetType().Name, isUnderPressure, cachePressureContributionCount, pressure, this.flowControlThreshold);
                 if(this.logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug(isUnderPressure
-                    ? $"Ingesting messages too fast. Throttling message reading. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}"
-                    : $"Message ingestion is healthy. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}");
+                    logger.LogDebug(isUnderPressure
+                        ? $"Ingesting messages too fast. Throttling message reading. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}"
+                        : $"Message ingestion is healthy. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}");
             }
             cachePressureContributionCount = 0.0;
             accumulatedCachePressure = 0.0;

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/SlowConsumingPressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/SlowConsumingPressureMonitor.cs
@@ -111,7 +111,7 @@ namespace Orleans.ServiceBus.Providers
                 this.nextCheckedTime = utcNow + this.PressureWindowSize;
                 this.CacheMonitor?.TrackCachePressureMonitorStatusChange(this.GetType().Name, underPressure, null, biggestPressureInCurrentWindow, this.FlowControlThreshold);
                 if(logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"Ingesting messages too fast. Throttling message reading. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
+                    logger.LogDebug($"Ingesting messages too fast. Throttling message reading. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
                 this.biggestPressureInCurrentWindow = 0;
             }
 
@@ -125,7 +125,7 @@ namespace Orleans.ServiceBus.Providers
                 {
                     this.CacheMonitor?.TrackCachePressureMonitorStatusChange(this.GetType().Name, underPressure, null, biggestPressureInCurrentWindow, this.FlowControlThreshold);
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"Message ingestion is healthy. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
+                        logger.LogDebug($"Message ingestion is healthy. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
                 }
                 this.wasUnderPressure = underPressure;
             }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -136,7 +136,7 @@ namespace Orleans.ServiceBus.Providers
             // if receiver initialization failed, retry
             if (this.receiver == null)
             {
-                this.logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead,
+                this.logger.LogWarning((int) OrleansServiceBusErrorCode.FailedPartitionRead,
                     "Retrying initialization of EventHub partition {0}-{1}.", this.settings.Hub.Path, this.settings.Partition);
                 await Initialize();
                 if (this.receiver == null)
@@ -159,7 +159,7 @@ namespace Orleans.ServiceBus.Providers
             {
                 watch.Stop();
                 this.monitor?.TrackRead(false, watch.Elapsed, ex);
-                this.logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead,
+                this.logger.LogWarning((int) OrleansServiceBusErrorCode.FailedPartitionRead,
                     "Failed to read from EventHub partition {0}-{1}. : Exception: {2}.", this.settings.Hub.Path,
                     this.settings.Partition, ex);
                 throw;

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -89,7 +89,7 @@ namespace Orleans.ServiceBus.Providers
 
         public Task Initialize(TimeSpan timeout)
         {
-            this.logger.Info("Initializing EventHub partition {0}-{1}.", this.settings.Hub.Path, this.settings.Partition);
+            this.logger.LogInformation("Initializing EventHub partition {0}-{1}.", this.settings.Hub.Path, this.settings.Partition);
             // if receiver was already running, do nothing
             return ReceiverRunning == Interlocked.Exchange(ref this.receiverState, ReceiverRunning)
                 ? Task.CompletedTask
@@ -236,7 +236,7 @@ namespace Orleans.ServiceBus.Providers
                     return;
                 }
 
-                this.logger.Info("Stopping reading from EventHub partition {0}-{1}", this.settings.Hub.Path, this.settings.Partition);
+                this.logger.LogInformation("Stopping reading from EventHub partition {0}-{1}", this.settings.Hub.Path, this.settings.Partition);
 
                 // clear cache and receiver
                 IEventHubQueueCache localCache = Interlocked.Exchange(ref this.cache, null);

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -162,7 +162,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (logger.IsEnabled(LogLevel.Debug) && lastItemPurged.HasValue && newestItem.HasValue)
             {
-                logger.Debug($"CachePeriod: EnqueueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.EnqueueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.EnqueueTimeUtc)}, DequeueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.DequeueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.DequeueTimeUtc)}");
+                logger.LogDebug($"CachePeriod: EnqueueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.EnqueueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.EnqueueTimeUtc)}, DequeueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.DequeueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.DequeueTimeUtc)}");
             }
             if (lastItemPurged.HasValue)
             {

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -413,7 +413,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 //The ETag of data is needed in further operations.
                 if (retrievedResult != null) return new Tuple<T, string>(retrievedResult, retrievedResult.ETag);
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Could not find table entry for PartitionKey={0} RowKey={1}", partitionKey, rowKey);
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Could not find table entry for PartitionKey={0} RowKey={1}", partitionKey, rowKey);
                 return null;  // No data
             }
             finally
@@ -827,8 +827,8 @@ namespace Orleans.GrainDirectory.AzureStorage
             if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out _) && AzureTableUtils.IsContentionError(httpStatusCode))
             {
                 // log at Verbose, since failure on conditional is not not an error. Will analyze and warn later, if required.
-                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug((int)Utilities.ErrorCode.AzureTable_13,
-                     $"Intermediate Azure table write error {operation} to table {TableName} data1 {(data1 ?? "null")} data2 {(data2 ?? "null")}", exc);
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug((int)Utilities.ErrorCode.AzureTable_13, exc,
+                     $"Intermediate Azure table write error {operation} to table {TableName} data1 {(data1 ?? "null")} data2 {(data2 ?? "null")}");
 
             }
             else

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -98,7 +98,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 bool didCreate = await tableRef.CreateIfNotExistsAsync();
 
 
-                Logger.Info((int)Utilities.ErrorCode.AzureTable_01, "{0} Azure storage table {1}", (didCreate ? "Created" : "Attached to"), TableName);
+                Logger.LogInformation((int)Utilities.ErrorCode.AzureTable_01, "{0} Azure storage table {1}", (didCreate ? "Created" : "Attached to"), TableName);
 
                 CloudTableClient tableOperationsClient = await GetCloudTableOperationsClientAsync();
                 Table = tableOperationsClient.GetTableReference(TableName);
@@ -138,7 +138,7 @@ namespace Orleans.GrainDirectory.AzureStorage
 
                 if (didDelete)
                 {
-                    Logger.Info((int)Utilities.ErrorCode.AzureTable_03, "Deleted Azure storage table {0}", TableName);
+                    Logger.LogInformation((int)Utilities.ErrorCode.AzureTable_03, "Deleted Azure storage table {0}", TableName);
                 }
             }
             catch (Exception exc)

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -228,8 +228,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_06,
-                        $"Intermediate error upserting entry {(data == null ? "null" : data.ToString())} to the table {TableName}", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_06, exc,
+                        $"Intermediate error upserting entry {(data == null ? "null" : data.ToString())} to the table {TableName}");
                     throw;
                 }
             }
@@ -263,8 +263,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_06,
-                        $"Intermediate error inserting entry {(data == null ? "null" : data.ToString())} to the table {TableName}", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_06, exc,
+                        $"Intermediate error inserting entry {(data == null ? "null" : data.ToString())} to the table {TableName}");
                     throw;
                 }
             }
@@ -303,8 +303,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_07,
-                        $"Intermediate error merging entry {(data == null ? "null" : data.ToString())} to the table {TableName}", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_07, exc,
+                        $"Intermediate error merging entry {(data == null ? "null" : data.ToString())} to the table {TableName}");
                     throw;
                 }
             }
@@ -373,8 +373,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_08,
-                        $"Intermediate error deleting entry {data} from the table {TableName}.", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_08, exc,
+                        $"Intermediate error deleting entry {data} from the table {TableName}.");
                     throw;
                 }
             }
@@ -490,8 +490,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_08,
-                        $"Intermediate error deleting entries {Utils.EnumerableToString(collection)} from the table {TableName}.", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_08, exc,
+                        $"Intermediate error deleting entries {Utils.EnumerableToString(collection)} from the table {TableName}.");
                     throw;
                 }
             }
@@ -555,7 +555,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                     var errorMsg = $"Failed to read Azure storage table {TableName}: {exc.Message}";
                     if (!AzureTableUtils.TableStorageDataNotFound(exc))
                     {
-                        Logger.Warn((int)Utilities.ErrorCode.AzureTable_09, errorMsg, exc);
+                        Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_09, exc, errorMsg);
                     }
                     throw new OrleansException(errorMsg, exc);
                 }
@@ -613,8 +613,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    Logger.Warn((int)Utilities.ErrorCode.AzureTable_37,
-                        $"Intermediate error bulk inserting {collection.Count} entries in the table {TableName}", exc);
+                    Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_37, exc,
+                        $"Intermediate error bulk inserting {collection.Count} entries in the table {TableName}");
                 }
             }
             finally
@@ -843,7 +843,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             var timeSpan = DateTime.UtcNow - startOperation;
             if (timeSpan > this.StoragePolicyOptions.OperationTimeout)
             {
-                Logger.Warn((int)Utilities.ErrorCode.AzureTable_15, "Slow access to Azure Table {0} for {1}, which took {2}.", TableName, operation, timeSpan);
+                Logger.LogWarning((int)Utilities.ErrorCode.AzureTable_15, "Slow access to Azure Table {0} for {1}, which took {2}.", TableName, operation, timeSpan);
             }
         }
 

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -106,12 +106,12 @@ namespace Orleans.GrainDirectory.AzureStorage
             catch (TimeoutException te)
             {
                 var errorMsg = $"Unable to create or connect to the Azure table in {this.StoragePolicyOptions.CreationTimeout}";
-                this.Logger.Error((int)Utilities.ErrorCode.AzureTable_TableNotCreated, errorMsg, te);
+                this.Logger.LogError((int)Utilities.ErrorCode.AzureTable_TableNotCreated, te, errorMsg);
                 throw new OrleansException(errorMsg, te);
             }
             catch (Exception exc)
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_02, $"Could not initialize connection to storage table {TableName}", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_02, exc, $"Could not initialize connection to storage table {TableName}");
                 throw;
             }
             finally
@@ -143,7 +143,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
             catch (Exception exc)
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_04, "Could not delete storage table {0}", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_04, exc, "Could not delete storage table {0}");
                 throw;
             }
             finally
@@ -735,7 +735,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
             catch (Exception exc)
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_17, "Error creating CloudTableOperationsClient.", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_17, exc, "Error creating CloudTableOperationsClient.");
                 throw;
             }
         }
@@ -753,7 +753,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
             catch (Exception exc)
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_18, "Error creating CloudTableCreationClient.", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_18, exc, "Error creating CloudTableCreationClient.");
                 throw;
             }
         }
@@ -812,7 +812,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
             catch (Exception exc)
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_19, $"Unable to retrieve table keys for resource {options.TableResourceId}", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_19, exc, $"Unable to retrieve table keys for resource {options.TableResourceId}");
                 throw;
             }
             finally
@@ -833,8 +833,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
             else
             {
-                Logger.Error((int)Utilities.ErrorCode.AzureTable_14,
-                    $"Azure table access write error {operation} to table {TableName} entry {data1}", exc);
+                Logger.LogError((int)Utilities.ErrorCode.AzureTable_14, exc, $"Azure table access write error {operation} to table {TableName} entry {data1}");
             }
         }
 

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -176,7 +176,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             const string operation = "CreateTableEntry";
             var startTime = DateTime.UtcNow;
 
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Creating {0} table entry: {1}", TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Creating {0} table entry: {1}", TableName, data);
 
             try
             {
@@ -213,7 +213,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "UpsertTableEntry";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} entry {1} into table {2}", operation, data, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} entry {1} into table {2}", operation, data, TableName);
 
             try
             {
@@ -248,7 +248,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "InsertTableEntry";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} entry {1} into table {2}", operation, data, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} entry {1} into table {2}", operation, data, TableName);
 
             try
             {
@@ -285,7 +285,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "MergeTableEntry";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} entry {1} into table {2}", operation, data, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} entry {1} into table {2}", operation, data, TableName);
 
             try
             {
@@ -325,7 +325,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "UpdateTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1}  entry {2}", operation, TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} table {1}  entry {2}", operation, TableName, data);
 
             try
             {
@@ -360,7 +360,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "DeleteTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1}  entry {2}", operation, TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} table {1}  entry {2}", operation, TableName, data);
 
             try
             {
@@ -394,7 +394,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "ReadSingleTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1} partitionKey {2} rowKey = {3}", operation, TableName, partitionKey, rowKey);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} table {1} partitionKey {2} rowKey = {3}", operation, TableName, partitionKey, rowKey);
             T retrievedResult = default(T);
 
             try
@@ -455,7 +455,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         {
             const string operation = "DeleteTableEntries";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Deleting {0} table entries: {1}", TableName, Utils.EnumerableToString(collection));
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Deleting {0} table entries: {1}", TableName, Utils.EnumerableToString(collection));
 
             if (collection == null) throw new ArgumentNullException("collection");
 
@@ -588,7 +588,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
 
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Bulk inserting {0} entries to {1} table", collection.Count, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("Bulk inserting {0} entries to {1} table", collection.Count, TableName);
 
             try
             {
@@ -629,7 +629,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             string data2Str = (data2 == null ? "null" : data2.ToString());
             var startTime = DateTime.UtcNow;
 
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} into table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} into table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
 
             try
             {
@@ -674,7 +674,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             const string operation = "UpdateTableEntryConditionally";
             string data2Str = (data2 == null ? "null" : data2.ToString());
             var startTime = DateTime.UtcNow;
-            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{0} table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
 
             try
             {

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -236,9 +236,8 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 isLastErrorRetriable = true;
                 var statusCode = we.Status;
-                logger.Warn((int)Utilities.ErrorCode.AzureTable_10,
-                    $"Intermediate issue reading Azure storage table {tableName}: HTTP status code={statusCode} Exception Type={exc.GetType().FullName} Message='{exc.Message}'",
-                    exc);
+                logger.LogWarning((int)Utilities.ErrorCode.AzureTable_10, exc,
+                    $"Intermediate issue reading Azure storage table {tableName}: HTTP status code={statusCode} Exception Type={exc.GetType().FullName} Message='{exc.Message}'");
             }
             else
             {
@@ -262,9 +261,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                     {
                         isLastErrorRetriable = IsRetriableHttpError(httpStatusCode, restStatus);
 
-                        logger.Warn((int)Utilities.ErrorCode.AzureTable_11,
-                            $"Intermediate issue reading Azure storage table {tableName}:{(iteration == 0 ? "" : (" Repeat=" + iteration))} IsRetriable={isLastErrorRetriable} HTTP status code={httpStatusCode} REST status code={restStatus} Exception Type={exc.GetType().FullName} Message='{exc.Message}'",
-                                exc);
+                        logger.LogWarning((int)Utilities.ErrorCode.AzureTable_11, exc,
+                            $"Intermediate issue reading Azure storage table {tableName}:{(iteration == 0 ? "" : (" Repeat=" + iteration))} IsRetriable={isLastErrorRetriable} HTTP status code={httpStatusCode} REST status code={restStatus} Exception Type={exc.GetType().FullName} Message='{exc.Message}'");
                     }
                 }
                 else

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -267,9 +267,8 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 else
                 {
-                    logger.Error((int)Utilities.ErrorCode.AzureTable_12,
-                        $"Unexpected issue reading Azure storage table {tableName}: Exception Type={exc.GetType().FullName} Message='{exc.Message}'",
-                                 exc);
+                    logger.LogError((int)Utilities.ErrorCode.AzureTable_12,
+                                 exc, $"Unexpected issue reading Azure storage table {tableName}: Exception Type={exc.GetType().FullName} Message='{exc.Message}'");
                     isLastErrorRetriable = false;
                 }
             }

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -248,7 +248,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 {
                     if (StorageErrorCodeStrings.ResourceNotFound.Equals(restStatus))
                     {
-                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug((int)Utilities.ErrorCode.AzureTable_DataNotFound,
+                        if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)Utilities.ErrorCode.AzureTable_DataNotFound,
                             "DataNotFound reading Azure storage table {0}:{1} HTTP status code={2} REST status code={3} Exception={4}",
                             tableName,
                             iteration == 0 ? "" : (" Repeat=" + iteration),

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime.Membership
             var deploymentKVAddresses = await consulClient.KV.List(ConsulSiloRegistrationAssembler.FormatDeploymentKVPrefix(clusterId, kvRootFolder));
             if (deploymentKVAddresses.Response == null)
             {
-                logger.Debug("Could not find any silo registrations for deployment {0}.", clusterId);
+                logger.LogDebug("Could not find any silo registrations for deployment {0}.", clusterId);
                 return new MembershipTableData(NotFoundTableVersion);
             }
 
@@ -109,7 +109,7 @@ namespace Orleans.Runtime.Membership
                 var responses = await _consulClient.KV.Txn(new List<KVTxnOp> { rowInsert, versionUpdate });
                 if (!responses.Response.Success)
                 {
-                    _logger.Debug("ConsulMembershipProvider failed to insert the row {0}.", entry.SiloAddress);
+                    _logger.LogDebug("ConsulMembershipProvider failed to insert the row {0}.", entry.SiloAddress);
                     return false;
                 }
 
@@ -136,7 +136,7 @@ namespace Orleans.Runtime.Membership
                 var responses = await _consulClient.KV.Txn(new List<KVTxnOp> { rowUpdate, versionUpdate });
                 if (!responses.Response.Success)
                 {
-                    _logger.Debug("ConsulMembershipProvider failed the CAS check when updating the registration for silo {0}.", entry.SiloAddress);
+                    _logger.LogDebug("ConsulMembershipProvider failed the CAS check when updating the registration for silo {0}.", entry.SiloAddress);
                     return false;
                 }
 
@@ -220,7 +220,7 @@ namespace Orleans.Runtime.Membership
             var allKVs = await _consulClient.KV.List(ConsulSiloRegistrationAssembler.FormatDeploymentKVPrefix(this.clusterId, this.kvRootFolder));
             if (allKVs.Response == null)
             {
-                _logger.Debug("Could not find any silo registrations for deployment {0}.", this.clusterId);
+                _logger.LogDebug("Could not find any silo registrations for deployment {0}.", this.clusterId);
                 return;
             }
 

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -117,7 +117,7 @@ namespace Orleans.Runtime.Membership
             }
             catch (Exception ex)
             {
-                _logger.Info("ConsulMembershipProvider failed to insert registration for silo {0}; {1}.", entry.SiloAddress, ex);
+                _logger.LogInformation(ex, "ConsulMembershipProvider failed to insert registration for silo {Silo}", entry.SiloAddress);
                 throw;
             }
         }
@@ -144,7 +144,7 @@ namespace Orleans.Runtime.Membership
             }
             catch (Exception ex)
             {
-                _logger.Info("ConsulMembershipProvider failed to update the registration for silo {0}: {1}.", entry.SiloAddress, ex);
+                _logger.LogInformation(ex, "ConsulMembershipProvider failed to update the registration for silo {0}", entry.SiloAddress);
                 throw;
             }
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -85,7 +85,7 @@ namespace Orleans.Runtime.Membership
                     await zk.createAsync(this.clusterPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     await zk.sync(this.clusterPath);
                     //if we got here we know that we've just created the deployment path with version=0
-                    this.logger.Info("Created new deployment path: " + this.clusterPath);
+                    this.logger.LogInformation("Created new deployment path: " + this.clusterPath);
                 }
                 catch (KeeperException.NodeExistsException)
                 {

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime.Membership
                 }
                 catch (KeeperException.NodeExistsException)
                 {
-                    this.logger.Debug("Deployment path already exists: " + this.clusterPath);
+                    this.logger.LogDebug("Deployment path already exists: " + this.clusterPath);
                 }
             });
         }
@@ -359,7 +359,7 @@ namespace Orleans.Runtime.Membership
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.Debug(@event.ToString());
+                logger.LogDebug(@event.ToString());
             }
             return Task.CompletedTask;
         }

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -168,7 +168,7 @@ namespace Orleans.Internal
             catch (Exception exc)
             {
                 _ = task.Exception; // Observe exception
-                logger.Error(errorCode, message, exc);
+                logger.LogError((int)errorCode, exc, message);
                 throw;
             }
         }

--- a/src/Orleans.Core/Logging/ILoggerExtensions.cs
+++ b/src/Orleans.Core/Logging/ILoggerExtensions.cs
@@ -7,6 +7,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Extension methods which preserves legacy orleans log methods style
     /// </summary>
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Logging.")]
     public static class OrleansLoggerExtension
     {
         /// <summary>
@@ -17,6 +18,7 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, string format, params object[] args)
         {
             logger.LogDebug(format, args);
@@ -29,6 +31,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="logger">The logger</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, string message)
         {
             logger.LogDebug(message);
@@ -42,6 +45,7 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, string format, params object[] args)
         {
             logger.LogTrace(format, args);
@@ -53,6 +57,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="logger">The logger</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, string message)
         {
             logger.LogTrace(message);
@@ -66,6 +71,7 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, string format, params object[] args)
         {
             logger.LogInformation(format, args);
@@ -76,6 +82,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="logger">Target logger.</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, string message)
         {
             logger.LogInformation(message);
@@ -90,11 +97,13 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, int logCode, string format, params object[] args)
         {
             logger.LogDebug(logCode, format, args);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, ErrorCode logCode, string format, params object[] args)
         {
             logger.LogDebug(LoggingUtils.CreateEventId(logCode), format, args);
@@ -106,11 +115,13 @@ namespace Orleans.Runtime
         /// <param name="logger">The logger</param>
         /// <param name="logCode">The log code associated with this message.</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, int logCode, string message)
         {
             logger.LogDebug(logCode, message);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogDebug instead.")]
         public static void Debug(this ILogger logger, ErrorCode logCode, string message)
         {
             logger.LogDebug(LoggingUtils.CreateEventId(logCode), message);
@@ -125,11 +136,13 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, int logCode, string format, params object[] args)
         {
             logger.LogTrace(logCode, format, args);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, ErrorCode logCode, string format, params object[] args)
         {
             logger.LogTrace(LoggingUtils.CreateEventId(logCode), format, args);
@@ -141,11 +154,13 @@ namespace Orleans.Runtime
         /// <param name="logger">The logger</param>
         /// <param name="logCode">The log code associated with this message.</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, int logCode, string message)
         {
             logger.LogTrace(logCode, message);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogTrace instead.")]
         public static void Trace(this ILogger logger, ErrorCode logCode, string message)
         {
             logger.LogTrace(LoggingUtils.CreateEventId(logCode), message);
@@ -160,11 +175,13 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, int logCode, string format, params object[] args)
         {
             logger.LogInformation(logCode, format, args);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, ErrorCode logCode, string format, params object[] args)
         {
             logger.LogInformation(LoggingUtils.CreateEventId(logCode), format, args);
@@ -176,11 +193,13 @@ namespace Orleans.Runtime
         /// <param name="logger">The logger</param>
         /// <param name="logCode">The log code associated with this message.</param>
         /// <param name="message">The log message.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, int logCode, string message)
         {
             logger.LogInformation(logCode, message);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogInformation instead.")]
         public static void Info(this ILogger logger, ErrorCode logCode, string message)
         {
             logger.LogInformation(LoggingUtils.CreateEventId(logCode), message);
@@ -195,11 +214,13 @@ namespace Orleans.Runtime
         /// <remarks>Not always suitable for <c>String.Format</c>. See Microsoft.Extensions.Logging MessageTemplate section for more information. Suggest to use their pattern over this extension method</remarks>
         /// </param>
         /// <param name="args">Any arguments to the format string.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogWarning instead.")]
         public static void Warn(this ILogger logger, int logCode, string format, params object[] args)
         {
             logger.LogWarning(logCode, format, args);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogWarning instead.")]
         public static void Warn(this ILogger logger, ErrorCode logCode, string format, params object[] args)
         {
             logger.LogWarning(LoggingUtils.CreateEventId(logCode), format, args);
@@ -212,11 +233,13 @@ namespace Orleans.Runtime
         /// <param name="logCode">The log code associated with this message.</param>
         /// <param name="message">The warning message to log.</param>
         /// <param name="exception">An exception related to the warning, if any.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogWarning instead.")]
         public static void Warn(this ILogger logger, int logCode, string message, Exception exception = null)
         {
             logger.LogWarning(logCode, exception, message);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogWarning instead.")]
         public static void Warn(this ILogger logger, ErrorCode logCode, string message, Exception exception = null)
         {
             logger.LogWarning(LoggingUtils.CreateEventId(logCode), exception, message);
@@ -229,11 +252,13 @@ namespace Orleans.Runtime
         /// <param name="logCode">The log code associated with this message.</param>
         /// <param name="message">The error message to log.</param>
         /// <param name="exception">An exception related to the error, if any.</param>
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogError instead.")]
         public static void Error(this ILogger logger, int logCode, string message, Exception exception = null)
         {
             logger.LogError(logCode, exception, message);
         }
 
+        [Obsolete("This method is obsolete. Please use Microsoft.Extensions.Logging.LoggerExtensions.LogError instead.")]
         public static void Error(this ILogger logger, ErrorCode logCode, string message, Exception exception = null)
         {
             logger.LogError(LoggingUtils.CreateEventId(logCode), exception, message);

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -247,7 +247,7 @@ namespace Orleans.Messaging
                 if (numGateways == 0)
                 {
                     RejectMessage(msg, "No gateways available");
-                    logger.Warn(ErrorCode.ProxyClient_CannotSend, "Unable to send message {0}; gateway manager state is {1}", msg, gatewayManager);
+                    logger.LogWarning((int)ErrorCode.ProxyClient_CannotSend, "Unable to send message {0}; gateway manager state is {1}", msg, gatewayManager);
                     return new ValueTask<Connection>(default(Connection));
                 }
 
@@ -281,7 +281,7 @@ namespace Orleans.Messaging
             if (addr == null)
             {
                 RejectMessage(msg, "No gateways available");
-                logger.Warn(ErrorCode.ProxyClient_CannotSend_NoGateway, "Unable to send message {0}; gateway manager state is {1}", msg, gatewayManager);
+                logger.LogWarning((int)ErrorCode.ProxyClient_CannotSend_NoGateway, "Unable to send message {0}; gateway manager state is {1}", msg, gatewayManager);
                 return new ValueTask<Connection>(default(Connection));
             }
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.ProxyClient_NewBucketIndex, "Starting new bucket index {0} for ordered messages to grain {1}", index, msg.TargetGrain);

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -99,7 +99,7 @@ namespace Orleans.Messaging
             numMessages = 0;
             this.grainBuckets = new WeakReference<Connection>[clientMessagingOptions.Value.ClientSenderBuckets];
             logger = loggerFactory.CreateLogger<ClientMessageCenter>();
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Proxy grain client constructed");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Proxy grain client constructed");
             IntValueStatistic.FindOrCreate(
                 StatisticNames.CLIENT_CONNECTED_GATEWAY_COUNT,
                 () =>
@@ -120,7 +120,7 @@ namespace Orleans.Messaging
             {
                 queueTracking.OnStartExecution();
             }
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Proxy grain client started");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Proxy grain client started");
         }
 
         public void Stop()
@@ -286,8 +286,8 @@ namespace Orleans.Messaging
             }
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.ProxyClient_NewBucketIndex, "Starting new bucket index {0} for ordered messages to grain {1}", index, msg.TargetGrain);
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(
-                ErrorCode.ProxyClient_CreatedGatewayToGrain,
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(
+                (int)ErrorCode.ProxyClient_CreatedGatewayToGrain,
                 "Creating gateway to {0} for message to grain {1}, bucket {2}, grain id hash code {3}X",
                 addr,
                 msg.TargetGrain,
@@ -374,11 +374,11 @@ namespace Orleans.Messaging
             
             if (msg.Direction != Message.Directions.Request)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.ProxyClient_DroppingMsg, "Dropping message: {0}. Reason = {1}", msg, reason);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.ProxyClient_DroppingMsg, "Dropping message: {0}. Reason = {1}", msg, reason);
             }
             else
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.ProxyClient_RejectingMsg, "Rejecting message: {0}. Reason = {1}", msg, reason);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.ProxyClient_RejectingMsg, "Rejecting message: {0}. Reason = {1}", msg, reason);
                 MessagingStatisticsGroup.OnRejectedMessage(msg);
                 var error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 OnReceivedMessage(error);

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -167,8 +167,8 @@ namespace Orleans.Messaging
 
                 if (this.logger.IsEnabled(LogLevel.Trace))
                 {
-                    this.logger.Trace(
-                        ErrorCode.ProxyClient_QueueRequest,
+                    this.logger.LogTrace(
+                        (int)ErrorCode.ProxyClient_QueueRequest,
                         "Sending message {0} via gateway {1}",
                         msg,
                         connection.RemoteEndPoint);
@@ -191,8 +191,8 @@ namespace Orleans.Messaging
 
                         if (this.logger.IsEnabled(LogLevel.Trace))
                         {
-                            this.logger.Trace(
-                                ErrorCode.ProxyClient_QueueRequest,
+                            this.logger.LogTrace(
+                                (int)ErrorCode.ProxyClient_QueueRequest,
                                 "Sending message {0} via gateway {1}",
                                 message,
                                 connection.RemoteEndPoint);
@@ -284,7 +284,7 @@ namespace Orleans.Messaging
                 logger.Warn(ErrorCode.ProxyClient_CannotSend_NoGateway, "Unable to send message {0}; gateway manager state is {1}", msg, gatewayManager);
                 return new ValueTask<Connection>(default(Connection));
             }
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.ProxyClient_NewBucketIndex, "Starting new bucket index {0} for ordered messages to grain {1}", index, msg.TargetGrain);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.ProxyClient_NewBucketIndex, "Starting new bucket index {0} for ordered messages to grain {1}", index, msg.TargetGrain);
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug(
                 (int)ErrorCode.ProxyClient_CreatedGatewayToGrain,

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -153,7 +153,7 @@ namespace Orleans.Messaging
         {
             if (!Running)
             {
-                this.logger.Error(ErrorCode.ProxyClient_MsgCtrNotRunning, $"Ignoring {msg} because the Client message center is not running");
+                this.logger.LogError((int)ErrorCode.ProxyClient_MsgCtrNotRunning, $"Ignoring {msg} because the Client message center is not running");
                 return;
             }
 

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -299,8 +299,8 @@ namespace Orleans.Messaging
 
                 if (live.Count == 0)
                 {
-                    logger.Warn(
-                        ErrorCode.GatewayManager_AllGatewaysDead,
+                    logger.LogWarning(
+                        (int)ErrorCode.GatewayManager_AllGatewaysDead,
                         "All gateways have previously been marked as dead. Clearing the list of dead gateways to expedite reconnection.");
                     live.AddRange(knownGateways);
                     knownDead.Clear();

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -240,7 +240,7 @@ namespace Orleans.Messaging
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.ProxyClient_GetGateways, "Exception occurred during RefreshSnapshotLiveGateways_TimerCallback -> listProvider.GetGateways()", exc);
+                logger.LogError((int)ErrorCode.ProxyClient_GetGateways, exc, "Exception occurred during RefreshSnapshotLiveGateways_TimerCallback -> listProvider.GetGateways()");
             }
         }
 

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -314,7 +314,7 @@ namespace Orleans.Messaging
                 lastRefreshTime = now;
                 if (logger.IsEnabled(LogLevel.Information))
                 {
-                    logger.Info(ErrorCode.GatewayManager_FoundKnownGateways,
+                    logger.LogInformation((int)ErrorCode.GatewayManager_FoundKnownGateways,
                             "Refreshed the live gateway list. Found {0} gateways from gateway list provider: {1}. Picked only known live out of them. Now has {2} live gateways: {3}. Previous refresh time was = {4}",
                             knownGateways.Count,
                             Utils.EnumerableToString(knownGateways),

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -143,7 +143,7 @@ namespace Orleans.Runtime
             response.RejectionType = type;
             response.RejectionInfo = info;
             response.BodyObject = ex;
-            if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
+            if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
             return response;
         }
 

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -135,7 +135,7 @@ namespace Orleans.Runtime.Messaging
             MessagingStatisticsGroup.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
-                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug(ErrorCode.MessagingSendingRejection, "Client is rejecting message: {Message}. Reason = {Reason}", msg, reason);
+                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.LogDebug((int)ErrorCode.MessagingSendingRejection, "Client is rejecting message: {Message}. Reason = {Reason}", msg, reason);
                 // Done retrying, send back an error instead
                 this.SendRejection(msg, Message.RejectionTypes.Transient, $"Client is rejecting message: {msg}. Reason = {reason}");
             }

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -141,7 +141,7 @@ namespace Orleans.Runtime.Messaging
             }
             else
             {
-                this.Log.Info(ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Client is dropping message: {<essage}. Reason = {Reason}", msg, reason);
+                this.Log.LogInformation((int)ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Client is dropping message: {Message}. Reason = {Reason}", msg, reason);
                 MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.CodeGeneration;
 using Orleans.Transactions;
 
@@ -55,7 +56,7 @@ namespace Orleans.Runtime
             string messageHistory = msg.GetTargetHistory();
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             string errorMsg = $"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}Target History is: {messageHistory}.";
-            this.shared.Logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
+            this.shared.Logger.LogWarning((int)ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = Message.CreatePromptExceptionResponse(msg, new TimeoutException(errorMsg));
             OnFail(msg, error, isOnTimeout: true);
@@ -71,7 +72,7 @@ namespace Orleans.Runtime
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             string errorMsg = 
                 $"The target silo became unavailable for message: {msg}. {statusMessage}Target History is: {messageHistory}. See {Constants.TroubleshootingHelpLink} for troubleshooting help.";
-            this.shared.Logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
+            this.shared.Logger.LogWarning((int)ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = Message.CreatePromptExceptionResponse(msg, new SiloUnavailableException(errorMsg));
             OnFail(msg, error, isOnTimeout: false);

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -159,7 +159,7 @@ namespace Orleans
                     this.Running = true;
                 }
 
-                if (_manager.logger.IsEnabled(LogLevel.Trace)) _manager.logger.Trace($"InvokeLocalObjectAsync {message} start {start}");
+                if (_manager.logger.IsEnabled(LogLevel.Trace)) _manager.logger.LogTrace($"InvokeLocalObjectAsync {message} start {start}");
 
                 if (start)
                 {

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -283,7 +283,7 @@ namespace Orleans
                 callbacks.TryAdd(message.Id, callbackData);
             }
 
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Send {0}", message);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Send {0}", message);
             MessageCenter.SendMessage(message);
         }
 
@@ -291,7 +291,7 @@ namespace Orleans
         {
             OrleansOutsideRuntimeClientEvent.Log.ReceiveResponse(response);
 
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Received {0}", response);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Received {0}", response);
 
             // ignore duplicate requests
             if (response.Result == Message.ResponseTypes.Rejection

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -344,7 +344,7 @@ namespace Orleans
             }
             else
             {
-                logger.Warn(ErrorCode.Runtime_Error_100011, "No callback for response message: " + response);
+                logger.LogWarning((int)ErrorCode.Runtime_Error_100011, "No callback for response message: " + response);
             }
         }
 

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -139,12 +139,12 @@ namespace Orleans
                 this.localAddress = this.clientMessagingOptions.LocalAddress ?? ConfigUtilities.GetLocalIPAddress(this.clientMessagingOptions.PreferredFamily, this.clientMessagingOptions.NetworkInterfaceName);
 
                 // Client init / sign-on message
-                logger.Info(ErrorCode.ClientInitializing, string.Format(
+                logger.LogInformation((int)ErrorCode.ClientInitializing, string.Format(
                     "{0} Initializing OutsideRuntimeClient on {1} at {2} Client Id = {3} {0}",
                     BARS, Dns.GetHostName(), localAddress,  clientId));
                 string startMsg = string.Format("{0} Starting OutsideRuntimeClient with runtime Version='{1}' in AppDomain={2}",
                     BARS, RuntimeVersion.Current, PrintAppDomainDetails());
-                logger.Info(ErrorCode.ClientStarting, startMsg);
+                logger.LogInformation((int)ErrorCode.ClientStarting, startMsg);
 
                 if (TestOnlyThrowExceptionDuringInit)
                 {
@@ -173,7 +173,7 @@ namespace Orleans
             // This helps to avoid any issues (such as deadlocks) caused by executing with the client's synchronization context/scheduler.
             await Task.Run(() => this.StartInternal(retryFilter)).ConfigureAwait(false);
 
-            logger.Info(ErrorCode.ProxyClient_StartDone, "{0} Started OutsideRuntimeClient with Global Client ID: {1}", BARS, CurrentActivationAddress.ToString() + ", client ID: " + clientId);
+            logger.LogInformation((int)ErrorCode.ProxyClient_StartDone, "{0} Started OutsideRuntimeClient with Global Client ID: {1}", BARS, CurrentActivationAddress.ToString() + ", client ID: " + clientId);
         }
         
         // used for testing to (carefully!) allow two clients in the same process
@@ -359,7 +359,7 @@ namespace Orleans
             {
                 if (logger != null)
                 {
-                    logger.Info("OutsideRuntimeClient.Reset(): client Id " + clientId);
+                    logger.LogInformation("OutsideRuntimeClient.Reset(): client Id " + clientId);
                 }
             }, this.logger);
 
@@ -391,7 +391,7 @@ namespace Orleans
             {
                 if (logger != null)
                 {
-                    logger.Info("OutsideRuntimeClient.ConstructorReset(): client Id " + clientId);
+                    logger.LogInformation("OutsideRuntimeClient.ConstructorReset(): client Id " + clientId);
                 }
             });
             

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -159,7 +159,7 @@ namespace Orleans
             }
             catch (Exception exc)
             {
-                if (logger != null) logger.Error(ErrorCode.Runtime_Error_100319, "OutsideRuntimeClient constructor failed.", exc);
+                if (logger != null) logger.LogError((int)ErrorCode.Runtime_Error_100319, exc, "OutsideRuntimeClient constructor failed.");
                 ConstructorReset();
                 throw;
             }
@@ -231,7 +231,7 @@ namespace Orleans
                         break;
                     }
                 default:
-                    logger.Error(ErrorCode.Runtime_Error_100327, $"Message not supported: {message}.");
+                    logger.LogError((int)ErrorCode.Runtime_Error_100327, $"Message not supported: {message}.");
                     break;
             }
         }
@@ -489,7 +489,7 @@ namespace Orleans
             }
             catch (Exception ex)
             {
-                this.logger.Error(ErrorCode.ClientError, "Error when sending cluster disconnection notification", ex);
+                this.logger.LogError((int)ErrorCode.ClientError, ex, "Error when sending cluster disconnection notification");
             }
         }
 
@@ -502,7 +502,7 @@ namespace Orleans
             }
             catch (Exception ex)
             {
-                this.logger.Error(ErrorCode.ClientError, "Error when sending gateway count changed notification", ex);
+                this.logger.LogError((int)ErrorCode.ClientError, ex, "Error when sending gateway count changed notification");
             }
         }
 

--- a/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
@@ -94,7 +94,7 @@ namespace Orleans.Runtime
                         }
                         catch (Exception exc)
                         {
-                            this.Log.Error(ErrorCode.Runtime_Error_100027, "Unable to restart AsynchAgent", exc);
+                            this.Log.LogError((int)ErrorCode.Runtime_Error_100027, exc, "Unable to restart AsynchAgent");
                             this.State = AgentState.Stopped;
                         }
                     }
@@ -183,7 +183,7 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exc)
                 {
-                    Log.Error(ErrorCode.Runtime_Error_100027, "Unable to restart AsynchAgent", exc);
+                    Log.LogError((int)ErrorCode.Runtime_Error_100027, exc, "Unable to restart AsynchAgent");
                     State = AgentState.Stopped;
                 }
             }
@@ -197,10 +197,10 @@ namespace Orleans.Runtime
             switch (OnFault)
             {
                 case FaultBehavior.IgnoreFault:
-                    Log.Error(ErrorCode.Runtime_Error_100025, $"{logMessagePrefix} The executor will exit.", exc);
+                    Log.LogError((int)ErrorCode.Runtime_Error_100025, exc, $"{logMessagePrefix} The executor will exit.");
                     break;
                 case FaultBehavior.RestartOnFault:
-                    Log.Error(ErrorCode.Runtime_Error_100026, $"{logMessagePrefix} The Stage will be restarted.", exc);
+                    Log.LogError((int)ErrorCode.Runtime_Error_100026, exc, $"{logMessagePrefix} The Stage will be restarted.");
                     break;
                 default:
                     throw new NotImplementedException();

--- a/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
 
             Task.Run(() => this.StartAsync()).Ignore();
 
-            if (Log.IsEnabled(LogLevel.Debug)) Log.Debug("Started asynch agent " + this.Name);
+            if (Log.IsEnabled(LogLevel.Debug)) Log.LogDebug("Started asynch agent " + this.Name);
         }
 
         private async Task StartAsync()
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
                     {
                         try
                         {
-                            if (Log.IsEnabled(LogLevel.Debug)) Log.Debug("Run completed on agent " + this.Name + " - restarting");
+                            if (Log.IsEnabled(LogLevel.Debug)) Log.LogDebug("Run completed on agent " + this.Name + " - restarting");
                             this.Start();
                         }
                         catch (Exception exc)
@@ -123,9 +123,9 @@ namespace Orleans.Runtime
             catch (Exception exc)
             {
                 // ignore. Just make sure stop does not throw.
-                Log.Debug("Ignoring error during Stop: {0}", exc);
+                Log.LogDebug(exc, "Ignoring error during Stop");
             }
-            Log.Debug("Stopped agent");
+            Log.LogDebug("Stopped agent");
         }
 
         public void Dispose()

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -634,7 +634,7 @@ namespace Orleans.Serialization
                     var source = (byte[])original;
                     if (source.Length > this.LargeObjectSizeThreshold)
                     {
-                        logger.Info(ErrorCode.Ser_LargeObjectAllocated,
+                        logger.LogInformation((int)ErrorCode.Ser_LargeObjectAllocated,
                             "Large byte array of size {0} is being copied. This will result in an allocation on the large object heap. " +
                             "Frequent allocations to the large object heap can result in frequent gen2 garbage collections and poor system performance. " +
                             "Please consider using Immutable<byte[]> instead.", source.Length);
@@ -650,7 +650,7 @@ namespace Orleans.Serialization
                     // Only check the size for primitive types because otherwise Buffer.ByteLength throws
                     if (et.IsPrimitive && Buffer.ByteLength(originalArray) > this.LargeObjectSizeThreshold)
                     {
-                        logger.Info(ErrorCode.Ser_LargeObjectAllocated,
+                        logger.LogInformation((int)ErrorCode.Ser_LargeObjectAllocated,
                             $"Large {t.OrleansTypeName()} array of total byte size {Buffer.ByteLength(originalArray)} is being copied. This will result in an allocation on the large object heap. " +
                             "Frequent allocations to the large object heap can result in frequent gen2 garbage collections and poor system performance. " +
                             $"Please consider using Immutable<{t.OrleansTypeName()}> instead.");

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -338,8 +338,8 @@ namespace Orleans.Serialization
             if (serializer == null && deserializer == null && copier == null)
             {
                 var msg = $"No serialization methods found on type {serializerType.GetParseableName(TypeFormattingOptions.LogFormat)}.";
-                logger.Warn(
-                    ErrorCode.SerMgr_SerializationMethodsMissing,
+                logger.LogWarning(
+                    (int)ErrorCode.SerMgr_SerializationMethodsMissing,
                     msg);
                 throw new ArgumentException(msg);
             }
@@ -350,8 +350,8 @@ namespace Orleans.Serialization
                     $"Inconsistency between serializer and deserializer methods on type {serializerType.GetParseableName(TypeFormattingOptions.LogFormat)}."
                     + " Either both must be specified or both must be null. "
                     + $"Instead, serializer = {serializer?.ToString() ?? "null"} and deserializer = {deserializer?.ToString() ?? "null"}";
-                logger.Warn(
-                    ErrorCode.SerMgr_SerializationMethodsMissing,
+                logger.LogWarning(
+                    (int)ErrorCode.SerMgr_SerializationMethodsMissing,
                     msg);
                 throw new ArgumentException(msg);
             }
@@ -398,8 +398,8 @@ namespace Orleans.Serialization
             }
             catch (ArgumentException)
             {
-                logger.Warn(
-                    ErrorCode.SerMgr_ErrorBindingMethods,
+                logger.LogWarning(
+                    (int)ErrorCode.SerMgr_ErrorBindingMethods,
                     "Error binding serialization methods for type {0}",
                     type.GetParseableName());
                 throw;

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1732,7 +1732,7 @@ namespace Orleans.Serialization
                     }
                     catch (Exception exception)
                     {
-                        logger.Error(ErrorCode.SerMgr_ErrorLoadingAssemblyTypes, "Failed to create instance of type: " + type.FullName, exception);
+                        logger.LogError((int)ErrorCode.SerMgr_ErrorLoadingAssemblyTypes, exception, "Failed to create instance of type: " + type.FullName);
                     }
                 });
 

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -264,7 +264,7 @@ namespace Orleans.Serialization
                         }
                     }
 
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Registered type {0} as {1}", t, name);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Registered type {0} as {1}", t, name);
                 }
             }
 
@@ -305,7 +305,7 @@ namespace Orleans.Serialization
                 registeredTypes.Add(t);
                 types[name] = t;
             }
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Registered type {0} as {1}", t, name);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Registered type {0} as {1}", t, name);
 
             // Register any interfaces this type implements, in order to support passing values that are statically of the interface type
             // but dynamically of this (implementation) type
@@ -406,7 +406,7 @@ namespace Orleans.Serialization
             }
 
             if (this.logger.IsEnabled(LogLevel.Trace))
-                this.logger.Trace(
+                this.logger.LogTrace(
                     "Loaded serialization info for type {0} from assembly {1}",
                     type.Name,
                     serializerType.Assembly.GetName().Name);

--- a/src/Orleans.Core/Statistics/LogStatistics.cs
+++ b/src/Orleans.Core/Statistics/LogStatistics.cs
@@ -95,7 +95,7 @@ namespace Orleans.Runtime
             if (counterData == null)
             {
                 // Flush remaining data
-                logger.Info(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                logger.LogInformation((int)ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
                 logMsgBuilder.Clear();
                 return;
             }
@@ -107,7 +107,7 @@ namespace Orleans.Runtime
             {
                 // Flush pending data and start over
                 logMsgBuilder.AppendLine(STATS_LOG_POSTFIX);
-                logger.Info(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                logger.LogInformation((int)ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
                 logMsgBuilder.Clear();
             }
 

--- a/src/Orleans.Core/Statistics/LogStatistics.cs
+++ b/src/Orleans.Core/Statistics/LogStatistics.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime
             catch (Exception exc)
             {
                 var e = exc.GetBaseException();
-                this.logger.Error(ErrorCode.Runtime_Error_100101, "Exception occurred during LogStatistics reporter.", e);
+                this.logger.LogError((int)ErrorCode.Runtime_Error_100101, e, "Exception occurred during LogStatistics reporter.");
             }
 
             return Task.CompletedTask;

--- a/src/Orleans.Core/Statistics/NoOpHostEnvironmentStatistics.cs
+++ b/src/Orleans.Core/Statistics/NoOpHostEnvironmentStatistics.cs
@@ -14,8 +14,8 @@ namespace Orleans.Runtime
 
         public NoOpHostEnvironmentStatistics(ILogger<NoOpHostEnvironmentStatistics> logger)
         {
-            logger.Warn(
-                ErrorCode.PerfCounterNotRegistered,
+            logger.LogWarning(
+                (int)ErrorCode.PerfCounterNotRegistered,
                 "No implementation of IHostEnvironmentStatistics was found. Load shedding will not work yet");
         }
     }

--- a/src/Orleans.Core/Statistics/ThreadCycleStopWatch.cs
+++ b/src/Orleans.Core/Statistics/ThreadCycleStopWatch.cs
@@ -87,7 +87,7 @@ namespace Orleans.Runtime
             else
             {
                 if (logger.IsEnabled(LogLevel.Trace))
-                    logger.Trace(0,
+                    logger.LogTrace(0,
                         $"Invalid cycle counts startCycles = {startCycles}, stopCycles = {stopCycles}");
 
                 // Some threadpool threads seem to be reset, this is normal with .NET threadpool threads as its assumed they are restart out of our control

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime
             this.dueTime = due;
             totalNumTicks = 0;
             this.logger = logger;
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.TimerChanging, "Creating timer {0} with dueTime={1} period={2}", GetFullName(), due, period);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.TimerChanging, "Creating timer {0} with dueTime={1} period={2}", GetFullName(), due, period);
 
             timer = NonCapturingTimer.Create(HandleTimerCallback, state, Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
         }
@@ -101,7 +101,7 @@ namespace Orleans.Runtime
                 {
                     var t = timer;
                     timer = null;
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.TimerDisposing, "Disposing timer {0}", GetFullName());
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.TimerDisposing, "Disposing timer {0}", GetFullName());
                     t.Dispose();
 
                 }
@@ -179,7 +179,7 @@ namespace Orleans.Runtime
 
             timerFrequency = period;
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.TimerChanging, "Changing timer {0} to dueTime={1} period={2}", GetFullName(), newDueTime, period);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.TimerChanging, "Changing timer {0} to dueTime={1} period={2}", GetFullName(), newDueTime, period);
 
             try
             {

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -156,7 +156,7 @@ namespace Orleans.Runtime
 
             if(freezeCheck)
             {
-                logger.Error(errorCode, errMsg);
+                logger.LogError((int)errorCode, errMsg);
             }else
             {
                 logger.LogWarning((int)errorCode, errMsg);
@@ -292,8 +292,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.TimerQueueTickError,
-                    string.Format("Error queueing next timer tick - WARNING: timer {0} is now stopped", GetFullName()), exc);
+                logger.LogError((int)ErrorCode.TimerQueueTickError, exc, "Error queueing next timer tick - WARNING: timer {0} is now stopped", GetFullName());
             }
         }
     }

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -213,9 +213,9 @@ namespace Orleans.Runtime
         {
             try
             {
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerBeforeCallback, "About to make sync timer callback for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerBeforeCallback, "About to make sync timer callback for timer {0}", GetFullName());
                 syncCallbackFunc(state);
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerAfterCallback, "Completed sync timer callback for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerAfterCallback, "Completed sync timer callback for timer {0}", GetFullName());
             }
             catch (Exception exc)
             {
@@ -244,9 +244,9 @@ namespace Orleans.Runtime
 
             try
             {
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerBeforeCallback, "About to make async task timer callback for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerBeforeCallback, "About to make async task timer callback for timer {0}", GetFullName());
                 await asyncTaskCallback(state);
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerAfterCallback, "Completed async task timer callback for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerAfterCallback, "Completed async task timer callback for timer {0}", GetFullName());
             }
             catch (Exception exc)
             {
@@ -269,20 +269,20 @@ namespace Orleans.Runtime
 
                 totalNumTicks++;
 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerChanging, "About to QueueNextTimerTick for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerChanging, "About to QueueNextTimerTick for timer {0}", GetFullName());
 
                 if (timerFrequency == Constants.INFINITE_TIMESPAN)
                 {
                     //timer.Change(Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
                     DisposeTimer();
 
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerStopped, "Timer {0} is now stopped and disposed", GetFullName());
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerStopped, "Timer {0} is now stopped and disposed", GetFullName());
                 }
                 else
                 {
                     timer.Change(timerFrequency, Constants.INFINITE_TIMESPAN);
 
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerNextTick, "Queued next tick for timer {0} in {1}", GetFullName(), timerFrequency);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerNextTick, "Queued next tick for timer {0} in {1}", GetFullName(), timerFrequency);
                 }
             }
             catch (ObjectDisposedException ode)

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -107,8 +107,8 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exc)
                 {
-                    logger.Warn(ErrorCode.TimerDisposeError,
-                        string.Format("Ignored error disposing timer {0}", GetFullName()), exc);
+                    logger.LogWarning((int)ErrorCode.TimerDisposeError, exc,
+                        "Ignored error disposing timer {0}", GetFullName());
                 }
             }
         }
@@ -159,7 +159,7 @@ namespace Orleans.Runtime
                 logger.Error(errorCode, errMsg);
             }else
             {
-                logger.Warn(errorCode, errMsg);
+                logger.LogWarning((int)errorCode, errMsg);
             }
             return false;
         }
@@ -188,8 +188,8 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Warn(ErrorCode.TimerChangeError,
-                    string.Format("Error changing timer period - timer {0} not changed", GetFullName()), exc);
+                logger.LogWarning((int)ErrorCode.TimerChangeError, exc,
+                    "Error changing timer period - timer {0} not changed", GetFullName());
                 return false;
             }
         }
@@ -219,7 +219,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Warn(ErrorCode.TimerCallbackError, string.Format("Ignored exception {0} during sync timer callback {1}", exc.Message, GetFullName()), exc);
+                logger.LogWarning((int)ErrorCode.TimerCallbackError, exc, "Ignored exception {0} during sync timer callback {1}", exc.Message, GetFullName());
             }
             finally
             {
@@ -250,7 +250,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Warn(ErrorCode.TimerCallbackError, string.Format("Ignored exception {0} during async task timer callback {1}", exc.Message, GetFullName()), exc);
+                logger.LogWarning((int)ErrorCode.TimerCallbackError, exc, "Ignored exception {0} during async task timer callback {1}", exc.Message, GetFullName());
             }
             finally
             {
@@ -287,8 +287,8 @@ namespace Orleans.Runtime
             }
             catch (ObjectDisposedException ode)
             {
-                logger.Warn(ErrorCode.TimerDisposeError,
-                    string.Format("Timer {0} already disposed - will not queue next timer tick", GetFullName()), ode);
+                logger.LogWarning((int)ErrorCode.TimerDisposeError, ode,
+                    "Timer {0} already disposed - will not queue next timer tick", GetFullName());
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Core/Utils/Utils.cs
+++ b/src/Orleans.Core/Utils/Utils.cs
@@ -243,8 +243,8 @@ namespace Orleans.Runtime
 
                         foreach (var e in exc.FlattenAggregate())
                         {
-                            logger.Warn(ErrorCode.Runtime_Error_100325,
-                                $"Ignoring {e.GetType().FullName} exception thrown from an action called by {caller ?? String.Empty}.", exc);
+                            logger.LogWarning((int)ErrorCode.Runtime_Error_100325, exc,
+                                $"Ignoring {e.GetType().FullName} exception thrown from an action called by {caller ?? String.Empty}.");
                         }
                     }
                     catch

--- a/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
@@ -42,7 +42,7 @@ namespace Orleans.Runtime.LogConsistency
         public void ProtocolError(string msg, bool throwexception)
         {
 
-            log?.Error((int)(throwexception ? ErrorCode.LogConsistency_ProtocolFatalError : ErrorCode.LogConsistency_ProtocolError),
+            log?.LogError((int)(throwexception ? ErrorCode.LogConsistency_ProtocolFatalError : ErrorCode.LogConsistency_ProtocolError),
                 string.Format("{0} Protocol Error: {1}",
                     grain.GrainReference,
                     msg));
@@ -55,10 +55,9 @@ namespace Orleans.Runtime.LogConsistency
 
         public void CaughtException(string where, Exception e)
         {
-            log?.Error((int)ErrorCode.LogConsistency_CaughtException,
-               string.Format("{0} Exception Caught at {1}",
-                   grain.GrainReference,
-                   where),e);
+            log?.LogError((int)ErrorCode.LogConsistency_CaughtException, e, "{0} Exception Caught at {1}",
+                grain.GrainReference,
+                @where);
         }
 
         public void CaughtUserCodeException(string callback, string where, Exception e)

--- a/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
@@ -63,11 +63,11 @@ namespace Orleans.Runtime.LogConsistency
 
         public void CaughtUserCodeException(string callback, string where, Exception e)
         {
-            log?.Warn((int)ErrorCode.LogConsistency_UserCodeException,
-                string.Format("{0} Exception caught in user code for {1}, called from {2}",
+            log?.LogWarning((int)ErrorCode.LogConsistency_UserCodeException, e,
+                "{0} Exception caught in user code for {1}, called from {2}",
                    grain.GrainReference,
                    callback,
-                   where), e);
+                   where);
         }
 
         public void Log(LogLevel level, string format, params object[] args)

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -191,7 +191,7 @@ namespace Orleans.Runtime
                             // If the activation is already in Deactivating or Invalid state, its already being collected or was collected 
                             // (both mean a bug, this activation should not be in the collector)
                             // So in any state except for Valid we should just not collect and not reschedule.
-                            logger.Warn(ErrorCode.Catalog_ActivationCollector_BadState_1,
+                            logger.LogWarning((int)ErrorCode.Catalog_ActivationCollector_BadState_1,
                                 "ActivationCollector found an activation in a non Valid state. All activation inside the ActivationCollector should be in Valid state. Activation: {0}",
                                 activation.ToDetailedString());
                         }
@@ -203,7 +203,7 @@ namespace Orleans.Runtime
                         else if (!activation.IsInactive)
                         {
                             // This is essentialy a bug, an active activation should not be in the last bucket.
-                            logger.Warn(ErrorCode.Catalog_ActivationCollector_BadState_2,
+                            logger.LogWarning((int)ErrorCode.Catalog_ActivationCollector_BadState_2,
                                 "ActivationCollector found an active activation in it's last bucket. This is violation of ActivationCollector invariants. " +
                                 "For now going to defer it's collection. Activation: {0}",
                                 activation.ToDetailedString());
@@ -212,7 +212,7 @@ namespace Orleans.Runtime
                         else if (!activation.IsStale(now))
                         {
                             // This is essentialy a bug, a non stale activation should not be in the last bucket.
-                            logger.Warn(ErrorCode.Catalog_ActivationCollector_BadState_3,
+                            logger.LogWarning((int)ErrorCode.Catalog_ActivationCollector_BadState_3,
                                 "ActivationCollector found a non stale activation in it's last bucket. This is violation of ActivationCollector invariants. Now: {0}" +
                                 "For now going to defer it's collection. Activation: {1}",
                                 LogFormatter.PrintDate(now),

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -356,13 +356,13 @@ namespace Orleans.Runtime
             {
                 if (State == ActivationState.Invalid)
                 {
-                    logger.Warn(ErrorCode.Dispatcher_InvalidActivation,
+                    logger.LogWarning((int)ErrorCode.Dispatcher_InvalidActivation,
                         "Cannot enqueue message to invalid activation {0} : {1}", this.ToDetailedString(), message);
                     return EnqueueMessageResult.ErrorInvalidActivation;
                 }
                 if (State == ActivationState.FailedToActivate)
                 {
-                    logger.Warn(ErrorCode.Dispatcher_InvalidActivation,
+                    logger.LogWarning((int)ErrorCode.Dispatcher_InvalidActivation,
                         "Cannot enqueue message to activation that failed in OnActivate {0} : {1}", this.ToDetailedString(), message);
                     return EnqueueMessageResult.ErrorActivateFailed;
                 }
@@ -388,7 +388,7 @@ namespace Orleans.Runtime
                     // Consider: Handle long request detection for reentrant activations -- this logic only works for non-reentrant activations
                     else if (currentRequestActiveTime > maxWarningRequestProcessingTime)
                     {
-                        logger.Warn(ErrorCode.Dispatcher_ExtendedMessageProcessing,
+                        logger.LogWarning((int)ErrorCode.Dispatcher_ExtendedMessageProcessing,
                              "Current request has been active for {0} for activation {1}. Currently executing {2}. Trying  to enqueue {3}.",
                              currentRequestActiveTime, this.ToDetailedString(), this.Blocking, message);
                     }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -371,7 +371,7 @@ namespace Orleans.Runtime
                     var deactivatingTime = DateTime.UtcNow - deactivationStartTime;
                     if (deactivatingTime > maxRequestProcessingTime)
                     {
-                        logger.Error(ErrorCode.Dispatcher_StuckActivation,
+                        logger.LogError((int)ErrorCode.Dispatcher_StuckActivation,
                             $"Current activation {ToDetailedString()} marked as Deactivating for {deactivatingTime}. Trying to enqueue {message}.");
                         return EnqueueMessageResult.ErrorStuckActivation;
                     }
@@ -381,7 +381,7 @@ namespace Orleans.Runtime
                     var currentRequestActiveTime = DateTime.UtcNow - currentRequestStartTime;
                     if (currentRequestActiveTime > maxRequestProcessingTime)
                     {
-                        logger.Error(ErrorCode.Dispatcher_StuckActivation,
+                        logger.LogError((int)ErrorCode.Dispatcher_StuckActivation,
                             $"Current request has been active for {currentRequestActiveTime} for activation {ToDetailedString()}. Currently executing {this.Blocking}. Trying to enqueue {message}.");
                         return EnqueueMessageResult.ErrorStuckActivation;
                     }

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -29,14 +29,14 @@ namespace Orleans.Runtime
 
         internal void IncrementGrainCounter(string grainTypeName)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Increment Grain Counter {0}", grainTypeName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Increment Grain Counter {0}", grainTypeName);
             CounterStatistic ctr = FindGrainCounter(grainTypeName);
             ctr.Increment();
         }
 
         internal void DecrementGrainCounter(string grainTypeName)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Decrement Grain Counter {0}", grainTypeName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Decrement Grain Counter {0}", grainTypeName);
             CounterStatistic ctr = FindGrainCounter(grainTypeName);
             ctr.DecrementBy(1);
         }

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -148,7 +148,7 @@ namespace Orleans.Runtime
                 string stats = Utils.EnumerableToString(all.Select(i => i.Value).OrderBy(act => act.Name), act => string.Format("++{0}", act.DumpStatus()), Environment.NewLine);
                 if (stats.Length > 0)
                 {
-                    logger.Info(ErrorCode.Catalog_ActivationDirectory_Statistics, $"ActivationDirectory.PrintActivationDirectory(): Size = { all.Count}, Directory:{Environment.NewLine}{stats}");
+                    logger.LogInformation((int)ErrorCode.Catalog_ActivationDirectory_Statistics, $"ActivationDirectory.PrintActivationDirectory(): Size = { all.Count}, Directory:{Environment.NewLine}{stats}");
                 }
             }
         }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -905,8 +905,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Catalog_ErrorCallingActivate,
-                    string.Format("Error calling grain's OnActivateAsync() method - Grain type = {1} Activation = {0}", activation, grainTypeName), exc);
+                logger.LogError((int)ErrorCode.Catalog_ErrorCallingActivate, exc, string.Format("Error calling grain's OnActivateAsync() method - Grain type = {1} Activation = {0}", activation, grainTypeName));
 
                 activationsFailedToActivate.Increment();
 
@@ -949,13 +948,12 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exc)
                 {
-                    logger.Error(ErrorCode.Catalog_ErrorCallingDeactivate,
-                        string.Format("Error calling grain's OnDeactivateAsync() method - Grain type = {1} Activation = {0}", activation, grainTypeName), exc);
+                    logger.LogError((int)ErrorCode.Catalog_ErrorCallingDeactivate, exc, string.Format("Error calling grain's OnDeactivateAsync() method - Grain type = {1} Activation = {0}", activation, grainTypeName));
                 }
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Catalog_FinishGrainDeactivateAndCleanupStreams_Exception, String.Format("CallGrainDeactivateAndCleanupStreams Activation = {0} failed.", activation), exc);
+                logger.LogError((int)ErrorCode.Catalog_FinishGrainDeactivateAndCleanupStreams_Exception, exc, String.Format("CallGrainDeactivateAndCleanupStreams Activation = {0} failed.", activation));
             }
             return activation;
         }
@@ -1129,8 +1127,7 @@ namespace Orleans.Runtime
                         }
                         catch (Exception exc)
                         {
-                            logger.Error(ErrorCode.Catalog_SiloStatusChangeNotification_Exception,
-                                String.Format("Catalog has thrown an exception while executing OnSiloStatusChange of silo {0}.", updatedSilo.ToStringWithHashCode()), exc);
+                            logger.LogError((int)ErrorCode.Catalog_SiloStatusChangeNotification_Exception, exc, String.Format("Catalog has thrown an exception while executing OnSiloStatusChange of silo {0}.", updatedSilo.ToStringWithHashCode()));
                         }
                     }
                 }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -455,7 +455,7 @@ namespace Orleans.Runtime
             {
                 if (failedActivations.TryGetValue(address, out var ex))
                 {
-                    logger.Warn(ErrorCode.Catalog_ActivationException, "Call to an activation that failed during OnActivateAsync()");
+                    logger.LogWarning((int)ErrorCode.Catalog_ActivationException, "Call to an activation that failed during OnActivateAsync()");
                     ex.Throw();
                 }
 
@@ -606,10 +606,9 @@ namespace Orleans.Runtime
                     }
                     catch (Exception ex)
                     {
-                        logger.Warn(
-                            ErrorCode.Catalog_UnregisterAsync,
-                            $"Failed to unregister activation {activation} after {initStage} stage failed",
-                            ex);
+                        logger.LogWarning(
+                            (int)ErrorCode.Catalog_UnregisterAsync, ex,
+                            $"Failed to unregister activation {activation} after {initStage} stage failed");
                     }
                 }
                 lock (activation)
@@ -619,7 +618,7 @@ namespace Orleans.Runtime
                     {
                         failedActivations.Add(activation.Address, ExceptionDispatchInfo.Capture(exception));
                         activation.SetState(ActivationState.FailedToActivate);
-                        logger.Warn(ErrorCode.Catalog_Failed_InvokeActivate, string.Format("Failed to InvokeActivate for {0}.", activation), exception);
+                        logger.LogWarning((int)ErrorCode.Catalog_Failed_InvokeActivate, exception, "Failed to InvokeActivate for {Activation}", activation);
                         // Reject all of the messages queued for this activation.
                         var activationFailedMsg = nameof(Grain.OnActivateAsync) + " failed";
                         RejectAllQueuedMessages(activation, activationFailedMsg, exception);
@@ -627,7 +626,7 @@ namespace Orleans.Runtime
                     else
                     {
                         activation.SetState(ActivationState.Invalid);
-                        logger.Warn(ErrorCode.Runtime_Error_100064, $"Failed to RegisterActivationInGrainDirectory for {activation}.", exception);
+                        logger.LogWarning((int)ErrorCode.Runtime_Error_100064, exception, "Failed to RegisterActivationInGrainDirectory for {Activation}", activation);
                         RerouteAllQueuedMessages(activation, null, "Failed RegisterActivationInGrainDirectory", exception);
                     }
                 }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -206,7 +206,7 @@ namespace Orleans.Runtime
             if (list != null && list.Count > 0)
             {
                 count = list.Count;
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("CollectActivations{0}", list.ToStrings(d => d.GrainId.ToString() + d.ActivationId));
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("CollectActivations{0}", list.ToStrings(d => d.GrainId.ToString() + d.ActivationId));
                 await DeactivateActivationsFromCollector(list);
             }
             
@@ -535,7 +535,7 @@ namespace Orleans.Runtime
 
                     // Success!! Log the result, and start processing messages
                     initStage = ActivationInitializationStage.Completed;
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("InitActivation is done: {0}", activation.Address);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("InitActivation is done: {0}", activation.Address);
                 }
                 catch (Exception ex)
                 {
@@ -585,7 +585,7 @@ namespace Orleans.Runtime
                                 $"GrainInstance Type is {activation.GrainInstance?.GetType()}. " +
                                 $"{(primary != null ? "Primary Directory partition for this grain is " + primary + ". " : string.Empty)}" +
                                 $"Full activation address is {address.ToFullString()}. We have {activation.WaitingCount} messages to forward.";
-                            logger.Debug(ErrorCode.Catalog_DuplicateActivation, logMsg);
+                            logger.LogDebug((int)ErrorCode.Catalog_DuplicateActivation, logMsg);
                         }
 
                         UnregisterMessageTarget(activation);
@@ -834,7 +834,7 @@ namespace Orleans.Runtime
         {
             if (list == null || list.Count == 0) return;
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("DeactivateActivations: {0} activations.", list.Count);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("DeactivateActivations: {0} activations.", list.Count);
 
             await Task.WhenAll(list.Select(DeactivateActivation));
         }
@@ -853,7 +853,7 @@ namespace Orleans.Runtime
                 List<Message> msgs = activation.DequeueAllWaitingMessages();
                 if (msgs == null || msgs.Count <= 0) return;
 
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_RerouteAllQueuedMessages, String.Format("RerouteAllQueuedMessages: {0} msgs from Invalid activation {1}.", msgs.Count, activation));
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Catalog_RerouteAllQueuedMessages, String.Format("RerouteAllQueuedMessages: {0} msgs from Invalid activation {1}.", msgs.Count, activation));
                 this.directory.InvalidateCacheEntry(activation.Address);
                 this.Dispatcher.ProcessRequestsToInvalidActivation(msgs, activation.Address, forwardingAddress, failedOperation, exc);
             }
@@ -876,8 +876,8 @@ namespace Orleans.Runtime
                 if (msgs == null || msgs.Count <= 0) return;
 
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug(
-                        ErrorCode.Catalog_RerouteAllQueuedMessages,
+                    logger.LogDebug(
+                        (int)ErrorCode.Catalog_RerouteAllQueuedMessages,
                         string.Format("RejectAllQueuedMessages: {0} msgs from Invalid activation {1}.", msgs.Count, activation));
                 this.directory.InvalidateCacheEntry(activation.Address);
                 this.Dispatcher.ProcessRequestsToInvalidActivation(
@@ -895,14 +895,14 @@ namespace Orleans.Runtime
             var grainTypeName = activation.GrainInstance?.GetType().FullName;
 
             // Note: This call is being made from within Scheduler.Queue wrapper, so we are already executing on worker thread
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_BeforeCallingActivate, "About to call {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Catalog_BeforeCallingActivate, "About to call {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
 
             // Start grain lifecycle within try-catch wrapper to safely capture any exceptions thrown from called function
             try
             {
                 RequestContextExtensions.Import(requestContextData);
                 await activation.ActivateAsync(CancellationToken.None);
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_AfterCallingActivate, "Returned from calling {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Catalog_AfterCallingActivate, "Returned from calling {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
             }
             catch (Exception exc)
             {
@@ -934,7 +934,7 @@ namespace Orleans.Runtime
                 var grainTypeName = activation.GrainInstance?.GetType().FullName;
 
                 // Note: This call is being made from within Scheduler.Queue wrapper, so we are already executing on worker thread
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_BeforeCallingDeactivate, "About to call {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Catalog_BeforeCallingDeactivate, "About to call {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
 
                 // Call OnDeactivateAsync inline, but within try-catch wrapper to safely capture any exceptions thrown from called function
                 try
@@ -946,7 +946,7 @@ namespace Orleans.Runtime
                         RequestContext.Clear(); // Clear any previous RC, so it does not leak into this call by mistake. 
                         await activation.Lifecycle.OnStop().WithCancellation(ct);
                     }
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
                 }
                 catch (Exception exc)
                 {

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -651,7 +651,7 @@ namespace Orleans.Runtime
             var cts = new CancellationTokenSource(this.collectionOptions.Value.DeactivationTimeout);
             var mtcs = new MultiTaskCompletionSource(list.Count);
 
-            logger.Info(ErrorCode.Catalog_ShutdownActivations_1, "DeactivateActivationsFromCollector: total {0} to promptly Destroy.", list.Count);
+            logger.LogInformation((int)ErrorCode.Catalog_ShutdownActivations_1, "DeactivateActivationsFromCollector: total {0} to promptly Destroy.", list.Count);
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_COLLECTION).IncrementBy(list.Count);
 
             for (var i = 0; i < list.Count; i++)
@@ -746,7 +746,7 @@ namespace Orleans.Runtime
                     alreadBeingDestroyed = true;
                 }
             }
-            logger.Info(ErrorCode.Catalog_ShutdownActivations_2,
+            logger.LogInformation((int)ErrorCode.Catalog_ShutdownActivations_2,
                 "DeactivateActivationOnIdle: {0} {1}.", data.ToString(), promptly ? "promptly" : (alreadBeingDestroyed ? "already being destroyed or invalid" : "later when become idle"));
 
             CounterStatistic.FindOrCreate(statisticName).Increment();
@@ -841,7 +841,7 @@ namespace Orleans.Runtime
 
         public Task DeactivateAllActivations()
         {
-            logger.Info(ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
+            logger.LogInformation((int)ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
             var activationsToShutdown = activations.Where(kv => !kv.Value.IsExemptFromCollection).Select(kv => kv.Value).ToList();
             return DeactivateActivations(activationsToShutdown);
         }
@@ -1135,7 +1135,7 @@ namespace Orleans.Runtime
                         }
                     }
                 }
-                logger.Info(ErrorCode.Catalog_SiloStatusChangeNotification,
+                logger.LogInformation((int)ErrorCode.Catalog_SiloStatusChangeNotification,
                     String.Format("Catalog is deactivating {0} activations due to a failure of silo {1}, since it is a primary directory partition to these grain ids.",
                         activationsToShutdown.Count, updatedSilo.ToStringWithHashCode()));
             }

--- a/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
@@ -104,7 +104,7 @@ namespace Orleans.Runtime.ConsistentRing
                     NotifyLocalRangeSubscribers(oldRange, myRange, false);
                 }
 
-                log.Info("Added Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
+                log.LogInformation("Added Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
             }
         }
 
@@ -163,7 +163,7 @@ namespace Orleans.Runtime.ConsistentRing
                         NotifyLocalRangeSubscribers(oldRange, myRange, true);
                     }
                 }
-                log.Info("Removed Server {0} hash {1}. Current view {2}", silo, silo.GetConsistentHashCode(), this.ToString());
+                log.LogInformation("Removed Server {0} hash {1}. Current view {2}", silo, silo.GetConsistentHashCode(), this.ToString());
             }
         }
 
@@ -188,7 +188,7 @@ namespace Orleans.Runtime.ConsistentRing
 
         private void NotifyLocalRangeSubscribers(IRingRange old, IRingRange now, bool increased)
         {
-            log.Info("-NotifyLocalRangeSubscribers about old {0} new {1} increased? {2}", old, now, increased);
+            log.LogInformation("-NotifyLocalRangeSubscribers about old {0} new {1} increased? {2}", old, now, increased);
             IRingRangeListener[] copy;
             lock (statusListeners)
             {

--- a/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
@@ -283,7 +283,7 @@ namespace Orleans.Runtime.ConsistentRing
                 }
             }
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Silo {0} calculated ring partition owner silo {1} for key {2}: {3} --> {4}", MyAddress, siloAddress, hash, hash, siloAddress.GetConsistentHashCode());
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Silo {0} calculated ring partition owner silo {1} for key {2}: {3} --> {4}", MyAddress, siloAddress, hash, hash, siloAddress.GetConsistentHashCode());
             return siloAddress;
         }
 

--- a/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
@@ -97,9 +97,8 @@ namespace Orleans.Runtime.ConsistentRing
                     }
                     catch (OverflowException exc)
                     {
-                        log.Error(ErrorCode.ConsistentRingProviderBase + 5,
-                            String.Format("OverflowException: hash as int= x{0, 8:X8}, hash as uint= x{1, 8:X8}, myKey as int x{2, 8:X8}, myKey as uint x{3, 8:X8}.",
-                            hash, (uint)hash, myKey, (uint)myKey), exc);
+                        log.LogError((int)ErrorCode.ConsistentRingProviderBase + 5, exc, String.Format("OverflowException: hash as int= x{0, 8:X8}, hash as uint= x{1, 8:X8}, myKey as int x{2, 8:X8}, myKey as uint x{3, 8:X8}.",
+                            hash, (uint)hash, myKey, (uint)myKey));
                     }
                     NotifyLocalRangeSubscribers(oldRange, myRange, false);
                 }
@@ -202,9 +201,8 @@ namespace Orleans.Runtime.ConsistentRing
                 }
                 catch (Exception exc)
                 {
-                    log.Error(ErrorCode.CRP_Local_Subscriber_Exception,
-                        String.Format("Local IRangeChangeListener {0} has thrown an exception when was notified about RangeChangeNotification about old {1} new {2} increased? {3}",
-                        listener.GetType().FullName, old, now, increased), exc);
+                    log.LogError((int)ErrorCode.CRP_Local_Subscriber_Exception, exc, String.Format("Local IRangeChangeListener {0} has thrown an exception when was notified about RangeChangeNotification about old {1} new {2} increased? {3}",
+                        listener.GetType().FullName, old, now, increased));
                 }
             }
         }

--- a/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
@@ -146,7 +146,7 @@ namespace Orleans.Runtime.ConsistentRing
                 bool wasMyPred = ((myNewIndex == indexOfFailedSilo) || (myNewIndex == 0 && indexOfFailedSilo == membershipRingList.Count)); // no need for '- 1'
                 if (wasMyPred) // failed node was our predecessor
                 {
-                    if (log.IsEnabled(LogLevel.Debug)) log.Debug("Failed server was my pred? {0}, updated view {1}", wasMyPred, this.ToString());
+                    if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("Failed server was my pred? {0}, updated view {1}", wasMyPred, this.ToString());
 
                     IRingRange oldRange = myRange;
                     if (membershipRingList.Count == 1) // i'm the only one left

--- a/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -292,7 +292,7 @@ namespace Orleans.Runtime.ConsistentRing
                     s = snapshotBucketsList.Length > 1 ? snapshotBucketsList[1] : default;
                 }
             }
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Calculated ring partition owner silo {0} for key {1}: {2} --> {3}", s.SiloAddress, hash, hash, s.Hash);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Calculated ring partition owner silo {0} for key {1}: {2} --> {3}", s.SiloAddress, hash, hash, s.Hash);
             return s.SiloAddress;
         }
     }

--- a/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime.ConsistentRing
             running = true;
             myRange = RangeFactory.CreateFullRange();
 
-            logger.Info("Starting {0} on silo {1}.", nameof(VirtualBucketsRingProvider), siloAddress.ToStringWithHashCode());
+            logger.LogInformation("Starting {0} on silo {1}.", nameof(VirtualBucketsRingProvider), siloAddress.ToStringWithHashCode());
 
             StringValueStatistic.FindOrCreate(StatisticNames.CONSISTENTRING_RING, ToString);
             IntValueStatistic.FindOrCreate(StatisticNames.CONSISTENTRING_RINGSIZE, () => GetRingSize());
@@ -92,7 +92,7 @@ namespace Orleans.Runtime.ConsistentRing
 
         private void NotifyLocalRangeSubscribers(IRingRange old, IRingRange now, bool increased)
         {
-            logger.Info(ErrorCode.CRP_Notify, "-NotifyLocalRangeSubscribers about old {0} new {1} increased? {2}", old.ToString(), now.ToString(), increased);
+            logger.LogInformation((int)ErrorCode.CRP_Notify, "-NotifyLocalRangeSubscribers about old {0} new {1} increased? {2}", old.ToString(), now.ToString(), increased);
             IRingRangeListener[] copy;
             lock (statusListeners)
             {
@@ -130,7 +130,7 @@ namespace Orleans.Runtime.ConsistentRing
 
                 var myOldRange = myRange;
                 var myNewRange = UpdateRange();
-                logger.Info(ErrorCode.CRP_Added_Silo, "Added Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
+                logger.LogInformation((int)ErrorCode.CRP_Added_Silo, "Added Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
 
                 NotifyLocalRangeSubscribers(myOldRange, myNewRange, true);
             }
@@ -150,7 +150,7 @@ namespace Orleans.Runtime.ConsistentRing
 
                 var myOldRange = this.myRange;
                 var myNewRange = UpdateRange();
-                logger.Info(ErrorCode.CRP_Removed_Silo, "Removed Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
+                logger.LogInformation((int)ErrorCode.CRP_Removed_Silo, "Removed Server {0}. Current view: {1}", silo.ToStringWithHashCode(), this.ToString());
 
                 NotifyLocalRangeSubscribers(myOldRange, myNewRange, true);
             }

--- a/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -106,9 +106,8 @@ namespace Orleans.Runtime.ConsistentRing
                 }
                 catch (Exception exc)
                 {
-                    logger.Error(ErrorCode.CRP_Local_Subscriber_Exception,
-                        String.Format("Local IRangeChangeListener {0} has thrown an exception when was notified about RangeChangeNotification about old {1} new {2} increased? {3}",
-                        listener.GetType().FullName, old, now, increased), exc);
+                    logger.LogError((int)ErrorCode.CRP_Local_Subscriber_Exception, exc, String.Format("Local IRangeChangeListener {0} has thrown an exception when was notified about RangeChangeNotification about old {1} new {2} increased? {3}",
+                        listener.GetType().FullName, old, now, increased));
                 }
             }
         }

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -209,7 +209,7 @@ namespace Orleans.Runtime
 
         private void ResendMessageImpl(Message message, ActivationAddress forwardingAddress = null)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Resend {0}", message);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Resend {0}", message);
             message.TargetHistory = message.GetTargetHistory();
 
             if (message.TargetGrain.IsSystemTarget())

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -500,7 +500,7 @@ namespace Orleans.Runtime
                 if (!message.TargetSilo.Matches(this.MySilo))
                 {
                     // gatewayed message - gateway back to sender
-                    if (logger.IsEnabled(LogLevel.Trace)) this.logger.Trace(ErrorCode.Dispatcher_NoCallbackForRejectionResp, "No callback for rejection response message: {0}", message);
+                    if (logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)ErrorCode.Dispatcher_NoCallbackForRejectionResp, "No callback for rejection response message: {0}", message);
                     this.Dispatcher.SendMessage(message).Ignore();
                     return;
                 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -336,7 +336,7 @@ namespace Orleans.Runtime
                         // Mark the exception so that it doesn't deactivate any other activations.
                         ise.IsSourceActivation = false;
 
-                        this.invokeExceptionLogger.Info($"Deactivating {target} due to inconsistent state.");
+                        this.invokeExceptionLogger.LogInformation($"Deactivating {target} due to inconsistent state.");
                         this.DeactivateOnIdle(target.ActivationId);
                     }
 
@@ -656,7 +656,7 @@ namespace Orleans.Runtime
             this.disposables.Add(this.callbackTimer);
 
             stopWatch.Stop();
-            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"Start InsideRuntimeClient took {stopWatch.ElapsedMilliseconds} Milliseconds");
+            this.logger.LogInformation((int)ErrorCode.SiloStartPerfMeasure, $"Start InsideRuntimeClient took {stopWatch.ElapsedMilliseconds} Milliseconds");
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -530,7 +530,7 @@ namespace Orleans.Runtime
                         // The message targeted an invalid (eg, defunct) activation and this response serves only to invalidate this silo's activation cache.
                         return;
                     default:
-                        this.logger.Error(ErrorCode.Dispatcher_InvalidEnum_RejectionType,
+                        this.logger.LogError((int)ErrorCode.Dispatcher_InvalidEnum_RejectionType,
                             "Missing enum in switch: " + message.RejectionType);
                         break;
                 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -169,7 +169,7 @@ namespace Orleans.Runtime
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             if (context is null && !oneWay)
             {
-                this.logger.Warn(ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, Utils.GetStackTrace());
+                this.logger.LogWarning((int)ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, Utils.GetStackTrace());
             }
 
             if (message.IsExpirableMessage(this.messagingOptions.DropExpiredMessages))
@@ -246,7 +246,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.IGC_SniffIncomingMessage_Exc, "SniffIncomingMessage has thrown exception. Ignoring.", exc);
+                this.logger.LogWarning((int)ErrorCode.IGC_SniffIncomingMessage_Exc, exc, "SniffIncomingMessage has thrown exception. Ignoring.");
             }
         }
 
@@ -304,8 +304,8 @@ namespace Orleans.Runtime
                 {
                     if (message.Direction == Message.Directions.OneWay)
                     {
-                        this.invokeExceptionLogger.Warn(ErrorCode.GrainInvokeException,
-                            "Exception during Grain method call of message: " + message + ": " + LogFormatter.PrintException(exc1), exc1);
+                        this.invokeExceptionLogger.LogWarning((int)ErrorCode.GrainInvokeException, exc1,
+                            "Exception during Grain method call of message: " + message + ": " + LogFormatter.PrintException(exc1));
                     }
                     else if (invokeExceptionLogger.IsEnabled(LogLevel.Debug))
                     {
@@ -404,7 +404,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc2)
             {
-                this.logger.Warn(ErrorCode.Runtime_Error_100329, "Exception during Invoke of message: " + message, exc2);
+                this.logger.LogWarning((int)ErrorCode.Runtime_Error_100329, exc2, "Exception during Invoke of message: " + message);
 
                 TransactionContext.Clear();
 
@@ -425,8 +425,8 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                this.logger.Warn(ErrorCode.IGC_SendResponseFailed,
-                    "Exception trying to send a response: " + exc.Message, exc);
+                this.logger.LogWarning((int)ErrorCode.IGC_SendResponseFailed, exc,
+                    "Exception trying to send a response: {Message}", exc.Message);
                 SendResponse(message, Response.ExceptionResponse(exc));
             }
         }
@@ -480,14 +480,14 @@ namespace Orleans.Runtime
             {
                 try
                 {
-                    this.logger.Warn(ErrorCode.IGC_SendExceptionResponseFailed,
-                        "Exception trying to send an exception response: " + exc1.Message, exc1);
+                    this.logger.LogWarning((int)ErrorCode.IGC_SendExceptionResponseFailed, exc1,
+                        "Exception trying to send an exception response: " + exc1.Message);
                     SendResponse(message, Response.ExceptionResponse(exc1));
                 }
                 catch (Exception exc2)
                 {
-                    this.logger.Warn(ErrorCode.IGC_UnhandledExceptionInInvoke,
-                        "Exception trying to send an exception. Ignoring and not trying to send again. Exc: " + exc2.Message, exc2);
+                    this.logger.LogWarning((int)ErrorCode.IGC_UnhandledExceptionInInvoke, exc2,
+                        "Exception trying to send an exception. Ignoring and not trying to send again. Exc: " + exc2.Message);
                 }
             }
         }
@@ -638,7 +638,7 @@ namespace Orleans.Runtime
                     }
                     catch (Exception e)
                     {
-                        this.logger.Warn(ErrorCode.IGC_DisposeError, "Exception while disposing: " + e.Message, e);
+                        this.logger.LogWarning((int)ErrorCode.IGC_DisposeError, e, "Exception while disposing: " + e.Message);
                     }
                 }
             }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -309,8 +309,8 @@ namespace Orleans.Runtime
                     }
                     else if (invokeExceptionLogger.IsEnabled(LogLevel.Debug))
                     {
-                        this.invokeExceptionLogger.Debug(ErrorCode.GrainInvokeException,
-                            "Exception during Grain method call of message: " + message + ": " + LogFormatter.PrintException(exc1), exc1);
+                        this.invokeExceptionLogger.LogDebug((int)ErrorCode.GrainInvokeException, exc1,
+                            "Exception during Grain method call of message: " + message + ": " + LogFormatter.PrintException(exc1));
                     }
 
                     if (transactionInfo != null)
@@ -505,7 +505,7 @@ namespace Orleans.Runtime
                     return;
                 }
 
-                if (logger.IsEnabled(LogLevel.Debug)) this.logger.Debug(ErrorCode.Dispatcher_HandleMsg, "HandleMessage {0}", message);
+                if (logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug((int)ErrorCode.Dispatcher_HandleMsg, "HandleMessage {0}", message);
                 switch (message.RejectionType)
                 {
                     case Message.RejectionTypes.DuplicateRequest:
@@ -582,7 +582,7 @@ namespace Orleans.Runtime
             }
             else
             {
-                if (logger.IsEnabled(LogLevel.Debug)) this.logger.Debug(ErrorCode.Dispatcher_NoCallbackForResp,
+                if (logger.IsEnabled(LogLevel.Debug)) this.logger.LogDebug((int)ErrorCode.Dispatcher_NoCallbackForResp,
                     "No callback for response message: " + message);
             }
         }

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -117,7 +117,7 @@ namespace Orleans.Runtime.Management
         public Task<SiloRuntimeStatistics[]> GetRuntimeStatistics(SiloAddress[] siloAddresses)
         {
             var silos = GetSiloAddresses(siloAddresses);
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("GetRuntimeStatistics on {0}", Utils.EnumerableToString(silos));
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("GetRuntimeStatistics on {0}", Utils.EnumerableToString(silos));
             var promises = new List<Task<SiloRuntimeStatistics>>();
             foreach (SiloAddress siloAddress in silos)
                 promises.Add(GetSiloControlReference(siloAddress).GetRuntimeStatistics());
@@ -306,7 +306,7 @@ namespace Orleans.Runtime.Management
 
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.Debug("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
+                logger.LogDebug("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
             }
 
             var actionPromises = new List<Task<object>>();

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -57,7 +57,7 @@ namespace Orleans.Runtime.Management
 
         public async Task<MembershipEntry[]> GetDetailedHosts(bool onlyActive = false)
         {
-            logger.Info("GetDetailedHosts onlyActive={0}", onlyActive);
+            logger.LogInformation("GetDetailedHosts onlyActive={0}", onlyActive);
 
             await this.membershipTableManager.Refresh();
 
@@ -84,7 +84,7 @@ namespace Orleans.Runtime.Management
         public Task ForceGarbageCollection(SiloAddress[] siloAddresses)
         {
             var silos = GetSiloAddresses(siloAddresses);
-            logger.Info("Forcing garbage collection on {0}", Utils.EnumerableToString(silos));
+            logger.LogInformation("Forcing garbage collection on {0}", Utils.EnumerableToString(silos));
             List<Task> actionPromises = PerformPerSiloAction(silos,
                 s => GetSiloControlReference(s).ForceGarbageCollection());
             return Task.WhenAll(actionPromises);
@@ -107,7 +107,7 @@ namespace Orleans.Runtime.Management
         public Task ForceRuntimeStatisticsCollection(SiloAddress[] siloAddresses)
         {
             var silos = GetSiloAddresses(siloAddresses);
-            logger.Info("Forcing runtime statistics collection on {0}", Utils.EnumerableToString(silos));
+            logger.LogInformation("Forcing runtime statistics collection on {0}", Utils.EnumerableToString(silos));
             List<Task> actionPromises = PerformPerSiloAction(
                 silos,
                 s => GetSiloControlReference(s).ForceRuntimeStatisticsCollection());

--- a/src/Orleans.Runtime/Counters/CountersStatistics.cs
+++ b/src/Orleans.Runtime/Counters/CountersStatistics.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime.Counters
                 }
                 else if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    logger.Trace(ErrorCode.PerfCounterWriteSuccess,
+                    logger.LogTrace((int)ErrorCode.PerfCounterWriteSuccess,
                                     "Completed writing Windows perf counters successfully");
                 }
 
@@ -90,7 +90,7 @@ namespace Orleans.Runtime.Counters
             }
             else if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace("Skipping - Writing Windows perf counters is disabled");
+                logger.LogTrace("Skipping - Writing Windows perf counters is disabled");
             }
         }
     }

--- a/src/Orleans.Runtime/Counters/CountersStatistics.cs
+++ b/src/Orleans.Runtime/Counters/CountersStatistics.cs
@@ -83,7 +83,7 @@ namespace Orleans.Runtime.Counters
 
                 if (numErrors > ERROR_THRESHOLD)
                 {
-                    logger.Error(ErrorCode.PerfCounterWriteTooManyErrors,
+                    logger.LogError((int)ErrorCode.PerfCounterWriteTooManyErrors,
                                 "Too many errors writing Windows perf counters -- disconnecting counters");
                     shouldWritePerfCounters = false;
                 }

--- a/src/Orleans.Runtime/Counters/CountersStatistics.cs
+++ b/src/Orleans.Runtime/Counters/CountersStatistics.cs
@@ -72,7 +72,7 @@ namespace Orleans.Runtime.Counters
 
                 if (numErrors > 0)
                 {
-                    logger.Warn(ErrorCode.PerfCounterWriteErrors,
+                    logger.LogWarning((int)ErrorCode.PerfCounterWriteErrors,
                                 "Completed writing Windows perf counters with {0} errors", numErrors);
                 }
                 else if (logger.IsEnabled(LogLevel.Trace))

--- a/src/Orleans.Runtime/Counters/CountersStatistics.cs
+++ b/src/Orleans.Runtime/Counters/CountersStatistics.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Counters
         /// </summary>
         public void Start()
         {
-            logger.Info(ErrorCode.PerfCounterStarting, "Starting Windows perf counter stats collection with frequency={0}", PerfCountersWriteInterval);
+            logger.LogInformation((int)ErrorCode.PerfCounterStarting, "Starting Windows perf counter stats collection with frequency={0}", PerfCountersWriteInterval);
 
             // Start the timer
             timer = new SafeTimer(this.loggerFactory.CreateLogger<SafeTimer>(), TimerTick, null, PerfCountersWriteInterval, PerfCountersWriteInterval);
@@ -52,7 +52,7 @@ namespace Orleans.Runtime.Counters
         /// </summary>
         public void Stop()
         {
-            logger.Info(ErrorCode.PerfCounterStopping, "Stopping  Windows perf counter stats collection");
+            logger.LogInformation((int)ErrorCode.PerfCounterStopping, "Stopping  Windows perf counter stats collection");
             if (timer != null)
                 timer.Dispose(); // Stop timer
 

--- a/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
+++ b/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.Counters
                 catch (Exception ex)
                 {
                     numWriteErrors++;
-                    logger.Error(ErrorCode.PerfCounterUnableToWrite, $"Unable to write to counter '{counter.Name}'", ex);
+                    logger.LogError((int)ErrorCode.PerfCounterUnableToWrite, ex, $"Unable to write to counter '{counter.Name}'");
                 }
             }
             return numWriteErrors;

--- a/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
+++ b/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime.Counters
     {
         public static int WriteCounters(ITelemetryProducer telemetryProducer, ILogger logger)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Writing counters.");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Writing counters.");
 
             int numWriteErrors = 0;
 

--- a/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
+++ b/src/Orleans.Runtime/Counters/OrleansCounterManager.cs
@@ -24,7 +24,7 @@ namespace Orleans.Runtime.Counters
             {
                 try
                 {
-                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.PerfCounterWriting, "Writing counter {0}", counter.Name);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.PerfCounterWriting, "Writing counter {0}", counter.Name);
 
                     counter.TrackMetric(telemetryProducer);
                 }

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -78,7 +78,7 @@ namespace Orleans.Runtime.GrainDirectory
                     {
                         // we found our owned entry in the cache -- it is not supposed to happen unless there were 
                         // changes in the membership
-                        Log.Warn(ErrorCode.Runtime_Error_100185, "Grain {grain} owned by {owner} was found in the cache of {owner}", grain, owner, owner);
+                        Log.LogWarning((int)ErrorCode.Runtime_Error_100185, "Grain {grain} owned by {owner} was found in the cache of {owner}", grain, owner, owner);
                         cache.Remove(grain);
                         cnt1++;                             // for debug
                     }
@@ -212,7 +212,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     // this may happen only if the LRU cache is full and decided to drop this grain
                     // while we try to refresh it
-                    Log.Warn(ErrorCode.Runtime_Error_100199, "Grain {0} disappeared from the cache during maintenance", grain);
+                    Log.LogWarning((int)ErrorCode.Runtime_Error_100199, "Grain {0} disappeared from the cache during maintenance", grain);
                 }
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
                 }
 
-                if (Log.IsEnabled(LogLevel.Trace)) Log.Trace("Silo {0} self-owned (and removed) {1}, kept {2}, removed {3} and tries to refresh {4} grains", router.MyAddress, cnt1, cnt2, cnt3, cnt4);
+                if (Log.IsEnabled(LogLevel.Trace)) Log.LogTrace("Silo {0} self-owned (and removed) {1}, kept {2}, removed {3} and tries to refresh {4} grains", router.MyAddress, cnt1, cnt2, cnt3, cnt4);
 
                 // send batch requests
                 SendBatchCacheRefreshRequests(fetchInBatchList);
@@ -146,7 +146,7 @@ namespace Orleans.Runtime.GrainDirectory
                     ProcessCacheRefreshResponse(silo, response);
                 }, router.CacheValidator).Ignore();
 
-                if (Log.IsEnabled(LogLevel.Trace)) Log.Trace("Silo {0} is sending request to silo {1} with {2} entries", router.MyAddress, silo, cachedGrainAndETagList.Count);
+                if (Log.IsEnabled(LogLevel.Trace)) Log.LogTrace("Silo {0} is sending request to silo {1} with {2} entries", router.MyAddress, silo, cachedGrainAndETagList.Count);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Orleans.Runtime.GrainDirectory
             SiloAddress silo,
             List<AddressAndTag> refreshResponse)
         {
-            if (Log.IsEnabled(LogLevel.Trace)) Log.Trace("Silo {0} received ProcessCacheRefreshResponse. #Response entries {1}.", router.MyAddress, refreshResponse.Count);
+            if (Log.IsEnabled(LogLevel.Trace)) Log.LogTrace("Silo {0} received ProcessCacheRefreshResponse. #Response entries {1}.", router.MyAddress, refreshResponse.Count);
 
             int cnt1 = 0, cnt2 = 0, cnt3 = 0;
 
@@ -186,7 +186,7 @@ namespace Orleans.Runtime.GrainDirectory
                     cnt3++;
                 }
             }
-            if (Log.IsEnabled(LogLevel.Trace)) Log.Trace("Silo {0} processed refresh response from {1} with {2} updated, {3} removed, {4} unchanged grains", router.MyAddress, silo, cnt1, cnt2, cnt3);
+            if (Log.IsEnabled(LogLevel.Trace)) Log.LogTrace("Silo {0} processed refresh response from {1} with {2} updated, {3} removed, {4} unchanged grains", router.MyAddress, silo, cnt1, cnt2, cnt3);
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Orleans.Runtime.GrainDirectory
             long numAccesses = curNumAccesses - lastNumAccesses;
             long numHits = curNumHits - lastNumHits;
 
-            if (Log.IsEnabled(LogLevel.Trace)) Log.Trace("#accesses: {0}, hit-ratio: {1}%", numAccesses, (numHits / Math.Max(numAccesses, 0.00001)) * 100);
+            if (Log.IsEnabled(LogLevel.Trace)) Log.LogTrace("#accesses: {0}, hit-ratio: {1}%", numAccesses, (numHits / Math.Max(numAccesses, 0.00001)) * 100);
 
             lastNumAccesses = curNumAccesses;
             lastNumHits = curNumHits;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             lock (this)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo remove event for " + removedSilo);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Processing silo remove event for " + removedSilo);
 
                 // Reset our follower list to take the changes into account
                 ResetFollowers();
@@ -61,7 +61,7 @@ namespace Orleans.Runtime.GrainDirectory
                 Dictionary<SiloAddress, List<ActivationAddress>> duplicates;
                 if (localDirectory.MyAddress.Equals(predecessor))
                 {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Merging my partition with the copy of silo " + removedSilo);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Merging my partition with the copy of silo " + removedSilo);
                     // now I am responsible for this directory part
                     duplicates = localDirectory.DirectoryPartition.Merge(partition);
                     // no need to send our new partition to all others, as they
@@ -69,12 +69,12 @@ namespace Orleans.Runtime.GrainDirectory
                 }
                 else
                 {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Merging partition of " + predecessor + " with the copy of silo " + removedSilo);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Merging partition of " + predecessor + " with the copy of silo " + removedSilo);
                     // adjust copy for the predecessor of the failed silo
                     duplicates = directoryPartitionsMap[predecessor].Merge(partition);
                 }
 
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removed copied partition of silo " + removedSilo);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Removed copied partition of silo " + removedSilo);
                 directoryPartitionsMap.Remove(removedSilo);
                 DestroyDuplicateActivations(duplicates);
             }
@@ -84,7 +84,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             lock (this)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo add event for " + addedSilo);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Processing silo add event for " + addedSilo);
 
                 // Reset our follower list to take the changes into account
                 ResetFollowers();
@@ -95,7 +95,7 @@ namespace Orleans.Runtime.GrainDirectory
                 List<SiloAddress> successors = localDirectory.FindSuccessors(localDirectory.MyAddress, 1);
                 if (!successors.Contains(addedSilo))
                 {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug($"{addedSilo} is not one of my successors.");
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug($"{addedSilo} is not one of my successors.");
                     return;
                 }
 
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.GrainDirectory
                 if (successors[0].Equals(addedSilo))
                 {
                     // split my local directory and send to my new immediate successor his share
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Splitting my partition between me and " + addedSilo);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Splitting my partition between me and " + addedSilo);
                     GrainDirectoryPartition splitPart = localDirectory.DirectoryPartition.Split(
                         grain =>
                         {
@@ -127,7 +127,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
                     else
                     {
-                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Splitting partition of " + predecessorOfNewSilo + " and creating a copy for " + addedSilo);
+                        if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Splitting partition of " + predecessorOfNewSilo + " and creating a copy for " + addedSilo);
                         GrainDirectoryPartition splitPart = predecessorPartition.Split(
                             grain =>
                             {
@@ -143,7 +143,7 @@ namespace Orleans.Runtime.GrainDirectory
                 SiloAddress oldSuccessor = directoryPartitionsMap.FirstOrDefault(pair => !successors.Contains(pair.Key)).Key;
                 if (oldSuccessor == null) return;
 
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removing copy of the directory partition of silo " + oldSuccessor + " (holding copy of " + addedSilo + " instead)");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Removing copy of the directory partition of silo " + oldSuccessor + " (holding copy of " + addedSilo + " instead)");
                 directoryPartitionsMap.Remove(oldSuccessor);
             }
         }
@@ -156,7 +156,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 if (splitPartListSingle.Count > 0)
                 {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Sending " + splitPartListSingle.Count + " single activation entries to " + addedSilo);
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Sending " + splitPartListSingle.Count + " single activation entries to " + addedSilo);
                 }
 
                 await localDirectory.GetDirectoryReference(addedSilo).AcceptSplitPartition(splitPartListSingle);
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (splitPartListSingle.Count > 0)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removing " + splitPartListSingle.Count + " single activation after partition split");
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Removing " + splitPartListSingle.Count + " single activation after partition split");
 
                 splitPartListSingle.ForEach(
                     activationAddress =>
@@ -243,7 +243,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             lock (this)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Got request to register " + (isFullCopy ? "FULL" : "DELTA") + " directory partition with " + partition.Count + " elements from " + source);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Got request to register " + (isFullCopy ? "FULL" : "DELTA") + " directory partition with " + partition.Count + " elements from " + source);
 
                 if (!directoryPartitionsMap.TryGetValue(source, out var sourcePartition))
                 {
@@ -273,7 +273,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             lock (this)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Got request to unregister directory partition copy from " + source);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Got request to unregister directory partition copy from " + source);
                 directoryPartitionsMap.Remove(source);
             }
         }
@@ -289,7 +289,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         private void RemoveOldFollower(SiloAddress silo)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removing my copy from silo " + silo);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Removing my copy from silo " + silo);
             // release this old copy, as we have got a new one
             silosHoldingMyPartition.Remove(silo);
             localDirectory.Scheduler.QueueTask(() =>

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -123,7 +123,7 @@ namespace Orleans.Runtime.GrainDirectory
                     if (!directoryPartitionsMap.TryGetValue(predecessorOfNewSilo, out var predecessorPartition))
                     {
                         // we should have the partition of the predcessor of our new successor
-                        logger.Warn(ErrorCode.DirectoryPartitionPredecessorExpected, "This silo is expected to hold directory partition of " + predecessorOfNewSilo);
+                        logger.LogWarning((int)ErrorCode.DirectoryPartitionPredecessorExpected, "This silo is expected to hold directory partition of " + predecessorOfNewSilo);
                     }
                     else
                     {
@@ -249,7 +249,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     if (!isFullCopy)
                     {
-                        logger.Warn(ErrorCode.DirectoryUnexpectedDelta,
+                        logger.LogWarning((int)ErrorCode.DirectoryUnexpectedDelta,
                             String.Format("Got delta of the directory partition from silo {0} (Membership status {1}) while not holding a full copy. Membership active cluster size is {2}",
                                 source, this.siloStatusOracle.GetApproximateSiloStatus(source),
                                 this.siloStatusOracle.GetApproximateSiloStatuses(true).Count));

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -303,7 +303,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     if (partitionData.ContainsKey(pair.Key))
                     {
-                        if (log.IsEnabled(LogLevel.Debug)) log.Debug("While merging two disjoint partitions, same grain " + pair.Key + " was found in both partitions");
+                        if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("While merging two disjoint partitions, same grain " + pair.Key + " was found in both partitions");
                         var activationToDrop = partitionData[pair.Key].Merge(pair.Value);
                         if (activationToDrop == null) continue;
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -185,7 +185,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns>The registered ActivationAddress and version associated with this directory mapping</returns>
         internal virtual AddressAndTag AddSingleActivation(ActivationAddress address)
         {
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Adding single activation for grain {0}{1}{2}", address.Silo, address.Grain, address.Activation);
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Adding single activation for grain {0}{1}{2}", address.Silo, address.Grain, address.Activation);
 
             AddressAndTag result = new AddressAndTag();
 
@@ -229,7 +229,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
             }
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Removing activation for grain {0} cause={1} was_removed={2}", grain.ToString(), cause, wasRemoved);
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Removing activation for grain {0} cause={1} was_removed={2}", grain.ToString(), cause, wasRemoved);
         }
 
    
@@ -243,7 +243,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 partitionData.Remove(grain);
             }
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Removing grain {0}", grain.ToString());
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Removing grain {0}", grain.ToString());
         }
 
         internal AddressAndTag LookUpActivation(GrainId grain)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -452,7 +452,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
                 }
 
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("Silo {0} looked for a system target {1}, returned {2}", MyAddress, grainId, MyAddress);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Silo {0} looked for a system target {1}, returned {2}", MyAddress, grainId, MyAddress);
                 // every silo owns its system targets
                 return MyAddress;
             }
@@ -495,7 +495,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
             }
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Silo {0} calculated directory partition owner silo {1} for grain {2}: {3} --> {4}", MyAddress, siloAddress, grainId, hash, siloAddress?.GetConsistentHashCode());
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Silo {0} calculated directory partition owner silo {1} for grain {2}: {3} --> {4}", MyAddress, siloAddress, grainId, hash, siloAddress?.GetConsistentHashCode());
             return siloAddress;
         }
 
@@ -577,7 +577,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task UnregisterAfterNonexistingActivation(ActivationAddress addr, SiloAddress origin)
         {
-            log.Trace("UnregisterAfterNonexistingActivation addr={0} origin={1}", addr, origin);
+            log.LogTrace("UnregisterAfterNonexistingActivation addr={0} origin={1}", addr, origin);
 
             if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
@@ -709,7 +709,7 @@ namespace Orleans.Runtime.GrainDirectory
             //this will only happen if I'm the only silo in the cluster and I'm shutting down
             if (silo == null)
             {
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("LocalLookup mine {0}=null", grain);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("LocalLookup mine {0}=null", grain);
                 result = new AddressAndTag();
                 return false;
             }
@@ -723,10 +723,10 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     // it can happen that we cannot find the grain in our partition if there were 
                     // some recent changes in the membership
-                    if (log.IsEnabled(LogLevel.Trace)) log.Trace("LocalLookup mine {0}=null", grain);
+                    if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("LocalLookup mine {0}=null", grain);
                     return false;
                 }
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("LocalLookup mine {0}={1}", grain, result.Address);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("LocalLookup mine {0}={1}", grain, result.Address);
                 LocalDirectorySuccesses.Increment();
                 localSuccesses.Increment();
                 return true;
@@ -737,7 +737,7 @@ namespace Orleans.Runtime.GrainDirectory
             var address = GetLocalCacheData(grain);
             if (address == null)
             {
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("TryFullLookup else {0}=null", grain);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("TryFullLookup else {0}=null", grain);
                 result = default;
                 return false;
             }
@@ -747,7 +747,7 @@ namespace Orleans.Runtime.GrainDirectory
                 Address = address,
             };
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("LocalLookup cache {0}={1}", grain, result.Address);
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("LocalLookup cache {0}={1}", grain, result.Address);
             cacheSuccesses.Increment();
             localSuccesses.Increment();
             return true;
@@ -796,13 +796,13 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     // it can happen that we cannot find the grain in our partition if there were 
                     // some recent changes in the membership
-                    if (log.IsEnabled(LogLevel.Trace)) log.Trace("FullLookup mine {0}=none", grainId);
+                    if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("FullLookup mine {0}=none", grainId);
                     localResult.Address = default;
                     localResult.VersionTag = GrainInfo.NO_ETAG;
                     return localResult;
                 }
 
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("FullLookup mine {0}={1}", grainId, localResult.Address);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("FullLookup mine {0}={1}", grainId, localResult.Address);
                 LocalDirectorySuccesses.Increment();
                 return localResult;
             }
@@ -823,7 +823,7 @@ namespace Orleans.Runtime.GrainDirectory
                     DirectoryCache.AddOrUpdate(address, result.VersionTag);
                 }
 
-                if (log.IsEnabled(LogLevel.Trace)) log.Trace("FullLookup remote {0}={1}", grainId, result.Address);
+                if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("FullLookup remote {0}={1}", grainId, result.Address);
 
                 return result;
             }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -371,7 +371,7 @@ namespace Orleans.Runtime.GrainDirectory
             int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
             if (index == -1)
             {
-                log.Warn(ErrorCode.Runtime_Error_100201, "Got request to find predecessors of silo " + silo + ", which is not in the list of members");
+                log.LogWarning((int)ErrorCode.Runtime_Error_100201, "Got request to find predecessors of silo " + silo + ", which is not in the list of members");
                 return null;
             }
 
@@ -391,7 +391,7 @@ namespace Orleans.Runtime.GrainDirectory
             int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
             if (index == -1)
             {
-                log.Warn(ErrorCode.Runtime_Error_100203, "Got request to find successors of silo " + silo + ", which is not in the list of members");
+                log.LogWarning((int)ErrorCode.Runtime_Error_100203, "Got request to find successors of silo " + silo + ", which is not in the list of members");
                 return null;
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -280,8 +280,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
                 catch (Exception exc)
                 {
-                    log.Error(ErrorCode.Directory_SiloStatusChangeNotification_Exception,
-                        String.Format("CatalogSiloStatusListener.SiloStatusChangeNotification has thrown an exception when notified about removed silo {0}.", silo.ToStringWithHashCode()), exc);
+                    log.LogError((int)ErrorCode.Directory_SiloStatusChangeNotification_Exception, exc, String.Format("CatalogSiloStatusListener.SiloStatusChangeNotification has thrown an exception when notified about removed silo {0}.", silo.ToStringWithHashCode()));
                 }
 
                 var existing = this.directoryMembership;

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -194,7 +194,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public void Start()
         {
-            log.Info("Start");
+            log.LogInformation("Start");
             Running = true;
             if (maintainer != null)
             {

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -265,7 +265,7 @@ namespace Orleans.Runtime.GrainDirectory
                 AdjustLocalDirectory(silo, dead: false);
                 AdjustLocalCache(silo, dead: false);
 
-                if (log.IsEnabled(LogLevel.Debug)) log.Debug("Silo {0} added silo {1}", MyAddress, silo);
+                if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("Silo {0} added silo {1}", MyAddress, silo);
             }
         }
 
@@ -301,7 +301,7 @@ namespace Orleans.Runtime.GrainDirectory
                 AdjustLocalDirectory(silo, dead: true);
                 AdjustLocalCache(silo, dead: true);
 
-                if (log.IsEnabled(LogLevel.Debug)) log.Debug("Silo {0} removed silo {1}", MyAddress, silo);
+                if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("Silo {0} removed silo {1}", MyAddress, silo);
             }
         }
 
@@ -704,7 +704,7 @@ namespace Orleans.Runtime.GrainDirectory
             SiloAddress silo = CalculateGrainDirectoryPartition(grain);
 
 
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("Silo {0} tries to lookup for {1}-->{2} ({3}-->{4})", MyAddress, grain, silo, grain.GetUniformHashCode(), silo?.GetConsistentHashCode());
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("Silo {0} tries to lookup for {1}-->{2} ({3}-->{4})", MyAddress, grain, silo, grain.GetUniformHashCode(), silo?.GetConsistentHashCode());
 
             //this will only happen if I'm the only silo in the cluster and I'm shutting down
             if (silo == null)

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -36,7 +36,7 @@ namespace Orleans.Runtime.GrainDirectory
             // validate that this request arrived correctly
             //logger.Assert(ErrorCode.Runtime_Error_100140, silo.Matches(router.MyAddress), "destination address != my address");
 
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("RegisterMany Count={0}", addresses.Count);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("RegisterMany Count={0}", addresses.Count);
 
 
             return Task.WhenAll(addresses.Select(addr => router.RegisterAsync(addr, 1)));
@@ -65,7 +65,7 @@ namespace Orleans.Runtime.GrainDirectory
         public Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
         {
             router.CacheValidationsReceived.Increment();
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("LookUpMany for {0} entries", grainAndETagList.Count);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("LookUpMany for {0} entries", grainAndETagList.Count);
 
             var result = new List<AddressAndTag>();
 

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -177,7 +177,7 @@ namespace Orleans.Runtime.MembershipService
             var result = newProbedSilos.ToImmutable();
             if (!AreTheSame(monitoredSilos, result))
             {
-                log.Info(ErrorCode.MembershipWatchList, "Will watch (actively ping) {0} silos: {1}",
+                log.LogInformation((int)ErrorCode.MembershipWatchList, "Will watch (actively ping) {0} silos: {1}",
                     newProbedSilos.Count, Utils.EnumerableToString(newProbedSilos.Keys, silo => silo.ToLongString()));
             }
 

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -132,7 +132,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 // this should not happen ...
                 var error = string.Format("This silo {0} status {1} is not in its own local silo list! This is a bug!", self.SiloAddress.ToLongString(), self.Status);
-                log.Error(ErrorCode.Runtime_Error_100305, error);
+                log.LogError((int)ErrorCode.Runtime_Error_100305, error);
                 throw new OrleansMissingMembershipEntryException(error);
             }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -276,7 +276,7 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeJoining()
         {
-            this.log.Info(ErrorCode.MembershipJoining, "-Joining");
+            this.log.LogInformation((int)ErrorCode.MembershipJoining, "-Joining");
             try
             {
                 await this.UpdateStatus(SiloStatus.Joining);
@@ -290,7 +290,7 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeShuttingDown()
         {
-            this.log.Info(ErrorCode.MembershipShutDown, "-Shutdown");
+            this.log.LogInformation((int)ErrorCode.MembershipShutDown, "-Shutdown");
             try
             {
                 await this.UpdateStatus(SiloStatus.ShuttingDown);
@@ -304,7 +304,7 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeStopping()
         {
-            log.Info(ErrorCode.MembershipStop, "-Stop");
+            log.LogInformation((int)ErrorCode.MembershipStop, "-Stop");
             try
             {
                 await this.UpdateStatus(SiloStatus.Stopping);

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -283,7 +283,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                this.log.Error(ErrorCode.MembershipFailedToJoin, "Error updating status to Joining", exc);
+                this.log.LogError((int)ErrorCode.MembershipFailedToJoin, exc, "Error updating status to Joining");
                 throw;
             }
         }
@@ -297,7 +297,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                this.log.Error(ErrorCode.MembershipFailedToShutdown, "Error updating status to ShuttingDown", exc);
+                this.log.LogError((int)ErrorCode.MembershipFailedToShutdown, exc, "Error updating status to ShuttingDown");
                 throw;
             }
         }
@@ -311,7 +311,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exc)
             {
-                log.Error(ErrorCode.MembershipFailedToStop, "Error updating status to Stopping", exc);
+                log.LogError((int)ErrorCode.MembershipFailedToStop, exc, "Error updating status to Stopping");
                 throw;
             }
         }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -522,7 +522,7 @@ namespace Orleans.Runtime.MembershipService
                 
                 if (entry.Status == SiloStatus.Dead)
                 {
-                    if (log.IsEnabled(LogLevel.Trace)) log.Trace("Skipping my previous old Dead entry in membership table: {0}", entry.ToFullString(full: true));
+                    if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Skipping my previous old Dead entry in membership table: {0}", entry.ToFullString(full: true));
                     continue;
                 }
 
@@ -712,7 +712,7 @@ namespace Orleans.Runtime.MembershipService
             // get all valid (non-expired) votes
             var freshVotes = entry.GetFreshVotes(DateTime.UtcNow, this.clusterMembershipOptions.DeathVoteExpirationTimeout);
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("-Current number of fresh Voters for {0} is {1}", silo, freshVotes.Count.ToString());
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("-Current number of fresh Voters for {0} is {1}", silo, freshVotes.Count.ToString());
 
             if (freshVotes.Count >= this.clusterMembershipOptions.NumVotesForDeathDeclaration)
             {

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -112,7 +112,7 @@ namespace Orleans.Runtime.MembershipService
                 if (localSiloEntry.Status == SiloStatus.Dead && this.CurrentStatus != SiloStatus.Dead)
                 {
                     var msg = $"I should be Dead according to membership table (in RefreshFromSnapshot). Local entry: {(localSiloEntry.ToFullString(full: true))}.";
-                    this.log.Warn(ErrorCode.MembershipFoundMyselfDead1, msg);
+                    this.log.LogWarning((int)ErrorCode.MembershipFoundMyselfDead1, msg);
                     this.KillMyselfLocally(msg);
                 }
 
@@ -220,13 +220,13 @@ namespace Orleans.Runtime.MembershipService
                 {
                     string error = string.Format("Silo {0} migrated from host {1} silo address {2} to host {3} silo address {4}.",
                         mySiloName, myHostname, myAddress, mostRecentPreviousEntry.HostName, mostRecentPreviousEntry.SiloAddress);
-                    log.Warn(ErrorCode.MembershipNodeMigrated, error);
+                    log.LogWarning((int)ErrorCode.MembershipNodeMigrated, error);
                 }
                 else
                 {
                     string error = string.Format("Silo {0} restarted on same host {1} New silo address = {2} Previous silo address = {3}",
                         mySiloName, myHostname, myAddress, mostRecentPreviousEntry.SiloAddress);
-                    log.Warn(ErrorCode.MembershipNodeRestarted, error);
+                    log.LogWarning((int)ErrorCode.MembershipNodeRestarted, error);
                 }
             }
         }
@@ -390,7 +390,7 @@ namespace Orleans.Runtime.MembershipService
             if (myEntry.Status == SiloStatus.Dead && myEntry.Status != newStatus)
             {
                 var msg = string.Format("I should be Dead according to membership table (in TryUpdateMyStatusGlobalOnce): myEntry = {0}.", myEntry.ToFullString(full: true));
-                this.log.Warn(ErrorCode.MembershipFoundMyselfDead1, msg);
+                this.log.LogWarning((int)ErrorCode.MembershipFoundMyselfDead1, msg);
                 this.KillMyselfLocally(msg);
                 return true;
             }
@@ -490,8 +490,8 @@ namespace Orleans.Runtime.MembershipService
                 var missedSince = entry.HasMissedIAmAlivesSince(this.clusterMembershipOptions, now);
                 if (missedSince != null)
                 {
-                    log.Warn(
-                    ErrorCode.MembershipMissedIAmAliveTableUpdate,
+                    log.LogWarning(
+                    (int)ErrorCode.MembershipMissedIAmAliveTableUpdate,
                     $"Noticed that silo {entry.SiloAddress} has not updated it's IAmAliveTime table column recently."
                     + $" Last update was at {missedSince}, now is {now}, no update for {now - missedSince}, which is more than {this.clusterMembershipOptions.AllowedIAmAliveMissPeriod}.");
                 }
@@ -514,7 +514,7 @@ namespace Orleans.Runtime.MembershipService
                     if (entry.Status == SiloStatus.Dead)
                     {
                         var msg = string.Format("I should be Dead according to membership table (in CleanupTableEntries): entry = {0}.", entry.ToFullString(full: true));
-                        log.Warn(ErrorCode.MembershipFoundMyselfDead2, msg);
+                        log.LogWarning((int)ErrorCode.MembershipFoundMyselfDead2, msg);
                         KillMyselfLocally(msg);
                     }
                     continue;
@@ -532,7 +532,7 @@ namespace Orleans.Runtime.MembershipService
                 // Temporal paradox - There is an older clone of this silo in the membership table
                 if (siloAddress.Generation < myAddress.Generation)
                 {
-                    log.Warn(ErrorCode.MembershipDetectedOlder, "Detected older version of myself - Marking other older clone as Dead -- Current Me={0} Older Me={1}, Old entry= {2}",
+                    log.LogWarning((int)ErrorCode.MembershipDetectedOlder, "Detected older version of myself - Marking other older clone as Dead -- Current Me={0} Older Me={1}, Old entry= {2}",
                         myAddress, siloAddress, entry.ToFullString());
                     // Declare older clone of me as Dead.
                     silosToDeclareDead.Add(tuple);   //return DeclareDead(entry, eTag, tableVersion);
@@ -542,7 +542,7 @@ namespace Orleans.Runtime.MembershipService
                     // I am the older clone - Newer version of me should survive - I need to kill myself
                     var msg = string.Format("Detected newer version of myself - I am the older clone so I will stop -- Current Me={0} Newer Me={1}, Current entry= {2}",
                         myAddress, siloAddress, entry.ToFullString());
-                    log.Warn(ErrorCode.MembershipDetectedNewer, msg);
+                    log.LogWarning((int)ErrorCode.MembershipDetectedNewer, msg);
                     await this.UpdateStatus(SiloStatus.Dead);
                     KillMyselfLocally(msg);
                     return true; // No point continuing!
@@ -679,7 +679,7 @@ namespace Orleans.Runtime.MembershipService
             if (localSiloEntry.Status == SiloStatus.Dead)
             {
                 var msg = string.Format("I should be Dead according to membership table (in TryToSuspectOrKill): entry = {0}.", localSiloEntry.ToFullString(full: true));
-                log.Warn(ErrorCode.MembershipFoundMyselfDead3, msg);
+                log.LogWarning((int)ErrorCode.MembershipFoundMyselfDead3, msg);
                 KillMyselfLocally(msg);
                 return true;
             }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -744,7 +744,7 @@ namespace Orleans.Runtime.MembershipService
             if (declareDead)
             {
                 // kick this silo off
-                log.Info(ErrorCode.MembershipMarkingAsDead, 
+                log.LogInformation((int)ErrorCode.MembershipMarkingAsDead, 
                     "-Going to mark silo {0} as DEAD in the table #1. I am the last voter: #freshVotes={1}, myVoteIndex = {2}, NumVotesForDeathDeclaration={3} , #activeSilos={4}, suspect list={5}",
                             entry.SiloAddress, 
                             freshVotes.Count, 
@@ -784,7 +784,7 @@ namespace Orleans.Runtime.MembershipService
                 var newEntry = new Tuple<SiloAddress, DateTime>(myAddress, now);
                 entry.SuspectTimes[indexToWrite] = newEntry;
             }
-            log.Info(ErrorCode.MembershipVotingForKill,
+            log.LogInformation((int)ErrorCode.MembershipVotingForKill,
                 "-Putting my vote to mark silo {0} as DEAD #2. Previous suspect list is {1}, trying to update to {2}, eTag={3}, freshVotes is {4}",
                 entry.SiloAddress, 
                 PrintSuspectList(prevList), 
@@ -834,11 +834,11 @@ namespace Orleans.Runtime.MembershipService
                     return true;
                 }
                 
-                log.Info(ErrorCode.MembershipMarkDeadWriteFailed, "-Failed to update {0} status to Dead in the Membership table, due to write conflicts. Will retry.", entry.SiloAddress);
+                log.LogInformation((int)ErrorCode.MembershipMarkDeadWriteFailed, "-Failed to update {0} status to Dead in the Membership table, due to write conflicts. Will retry.", entry.SiloAddress);
                 return false;
             }
             
-            log.Info(ErrorCode.MembershipCantWriteLivenessDisabled, "-Want to mark silo {0} as DEAD, but will ignore because Liveness is Disabled.", entry.SiloAddress);
+            log.LogInformation((int)ErrorCode.MembershipCantWriteLivenessDisabled, "-Want to mark silo {0} as DEAD, but will ignore because Liveness is Disabled.", entry.SiloAddress);
             return true;
         }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -356,7 +356,7 @@ namespace Orleans.Runtime.MembershipService
                 else
                 {
                     errorString = $"-Silo {myAddress} failed to update its status to {status} in the Membership table due to write contention on the table after {numCalls} attempts.";
-                    log.Error(ErrorCode.MembershipFailedToWriteConditional, errorString);
+                    log.LogError((int)ErrorCode.MembershipFailedToWriteConditional, errorString);
                     throw new OrleansException(errorString);
                 }
             }
@@ -365,7 +365,7 @@ namespace Orleans.Runtime.MembershipService
                 if (errorString == null)
                 {
                     errorString = $"-Silo {this.myAddress} failed to update its status to {status} in the table due to failures (socket failures or table read/write failures) after {numCalls} attempts: {exc.Message}";
-                    log.Error(ErrorCode.MembershipFailedToWrite, errorString);
+                    log.LogError((int)ErrorCode.MembershipFailedToWrite, errorString);
                     throw new OrleansException(errorString, exc);
                 }
 
@@ -572,7 +572,7 @@ namespace Orleans.Runtime.MembershipService
         private void KillMyselfLocally(string reason)
         {
             var msg = "I have been told I am dead, so this silo will stop! " + reason;
-            log.Error(ErrorCode.MembershipKillMyselfLocally, msg);
+            log.LogError((int)ErrorCode.MembershipKillMyselfLocally, msg);
             this.CurrentStatus = SiloStatus.Dead;
             this.fatalErrorHandler.OnFatalException(this, msg, null);
         }
@@ -688,7 +688,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 // this should not happen ...
                 var str = string.Format("-Could not find silo entry for silo {0} in the table.", silo);
-                log.Error(ErrorCode.MembershipFailedToReadSilo, str);
+                log.LogError((int)ErrorCode.MembershipFailedToReadSilo, str);
                 throw new KeyNotFoundException(str);
             }
 
@@ -719,7 +719,7 @@ namespace Orleans.Runtime.MembershipService
                 // this should not happen ...
                 var str = string.Format("-Silo {0} is suspected by {1} which is more or equal than {2}, but is not marked as dead. This is a bug!!!",
                     entry.SiloAddress, freshVotes.Count.ToString(), this.clusterMembershipOptions.NumVotesForDeathDeclaration.ToString());
-                log.Error(ErrorCode.Runtime_Error_100053, str);
+                log.LogError((int)ErrorCode.Runtime_Error_100053, str);
                 KillMyselfLocally("Found a bug! Will stop.");
                 return false;
             }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -306,7 +306,7 @@ namespace Orleans.Runtime.MembershipService
                 Func<int, Task<bool>> updateMyStatusTask = async counter =>
                 {
                     numCalls++;
-                    if (log.IsEnabled(LogLevel.Debug)) log.Debug("-Going to try to TryUpdateMyStatusGlobalOnce #{0}", counter);
+                    if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-Going to try to TryUpdateMyStatusGlobalOnce #{0}", counter);
                     return await TryUpdateMyStatusGlobalOnce(status);  // function to retry
                 };
                 
@@ -330,7 +330,7 @@ namespace Orleans.Runtime.MembershipService
 
                 if (ok)
                 {
-                    if (log.IsEnabled(LogLevel.Debug)) log.Debug("-Silo {0} Successfully updated my Status in the Membership table to {1}", myAddress, status);
+                    if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-Silo {0} Successfully updated my Status in the Membership table to {1}", myAddress, status);
 
                     var gossipTask = this.GossipToOthers(this.myAddress, status);
                     gossipTask.Ignore();
@@ -383,7 +383,7 @@ namespace Orleans.Runtime.MembershipService
         {
             var table = await membershipTableProvider.ReadAll();
 
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("-TryUpdateMyStatusGlobalOnce: Read{0} Membership table {1}", (newStatus.Equals(SiloStatus.Active) ? "All" : " my entry from"), table.ToString());
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-TryUpdateMyStatusGlobalOnce: Read{0} Membership table {1}", (newStatus.Equals(SiloStatus.Active) ? "All" : " my entry from"), table.ToString());
             LogMissedIAmAlives(table);
             var (myEntry, myEtag) = this.GetOrCreateLocalSiloEntry(table, newStatus);
 
@@ -526,7 +526,7 @@ namespace Orleans.Runtime.MembershipService
                     continue;
                 }
 
-                if (log.IsEnabled(LogLevel.Debug)) log.Debug("Temporal anomaly detected in membership table -- Me={0} Other me={1}",
+                if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("Temporal anomaly detected in membership table -- Me={0} Other me={1}",
                     myAddress, siloAddress);
 
                 // Temporal paradox - There is an older clone of this silo in the membership table
@@ -551,7 +551,7 @@ namespace Orleans.Runtime.MembershipService
 
             if (silosToDeclareDead.Count == 0) return true;
 
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("CleanupTableEntries: About to DeclareDead {0} outdated silos in the table: {1}", silosToDeclareDead.Count,
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("CleanupTableEntries: About to DeclareDead {0} outdated silos in the table: {1}", silosToDeclareDead.Count,
                 Utils.EnumerableToString(silosToDeclareDead.Select(tuple => tuple.Item1), entry => entry.ToString()));
 
             var result = true;
@@ -664,7 +664,7 @@ namespace Orleans.Runtime.MembershipService
         {
             var table = await membershipTableProvider.ReadAll();
 
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("-TryToSuspectOrKill: Read Membership table {0}", table.ToString());
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-TryToSuspectOrKill: Read Membership table {0}", table.ToString());
 
             if (this.IsStopping)
             {
@@ -695,7 +695,7 @@ namespace Orleans.Runtime.MembershipService
             var tuple = table.Get(silo);
             var entry = tuple.Item1.Copy();
             string eTag = tuple.Item2;
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("-TryToSuspectOrKill {siloAddress}: The current status of {siloAddress} in the table is {status}, its entry is {entry}",
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-TryToSuspectOrKill {siloAddress}: The current status of {siloAddress} in the table is {status}, its entry is {entry}",
                 entry.SiloAddress, // First
                 entry.SiloAddress, // Second
                 entry.Status, 
@@ -821,12 +821,12 @@ namespace Orleans.Runtime.MembershipService
                 // add the killer (myself) to the suspect list, for easier diagnosis later on.
                 entry.AddSuspector(myAddress, DateTime.UtcNow);
 
-                if (log.IsEnabled(LogLevel.Debug)) log.Debug("-Going to DeclareDead silo {0} in the table. About to write entry {1}.", entry.SiloAddress, entry.ToFullString());
+                if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-Going to DeclareDead silo {0} in the table. About to write entry {1}.", entry.SiloAddress, entry.ToFullString());
                 entry.Status = SiloStatus.Dead;
                 bool ok = await membershipTableProvider.UpdateRow(entry, etag, tableVersion.Next());
                 if (ok)
                 {
-                    if (log.IsEnabled(LogLevel.Debug)) log.Debug("-Successfully updated {0} status to Dead in the Membership table.", entry.SiloAddress);
+                    if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("-Successfully updated {0} status to Dead in the Membership table.", entry.SiloAddress);
 
                     var table = await membershipTableProvider.ReadAll();
                     this.ProcessTableUpdate(table, "DeclareDead");

--- a/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
@@ -39,7 +39,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 if (this.CurrentStatus == SiloStatus.Active && this.log.IsEnabled(LogLevel.Debug))
                 {
-                    this.log.Debug(ErrorCode.Runtime_Error_100209, "-The given siloAddress {0} is not registered in this MembershipOracle.", silo);
+                    this.log.LogDebug((int)ErrorCode.Runtime_Error_100209, "-The given siloAddress {0} is not registered in this MembershipOracle.", silo);
                 }
             }
 

--- a/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.MembershipService
             bool isPrimarySilo = siloDetails.SiloAddress.Endpoint.Equals(options.PrimarySiloEndpoint);
             if (isPrimarySilo)
             {
-                this.logger.Info(ErrorCode.MembershipFactory1, "Creating in-memory membership table");
+                this.logger.LogInformation((int)ErrorCode.MembershipFactory1, "Creating in-memory membership table");
                 var catalog = serviceProvider.GetRequiredService<Catalog>();
                 catalog.RegisterSystemTarget(ActivatorUtilities.CreateInstance<MembershipTableSystemTarget>(serviceProvider));
             }
@@ -67,7 +67,7 @@ namespace Orleans.Runtime.MembershipService
                 try
                 {
                     await membershipTableSystemTarget.ReadAll().WithTimeout(timespan, $"MembershipGrain trying to read all content of the membership table, failed due to timeout {timespan}");
-                    logger.Info(ErrorCode.MembershipTableGrainInit2, "-Connected to membership table provider.");
+                    logger.LogInformation((int)ErrorCode.MembershipTableGrainInit2, "-Connected to membership table provider.");
                     return;
                 }
                 catch (Exception exc)
@@ -75,14 +75,14 @@ namespace Orleans.Runtime.MembershipService
                     var type = exc.GetBaseException().GetType();
                     if (type == typeof(TimeoutException) || type == typeof(OrleansException))
                     {
-                        logger.Info(
-                            ErrorCode.MembershipTableGrainInit3,
+                        logger.LogInformation(
+                            (int)ErrorCode.MembershipTableGrainInit3,
                             "-Waiting for membership table provider to initialize. Going to sleep for {0} and re-try to reconnect.",
                             timespan);
                     }
                     else
                     {
-                        logger.Info(ErrorCode.MembershipTableGrainInit4, "-Membership table provider failed to initialize. Giving up.");
+                        logger.LogInformation((int)ErrorCode.MembershipTableGrainInit4, "-Membership table provider failed to initialize. Giving up.");
                         throw;
                     }
                 }
@@ -123,7 +123,7 @@ namespace Orleans.Runtime.MembershipService
         {
             logger = loggerFactory.CreateLogger<MembershipTableSystemTarget>();
             table = new InMemoryMembershipTable(serializationManager);
-            logger.Info(ErrorCode.MembershipGrainBasedTable1, "GrainBasedMembershipTable Activated.");
+            logger.LogInformation((int)ErrorCode.MembershipGrainBasedTable1, "GrainBasedMembershipTable Activated.");
         }
 
         private static SystemTargetGrainId CreateId(ILocalSiloDetails localSiloDetails)
@@ -133,13 +133,13 @@ namespace Orleans.Runtime.MembershipService
 
         public Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            logger.Info("InitializeMembershipTable {0}.", tryInitTableVersion);
+            logger.LogInformation("InitializeMembershipTable {0}.", tryInitTableVersion);
             return Task.CompletedTask;
         }
 
         public Task DeleteMembershipTableEntries(string clusterId)
         {
-            logger.Info("DeleteMembershipTableEntries {0}", clusterId);
+            logger.LogInformation("DeleteMembershipTableEntries {0}", clusterId);
             table = null;
             return Task.CompletedTask;
         }
@@ -160,7 +160,7 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("InsertRow entry = {0}, table version = {1}", entry.ToFullString(), tableVersion);
             bool result = table.Insert(entry, tableVersion);
             if (result == false)
-                logger.Info(ErrorCode.MembershipGrainBasedTable2,
+                logger.LogInformation((int)ErrorCode.MembershipGrainBasedTable2,
                     "Insert of {0} and table version {1} failed. Table now is {2}",
                     entry.ToFullString(), tableVersion, table.ReadAll());
 
@@ -172,7 +172,7 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("UpdateRow entry = {0}, etag = {1}, table version = {2}", entry.ToFullString(), etag, tableVersion);
             bool result = table.Update(entry, etag, tableVersion);
             if (result == false)
-                logger.Info(ErrorCode.MembershipGrainBasedTable3,
+                logger.LogInformation((int)ErrorCode.MembershipGrainBasedTable3,
                     "Update of {0}, eTag {1}, table version {2} failed. Table now is {3}",
                     entry.ToFullString(), etag, tableVersion, table.ReadAll());
 

--- a/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/SystemTargetBasedMembershipTable.cs
@@ -157,7 +157,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("InsertRow entry = {0}, table version = {1}", entry.ToFullString(), tableVersion);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("InsertRow entry = {0}, table version = {1}", entry.ToFullString(), tableVersion);
             bool result = table.Insert(entry, tableVersion);
             if (result == false)
                 logger.Info(ErrorCode.MembershipGrainBasedTable2,
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("UpdateRow entry = {0}, etag = {1}, table version = {2}", entry.ToFullString(), etag, tableVersion);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("UpdateRow entry = {0}, etag = {1}, table version = {2}", entry.ToFullString(), etag, tableVersion);
             bool result = table.Update(entry, etag, tableVersion);
             if (result == false)
                 logger.Info(ErrorCode.MembershipGrainBasedTable3,
@@ -181,7 +181,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task UpdateIAmAlive(MembershipEntry entry)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("UpdateIAmAlive entry = {0}", entry.ToFullString());
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("UpdateIAmAlive entry = {0}", entry.ToFullString());
             table.UpdateIAmAlive(entry);
             return Task.CompletedTask;
         }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -385,7 +385,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     if (msg == null) return;
 
-                    this.log.Info(ErrorCode.GatewayTryingToSendToUnrecognizedClient, "Trying to send a message {0} to an unrecognized client {1}", msg.ToString(), msg.TargetGrain);
+                    this.log.LogInformation((int)ErrorCode.GatewayTryingToSendToUnrecognizedClient, "Trying to send a message {0} to an unrecognized client {1}", msg.ToString(), msg.TargetGrain);
                     MessagingStatisticsGroup.OnFailedSentMessage(msg);
                     // Message for unrecognized client -- reject it
                     if (msg.Direction == Message.Directions.Request)

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -411,7 +411,7 @@ namespace Orleans.Runtime.Messaging
                     {
                         if (msg == null) return;
 
-                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.Trace("Queued message {0} for client {1}", msg, msg.TargetGrain);
+                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace("Queued message {0} for client {1}", msg, msg.TargetGrain);
                         clientState.PendingToSend.Enqueue(msg);
                         return;
                     }
@@ -433,12 +433,12 @@ namespace Orleans.Runtime.Messaging
 
                     if (!Send(msg, clientState))
                     {
-                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.Trace("Queued message {0} for client {1}", msg, msg.TargetGrain);
+                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace("Queued message {0} for client {1}", msg, msg.TargetGrain);
                         clientState.PendingToSend.Enqueue(msg);
                     }
                     else
                     {
-                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.Trace("Sent message {0} to client {1}", msg, msg.TargetGrain);
+                        if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace("Sent message {0} to client {1}", msg, msg.TargetGrain);
                     }
                 }
             }
@@ -452,7 +452,7 @@ namespace Orleans.Runtime.Messaging
                         var m = clientState.PendingToSend.Peek();
                         if (Send(m, clientState))
                         {
-                            if (this.log.IsEnabled(LogLevel.Trace)) this.log.Trace("Sent queued message {0} to client {1}", m, clientState.Id);
+                            if (this.log.IsEnabled(LogLevel.Trace)) this.log.LogTrace("Sent queued message {0} to client {1}", m, clientState.Id);
                             clientState.PendingToSend.Dequeue();
                         }
                         else

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -106,7 +106,7 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exc)
             {
-                log.Error(ErrorCode.Runtime_Error_100110, "Stop failed.", exc);
+                log.LogError((int)ErrorCode.Runtime_Error_100110, exc, "Stop failed.");
             }
         }
 
@@ -119,7 +119,7 @@ namespace Orleans.Runtime.Messaging
             {
                 Gateway.Stop();
             }
-            catch (Exception exc) { log.Error(ErrorCode.Runtime_Error_100109, "Stop failed.", exc); }
+            catch (Exception exc) { log.LogError((int)ErrorCode.Runtime_Error_100109, exc, "Stop failed."); }
             Gateway = null;
         }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -112,7 +112,7 @@ namespace Orleans.Runtime.Messaging
 
         public void StopAcceptingClientMessages()
         {
-            if (log.IsEnabled(LogLevel.Debug)) log.Debug("StopClientMessages");
+            if (log.IsEnabled(LogLevel.Debug)) log.LogDebug("StopClientMessages");
             if (Gateway == null) return;
 
             try
@@ -207,7 +207,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // Do not send reject a rejection locally, it will create a stack overflow
                 MessagingStatisticsGroup.OnDroppedSentMessage(msg);
-                if (this.log.IsEnabled(LogLevel.Debug)) log.Debug("Dropping rejection {msg}", msg);
+                if (this.log.IsEnabled(LogLevel.Debug)) log.LogDebug("Dropping rejection {msg}", msg);
             }
             else
             {
@@ -240,7 +240,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         public void BlockApplicationMessages()
         {
-            if(log.IsEnabled(LogLevel.Debug)) log.Debug("BlockApplicationMessages");
+            if(log.IsEnabled(LogLevel.Debug)) log.LogDebug("BlockApplicationMessages");
             IsBlockingApplicationMessages = true;
         }
     }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -56,11 +56,11 @@ namespace Orleans.Runtime.Messaging
             this.messageFactory = messageFactory;
             this.MyAddress = siloDetails.SiloAddress;
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Starting initialization.");
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Starting initialization.");
 
             OutboundQueue = new OutboundMessageQueue(this, this.loggerFactory.CreateLogger<OutboundMessageQueue>(), this.senderManager, siloStatusOracle, this.messagingTrace);
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Completed initialization.");
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Completed initialization.");
 
             if (siloDetails.GatewayAddress != null)
             {
@@ -192,7 +192,7 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            if (log.IsEnabled(LogLevel.Trace)) log.Trace("Message has been looped back to this silo: {0}", message);
+            if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Message has been looped back to this silo: {0}", message);
             MessagingStatisticsGroup.LocalMessagesSent.Increment();
             this.OnReceivedMessage(message);
 

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -155,7 +155,7 @@ namespace Orleans.Runtime.Messaging
             }
             else
             {
-                this.Log.Info(ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Silo {siloAddress} is dropping message: {message}. Reason = {reason}", this.myAddress, msg, reason);
+                this.Log.LogInformation((int)ErrorCode.Messaging_OutgoingMS_DroppingMessage, "Silo {siloAddress} is dropping message: {message}. Reason = {reason}", this.myAddress, msg, reason);
                 MessagingStatisticsGroup.OnDroppedSentMessage(msg);
             }
         }

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -60,7 +60,7 @@ namespace Orleans.Runtime.Messaging
                 MessagingStatisticsGroup.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
                 this.messageCenter.TryDeliverToProxy(rejection);
-                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug("Rejecting a request due to overloading: {0}", msg.ToString());
+                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.LogDebug("Rejecting a request due to overloading: {0}", msg.ToString());
                 loadSheddingCounter.Increment();
                 return;
             }
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.Messaging
             MessagingStatisticsGroup.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
-                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug(ErrorCode.MessagingSendingRejection, "Silo {siloAddress} is rejecting message: {message}. Reason = {reason}", this.myAddress, msg, reason);
+                if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.LogDebug((int)ErrorCode.MessagingSendingRejection, "Silo {siloAddress} is rejecting message: {message}. Reason = {reason}", this.myAddress, msg, reason);
 
                 // Done retrying, send back an error instead
                 this.messageCenter.SendRejection(msg, Message.RejectionTypes.Transient, String.Format("Silo {0} is rejecting message: {1}. Reason = {2}", this.myAddress, msg, reason));

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -102,7 +102,7 @@ namespace Orleans.Runtime.Messaging
             if (!msg.TargetSilo.Endpoint.Equals(this.LocalSiloAddress.Endpoint))
             {
                 // If the message is for some other silo altogether, then we need to forward it.
-                if (this.Log.IsEnabled(LogLevel.Trace)) this.Log.Trace("Forwarding message {0} from {1} to silo {2}", msg.Id, msg.SendingSilo, msg.TargetSilo);
+                if (this.Log.IsEnabled(LogLevel.Trace)) this.Log.LogTrace("Forwarding message {0} from {1} to silo {2}", msg.Id, msg.SendingSilo, msg.TargetSilo);
                 messageCenter.OutboundQueue.SendMessage(msg);
                 return;
             }

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -127,7 +127,7 @@ namespace Orleans.Runtime.Messaging
 
                 if (this.Log.IsEnabled(LogLevel.Debug))
                 {
-                    this.Log.Debug(
+                    this.Log.LogDebug(
                         "Rejecting an obsolete request; target was {0}, but this silo is {1}. The rejected message is {2}.",
                         msg.TargetSilo.ToLongString(),
                         this.LocalSiloAddress.ToLongString(),

--- a/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
@@ -105,7 +105,7 @@ namespace Orleans.Runtime.Placement
                 Utils.EnumerableToString(
                     all,
                     kvp => String.Format("SiloAddress = {0} -> {1}", kvp.Key.ToString(), kvp.Value.ToString())));
-            logger.Warn(ErrorCode.Placement_ActivationCountBasedDirector_NoSilos, debugLog);
+            logger.LogWarning((int)ErrorCode.Placement_ActivationCountBasedDirector_NoSilos, debugLog);
             throw new OrleansException(debugLog);
         }
 

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime
 
         public async Task Start()
         {
-            logger.Info("Starting DeploymentLoadPublisher.");
+            logger.LogInformation("Starting DeploymentLoadPublisher.");
             if (statisticsRefreshTime > TimeSpan.Zero)
             {
                 // Randomize PublishStatistics timer,
@@ -79,7 +79,7 @@ namespace Orleans.Runtime
             }
             await RefreshStatistics();
             await PublishStatistics(null);
-            logger.Info("Started DeploymentLoadPublisher.");
+            logger.LogInformation("Started DeploymentLoadPublisher.");
         }
 
         private async Task PublishStatistics(object _)

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -86,7 +86,7 @@ namespace Orleans.Runtime
         {
             try
             {
-                if(logger.IsEnabled(LogLevel.Debug)) logger.Debug("PublishStatistics.");
+                if(logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("PublishStatistics.");
                 var members = this.siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
                 var tasks = new List<Task>();
                 var activationCount = this.activationDirectory.Count;
@@ -125,7 +125,7 @@ namespace Orleans.Runtime
 
         public Task UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("UpdateRuntimeStatistics from {0}", siloAddress);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("UpdateRuntimeStatistics from {0}", siloAddress);
             if (this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
                 return Task.CompletedTask;
 
@@ -141,7 +141,7 @@ namespace Orleans.Runtime
 
         internal async Task<ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>> RefreshStatistics()
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("RefreshStatistics.");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("RefreshStatistics.");
             await this.scheduler.RunOrQueueTask(() =>
                 {
                     var tasks = new List<Task>();

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -109,7 +109,7 @@ namespace Orleans.Runtime
                     }
                     catch (Exception)
                     {
-                        logger.Warn(ErrorCode.Placement_RuntimeStatisticsUpdateFailure_1,
+                        logger.LogWarning((int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_1,
                             String.Format("An unexpected exception was thrown by PublishStatistics.UpdateRuntimeStatistics(). Ignored."));
                     }
                 }
@@ -117,8 +117,8 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Warn(ErrorCode.Placement_RuntimeStatisticsUpdateFailure_2,
-                    String.Format("An exception was thrown by PublishStatistics.UpdateRuntimeStatistics(). Ignoring."), exc);
+                logger.LogWarning((int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_2, exc,
+                    "An exception was thrown by PublishStatistics.UpdateRuntimeStatistics(). Ignoring.");
             }
         }
 
@@ -159,9 +159,8 @@ namespace Orleans.Runtime
                                         }
                                         else
                                         {
-                                            logger.Warn(ErrorCode.Placement_RuntimeStatisticsUpdateFailure_3,
-                                                String.Format("An unexpected exception was thrown from RefreshStatistics by ISiloControl.GetRuntimeStatistics({0}). Will keep using stale statistics.", capture),
-                                                statsTask.Exception);
+                                            logger.LogWarning((int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_3, statsTask.Exception,
+                                                "An unexpected exception was thrown from RefreshStatistics by ISiloControl.GetRuntimeStatistics({0}). Will keep using stale statistics.", capture);
                                         }
                                     });
                         tasks.Add(task);

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -160,7 +160,7 @@ namespace Orleans.Runtime.Placement
                 var result = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
                 if (result.Length > 0) return result;
 
-                _logger.Warn(ErrorCode.Catalog_GetApproximateSiloStatuses, "AllActiveSilos SiloStatusOracle.GetApproximateSiloStatuses empty");
+                _logger.LogWarning((int)ErrorCode.Catalog_GetApproximateSiloStatuses, "AllActiveSilos SiloStatusOracle.GetApproximateSiloStatuses empty");
                 return new SiloAddress[] { LocalSilo };
             }
         }

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -119,7 +119,7 @@ namespace Orleans.Runtime.Placement
                 CounterStatistic.FindOrCreate(StatisticNames.DISPATCHER_NEW_PLACEMENT).Increment();
             }
 #if DEBUG
-            if (_logger.IsEnabled(LogLevel.Trace)) _logger.Trace(ErrorCode.Dispatcher_AddressMsg_SelectTarget, "AddressMessage Placement SelectTarget {0}", message);
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace((int)ErrorCode.Dispatcher_AddressMsg_SelectTarget, "AddressMessage Placement SelectTarget {0}", message);
 #endif
         }
 

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.ReminderService
             }
 
             var msg = string.Format("Could not register reminder {0} to reminder table due to a race. Please try again later.", entry);
-            logger.Error(ErrorCode.RS_Register_TableError, msg);
+            logger.LogError((int)ErrorCode.RS_Register_TableError, msg);
             throw new ReminderException(msg);
         }
 
@@ -145,7 +145,7 @@ namespace Orleans.Runtime.ReminderService
             else
             {
                 var msg = string.Format("Could not unregister reminder {0} from the reminder table, due to tag mismatch. You can retry.", reminder);
-                logger.Error(ErrorCode.RS_Unregister_TableError, msg);
+                logger.LogError((int)ErrorCode.RS_Unregister_TableError, msg);
                 throw new ReminderException(msg);
             }
         }
@@ -270,8 +270,7 @@ namespace Orleans.Runtime.ReminderService
                 else
                 {
                     const string baseErrorMsg = "ReminderService failed initial load of reminders and cannot guarantee that the service will be eventually start without manual intervention or restarting the silo.";
-                    var logErrorMessage = string.Format(baseErrorMsg + " Attempt #{0}", this.initialReadCallCount);
-                    logger.Error(ErrorCode.RS_ServiceInitialLoadFailed, logErrorMessage, ex);
+                    logger.LogError((int)ErrorCode.RS_ServiceInitialLoadFailed, ex, baseErrorMsg + " Attempt #{0}", this.initialReadCallCount);
                     startedTask.TrySetException(new OrleansException(baseErrorMsg, ex));
                 }
             }
@@ -378,7 +377,7 @@ namespace Orleans.Runtime.ReminderService
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.RS_FailedToReadTableAndStartTimer, "Failed to read rows from table.", exc);
+                logger.LogError((int)ErrorCode.RS_FailedToReadTableAndStartTimer, exc, "Failed to read rows from table.");
                 throw;
             }
         }
@@ -623,10 +622,9 @@ namespace Orleans.Runtime.ReminderService
                 catch (Exception exc)
                 {
                     var after = DateTime.UtcNow;
-                    logger.Error(
-                        ErrorCode.RS_Tick_Delivery_Error,
-                        string.Format("Could not deliver reminder tick for {0}, next {1}.",  this.ToString(), after + this.period),
-                            exc);
+                    logger.LogError(
+                        (int)ErrorCode.RS_Tick_Delivery_Error,
+                            exc, string.Format("Could not deliver reminder tick for {0}, next {1}.",  this.ToString(), after + this.period));
                     // What to do with repeated failures to deliver a reminder's ticks?
                 }
             }

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -199,7 +199,7 @@ namespace Orleans.Runtime.ReminderService
                 localReminders.Remove(reminder.Identity);
             }
 
-            if (logger.IsEnabled(LogLevel.Information) && remindersOutOfRange.Length > 0) logger.Info($"Removed {remindersOutOfRange.Length} local reminders that are now out of my range.");
+            if (logger.IsEnabled(LogLevel.Information) && remindersOutOfRange.Length > 0) logger.LogInformation($"Removed {remindersOutOfRange.Length} local reminders that are now out of my range.");
         }
 
         public override Task OnRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -175,7 +175,7 @@ namespace Orleans.Runtime.ReminderService
 
             // try to retrieve reminders from all my subranges
             var rangeSerialNumberCopy = RangeSerialNumber;
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace($"My range= {RingRange}, RangeSerialNumber {RangeSerialNumber}. Local reminders count {localReminders.Count}");
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace($"My range= {RingRange}, RangeSerialNumber {RangeSerialNumber}. Local reminders count {localReminders.Count}");
             var acks = new List<Task>();
             foreach (var range in RangeFactory.GetSubRanges(RingRange))
             {
@@ -193,7 +193,7 @@ namespace Orleans.Runtime.ReminderService
             foreach (var reminder in remindersOutOfRange)
             {
                 if (logger.IsEnabled(LogLevel.Trace))
-                    logger.Trace("Not in my range anymore, so removing. {0}", reminder);
+                    logger.LogTrace("Not in my range anymore, so removing. {0}", reminder);
                 // remove locally
                 reminder.StopReminder();
                 localReminders.Remove(reminder.Identity);
@@ -315,13 +315,13 @@ namespace Orleans.Runtime.ReminderService
                         {
                             if (localRem.IsRunning) // if ticking
                             {
-                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Old, & Ticking {0}", localRem);
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("In table, In local, Old, & Ticking {0}", localRem);
                                 // it might happen that our local reminder is different than the one in the table, i.e., eTag is different
                                 // if so, stop the local timer for the old reminder, and start again with new info
                                 if (!localRem.ETag.Equals(entry.ETag))
                                 // this reminder needs a restart
                                 {
-                                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("{0} Needs a restart", localRem);
+                                    if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("{0} Needs a restart", localRem);
                                     localRem.StopReminder();
                                     localReminders.Remove(localRem.Identity);
                                     StartAndAddTimer(entry);
@@ -330,7 +330,7 @@ namespace Orleans.Runtime.ReminderService
                             else // if not ticking
                             {
                                 // no-op
-                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Old, & Not Ticking {0}", localRem);
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("In table, In local, Old, & Not Ticking {0}", localRem);
                             }
                         }
                         else // cachedSequence < localRem.LocalSequenceNumber ... // info read from table is older than local info
@@ -338,18 +338,18 @@ namespace Orleans.Runtime.ReminderService
                             if (localRem.IsRunning) // if ticking
                             {
                                 // no-op
-                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Newer, & Ticking {0}", localRem);
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("In table, In local, Newer, & Ticking {0}", localRem);
                             }
                             else // if not ticking
                             {
                                 // no-op
-                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Newer, & Not Ticking {0}", localRem);
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("In table, In local, Newer, & Not Ticking {0}", localRem);
                             }
                         }
                     }
                     else // exists in table, but not locally
                     {
-                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, Not in local, {0}", entry);
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("In table, Not in local, {0}", entry);
                         // create and start the reminder
                         StartAndAddTimer(entry);
                     }
@@ -365,11 +365,11 @@ namespace Orleans.Runtime.ReminderService
                     if (cachedSequence < reminder.LocalSequenceNumber)
                     {
                         // no-op
-                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Not in table, In local, Newer, {0}", reminder);
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Not in table, In local, Newer, {0}", reminder);
                     }
                     else // cachedSequence > reminder.LocalSequenceNumber
                     {
-                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Not in table, In local, Old, so removing. {0}", reminder);
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Not in table, In local, Old, so removing. {0}", reminder);
                         // remove locally
                         reminder.StopReminder();
                         localReminders.Remove(reminder.Identity);
@@ -481,7 +481,7 @@ namespace Orleans.Runtime.ReminderService
 
             var str = String.Format("{0}{1}{2}", (msg ?? "Current list of reminders:"), Environment.NewLine,
                 Utils.EnumerableToString(localReminders, null, Environment.NewLine));
-            logger.Trace(str);
+            logger.LogTrace(str);
         }
 
         private class LocalReminderData
@@ -595,7 +595,7 @@ namespace Orleans.Runtime.ReminderService
                 var logger = this.reminderService.logger;
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    logger.Trace("Triggering tick for {0}, status {1}, now {2}", this.ToString(), status, before);
+                    logger.LogTrace("Triggering tick for {0}, status {1}, now {2}", this.ToString(), status, before);
                 }
 
                 try
@@ -614,7 +614,7 @@ namespace Orleans.Runtime.ReminderService
                     var after = DateTime.UtcNow;
                     if (logger.IsEnabled(LogLevel.Trace))
                     {
-                        logger.Trace("Tick triggered for {0}, dt {1} sec, next@~ {2}", this.ToString(), (after - before).TotalSeconds,
+                        logger.LogTrace("Tick triggered for {0}, dt {1} sec, next@~ {2}", this.ToString(), (after - before).TotalSeconds,
                               // the next tick isn't actually scheduled until we return control to
                               // AsyncSafeTimer but we can approximate it by adding the period of the reminder
                               // to the after time.

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -263,10 +263,9 @@ namespace Orleans.Runtime.ReminderService
 
                 if (initialReadCallCount <= InitialReadRetryCountBeforeFastFailForUpdates)
                 {
-                    logger.Warn(
-                        ErrorCode.RS_ServiceInitialLoadFailing,
-                        string.Format("ReminderService failed initial load of reminders and will retry. Attempt #{0}", this.initialReadCallCount),
-                        ex);
+                    logger.LogWarning(
+                        (int)ErrorCode.RS_ServiceInitialLoadFailing, ex,
+                        "ReminderService failed initial load of reminders and will retry. Attempt #{0}", this.initialReadCallCount);
                 }
                 else
                 {
@@ -466,7 +465,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 if (!RingRange.InRange(grainRef))
                 {
-                    logger.Warn(ErrorCode.RS_NotResponsible, "I shouldn't have received request '{0}' for {1}. It is not in my responsibility range: {2}",
+                    logger.LogWarning((int)ErrorCode.RS_NotResponsible, "I shouldn't have received request '{0}' for {1}. It is not in my responsibility range: {2}",
                         debugInfo, grainRef.ToString(), RingRange);
                     // For now, we still let the caller proceed without throwing an exception... the periodical mechanism will take care of reminders being registered at the wrong silo
                     // otherwise, we can either reject the request, or re-route the request

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -53,7 +53,7 @@ namespace Orleans.Runtime.Scheduler
         protected override void QueueTask(Task task)
         {
 #if DEBUG
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(myId + " QueueTask Task Id={0}", task.Id);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(myId + " QueueTask Task Id={0}", task.Id);
 #endif
             workerGroup.EnqueueTask(task);
         }
@@ -74,7 +74,7 @@ namespace Orleans.Runtime.Scheduler
 #if DEBUG
             if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.Trace(myId + " --> TryExecuteTaskInline Task Id={0} Status={1} PreviouslyQueued={2} CanExecute={3} Queued={4}",
+                logger.LogTrace(myId + " --> TryExecuteTaskInline Task Id={0} Status={1} PreviouslyQueued={2} CanExecute={3} Queued={4}",
                     task.Id, task.Status, taskWasPreviouslyQueued, canExecuteInline, workerGroup.ExternalWorkItemCount);
             }
 #endif
@@ -88,7 +88,7 @@ namespace Orleans.Runtime.Scheduler
             if (!canExecuteInline)
             {
 #if DEBUG
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(myId + " <-X TryExecuteTaskInline Task Id={0} Status={1} Execute=No", task.Id, task.Status);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(myId + " <-X TryExecuteTaskInline Task Id={0} Status={1} Execute=No", task.Id, task.Status);
 #endif
                 return false;
             }
@@ -97,7 +97,7 @@ namespace Orleans.Runtime.Scheduler
             turnsExecutedStatistic.Increment();
 #endif
 #if DEBUG
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(myId + " TryExecuteTaskInline Task Id={0} Thread={1} Execute=Yes", task.Id, Thread.CurrentThread.ManagedThreadId);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(myId + " TryExecuteTaskInline Task Id={0} Thread={1} Execute=Yes", task.Id, Thread.CurrentThread.ManagedThreadId);
 #endif
             // Try to run the task.
             bool done = TryExecuteTask(task);
@@ -107,7 +107,7 @@ namespace Orleans.Runtime.Scheduler
                     task.Id, task.Status);
             }
 #if DEBUG
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(myId + " <-- TryExecuteTaskInline Task Id={0} Thread={1} Execute=Done Ok={2}", task.Id, Thread.CurrentThread.ManagedThreadId, done);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace(myId + " <-- TryExecuteTaskInline Task Id={0} Thread={1} Execute=Done Ok={2}", task.Id, Thread.CurrentThread.ManagedThreadId, done);
 #endif
             return done;
         }

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -29,7 +29,7 @@ namespace Orleans.Runtime.Scheduler
 #if EXTRA_STATS
             turnsExecutedStatistic = CounterStatistic.FindOrCreate(name + ".TasksExecuted");
 #endif
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Created {0} with GrainContext={1}", this, workerGroup.GrainContext);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Created {0} with GrainContext={1}", this, workerGroup.GrainContext);
         }
 
         /// <summary>Gets an enumerable of the tasks currently scheduled on this scheduler.</summary>

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Scheduler
             RuntimeContext.SetExecutionContext(workerGroup.GrainContext);
             bool done = TryExecuteTask(task);
             if (!done)
-                logger.Warn(ErrorCode.SchedulerTaskExecuteIncomplete4, "RunTask: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",
+                logger.LogWarning((int)ErrorCode.SchedulerTaskExecuteIncomplete4, "RunTask: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",
                     task.Id, task.Status);
             
             //  Consider adding ResetExecutionContext() or even better:
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.Scheduler
             bool done = TryExecuteTask(task);
             if (!done)
             {
-                logger.Warn(ErrorCode.SchedulerTaskExecuteIncomplete3, "TryExecuteTaskInline: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",
+                logger.LogWarning((int)ErrorCode.SchedulerTaskExecuteIncomplete3, "TryExecuteTaskInline: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",
                     task.Id, task.Status);
             }
 #if DEBUG

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.Scheduler
         private void ThrowNoWorkItemGroup(IGrainContext context)
         {
             var error = $"QueueWorkItem was called on a non-null context {context} but there is no valid WorkItemGroup for it.";
-            logger.Error(ErrorCode.SchedulerQueueWorkItemWrongContext, error);
+            logger.LogError((int)ErrorCode.SchedulerQueueWorkItemWrongContext, error);
             throw new InvalidSchedulingContextException(error);
         }
 

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -282,7 +282,7 @@ namespace Orleans.Runtime.Scheduler
             {
                 var stats = Utils.EnumerableToString(all.Select(i => i.Value).OrderBy(wg => wg.Name), wg => string.Format("--{0}", wg.DumpStatus()), Environment.NewLine);
                 if (stats.Length > 0)
-                    logger.Info(ErrorCode.SchedulerStatistics,
+                    logger.LogInformation((int)ErrorCode.SchedulerStatistics,
                         "OrleansTaskScheduler.PrintStatistics(): WorkItems={0}, Directory:" + Environment.NewLine + "{1}", all.Count, stats);
             }
 
@@ -301,7 +301,7 @@ namespace Orleans.Runtime.Scheduler
             foreach (var workgroup in all)
                 sb.AppendLine(workgroup.Value.DumpStatus());
             
-            logger.Info(ErrorCode.SchedulerStatus, sb.ToString());
+            logger.LogInformation((int)ErrorCode.SchedulerStatus, sb.ToString());
         }
     }
 }

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -147,7 +147,7 @@ namespace Orleans.Runtime.Scheduler
         public void QueueWorkItem(IWorkItem workItem)
         {
 #if DEBUG
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("QueueWorkItem " + workItem);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("QueueWorkItem " + workItem);
 #endif
             var workItemGroup = GetWorkItemGroup(workItem.GrainContext);
             if (applicationTurnsStopped && (workItemGroup != null) && !workItemGroup.IsSystemGroup)

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -154,7 +154,7 @@ namespace Orleans.Runtime.Scheduler
             {
                 // Drop the task on the floor if it's an application work item and application turns are stopped
                 var msg = $"Dropping work item {workItem} because application turns are stopped";
-                logger.Warn(ErrorCode.SchedulerAppTurnsStopped_1, msg);
+                logger.LogWarning((int)ErrorCode.SchedulerAppTurnsStopped_1, msg);
                 return;
             }
 

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -86,7 +86,7 @@ namespace Orleans.Runtime.Scheduler
         public void StopApplicationTurns()
         {
 #if DEBUG
-            logger.Debug("StopApplicationTurns");
+            logger.LogDebug("StopApplicationTurns");
 #endif
             // Do not RunDown the application run queue, since it is still used by low priority system targets.
 

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -79,7 +79,7 @@ namespace Orleans.Runtime
         public virtual Task Start()
         {
             RingRange = ring.GetMyRange();
-            Logger.Info(ErrorCode.RS_ServiceStarting, "Starting {0} grain service on: {1} x{2,8:X8}, with range {3}", this.typeName, Silo, Silo.GetConsistentHashCode(), RingRange);
+            Logger.LogInformation((int)ErrorCode.RS_ServiceStarting, "Starting {0} grain service on: {1} x{2,8:X8}, with range {3}", this.typeName, Silo, Silo.GetConsistentHashCode(), RingRange);
             StartInBackground().Ignore();
 
             return Task.CompletedTask;
@@ -100,7 +100,7 @@ namespace Orleans.Runtime
         {
             StoppedCancellationTokenSource.Cancel();
 
-            Logger.Info(ErrorCode.RS_ServiceStopping, $"Stopping {this.typeName} grain service");
+            Logger.LogInformation((int)ErrorCode.RS_ServiceStopping, $"Stopping {this.typeName} grain service");
             Status = GrainServiceStatus.Stopped;
             
             return Task.CompletedTask;
@@ -115,7 +115,7 @@ namespace Orleans.Runtime
         /// <summary>Invoked when the ring range owned by the service instance changes because of a change in the cluster state</summary>
         public virtual Task OnRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
         {
-            Logger.Info(ErrorCode.RS_RangeChanged, "My range changed from {0} to {1} increased = {2}", oldRange, newRange, increased);
+            Logger.LogInformation((int)ErrorCode.RS_RangeChanged, "My range changed from {0} to {1} increased = {2}", oldRange, newRange, increased);
             RingRange = newRange;
             RangeSerialNumber++;
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -143,7 +143,7 @@ namespace Orleans.Runtime
             }
             catch (InvalidOperationException exc)
             {
-                logger.Error(ErrorCode.SiloStartError, "Exception during Silo.Start, GrainFactory was not registered in Dependency Injection container", exc);
+                logger.LogError((int)ErrorCode.SiloStartError, exc, "Exception during Silo.Start, GrainFactory was not registered in Dependency Injection container");
                 throw;
             }
 
@@ -216,7 +216,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.SiloStartError, "Exception during Silo.Start", exc);
+                logger.LogError((int)ErrorCode.SiloStartError, exc, "Exception during Silo.Start");
                 throw;
             }
         }
@@ -356,7 +356,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                this.SafeExecute(() => this.logger.Error(ErrorCode.Runtime_Error_100330, String.Format("Error starting silo {0}. Going to FastKill().", this.SiloAddress), exc));
+                this.SafeExecute(() => this.logger.LogError((int)ErrorCode.Runtime_Error_100330, exc, String.Format("Error starting silo {0}. Going to FastKill().", this.SiloAddress)));
                 throw;
             }
             if (logger.IsEnabled(LogLevel.Debug)) { logger.LogDebug("Silo.Start complete: System status = {0}", this.SystemStatus); }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -115,7 +115,7 @@ namespace Orleans.Runtime
             this.loggerFactory = this.Services.GetRequiredService<ILoggerFactory>();
             logger = this.loggerFactory.CreateLogger<Silo>();
 
-            logger.Info(ErrorCode.SiloGcSetting, "Silo starting with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
+            logger.LogInformation((int)ErrorCode.SiloGcSetting, "Silo starting with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
             if (!GCSettings.IsServerGC)
             {
                 logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\">");
@@ -130,9 +130,9 @@ namespace Orleans.Runtime
                     $"A verbose logging level ({highestLogLevel}) is configured. This will impact performance. The recommended log level is {nameof(LogLevel.Information)}.");
             }
 
-            logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing silo on host {0} MachineName {1} at {2}, gen {3} --------------",
+            logger.LogInformation((int)ErrorCode.SiloInitializing, "-------------- Initializing silo on host {0} MachineName {1} at {2}, gen {3} --------------",
                 this.siloDetails.DnsHostName, Environment.MachineName, localEndpoint, this.siloDetails.SiloAddress.Generation);
-            logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0}", name);
+            logger.LogInformation((int)ErrorCode.SiloInitConfig, "Starting silo {0}", name);
 
             var siloMessagingOptions = this.Services.GetRequiredService<IOptions<SiloMessagingOptions>>();
             BufferPool.InitGlobalBufferPool(siloMessagingOptions.Value);
@@ -200,7 +200,7 @@ namespace Orleans.Runtime
             // add self to lifecycle
             this.Participate(this.siloLifecycle);
 
-            logger.Info(ErrorCode.SiloInitializingFinished, "-------------- Started silo {0}, ConsistentHashCode {1:X} --------------", SiloAddress.ToLongString(), SiloAddress.GetConsistentHashCode());
+            logger.LogInformation((int)ErrorCode.SiloInitializingFinished, "-------------- Started silo {0}, ConsistentHashCode {1:X} --------------", SiloAddress.ToLongString(), SiloAddress.GetConsistentHashCode());
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -251,7 +251,7 @@ namespace Orleans.Runtime
             var reminderTable = Services.GetService<IReminderTable>();
             if (reminderTable != null)
             {
-                logger.Info($"Creating reminder grain service for type={reminderTable.GetType()}");
+                logger.LogInformation($"Creating reminder grain service for type={reminderTable.GetType()}");
 
                 // Start the reminder service system target
                 var timerFactory = this.Services.GetRequiredService<IAsyncTimerFactory>();
@@ -279,7 +279,7 @@ namespace Orleans.Runtime
                 this.SystemStatus = SystemStatus.Starting;
             }
 
-            logger.Info(ErrorCode.SiloStarting, "Silo Start()");
+            logger.LogInformation((int)ErrorCode.SiloStarting, "Silo Start()");
 
             //TODO: setup thead pool directly to lifecycle
             StartTaskWithPerfAnalysis("ConfigureThreadPoolAndServicePointSettings",
@@ -292,7 +292,7 @@ namespace Orleans.Runtime
             stopWatch.Restart();
             task.Invoke();
             stopWatch.Stop();
-            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
+            this.logger.LogInformation((int)ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
         }
 
         private async Task StartAsyncTaskWithPerfAnalysis(string taskName, Func<Task> task, Stopwatch stopWatch)
@@ -300,7 +300,7 @@ namespace Orleans.Runtime
             stopWatch.Restart();
             await task.Invoke();
             stopWatch.Stop();
-            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
+            this.logger.LogInformation((int)ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
         }
 
         private async Task OnRuntimeServicesStart(CancellationToken ct)
@@ -418,7 +418,7 @@ namespace Orleans.Runtime
             grainServices.Add(grainService);
 
             await this.LocalScheduler.QueueTask(() => grainService.Init(Services), grainService).WithTimeout(this.initTimeout, $"GrainService Initializing failed due to timeout {initTimeout}");
-            logger.Info($"Grain Service {service.GetType().FullName} registered successfully.");
+            logger.LogInformation($"Grain Service {service.GetType().FullName} registered successfully.");
         }
 
         private async Task StartGrainService(IGrainService service)
@@ -426,7 +426,7 @@ namespace Orleans.Runtime
             var grainService = (GrainService)service;
 
             await this.LocalScheduler.QueueTask(grainService.Start, grainService).WithTimeout(this.initTimeout, $"Starting GrainService failed due to timeout {initTimeout}");
-            logger.Info($"Grain Service {service.GetType().FullName} started successfully.");
+            logger.LogInformation($"Grain Service {service.GetType().FullName} started successfully.");
         }
 
         private void ConfigureThreadPoolAndServicePointSettings()
@@ -446,7 +446,7 @@ namespace Orleans.Runtime
                     bool ok = ThreadPool.SetMinThreads(newWorkerThreads, newCompletionPortThreads);
                     if (ok)
                     {
-                        logger.Info(ErrorCode.SiloConfiguredThreadPool,
+                        logger.LogInformation((int)ErrorCode.SiloConfiguredThreadPool,
                                     "Configured ThreadPool.SetMinThreads() to values: {0},{1}. Previous values are: {2},{3}.",
                                     newWorkerThreads, newCompletionPortThreads, workerThreads, completionPortThreads);
                     }
@@ -461,7 +461,7 @@ namespace Orleans.Runtime
 
             // Set .NET ServicePointManager settings to optimize throughput performance when using Azure storage
             // http://blogs.msdn.com/b/windowsazurestorage/archive/2010/06/25/nagle-s-algorithm-is-not-friendly-towards-small-requests.aspx
-            logger.Info(ErrorCode.SiloConfiguredServicePointManager,
+            logger.LogInformation((int)ErrorCode.SiloConfiguredServicePointManager,
                 "Configured .NET ServicePointManager to Expect100Continue={0}, DefaultConnectionLimit={1}, UseNagleAlgorithm={2} to improve Azure storage performance.",
                 performanceTuningOptions.Expect100Continue, performanceTuningOptions.DefaultConnectionLimit, performanceTuningOptions.UseNagleAlgorithm);
             ServicePointManager.Expect100Continue = performanceTuningOptions.Expect100Continue;
@@ -526,11 +526,11 @@ namespace Orleans.Runtime
 
             if (stopAlreadyInProgress)
             {
-                logger.Info(ErrorCode.SiloStopInProgress, "Silo termination is in progress - Will wait for it to finish");
+                logger.LogInformation((int)ErrorCode.SiloStopInProgress, "Silo termination is in progress - Will wait for it to finish");
                 var pause = TimeSpan.FromSeconds(1);
                 while (!this.SystemStatus.Equals(SystemStatus.Terminated))
                 {
-                    logger.Info(ErrorCode.WaitingForSiloStop, "Waiting {0} for termination to complete", pause);
+                    logger.LogInformation((int)ErrorCode.WaitingForSiloStop, "Waiting {0} for termination to complete", pause);
                     await Task.Delay(pause).ConfigureAwait(false);
                 }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -118,8 +118,8 @@ namespace Orleans.Runtime
             logger.LogInformation((int)ErrorCode.SiloGcSetting, "Silo starting with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
             if (!GCSettings.IsServerGC)
             {
-                logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\">");
-                logger.Warn(ErrorCode.SiloGcWarning, "Note: ServerGC only kicks in on multi-core systems (settings enabling ServerGC have no effect on single-core machines).");
+                logger.LogWarning((int)ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\">");
+                logger.LogWarning((int)ErrorCode.SiloGcWarning, "Note: ServerGC only kicks in on multi-core systems (settings enabling ServerGC have no effect on single-core machines).");
             }
 
             if (logger.IsEnabled(LogLevel.Debug))
@@ -452,7 +452,7 @@ namespace Orleans.Runtime
                     }
                     else
                     {
-                        logger.Warn(ErrorCode.SiloFailedToConfigureThreadPool,
+                        logger.LogWarning((int)ErrorCode.SiloFailedToConfigureThreadPool,
                                     "Failed to configure ThreadPool.SetMinThreads(). Tried to set values to: {0},{1}. Previous values are: {2},{3}.",
                                     newWorkerThreads, newCompletionPortThreads, workerThreads, completionPortThreads);
                     }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -336,7 +336,7 @@ namespace Orleans.Runtime
             {
                 StatisticsOptions statisticsOptions = Services.GetRequiredService<IOptions<StatisticsOptions>>().Value;
                 StartTaskWithPerfAnalysis("Start silo statistics", () => this.siloStatistics.Start(statisticsOptions), stopWatch);
-                logger.Debug("Silo statistics manager started successfully.");
+                logger.LogDebug("Silo statistics manager started successfully.");
 
                 // Finally, initialize the deployment load collector, for grains with load-based placement
                 await StartAsyncTaskWithPerfAnalysis("Start deployment load collector", StartDeploymentLoadCollector, stopWatch);
@@ -345,21 +345,21 @@ namespace Orleans.Runtime
                     var deploymentLoadPublisher = Services.GetRequiredService<DeploymentLoadPublisher>();
                     await this.LocalScheduler.QueueTask(deploymentLoadPublisher.Start, deploymentLoadPublisher)
                         .WithTimeout(this.initTimeout, $"Starting DeploymentLoadPublisher failed due to timeout {initTimeout}");
-                    logger.Debug("Silo deployment load publisher started successfully.");
+                    logger.LogDebug("Silo deployment load publisher started successfully.");
                 }
 
                 // Start background timer tick to watch for platform execution stalls, such as when GC kicks in
                 var healthCheckParticipants = this.Services.GetService<IEnumerable<IHealthCheckParticipant>>().ToList();
                 this.platformWatchdog = new Watchdog(statisticsOptions.LogWriteInterval, healthCheckParticipants, this.loggerFactory.CreateLogger<Watchdog>());
                 this.platformWatchdog.Start();
-                if (this.logger.IsEnabled(LogLevel.Debug)) { logger.Debug("Silo platform watchdog started successfully."); }
+                if (this.logger.IsEnabled(LogLevel.Debug)) { logger.LogDebug("Silo platform watchdog started successfully."); }
             }
             catch (Exception exc)
             {
                 this.SafeExecute(() => this.logger.Error(ErrorCode.Runtime_Error_100330, String.Format("Error starting silo {0}. Going to FastKill().", this.SiloAddress), exc));
                 throw;
             }
-            if (logger.IsEnabled(LogLevel.Debug)) { logger.Debug("Silo.Start complete: System status = {0}", this.SystemStatus); }
+            if (logger.IsEnabled(LogLevel.Debug)) { logger.LogDebug("Silo.Start complete: System status = {0}", this.SystemStatus); }
         }
 
         private Task OnBecomeActiveStart(CancellationToken ct)
@@ -371,7 +371,7 @@ namespace Orleans.Runtime
                 // Now that we're active, we can start the gateway
                 var mc = this.messageCenter as MessageCenter;
                 mc?.StartGateway();
-                logger.Debug("Message gateway service started successfully.");
+                logger.LogDebug("Message gateway service started successfully.");
             }
 
             this.SystemStatus = SystemStatus.Running;
@@ -391,7 +391,7 @@ namespace Orleans.Runtime
                     this.reminderServiceContext = (this.reminderService as IGrainContext) ?? this.fallbackScheduler;
                     await this.LocalScheduler.QueueTask(this.reminderService.Start, this.reminderServiceContext)
                         .WithTimeout(this.initTimeout, $"Starting ReminderService failed due to timeout {initTimeout}");
-                    this.logger.Debug("Reminder service started successfully.");
+                    this.logger.LogDebug("Reminder service started successfully.");
                 }
             }
             foreach (var grainService in grainServices)
@@ -644,7 +644,7 @@ namespace Orleans.Runtime
 
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.Debug(
+                    logger.LogDebug(
                         "{GrainServiceType} Grain Service with Id {GrainServiceId} stopped successfully.",
                         grainService.GetType().FullName,
                         grainService.GetPrimaryKeyLong(out string ignored));

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -108,13 +108,13 @@ namespace Orleans.Runtime
 
         public Task ForceRuntimeStatisticsCollection()
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("ForceRuntimeStatisticsCollection");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("ForceRuntimeStatisticsCollection");
             return this.deploymentLoadPublisher.RefreshStatistics();
         }
 
         public Task<SiloRuntimeStatistics> GetRuntimeStatistics()
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("GetRuntimeStatistics");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("GetRuntimeStatistics");
             var activationCount = this.activationDirectory.Count;
             var recentlyUsedActivationCount = this.activationCollector.GetNumRecentlyUsed(TimeSpan.FromMinutes(10));
             var stats = new SiloRuntimeStatistics(
@@ -136,7 +136,7 @@ namespace Orleans.Runtime
 
         public Task<List<DetailedGrainStatistic>> GetDetailedGrainStatistics(string[] types=null)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("GetDetailedGrainStatistics");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("GetDetailedGrainStatistics");
             return Task.FromResult(this.catalog.GetDetailedGrainStatistics(types));
         }
 

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -88,21 +88,21 @@ namespace Orleans.Runtime
 
         public Task Ping(string message)
         {
-            logger.Info("Ping");
+            logger.LogInformation("Ping");
             return Task.CompletedTask;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect")]
         public Task ForceGarbageCollection()
         {
-            logger.Info("ForceGarbageCollection");
+            logger.LogInformation("ForceGarbageCollection");
             GC.Collect();
             return Task.CompletedTask;
         }
 
         public Task ForceActivationCollection(TimeSpan ageLimit)
         {
-            logger.Info("ForceActivationCollection");
+            logger.LogInformation("ForceActivationCollection");
             return this.catalog.CollectActivations(ageLimit);
         }
 
@@ -130,7 +130,7 @@ namespace Orleans.Runtime
 
         public Task<List<Tuple<GrainId, string, int>>> GetGrainStatistics()
         {
-            logger.Info("GetGrainStatistics");
+            logger.LogInformation("GetGrainStatistics");
             return Task.FromResult(this.catalog.GetGrainStatistics());
         }
 
@@ -142,14 +142,14 @@ namespace Orleans.Runtime
 
         public Task<SimpleGrainStatistic[]> GetSimpleGrainStatistics()
         {
-            logger.Info("GetSimpleGrainStatistics");
+            logger.LogInformation("GetSimpleGrainStatistics");
             return Task.FromResult( this.catalog.GetSimpleGrainStatistics().Select(p =>
                 new SimpleGrainStatistic { SiloAddress = this.localSiloDetails.SiloAddress, GrainType = p.Key, ActivationCount = (int)p.Value }).ToArray());
         }
 
         public Task<DetailedGrainReport> GetDetailedGrainReport(GrainId grainId)
         {
-            logger.Info("DetailedGrainReport for grain id {0}", grainId);
+            logger.LogInformation("DetailedGrainReport for grain id {0}", grainId);
             return Task.FromResult( this.catalog.GetDetailedGrainReport(grainId));
         }
 

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -164,7 +164,7 @@ namespace Orleans.Runtime
             if(!this.controllables.TryGetValue(Tuple.Create(providerTypeFullName, providerName), out controllable))
             {
                 string error = $"Could not find a controllable service for type {providerTypeFullName} and name {providerName}.";
-                logger.Error(ErrorCode.Provider_ProviderNotFound, error);
+                logger.LogError((int)ErrorCode.Provider_ProviderNotFound, error);
                 throw new ArgumentException(error);
             }
 

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime
 
         public void Start()
         {
-            logger.Info("Starting Silo Watchdog.");
+            logger.LogInformation("Starting Silo Watchdog.");
             var now = DateTime.UtcNow;
             lastHeartbeat = now;
             lastWatchdogCheck = now;

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -70,7 +70,7 @@ namespace Orleans.Core
                 StorageStatisticsGroup.OnStorageReadError(name, grainRef);
 
                 string errMsg = MakeErrorMsg(what, exc);
-                this.logger.Error((int)ErrorCode.StorageProvider_ReadFailed, errMsg, exc);
+                this.logger.LogError((int)ErrorCode.StorageProvider_ReadFailed, exc, errMsg);
                 if (!(exc is OrleansException))
                 {
                     throw new OrleansException(errMsg, exc);
@@ -102,7 +102,7 @@ namespace Orleans.Core
             {
                 StorageStatisticsGroup.OnStorageWriteError(name, grainRef);
                 string errMsgToLog = MakeErrorMsg(what, exc);
-                this.logger.Error((int)ErrorCode.StorageProvider_WriteFailed, errMsgToLog, exc);
+                this.logger.LogError((int)ErrorCode.StorageProvider_WriteFailed, exc, errMsgToLog);
                 // If error is not specialization of OrleansException, wrap it
                 if (!(exc is OrleansException))
                 {
@@ -138,7 +138,7 @@ namespace Orleans.Core
                 StorageStatisticsGroup.OnStorageDeleteError(name, grainRef);
 
                 string errMsg = MakeErrorMsg(what, exc);
-                this.logger.Error((int)ErrorCode.StorageProvider_DeleteFailed, errMsg, exc);
+                this.logger.LogError((int)ErrorCode.StorageProvider_DeleteFailed, exc, errMsg);
                 if (!(exc is OrleansException))
                 {
                     throw new OrleansException(errMsg, exc);

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -79,9 +79,8 @@ namespace Orleans.Runtime
             }
             catch (InvalidSchedulingContextException exc)
             {
-                logger.Error(ErrorCode.Timer_InvalidContext,
-                    string.Format("Caught an InvalidSchedulingContextException on timer {0}, context is {1}. Going to dispose this timer!",
-                        GetFullName(), context), exc);
+                logger.LogError((int)ErrorCode.Timer_InvalidContext, exc, string.Format("Caught an InvalidSchedulingContextException on timer {0}, context is {1}. Going to dispose this timer!",
+                    GetFullName(), context));
                 DisposeTimer();
             }
         }
@@ -107,13 +106,12 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                logger.Error( 
-                    ErrorCode.Timer_GrainTimerCallbackError,
-                    string.Format( "Caught and ignored exception: {0} with message: {1} thrown from timer callback {2}",
+                logger.LogError( 
+                    (int)ErrorCode.Timer_GrainTimerCallbackError,
+                    exc, string.Format( "Caught and ignored exception: {0} with message: {1} thrown from timer callback {2}",
                         exc.GetType(),
                         exc.Message,
-                        GetFullName()),
-                    exc);       
+                        GetFullName()));       
             }
             finally
             {

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -95,7 +95,7 @@ namespace Orleans.Runtime
             totalNumTicks++;
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace(ErrorCode.TimerBeforeCallback, "About to make timer callback for timer {0}", GetFullName());
+                logger.LogTrace((int)ErrorCode.TimerBeforeCallback, "About to make timer callback for timer {0}", GetFullName());
 
             try
             {
@@ -103,7 +103,7 @@ namespace Orleans.Runtime
                 currentlyExecutingTickTask = callback(state);
                 await currentlyExecutingTickTask;
                 
-                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.TimerAfterCallback, "Completed timer callback for timer {0}", GetFullName());
+                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.TimerAfterCallback, "Completed timer callback for timer {0}", GetFullName());
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Streaming.GCP/GoogleErrorCodes.cs
+++ b/src/Orleans.Streaming.GCP/GoogleErrorCodes.cs
@@ -1,7 +1,4 @@
-﻿using Orleans.Runtime;
-using System;
-using Microsoft.Extensions.Logging;
-namespace Orleans.Providers.GCP
+﻿namespace Orleans.Providers.GCP
 {
     internal enum GoogleErrorCode
     {
@@ -12,38 +9,5 @@ namespace Orleans.Providers.GCP
         GetMessages = GoogleErrorCodeBase + 4,
         DeleteMessage = GoogleErrorCodeBase + 5,
         AcknowledgeMessage = GoogleErrorCodeBase + 6
-    }
-
-    internal static class LoggerExtensions
-    {
-        internal static void Debug(this ILogger logger, GoogleErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogDebug((int)errorCode, format, args);
-        }
-
-        internal static void Trace(this ILogger logger, GoogleErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogTrace((int)errorCode, format, args);
-        }
-
-        internal static void Info(this ILogger logger, GoogleErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogInformation((int)errorCode, format, args);
-        }
-
-        internal static void Warn(this ILogger logger, GoogleErrorCode errorCode, string format, params object[] args)
-        {
-            logger.LogWarning((int)errorCode, format, args);
-        }
-
-        internal static void Warn(this ILogger logger, GoogleErrorCode errorCode, string message, Exception exception)
-        {
-            logger.LogWarning((int)errorCode, exception, message);
-        }
-
-        internal static void Error(this ILogger logger, GoogleErrorCode errorCode, string message, Exception exception = null)
-        {
-            logger.LogError((int)errorCode, exception, message);
-        }
     }
 }

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
@@ -129,8 +129,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
                 }
                 catch (Exception exc)
                 {
-                    _logger.Warn((int)GoogleErrorCode.AcknowledgeMessage,
-                        $"Exception upon AcknowledgeMessages on queue {Id}. Ignoring.", exc);
+                    _logger.LogWarning((int)GoogleErrorCode.AcknowledgeMessage, exc, "Exception upon AcknowledgeMessages on queue {Id}. Ignoring.", Id);
                 }
             }
             finally

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -186,7 +186,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             var errMsg = String.Format(
                 "Error doing {0} for Google Project {1} at PubSub Topic {2} " + Environment.NewLine
                 + "Exception = {3}", operation, TopicName.ProjectId, TopicName.TopicId, exc);
-            _logger.Error((int)errorCode, errMsg, exc);
+            _logger.LogError((int)errorCode, exc, errMsg);
             throw new AggregateException(errMsg, exc);
         }
     }

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -123,7 +123,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             var count = messages.Count();
             if (count < 1) return;
 
-            if (_logger.IsEnabled(LogLevel.Trace)) _logger.Trace("Publishing {0} message to topic {1}", count, TopicName.TopicId);
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Publishing {0} message to topic {1}", count, TopicName.TopicId);
 
             try
             {
@@ -137,7 +137,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
 
         public async Task<IEnumerable<ReceivedMessage>> GetMessages(int count = 1)
         {
-            if (_logger.IsEnabled(LogLevel.Trace)) _logger.Trace("Getting {0} message(s) from Google PubSub topic {1}", count, TopicName.TopicId);
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Getting {0} message(s) from Google PubSub topic {1}", count, TopicName.TopicId);
 
             PullResponse response = null;
             try
@@ -152,11 +152,11 @@ namespace Orleans.Providers.GCP.Streams.PubSub
 
             if (_logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.Trace("Received {0} message(s) from Google PubSub topic {1}", response.ReceivedMessages.Count, TopicName.TopicId);
+                _logger.LogTrace("Received {0} message(s) from Google PubSub topic {1}", response.ReceivedMessages.Count, TopicName.TopicId);
 
                 foreach (var received in response.ReceivedMessages)
                 {
-                    _logger.Trace("Received message {0} published {1} from Google PubSub topic {2}", received.Message.MessageId,
+                    _logger.LogTrace("Received message {0} published {1} from Google PubSub topic {2}", received.Message.MessageId,
                             received.Message.PublishTime.ToDateTime(), TopicName.TopicId);
                 }
             }
@@ -169,7 +169,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             var count = messages.Count();
             if (count < 1) return;
 
-            if (_logger.IsEnabled(LogLevel.Trace)) _logger.Trace("Deleting {0} message(s) from Google PubSub topic {1}", count, TopicName.TopicId);
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Deleting {0} message(s) from Google PubSub topic {1}", count, TopicName.TopicId);
 
             try
             {

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -106,7 +106,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
 
         public async Task DeleteTopic()
         {
-            if (_logger.IsEnabled(LogLevel.Debug)) _logger.Debug("Deleting Google PubSub topic: {0}", TopicName.TopicId);
+            if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebug("Deleting Google PubSub topic: {0}", TopicName.TopicId);
             try
             {
                 await _publisher?.DeleteTopicAsync(TopicName);

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -83,7 +83,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
                 _topic = await _publisher.GetTopicAsync(TopicName);
             }
 
-            _logger.Info((int)GoogleErrorCode.Initializing, "{0} Google PubSub Topic {1}", (didCreate ? "Created" : "Attached to"), TopicName.TopicId);
+            _logger.LogInformation((int)GoogleErrorCode.Initializing, "{0} Google PubSub Topic {1}", (didCreate ? "Created" : "Attached to"), TopicName.TopicId);
 
             didCreate = false;
 
@@ -101,7 +101,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
 
                 _subscription = await _subscriber.GetSubscriptionAsync(SubscriptionName);
             }
-            _logger.Info((int)GoogleErrorCode.Initializing, "{0} Google PubSub Subscription {1} to Topic {2}", (didCreate ? "Created" : "Attached to"), SubscriptionName.SubscriptionId, TopicName.TopicId);
+            _logger.LogInformation((int)GoogleErrorCode.Initializing, "{0} Google PubSub Subscription {1} to Topic {2}", (didCreate ? "Created" : "Attached to"), SubscriptionName.SubscriptionId, TopicName.TopicId);
         }
 
         public async Task DeleteTopic()
@@ -110,7 +110,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             try
             {
                 await _publisher?.DeleteTopicAsync(TopicName);
-                _logger.Info((int)GoogleErrorCode.Initializing, "Deleted Google PubSub topic {0}", TopicName.TopicId);
+                _logger.LogInformation((int)GoogleErrorCode.Initializing, "Deleted Google PubSub topic {0}", TopicName.TopicId);
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -85,10 +85,10 @@ namespace Orleans.Streams
             if (batchObserver is GrainReference)
                 throw new ArgumentException("On-behalf subscription via grain references is not supported. Only passing of object references is allowed.", nameof(batchObserver));
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Subscribe Token={Token}", token);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Subscribe Token={Token}", token);
             await BindExtensionLazy();
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Subscribe - Connecting to Rendezvous {0} My GrainRef={1} Token={2}",
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Subscribe - Connecting to Rendezvous {0} My GrainRef={1} Token={2}",
                 pubSub, myGrainReference, token);
 
             GuidId subscriptionId = pubSub.CreateSubscriptionId(stream.InternalStreamId, myGrainReference);
@@ -146,10 +146,10 @@ namespace Orleans.Streams
             if (token != null && !IsRewindable)
                 throw new ArgumentNullException("token", "Passing a non-null token to a non-rewindable IAsyncObservable.");
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Resume Token={Token}", token);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Resume Token={Token}", token);
             await BindExtensionLazy();
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Resume - Connecting to Rendezvous {0} My GrainRef={1} Token={2}",
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Resume - Connecting to Rendezvous {0} My GrainRef={1} Token={2}",
                 pubSub, myGrainReference, token);
 
             StreamSubscriptionHandle<T> newHandle = myExtension.SetObserver(oldHandleImpl.SubscriptionId, stream, observer, batchObserver, token, null);
@@ -166,12 +166,12 @@ namespace Orleans.Streams
 
             StreamSubscriptionHandleImpl<T> handleImpl = CheckHandleValidity(handle);
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Unsubscribe StreamSubscriptionHandle={0}", handle);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Unsubscribe StreamSubscriptionHandle={0}", handle);
 
             myExtension.RemoveObserver(handleImpl.SubscriptionId);
             // UnregisterConsumer from pubsub even if does not have this handle localy, to allow UnsubscribeAsync retries.
 
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Unsubscribe - Disconnecting from Rendezvous {0} My GrainRef={1}",
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Unsubscribe - Disconnecting from Rendezvous {0} My GrainRef={1}",
                 pubSub, myGrainReference);
 
             await pubSub.UnregisterConsumer(handleImpl.SubscriptionId, stream.InternalStreamId);
@@ -190,7 +190,7 @@ namespace Orleans.Streams
 
         public async Task Cleanup()
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Cleanup() called");
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Cleanup() called");
             if (myExtension == null)
                 return;
 
@@ -232,9 +232,9 @@ namespace Orleans.Streams
                 {
                     if (myExtension == null)
                     {
-                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("BindExtensionLazy - Binding local extension to stream runtime={0}", providerRuntime);
+                        if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("BindExtensionLazy - Binding local extension to stream runtime={0}", providerRuntime);
                         (myExtension, myGrainReference) = providerRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(() => new StreamConsumerExtension(providerRuntime));
-                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("BindExtensionLazy - Connected Extension={0} GrainRef={1}", myExtension, myGrainReference);                        
+                        if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("BindExtensionLazy - Connected Extension={0} GrainRef={1}", myExtension, myGrainReference);                        
                     }
                 }
             }

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -207,8 +207,8 @@ namespace Orleans.Streams
 
             } catch (Exception exc)
             {
-                logger.Warn(ErrorCode.StreamProvider_ConsumerFailedToUnregister,
-                    "Ignoring unhandled exception during PubSub.UnregisterConsumer", exc);
+                logger.LogWarning((int)ErrorCode.StreamProvider_ConsumerFailedToUnregister, exc,
+                    "Ignoring unhandled exception during PubSub.UnregisterConsumer");
             }
             myExtension = null;
         }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -89,7 +89,7 @@ namespace Orleans.Streams
             {
                 var itemString = item.ToString();
                 itemString = (itemString.Length > MAXIMUM_ITEM_STRING_LOG_LENGTH) ? itemString.Substring(0, MAXIMUM_ITEM_STRING_LOG_LENGTH) + "..." : itemString;
-                logger.Trace("DeliverItem {0} for subscription {1}", itemString, subscriptionId);
+                logger.LogTrace("DeliverItem {0} for subscription {1}", itemString, subscriptionId);
             }
             IStreamSubscriptionHandle observer;
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))
@@ -120,7 +120,7 @@ namespace Orleans.Streams
 
         public async Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, InternalStreamId streamId, Immutable<IBatchContainer> batch, StreamHandshakeToken handshakeToken)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("DeliverBatch {0} for subscription {1}", batch.Value, subscriptionId);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("DeliverBatch {0} for subscription {1}", batch.Value, subscriptionId);
 
             IStreamSubscriptionHandle observer;
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))
@@ -151,7 +151,7 @@ namespace Orleans.Streams
 
         public Task CompleteStream(GuidId subscriptionId)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("CompleteStream for subscription {0}", subscriptionId);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("CompleteStream for subscription {0}", subscriptionId);
 
             IStreamSubscriptionHandle observer;
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))
@@ -166,7 +166,7 @@ namespace Orleans.Streams
 
         public Task ErrorInStream(GuidId subscriptionId, Exception exc)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("ErrorInStream {0} for subscription {1}", exc, subscriptionId);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("ErrorInStream {0} for subscription {1}", exc, subscriptionId);
 
             IStreamSubscriptionHandle observer;
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -111,7 +111,7 @@ namespace Orleans.Streams
                 }
             }
 
-            logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
+            logger.LogWarning((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
@@ -142,7 +142,7 @@ namespace Orleans.Streams
                 }
             }
 
-            logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForBatch), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
+            logger.LogWarning((int)(ErrorCode.StreamProvider_NoStreamForBatch), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
@@ -157,7 +157,7 @@ namespace Orleans.Streams
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))
                 return observer.CompleteStream();
 
-            logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got a Complete for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
+            logger.LogWarning((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got a Complete for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
@@ -172,7 +172,7 @@ namespace Orleans.Streams
             if (allStreamObservers.TryGetValue(subscriptionId, out observer))
                 return observer.ErrorInStream(exc);
 
-            logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an Error for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
+            logger.LogWarning((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an Error for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -58,7 +58,7 @@ namespace Orleans.Streams
 
             try
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("{0} AddObserver for stream {1}", providerRuntime.ExecutingEntityIdentity(), stream.InternalStreamId);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("{0} AddObserver for stream {1}", providerRuntime.ExecutingEntityIdentity(), stream.InternalStreamId);
 
                 // Note: The caller [StreamConsumer] already handles locking for Add/Remove operations, so we don't need to repeat here.
                 var handle = new StreamSubscriptionHandleImpl<T>(subscriptionId, observer, batchObserver, stream, token, filterData);

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -67,8 +67,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.StreamProvider_AddObserverException,
-                    $"{providerRuntime.ExecutingEntityIdentity()} StreamConsumerExtension.AddObserver({stream.InternalStreamId}) caugth exception.", exc);
+                logger.LogError((int)ErrorCode.StreamProvider_AddObserverException, exc, $"{providerRuntime.ExecutingEntityIdentity()} StreamConsumerExtension.AddObserver({stream.InternalStreamId}) caugth exception.");
                 throw;
             }
         }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProducer.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streams
             this.serializationManager = serializationManager;
             IsRewindable = isRewindable;
             var logger = providerUtilities.ServiceProvider.GetRequiredService<ILogger<PersistentStreamProducer<T>>>();
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Created PersistentStreamProducer for stream {0}, of type {1}, and with Adapter: {2}.",
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Created PersistentStreamProducer for stream {0}, of type {1}, and with Adapter: {2}.",
                 stream.ToString(), typeof (T), this.queueAdapter.Name);
         }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -157,7 +157,7 @@ namespace Orleans.Providers.Streams.Common
                 return pullingAgentManager.ExecuteCommand((PersistentStreamProviderCommand)command, arg);
             }
 
-            logger.Warn(0, $"Got command {(PersistentStreamProviderCommand)command} with arg {arg}, but PullingAgentManager is not initialized yet. Ignoring the command.");
+            logger.LogWarning(0, $"Got command {(PersistentStreamProviderCommand)command} with arg {arg}, but PullingAgentManager is not initialized yet. Ignoring the command.");
             throw new ArgumentException("PullingAgentManager is not initialized yet.");
         }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -62,7 +62,7 @@ namespace Orleans.Streams
             numMessages = 0;
 
             logger = loggerFactory.CreateLogger($"{this.GetType().Namespace}.{streamProviderName}");
-            logger.Info(ErrorCode.PersistentStreamPullingAgent_01,
+            logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_01,
                 "Created {0} {1} for Stream Provider {2} on silo {3} for Queue {4}.",
                 GetType().Name, ((ISystemTargetBase)this).GrainId.ToString(), streamProviderName, Silo, QueueId.ToStringWithHashCode());
             numReadMessagesCounter = CounterStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_READ_MESSAGES, StatisticUniquePostfix));
@@ -94,7 +94,7 @@ namespace Orleans.Streams
 
         private void InitializeInternal(IQueueAdapter qAdapter, IQueueAdapterCache queueAdapterCache, IStreamFailureHandler failureHandler)
         {
-            logger.Info(ErrorCode.PersistentStreamPullingAgent_02, "Init of {0} {1} on silo {2} for queue {3}.",
+            logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_02, "Init of {0} {1} on silo {2} for queue {3}.",
                 GetType().Name, ((ISystemTargetBase)this).GrainId.ToString(), Silo, QueueId.ToStringWithHashCode());
 
             // Remove cast once we cleanup
@@ -143,13 +143,13 @@ namespace Orleans.Streams
 
             IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE, StatisticUniquePostfix), () => pubSubCache.Count);
 
-            logger.Info((int)ErrorCode.PersistentStreamPullingAgent_04, "Taking queue {0} under my responsibility.", QueueId.ToStringWithHashCode());
+            logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_04, "Taking queue {0} under my responsibility.", QueueId.ToStringWithHashCode());
         }
 
         public async Task Shutdown()
         {
             // Stop pulling from queues that are not in my range anymore.
-            logger.Info(ErrorCode.PersistentStreamPullingAgent_05, "Shutdown of {0} responsible for queue: {1}", GetType().Name, QueueId.ToStringWithHashCode());
+            logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_05, "Shutdown of {0} responsible for queue: {1}", GetType().Name, QueueId.ToStringWithHashCode());
 
             if (timer != null)
             {
@@ -199,7 +199,7 @@ namespace Orleans.Streams
             {
                 tuple.Value.DisposeAll(logger);
                 var streamId = tuple.Key;
-                logger.Info(ErrorCode.PersistentStreamPullingAgent_06, "Unregister PersistentStreamPullingAgent Producer for stream {0}.", streamId);
+                logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_06, "Unregister PersistentStreamPullingAgent Producer for stream {0}.", streamId);
                 unregisterTasks.Add(pubSub.UnregisterProducer(streamId, meAsStreamProducer));
             }
 
@@ -427,7 +427,7 @@ namespace Orleans.Streams
             if (queueCache != null && queueCache.IsUnderPressure())
             {
                 // Under back pressure. Exit the loop. Will attempt again in the next timer callback.
-                logger.Info((int)ErrorCode.PersistentStreamPullingAgent_24, "Stream cache is under pressure. Backing off.");
+                logger.LogInformation((int)ErrorCode.PersistentStreamPullingAgent_24, "Stream cache is under pressure. Backing off.");
                 return false;
             }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -223,7 +223,7 @@ namespace Orleans.Streams
             IStreamConsumerExtension streamConsumer,
             string filterData)
         {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.PersistentStreamPullingAgent_09, "AddSubscriber: Stream={0} Subscriber={1}.", streamId, streamConsumer);
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.PersistentStreamPullingAgent_09, "AddSubscriber: Stream={0} Subscriber={1}.", streamId, streamConsumer);
             // cannot await here because explicit consumers trigger this call, so it could cause a deadlock.
             AddSubscriber_Impl(subscriptionId, streamId, streamConsumer, filterData, null)
                 .LogException(logger, ErrorCode.PersistentStreamPullingAgent_26,
@@ -330,7 +330,7 @@ namespace Orleans.Streams
 
             // remove consumer
             bool removed = streamData.RemoveConsumer(subscriptionId, logger);
-            if (removed && logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.PersistentStreamPullingAgent_10, "Removed Consumer: subscription={0}, for stream {1}.", subscriptionId, streamId);
+            if (removed && logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.PersistentStreamPullingAgent_10, "Removed Consumer: subscription={0}, for stream {1}.", subscriptionId, streamId);
 
             if (streamData.Count == 0)
                 pubSubCache.Remove(streamId);
@@ -783,7 +783,7 @@ namespace Orleans.Streams
                                 DeliveryBackoffProvider);
                
                 
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.PersistentStreamPullingAgent_16, "Got back {0} Subscribers for stream {1}.", streamData.Count, streamId);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug((int)ErrorCode.PersistentStreamPullingAgent_16, "Got back {0} Subscribers for stream {1}.", streamData.Count, streamId);
 
                 var addSubscriptionTasks = new List<Task>(streamData.Count);
                 foreach (PubSubSubscriptionState item in streamData)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -439,7 +439,7 @@ namespace Orleans.Streams
             queueCache?.AddToCache(multiBatch);
             numMessages += multiBatch.Count;
             numReadMessagesCounter.IncrementBy(multiBatch.Count);
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.PersistentStreamPullingAgent_11, "Got {0} messages from queue {1}. So far {2} msgs from this queue.",
+            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace((int)ErrorCode.PersistentStreamPullingAgent_11, "Got {0} messages from queue {1}. So far {2} msgs from this queue.",
                 multiBatch.Count, myQueueId.ToStringWithHashCode(), numMessages);
 
             foreach (var group in

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -209,8 +209,8 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Warn(ErrorCode.PersistentStreamPullingAgent_08,
-                    "Failed to unregister myself as stream producer to some streams that used to be in my responsibility.", exc);
+                logger.LogWarning((int)ErrorCode.PersistentStreamPullingAgent_08, exc,
+                    "Failed to unregister myself as stream producer to some streams that used to be in my responsibility.");
             }
             pubSubCache.Clear();
             IntValueStatistic.Delete(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE, StatisticUniquePostfix));
@@ -380,7 +380,7 @@ namespace Orleans.Streams
 
         private bool ReadLoopRetryExceptionFilter(Exception e, int retryCounter)
         {
-            this.logger.Warn(ErrorCode.PersistentStreamPullingAgent_12, $"Exception while retrying the {retryCounter}th time reading from queue {this.QueueId}", e);
+            this.logger.LogWarning((int)ErrorCode.PersistentStreamPullingAgent_12, e, $"Exception while retrying the {retryCounter}th time reading from queue {this.QueueId}");
             return !IsShutdown;
         }
 
@@ -418,8 +418,8 @@ namespace Orleans.Streams
                     }
                     catch (Exception exc)
                     {
-                        logger.Warn(ErrorCode.PersistentStreamPullingAgent_27,
-                            $"Exception calling MessagesDeliveredAsync on queue {myQueueId}. Ignoring.", exc);
+                        logger.LogWarning((int)ErrorCode.PersistentStreamPullingAgent_27, exc,
+                            $"Exception calling MessagesDeliveredAsync on queue {myQueueId}. Ignoring.");
                     }
                 }
             }
@@ -706,7 +706,7 @@ namespace Orleans.Streams
             // for loss of client, we just remove the subscription
             if (exceptionOccured is ClientNotAvailableException)
             {
-                logger.Warn(ErrorCode.Stream_ConsumerIsDead,
+                logger.LogWarning((int)ErrorCode.Stream_ConsumerIsDead,
                     "Consumer {0} on stream {1} is no longer active - permanently removing Consumer.", consumerData.StreamConsumer, consumerData.StreamId);
                 pubSub.UnregisterConsumer(consumerData.SubscriptionId, consumerData.StreamId).Ignore();
                 return true;
@@ -817,7 +817,7 @@ namespace Orleans.Streams
             catch (Exception exc)
             {
                 var message = $"Ignoring exception while trying to evaluate subscription filter '{this.streamFilter.GetType().Name}' with data '{filterData}' on stream {streamId}";
-                logger.Warn((int)ErrorCode.PersistentStreamPullingAgent_13, message, exc);
+                logger.LogWarning((int)ErrorCode.PersistentStreamPullingAgent_13, exc, message);
             }
             return true;
         }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -108,7 +108,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_02, "Exception while calling IQueueAdapter.CreateNewReceiver.", exc);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_02, exc, "Exception while calling IQueueAdapter.CreateNewReceiver.");
                 throw;
             }
 
@@ -121,7 +121,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_23, "Exception while calling IQueueAdapterCache.CreateQueueCache.", exc);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_23, exc, "Exception while calling IQueueAdapterCache.CreateQueueCache.");
                 throw;
             }
 
@@ -374,7 +374,7 @@ namespace Orleans.Streams
             catch (Exception exc)
             {
                 receiverInitTask = null;
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_12, $"Giving up reading from queue {queueId} after retry attempts {ReadLoopRetryMax}", exc);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_12, exc, $"Giving up reading from queue {queueId} after retry attempts {ReadLoopRetryMax}");
             }
         }
 
@@ -581,7 +581,7 @@ namespace Orleans.Streams
                         consumerData.Cursor?.RecordDeliveryFailure();
                         var message =
                             $"Exception while trying to deliver msgs to stream {consumerData.StreamId} in PersistentStreamPullingAgentGrain.RunConsumerCursor";
-                        logger.Error(ErrorCode.PersistentStreamPullingAgent_14, message, exc);
+                        logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_14, exc, message);
                         exceptionOccured = exc is ClientNotAvailableException
                             ? exc
                             : new StreamEventDeliveryFailureException(consumerData.StreamId);
@@ -598,7 +598,7 @@ namespace Orleans.Streams
             catch (Exception exc)
             {
                 // RunConsumerCursor is fired with .Ignore so we should log if anything goes wrong, because there is no one to catch the exception
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_15, "Ignored RunConsumerCursor Error", exc);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_15, exc, "Ignored RunConsumerCursor Error");
                 consumerData.State = StreamConsumerDataState.Inactive;
                 throw;
             }
@@ -761,7 +761,7 @@ namespace Orleans.Streams
             }
             catch (Exception e)
             {
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_17, $"RegisterAsStreamProducer failed due to {e}", e);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_17, e, $"RegisterAsStreamProducer failed due to {e}");
                 throw;
             }
         }
@@ -795,7 +795,7 @@ namespace Orleans.Streams
             catch (Exception exc)
             {
                 // RegisterAsStreamProducer is fired with .Ignore so we should log if anything goes wrong, because there is no one to catch the exception
-                logger.Error(ErrorCode.PersistentStreamPullingAgent_17, "Ignored RegisterAsStreamProducer Error", exc);
+                logger.LogError((int)ErrorCode.PersistentStreamPullingAgent_17, exc, "Ignored RegisterAsStreamProducer Error");
                 throw;
             }
         }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -230,7 +230,7 @@ namespace Orleans.Streams
                 }
                 catch (Exception exc)
                 {
-                    logger.Error(ErrorCode.PersistentStreamPullingManager_07, "Exception while creating PersistentStreamPullingAgent.", exc);
+                    logger.LogError((int)ErrorCode.PersistentStreamPullingManager_07, exc, "Exception while creating PersistentStreamPullingAgent.");
                     // What should we do? This error is not recoverable and considered a bug. But we don't want to bring the silo down.
                     // If this is when silo is starting and agent is initializing, fail the silo startup. Otherwise, just swallow to limit impact on other receivers.
                     if (failOnInit) throw;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -405,7 +405,7 @@ namespace Orleans.Streams
 
         private void Log(ErrorCode logCode, string format, params object[] args)
         {
-            logger.Info(logCode, format, args);
+            logger.LogInformation((int) logCode, format, args);
         }
     }
 }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -196,7 +196,7 @@ namespace Orleans.Streams
 
         private void RemoveProducer(PubSubPublisherState producer)
         {
-            logger.Warn(ErrorCode.Stream_ProducerIsDead,
+            logger.LogWarning((int)ErrorCode.Stream_ProducerIsDead,
                 "Producer {0} on stream {1} is no longer active - permanently removing producer.",
                 producer, producer.Stream);
 

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -270,7 +270,7 @@ namespace Orleans.Streams
                     numConsumers = State.Consumers.Count;
 
                 string when = args != null && args.Length != 0 ? string.Format(fmt, args) : fmt;
-                logger.Info("{0}. Now have total of {1} producers and {2} consumers. All Consumers = {3}, All Producers = {4}",
+                logger.LogInformation("{0}. Now have total of {1} producers and {2} consumers. All Consumers = {3}, All Producers = {4}",
                     when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers), Utils.EnumerableToString(State?.Producers));
             }
         }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -70,7 +70,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_RegisterProducerFailed, $"Failed to register a stream producer.  Stream: {streamId}, Producer: {streamProducer}", exc);
+                logger.LogError((int)ErrorCode.Stream_RegisterProducerFailed, exc, $"Failed to register a stream producer.  Stream: {streamId}, Producer: {streamProducer}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;
@@ -97,8 +97,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_UnegisterProducerFailed,
-                    $"Failed to unregister a stream producer.  Stream: {streamId}, Producer: {streamProducer}", exc);
+                logger.LogError((int)ErrorCode.Stream_UnegisterProducerFailed, exc, $"Failed to unregister a stream producer.  Stream: {streamId}, Producer: {streamProducer}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;
@@ -136,8 +135,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_RegisterConsumerFailed,
-                    $"Failed to register a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}, Consumer: {streamConsumer}", exc);
+                logger.LogError((int)ErrorCode.Stream_RegisterConsumerFailed, exc, $"Failed to register a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}, Consumer: {streamConsumer}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;
@@ -186,8 +184,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_RegisterConsumerFailed,
-                    $"Failed to update producers while register a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}, Consumer: {streamConsumer}", exc);
+                logger.LogError((int)ErrorCode.Stream_RegisterConsumerFailed, exc, $"Failed to update producers while register a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}, Consumer: {streamConsumer}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;
@@ -230,8 +227,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_UnregisterConsumerFailed,
-                    $"Failed to unregister a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}", exc);
+                logger.LogError((int)ErrorCode.Stream_UnregisterConsumerFailed, exc, $"Failed to unregister a stream consumer.  Stream: {streamId}, SubscriptionId {subscriptionId}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;
@@ -352,8 +348,7 @@ namespace Orleans.Streams
             }
             catch (Exception exc)
             {
-                logger.Error(ErrorCode.Stream_SetSubscriptionToFaultedFailed,
-                    $"Failed to set subscription state to faulted.  SubscriptionId {subscriptionId}", exc);
+                logger.LogError((int)ErrorCode.Stream_SetSubscriptionToFaultedFailed, exc, $"Failed to set subscription state to faulted.  SubscriptionId {subscriptionId}");
                 // Corrupted state, deactivate grain.
                 DeactivateOnIdle();
                 throw;

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -148,7 +148,7 @@ namespace Orleans.Streams
                 return;
 
             if (logger.IsEnabled(LogLevel.Debug))
-                logger.Debug("Notifying {0} existing producer(s) about new consumer {1}. Producers={2}",
+                logger.LogDebug("Notifying {0} existing producer(s) about new consumer {1}. Producers={2}",
                     numProducers, streamConsumer, Utils.EnumerableToString(State.Producers));
 
             // Notify producers about a new streamConsumer.
@@ -345,7 +345,7 @@ namespace Orleans.Streams
             try
             {
                 pubSubState.Fault();
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Setting subscription {0} to a faulted state.", subscriptionId.Guid);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Setting subscription {0} to a faulted state.", subscriptionId.Guid);
 
                 await WriteStateAsync();
                 await NotifyProducersOfRemovedSubscription(pubSubState.SubscriptionId, pubSubState.Stream);
@@ -365,7 +365,7 @@ namespace Orleans.Streams
             int numProducersBeforeNotify = State.Producers.Count;
             if (numProducersBeforeNotify > 0)
             {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Notifying {0} existing producers about unregistered consumer.", numProducersBeforeNotify);
+                if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Notifying {0} existing producers about unregistered consumer.", numProducersBeforeNotify);
 
                 // Notify producers about unregistered consumer.
                 List<Task> tasks = State.Producers

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -145,7 +145,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         public async Task Cleanup()
         {
-            if(logger.IsEnabled(LogLevel.Debug)) logger.Debug("Cleanup() called");
+            if(logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Cleanup() called");
 
             myExtension.RemoveStream(stream.InternalStreamId);
 

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -160,8 +160,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 }
                 catch (Exception exc)
                 {
-                    logger.Warn((int) ErrorCode.StreamProvider_ProducerFailedToUnregister,
-                        "Ignoring unhandled exception during PubSub.UnregisterProducer", exc);
+                    logger.LogWarning((int) ErrorCode.StreamProvider_ProducerFailedToUnregister, exc,
+                        "Ignoring unhandled exception during PubSub.UnregisterProducer");
                 }
             }
             isDisposed = true;

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -57,7 +57,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         internal void AddSubscribers(InternalStreamId streamId, ICollection<PubSubSubscriptionState> newSubscribers)
         {
             if (logger.IsEnabled(LogLevel.Debug))
-                logger.Debug("{0} AddSubscribers {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), Utils.EnumerableToString(newSubscribers), streamId);
+                logger.LogDebug("{0} AddSubscribers {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), Utils.EnumerableToString(newSubscribers), streamId);
             
             StreamConsumerExtensionCollection consumers;
             if (remoteConsumers.TryGetValue(streamId, out consumers))
@@ -129,7 +129,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.Debug("{0} AddSubscriber {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), streamConsumer, streamId);
+                logger.LogDebug("{0} AddSubscriber {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), streamConsumer, streamId);
             }
 
             StreamConsumerExtensionCollection consumers;
@@ -149,7 +149,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                logger.Debug("{0} RemoveSubscription {1}", providerRuntime.ExecutingEntityIdentity(),
+                logger.LogDebug("{0} RemoveSubscription {1}", providerRuntime.ExecutingEntityIdentity(),
                     subscriptionId);
             }
 

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -228,7 +228,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                     if (consumers.TryRemove(subscriptionId, out _))
                     {
                         streamPubSub.UnregisterConsumer(subscriptionId, streamId).Ignore();
-                        logger.Warn(ErrorCode.Stream_ConsumerIsDead,
+                        logger.LogWarning((int)ErrorCode.Stream_ConsumerIsDead,
                             "Consumer {0} on stream {1} is no longer active - permanently removing Consumer.", remoteConsumer, streamId);
                     }
                 }

--- a/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Streaming/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -49,7 +49,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                     .GetService<IStreamSubscriptionManagerAdmin>()
                     .GetStreamSubscriptionManager(StreamSubscriptionManagerType.ExplicitSubscribeOnly);
             }
-            logger.Info(
+            logger.LogInformation(
                 "Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}, OptimizeForImmutableData: {2} " +
                 "and PubSubType: {3}", Name, this.options.FireAndForgetDelivery, this.options.OptimizeForImmutableData,
                 this.options.PubSubType);

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -64,10 +64,10 @@ namespace Orleans.TestingHost
             }
             catch (Exception)
             {
-                logger.Info($"Fault injected for ReadState for grain {grainReference} of type {grainType}, ");
+                logger.LogInformation($"Fault injected for ReadState for grain {grainReference} of type {grainType}, ");
                 throw;
             }
-            logger.Info($"ReadState for grain {grainReference} of type {grainType}");
+            logger.LogInformation($"ReadState for grain {grainReference} of type {grainType}");
             await realStorageProvider.ReadStateAsync(grainType, grainReference, grainState);
         }
 
@@ -86,10 +86,10 @@ namespace Orleans.TestingHost
             }
             catch (Exception)
             {
-                logger.Info($"Fault injected for WriteState for grain {grainReference} of type {grainType}");
+                logger.LogInformation($"Fault injected for WriteState for grain {grainReference} of type {grainType}");
                 throw;
             }
-            logger.Info($"WriteState for grain {grainReference} of type {grainType}");
+            logger.LogInformation($"WriteState for grain {grainReference} of type {grainType}");
             await realStorageProvider.WriteStateAsync(grainType, grainReference, grainState);
         }
 
@@ -108,10 +108,10 @@ namespace Orleans.TestingHost
             }
             catch (Exception)
             {
-                logger.Info($"Fault injected for ClearState for grain {grainReference} of type {grainType}");
+                logger.LogInformation($"Fault injected for ClearState for grain {grainReference} of type {grainType}");
                 throw;
             }
-            logger.Info($"ClearState for grain {grainReference} of type {grainType}");
+            logger.LogInformation($"ClearState for grain {grainReference} of type {grainType}");
             await realStorageProvider.ClearStateAsync(grainType, grainReference, grainState);
         }
 

--- a/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -30,7 +30,7 @@ namespace Orleans.TestingHost
             readFaults = new Dictionary<GrainReference, Exception>();
             writeFaults = new Dictionary<GrainReference, Exception>();
             clearfaults = new Dictionary<GrainReference, Exception>();
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Orleans.TestingHost
         public Task AddFaultOnRead(GrainReference grainReference, Exception exception)
         {
             readFaults.Add(grainReference, exception);
-            logger.Info($"Added ReadState fault for {grainReference}.");
+            logger.LogInformation($"Added ReadState fault for {grainReference}.");
             return Task.CompletedTask;
         }
 
@@ -55,7 +55,7 @@ namespace Orleans.TestingHost
         public Task AddFaultOnWrite(GrainReference grainReference, Exception exception)
         {
             writeFaults.Add(grainReference, exception);
-            logger.Info($"Added WriteState fault for {grainReference}.");
+            logger.LogInformation($"Added WriteState fault for {grainReference}.");
             return Task.CompletedTask;
         }
 
@@ -68,7 +68,7 @@ namespace Orleans.TestingHost
         public Task AddFaultOnClear(GrainReference grainReference, Exception exception)
         {
             clearfaults.Add(grainReference, exception);
-            logger.Info($"Added ClearState fault for {grainReference}.");
+            logger.LogInformation($"Added ClearState fault for {grainReference}.");
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
+++ b/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
@@ -29,21 +29,21 @@ namespace Orleans.Transactions.TestKit
 
         public async Task<TransactionalStatus> PrepareAndCommit(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeParticipants, int totalParticipants)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started PrepareAndCommit transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started PrepareAndCommit transaction {transactionId}");
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.BeforePrepareAndCommit)
             {
                 if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionBeforeStore)
                     this.faultInjector.InjectBeforeStore = true;
                 if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                this.logger.Info($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} PrepareAndCommit, " +
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} PrepareAndCommit, " +
                                  $"with fault type {this.faultInjectionControl.FaultInjectionType}");
             }
             var result = await this.tm.PrepareAndCommit(transactionId, accessCount, timeStamp, writeParticipants, totalParticipants);
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepareAndCommit && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} PrepareAndCommit");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} PrepareAndCommit");
             }
             this.faultInjectionControl.Reset();
             return result;
@@ -51,26 +51,26 @@ namespace Orleans.Transactions.TestKit
 
         public async Task Prepared(Guid transactionId, DateTime timeStamp, ParticipantId participant, TransactionalStatus status)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started Prepared transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started Prepared transaction {transactionId}");
             await this.tm.Prepared(transactionId, timeStamp, participant, status);
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepared
                 && this.faultInjectionControl?.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepared");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepared");
             }
             this.faultInjectionControl.Reset();
         }
 
         public async Task Ping(Guid transactionId, DateTime timeStamp, ParticipantId participant)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started Ping transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started Ping transaction {transactionId}");
             await this.tm.Ping(transactionId, timeStamp, participant);
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPing
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Ping");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Ping");
             }
             this.faultInjectionControl.Reset();
         }
@@ -100,13 +100,13 @@ namespace Orleans.Transactions.TestKit
 
         public async Task<TransactionalStatus> CommitReadOnly(Guid transactionId, AccessCounter accessCount, DateTime timeStamp)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started CommitReadOnly transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started CommitReadOnly transaction {transactionId}");
             var result = await this.tResource.CommitReadOnly(transactionId, accessCount, timeStamp);
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCommitReadOnly
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} CommitReadOnly");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} CommitReadOnly");
             }
 
             this.faultInjectionControl.Reset();
@@ -115,40 +115,40 @@ namespace Orleans.Transactions.TestKit
 
         public async Task Abort(Guid transactionId)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} aborting transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} aborting transaction {transactionId}");
             await this.tResource.Abort(transactionId);
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterAbort
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} abort");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} abort");
             }
             this.faultInjectionControl.Reset();
         }
 
         public async Task Cancel(Guid transactionId, DateTime timeStamp, TransactionalStatus status)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} canceling transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} canceling transaction {transactionId}");
             await this.tResource.Cancel(transactionId, timeStamp, status);
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCancel
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} cancel");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} cancel");
             }
             this.faultInjectionControl.Reset();
         }
 
         public async Task Confirm(Guid transactionId, DateTime timeStamp)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started Confirm transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started Confirm transaction {transactionId}");
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.BeforeConfirm)
             {
                 if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionBeforeStore)
                     this.faultInjector.InjectBeforeStore = true;
                 if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                this.logger.Info($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} Confirm, " +
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} Confirm, " +
                                  $"with fault type {this.faultInjectionControl.FaultInjectionType}");
             }
             await this.tResource.Confirm(transactionId, timeStamp);
@@ -156,14 +156,14 @@ namespace Orleans.Transactions.TestKit
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Confirm");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Confirm");
             }
             this.faultInjectionControl.Reset();
         }
 
         public async Task Prepare(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, ParticipantId transactionManager)
         {
-            this.logger.Info($"Grain {this.context.GrainInstance} started Prepare transaction {transactionId}");
+            this.logger.LogInformation($"Grain {this.context.GrainInstance} started Prepare transaction {transactionId}");
 
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.BeforePrepare)
             {
@@ -171,7 +171,7 @@ namespace Orleans.Transactions.TestKit
                     this.faultInjector.InjectBeforeStore = true;
                 if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                this.logger.Info($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} Prepare, " +
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} injected fault before transaction {transactionId} Prepare, " +
                                  $"with fault type {this.faultInjectionControl.FaultInjectionType}");
             }
 
@@ -180,7 +180,7 @@ namespace Orleans.Transactions.TestKit
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
                 this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
-                this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepare");
+                this.logger.LogInformation($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepare");
             }
             this.faultInjectionControl.Reset();
         }

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
@@ -107,7 +107,7 @@ namespace Orleans.Transactions
                     {
                         status = s;
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} fail {transactionInfo.TransactionId} prepare response status={status}");
+                            logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} fail {transactionInfo.TransactionId} prepare response status={status}");
                         break;
                     }
                 }
@@ -117,14 +117,14 @@ namespace Orleans.Transactions
             catch (TimeoutException ex)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} timeout {transactionInfo.TransactionId} on CommitReadOnly");
+                    logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} timeout {transactionInfo.TransactionId} on CommitReadOnly");
                 status = TransactionalStatus.ParticipantResponseTimeout;
                 exception = ex;
             }
             catch (Exception ex)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure {transactionInfo.TransactionId} CommitReadOnly");
+                    logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure {transactionInfo.TransactionId} CommitReadOnly");
                 this.logger.LogWarning(ex, "Unknown error while commiting readonly transaction {TransactionId}", transactionInfo.TransactionId);
                 status = TransactionalStatus.PresumedAbort;
                 exception = ex;
@@ -140,7 +140,7 @@ namespace Orleans.Transactions
                 catch (Exception ex)
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure aborting {transactionInfo.TransactionId} CommitReadOnly");
+                        logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure aborting {transactionInfo.TransactionId} CommitReadOnly");
                     this.logger.LogWarning(ex, "Failed to abort readonly transaction {TransactionId}", transactionInfo.TransactionId);
                 }
             }
@@ -176,14 +176,14 @@ namespace Orleans.Transactions
             catch (TimeoutException ex)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} timeout {transactionInfo.TransactionId} on CommitReadWriteTransaction");
+                    logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} timeout {transactionInfo.TransactionId} on CommitReadWriteTransaction");
                 status = TransactionalStatus.TMResponseTimeout;
                 exception = ex;
             }
             catch (Exception ex)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure {transactionInfo.TransactionId} CommitReadWriteTransaction");
+                    logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure {transactionInfo.TransactionId} CommitReadWriteTransaction");
                 this.logger.LogWarning(ex, "Unknown error while committing transaction {TransactionId}", transactionInfo.TransactionId);
                 status = TransactionalStatus.PresumedAbort;
                 exception = ex;
@@ -194,7 +194,7 @@ namespace Orleans.Transactions
                 try
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failed {transactionInfo.TransactionId} with status={status}");
+                        logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failed {transactionInfo.TransactionId} with status={status}");
 
                     // notify participants
                     if (status.DefinitelyAborted())
@@ -208,7 +208,7 @@ namespace Orleans.Transactions
                 catch (Exception ex)
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure aborting {transactionInfo.TransactionId} CommitReadWriteTransaction");
+                        logger.LogDebug($"{stopwatch.Elapsed.TotalMilliseconds:f2} failure aborting {transactionInfo.TransactionId} CommitReadWriteTransaction");
                     this.logger.LogWarning(ex, "Failed to abort transaction {TransactionId}", transactionInfo.TransactionId);
                 }
             }

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
@@ -40,7 +40,7 @@ namespace Orleans.Transactions
             DateTime ts = this.clock.UtcNow();
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"{stopwatch.Elapsed.TotalMilliseconds:f2} start transaction {guid} at {ts:o}");
+                logger.LogTrace($"{stopwatch.Elapsed.TotalMilliseconds:f2} start transaction {guid} at {ts:o}");
             this.statistics.TrackTransactionStarted();
             return Task.FromResult<ITransactionInfo>(new TransactionInfo(guid, ts, ts));
         }
@@ -52,7 +52,7 @@ namespace Orleans.Transactions
             transactionInfo.TimeStamp = this.clock.MergeUtcNow(transactionInfo.TimeStamp);
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"{stopwatch.Elapsed.TotalMilliseconds:f2} prepare {transactionInfo}");
+                logger.LogTrace($"{stopwatch.Elapsed.TotalMilliseconds:f2} prepare {transactionInfo}");
 
             if (transactionInfo.Participants.Count == 0)
             {
@@ -146,7 +146,7 @@ namespace Orleans.Transactions
             }
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"{stopwatch.Elapsed.TotalMilliseconds:f2} finish (reads only) {transactionInfo.TransactionId}");
+                logger.LogTrace($"{stopwatch.Elapsed.TotalMilliseconds:f2} finish (reads only) {transactionInfo.TransactionId}");
 
             return (status, exception);
         }
@@ -214,7 +214,7 @@ namespace Orleans.Transactions
             }
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"{stopwatch.Elapsed.TotalMilliseconds:f2} finish {transactionInfo.TransactionId}");
+                logger.LogTrace($"{stopwatch.Elapsed.TotalMilliseconds:f2} finish {transactionInfo.TransactionId}");
 
             return (status, exception);
         }
@@ -227,7 +227,7 @@ namespace Orleans.Transactions
             List<ParticipantId> participants = transactionInfo.Participants.Keys.ToList();
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"abort {transactionInfo} {string.Join(",", participants.Select(p => p.ToString()))}");
+                logger.LogTrace($"abort {transactionInfo} {string.Join(",", participants.Select(p => p.ToString()))}");
 
             // send one-way abort messages to release the locks and roll back any updates
             await Task.WhenAll(participants.Select(p => p.Reference.AsReference<ITransactionalResourceExtension>()

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -116,7 +116,7 @@ namespace Orleans.Transactions.State
                     group.Deadline = DateTime.UtcNow + this.options.LockTimeout;
 
                     if (logger.IsEnabled(LogLevel.Trace))
-                        logger.Trace("set lock expiration at {Deadline}", group.Deadline.Value.ToString("o"));
+                        logger.LogTrace("set lock expiration at {Deadline}", group.Deadline.Value.ToString("o"));
                 }
 
                 // create a new record for this transaction
@@ -133,9 +133,9 @@ namespace Orleans.Transactions.State
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
                     if (group == currentGroup)
-                        logger.Trace($"enter-lock {transactionId} fc={group.FillCount}");
+                        logger.LogTrace($"enter-lock {transactionId} fc={group.FillCount}");
                     else
-                        logger.Trace($"enter-lock-queue {transactionId} fc={group.FillCount}");
+                        logger.LogTrace($"enter-lock-queue {transactionId} fc={group.FillCount}");
                 }
             }
 
@@ -232,7 +232,7 @@ namespace Orleans.Transactions.State
         private Task BreakLock(Guid transactionId, TransactionRecord<TState> entry, Exception exception)
         {
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace("Break-lock for transaction {TransactionId}", transactionId);
+                logger.LogTrace("Break-lock for transaction {TransactionId}", transactionId);
 
             return this.queue.NotifyOfAbort(entry, TransactionalStatus.BrokenLock, exception);
         }
@@ -320,7 +320,7 @@ namespace Orleans.Transactions.State
                             else
                             {
                                 if (logger.IsEnabled(LogLevel.Trace))
-                                    logger.Trace("recheck lock expiration at {Deadline}", currentGroup.Deadline.Value.ToString("o"));
+                                    logger.LogTrace("recheck lock expiration at {Deadline}", currentGroup.Deadline.Value.ToString("o"));
 
                                 // check again when the group expires
                                 lockWorker.Notify(currentGroup.Deadline.Value);
@@ -355,7 +355,7 @@ namespace Orleans.Transactions.State
                                     expiredWaiters.Add(kvp.Key);
 
                                     if (logger.IsEnabled(LogLevel.Trace))
-                                        logger.Trace($"expire-lock-waiter {kvp.Key}");
+                                        logger.LogTrace($"expire-lock-waiter {kvp.Key}");
                                 }
                             }
 
@@ -369,9 +369,9 @@ namespace Orleans.Transactions.State
 
                             if (logger.IsEnabled(LogLevel.Trace))
                             {
-                                logger.Trace($"lock groupsize={currentGroup.Count} deadline={currentGroup.Deadline:o}");
+                                logger.LogTrace($"lock groupsize={currentGroup.Count} deadline={currentGroup.Deadline:o}");
                                 foreach (var kvp in currentGroup)
-                                    logger.Trace($"enter-lock {kvp.Key}");
+                                    logger.LogTrace($"enter-lock {kvp.Key}");
                             }
 
                             // execute all the read and update tasks

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -497,7 +497,7 @@ namespace Orleans.Transactions.State
                     currentGroup.Remove(single.TransactionId);
 
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"exit-lock {single.TransactionId} {single.Timestamp:o}");
+                        logger.LogDebug($"exit-lock {single.TransactionId} {single.Timestamp:o}");
 
                     return true;
                 }
@@ -553,7 +553,7 @@ namespace Orleans.Transactions.State
                         currentGroup.Remove(multiple[i].TransactionId);
 
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.Debug($"exit-lock ({i}/{multiple.Count}) {multiple[i].TransactionId} {multiple[i].Timestamp:o}");
+                            logger.LogDebug($"exit-lock ({i}/{multiple.Count}) {multiple[i].TransactionId} {multiple[i].Timestamp:o}");
                     }
 
                     return true;

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -439,7 +439,7 @@ namespace Orleans.Transactions.State
             this.stableSequenceNumber = loadresponse.CommittedSequenceId;
 
             if (logger.IsEnabled(LogLevel.Debug))
-                logger.Debug($"Load v{this.stableSequenceNumber} {loadresponse.PendingStates.Count}p {storageBatch.MetaData.CommitRecords.Count}c");
+                logger.LogDebug($"Load v{this.stableSequenceNumber} {loadresponse.PendingStates.Count}p {storageBatch.MetaData.CommitRecords.Count}c");
 
             // ensure clock is consistent with loaded state
             this.Clock.Merge(storageBatch.MetaData.TimeStamp);
@@ -450,7 +450,7 @@ namespace Orleans.Transactions.State
                 if (pr.SequenceId > loadresponse.CommittedSequenceId && pr.TransactionManager.Reference != null)
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"recover two-phase-commit {pr.TransactionId}");
+                        logger.LogDebug($"recover two-phase-commit {pr.TransactionId}");
 
                     ParticipantId tm = pr.TransactionManager;
 
@@ -475,7 +475,7 @@ namespace Orleans.Transactions.State
             foreach (var kvp in storageBatch.MetaData.CommitRecords)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
-                    logger.Debug($"recover commit confirmation {kvp.Key}");
+                    logger.LogDebug($"recover commit confirmation {kvp.Key}");
                 this.confirmationWorker.Add(kvp.Key, kvp.Value.Timestamp, kvp.Value.WriteParticipants);
             }
 
@@ -536,7 +536,7 @@ namespace Orleans.Transactions.State
                         if (logger.IsEnabled(LogLevel.Debug))
                         {
                             var r = commitQueue.Count > committableEntries ? commitQueue[committableEntries].ToString() : "";
-                            logger.Debug($"batchcommit={committableEntries} leave={commitQueue.Count - committableEntries} {r}");
+                            logger.LogDebug($"batchcommit={committableEntries} leave={commitQueue.Count - committableEntries} {r}");
                         }
                     }
                     else
@@ -633,7 +633,7 @@ namespace Orleans.Transactions.State
             await Task.WhenAll(pending);
             if (++failCounter >= 10 || force)
             {
-                logger.Debug("StorageWorker triggering grain Deactivation");
+                logger.LogDebug("StorageWorker triggering grain Deactivation");
                 this.deactivate();
             }
             await this.Restore();

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -165,7 +165,7 @@ namespace Orleans.Transactions.State
             }
             catch (Exception exception)
             {
-                logger.Error(666, $"transaction abort due to internal error in {nameof(EnqueueCommit)}: ", exception);
+                logger.LogError(666, exception, $"transaction abort due to internal error in {nameof(EnqueueCommit)}: ");
                 await NotifyOfAbort(record, TransactionalStatus.UnknownException, exception);
             }
         }
@@ -183,7 +183,7 @@ namespace Orleans.Transactions.State
 
                 if (localEntry.Role != CommitRole.LocalCommit)
                 {
-                    logger.Error(666, $"transaction abort due to internal error in {nameof(NotifyOfPrepared)}: Wrong commit type");
+                    logger.LogError(666, $"transaction abort due to internal error in {nameof(NotifyOfPrepared)}: Wrong commit type");
                     throw new InvalidOperationException($"Wrong commit type: {localEntry.Role}");
                 }
 
@@ -369,7 +369,7 @@ namespace Orleans.Transactions.State
 
             if (remoteEntry.Role != CommitRole.RemoteCommit)
             {
-                logger.Error(666, $"internal error in {nameof(NotifyOfConfirm)}: wrong commit type");
+                logger.LogError(666, $"internal error in {nameof(NotifyOfConfirm)}: wrong commit type");
                 throw new InvalidOperationException($"Wrong commit type: {remoteEntry.Role}");
             }
 

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -576,7 +576,7 @@ namespace Orleans.Transactions.State
                         }
                         catch (Exception exception)
                         {
-                            logger.Warn(888, $"Storage exception in storageWorker.", exception);
+                            logger.LogWarning(888, exception, "Storage exception in storageWorker.");
                             await AbortAndRestore(TransactionalStatus.UnknownException, exception);
                             return;
                         }

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -86,7 +86,7 @@ namespace Orleans.Transactions
                      }
 
                      if (logger.IsEnabled(LogLevel.Debug))
-                         logger.Debug($"update-lock read v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
+                         logger.LogDebug($"update-lock read v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
 
                      // record this read in the transaction info data structure
                      info.RecordRead(this.participantId, record.Timestamp);
@@ -159,7 +159,7 @@ namespace Orleans.Transactions
                     }
 
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"update-lock write v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
+                        logger.LogDebug($"update-lock write v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
 
                     // record this write in the transaction info data structure
                     info.RecordWrite(this.participantId, record.Timestamp);

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -63,7 +63,7 @@ namespace Orleans.Transactions
             var info = (TransactionInfo)TransactionContext.GetRequiredTransactionInfo<TransactionInfo>();
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"StartRead {info}");
+                logger.LogTrace($"StartRead {info}");
 
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
@@ -102,7 +102,7 @@ namespace Orleans.Transactions
                      finally
                      {
                          if (logger.IsEnabled(LogLevel.Trace))
-                             logger.Trace($"EndRead {info} {result} {record.State}");
+                             logger.LogTrace($"EndRead {info} {result} {record.State}");
 
                          detectReentrancy = false;
                      }
@@ -123,7 +123,7 @@ namespace Orleans.Transactions
             var info = (TransactionInfo)TransactionContext.GetRequiredTransactionInfo<TransactionInfo>();
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"StartWrite {info}");
+                logger.LogTrace($"StartWrite {info}");
 
             if (info.IsReadOnly)
             {
@@ -174,7 +174,7 @@ namespace Orleans.Transactions
                     finally
                     {
                         if (logger.IsEnabled(LogLevel.Trace))
-                            logger.Trace($"EndWrite {info} {record.TransactionId} {record.Timestamp}");
+                            logger.LogTrace($"EndWrite {info} {record.TransactionId} {record.Timestamp}");
 
                         detectReentrancy = false;
                     }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -57,7 +57,7 @@ namespace Orleans.Transactions
             var info = (TransactionInfo)TransactionContext.GetRequiredTransactionInfo<TransactionInfo>();
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.Trace($"StartWrite {info}");
+                logger.LogTrace($"StartWrite {info}");
 
             if (info.IsReadOnly)
             {
@@ -109,7 +109,7 @@ namespace Orleans.Transactions
                     finally
                     {
                         if (logger.IsEnabled(LogLevel.Trace))
-                            logger.Trace($"EndWrite {info} {record.TransactionId} {record.Timestamp}");
+                            logger.LogTrace($"EndWrite {info} {record.TransactionId} {record.Timestamp}");
 
                         detectReentrancy = false;
                     }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -93,7 +93,7 @@ namespace Orleans.Transactions
                     }
 
                     if (logger.IsEnabled(LogLevel.Debug))
-                        logger.Debug($"update-lock write v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
+                        logger.LogDebug($"update-lock write v{record.SequenceNumber} {record.TransactionId} {record.Timestamp:o}");
 
                     // record this write in the transaction info data structure
                     info.RecordWrite(this.participantId, record.Timestamp);

--- a/src/Serializers/Orleans.Serialization.Bond/BondSerializer.cs
+++ b/src/Serializers/Orleans.Serialization.Bond/BondSerializer.cs
@@ -165,7 +165,7 @@ namespace Orleans.Serialization
         private void LogWarning(int code, string format, params object[] parameters)
         {
             if(logger.IsEnabled(LogLevel.Warning))
-                logger.Warn(code, format, parameters);
+                logger.LogWarning(code, format, parameters);
         }
 
         private void Register(Type type)

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -206,11 +207,11 @@ namespace DefaultCluster.Tests.General
             ITestGrain simple = this.GrainFactory.GetGrain<ITestGrain>(GetRandomGrainId());
 
             simple.GetMultipleGrainInterfaces_List().Wait();
-            this.Logger.Info("GetMultipleGrainInterfaces_List() worked");
+            this.Logger.LogInformation("GetMultipleGrainInterfaces_List() worked");
 
             simple.GetMultipleGrainInterfaces_Array().Wait();
 
-            this.Logger.Info("GetMultipleGrainInterfaces_Array() worked");
+            this.Logger.LogInformation("GetMultipleGrainInterfaces_Array() worked");
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"),
@@ -240,7 +241,7 @@ namespace DefaultCluster.Tests.General
                 }
                 catch (Exception)
                 {
-                    this.Logger.Info("Done with stress iteration.");
+                    this.Logger.LogInformation("Done with stress iteration.");
                 }
 
                 // wait a bit to make sure expired msgs in the silo is trigered.
@@ -249,9 +250,9 @@ namespace DefaultCluster.Tests.General
                 // set the regular response time back, expect msgs ot succeed.
                 this.SetResponseTimeout(prevTimeout);
                 
-                this.Logger.Info("About to send a next legit request that should succeed.");
+                this.Logger.LogInformation("About to send a next legit request that should succeed.");
                 grain.DoLongAction(TimeSpan.FromMilliseconds(1), "B_" + 0).Wait();
-                this.Logger.Info("The request succeeded.");
+                this.Logger.LogInformation("The request succeeded.");
             }
             finally
             {
@@ -266,7 +267,7 @@ namespace DefaultCluster.Tests.General
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(GetRandomGrainId());
             Task<Tuple<string, string>> promise1 = g1.TestRequestContext();
             Tuple<string, string> requstContext = promise1.Result;
-            this.Logger.Info("Request Context is: " + requstContext);
+            this.Logger.LogInformation("Request Context is: " + requstContext);
             Assert.NotNull(requstContext.Item2);
             Assert.NotNull(requstContext.Item1);
         }

--- a/test/DefaultCluster.Tests/DeactivationTests.cs
+++ b/test/DefaultCluster.Tests/DeactivationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -29,7 +30,7 @@ namespace DefaultCluster.Tests.General
             sw.Stop();
 
             Assert.True(sw.ElapsedMilliseconds < 1000);
-            this.Logger.Info("Took {0}ms to deactivate and reactivate the grain", sw.ElapsedMilliseconds);
+            this.Logger.LogInformation("Took {0}ms to deactivate and reactivate the grain", sw.ElapsedMilliseconds);
 
             var a = await grain.GetA();
             Assert.Equal(99, a); // value of A survive deactivation and reactivation of the grain

--- a/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
+++ b/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.TestingHost;
@@ -44,11 +45,11 @@ namespace DefaultCluster.Tests.General
 
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("CreateGrain took " + clock.Elapsed);
+            this.Logger.LogInformation("CreateGrain took " + clock.Elapsed);
 
             clock.Restart();
             string received = await grain.EchoAsync(expectedEcho);
-            this.Logger.Info("EchoGrain.Echo took " + clock.Elapsed);
+            this.Logger.LogInformation("EchoGrain.Echo took " + clock.Elapsed);
 
             Assert.Equal(expectedEcho, received);
         }
@@ -152,7 +153,7 @@ namespace DefaultCluster.Tests.General
 
             clock.Start();
             string received = await grain.GetLastEchoAsync();
-            this.Logger.Info("EchoGrain.LastEcho took " + clock.Elapsed);
+            this.Logger.LogInformation("EchoGrain.LastEcho took " + clock.Elapsed);
 
             Assert.Equal(expectedEcho, received); // LastEcho-Echo
 
@@ -160,7 +161,7 @@ namespace DefaultCluster.Tests.General
 
             clock.Restart();
             received = await grain.GetLastEchoAsync();
-            this.Logger.Info("EchoGrain.LastEcho-Error took " + clock.Elapsed);
+            this.Logger.LogInformation("EchoGrain.LastEcho-Error took " + clock.Elapsed);
 
             Assert.Equal(expectedEchoError, received); // LastEcho-Error
         }
@@ -173,13 +174,13 @@ namespace DefaultCluster.Tests.General
             string what = "CreateGrain";
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             what = "EchoGrain.Ping";
             clock.Restart();
             
             await grain.PingAsync().WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
@@ -190,12 +191,12 @@ namespace DefaultCluster.Tests.General
             string what = "CreateGrain";
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             what = "EchoGrain.PingLocalSilo";
             clock.Restart();
             await grain.PingLocalSiloAsync().WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
@@ -206,7 +207,7 @@ namespace DefaultCluster.Tests.General
             string what = "CreateGrain";
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             SiloAddress silo1 = HostedCluster.Primary.SiloAddress;
             SiloAddress silo2 = HostedCluster.SecondarySilos[0].SiloAddress;
@@ -214,12 +215,12 @@ namespace DefaultCluster.Tests.General
             what = "EchoGrain.PingRemoteSilo[1]";
             clock.Restart();
             await grain.PingRemoteSiloAsync(silo1).WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             what = "EchoGrain.PingRemoteSilo[2]";
             clock.Restart();
             await grain.PingRemoteSiloAsync(silo2).WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
@@ -230,12 +231,12 @@ namespace DefaultCluster.Tests.General
             string what = "CreateGrain";
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             what = "EchoGrain.PingOtherSilo";
             clock.Restart();
             await grain.PingOtherSiloAsync().WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
@@ -246,12 +247,12 @@ namespace DefaultCluster.Tests.General
             string what = "CreateGrain";
             clock.Start();
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
 
             what = "EchoGrain.PingOtherSiloMembership";
             clock.Restart();
             await grain.PingClusterMemberAsync().WithTimeout(timeout);
-            this.Logger.Info("{0} took {1}", what, clock.Elapsed);
+            this.Logger.LogInformation("{0} took {1}", what, clock.Elapsed);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
@@ -291,18 +292,18 @@ namespace DefaultCluster.Tests.General
 
             clock.Start();
             var grain = this.GrainFactory.GetGrain<IEchoGrain>(Guid.NewGuid());
-            this.Logger.Info("CreateGrain took " + clock.Elapsed);
+            this.Logger.LogInformation("CreateGrain took " + clock.Elapsed);
 
             clock.Restart();
             var now = DateTime.Now;
             var received = await grain.EchoNullable(now);
-            this.Logger.Info("EchoGrain.EchoNullable took " + clock.Elapsed);
+            this.Logger.LogInformation("EchoGrain.EchoNullable took " + clock.Elapsed);
 
             Assert.Equal(now, received);
 
             clock.Restart();
             received = await grain.EchoNullable(null);
-            this.Logger.Info("EchoGrain.EchoNullable took " + clock.Elapsed);
+            this.Logger.LogInformation("EchoGrain.EchoNullable took " + clock.Elapsed);
             Assert.Null(received);
         }
 
@@ -310,13 +311,13 @@ namespace DefaultCluster.Tests.General
 
         private bool TimeIsLonger(TimeSpan time, TimeSpan limit)
         {
-            this.Logger.Info("Compare TimeIsLonger: Actual={0} Limit={1} Epsilon={2}", time, limit, Epsilon);
+            this.Logger.LogInformation("Compare TimeIsLonger: Actual={0} Limit={1} Epsilon={2}", time, limit, Epsilon);
             return time >= (limit - Epsilon);
         }
 
         private bool TimeIsShorter(TimeSpan time, TimeSpan limit)
         {
-            this.Logger.Info("Compare TimeIsShorter: Actual={0} Limit={1} Epsilon={2}", time, limit, Epsilon);
+            this.Logger.LogInformation("Compare TimeIsShorter: Actual={0} Limit={1} Epsilon={2}", time, limit, Epsilon);
             return time <= (limit + Epsilon);
         }
     }

--- a/test/DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/DefaultCluster.Tests/ErrorGrainTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Internal;
@@ -206,7 +207,7 @@ namespace DefaultCluster.Tests
             CreateGR(n + 3, 1);
             CreateGR(n + 4, 1);
 
-            Logger.Info("================");
+            Logger.LogInformation("================");
 
             CreateGR(n, 2);
             CreateGR(n + 1, 2);
@@ -214,7 +215,7 @@ namespace DefaultCluster.Tests
             CreateGR(n + 3, 2);
             CreateGR(n + 4, 2);
 
-            Logger.Info("DONE.");
+            Logger.LogInformation("DONE.");
         }
 
         private void CreateGR(int n, int type)

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -268,7 +269,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
             }
             catch(InvalidOperationException exc)
             {
-                this.Logger.Info("Thrown as expected:", exc);
+                this.Logger.LogInformation(exc, "Thrown as expected");
                 Assert.True(
                     exc.Message.Contains("DeactivateOnIdle from within OnActivateAsync"),
                     "Did not get expected exception message returned: " + exc.Message);

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -336,7 +336,7 @@ namespace DefaultCluster.Tests.General
 
             public void StateChanged(int a, int b)
             {
-                this.logger.Debug("SimpleGrainObserver.StateChanged a={0} b={1}", a, b);
+                this.logger.LogDebug("SimpleGrainObserver.StateChanged a={0} b={1}", a, b);
                 action?.Invoke(a, b, result);
             }
         }

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -83,7 +83,7 @@ namespace DefaultCluster.Tests.General
         void ObserverTest_SimpleNotification_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
-            this.Logger.Info("Invoking ObserverTest_SimpleNotification_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
+            this.Logger.LogInformation("Invoking ObserverTest_SimpleNotification_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
 
             if (a == 3 && b == 0)
                 callbacksReceived[0] = true;
@@ -130,7 +130,7 @@ namespace DefaultCluster.Tests.General
             catch (Exception exc)
             {
                 Exception baseException = exc.GetBaseException();
-                this.Logger.Info("Received exception: {0}", baseException);
+                this.Logger.LogInformation("Received exception: {0}", baseException);
                 Assert.IsAssignableFrom<OrleansException>(baseException);
                 if (!baseException.Message.StartsWith("Cannot subscribe already subscribed observer"))
                 {
@@ -148,7 +148,7 @@ namespace DefaultCluster.Tests.General
         void ObserverTest_DoubleSubscriptionSameReference_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
-            this.Logger.Info("Invoking ObserverTest_DoubleSubscriptionSameReference_Callback for {0} time with a={1} and b={2}", this.callbackCounter, a, b);
+            this.Logger.LogInformation("Invoking ObserverTest_DoubleSubscriptionSameReference_Callback for {0} time with a={1} and b={2}", this.callbackCounter, a, b);
             Assert.True(callbackCounter <= 2, "Callback has been called more times than was expected " + callbackCounter);
             if (callbackCounter == 2)
             {
@@ -180,7 +180,7 @@ namespace DefaultCluster.Tests.General
         void ObserverTest_SubscribeUnsubscribe_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
-            this.Logger.Info("Invoking ObserverTest_SubscribeUnsubscribe_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
+            this.Logger.LogInformation("Invoking ObserverTest_SubscribeUnsubscribe_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
             Assert.True(callbackCounter < 2, "Callback has been called more times than was expected.");
 
             Assert.Equal(5, a);
@@ -239,7 +239,7 @@ namespace DefaultCluster.Tests.General
         void ObserverTest_DoubleSubscriptionDifferentReferences_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
-            this.Logger.Info("Invoking ObserverTest_DoubleSubscriptionDifferentReferences_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
+            this.Logger.LogInformation("Invoking ObserverTest_DoubleSubscriptionDifferentReferences_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
             Assert.True(callbackCounter < 3, "Callback has been called more times than was expected.");
 
             Assert.Equal(6, a);
@@ -270,7 +270,7 @@ namespace DefaultCluster.Tests.General
         void ObserverTest_DeleteObject_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
-            this.Logger.Info("Invoking ObserverTest_DeleteObject_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
+            this.Logger.LogInformation("Invoking ObserverTest_DeleteObject_Callback for {0} time with a = {1} and b = {2}", this.callbackCounter, a, b);
             Assert.True(callbackCounter < 2, "Callback has been called more times than was expected.");
 
             Assert.Equal(5, a);

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 using OrleansAWSUtils.Streams;
 using Orleans.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 
@@ -86,7 +87,7 @@ namespace AWSUtils.Tests.Streaming
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSStreamProducerOnDroppedClientTest()
         {
-            logger.Info("************************ AQStreamProducerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ AQStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(SQSStreamProviderName, StreamNamespace);
         }
     }

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
 using AWSUtils.Tests.StorageTests;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Orleans;
 using Orleans.Runtime;
@@ -76,56 +77,56 @@ namespace AWSUtils.Tests.Streaming
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSMultipleParallelSubscriptionTest()
         {
-            logger.Info("************************ SQSMultipleParallelSubscriptionTest *********************************");
+            logger.LogInformation("************************ SQSMultipleParallelSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSMultipleLinearSubscriptionTest()
         {
-            logger.Info("************************ SQSMultipleLinearSubscriptionTest *********************************");
+            logger.LogInformation("************************ SQSMultipleLinearSubscriptionTest *********************************");
             await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSMultipleSubscriptionTest_AddRemove()
         {
-            logger.Info("************************ SQSMultipleSubscriptionTest_AddRemove *********************************");
+            logger.LogInformation("************************ SQSMultipleSubscriptionTest_AddRemove *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSResubscriptionTest()
         {
-            logger.Info("************************ SQSResubscriptionTest *********************************");
+            logger.LogInformation("************************ SQSResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSResubscriptionAfterDeactivationTest()
         {
-            logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
+            logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSActiveSubscriptionTest()
         {
-            logger.Info("************************ SQSActiveSubscriptionTest *********************************");
+            logger.LogInformation("************************ SQSActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSTwoIntermitentStreamTest()
         {
-            logger.Info("************************ SQSTwoIntermitentStreamTest *********************************");
+            logger.LogInformation("************************ SQSTwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
 
         [SkippableFact, TestCategory("AWS")]
         public async Task SQSSubscribeFromClientTest()
         {
-            logger.Info("************************ SQSSubscribeFromClientTest *********************************");
+            logger.LogInformation("************************ SQSSubscribeFromClientTest *********************************");
             await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
         }
     }

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 using Orleans.Providers.GCP.Streams.PubSub;
 using Orleans.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 
@@ -78,14 +79,14 @@ namespace GoogleUtils.Tests.Streaming
         [SkippableFact]
         public async Task GPS_StreamProducerOnDroppedClientTest()
         {
-            logger.Info("************************ AQStreamProducerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ AQStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(PROVIDER_NAME, STREAM_NAMESPACE);
         }
 
         [SkippableFact(Skip = "PubSub has unpredictable event delivery counts - re-enable when we figure out how to handle this.")]
         public async Task GPS_StreamConsumerOnDroppedClientTest()
         {
-            logger.Info("************************ AQStreamConsumerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ AQStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(PROVIDER_NAME, STREAM_NAMESPACE, output);
         }
     }

--- a/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Serializers/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
@@ -7,6 +7,7 @@ using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using TestExtensions;
 using UnitTests.StreamingTests;
 using Xunit;
@@ -70,56 +71,56 @@ namespace GoogleUtils.Tests.Streaming
         [SkippableFact]
         public async Task GPS_MultipleParallelSubscriptionTest()
         {
-            logger.Info("************************ GPS_MultipleParallelSubscriptionTest *********************************");
+            logger.LogInformation("************************ GPS_MultipleParallelSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_MultipleLinearSubscriptionTest()
         {
-            logger.Info("************************ GPS_MultipleLinearSubscriptionTest *********************************");
+            logger.LogInformation("************************ GPS_MultipleLinearSubscriptionTest *********************************");
             await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_MultipleSubscriptionTest_AddRemove()
         {
-            logger.Info("************************ GPS_MultipleSubscriptionTest_AddRemove *********************************");
+            logger.LogInformation("************************ GPS_MultipleSubscriptionTest_AddRemove *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_ResubscriptionTest()
         {
-            logger.Info("************************ GPS_ResubscriptionTest *********************************");
+            logger.LogInformation("************************ GPS_ResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_ResubscriptionAfterDeactivationTest()
         {
-            logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
+            logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_ActiveSubscriptionTest()
         {
-            logger.Info("************************ GPS_ActiveSubscriptionTest *********************************");
+            logger.LogInformation("************************ GPS_ActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
 
         [SkippableFact]
         public async Task GPS_TwoIntermitentStreamTest()
         {
-            logger.Info("************************ GPS_TwoIntermitentStreamTest *********************************");
+            logger.LogInformation("************************ GPS_TwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
 
         [SkippableFact]
         public async Task GPS_SubscribeFromClientTest()
         {
-            logger.Info("************************ GPS_SubscribeFromClientTest *********************************");
+            logger.LogInformation("************************ GPS_SubscribeFromClientTest *********************************");
             await runner.SubscribeFromClientTest(Guid.NewGuid(), STREAM_NAMESPACE);
         }
     }

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Hosting;
 using Orleans.TestingHost;
@@ -66,49 +67,49 @@ namespace ServiceBus.Tests.StreamingTests
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedMultipleParallelSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedMultipleParallelSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedMultipleParallelSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedMultipleLinearSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedMultipleLinearSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedMultipleLinearSubscriptionTest *********************************");
             await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedMultipleSubscriptionTest_AddRemove()
         {
-            this.fixture.Logger.Info("************************ EHBatchedMultipleSubscriptionTest_AddRemove *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedMultipleSubscriptionTest_AddRemove *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedResubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedResubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedResubscriptionAfterDeactivationTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedResubscriptionAfterDeactivationTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedActiveSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedActiveSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedTwoIntermitentStreamTest()
         {
-            this.fixture.Logger.Info("************************ EHBatchedTwoIntermitentStreamTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHBatchedTwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
     }

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -92,14 +93,14 @@ namespace ServiceBus.Tests.StreamingTests
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5657")]
         public async Task EHStreamProducerOnDroppedClientTest()
         {
-            logger.Info("************************ EHStreamProducerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ EHStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(StreamProviderName, StreamNamespace);
         }
 
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5634")]
         public async Task EHStreamConsumerOnDroppedClientTest()
         {
-            logger.Info("************************ EHStreamConsumerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ EHStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(StreamProviderName, StreamNamespace, output,
                     () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(StreamProviderName), true);
         }

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -90,14 +91,14 @@ namespace ServiceBus.Tests.StreamingTests
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5633")]
         public async Task Recoverable100EventStreamsWithTransientErrorsTest()
         {
-            this.fixture.Logger.Info("************************ EHRecoverable100EventStreamsWithTransientErrorsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHRecoverable100EventStreamsWithTransientErrorsTest *********************************");
             await runner.Recoverable100EventStreamsWithTransientErrors(GenerateEvents, ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.StreamNamespace, 4, 100);
         }
 
         [SkippableFact(Skip= "https://github.com/dotnet/orleans/issues/5638")]
         public async Task Recoverable100EventStreamsWith1NonTransientErrorTest()
         {
-            this.fixture.Logger.Info("************************ EHRecoverable100EventStreamsWith1NonTransientErrorTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHRecoverable100EventStreamsWith1NonTransientErrorTest *********************************");
             await runner.Recoverable100EventStreamsWith1NonTransientError(GenerateEvents, ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.StreamNamespace, 4, 100);
         }
 

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -14,6 +14,7 @@ using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace ServiceBus.Tests.StreamingTests
 {
@@ -88,7 +89,7 @@ namespace ServiceBus.Tests.StreamingTests
                               "left from previous tests")]
         public async Task EH100StreamsTo4PartitionStreamsTest()
         {
-            this.fixture.Logger.Info("************************ EH100StreamsTo4PartitionStreamsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EH100StreamsTo4PartitionStreamsTest *********************************");
 
             int streamCount = 100;
             int eventsInStream = 10;

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Providers.Streams.Common;
 using Orleans.Providers.Streams.Generator;
@@ -89,14 +90,14 @@ namespace ServiceBus.Tests.StreamingTests
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5356")]
         public async Task ReloadFromCheckpointTest()
         {
-            logger.Info("************************ EHReloadFromCheckpointTest *********************************");
+            logger.LogInformation("************************ EHReloadFromCheckpointTest *********************************");
             await this.ReloadFromCheckpointTestRunner(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 1, 256);
         }
 
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5356")]
         public async Task RestartSiloAfterCheckpointTest()
         {
-            logger.Info("************************ EHRestartSiloAfterCheckpointTest *********************************");
+            logger.LogInformation("************************ EHRestartSiloAfterCheckpointTest *********************************");
             await this.RestartSiloAfterCheckpointTestRunner(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 8, 32);
         }
 

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -64,49 +65,49 @@ namespace ServiceBus.Tests.StreamingTests
         [SkippableFact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleParallelSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHMultipleParallelSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHMultipleParallelSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleLinearSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHMultipleLinearSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHMultipleLinearSubscriptionTest *********************************");
             await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5647"), TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleSubscriptionTest_AddRemove()
         {
-            this.fixture.Logger.Info("************************ EHMultipleSubscriptionTest_AddRemove *********************************");
+            this.fixture.Logger.LogInformation("************************ EHMultipleSubscriptionTest_AddRemove *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHResubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionAfterDeactivationTest()
         {
-            this.fixture.Logger.Info("************************ EHResubscriptionAfterDeactivationTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHActiveSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ EHActiveSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5653"), TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHTwoIntermitentStreamTest()
         {
-            this.fixture.Logger.Info("************************ EHTwoIntermitentStreamTest *********************************");
+            this.fixture.Logger.LogInformation("************************ EHTwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
     }

--- a/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -56,15 +56,15 @@ namespace Tester.AzureUtils
             Assert.Equal(1, await manager.GetApproximateMessageCount());
 
             var outMessage1 = await manager.PeekQueueMessage();
-            logger.Info("PeekQueueMessage 1: {0}", PrintQueueMessage(outMessage1));
+            logger.LogInformation("PeekQueueMessage 1: {0}", PrintQueueMessage(outMessage1));
             Assert.Equal(inMessage, outMessage1.MessageText);
 
             var outMessage2 = await manager.PeekQueueMessage();
-            logger.Info("PeekQueueMessage 2: {0}", PrintQueueMessage(outMessage2));
+            logger.LogInformation("PeekQueueMessage 2: {0}", PrintQueueMessage(outMessage2));
             Assert.Equal(inMessage, outMessage2.MessageText);
 
             QueueMessage outMessage3 = await manager.GetQueueMessage();
-            logger.Info("GetQueueMessage 3: {0}", PrintQueueMessage(outMessage3));
+            logger.LogInformation("GetQueueMessage 3: {0}", PrintQueueMessage(outMessage3));
             Assert.Equal(inMessage, outMessage3.MessageText);
             Assert.Equal(1, await manager.GetApproximateMessageCount());
 
@@ -141,7 +141,7 @@ namespace Tester.AzureUtils
             Assert.Equal(1, await manager.GetApproximateMessageCount());
 
             QueueMessage outMessage = await manager.GetQueueMessage();
-            logger.Info("GetQueueMessage: {0}", PrintQueueMessage(outMessage));
+            logger.LogInformation("GetQueueMessage: {0}", PrintQueueMessage(outMessage));
             Assert.Equal(inMessage, outMessage.MessageText);
 
             await Task.Delay(visibilityTimeout);

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_AzureTable.cs
@@ -7,6 +7,7 @@ using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using UnitTests.TimerTests;
 using Orleans.Hosting;
 using Orleans.Internal;
@@ -148,7 +149,7 @@ namespace Tester.AzureUtils.TimerTests
             await Task.Delay(period.Multiply(5));
 
             // start two extra silos ... although it will take it a while before they stabilize
-            log.Info("Starting 2 extra silos");
+            log.LogInformation("Starting 2 extra silos");
 
             await this.HostedCluster.StartAdditionalSilosAsync(2, true);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
@@ -190,7 +191,7 @@ namespace Tester.AzureUtils.TimerTests
 
             Thread.Sleep(period.Multiply(failAfter));
             // stop the secondary silo
-            log.Info("Stopping secondary silo");
+            log.LogInformation("Stopping secondary silo");
             await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos.First());
 
             await test; // Block until test completes.
@@ -221,7 +222,7 @@ namespace Tester.AzureUtils.TimerTests
             Thread.Sleep(period.Multiply(failAfter));
 
             // stop a couple of silos
-            log.Info("Stopping 2 silos");
+            log.LogInformation("Stopping 2 silos");
             int i = random.Next(silos.Count);
             await this.HostedCluster.StopSiloAsync(silos[i]);
             silos.RemoveAt(i);
@@ -257,7 +258,7 @@ namespace Tester.AzureUtils.TimerTests
 
             var siloToKill = silos[random.Next(silos.Count)];
             // stop a silo and join a new one in parallel
-            log.Info("Stopping a silo and joining a silo");
+            log.LogInformation("Stopping a silo and joining a silo");
             Task t1 = Task.Factory.StartNew(async () => await this.HostedCluster.StopSiloAsync(siloToKill));
             Task t2 = this.HostedCluster.StartAdditionalSilosAsync(1, true).ContinueWith(t =>
             {
@@ -266,7 +267,7 @@ namespace Tester.AzureUtils.TimerTests
             await Task.WhenAll(new[] { t1, t2 }).WithTimeout(ENDWAIT);
 
             await Task.WhenAll(tasks).WithTimeout(ENDWAIT); // Block until all tasks complete.
-            log.Info("\n\n\nReminderTest_1F1J_MultiGrain passed OK.\n\n\n");
+            log.LogInformation("\n\n\nReminderTest_1F1J_MultiGrain passed OK.\n\n\n");
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -331,7 +332,7 @@ namespace Tester.AzureUtils.TimerTests
 
             var siloToKill = silos[random.Next(silos.Count)];
             // stop a silo and join a new one in parallel
-            log.Info("Stopping a silo and joining a silo");
+            log.LogInformation("Stopping a silo and joining a silo");
             Task t1 = Task.Run(async () => await this.HostedCluster.StopSiloAsync(siloToKill));
             Task t2 = Task.Run(async () => await this.HostedCluster.StartAdditionalSilosAsync(1));
             await Task.WhenAll(new[] { t1, t2 }).WithTimeout(ENDWAIT);

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -113,17 +113,17 @@ namespace Tester.AzureUtils.TimerTests
                         return true;
                     });
                     promises.Add(promise);
-                    this.log.Info("Started " + capture);
+                    this.log.LogInformation("Started " + capture);
                 }
-                this.log.Info("Started all, now waiting...");
+                this.log.LogInformation("Started all, now waiting...");
                 await Task.WhenAll(promises).WithTimeout(TimeSpan.FromSeconds(500));
             }
             catch (Exception exc)
             {
-                this.log.Info("Exception caught {0}", exc);
+                this.log.LogInformation("Exception caught {0}", exc);
             }
             TimeSpan dur = DateTime.UtcNow - startedAt;
-            this.log.Info("Inserted {0} rows in {1}, i.e., {2:f2} upserts/sec", numOfInserts, dur, (numOfInserts / dur.TotalSeconds));
+            this.log.LogInformation("Inserted {0} rows in {1}, i.e., {2:f2} upserts/sec", numOfInserts, dur, (numOfInserts / dur.TotalSeconds));
         }
 
         private ReminderEntry NewReminderEntry()

--- a/test/Extensions/TesterAzureUtils/Streaming/AQClientStreamTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQClientStreamTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans;
@@ -86,14 +87,14 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5639"), TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQStreamProducerOnDroppedClientTest()
         {
-            logger.Info("************************ AQStreamProducerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ AQStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(AQStreamProviderName, StreamNamespace);
         }
 
         [SkippableFact(Skip = "AzureQueue has unpredictable event delivery counts - re-enable when we figure out how to handle this."), TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQStreamConsumerOnDroppedClientTest()
         {
-            logger.Info("************************ AQStreamConsumerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ AQStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(AQStreamProviderName, StreamNamespace, output,
                     () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(AQStreamProviderName));
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans;
@@ -80,56 +81,56 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task AQMultipleParallelSubscriptionTest()
         {
-            logger.Info("************************ AQMultipleParallelSubscriptionTest *********************************");
+            logger.LogInformation("************************ AQMultipleParallelSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQMultipleLinearSubscriptionTest()
         {
-            logger.Info("************************ AQMultipleLinearSubscriptionTest *********************************");
+            logger.LogInformation("************************ AQMultipleLinearSubscriptionTest *********************************");
             await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQMultipleSubscriptionTest_AddRemove()
         {
-            logger.Info("************************ AQMultipleSubscriptionTest_AddRemove *********************************");
+            logger.LogInformation("************************ AQMultipleSubscriptionTest_AddRemove *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQResubscriptionTest()
         {
-            logger.Info("************************ AQResubscriptionTest *********************************");
+            logger.LogInformation("************************ AQResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQResubscriptionAfterDeactivationTest()
         {
-            logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
+            logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQActiveSubscriptionTest()
         {
-            logger.Info("************************ AQActiveSubscriptionTest *********************************");
+            logger.LogInformation("************************ AQActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQTwoIntermitentStreamTest()
         {
-            logger.Info("************************ AQTwoIntermitentStreamTest *********************************");
+            logger.LogInformation("************************ AQTwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQSubscribeFromClientTest()
         {
-            logger.Info("************************ AQSubscribeFromClientTest *********************************");
+            logger.LogInformation("************************ AQSubscribeFromClientTest *********************************");
             await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
         }
     }

--- a/test/Extensions/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
@@ -113,7 +113,7 @@ namespace Tester.AzureUtils.Streaming
             // Convert.ToInt32 is used because of different behavior of the fallback serializers: binary formatter and Json.Net.
             // The binary one deserializes object[] into array of ints when the latter one - into longs. http://stackoverflow.com/a/17918824
             var numAgents = results.Select(Convert.ToInt32).ToArray();
-            logger.Info($"Got back NumberRunningAgents: {Utils.EnumerableToString(numAgents)}");
+            logger.LogInformation($"Got back NumberRunningAgents: {Utils.EnumerableToString(numAgents)}");
             int i = 0;
             foreach (var agents in numAgents)
             {

--- a/test/Extensions/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -106,7 +106,7 @@ namespace UnitTests.HaloTests.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task Halo_SMS_ResubscribeTest_ConsumerProducer()
         {
-            this.fixture.Logger.Info("\n\n************************ Halo_SMS_ResubscribeTest_ConsumerProducer ********************************* \n\n");
+            this.fixture.Logger.LogInformation("\n\n************************ Halo_SMS_ResubscribeTest_ConsumerProducer ********************************* \n\n");
             _streamId = Guid.NewGuid();
             _streamProvider = SmsStreamProviderName;
             Guid consumerGuid = Guid.NewGuid();
@@ -118,7 +118,7 @@ namespace UnitTests.HaloTests.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task Halo_SMS_ResubscribeTest_ProducerConsumer()
         {
-            this.fixture.Logger.Info("\n\n************************ Halo_SMS_ResubscribeTest_ProducerConsumer ********************************* \n\n");
+            this.fixture.Logger.LogInformation("\n\n************************ Halo_SMS_ResubscribeTest_ProducerConsumer ********************************* \n\n");
             _streamId = Guid.NewGuid();
             _streamProvider = SmsStreamProviderName;
             Guid producerGuid = Guid.NewGuid();
@@ -130,7 +130,7 @@ namespace UnitTests.HaloTests.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task Halo_AzureQueue_ResubscribeTest_ConsumerProducer()
         {
-            this.fixture.Logger.Info("\n\n************************ Halo_AzureQueue_ResubscribeTest_ConsumerProducer ********************************* \n\n");
+            this.fixture.Logger.LogInformation("\n\n************************ Halo_AzureQueue_ResubscribeTest_ConsumerProducer ********************************* \n\n");
             _streamId = Guid.NewGuid();
             _streamProvider = AzureQueueStreamProviderName;
             Guid consumerGuid = Guid.NewGuid();
@@ -142,7 +142,7 @@ namespace UnitTests.HaloTests.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task Halo_AzureQueue_ResubscribeTest_ProducerConsumer()
         {
-            this.fixture.Logger.Info("\n\n************************ Halo_AzureQueue_ResubscribeTest_ProducerConsumer ********************************* \n\n");
+            this.fixture.Logger.LogInformation("\n\n************************ Halo_AzureQueue_ResubscribeTest_ProducerConsumer ********************************* \n\n");
             _streamId = Guid.NewGuid();
             _streamProvider = AzureQueueStreamProviderName;
             Guid producerGuid = Guid.NewGuid();
@@ -191,7 +191,7 @@ namespace UnitTests.HaloTests.Streaming
         {
             var numProduced = await producer.GetNumberProduced();
             var numConsumed = await consumer.GetNumberConsumed();
-            this.fixture.Logger.Info("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
+            this.fixture.Logger.LogInformation("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
             return numProduced == numConsumed;
         }
     }

--- a/test/Extensions/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -54,7 +55,7 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task SampleStreamingTests_4()
         {
-            logger.Info("************************ SampleStreamingTests_4 *********************************");
+            logger.LogInformation("************************ SampleStreamingTests_4 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.HostedCluster);
             await runner.StreamingTests_Consumer_Producer(Guid.NewGuid());
         }
@@ -62,7 +63,7 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task SampleStreamingTests_5()
         {
-            logger.Info("************************ SampleStreamingTests_5 *********************************");
+            logger.LogInformation("************************ SampleStreamingTests_5 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.HostedCluster);
             await runner.StreamingTests_Producer_Consumer(Guid.NewGuid());
         }

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans;
@@ -305,9 +306,9 @@ namespace UnitTests.StreamingTests
         private async Task WaitForDeactivation()
         {
             var delay = TimeSpan.FromSeconds(1);
-            logger.Info("Waiting for {0} to allow time for grain deactivation to occur", delay);
+            logger.LogInformation("Waiting for {0} to allow time for grain deactivation to occur", delay);
             await Task.Delay(delay); // Allow time for Deactivate
-            logger.Info("Awake again.");
+            logger.LogInformation("Awake again.");
         }
     }
 }

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans;
@@ -352,7 +353,7 @@ namespace UnitTests.Streaming.Reliability
         private async Task<IStreamReliabilityTestGrain> Do_BaselineTest(long consumerGrainId, long producerGrainId)
 #endif
         {
-            logger.Info("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
+            logger.LogInformation("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
             var consumerGrain = GetGrain(consumerGrainId);
             var producerGrain = GetGrain(producerGrainId);
 #if DELETE_AFTER_TEST
@@ -365,9 +366,9 @@ namespace UnitTests.Streaming.Reliability
             string when = "Before subscribe";
             await CheckConsumerProducerStatus(when, producerGrainId, consumerGrainId, false, false);
 
-            logger.Info("AddConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("AddConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.AddConsumer(_streamId, _streamProviderName);
-            logger.Info("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await producerGrain.BecomeProducer(_streamId, _streamProviderName);
 
             when = "After subscribe";
@@ -390,7 +391,7 @@ namespace UnitTests.Streaming.Reliability
         private async Task<IStreamReliabilityTestGrain[]> Do_AddConsumerGrains(long baseId, int numGrains)
 #endif
         {
-            logger.Info("Initializing: BaseId={0} NumGrains={1}", baseId, numGrains);
+            logger.LogInformation("Initializing: BaseId={0} NumGrains={1}", baseId, numGrains);
 
 #if USE_GENERICS
             var grains = new IStreamReliabilityTestGrain<int>[numGrains];
@@ -409,7 +410,7 @@ namespace UnitTests.Streaming.Reliability
             }
             await Task.WhenAll(promises);
 
-            logger.Info("AddConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("AddConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await Task.WhenAll(grains.Select(g => g.AddConsumer(_streamId, _streamProviderName)));
 
             return grains;
@@ -489,11 +490,11 @@ namespace UnitTests.Streaming.Reliability
             long producerGrainId = random.Next();
 
             string when;
-            logger.Info("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
+            logger.LogInformation("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
             var consumerGrain = GetGrain(consumerGrainId);
             var producerGrain = GetGrain(producerGrainId);
 
-            logger.Info("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await producerGrain.BecomeProducer(_streamId, _streamProviderName);
 
             when = "After BecomeProducer";
@@ -501,7 +502,7 @@ namespace UnitTests.Streaming.Reliability
             await producerGrain.SendItem(0);
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 0, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
 
-            logger.Info("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.AddConsumer(_streamId, _streamProviderName);
             when = "After first AddConsumer";
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 1, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
@@ -526,11 +527,11 @@ namespace UnitTests.Streaming.Reliability
             long producerGrainId = random.Next();
 
             string when;
-            logger.Info("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
+            logger.LogInformation("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
             var consumerGrain = GetGrain(consumerGrainId);
             var producerGrain = GetGrain(producerGrainId);
 
-            logger.Info("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await producerGrain.BecomeProducer(_streamId, _streamProviderName);
             when = "After first BecomeProducer";
             // Note: Only semantics guarenteed for producer is that they will have been registered by time that first msg is sent.
@@ -542,7 +543,7 @@ namespace UnitTests.Streaming.Reliability
             await producerGrain.SendItem(0);
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 0, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
 
-            logger.Info("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.AddConsumer(_streamId, _streamProviderName);
             when = "After first AddConsumer";
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 1, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
@@ -568,11 +569,11 @@ namespace UnitTests.Streaming.Reliability
             long producerGrainId = random.Next();
 
             string when;
-            logger.Info("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
+            logger.LogInformation("Initializing: ConsumerGrain={0} ProducerGrain={1}", consumerGrainId, producerGrainId);
             var consumerGrain = GetGrain(consumerGrainId);
             var producerGrain = GetGrain(producerGrainId);
 
-            logger.Info("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("BecomeProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await producerGrain.BecomeProducer(_streamId, _streamProviderName);
             await producerGrain.BecomeProducer(_streamId, _streamProviderName);
             when = "After BecomeProducer";
@@ -580,7 +581,7 @@ namespace UnitTests.Streaming.Reliability
             await producerGrain.SendItem(0);
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 0, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
 
-            logger.Info("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("AddConsumer x 2 : StreamId={0} Provider={1}", _streamId, _streamProviderName);
             var c1 = await consumerGrain.AddConsumer(_streamId, _streamProviderName);
             when = "After first AddConsumer";
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 1, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
@@ -590,19 +591,19 @@ namespace UnitTests.Streaming.Reliability
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 2, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
             await CheckConsumerCounts(when, consumerGrain, 2);
 
-            logger.Info("RemoveConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("RemoveConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.RemoveConsumer(_streamId, _streamProviderName, c1);
             when = "After first RemoveConsumer";
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, output, when, 1, 1, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
             await CheckConsumerCounts(when, consumerGrain, 1);
 #if REMOVE_PRODUCER
-            logger.Info("RemoveProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("RemoveProducer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await producerGrain.RemoveProducer(_streamId, _streamProviderName);
             when = "After RemoveProducer";
             await CheckPubSubCounts(when, 0, 1);
             await CheckConsumerCounts(when, consumerGrain, 1);
 #endif
-            logger.Info("RemoveConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("RemoveConsumer: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.RemoveConsumer(_streamId, _streamProviderName, c2);
             when = "After second RemoveConsumer";
 #if REMOVE_PRODUCER
@@ -627,7 +628,7 @@ namespace UnitTests.Streaming.Reliability
             long consumerGrainId = random.Next();
             var consumerGrain = this.GrainFactory.GetGrain<IStreamUnsubscribeTestGrain>(consumerGrainId);
 
-            logger.Info("Subscribe: StreamId={0} Provider={1}", _streamId, _streamProviderName);
+            logger.LogInformation("Subscribe: StreamId={0} Provider={1}", _streamId, _streamProviderName);
             await consumerGrain.Subscribe(_streamId, _streamProviderName);
 
             // Restart silos
@@ -994,7 +995,7 @@ namespace UnitTests.Streaming.Reliability
                 //RestartRuntime(silo, kill);
                 SiloHandle newSilo = await this.HostedCluster.RestartSiloAsync(silo);
 
-                logger.Info("Restarted new {0} silo {1}", siloType, newSilo.SiloAddress);
+                logger.LogInformation("Restarted new {0} silo {1}", siloType, newSilo.SiloAddress);
 
                 Assert.NotEqual(oldSilo, newSilo.SiloAddress); //"Should be different silo address after Restart"
             }

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -988,7 +988,7 @@ namespace UnitTests.Streaming.Reliability
             if (restart)    action = kill ? "Kill+Restart" : "Stop+Restart";
             else            action = kill ? "Kill" : "Stop";
 
-            logger.Warn(2, "{0} {1} silo {2}", action, siloType, oldSilo);
+            logger.LogWarning(2, "{0} {1} silo {2}", action, siloType, oldSilo);
 
             if (restart)
             {

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Orleans;
@@ -50,8 +50,7 @@ namespace BenchmarkGrains.GrainStorage
             } catch(Exception ex)
             {
                 sw.Stop();
-                object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
-                this.logger.LogError(ex, "Grain {GrainId} failed to set state in {WriteTimeMs}ms to set state.", args);
+                this.logger.LogError(ex, "Grain {GrainId} failed to set state in {WriteTimeMs}ms to set state.", this.GetPrimaryKey(), sw.ElapsedMilliseconds);
                 success = false;
             }
 

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -45,8 +45,7 @@ namespace BenchmarkGrains.GrainStorage
                 this.persistentState.State.Payload[index] = (byte)(this.persistentState.State.Payload[index] + 1);
                 await this.persistentState.WriteStateAsync();
                 sw.Stop();
-                object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
-                logger.LogInformation("Grain {GrainId} took {WriteTimeMs}ms to set state.", args);
+                logger.LogInformation("Grain {GrainId} took {WriteTimeMs}ms to set state.", this.GetPrimaryKey(), sw.ElapsedMilliseconds);
                 success = true;
             } catch(Exception ex)
             {

--- a/test/Grains/TestGrains/ChainedGrain.cs
+++ b/test/Grains/TestGrains/ChainedGrain.cs
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
             }
 
             string msg = String.Format("ChainGrain Id={0} is in an invalid state. Next={1}", State.Id, State.Next);
-            logger.Warn(0, msg);
+            logger.LogWarning(0, msg);
             throw new OrleansException(msg);
         }
 

--- a/test/Grains/TestGrains/ConcurrentGrain.cs
+++ b/test/Grains/TestGrains/ConcurrentGrain.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
         public async Task Initialize(int ind)
         {
             this.index = ind;
-            logger.Info("Initialize(" + index + ")");
+            logger.LogInformation("Initialize(" + index + ")");
             if (index == 0)
             {
                 children = new List<IConcurrentGrain>();
@@ -42,24 +42,24 @@ namespace UnitTests.Grains
         {
             callNumber++;
             int call = callNumber;
-            logger.Info("A() start callNumber " + call);
+            logger.LogInformation("A() start callNumber " + call);
             int i = 1;
             foreach (IConcurrentGrain child in children)
             {
-                logger.Info("Calling B(" + i + "," + call + ")");
+                logger.LogInformation("Calling B(" + i + "," + call + ")");
                 int ret = await child.B(call);
-                logger.Info("Resolved the calling B(" + i + "," + call + ")");
+                logger.LogInformation("Resolved the calling B(" + i + "," + call + ")");
                 i++;
             }
-            logger.Info("A() END callNumber " + call);
+            logger.LogInformation("A() END callNumber " + call);
             return 1;
         }
 
         public Task<int> B(int number)
         {
-            logger.Info("B(" + index + ") call " + number);
+            logger.LogInformation("B(" + index + ") call " + number);
             Thread.Sleep(100);
-            logger.Info("B(" + index + ") call " + number + " after sleep");
+            logger.LogInformation("B(" + index + ") call " + number + " after sleep");
             return Task.FromResult(1);
         }
 
@@ -86,14 +86,14 @@ namespace UnitTests.Grains
         public Task Initialize_2(int ind)
         {
             index = ind;
-            logger.Info("Initialize(" + index + ")");
+            logger.LogInformation("Initialize(" + index + ")");
             return Task.CompletedTask;
         }
 
         // start a long tail call on the 1st grain by calling into the 2nd grain 
         public async Task<int> TailCall_Caller(IConcurrentReentrantGrain another, bool doCW)
         {
-            logger.Info("TailCall_Caller");
+            logger.LogInformation("TailCall_Caller");
             if (doCW)
             {
                 int i = await another.TailCall_Called();
@@ -107,7 +107,7 @@ namespace UnitTests.Grains
         // if tail call optimization is working, this call should go in (the grain should be considered not executing request).
         public Task<int> TailCall_Resolver(IConcurrentReentrantGrain another)
         {
-            logger.Info("TailCall_Resolver");
+            logger.LogInformation("TailCall_Resolver");
             return another.TailCall_Resolve();
         }
     }
@@ -127,20 +127,20 @@ namespace UnitTests.Grains
         public Task Initialize_2(int ind)
         {
             index = ind;
-            logger.Info("Initialize(" + index + ")");
+            logger.LogInformation("Initialize(" + index + ")");
             return Task.CompletedTask;
         }
 
         public Task<int> TailCall_Called()
         {
-            logger.Info("TailCall_Called");
+            logger.LogInformation("TailCall_Called");
             resolver = new TaskCompletionSource<int>();
             return resolver.Task;
         }
 
         public Task<int> TailCall_Resolve()
         {
-            logger.Info("TailCall_Resolve");
+            logger.LogInformation("TailCall_Resolve");
             resolver.SetResult(7);
             return Task.FromResult(8);
         }

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -48,7 +48,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            _logger.Info("Consumer.OnActivateAsync");
+            _logger.LogInformation("Consumer.OnActivateAsync");
             _numConsumedItems = 0;
             _subscriptionHandle = null;
             return base.OnActivateAsync();
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
 
         public override async Task OnDeactivateAsync()
         {
-            _logger.Info("Consumer.OnDeactivateAsync");
+            _logger.LogInformation("Consumer.OnDeactivateAsync");
             await StopConsuming();
             _numConsumedItems = 0;
             await base.OnDeactivateAsync();
@@ -64,7 +64,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeConsumer(Guid streamId, string providerToUse)
         {
-            _logger.Info("Consumer.BecomeConsumer");
+            _logger.LogInformation("Consumer.BecomeConsumer");
             if (streamId == null)
             {
                 throw new ArgumentNullException("streamId");
@@ -82,13 +82,13 @@ namespace UnitTests.Grains
         private Task EventArrived(int evt)
         {
             _numConsumedItems++;
-            _logger.Info("Consumer.EventArrived. NumConsumed so far: " + _numConsumedItems);
+            _logger.LogInformation("Consumer.EventArrived. NumConsumed so far: " + _numConsumedItems);
             return Task.CompletedTask;
         }
 
         public async Task StopConsuming()
         {
-            _logger.Info("Consumer.StopConsuming");
+            _logger.LogInformation("Consumer.StopConsuming");
             if (_subscriptionHandle != null && _consumer != null)
             {
                 await _subscriptionHandle.UnsubscribeAsync();

--- a/test/Grains/TestGrains/DeadlockGrain.cs
+++ b/test/Grains/TestGrains/DeadlockGrain.cs
@@ -43,13 +43,13 @@ namespace UnitTests.Grains
 
         public Task CallNext_1(List<Tuple<long, bool>> callChain, int currCallIndex)
         {
-            this.logger.Info("Inside grain {0} CallNext_1().", Id);
+            this.logger.LogInformation("Inside grain {0} CallNext_1().", Id);
             return DeadlockGrain.CallNext(GrainFactory, callChain, currCallIndex);
         }
 
         public Task CallNext_2(List<Tuple<long, bool>> callChain, int currCallIndex)
         {
-            this.logger.Info("Inside grain {0} CallNext_2().", Id);
+            this.logger.LogInformation("Inside grain {0} CallNext_2().", Id);
             return DeadlockGrain.CallNext(GrainFactory, callChain, currCallIndex);
         }
     }
@@ -63,13 +63,13 @@ namespace UnitTests.Grains
 
         public Task CallNext_1(List<Tuple<long, bool>> callChain, int currCallIndex)
         {
-            this.logger.Info("Inside grain {0} CallNext_1()", Id);
+            this.logger.LogInformation("Inside grain {0} CallNext_1()", Id);
             return DeadlockGrain.CallNext(GrainFactory, callChain, currCallIndex);
         }
 
         public Task CallNext_2(List<Tuple<long, bool>> callChain, int currCallIndex)
         {
-            this.logger.Info("Inside grain {0} CallNext_2()", Id);
+            this.logger.LogInformation("Inside grain {0} CallNext_2()", Id);
             return DeadlockGrain.CallNext(GrainFactory, callChain, currCallIndex);
         }
     }

--- a/test/Grains/TestGrains/FaultableConsumerGrain.cs
+++ b/test/Grains/TestGrains/FaultableConsumerGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             eventsConsumedCount = 0;
             errorsCount = 0;
             eventsFailedCount = 0;
@@ -38,13 +38,13 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeConsumer");
+            logger.LogInformation("BecomeConsumer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
             consumerHandle = await consumer.SubscribeAsync(OnNextAsync, OnErrorAsync, OnActivateAsync);
@@ -59,7 +59,7 @@ namespace UnitTests.Grains
 
         public async Task StopConsuming()
         {
-            logger.Info("StopConsuming");
+            logger.LogInformation("StopConsuming");
             if (consumerHandle != null)
             {
                 await consumerHandle.UnsubscribeAsync();
@@ -84,7 +84,7 @@ namespace UnitTests.Grains
 
         public Task OnNextAsync(int item, StreamSequenceToken token = null)
         {
-            logger.Info("OnNextAsync(item={0}, token={1})", item, token != null ? token.ToString() : "null");
+            logger.LogInformation("OnNextAsync(item={0}, token={1})", item, token != null ? token.ToString() : "null");
             if (failPeriodTimer == null)
             {
                 eventsConsumedCount++;
@@ -105,13 +105,13 @@ namespace UnitTests.Grains
 
         public Task OnCompletedAsync()
         {
-            logger.Info("OnCompletedAsync()");
+            logger.LogInformation("OnCompletedAsync()");
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
-            logger.Info("OnErrorAsync({0})", ex);
+            logger.LogInformation("OnErrorAsync({0})", ex);
             errorsCount++;
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             var streamProvider = this.GetStreamProvider("SMSProvider");
             var streamNamespaces = new[] { "red1", "red2", "blue3", "blue4" };
             counters = new Dictionary<string, int>();
@@ -32,7 +32,7 @@ namespace UnitTests.Grains
                 await stream.SubscribeAsync(
                     (e, t) =>
                     {
-                        logger.Info($"Received a {streamNamespace} event {e}");
+                        logger.LogInformation($"Received a {streamNamespace} event {e}");
                         counters[streamNamespace]++;
                         return Task.CompletedTask;
                     });

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             var streamProvider = this.GetStreamProvider("SMSProvider");
 
             var streamIdentity = this.GetImplicitStreamIdentity();
@@ -28,7 +28,7 @@ namespace UnitTests.Grains
             await stream.SubscribeAsync(
                 (e, t) =>
                 {
-                    logger.Info($"Received a {streamIdentity.Namespace} event {e}");
+                    logger.LogInformation($"Received a {streamIdentity.Namespace} event {e}");
                     ++counter;
                     return Task.CompletedTask;
                 });

--- a/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
@@ -29,7 +29,7 @@ namespace TestGrains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             var streamProvider = this.GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
             stream = streamProvider.GetStream<GeneratedEvent>(this.GetPrimaryKey(), StreamNamespace);
@@ -51,7 +51,7 @@ namespace TestGrains
         public Task OnNextAsync(IList<SequentialItem<GeneratedEvent>> items)
         {
             this.accumulated += items.Count;
-            logger.Info("Received {Count} generated event.  Accumulated {Accumulated} events so far.", items.Count, this.accumulated);
+            logger.LogInformation("Received {Count} generated event.  Accumulated {Accumulated} events so far.", items.Count, this.accumulated);
             if (items.Last().Item.EventType == GeneratedEvent.GeneratedEventType.Fill)
             {
                 return Task.CompletedTask;

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -21,7 +21,7 @@ namespace TestGrains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
             return base.OnActivateAsync();
@@ -36,7 +36,7 @@ namespace TestGrains
                 counts = new Dictionary<Guid, int>();
                 reports[key] = counts;
             }
-            logger.Info("ReportResult. StreamProvider: {0}, StreamNamespace: {1}, StreamGuid: {2}, Count: {3}", streamProvider, streamNamespace, streamGuid, count);
+            logger.LogInformation("ReportResult. StreamProvider: {0}, StreamNamespace: {1}, StreamGuid: {2}, Count: {3}", streamProvider, streamNamespace, streamGuid, count);
             counts[streamGuid] = count;
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -38,7 +38,7 @@ namespace TestGrains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             await ReadStateAsync();
 
@@ -61,11 +61,11 @@ namespace TestGrains
             // Ignore duplicates
             if (State.IsDuplicate(sequenceToken))
             {
-                logger.Info("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+                logger.LogInformation("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
                 return;
             }
 
-            logger.Info("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+            logger.LogInformation("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
 
             // We will only update the start token if this is the first event we're processed
             // In that case, we'll want to save the start token in case something goes wrong.
@@ -86,11 +86,11 @@ namespace TestGrains
             {
                 // every 10 events, checkpoint our grain state
                 if (State.Accumulator%10 != 0) return;
-                logger.Info("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+                logger.LogInformation("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
                 await WriteStateAsync();
                 return;
             }
-            logger.Info("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+            logger.LogInformation("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
             await WriteStateAsync();
             var reporter = GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, State.Accumulator);
@@ -98,14 +98,14 @@ namespace TestGrains
 
         private Task OnErrorAsync(Exception ex)
         {
-            logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
+            logger.LogInformation("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
             Faults.FaultCleared = true;
             return Task.CompletedTask;
         }
 
         private void InjectFault()
         {
-            logger.Info("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
+            logger.LogInformation("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
             throw new ApplicationException("Injecting Fault");
         }
     }

--- a/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
@@ -30,7 +30,7 @@ namespace TestGrains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             await ReadStateAsync();
 
@@ -54,11 +54,11 @@ namespace TestGrains
             // ignore duplicates
             if (State.IsDuplicate(sequenceToken))
             {
-                logger.Info("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+                logger.LogInformation("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
                 return;
             }
 
-            logger.Info("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+            logger.LogInformation("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
 
             // We will only update the start token if this is the first event we're processed
             // In that case, we'll want to save the start token in case something goes wrong.
@@ -73,11 +73,11 @@ namespace TestGrains
             {
                 // every 10 events, checkpoint our grain state
                 if (State.Accumulator % 10 != 0) return;
-                logger.Info("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+                logger.LogInformation("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
                 await WriteStateAsync();
                 return;
             }
-            logger.Info("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+            logger.LogInformation("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
             await WriteStateAsync();
             var reporter = GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, State.Accumulator);
@@ -85,7 +85,7 @@ namespace TestGrains
 
         private Task OnErrorAsync(Exception ex)
         {
-            logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
+            logger.LogInformation("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -81,7 +81,7 @@ namespace TestGrains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             Faults.onActivateFault.TryFire(InjectFault);
             await ReadStateAsync();
@@ -108,11 +108,11 @@ namespace TestGrains
             // ignore duplicates
             if (State.IsDuplicate(sequenceToken))
             {
-                logger.Info("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+                logger.LogInformation("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
                 return;
             }
 
-            logger.Info("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+            logger.LogInformation("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
 
             // We will only update the start token if this is the first event we're processed
             // In that case, we'll want to save the start token in case something goes wrong.
@@ -130,12 +130,12 @@ namespace TestGrains
                 Faults.on33rdMessageFault.TryFire(InjectFault);
                 // every 10 events, checkpoint our grain state
                 if (State.Accumulator%10 != 0) return;
-                logger.Info("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+                logger.LogInformation("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
                 await WriteStateAsync();
                 return;
             }
             Faults.onLastMessageFault.TryFire(InjectFault);
-            logger.Info("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+            logger.LogInformation("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
             await WriteStateAsync();
             var reporter = GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, State.Accumulator);
@@ -143,13 +143,13 @@ namespace TestGrains
 
         private Task OnErrorAsync(Exception ex)
         {
-            logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
+            logger.LogInformation("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
             return Task.CompletedTask;
         }
 
         private void InjectFault()
         {
-            logger.Info("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
+            logger.LogInformation("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
             DeactivateOnIdle(); // kill grain and reaload from checkpoint
             throw new ApplicationException("Injecting Fault");
         }

--- a/test/Grains/TestGrains/LivenessTestGrain.cs
+++ b/test/Grains/TestGrains/LivenessTestGrain.cs
@@ -25,14 +25,14 @@ namespace UnitTests.Grains
 
             uniqueId = Guid.NewGuid();
             label = this.GetPrimaryKeyLong().ToString();
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             return base.OnActivateAsync();
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("!!! OnDeactivateAsync");
+            logger.LogInformation("!!! OnDeactivateAsync");
             return base.OnDeactivateAsync();
         }
 
@@ -44,13 +44,13 @@ namespace UnitTests.Grains
         public Task SetLabel(string label)
         {
             this.label = label;
-            logger.Info("SetLabel {0} received", label);
+            logger.LogInformation("SetLabel {0} received", label);
             return Task.CompletedTask;
         }
 
         public Task StartTimer()
         {
-            logger.Info("StartTimer.");
+            logger.LogInformation("StartTimer.");
             base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
             
             return Task.CompletedTask;
@@ -58,7 +58,7 @@ namespace UnitTests.Grains
 
         private Task TimerTick(object data)
         {
-            logger.Info("TimerTick.");
+            logger.LogInformation("TimerTick.");
             return Task.CompletedTask;
         }
 

--- a/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             var streamProvider = this.GetStreamProvider("SMSProvider");
             redStream = streamProvider.GetStream<int>(this.GetPrimaryKey(), "red");
@@ -33,7 +33,7 @@ namespace UnitTests.Grains
             await redStream.SubscribeAsync(
                 (e, t) =>
                 {
-                    logger.Info("Received a red event {0}", e);
+                    logger.LogInformation("Received a red event {0}", e);
                     redCounter++;
                     return Task.CompletedTask;
                 });
@@ -41,7 +41,7 @@ namespace UnitTests.Grains
             await blueStream.SubscribeAsync(
                 (e, t) =>
                 {
-                    logger.Info("Received a blue event {0}", e);
+                    logger.LogInformation("Received a blue event {0}", e);
                     blueCounter++;
                     return Task.CompletedTask;
                 });

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -39,13 +39,13 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
 
         public async Task<StreamSubscriptionHandle<int>> BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeConsumer");
+            logger.LogInformation("BecomeConsumer");
 
             // new counter for this subscription
             var count = new Counter();
@@ -71,7 +71,7 @@ namespace UnitTests.Grains
 
         public async Task<StreamSubscriptionHandle<int>> Resume(StreamSubscriptionHandle<int> handle)
         {
-            logger.Info("Resume");
+            logger.LogInformation("Resume");
             if(handle == null)
                 throw new ArgumentNullException("handle");
 
@@ -99,7 +99,7 @@ namespace UnitTests.Grains
 
         public async Task StopConsuming(StreamSubscriptionHandle<int> handle)
         {
-            logger.Info("StopConsuming");
+            logger.LogInformation("StopConsuming");
             // unsubscribe
             await handle.UnsubscribeAsync();
 
@@ -109,7 +109,7 @@ namespace UnitTests.Grains
 
         public Task<IList<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("GetAllSubscriptionHandles");
+            logger.LogInformation("GetAllSubscriptionHandles");
 
             // get stream
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
@@ -121,7 +121,7 @@ namespace UnitTests.Grains
 
         public Task<Dictionary<StreamSubscriptionHandle<int>, Tuple<int,int>>> GetNumberConsumed()
         {
-            logger.Info(String.Format("ConsumedMessageCounts = \n{0}", 
+            logger.LogInformation(String.Format("ConsumedMessageCounts = \n{0}", 
                 Utils.EnumerableToString(consumedMessageCounts, kvp => String.Format("Consumer: {0} -> count: {1}", kvp.Key.HandleId.ToString(), kvp.Value.ToString()))));
 
             return Task.FromResult(consumedMessageCounts.ToDictionary(kvp => kvp.Key, kvp => Tuple.Create(kvp.Value.Item1.Value, kvp.Value.Item2.Value)));
@@ -129,7 +129,7 @@ namespace UnitTests.Grains
 
         public Task ClearNumberConsumed()
         {
-            logger.Info("ClearNumberConsumed");
+            logger.LogInformation("ClearNumberConsumed");
             foreach (var counters in consumedMessageCounts.Values)
             {
                 counters.Item1.Clear();
@@ -146,7 +146,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
@@ -154,7 +154,7 @@ namespace UnitTests.Grains
         {
             foreach(SequentialItem<int> item in items)
             {
-                logger.Info("Got next event {0} on handle {1}", item.Item, countCapture);
+                logger.LogInformation("Got next event {0} on handle {1}", item.Item, countCapture);
                 var contextValue = RequestContext.Get(SampleStreaming_ProducerGrain.RequestContextKey) as string;
                 if (!String.Equals(contextValue, SampleStreaming_ProducerGrain.RequestContextValue))
                 {
@@ -167,7 +167,7 @@ namespace UnitTests.Grains
 
         private Task OnError(Exception e, int countCapture, Counter error)
         {
-            logger.Info("Got exception {0} on handle {1}", e.ToString(), countCapture);
+            logger.LogInformation("Got exception {0} on handle {1}", e.ToString(), countCapture);
             error.Increment();
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/ObserverManager.cs
+++ b/test/Grains/TestGrains/ObserverManager.cs
@@ -271,7 +271,7 @@ namespace UnitTests.Grains
             // Remove defunct observers.
             if (defunct != default(List<TAddress>) && defunct.Count > 0)
             {
-                this.log.Info(this.logPrefix + ": Removing {0} defunct observers entries.", defunct.Count);
+                this.log.LogInformation(this.logPrefix + ": Removing {0} defunct observers entries.", defunct.Count);
                 foreach (var observer in defunct)
                 {
                     this.observers.TryRemove(observer, out _);

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -21,21 +21,21 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            _logger.Info("Producer.OnActivateAsync");
+            _logger.LogInformation("Producer.OnActivateAsync");
             _numProducedItems = 0;
             return base.OnActivateAsync();
         }
 
         public override async Task OnDeactivateAsync()
         {
-            _logger.Info("Producer.OnDeactivateAsync");
+            _logger.LogInformation("Producer.OnDeactivateAsync");
             _numProducedItems = 0;
             await base.OnDeactivateAsync();
         }
 
         public Task BecomeProducer(Guid streamId, string providerToUse)
         {
-            _logger.Info("Producer.BecomeProducer");
+            _logger.LogInformation("Producer.BecomeProducer");
             if (streamId == null)
             {
                 throw new ArgumentNullException("streamId");
@@ -57,7 +57,7 @@ namespace UnitTests.Grains
 
         public async Task SendEvent()
         {
-            _logger.Info("Producer.SendEvent called");
+            _logger.LogInformation("Producer.SendEvent called");
             if (_producer == null)
             {
                 throw new ApplicationException("Not yet a producer on a stream.  Must call BecomeProducer first.");
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
 
             // update after send in case of error
             _numProducedItems++;
-            _logger.Info("Producer.SendEvent - TotalSent: ({0})", _numProducedItems);
+            _logger.LogInformation("Producer.SendEvent - TotalSent: ({0})", _numProducedItems);
         }
     }
 }

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             onAddCalledCount = 0;
             consumerObservers = new List<ICounterObserver>();
             consumerHandles = new List<StreamSubscriptionHandle<IFruit>>();
@@ -45,13 +45,13 @@ namespace UnitTests.Grains
                 sum += observer.NumConsumed;
             }
 
-            logger.Info($"GetNumberConsumed {sum}");
+            logger.LogInformation($"GetNumberConsumed {sum}");
             return Task.FromResult(sum);
         }
 
         public async Task StopConsuming()
         {
-            logger.Info("StopConsuming");
+            logger.LogInformation("StopConsuming");
             foreach (var handle in consumerHandles)
             {
                 await handle.UnsubscribeAsync();
@@ -62,13 +62,13 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
         public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
         {
-            logger.Info("OnAdd");
+            logger.LogInformation("OnAdd");
             this.onAddCalledCount++;
             var observer = new CounterObserver<IFruit>(this.logger);
             var newhandle = handleFactory.Create<IFruit>();
@@ -88,7 +88,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
 
@@ -118,19 +118,19 @@ namespace UnitTests.Grains
         public Task OnNextAsync(T item, StreamSequenceToken token = null)
         {
             this.NumConsumed++;
-            this.logger.Info($"Consumer {this.GetHashCode()} OnNextAsync() with NumConsumed {this.NumConsumed}");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnNextAsync() with NumConsumed {this.NumConsumed}");
             return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
-            this.logger.Info($"Consumer {this.GetHashCode()} OnCompletedAsync()");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnCompletedAsync()");
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
-            this.logger.Info($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -28,14 +28,14 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             numProducedItems = 0;
             return Task.CompletedTask;
         }
 
         public Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeProducer");
+            logger.LogInformation("BecomeProducer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             producer = streamProvider.GetStream<T>(streamId, streamNamespace);
             return Task.CompletedTask;
@@ -43,7 +43,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
 
         public Task StartPeriodicProducing(TimeSpan? firePeriod = null)
         {
-            logger.Info("StartPeriodicProducing");
+            logger.LogInformation("StartPeriodicProducing");
             var period = (firePeriod == null)? defaultFirePeriod : firePeriod;
             producerTimer = base.RegisterTimer(TimerCallback, null, TimeSpan.Zero, period.Value);
             return Task.CompletedTask;
@@ -51,7 +51,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
 
         public Task StopPeriodicProducing()
         {
-            logger.Info("StopPeriodicProducing");
+            logger.LogInformation("StopPeriodicProducing");
             producerTimer.Dispose();
             producerTimer = null;
             return Task.CompletedTask;
@@ -59,7 +59,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
 
         public Task<int> GetNumberProduced()
         {
-            logger.Info("GetNumberProduced {0}", numProducedItems);
+            logger.LogInformation("GetNumberProduced {0}", numProducedItems);
             return Task.FromResult(numProducedItems);
         }
 
@@ -88,12 +88,12 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
         {
             numProducedItems++;
             await ProducerOnNextAsync(this.producer);
-            logger.Info("{0} (item={1})", caller, numProducedItems);
+            logger.LogInformation("{0} (item={1})", caller, numProducedItems);
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -47,30 +47,30 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             return base.OnActivateAsync();
         }
 
         public Task<string> One()
         {
-            logger.Info("Entering One");
+            logger.LogInformation("Entering One");
             string result = "one";
-            logger.Info("Exiting One");
+            logger.LogInformation("Exiting One");
             return Task.FromResult(result);
         }
 
         public async Task<string> Two()
         {
-            logger.Info("Entering Two");
+            logger.LogInformation("Entering Two");
             string result = await Self.One();
             result = result + " two";
-            logger.Info("Exiting Two");
+            logger.LogInformation("Exiting Two");
             return result;
         }
 
         public Task SetSelf(INonReentrantGrain self)
         {
-            logger.Info("SetSelf {0}", self);
+            logger.LogInformation("SetSelf {0}", self);
             Self = self;
             return Task.CompletedTask;
         }
@@ -140,7 +140,7 @@ namespace UnitTests.Grains
 
             await stream.SubscribeAsync((item, _) =>
             {
-                logger.Info("Received stream item:" + item);
+                logger.LogInformation("Received stream item:" + item);
                 return Task.CompletedTask;
             });
         }
@@ -209,7 +209,7 @@ namespace UnitTests.Grains
 
         public Task Ping(int seconds)
         {
-            logger.Info("Start Ping({0})", seconds);
+            logger.LogInformation("Start Ping({0})", seconds);
             var start = DateTime.UtcNow;
             var end = start + TimeSpan.FromSeconds(seconds);
             int foo = 0;
@@ -220,10 +220,10 @@ namespace UnitTests.Grains
                     foo = 0;
             }
 
-            logger.Info("Before GetCounter - OtherId={0}", destination);
+            logger.LogInformation("Before GetCounter - OtherId={0}", destination);
             IReentrantSelfManagedGrain otherGrain = GrainFactory.GetGrain<IReentrantSelfManagedGrain>(destination);
             var ctr = otherGrain.GetCounter();
-            logger.Info("After GetCounter() - returning promise");
+            logger.LogInformation("After GetCounter() - returning promise");
             return ctr;
         }
     }
@@ -256,7 +256,7 @@ namespace UnitTests.Grains
 
         public Task Ping(int seconds)
         {
-            logger.Info("Start Ping({0})", seconds);
+            logger.LogInformation("Start Ping({0})", seconds);
             var start = DateTime.UtcNow;
             var end = start + TimeSpan.FromSeconds(seconds);
             int foo = 0;
@@ -267,10 +267,10 @@ namespace UnitTests.Grains
                     foo = 0;
             }
 
-            logger.Info("Before GetCounter - OtherId={0}", destination);
+            logger.LogInformation("Before GetCounter - OtherId={0}", destination);
             INonReentrantSelfManagedGrain otherGrain = GrainFactory.GetGrain<INonReentrantSelfManagedGrain>(destination);
             var ctr = otherGrain.GetCounter();
-            logger.Info("After GetCounter() - returning promise");
+            logger.LogInformation("After GetCounter() - returning promise");
             return ctr;
         }
     }
@@ -295,7 +295,7 @@ namespace UnitTests.Grains
         {
             IReentrantTaskGrain[] fanOutGrains = await InitTaskGrains_Reentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
@@ -303,16 +303,16 @@ namespace UnitTests.Grains
                 Task promise = fanOutGrains[i].GetCounter();
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains with offset={2}", num, "reentrant", offset);
+            logger.LogInformation("Waiting for responses from {0} grains with offset={2}", num, "reentrant", offset);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutNonReentrant(int offset, int num)
         {
             INonReentrantTaskGrain[] fanOutGrains = await InitTaskGrains_NonReentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
@@ -320,48 +320,48 @@ namespace UnitTests.Grains
                 Task promise = fanOutGrains[i].GetCounter();
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutReentrant_Chain(int offset, int num)
         {
             IReentrantTaskGrain[] fanOutGrains = await InitTaskGrains_Reentrant(offset, num);
 
-            logger.Info("Starting fan-out chain calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out chain calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].Ping(OneSecond);
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains with offset={2}", num, "reentrant", offset);
+            logger.LogInformation("Waiting for responses from {0} grains with offset={2}", num, "reentrant", offset);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutNonReentrant_Chain(int offset, int num)
         {
             INonReentrantTaskGrain[] fanOutGrains = await InitTaskGrains_NonReentrant(offset, num);
 
-            logger.Info("Starting fan-out chain calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out chain calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].Ping(OneSecond);
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         private async Task<IReentrantTaskGrain[]> InitTaskGrains_Reentrant(int offset, int num)
         {
             IReentrantTaskGrain[] fanOutGrains = new IReentrantTaskGrain[num];
 
-            logger.Info("Creating {0} fan-out {1} worker grains", num, "reentrant");
+            logger.LogInformation("Creating {0} fan-out {1} worker grains", num, "reentrant");
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
@@ -379,7 +379,7 @@ namespace UnitTests.Grains
         {
             INonReentrantTaskGrain[] fanOutGrains = new INonReentrantTaskGrain[num];
 
-            logger.Info("Creating {0} fan-out {1} worker grains", num, "non-reentrant");
+            logger.LogInformation("Creating {0} fan-out {1} worker grains", num, "non-reentrant");
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
@@ -415,71 +415,71 @@ namespace UnitTests.Grains
         {
             IReentrantSelfManagedGrain[] fanOutGrains = await InitACGrains_Reentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].GetCounter();
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutACNonReentrant(int offset, int num)
         {
             INonReentrantSelfManagedGrain[] fanOutGrains = await InitACGrains_NonReentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].GetCounter();
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutACReentrant_Chain(int offset, int num)
         {
             IReentrantSelfManagedGrain[] fanOutGrains = await InitACGrains_Reentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].Ping(OneSecond.Seconds);
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         public async Task FanOutACNonReentrant_Chain(int offset, int num)
         {
             INonReentrantSelfManagedGrain[] fanOutGrains = await InitACGrains_NonReentrant(offset, num);
 
-            logger.Info("Starting fan-out calls to {0} grains", num);
+            logger.LogInformation("Starting fan-out calls to {0} grains", num);
             List<Task> promises = new List<Task>();
             for (int i = 0; i < num; i++)
             {
                 Task promise = fanOutGrains[i].Ping(OneSecond.Seconds);
                 promises.Add(promise);
             }
-            logger.Info("Waiting for responses from {0} grains", num);
+            logger.LogInformation("Waiting for responses from {0} grains", num);
             await Task.WhenAll(promises);
-            logger.Info("Received {0} responses", num);
+            logger.LogInformation("Received {0} responses", num);
         }
 
         private async Task<IReentrantSelfManagedGrain[]> InitACGrains_Reentrant(int offset, int num)
         {
             var fanOutGrains = new IReentrantSelfManagedGrain[num];
             List<Task> promises = new List<Task>();
-            logger.Info("Creating {0} fan-out {1} worker grains with offset={2}", num, "reentrant", offset);
+            logger.LogInformation("Creating {0} fan-out {1} worker grains with offset={2}", num, "reentrant", offset);
             for (int i = 0; i < num; i++)
             {
                 int idx = offset + i;
@@ -497,7 +497,7 @@ namespace UnitTests.Grains
         {
             var fanOutGrains = new INonReentrantSelfManagedGrain[num];
             List<Task> promises = new List<Task>();
-            logger.Info("Creating {0} fan-out {1} worker grains with offset={2}", num, "non-reentrant", offset);
+            logger.LogInformation("Creating {0} fan-out {1} worker grains with offset={2}", num, "non-reentrant", offset);
             for (int i = 0; i < num; i++)
             {
                 int idx = offset + i;
@@ -537,12 +537,12 @@ namespace UnitTests.Grains
 
         public async Task Ping(TimeSpan wait)
         {
-            logger.Info("Ping Delay={0}", wait);
+            logger.LogInformation("Ping Delay={0}", wait);
             await Task.Delay(wait);
-            logger.Info("Before GetCounter - OtherId={0}", otherId);
+            logger.LogInformation("Before GetCounter - OtherId={0}", otherId);
             var otherGrain = GrainFactory.GetGrain<IReentrantTaskGrain>(otherId);
             var ctr = await otherGrain.GetCounter();
-            logger.Info("After GetCounter() - got value={0}", ctr);
+            logger.LogInformation("After GetCounter() - got value={0}", ctr);
         }
 
         public Task<int> GetCounter()
@@ -575,12 +575,12 @@ namespace UnitTests.Grains
 
         public async Task Ping(TimeSpan wait)
         {
-            logger.Info("Ping Delay={0}", wait);
+            logger.LogInformation("Ping Delay={0}", wait);
             await Task.Delay(wait);
-            logger.Info("Before GetCounter - OtherId={0}", otherId);
+            logger.LogInformation("Before GetCounter - OtherId={0}", otherId);
             var otherGrain = GrainFactory.GetGrain<INonReentrantTaskGrain>(otherId);
             var ctr = await otherGrain.GetCounter();
-            logger.Info("After GetCounter() - got value={0}", ctr);
+            logger.LogInformation("After GetCounter() - got value={0}", ctr);
         }
 
         public Task<int> GetCounter()

--- a/test/Grains/TestGrains/RequestContextTestGrain.cs
+++ b/test/Grains/TestGrains/RequestContextTestGrain.cs
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
         public Task<string> TraceIdEcho()
         {
             string traceId = RequestContext.Get("TraceId") as string;
-            logger.Info(0, "{0}: TraceId={1}", "TraceIdEcho", traceId);
+            logger.LogInformation(0, "{0}: TraceId={1}", "TraceIdEcho", traceId);
             return Task.FromResult(traceId);
         }
 
@@ -69,14 +69,14 @@ namespace UnitTests.Grains
         public Task<string> TraceIdDelayedEcho1()
         {
             string method = "TraceIdDelayedEcho1";
-            logger.Info(0, "{0}: Entered", method);
+            logger.LogInformation(0, "{0}: Entered", method);
             string traceIdOutside = RequestContext.Get("TraceId") as string;
-            logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
+            logger.LogInformation(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
             return Task.Factory.StartNew(() =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
-                logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);
+                logger.LogInformation(0, "{0}: Inside TraceId={1}", method, traceIdInside);
                 return traceIdInside;
             });
         }
@@ -84,14 +84,14 @@ namespace UnitTests.Grains
         public Task<string> TraceIdDelayedEcho2()
         {
             string method = "TraceIdDelayedEcho2";
-            logger.Info(0, "{0}: Entered", method);
+            logger.LogInformation(0, "{0}: Entered", method);
             string traceIdOutside = RequestContext.Get("TraceId") as string;
-            logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
+            logger.LogInformation(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
             return Task.CompletedTask.ContinueWith(task =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
-                logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);
+                logger.LogInformation(0, "{0}: Inside TraceId={1}", method, traceIdInside);
                 return traceIdInside;
             });
         }
@@ -99,31 +99,31 @@ namespace UnitTests.Grains
         public async Task<string> TraceIdDelayedEchoAwait()
         {
             string method = "TraceIdDelayedEchoAwait";
-            logger.Info(0, "{0}: Entered", method);
+            logger.LogInformation(0, "{0}: Entered", method);
             string traceIdOutside = RequestContext.Get("TraceId") as string;
-            logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
+            logger.LogInformation(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
             string traceId = await Task.CompletedTask.ContinueWith(task =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
-                logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);
+                logger.LogInformation(0, "{0}: Inside TraceId={1}", method, traceIdInside);
                 return traceIdInside;
             });
-            logger.Info(0, "{0}: After await TraceId={1}", "TraceIdDelayedEchoAwait", traceId);
+            logger.LogInformation(0, "{0}: After await TraceId={1}", "TraceIdDelayedEchoAwait", traceId);
             return traceId;
         }
 
         public Task<string> TraceIdDelayedEchoTaskRun()
         {
             string method = "TraceIdDelayedEchoTaskRun";
-            logger.Info(0, "{0}: Entered", method);
+            logger.LogInformation(0, "{0}: Entered", method);
             string traceIdOutside = RequestContext.Get("TraceId") as string;
-            logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
+            logger.LogInformation(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
             return Task.Run(() =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
-                logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);
+                logger.LogInformation(0, "{0}: Inside TraceId={1}", method, traceIdInside);
                 return traceIdInside;
             });
         }
@@ -141,14 +141,14 @@ namespace UnitTests.Grains
             Task task = Task.Factory.StartNew(() =>
             {
                 bar1 = (string)RequestContext.Get("jarjar");
-                logger.Info("jarjar inside Task.Factory.StartNew = {0}.", bar1);
+                logger.LogInformation("jarjar inside Task.Factory.StartNew = {0}.", bar1);
             });
 
             string bar2 = null;
             Task ac = Task.Factory.StartNew(() =>
             {
                 bar2 = (string)RequestContext.Get("jarjar");
-                logger.Info("jarjar inside Task.StartNew  = {0}.", bar2);
+                logger.LogInformation("jarjar inside Task.StartNew  = {0}.", bar2);
             });
 
             await Task.WhenAll(task, ac);

--- a/test/Grains/TestGrains/SampleStreamingGrain.cs
+++ b/test/Grains/TestGrains/SampleStreamingGrain.cs
@@ -20,20 +20,20 @@ namespace UnitTests.Grains
 
         public Task OnNextAsync(T item, StreamSequenceToken token = null)
         {
-            hostingGrain.logger.Info("OnNextAsync(item={0}, token={1})", item, token != null ? token.ToString() : "null");
+            hostingGrain.logger.LogInformation("OnNextAsync(item={0}, token={1})", item, token != null ? token.ToString() : "null");
             hostingGrain.numConsumedItems++;
             return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
-            hostingGrain.logger.Info("OnCompletedAsync()");
+            hostingGrain.logger.LogInformation("OnCompletedAsync()");
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
-            hostingGrain.logger.Info("OnErrorAsync({0})", ex);
+            hostingGrain.logger.LogInformation("OnErrorAsync({0})", ex);
             return Task.CompletedTask;
         }
     }
@@ -54,14 +54,14 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             numProducedItems = 0;
             return Task.CompletedTask;
         }
 
         public Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeProducer");
+            logger.LogInformation("BecomeProducer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             producer = streamProvider.GetStream<int>(streamId, streamNamespace);
             return Task.CompletedTask;
@@ -69,14 +69,14 @@ namespace UnitTests.Grains
 
         public Task StartPeriodicProducing()
         {
-            logger.Info("StartPeriodicProducing");
+            logger.LogInformation("StartPeriodicProducing");
             producerTimer = base.RegisterTimer(TimerCallback, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
             return Task.CompletedTask;
         }
 
         public Task StopPeriodicProducing()
         {
-            logger.Info("StopPeriodicProducing");
+            logger.LogInformation("StopPeriodicProducing");
             producerTimer.Dispose();
             producerTimer = null;
             return Task.CompletedTask;
@@ -84,7 +84,7 @@ namespace UnitTests.Grains
 
         public Task<int> GetNumberProduced()
         {
-            logger.Info("GetNumberProduced {0}", numProducedItems);
+            logger.LogInformation("GetNumberProduced {0}", numProducedItems);
             return Task.FromResult(numProducedItems);
         }
 
@@ -109,12 +109,12 @@ namespace UnitTests.Grains
             RequestContext.Set(RequestContextKey, RequestContextValue);
             await producer.OnNextAsync(numProducedItems);
             numProducedItems++;
-            logger.Info("{0} (item={1})", caller, numProducedItems);
+            logger.LogInformation("{0} (item={1})", caller, numProducedItems);
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
     }
@@ -134,7 +134,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             numConsumedItems = 0;
             consumerHandle = null;
             return Task.CompletedTask;
@@ -142,7 +142,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeConsumer");
+            logger.LogInformation("BecomeConsumer");
             consumerObserver = new SampleConsumerObserver<int>(this);
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
@@ -151,7 +151,7 @@ namespace UnitTests.Grains
 
         public async Task StopConsuming()
         {
-            logger.Info("StopConsuming");
+            logger.LogInformation("StopConsuming");
             if (consumerHandle != null)
             {
                 await consumerHandle.UnsubscribeAsync();
@@ -166,7 +166,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
     }
@@ -185,7 +185,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info( "OnActivateAsync" );
+            logger.LogInformation( "OnActivateAsync" );
             numConsumedItems = 0;
             consumerHandle = null;
             return Task.CompletedTask;
@@ -193,7 +193,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info( "BecomeConsumer" );
+            logger.LogInformation( "BecomeConsumer" );
             IStreamProvider streamProvider = this.GetStreamProvider( providerToUse );
             consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
             consumerHandle = await consumer.SubscribeAsync( OnNextAsync, OnErrorAsync, OnCompletedAsync );
@@ -201,7 +201,7 @@ namespace UnitTests.Grains
 
         public async Task StopConsuming()
         {
-            logger.Info( "StopConsuming" );
+            logger.LogInformation( "StopConsuming" );
             if ( consumerHandle != null )
             {
                 await consumerHandle.UnsubscribeAsync();
@@ -217,26 +217,26 @@ namespace UnitTests.Grains
 
         public Task OnNextAsync( int item, StreamSequenceToken token = null )
         {
-            logger.Info( "OnNextAsync({0}{1})", item, token != null ? token.ToString() : "null" );
+            logger.LogInformation( "OnNextAsync({0}{1})", item, token != null ? token.ToString() : "null" );
             numConsumedItems++;
             return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
-            logger.Info( "OnCompletedAsync()" );
+            logger.LogInformation( "OnCompletedAsync()" );
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync( Exception ex )
         {
-            logger.Info( "OnErrorAsync({0})", ex );
+            logger.LogInformation( "OnErrorAsync({0})", ex );
             return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/SimpleDIGrain.cs
+++ b/test/Grains/TestGrains/SimpleDIGrain.cs
@@ -132,7 +132,7 @@ namespace UnitTests.Grains
 
         public void Dispose()
         {
-            logger?.Info($"Disposed instance {this.instanceValue}");
+            logger?.LogInformation($"Disposed instance {this.instanceValue}");
         }
 
     }
@@ -154,7 +154,7 @@ namespace UnitTests.Grains
 
         public void Dispose()
         {
-            logger.Info($"Disposed instance {this.instanceValue}");
+            logger.LogInformation($"Disposed instance {this.instanceValue}");
         }
 
         public string GetInstanceValue() =>  this.instanceValue;

--- a/test/Grains/TestGrains/SimpleGrain.cs
+++ b/test/Grains/TestGrains/SimpleGrain.cs
@@ -27,13 +27,13 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
             return Task.CompletedTask;
         }
 
         public Task SetA(int a)
         {
-            logger.Info("SetA={0}", a);
+            logger.LogInformation("SetA={0}", a);
             A = a;
             return Task.CompletedTask;
         }
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync.");
+            logger.LogInformation("OnDeactivateAsync.");
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/SimpleObserverableGrain.cs
+++ b/test/Grains/TestGrains/SimpleObserverableGrain.cs
@@ -25,13 +25,13 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
             return Task.CompletedTask;
         }
 
         public async Task SetA(int a)
         {
-            logger.Info("SetA={0}", a);
+            logger.LogInformation("SetA={0}", a);
             A = a;
 
             //If this were run with Task.Run there were no need for the added Unwrap call.

--- a/test/Grains/TestGrains/SimplePersistentGrain.cs
+++ b/test/Grains/TestGrains/SimplePersistentGrain.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
             version = Guid.NewGuid();
             return base.OnActivateAsync();
         }

--- a/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
+++ b/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             ConsumerHandle = null;
             return Task.CompletedTask;
         }
@@ -39,7 +39,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
         {
-            logger.Info("BecomeConsumer");
+            logger.LogInformation("BecomeConsumer");
             ConsumerObserver = new SlowObserver<int>(this, logger);
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             var consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
@@ -48,7 +48,7 @@ namespace UnitTests.Grains
 
         public async Task StopConsuming()
         {
-            logger.Info("StopConsuming");
+            logger.LogInformation("StopConsuming");
             if (ConsumerHandle != null)
             {
                 await ConsumerHandle.UnsubscribeAsync();
@@ -78,18 +78,18 @@ namespace UnitTests.Grains
             NumConsumed++;
             // slow consumer keep asking for the first item it received to mimic slow consuming behavior
             this.slowConsumingGrain.ConsumerHandle = await this.slowConsumingGrain.ConsumerHandle.ResumeAsync(this.slowConsumingGrain.ConsumerObserver, token);
-            this.logger.Info($"Consumer {this.GetHashCode()} OnNextAsync() received item {item.ToString()}, with NumConsumed {NumConsumed}");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnNextAsync() received item {item.ToString()}, with NumConsumed {NumConsumed}");
         }
 
         public Task OnCompletedAsync()
         {
-            this.logger.Info($"Consumer {this.GetHashCode()} OnCompletedAsync()");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnCompletedAsync()");
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
-            this.logger.Info($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
+            this.logger.LogInformation($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
             return Task.CompletedTask;
         }
     }

--- a/test/Grains/TestGrains/StatelessWorkerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerGrain.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             activationGuid = Guid.NewGuid();
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
             return Task.CompletedTask;
         }
 
@@ -53,8 +53,8 @@ namespace UnitTests.Grains
                 {
                     DateTime stop = DateTime.UtcNow;
                     calls.Add(new Tuple<DateTime, DateTime>(start, stop));
-                    logger.Info((stop - start).TotalMilliseconds.ToString());
-                    logger.Info($"Start {LogFormatter.PrintDate(start)}, stop {LogFormatter.PrintDate(stop)}, duration {stop - start}. #act {count}");
+                    logger.LogInformation((stop - start).TotalMilliseconds.ToString());
+                    logger.LogInformation($"Start {LogFormatter.PrintDate(start)}, stop {LogFormatter.PrintDate(stop)}, duration {stop - start}. #act {count}");
                 });
         }
 
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
             {
                 ids = allActivationIds.ToList();
             }
-            logger.Info($"# allActivationIds {ids.Count} for silo {silo}: {Utils.EnumerableToString(ids)}");
+            logger.LogInformation($"# allActivationIds {ids.Count} for silo {silo}: {Utils.EnumerableToString(ids)}");
             return Task.FromResult(Tuple.Create(activationGuid, silo, calls));
         }
 

--- a/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
@@ -37,7 +37,7 @@ namespace UnitTests.Grains
 
         public override async Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
             doingDeactivate = true;
@@ -48,7 +48,7 @@ namespace UnitTests.Grains
 
         public Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             return Task.FromResult(Data.ActivationId.ToString());
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
 
         public Task DoDeactivate()
         {
-            logger.Info("DoDeactivate");
+            logger.LogInformation("DoDeactivate");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
@@ -80,7 +80,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
@@ -96,7 +96,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
             doingDeactivate = true;
@@ -111,7 +111,7 @@ namespace UnitTests.Grains
 
         public Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             return Task.FromResult(Data.ActivationId.ToString());
@@ -119,7 +119,7 @@ namespace UnitTests.Grains
 
         public Task DoDeactivate()
         {
-            logger.Info("DoDeactivate");
+            logger.LogInformation("DoDeactivate");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
@@ -149,54 +149,54 @@ namespace UnitTests.Grains
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
             doingActivate = true;
 
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             // Spawn Task to run on default .NET thread pool
             var task = Task.Factory.StartNew(() =>
             {
-                logger.Info("Started-OnActivateAsync-SubTask");
+                logger.LogInformation("Started-OnActivateAsync-SubTask");
                 Assert.True(TaskScheduler.Current == TaskScheduler.Default,
                     "Running under default .NET Task scheduler");
                 Assert.True(doingActivate, "Still doing Activate in Sub-Task");
-                logger.Info("Finished-OnActivateAsync-SubTask");
+                logger.LogInformation("Finished-OnActivateAsync-SubTask");
             }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
             await task;
 
-            logger.Info("Started-OnActivateAsync");
+            logger.LogInformation("Started-OnActivateAsync");
 
             await watcher.RecordActivateCall(Data.ActivationId.ToString());
             Assert.True(doingActivate, "Doing Activate");
 
-            logger.Info("OnActivateAsync-Sleep");
+            logger.LogInformation("OnActivateAsync-Sleep");
             Thread.Sleep(TimeSpan.FromSeconds(1));
             Assert.True(doingActivate, "Still doing Activate after Sleep");
 
-            logger.Info("Finished-OnActivateAsync");
+            logger.LogInformation("Finished-OnActivateAsync");
             doingActivate = false;
         }
 
         public override async Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
 
             Assert.False(doingActivate, "Not doing Activate yet");
             Assert.False(doingDeactivate, "Not doing Deactivate yet");
             doingDeactivate = true;
 
-            logger.Info("Started-OnDeactivateAsync");
+            logger.LogInformation("Started-OnDeactivateAsync");
 
             await watcher.RecordDeactivateCall(Data.ActivationId.ToString());
             Assert.True(doingDeactivate, "Doing Deactivate");
 
-            logger.Info("OnDeactivateAsync-Sleep");
+            logger.LogInformation("OnDeactivateAsync-Sleep");
             Thread.Sleep(TimeSpan.FromSeconds(1));
-            logger.Info("Finished-OnDeactivateAsync");
+            logger.LogInformation("Finished-OnDeactivateAsync");
             doingDeactivate = false;
         }
 
         public Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             return Task.FromResult(Data.ActivationId.ToString());
@@ -204,7 +204,7 @@ namespace UnitTests.Grains
 
         public Task DoDeactivate()
         {
-            logger.Info("DoDeactivate");
+            logger.LogInformation("DoDeactivate");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
@@ -236,7 +236,7 @@ namespace UnitTests.Grains
                     {
                         Assert.NotNull(TaskScheduler.Current);
                         Assert.NotEqual(TaskScheduler.Current, TaskScheduler.Default);
-                        logger.Info("OnActivateAsync");
+                        logger.LogInformation("OnActivateAsync");
 
                         watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
 
@@ -251,16 +251,16 @@ namespace UnitTests.Grains
                 {
                     Assert.NotNull(TaskScheduler.Current);
                     Assert.NotEqual(TaskScheduler.Current, TaskScheduler.Default);
-                    logger.Info("Started-OnActivateAsync");
+                    logger.LogInformation("Started-OnActivateAsync");
 
                     Assert.True(doingActivate, "Doing Activate 1");
                     Assert.False(doingDeactivate, "Not doing Deactivate");
 
                     try
                     {
-                        logger.Info("Calling RecordActivateCall");
+                        logger.LogInformation("Calling RecordActivateCall");
                         await watcher.RecordActivateCall(Data.ActivationId.ToString());
-                        logger.Info("Returned from calling RecordActivateCall");
+                        logger.LogInformation("Returned from calling RecordActivateCall");
                     }
                     catch (Exception exc)
                     {
@@ -276,7 +276,7 @@ namespace UnitTests.Grains
 
                     doingActivate = false;
 
-                    logger.Info("Finished-OnActivateAsync");
+                    logger.LogInformation("Finished-OnActivateAsync");
                 };
             var awaitMe = startMe.ContinueWith(_ => asyncCont()).Unwrap();
             startMe.Start();
@@ -285,13 +285,13 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            Task.Factory.StartNew(() => logger.Info("OnDeactivateAsync"));
+            Task.Factory.StartNew(() => logger.LogInformation("OnDeactivateAsync"));
 
             Assert.False(doingActivate, "Not doing Activate");
             Assert.False(doingDeactivate, "Not doing Deactivate");
             doingDeactivate = true;
 
-            logger.Info("Started-OnDeactivateAsync");
+            logger.LogInformation("Started-OnDeactivateAsync");
             return watcher.RecordDeactivateCall(Data.ActivationId.ToString())
                 .ContinueWith((Task t) =>
                 {
@@ -300,13 +300,13 @@ namespace UnitTests.Grains
                     Thread.Sleep(TimeSpan.FromSeconds(1));
                     doingDeactivate = false;
                 })
-                .ContinueWith((Task t) => logger.Info("Finished-OnDeactivateAsync"),
+                .ContinueWith((Task t) => logger.LogInformation("Finished-OnDeactivateAsync"),
                     TaskContinuationOptions.ExecuteSynchronously);
         }
 
         public Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             return Task.FromResult(Data.ActivationId.ToString());
@@ -314,7 +314,7 @@ namespace UnitTests.Grains
 
         public Task DoDeactivate()
         {
-            logger.Info("DoDeactivate");
+            logger.LogInformation("DoDeactivate");
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
@@ -333,25 +333,25 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             throw new ApplicationException("Thrown from Application-OnActivateAsync");
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             throw new ApplicationException("Thrown from Application-OnDeactivateAsync");
         }
 
         public Task ThrowSomething()
         {
-            logger.Info("ThrowSomething");
+            logger.LogInformation("ThrowSomething");
             throw new InvalidOperationException("Exception should have been thrown from Activate");
         }
 
         public Task<long> GetKey()
         {
-            logger.Info("GetKey");
+            logger.LogInformation("GetKey");
             //return this.GetPrimaryKeyLong();
             throw new InvalidOperationException("Exception should have been thrown from Activate");
         }
@@ -391,20 +391,20 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             this.DeactivateOnIdle();
             return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
         public Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             throw new NotImplementedException("DoSomething should not have been called");
         }
     }
@@ -424,14 +424,14 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             grain = GrainFactory.GetGrain<ITestGrain>(1);
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             grain = GrainFactory.GetGrain<ITestGrain>(1);
             return Task.CompletedTask;
         }
 
         public async Task<string> DoSomething()
         {
-            logger.Info("DoSomething");
+            logger.LogInformation("DoSomething");
             var guid = Guid.NewGuid();
             await grain.SetLabel(guid.ToString());
             var label = await grain.GetLabel();
@@ -445,7 +445,7 @@ namespace UnitTests.Grains
 
         public async Task ForwardCall(IBadActivateDeactivateTestGrain otherGrain)
         {
-            logger.Info("ForwardCall to " + otherGrain);
+            logger.LogInformation("ForwardCall to " + otherGrain);
             await otherGrain.ThrowSomething();
         }
     }

--- a/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -265,7 +265,7 @@ namespace UnitTests.Grains
                     catch (Exception exc)
                     {
                         var msg = "RecordActivateCall failed with error " + exc;
-                        logger.Error(0, msg);
+                        logger.LogError(0, msg);
                         Assert.True(false, msg);
                     }
 

--- a/test/Grains/TestInternalGrains/CollectionTestGrain.cs
+++ b/test/Grains/TestInternalGrains/CollectionTestGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, Data.ActivationId, RuntimeIdentity));
-            logger.Info("OnActivateAsync.");
+            logger.LogInformation("OnActivateAsync.");
             activated = DateTime.UtcNow;
             counter = 0;
             return Task.CompletedTask;
@@ -35,7 +35,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            Logger().Info("OnDeactivateAsync.");
+            Logger().LogInformation("OnDeactivateAsync.");
             return Task.CompletedTask;
         }
 
@@ -44,45 +44,45 @@ namespace UnitTests.Grains
             staticCounter++;
             counter++;
             int tmpCounter = counter;
-            Logger().Info("IncrCounter {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("IncrCounter {0}, staticCounter {1}.", tmpCounter, staticCounter);
             return Task.FromResult(counter);
         }
 
         public Task<TimeSpan> GetAge()
         {
-            Logger().Info("GetAge.");
+            Logger().LogInformation("GetAge.");
             return Task.FromResult(DateTime.UtcNow.Subtract(activated));
         }
 
         public virtual Task DeactivateSelf()
         {
-            Logger().Info("DeactivateSelf.");
+            Logger().LogInformation("DeactivateSelf.");
             DeactivateOnIdle();
             return Task.CompletedTask;
         }
 
         public Task SetOther(ICollectionTestGrain other)
         {
-            Logger().Info("SetOther.");
+            Logger().LogInformation("SetOther.");
             this.other = other;
             return Task.CompletedTask;
         }
 
         public Task<TimeSpan> GetOtherAge()
         {
-            Logger().Info("GetOtherAge.");
+            Logger().LogInformation("GetOtherAge.");
             return other.GetAge();
         }
 
         public Task<string> GetRuntimeInstanceId()
         {
-            Logger().Info("GetRuntimeInstanceId.");
+            Logger().LogInformation("GetRuntimeInstanceId.");
             return Task.FromResult(RuntimeIdentity);
         }
 
         public Task<ICollectionTestGrain> GetGrainReference()
         {
-            Logger().Info("GetGrainReference.");
+            Logger().LogInformation("GetGrainReference.");
             return Task.FromResult(this.AsReference<ICollectionTestGrain>());
         }
         public Task StartTimer(TimeSpan timerPeriod, TimeSpan delayPeriod)
@@ -97,11 +97,11 @@ namespace UnitTests.Grains
             staticCounter++;
             counter++;
             int tmpCounter = counter;
-            Logger().Info("Start TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("Start TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
             await Task.Delay(delayPeriod);
-            Logger().Info("After first delay TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("After first delay TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
             await Task.Delay(delayPeriod);
-            Logger().Info("After second delay TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("After second delay TimerCallback {0}, staticCounter {1}.", tmpCounter, staticCounter);
         }
     }
 
@@ -121,14 +121,14 @@ namespace UnitTests.Grains
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, Data.ActivationId, RuntimeIdentity));
-            logger.Info("OnActivateAsync.");
+            logger.LogInformation("OnActivateAsync.");
             counter = 0;
             return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
-            Logger().Info("OnDeactivateAsync.");
+            Logger().LogInformation("OnDeactivateAsync.");
             return Task.CompletedTask;
         }
 
@@ -136,9 +136,9 @@ namespace UnitTests.Grains
         {
             staticCounter++;
             int tmpCounter = counter++;
-            Logger().Info("Reentrant:IncrCounter BEFORE Delay {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("Reentrant:IncrCounter BEFORE Delay {0}, staticCounter {1}.", tmpCounter, staticCounter);
             await Task.Delay(TimeSpan.FromMilliseconds(1000));
-            Logger().Info("Reentrant:IncrCounter AFTER Delay {0}, staticCounter {1}.", tmpCounter, staticCounter);
+            Logger().LogInformation("Reentrant:IncrCounter AFTER Delay {0}, staticCounter {1}.", tmpCounter, staticCounter);
             return counter;
         }
     }

--- a/test/Grains/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/Grains/TestInternalGrains/EchoTaskGrain.cs
@@ -33,7 +33,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info(GetType().FullName + " created");
+            logger.LogInformation(GetType().FullName + " created");
             return base.OnActivateAsync();
         }
 
@@ -44,14 +44,14 @@ namespace UnitTests.Grains
 
         public Task<string> Echo(string data)
         {
-            logger.Info("IEchoGrain.Echo=" + data);
+            logger.LogInformation("IEchoGrain.Echo=" + data);
             State.LastEcho = data;
             return Task.FromResult(data);
         }
 
         public Task<string> EchoError(string data)
         {
-            logger.Info("IEchoGrain.EchoError=" + data);
+            logger.LogInformation("IEchoGrain.EchoError=" + data);
             State.LastEcho = data;
             throw new Exception(data);
         }
@@ -76,109 +76,109 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info(GetType().FullName + " created");
+            logger.LogInformation(GetType().FullName + " created");
             return base.OnActivateAsync();
         }
 
         public Task<string> EchoAsync(string data)
         {
-            logger.Info("IEchoGrainAsync.Echo=" + data);
+            logger.LogInformation("IEchoGrainAsync.Echo=" + data);
             State.LastEcho = data;
             return Task.FromResult(data);
         }
 
         public Task<string> EchoErrorAsync(string data)
         {
-            logger.Info("IEchoGrainAsync.EchoError=" + data);
+            logger.LogInformation("IEchoGrainAsync.EchoError=" + data);
             State.LastEcho = data;
             throw new Exception(data);
         }
 
         private Task<string> EchoErrorAV(string data)
         {
-            logger.Info("IEchoGrainAsync.EchoErrorAV=" + data);
+            logger.LogInformation("IEchoGrainAsync.EchoErrorAV=" + data);
             State.LastEcho = data;
             throw new Exception(data);
         }
 
         public async Task<string> AwaitMethodErrorAsync(string data)
         {
-            logger.Info("IEchoGrainAsync.CallMethodErrorAsync=" + data);
+            logger.LogInformation("IEchoGrainAsync.CallMethodErrorAsync=" + data);
             return await EchoErrorAsync(data);
         }
 
         public async Task<string> AwaitAVMethodErrorAsync(string data)
         {
-            logger.Info("IEchoGrainAsync.CallMethodErrorAsync=" + data);
+            logger.LogInformation("IEchoGrainAsync.CallMethodErrorAsync=" + data);
             return await EchoErrorAV(data);
         }
 
         public async Task<string> AwaitAVGrainCallErrorAsync(string data)
         {
-            logger.Info("IEchoGrainAsync.AwaitAVGrainErrorAsync=" + data);
+            logger.LogInformation("IEchoGrainAsync.AwaitAVGrainErrorAsync=" + data);
             IEchoGrain avGrain = GrainFactory.GetGrain<IEchoGrain>(this.GetPrimaryKey());
             return await avGrain.EchoError(data);
         }
 
         public Task<int> BlockingCallTimeoutAsync(TimeSpan delay)
         {
-            logger.Info("IEchoGrainAsync.BlockingCallTimeout Delay={0}", delay);
+            logger.LogInformation("IEchoGrainAsync.BlockingCallTimeout Delay={0}", delay);
             Stopwatch sw = new Stopwatch();
             sw.Start();
             Thread.Sleep(delay);
-            logger.Info("IEchoGrainAsync.BlockingCallTimeout Awoke from sleep after {0}", sw.Elapsed);
+            logger.LogInformation("IEchoGrainAsync.BlockingCallTimeout Awoke from sleep after {0}", sw.Elapsed);
             throw new InvalidOperationException("Timeout should have been returned to caller before " + delay);
         }
 
         public Task PingAsync()
         {
-            logger.Info("IEchoGrainAsync.Ping");
+            logger.LogInformation("IEchoGrainAsync.Ping");
             return Task.CompletedTask;
         }
 
         public Task PingLocalSiloAsync()
         {
-            logger.Info("IEchoGrainAsync.PingLocal");
+            logger.LogInformation("IEchoGrainAsync.PingLocal");
             SiloAddress mySilo = Data.Address.Silo;
             return GetSiloControlReference(mySilo).Ping("PingLocal");
         }
 
         public Task PingRemoteSiloAsync(SiloAddress siloAddress)
         {
-            logger.Info("IEchoGrainAsync.PingRemote");
+            logger.LogInformation("IEchoGrainAsync.PingRemote");
             return GetSiloControlReference(siloAddress).Ping("PingRemote");
         }
 
         public async Task PingOtherSiloAsync()
         {
-            logger.Info("IEchoGrainAsync.PingOtherSilo");
+            logger.LogInformation("IEchoGrainAsync.PingOtherSilo");
             SiloAddress mySilo = Data.Address.Silo;
 
             IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(0);
             var silos = await mgmtGrain.GetHosts();
 
             SiloAddress siloAddress = silos.Where(pair => !pair.Key.Equals(mySilo)).Select(pair => pair.Key).First();
-            logger.Info("Sending Ping to remote silo {0}", siloAddress);
+            logger.LogInformation("Sending Ping to remote silo {0}", siloAddress);
 
             await GetSiloControlReference(siloAddress).Ping("PingOtherSilo-" + siloAddress);
-            logger.Info("Ping reply received for {0}", siloAddress);
+            logger.LogInformation("Ping reply received for {0}", siloAddress);
         }
 
         public async Task PingClusterMemberAsync()
         {
-            logger.Info("IEchoGrainAsync.PingClusterMemberAsync");
+            logger.LogInformation("IEchoGrainAsync.PingClusterMemberAsync");
             SiloAddress mySilo = Data.Address.Silo;
 
             IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(0);
             var silos = await mgmtGrain.GetHosts();
 
             SiloAddress siloAddress = silos.Where(pair => !pair.Key.Equals(mySilo)).Select(pair => pair.Key).First();
-            logger.Info("Sending Ping to remote silo {0}", siloAddress);
+            logger.LogInformation("Sending Ping to remote silo {0}", siloAddress);
 
             var oracle = this.internalGrainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipServiceType, siloAddress);
 
             await oracle.Ping(1);
-            logger.Info("Ping reply received for {0}", siloAddress);
+            logger.LogInformation("Ping reply received for {0}", siloAddress);
         }
 
         private ISiloControl GetSiloControlReference(SiloAddress silo)
@@ -216,7 +216,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info(GetType().FullName + " created");
+            logger.LogInformation(GetType().FullName + " created");
             return base.OnActivateAsync();
         }
 
@@ -234,10 +234,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".Echo";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             State.LastEcho = data;
             var result = Task.FromResult(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -245,10 +245,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodTask_Await";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoTaskGrain avGrain = GrainFactory.GetGrain<IEchoTaskGrain>(this.GetPrimaryKey());
             var result = await avGrain.EchoAsync(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -256,10 +256,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodAV_Await";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoGrain avGrain = GrainFactory.GetGrain<IEchoGrain>(this.GetPrimaryKey());
             var result = await avGrain.Echo(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -268,13 +268,13 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodTask_Block";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoTaskGrain avGrain = GrainFactory.GetGrain<IEchoTaskGrain>(this.GetPrimaryKey());
 
             // Note: We deliberately use .Result here in this test case to block current executing thread
             var result = avGrain.EchoAsync(data).Result;
 
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
         #pragma warning restore 1998
@@ -284,13 +284,13 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodAV_Block";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoGrain avGrain = GrainFactory.GetGrain<IEchoGrain>(this.GetPrimaryKey());
 
             // Note: We deliberately use .Result here in this test case to block current executing thread
             var result = avGrain.Echo(data).Result;
             
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
         #pragma warning restore 1998
@@ -309,7 +309,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info(GetType().FullName + " created");
+            logger.LogInformation(GetType().FullName + " created");
             return base.OnActivateAsync();
         }
 
@@ -327,10 +327,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".Echo";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             State.LastEcho = data;
             var result = Task.FromResult(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -338,10 +338,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodTask_Await";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoTaskGrain avGrain = GrainFactory.GetGrain<IEchoTaskGrain>(this.GetPrimaryKey());
             var result = await avGrain.EchoAsync(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -349,10 +349,10 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodAV_Await";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoGrain avGrain = GrainFactory.GetGrain<IEchoGrain>(this.GetPrimaryKey());
             var result = await avGrain.Echo(data);
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 
@@ -361,13 +361,13 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodTask_Block";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoTaskGrain avGrain = GrainFactory.GetGrain<IEchoTaskGrain>(this.GetPrimaryKey());
 
             // Note: We deliberately use .Result here in this test case to block current executing thread
             var result = avGrain.EchoAsync(data).Result;
 
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 #pragma warning restore 1998
@@ -377,13 +377,13 @@ namespace UnitTests.Grains
         {
             string name = GetType().Name + ".CallMethodAV_Block";
 
-            logger.Info(name + " Data=" + data);
+            logger.LogInformation(name + " Data=" + data);
             IEchoGrain avGrain = GrainFactory.GetGrain<IEchoGrain>(this.GetPrimaryKey());
 
             // Note: We deliberately use .Result here in this test case to block current executing thread
             var result = avGrain.Echo(data).Result;
             
-            logger.Info(name + " Result=" + result);
+            logger.LogInformation(name + " Result=" + result);
             return result;
         }
 #pragma warning restore 1998

--- a/test/Grains/TestInternalGrains/ErrorGrain.cs
+++ b/test/Grains/TestInternalGrains/ErrorGrain.cs
@@ -22,19 +22,19 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("Activate.");
+            logger.LogInformation("Activate.");
             return Task.CompletedTask;
         }
 
         public Task LogMessage(string msg)
         {
-           logger.Info(msg);
+           logger.LogInformation(msg);
            return Task.CompletedTask;
         }
 
         public Task SetAError(int a)
         {
-            logger.Info("SetAError={0}", a);
+            logger.LogInformation("SetAError={0}", a);
             A = a;
             throw new Exception("SetAError-Exception");
         }
@@ -68,20 +68,20 @@ namespace UnitTests.Grains
 
         public async Task DelayMethod(int milliseconds)
         {
-            logger.Info("DelayMethod {0}.", counter);
+            logger.LogInformation("DelayMethod {0}.", counter);
             counter++;
             await Task.Delay(TimeSpan.FromMilliseconds(milliseconds));
         }
 
         public Task Dispose()
         {
-            logger.Info("Dispose()");
+            logger.LogInformation("Dispose()");
             return Task.CompletedTask;
         }
 
         public Task<int> UnobservedErrorImmediate()
         {
-            logger.Info("UnobservedErrorImmediate()");
+            logger.LogInformation("UnobservedErrorImmediate()");
 
             bool doThrow = true;
             // the grain method returns OK, but leaves some unobserved promise
@@ -89,7 +89,7 @@ namespace UnitTests.Grains
             {
                 if (!doThrow)
                     return 0;
-                logger.Info("About to throw 1.");
+                logger.LogInformation("About to throw 1.");
                 throw new ArgumentException("ErrorGrain left Immediate Unobserved Error 1.");
             });
             promise = null;
@@ -102,7 +102,7 @@ namespace UnitTests.Grains
 
         public Task<int> UnobservedErrorDelayed()
         {
-            logger.Info("UnobservedErrorDelayed()");
+            logger.LogInformation("UnobservedErrorDelayed()");
             bool doThrow = true;
             // the grain method rturns OK, but leaves some unobserved promise
             Task<long> promise = Task<long>.Factory.StartNew(() =>
@@ -110,7 +110,7 @@ namespace UnitTests.Grains
                 if (!doThrow)
                     return 0;
                 Thread.Sleep(100);
-                logger.Info("About to throw 1.5.");
+                logger.LogInformation("About to throw 1.5.");
                 throw new ArgumentException("ErrorGrain left Delayed Unobserved Error 1.5.");
             });
             promise = null;
@@ -123,12 +123,12 @@ namespace UnitTests.Grains
 
         public Task<int> UnobservedErrorContinuation2()
         {
-            logger.Info("UnobservedErrorContinuation2()");
+            logger.LogInformation("UnobservedErrorContinuation2()");
             // the grain method returns OK, but leaves some unobserved promise
             Task<long> promise = Task.FromResult((long)25);
             Task cont = promise.ContinueWith(_ =>
                 {
-                    logger.Info("About to throw 2.");
+                    logger.LogInformation("About to throw 2.");
                     throw new ArgumentException("ErrorGrain left ContinueWith Unobserved Error 2.");
                 });
             promise = null;
@@ -142,19 +142,19 @@ namespace UnitTests.Grains
 
         public Task<int> UnobservedErrorContinuation3()
         {
-            logger.Info("UnobservedErrorContinuation3() from Task " + Task.CurrentId);
+            logger.LogInformation("UnobservedErrorContinuation3() from Task " + Task.CurrentId);
             // the grain method returns OK, but leaves some unobserved promise
             Task<long> promise = Task<long>.Factory.StartNew(() =>
             {
-                logger.Info("First promise from Task " + Task.CurrentId);
+                logger.LogInformation("First promise from Task " + Task.CurrentId);
                 return 26;
             });
             Task cont = promise.ContinueWith(_ =>
             {
-                logger.Info("About to throw 3 from Task " + Task.CurrentId);
+                logger.LogInformation("About to throw 3 from Task " + Task.CurrentId);
                 throw new ArgumentException("ErrorGrain left ContinueWith Unobserved Error 3.");
             });
-            //logger.Info("cont.number=" + cont.task.number + " cont.m_Task.number=" + cont.task.m_Task.Id);
+            //logger.LogInformation("cont.number=" + cont.task.number + " cont.m_Task.number=" + cont.task.m_Task.Id);
             promise = null;
             cont = null;
             GC.Collect();
@@ -166,7 +166,7 @@ namespace UnitTests.Grains
 
         public Task<int> UnobservedIgnoredError()
         {
-            logger.Info("UnobservedIgnoredError()");
+            logger.LogInformation("UnobservedIgnoredError()");
             bool doThrow = true;
             // the grain method rturns OK, but leaves some unobserved promise
             Task<long> promise = Task<long>.Factory.StartNew(() =>

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -292,13 +292,13 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            this.logger.Info(1, "OnActivateAsync");
+            this.logger.LogInformation(1, "OnActivateAsync");
             return Task.CompletedTask;
         }
 
         public Task DoSomething()
         {
-            this.logger.Info(1, "DoSomething");
+            this.logger.LogInformation(1, "DoSomething");
             return Task.CompletedTask;
         }
     }
@@ -710,14 +710,14 @@ namespace UnitTests.Grains
 
         public Task Setup(IReentrentGrainWithState other)
         {
-            logger.Info("Setup");
+            logger.LogInformation("Setup");
             _other = other;
             return Task.CompletedTask;
         }
 
         public async Task SetOne(int val)
         {
-            logger.Info("SetOne Start");
+            logger.LogInformation("SetOne Start");
             CheckRuntimeEnvironment();
             var iStr = val.ToString(CultureInfo.InvariantCulture);
             State.One = val;
@@ -730,7 +730,7 @@ namespace UnitTests.Grains
 
         public async Task SetTwo(int val)
         {
-            logger.Info("SetTwo Start");
+            logger.LogInformation("SetTwo Start");
             CheckRuntimeEnvironment();
             var iStr = val.ToString(CultureInfo.InvariantCulture);
             State.Two = val;
@@ -743,7 +743,7 @@ namespace UnitTests.Grains
 
         public async Task Test1()
         {
-            logger.Info(" ==================================== Test1 Started");
+            logger.LogInformation(" ==================================== Test1 Started");
             CheckRuntimeEnvironment();
             for (var i = 1*Multiple; i < 2*Multiple; i++)
             {
@@ -764,12 +764,12 @@ namespace UnitTests.Grains
                 CheckRuntimeEnvironment();
             }
             CheckRuntimeEnvironment();
-            logger.Info(" ==================================== Test1 Done");
+            logger.LogInformation(" ==================================== Test1 Done");
         }
 
         public async Task Test2()
         {
-            logger.Info("==================================== Test2 Started");
+            logger.LogInformation("==================================== Test2 Started");
             CheckRuntimeEnvironment();
             for (var i = 2*Multiple; i < 3*Multiple; i++)
             {
@@ -790,18 +790,18 @@ namespace UnitTests.Grains
                 CheckRuntimeEnvironment();
             }
             CheckRuntimeEnvironment();
-            logger.Info(" ==================================== Test2 Done");
+            logger.LogInformation(" ==================================== Test2 Done");
         }
 
         public async Task Task_Delay(bool doStart)
         {
             var wrapper = new Task(async () =>
             {
-                logger.Info("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(1);
-                logger.Info("After Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("After Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(2);
-                logger.Info("After Task.Delay #2 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("After Task.Delay #2 TaskScheduler.Current=" + TaskScheduler.Current);
             });
 
             if (doStart)
@@ -814,9 +814,9 @@ namespace UnitTests.Grains
 
         private async Task DoDelay(int i)
         {
-            logger.Info("Before Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
+            logger.LogInformation("Before Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
             await Task.Delay(1);
-            logger.Info("After Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
+            logger.LogInformation("After Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
         }
 
         private void CheckRuntimeEnvironment()
@@ -955,11 +955,11 @@ namespace UnitTests.Grains
         {
             var wrapper = new Task(async () =>
             {
-                logger.Info("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(1);
-                logger.Info("After Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("After Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(2);
-                logger.Info("After Task.Delay #2 TaskScheduler.Current=" + TaskScheduler.Current);
+                logger.LogInformation("After Task.Delay #2 TaskScheduler.Current=" + TaskScheduler.Current);
             });
 
             if (doStart)
@@ -972,9 +972,9 @@ namespace UnitTests.Grains
 
         private async Task DoDelay(int i)
         {
-            logger.Info("Before Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
+            logger.LogInformation("Before Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
             await Task.Delay(1);
-            logger.Info("After Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
+            logger.LogInformation("After Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
         }
 
         private void CheckRuntimeEnvironment(string str)
@@ -1007,7 +1007,7 @@ namespace UnitTests.Grains
         private void Log(string fmt, params object[] args)
         {
             var msg = fmt; // +base.CaptureRuntimeEnvironment();
-            logger.Info(msg, args);
+            logger.LogInformation(msg, args);
         }
     }
 
@@ -1029,7 +1029,7 @@ namespace UnitTests.Grains
 
         public Task SetOne(int val)
         {
-            logger.Info("SetOne");
+            logger.LogInformation("SetOne");
             State.One = val;
             return Task.CompletedTask;
         }
@@ -1060,21 +1060,21 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             return base.OnActivateAsync();
         }
 
         public Task<int> GetValue()
         {
             var val = State.Field1;
-            logger.Info("GetValue {0}", val);
+            logger.LogInformation("GetValue {0}", val);
             return Task.FromResult(val);
         }
 
         public Task SetValue(int val)
         {
             State.Field1 = val;
-            logger.Info("SetValue {0}", val);
+            logger.LogInformation("SetValue {0}", val);
             return WriteStateAsync();
         }
     }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -826,7 +826,7 @@ namespace UnitTests.Grains
                 var errorMsg = "Found out that this grain is already in the middle of execution."
                                + " Single threaded-ness violation!\n" +
                                TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment();
-                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                this.logger.LogError(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 throw new Exception(errorMsg);
                 //Environment.Exit(1);
             }
@@ -834,7 +834,7 @@ namespace UnitTests.Grains
             if (RuntimeContext.CurrentGrainContext == null)
             {
                 var errorMsg = "Found RuntimeContext.Current == null.\n" + TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment();
-                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                this.logger.LogError(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 throw new Exception(errorMsg);
                 //Environment.Exit(1);
             }
@@ -990,7 +990,7 @@ namespace UnitTests.Grains
                     this._id,
                     TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment(),
                     callStack);
-                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                this.logger.LogError(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 this.scheduler.DumpSchedulerStatus();
                 //Environment.Exit(1);
                 throw new Exception(errorMsg);

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -181,7 +181,7 @@ namespace UnitTests.Grains
             {
                 if (!recover) throw;
 
-                this.logger.Warn(0, "Grain is handling error in DoWrite - Resetting value to " + original, exc);
+                this.logger.LogWarning(0, exc, "Grain is handling error in DoWrite - Resetting value to {Original}", original);
                 State = (PersistenceTestGrainState)original;
             }
         }
@@ -197,7 +197,7 @@ namespace UnitTests.Grains
             {
                 if (!recover) throw;
 
-                this.logger.Warn(0, "Grain is handling error in DoRead - Resetting value to " + original, exc);
+                this.logger.LogWarning(0, exc, "Grain is handling error in DoRead - Resetting value to {Original}", original);
                 State = (PersistenceTestGrainState)original;
             }
             return State.Field1;
@@ -268,13 +268,13 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            this.logger.Warn(1, "OnActivateAsync");
+            this.logger.LogWarning(1, "OnActivateAsync");
             return Task.CompletedTask;
         }
 
         public Task DoSomething()
         {
-            this.logger.Warn(1, "DoSomething");
+            this.logger.LogWarning(1, "DoSomething");
             throw new ApplicationException(
                 "BadProviderTestGrain.DoSomething should never get called when provider is missing");
         }

--- a/test/Grains/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/Grains/TestInternalGrains/PlacementTestGrain.cs
@@ -207,7 +207,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             DelayDeactivation(TimeSpan.MaxValue);   // make sure this activation is not collected.
             cachedContent = RuntimeIdentity;        // store your silo identity as a local cached content in this grain.
             InstanceIdForThisSilo = this.AsReference<ILocalContentGrain>();
@@ -216,7 +216,7 @@ namespace UnitTests.Grains
 
         public Task Init()
         {
-            logger.Info("Init LocalContentGrain on silo " + RuntimeIdentity);
+            logger.LogInformation("Init LocalContentGrain on silo " + RuntimeIdentity);
             return Task.FromResult(0);
         }
 
@@ -237,26 +237,26 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
             return base.OnActivateAsync();
         }
 
         public Task<string> GetRuntimeInstanceId()
         {
-            logger.Info("GetRuntimeInstanceId");
+            logger.LogInformation("GetRuntimeInstanceId");
             return Task.FromResult(RuntimeIdentity);
         }
 
         public async Task<object> FetchContentFromLocalGrain()
         {
-            logger.Info("FetchContentFromLocalGrain");
+            logger.LogInformation("FetchContentFromLocalGrain");
             var localContentGrain = LocalContentGrain.InstanceIdForThisSilo;
             if (localContentGrain == null)
             {
                 throw new Exception("LocalContentGrain was not correctly initialized during silo startup!");
             }
             object content = await localContentGrain.GetContent();
-            logger.Info("Received content = {0}", content);
+            logger.LogInformation("Received content = {0}", content);
             return content;
         }
     }

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -52,21 +52,21 @@ namespace UnitTests.Grains
             this.allReminders = new Dictionary<string, IGrainReminder>();
             this.sequence = new Dictionary<string, long>();
             this.period = GetDefaultPeriod(this.logger);
-            this.logger.Info("OnActivateAsync.");
+            this.logger.LogInformation("OnActivateAsync.");
             this.filePrefix = "g" + this.GrainId.ToString().Replace('/', '_') + "_";
             return GetMissingReminders();
         }
 
         public override Task OnDeactivateAsync()
         {
-            this.logger.Info("OnDeactivateAsync");
+            this.logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
         public async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
         {
             TimeSpan usePeriod = p ?? this.period;
-            this.logger.Info("Starting reminder {0}.", reminderName);
+            this.logger.LogInformation("Starting reminder {0}.", reminderName);
             TimeSpan dueTime;
             if (reminderOptions.Value.MinimumReminderPeriod < TimeSpan.FromSeconds(2))
                 dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimumReminderPeriod;
@@ -83,7 +83,7 @@ namespace UnitTests.Grains
 
             string fileName = GetFileName(reminderName);
             File.Delete(fileName); // if successfully started, then remove any old data
-            this.logger.Info("Started reminder {0}", r);
+            this.logger.LogInformation("Started reminder {0}", r);
             return r;
         }
 
@@ -116,12 +116,12 @@ namespace UnitTests.Grains
             // do switch-ing here
             if (sequenceNumber < this.sequence[reminderName])
             {
-                this.logger.Info("ReceiveReminder: {0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
+                this.logger.LogInformation("ReceiveReminder: {0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
                 return Task.CompletedTask;
             }
 
             this.sequence[reminderName] = sequenceNumber;
-            this.logger.Info("ReceiveReminder: {0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
+            this.logger.LogInformation("ReceiveReminder: {0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
 
             string fileName = GetFileName(reminderName);
             string counterValue = this.sequence[reminderName].ToString(CultureInfo.InvariantCulture);
@@ -132,7 +132,7 @@ namespace UnitTests.Grains
 
         public async Task StopReminder(string reminderName)
         {
-            this.logger.Info("Stopping reminder {0}.", reminderName);
+            this.logger.LogInformation("Stopping reminder {0}.", reminderName);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             //return UnregisterReminder(allReminders[reminderName]);
             IGrainReminder reminder;
@@ -161,7 +161,7 @@ namespace UnitTests.Grains
         private async Task GetMissingReminders()
         {
             List<IGrainReminder> reminders = await base.GetReminders();
-            this.logger.Info("Got missing reminders {0}", Utils.EnumerableToString(reminders));
+            this.logger.LogInformation("Got missing reminders {0}", Utils.EnumerableToString(reminders));
             foreach (IGrainReminder l in reminders)
             {
                 if (!this.allReminders.ContainsKey(l.ReminderName))
@@ -174,7 +174,7 @@ namespace UnitTests.Grains
 
         public async Task StopReminder(IGrainReminder reminder)
         {
-            this.logger.Info("Stopping reminder (using ref) {0}.", reminder);
+            this.logger.LogInformation("Stopping reminder (using ref) {0}.", reminder);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             await UnregisterReminder(reminder);
         }
@@ -210,7 +210,7 @@ namespace UnitTests.Grains
         {
             int period = 12; // Seconds
             var reminderPeriod = TimeSpan.FromSeconds(period);
-            log.Info("Using reminder period of {0} in ReminderTestGrain", reminderPeriod);
+            log.LogInformation("Using reminder period of {0} in ReminderTestGrain", reminderPeriod);
             return reminderPeriod;
         }
 
@@ -250,21 +250,21 @@ namespace UnitTests.Grains
             this.allReminders = new Dictionary<string, IGrainReminder>();
             this.sequence = new Dictionary<string, long>();
             this.period = ReminderTestGrain2.GetDefaultPeriod(this.logger);
-            this.logger.Info("OnActivateAsync.");
+            this.logger.LogInformation("OnActivateAsync.");
             this.filePrefix = "gc" + this.GrainId.Key + "_";
             await GetMissingReminders();
         }
 
         public override Task OnDeactivateAsync()
         {
-            this.logger.Info("OnDeactivateAsync.");
+            this.logger.LogInformation("OnDeactivateAsync.");
             return Task.CompletedTask;
         }
 
         public async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
         {
             TimeSpan usePeriod = p ?? this.period;
-            this.logger.Info("Starting reminder {0} for {1}", reminderName, this.GrainId);
+            this.logger.LogInformation("Starting reminder {0} for {1}", reminderName, this.GrainId);
             IGrainReminder r;
             if (validate)
                 r = await RegisterOrUpdateReminder(reminderName, /*TimeSpan.FromSeconds(3)*/usePeriod - TimeSpan.FromSeconds(2), usePeriod);
@@ -285,7 +285,7 @@ namespace UnitTests.Grains
             }
 
             File.Delete(GetFileName(reminderName)); // if successfully started, then remove any old data
-            this.logger.Info("Started reminder {0}.", r);
+            this.logger.LogInformation("Started reminder {0}.", r);
             return r;
         }
 
@@ -318,12 +318,12 @@ namespace UnitTests.Grains
             // do switch-ing here
             if (sequenceNumber < this.sequence[reminderName])
             {
-                this.logger.Info("{0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
+                this.logger.LogInformation("{0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
                 return Task.CompletedTask;
             }
 
             this.sequence[reminderName] = sequenceNumber;
-            this.logger.Info("{0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
+            this.logger.LogInformation("{0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
 
             File.WriteAllText(GetFileName(reminderName), this.sequence[reminderName].ToString());
 
@@ -332,7 +332,7 @@ namespace UnitTests.Grains
 
         public async Task StopReminder(string reminderName)
         {
-            this.logger.Info("Stopping reminder {0}.", reminderName);
+            this.logger.LogInformation("Stopping reminder {0}.", reminderName);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             //return UnregisterReminder(allReminders[reminderName]);
             IGrainReminder reminder;
@@ -363,7 +363,7 @@ namespace UnitTests.Grains
 
         public async Task StopReminder(IGrainReminder reminder)
         {
-            this.logger.Info("Stopping reminder (using ref) {0}.", reminder);
+            this.logger.LogInformation("Stopping reminder (using ref) {0}.", reminder);
             // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
             await UnregisterReminder(reminder);
         }
@@ -404,15 +404,15 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            this.logger.Info("OnActivateAsync.");
+            this.logger.LogInformation("OnActivateAsync.");
             return Task.CompletedTask;
         }
 
         public async Task<bool> StartReminder(string reminderName)
         {
-            this.logger.Info("Starting reminder {0}.", reminderName);
+            this.logger.LogInformation("Starting reminder {0}.", reminderName);
             IGrainReminder r = await RegisterOrUpdateReminder(reminderName, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
-            this.logger.Info("Started reminder {0}. It shouldn't have succeeded!", r);
+            this.logger.LogInformation("Started reminder {0}. It shouldn't have succeeded!", r);
             return true;
         }
     }

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -337,7 +337,7 @@ namespace UnitTests.Grains
             }
             catch (Exception exc)
             {
-                logger.Error(0, "Error from SendItem " + item, exc);
+                logger.LogError(0, exc, "Error from SendItem " + item);
                 State.NumErrors++;
                 error = exc;
             }

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -180,7 +180,7 @@ namespace UnitTests.Grains
                 if (State.ConsumerSubscriptionHandles.Count > 0)
                 {
                     var handles = State.ConsumerSubscriptionHandles.ToArray();
-                    logger.Info("ReconnectConsumerHandles SubscriptionHandles={0} Grain={1}", Utils.EnumerableToString(handles), this.AsReference<IStreamLifecycleConsumerGrain>());
+                    logger.LogInformation("ReconnectConsumerHandles SubscriptionHandles={0} Grain={1}", Utils.EnumerableToString(handles), this.AsReference<IStreamLifecycleConsumerGrain>());
                     foreach (var handle in handles)
                     {
                         var observer = new MyStreamObserver<int>(this.logger);
@@ -215,7 +215,7 @@ namespace UnitTests.Grains
 
         public Task Ping()
         {
-            logger.Info("Ping");
+            logger.LogInformation("Ping");
             return Task.CompletedTask;
         }
 
@@ -261,7 +261,7 @@ namespace UnitTests.Grains
 
         public async Task ClearGrain()
         {
-            logger.Info("ClearGrain");
+            logger.LogInformation("ClearGrain");
             var subsHandles = State.ConsumerSubscriptionHandles.ToArray();
             foreach (var handle in subsHandles)
             {
@@ -319,7 +319,7 @@ namespace UnitTests.Grains
 
         public Task Ping()
         {
-            logger.Info("Ping");
+            logger.LogInformation("Ping");
             return Task.CompletedTask;
         }
 
@@ -365,7 +365,7 @@ namespace UnitTests.Grains
 
         public async Task ClearGrain()
         {
-            logger.Info("ClearGrain");
+            logger.LogInformation("ClearGrain");
             State.IsProducer = false;
             State.Stream = null;
             await ClearStateAsync();
@@ -413,7 +413,7 @@ namespace UnitTests.Grains
         {
             if (logger != null)
             {
-                logger.Info("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
+                logger.LogInformation("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
             }
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -424,7 +424,7 @@ namespace UnitTests.Grains
 
             if (logger != null)
             {
-                logger.Warn(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
+                logger.LogWarning(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
             }
 
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -336,7 +336,7 @@ namespace UnitTests.Grains
     //    public Task OnErrorAsync(Exception ex)
     //    {
     //        NumErrors++;
-    //        logger.Warn(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
+    //        logger.LogWarning(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
     //        return Task.CompletedTask;
     //    }
     //}

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -75,7 +75,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync()
         {
-            logger.Info(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
+            logger.LogInformation(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));
 
             if (Observers == null)
@@ -105,38 +105,38 @@ namespace UnitTests.Grains
             }
             else
             {
-                logger.Info("No stream yet.");
+                logger.LogInformation("No stream yet.");
             }
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("OnDeactivateAsync");
+            logger.LogInformation("OnDeactivateAsync");
             return base.OnDeactivateAsync();
         }
 
         public Task<int> GetConsumerCount()
         {
             int numConsumers = State.ConsumerSubscriptionHandles.Count;
-            logger.Info("ConsumerCount={0}", numConsumers);
+            logger.LogInformation("ConsumerCount={0}", numConsumers);
             return Task.FromResult(numConsumers);
         }
         public Task<int> GetReceivedCount()
         {
             int numReceived = Observers.Sum(o => o.Value.NumItems);
-            logger.Info("ReceivedCount={0}", numReceived);
+            logger.LogInformation("ReceivedCount={0}", numReceived);
             return Task.FromResult(numReceived);
         }
         public Task<int> GetErrorsCount()
         {
             int numErrors = Observers.Sum(o => o.Value.NumErrors);
-            logger.Info("ErrorsCount={0}", numErrors);
+            logger.LogInformation("ErrorsCount={0}", numErrors);
             return Task.FromResult(numErrors);
         }
 
         public Task Ping()
         {
-            logger.Info("Ping");
+            logger.LogInformation("Ping");
             return Task.CompletedTask;
         }
 
@@ -146,7 +146,7 @@ namespace UnitTests.Grains
         public async Task<StreamSubscriptionHandle<int>> AddConsumer(Guid streamId, string providerName)
 #endif
         {
-            logger.Info("AddConsumer StreamId={0} StreamProvider={1} Grain={2}", streamId, providerName, this.AsReference<IStreamReliabilityTestGrain>());
+            logger.LogInformation("AddConsumer StreamId={0} StreamProvider={1} Grain={2}", streamId, providerName, this.AsReference<IStreamReliabilityTestGrain>());
             TryInitStream(streamId, providerName);
 #if USE_GENERICS
             var observer = new MyStreamObserver<T>();
@@ -166,7 +166,7 @@ namespace UnitTests.Grains
         public async Task RemoveConsumer(Guid streamId, string providerName, StreamSubscriptionHandle<int> subsHandle)
 #endif
         {
-            logger.Info("RemoveConsumer StreamId={0} StreamProvider={1}", streamId, providerName);
+            logger.LogInformation("RemoveConsumer StreamId={0} StreamProvider={1}", streamId, providerName);
             if (State.ConsumerSubscriptionHandles.Count == 0) throw new InvalidOperationException("Not a Consumer");
             await subsHandle.UnsubscribeAsync();
             Observers.Remove(subsHandle);
@@ -176,7 +176,7 @@ namespace UnitTests.Grains
 
         public async Task RemoveAllConsumers()
         {
-            logger.Info("RemoveAllConsumers: State.ConsumerSubscriptionHandles.Count={0}", State.ConsumerSubscriptionHandles.Count);
+            logger.LogInformation("RemoveAllConsumers: State.ConsumerSubscriptionHandles.Count={0}", State.ConsumerSubscriptionHandles.Count);
             if (State.ConsumerSubscriptionHandles.Count == 0) throw new InvalidOperationException("Not a Consumer");
             var handles = State.ConsumerSubscriptionHandles.ToArray();
             foreach (var handle in handles)
@@ -190,7 +190,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeProducer(Guid streamId, string providerName)
         {
-            logger.Info("BecomeProducer StreamId={0} StreamProvider={1}", streamId, providerName);
+            logger.LogInformation("BecomeProducer StreamId={0} StreamProvider={1}", streamId, providerName);
             TryInitStream(streamId, providerName);
             Producer = Stream;
             State.IsProducer = true;
@@ -199,7 +199,7 @@ namespace UnitTests.Grains
 
         public async Task RemoveProducer(Guid streamId, string providerName)
         {
-            logger.Info("RemoveProducer StreamId={0} StreamProvider={1}", streamId, providerName);
+            logger.LogInformation("RemoveProducer StreamId={0} StreamProvider={1}", streamId, providerName);
             if (!State.IsProducer) throw new InvalidOperationException("Not a Producer");
             Producer = null;
             State.IsProducer = false;
@@ -208,7 +208,7 @@ namespace UnitTests.Grains
 
         public async Task ClearGrain()
         {
-            logger.Info("ClearGrain.");
+            logger.LogInformation("ClearGrain.");
             State.ConsumerSubscriptionHandles.Clear();
             State.IsProducer = false;
             Observers.Clear();
@@ -219,13 +219,13 @@ namespace UnitTests.Grains
         public Task<bool> IsConsumer()
         {
             bool isConsumer = State.ConsumerSubscriptionHandles.Count > 0;
-            logger.Info("IsConsumer={0}", isConsumer);
+            logger.LogInformation("IsConsumer={0}", isConsumer);
             return Task.FromResult(isConsumer);
         }
         public Task<bool> IsProducer()
         {
             bool isProducer = State.IsProducer;
-            logger.Info("IsProducer={0}", isProducer);
+            logger.LogInformation("IsProducer={0}", isProducer);
             return Task.FromResult(isProducer);
         }
         public Task<int> GetConsumerHandlesCount()
@@ -250,14 +250,14 @@ namespace UnitTests.Grains
         public async Task SendItem(int item)
 #endif
         {
-            logger.Info("SendItem Item={0}", item);
+            logger.LogInformation("SendItem Item={0}", item);
             await Producer.OnNextAsync(item);
         }
 
         public Task<SiloAddress> GetLocation()
         {
             SiloAddress siloAddress = Data.Address.Silo;
-            logger.Info("GetLocation SiloAddress={0}", siloAddress);
+            logger.LogInformation("GetLocation SiloAddress={0}", siloAddress);
             return Task.FromResult(siloAddress);
         }
 
@@ -269,7 +269,7 @@ namespace UnitTests.Grains
 
             if (State.Stream == null)
             {
-                logger.Info("InitStream StreamId={0} StreamProvider={1}", streamId, providerName);
+                logger.LogInformation("InitStream StreamId={0} StreamProvider={1}", streamId, providerName);
 
                 IStreamProvider streamProvider = this.GetStreamProvider(providerName);
 #if USE_GENERICS
@@ -286,7 +286,7 @@ namespace UnitTests.Grains
         private async Task ReconnectConsumerHandles(StreamSubscriptionHandle<int>[] subscriptionHandles)
 #endif
         {
-            logger.Info("ReconnectConsumerHandles SubscriptionHandles={0} Grain={1}", Utils.EnumerableToString(subscriptionHandles), this.AsReference<IStreamReliabilityTestGrain>());
+            logger.LogInformation("ReconnectConsumerHandles SubscriptionHandles={0} Grain={1}", Utils.EnumerableToString(subscriptionHandles), this.AsReference<IStreamReliabilityTestGrain>());
 
 
             foreach (var subHandle in subscriptionHandles)
@@ -329,7 +329,7 @@ namespace UnitTests.Grains
 
     //    public Task OnCompletedAsync()
     //    {
-    //        logger.Info("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
+    //        logger.LogInformation("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
     //        return Task.CompletedTask;
     //    }
 
@@ -357,19 +357,19 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger.Info(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
+            logger.LogInformation(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));
             return Task.CompletedTask;
         }
 
         public async Task Subscribe(Guid streamId, string providerName)
         {
-            logger.Info("Subscribe StreamId={0} StreamProvider={1} Grain={2}", streamId, providerName, this.AsReference<IStreamUnsubscribeTestGrain>());
+            logger.LogInformation("Subscribe StreamId={0} StreamProvider={1} Grain={2}", streamId, providerName, this.AsReference<IStreamUnsubscribeTestGrain>());
 
             State.StreamProviderName = providerName;
             if (State.Stream == null)
             {
-                logger.Info("InitStream StreamId={0} StreamProvider={1}", streamId, providerName);
+                logger.LogInformation("InitStream StreamId={0} StreamProvider={1}", streamId, providerName);
                 IStreamProvider streamProvider = this.GetStreamProvider(providerName);
                 State.Stream = streamProvider.GetStream<int>(streamId, StreamNamespace);
             }
@@ -383,7 +383,7 @@ namespace UnitTests.Grains
 
         public async Task UnSubscribeFromAllStreams()
         {
-            logger.Info("UnSubscribeFromAllStreams: State.ConsumerSubscriptionHandles.Count={0}", State.ConsumerSubscriptionHandles.Count);
+            logger.LogInformation("UnSubscribeFromAllStreams: State.ConsumerSubscriptionHandles.Count={0}", State.ConsumerSubscriptionHandles.Count);
             if (State.ConsumerSubscriptionHandles.Count == 0) throw new InvalidOperationException("Not a Consumer");
             var handles = State.ConsumerSubscriptionHandles.ToArray();
             foreach (var handle in handles)

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -69,7 +69,7 @@ namespace UnitTests.Grains
                 string excStr = String.Format("ConsumerObserver.OnNextAsync: received an item from the wrong stream." + 
                         " Got item {0} from stream = {1}, expecting stream = {2}, numConsumed={3}", 
                         item, item.StreamId, _streamId, _itemsConsumed);
-                _logger.Error(0, excStr);
+                _logger.LogError(0, excStr);
                 throw new ArgumentException(excStr);
             }
             ++_itemsConsumed;
@@ -374,7 +374,7 @@ namespace UnitTests.Grains
                     }
                     catch (Exception exc)
                     {
-                        _logger.Error(1, "StopBeingProducer: Timer Dispose() has thrown", exc);
+                        _logger.LogError(1, exc, "StopBeingProducer: Timer Dispose() has thrown");
                     }
                 }
                 _timers = null;

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -82,7 +82,7 @@ namespace UnitTests.Grains
             }
             else
             {
-                _logger.Debug(str);
+                _logger.LogDebug(str);
             }
             return Task.CompletedTask;
         }
@@ -249,7 +249,7 @@ namespace UnitTests.Grains
             }
             else
             {
-                _logger.Debug(str);
+                _logger.LogDebug(str);
             }
             return true;
         }

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -78,7 +78,7 @@ namespace UnitTests.Grains
                 _streamId, item.Data, _itemsConsumed, token != null ? ", token = " + token : "");
             if (ProducerObserver.DEBUG_STREAMING_GRAINS)
             {
-                _logger.Info(str);
+                _logger.LogInformation(str);
             }
             else
             {
@@ -89,19 +89,19 @@ namespace UnitTests.Grains
 
         public Task OnCompletedAsync()
         {            
-            _logger.Info("ConsumerObserver.OnCompletedAsync");
+            _logger.LogInformation("ConsumerObserver.OnCompletedAsync");
             return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {            
-            _logger.Info("ConsumerObserver.OnErrorAsync: ex={0}", ex);
+            _logger.LogInformation("ConsumerObserver.OnErrorAsync: ex={0}", ex);
             return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, IStreamProvider streamProvider, string streamNamespace)
         {
-            _logger.Info("BecomeConsumer");
+            _logger.LogInformation("BecomeConsumer");
             if (ProviderName != null)
                 throw new InvalidOperationException("redundant call to BecomeConsumer");
             _streamId = streamId;
@@ -115,14 +115,14 @@ namespace UnitTests.Grains
         public async Task RenewConsumer(ILogger logger, IStreamProvider streamProvider)
         {
             _logger = logger;
-            _logger.Info("RenewConsumer");
+            _logger.LogInformation("RenewConsumer");
             IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamId, _streamNamespace);
             _subscription = await stream.SubscribeAsync(this);
         }
 
         public async Task StopBeingConsumer(IStreamProvider streamProvider)
         {
-            _logger.Info("StopBeingConsumer");
+            _logger.LogInformation("StopBeingConsumer");
             if (_subscription != null)
             {
                 await _subscription.UnsubscribeAsync();
@@ -188,19 +188,19 @@ namespace UnitTests.Grains
         {
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
-            _logger.Info("BecomeProducer");
+            _logger.LogInformation("BecomeProducer");
             IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(streamId, streamNamespace);
             _observer = stream;
             var observerAsSMSProducer = _observer as SimpleMessageStreamProducer<StreamItem>;
             // only SimpleMessageStreamProducer implements IDisposable and a means to verify it was cleaned up.
             if (null == observerAsSMSProducer)
             {
-                _logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
+                _logger.LogInformation("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
                 _observerDisposedYet = true;
             }
             else
             {
-                _logger.Info("ProducerObserver.BecomeProducer: producer performs disposal during finalization.");
+                _logger.LogInformation("ProducerObserver.BecomeProducer: producer performs disposal during finalization.");
                 observerAsSMSProducer.OnDisposeTestHook += 
                     () => 
                         _observerDisposedYet = true;
@@ -215,19 +215,19 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             _logger = logger;
-            _logger.Info("RenewProducer");
+            _logger.LogInformation("RenewProducer");
             IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamId, _streamNamespace);
             _observer = stream;
             var observerAsSMSProducer = _observer as SimpleMessageStreamProducer<StreamItem>;
             // only SimpleMessageStreamProducer implements IDisposable and a means to verify it was cleaned up.
             if (null == observerAsSMSProducer)
             {
-                //_logger.Info("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
+                //_logger.LogInformation("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
                 _observerDisposedYet = true;
             }
             else
             {
-                //_logger.Info("ProducerObserver.BecomeProducer: producer performs disposal during finalization.");
+                //_logger.LogInformation("ProducerObserver.BecomeProducer: producer performs disposal during finalization.");
                 observerAsSMSProducer.OnDisposeTestHook +=
                     () =>
                         _observerDisposedYet = true;
@@ -245,7 +245,7 @@ namespace UnitTests.Grains
             string str = String.Format("ProducerObserver.ProduceItem: streamId={0}, data={1}, numProduced so far={2}.", _streamId, data, _itemsProduced);
             if (DEBUG_STREAMING_GRAINS)
             {
-                _logger.Info(str);
+                _logger.LogInformation(str);
             }
             else
             {
@@ -261,7 +261,7 @@ namespace UnitTests.Grains
             if (0 >= count)
                 throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
             _expectedItemsProduced += count;
-            _logger.Info("ProducerObserver.ProduceSequentialSeries: streamId={0}, num items to produce={1}.", _streamId, count);
+            _logger.LogInformation("ProducerObserver.ProduceSequentialSeries: streamId={0}, num items to produce={1}.", _streamId, count);
             for (var i = 1; i <= count; ++i)
                 await ProduceItem(String.Format("sequential#{0}", i));
         }
@@ -272,7 +272,7 @@ namespace UnitTests.Grains
 
             if (0 >= count)
                 throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
-            _logger.Info("ProducerObserver.ProduceParallelSeries: streamId={0}, num items to produce={1}.", _streamId, count);
+            _logger.LogInformation("ProducerObserver.ProduceParallelSeries: streamId={0}, num items to produce={1}.", _streamId, count);
             _expectedItemsProduced += count;
             var tasks = new Task<bool>[count];
             for (var i = 1; i <= count; ++i)
@@ -301,7 +301,7 @@ namespace UnitTests.Grains
         {
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
-            _logger.Info("ProducerObserver.ProducePeriodicSeries: streamId={0}, num items to produce={1}.", _streamId, count);
+            _logger.LogInformation("ProducerObserver.ProducePeriodicSeries: streamId={0}, num items to produce={1}.", _streamId, count);
             var timer = TimerState.NewTimer(createTimerFunc, ProduceItem, RemoveTimer, count);
             // we can't pass the TimerState object in as the argument-- it might be prematurely collected, so we root
             // it to this object via the _timers dictionary.
@@ -313,7 +313,7 @@ namespace UnitTests.Grains
 
         private void RemoveTimer(IDisposable handle)
         {
-            _logger.Info("ProducerObserver.RemoveTimer: streamId={0}.", _streamId);
+            _logger.LogInformation("ProducerObserver.RemoveTimer: streamId={0}.", _streamId);
             if (handle == null)
                 throw new ArgumentNullException("handle");
             if (!_timers.Remove(handle))
@@ -360,7 +360,7 @@ namespace UnitTests.Grains
 
         public Task StopBeingProducer()
         {
-            _logger.Info("StopBeingProducer");
+            _logger.LogInformation("StopBeingProducer");
             if (!_cleanedUpFlag.TrySet())
                 return Task.CompletedTask;
 
@@ -385,14 +385,14 @@ namespace UnitTests.Grains
 
         public async Task VerifyFinished()
         {
-            _logger.Info("ProducerObserver.VerifyFinished: waiting for observer disposal; streamId={0}", _streamId);
+            _logger.LogInformation("ProducerObserver.VerifyFinished: waiting for observer disposal; streamId={0}", _streamId);
             while (!_observerDisposedYet)
             {
                 await Task.Delay(1000);
                 GC.Collect();
                 GC.WaitForPendingFinalizers(); 
             }
-            _logger.Info("ProducerObserver.VerifyFinished: observer disposed; streamId={0}", _streamId);
+            _logger.LogInformation("ProducerObserver.VerifyFinished: observer disposed; streamId={0}", _streamId);
         }
 
         private class TimerState : IDisposable
@@ -476,7 +476,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("OnActivateAsync");
+            _logger.LogInformation("OnActivateAsync");
              _producers = new List<IProducerObserver>();
             _cleanedUpFlag = new InterlockedFlag();
             return Task.CompletedTask;
@@ -484,7 +484,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
@@ -573,7 +573,7 @@ namespace UnitTests.Grains
 
         public virtual Task DeactivateProducerOnIdle()
         {
-            _logger.Info("DeactivateProducerOnIdle");
+            _logger.LogInformation("DeactivateProducerOnIdle");
             DeactivateOnIdle();
             return Task.CompletedTask;
         }
@@ -588,7 +588,7 @@ namespace UnitTests.Grains
         {
             await base.OnActivateAsync();
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("OnActivateAsync");
+            _logger.LogInformation("OnActivateAsync");
             if (State.Producers == null)
             {
                 State.Producers = new List<IProducerObserver>();
@@ -606,7 +606,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             return base.OnDeactivateAsync();
         }
 
@@ -655,14 +655,14 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("OnActivateAsync");    
+            _logger.LogInformation("OnActivateAsync");    
             _observers = new List<IConsumerObserver>();
             return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
@@ -697,9 +697,9 @@ namespace UnitTests.Grains
 
         public virtual Task DeactivateConsumerOnIdle()
         {
-            _logger.Info("DeactivateConsumerOnIdle");
+            _logger.LogInformation("DeactivateConsumerOnIdle");
 
-            Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.Info("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
+            Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.LogInformation("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
             DeactivateOnIdle();
             return Task.CompletedTask;
         }
@@ -714,7 +714,7 @@ namespace UnitTests.Grains
         {
             await base.OnActivateAsync();
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("OnActivateAsync");
+            _logger.LogInformation("OnActivateAsync");
 
             if (State.Consumers == null)
             {
@@ -733,7 +733,7 @@ namespace UnitTests.Grains
 
         public override async Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             await base.OnDeactivateAsync();
         }
 
@@ -761,7 +761,7 @@ namespace UnitTests.Grains
         public override async Task OnActivateAsync()
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_Reentrant_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId) ;
-            _logger.Info("OnActivateAsync");
+            _logger.LogInformation("OnActivateAsync");
             await base.OnActivateAsync();
         }
     }
@@ -776,12 +776,12 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("OnActivateAsync");
+            _logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
         public override Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
@@ -872,7 +872,7 @@ namespace UnitTests.Grains
 
         public Task DeactivateProducerOnIdle()
         {
-            _logger.Info("DeactivateProducerOnIdle");
+            _logger.LogInformation("DeactivateProducerOnIdle");
             DeactivateOnIdle();
             return Task.CompletedTask;
         }
@@ -886,7 +886,7 @@ namespace UnitTests.Grains
         public override async Task OnActivateAsync()
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ImplicitConsumerGrain1 " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
-            _logger.Info("{0}.OnActivateAsync", GetType().FullName);    
+            _logger.LogInformation("{0}.OnActivateAsync", GetType().FullName);    
             _observers = new Dictionary<string, IConsumerObserver>();
             // discuss: Note that we need to know the provider that will be used in advance. I think it would be beneficial if we specified the provider as an argument to ImplicitConsumerActivationAttribute.
 
@@ -899,7 +899,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync()
         {
-            _logger.Info("OnDeactivateAsync");
+            _logger.LogInformation("OnDeactivateAsync");
             return Task.CompletedTask;
         }
 
@@ -954,9 +954,9 @@ namespace UnitTests.Grains
 
         public Task DeactivateConsumerOnIdle()
         {
-            _logger.Info("DeactivateConsumerOnIdle");
+            _logger.LogInformation("DeactivateConsumerOnIdle");
 
-            Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.Info("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
+            Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.LogInformation("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
             DeactivateOnIdle();
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/StressTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StressTestGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
 
             this.label = this.GetPrimaryKeyLong().ToString();
-            this.logger.Info("OnActivateAsync");
+            this.logger.LogInformation("OnActivateAsync");
 
             return Task.CompletedTask;
         }
@@ -43,7 +43,7 @@ namespace UnitTests.Grains
         {
             this.label = label;
 
-            //logger.Info("SetLabel {0} received", label);
+            //logger.LogInformation("SetLabel {0} received", label);
             return Task.CompletedTask;
         }
 
@@ -123,7 +123,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             this.label = this.GetPrimaryKeyLong().ToString();
-            this.logger.Info("OnActivateAsync");
+            this.logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
 
@@ -280,7 +280,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             this.label = this.GetPrimaryKeyLong().ToString();
-            this.logger.Info("OnActivateAsync");
+            this.logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
 

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -28,14 +28,14 @@ namespace UnitTests.Grains
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
 
             label = this.GetPrimaryKeyLong().ToString();
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             return base.OnActivateAsync();
         }
 
         public override Task OnDeactivateAsync()
         {
-            logger.Info("!!! OnDeactivateAsync");
+            logger.LogInformation("!!! OnDeactivateAsync");
             return base.OnDeactivateAsync();
         }
 
@@ -51,20 +51,20 @@ namespace UnitTests.Grains
 
         public async Task DoLongAction(TimeSpan timespan, string str)
         {
-            logger.Info("DoLongAction {0} received", str);
+            logger.LogInformation("DoLongAction {0} received", str);
             await Task.Delay(timespan);
         }
 
         public Task SetLabel(string label)
         {
             this.label = label;
-            logger.Info("SetLabel {0} received", label);
+            logger.LogInformation("SetLabel {0} received", label);
             return Task.CompletedTask;
         }
 
         public Task StartTimer()
         {
-            logger.Info("StartTimer.");
+            logger.LogInformation("StartTimer.");
             timer = base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
             
             return Task.CompletedTask;
@@ -72,7 +72,7 @@ namespace UnitTests.Grains
 
         private Task TimerTick(object data)
         {
-            logger.Info("TimerTick.");
+            logger.LogInformation("TimerTick.");
             return Task.CompletedTask;
         }
 
@@ -84,14 +84,14 @@ namespace UnitTests.Grains
             var task = Task.Factory.StartNew(() =>
             {
                 bar1 = (string) RequestContext.Get("jarjar");
-                logger.Info("bar = {0}.", bar1);
+                logger.LogInformation("bar = {0}.", bar1);
             });
 
             string bar2 = null;
             var ac = Task.Factory.StartNew(() =>
             {
                 bar2 = (string) RequestContext.Get("jarjar");
-                logger.Info("bar = {0}.", bar2);
+                logger.LogInformation("bar = {0}.", bar2);
             });
 
             await Task.WhenAll(task, ac);
@@ -172,7 +172,7 @@ namespace UnitTests.Grains
             //    throw new ArgumentException("Primary key cannot be -2 for this test case");
 
             label = this.GetPrimaryKey().ToString();
-            logger.Info("OnActivateAsync");
+            logger.LogInformation("OnActivateAsync");
 
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -51,7 +51,7 @@ namespace UnitTestGrains
 
             // make sure we run in the right activation context.
             if(!Equals(context, RuntimeContext.CurrentGrainContext))
-                logger.Error((int)ErrorCode.Runtime_Error_100146, "grain not running in the right activation context");
+                logger.LogError((int)ErrorCode.Runtime_Error_100146, "grain not running in the right activation context");
 
             string name = (string)data;
             IDisposable timer;
@@ -64,7 +64,7 @@ namespace UnitTestGrains
                 timer = allTimers[(string)data];
             }
             if(timer == null)
-                logger.Error((int)ErrorCode.Runtime_Error_100146, "Timer is null");
+                logger.LogError((int)ErrorCode.Runtime_Error_100146, "Timer is null");
             if (timer != null && counter > 10000)
             {
                 // do not let orphan timers ticking for long periods

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -47,7 +47,7 @@ namespace UnitTestGrains
         private Task Tick(object data)
         {
             counter++;
-            logger.Info(data.ToString() + " Tick # " + counter + " RuntimeContext = " + RuntimeContext.Current?.ToString());
+            logger.LogInformation(data.ToString() + " Tick # " + counter + " RuntimeContext = " + RuntimeContext.Current?.ToString());
 
             // make sure we run in the right activation context.
             if(!Equals(context, RuntimeContext.CurrentGrainContext))
@@ -157,7 +157,7 @@ namespace UnitTestGrains
 
         public Task StartTimer(string name, TimeSpan delay)
         {
-            logger.Info("StartTimer Name={0} Delay={1}", name, delay);
+            logger.LogInformation("StartTimer Name={0} Delay={1}", name, delay);
             this.timerName = name;
             this.timer = base.RegisterTimer(TimerTick, name, delay, Constants.INFINITE_TIMESPAN); // One shot timer
             return Task.CompletedTask;
@@ -165,7 +165,7 @@ namespace UnitTestGrains
 
         public Task StopTimer(string name)
         {
-            logger.Info("StopTimer Name={0}", name);
+            logger.LogInformation("StopTimer Name={0}", name);
             if (name != this.timerName)
             {
                 throw new ArgumentException(string.Format("Wrong timer name: Expected={0} Actual={1}", this.timerName, name));
@@ -252,7 +252,7 @@ namespace UnitTestGrains
 
         private void LogStatus(string what)
         {
-            logger.Info("{0} Tick # {1} - {2} - RuntimeContext.Current={3} TaskScheduler.Current={4} CurrentWorkerThread={5}",
+            logger.LogInformation("{0} Tick # {1} - {2} - RuntimeContext.Current={3} TaskScheduler.Current={4} CurrentWorkerThread={5}",
                         timerName, tickCount, what, RuntimeContext.Current, TaskScheduler.Current,
                         Thread.CurrentThread.Name);
         }

--- a/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
+++ b/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
@@ -95,13 +95,13 @@ namespace UnitTests.StorageTests
             this.Name = name;
             this.logger = loggerFactory.CreateLogger(string.Format("Storage.{0}-{1}", this.GetType().Name, this._id));
 
-            logger.Info(0, "Init Name={0}", name);
+            logger.LogInformation(0, "Init Name={0}", name);
             this.serializationManager = serializationManager;
             Interlocked.Increment(ref initCount);
 
             StateStore = new HierarchicalKeyStore(numKeys);
 
-            logger.Info(0, "Finished Init Name={0}", name);
+            logger.LogInformation(0, "Finished Init Name={0}", name);
         }
 
         public StateForTest GetProviderState()
@@ -135,7 +135,7 @@ namespace UnitTests.StorageTests
         {
             lock (StateStore)
             {
-                this.logger.Info("Setting stored value {0} for {1} to {2}", name, grainReference, val);
+                this.logger.LogInformation("Setting stored value {0} for {1} to {2}", name, grainReference, val);
                 var keys = MakeGrainStateKeys(grainType, grainReference);
                 var storedDict = StateStore.ReadRow(keys);
                 if (!storedDict.ContainsKey(stateStoreKey))
@@ -181,7 +181,7 @@ namespace UnitTests.StorageTests
 
         public virtual Task Close()
         {
-            logger.Info(0, "Close");
+            logger.LogInformation(0, "Close");
             Interlocked.Increment(ref closeCount);
             StateStore.Clear();
             return Task.CompletedTask;
@@ -189,7 +189,7 @@ namespace UnitTests.StorageTests
 
         public virtual Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            logger.Info(0, "ReadStateAsync for {0} {1}", grainType, grainReference);
+            logger.LogInformation(0, "ReadStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref readCount);
             lock (StateStore)
             {
@@ -202,7 +202,7 @@ namespace UnitTests.StorageTests
 
         public virtual Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            logger.Info(0, "WriteStateAsync for {0} {1}", grainType, grainReference);
+            logger.LogInformation(0, "WriteStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref writeCount);
             lock (StateStore)
             {
@@ -219,7 +219,7 @@ namespace UnitTests.StorageTests
 
         public virtual Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            logger.Info(0, "ClearStateAsync for {0} {1}", grainType, grainReference);
+            logger.LogInformation(0, "ClearStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref deleteCount);
             var keys = MakeGrainStateKeys(grainType, grainReference);
             lock (StateStore)

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -82,7 +82,7 @@ namespace UnitTests.MembershipTests
 
             SiloHandle silo2KillHandle = this.HostedCluster.Silos[silo2Kill];
 
-            logger.Info("\n\n\n\nAbout to kill {0}\n\n\n", silo2KillHandle.SiloAddress.Endpoint);
+            logger.LogInformation("\n\n\n\nAbout to kill {0}\n\n\n", silo2KillHandle.SiloAddress.Endpoint);
 
             if (restart)
                 await this.HostedCluster.RestartSiloAsync(silo2KillHandle);
@@ -92,7 +92,7 @@ namespace UnitTests.MembershipTests
             bool didKill = !restart;
             await this.HostedCluster.WaitForLivenessToStabilizeAsync(didKill);
 
-            logger.Info("\n\n\n\nAbout to start sending msg to grain again\n\n\n");
+            logger.LogInformation("\n\n\n\nAbout to start sending msg to grain again\n\n\n");
 
             for (int i = 0; i < numGrains; i++)
             {
@@ -103,7 +103,7 @@ namespace UnitTests.MembershipTests
             {
                 await SendTraffic(i + 1);
             }
-            logger.Info("======================================================");
+            logger.LogInformation("======================================================");
         }
 
         protected async Task Do_Liveness_OracleTest_3()
@@ -113,29 +113,29 @@ namespace UnitTests.MembershipTests
 
             await TestTraffic();
 
-            logger.Info("\n\n\n\nAbout to stop a first silo.\n\n\n");
+            logger.LogInformation("\n\n\n\nAbout to stop a first silo.\n\n\n");
             var siloToStop = this.HostedCluster.SecondarySilos[0];
             await this.HostedCluster.StopSiloAsync(siloToStop);
 
             await TestTraffic();
 
-            logger.Info("\n\n\n\nAbout to re-start a first silo.\n\n\n");
+            logger.LogInformation("\n\n\n\nAbout to re-start a first silo.\n\n\n");
             
             await this.HostedCluster.RestartStoppedSecondarySiloAsync(siloToStop.Name);
 
             await TestTraffic();
 
-            logger.Info("\n\n\n\nAbout to stop a second silo.\n\n\n");
+            logger.LogInformation("\n\n\n\nAbout to stop a second silo.\n\n\n");
             await this.HostedCluster.StopSiloAsync(moreSilos[0]);
 
             await TestTraffic();
 
-            logger.Info("======================================================");
+            logger.LogInformation("======================================================");
         }
 
         private async Task TestTraffic()
         {
-            logger.Info("\n\n\n\nAbout to start sending msg to grain again.\n\n\n");
+            logger.LogInformation("\n\n\n\nAbout to start sending msg to grain again.\n\n\n");
             // same grains
             for (int i = 0; i < numGrains; i++)
             {
@@ -163,14 +163,14 @@ namespace UnitTests.MembershipTests
             }
             catch (Exception exc)
             {
-                logger.Info("Exception making grain call: {0}", exc);
+                logger.LogInformation("Exception making grain call: {0}", exc);
                 throw;
             }
         }
 
         private async Task LogGrainIdentity(ILogger logger, ILivenessTestGrain grain)
         {
-            logger.Info("Grain {0}, activation {1} on {2}",
+            logger.LogInformation("Grain {0}, activation {1} on {2}",
                 await grain.GetGrainReference(),
                 await grain.GetUniqueId(),
                 await grain.GetRuntimeInstanceId());

--- a/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -62,14 +63,14 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ValidateControllableGeneratedStreamsTest()
         {
-            this.fixture.Logger.Info("************************ ValidateControllableGeneratedStreamsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ValidateControllableGeneratedStreamsTest *********************************");
             await ValidateControllableGeneratedStreams();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task Validate2ControllableGeneratedStreamsTest()
         {
-            this.fixture.Logger.Info("************************ Validate2ControllableGeneratedStreamsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ Validate2ControllableGeneratedStreamsTest *********************************");
             await ValidateControllableGeneratedStreams();
             await ValidateControllableGeneratedStreams();
         }

--- a/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers.Streams.Common;
@@ -52,7 +53,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task ControllableAdapterEchoTest()
         {
-            this.fixture.Logger.Info("************************ ControllableAdapterEchoTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ControllableAdapterEchoTest *********************************");
             const string echoArg = "blarg";
             await this.ControllableAdapterEchoTestRunner(ControllableTestStreamProviderCommands.AdapterEcho, echoArg);
         }
@@ -60,14 +61,14 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task ControllableAdapterFactoryEchoTest()
         {
-            this.fixture.Logger.Info("************************ ControllableAdapterFactoryEchoTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ControllableAdapterFactoryEchoTest *********************************");
             const string echoArg = "blarg";
             await this.ControllableAdapterEchoTestRunner(ControllableTestStreamProviderCommands.AdapterFactoryEcho, echoArg);
         }
 
         private async Task ControllableAdapterEchoTestRunner(ControllableTestStreamProviderCommands command, object echoArg)
         {
-            this.fixture.Logger.Info("************************ ControllableAdapterEchoTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ControllableAdapterEchoTest *********************************");
             var mgmt = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
 
             object[] results = await mgmt.SendControlCommandToProvider(this.fixture.StreamProviderTypeName, Fixture.StreamProviderName, (int)command, echoArg);

--- a/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -62,7 +63,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWithTransientErrorsTest()
         {
-            this.fixture.Logger.Info("************************ Recoverable100EventStreamsWithTransientErrorsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ Recoverable100EventStreamsWithTransientErrorsTest *********************************");
             await runner.Recoverable100EventStreamsWithTransientErrors(GenerateEvents,
                 ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.StreamNamespace,
                 TotalQueueCount,
@@ -72,7 +73,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWith1NonTransientErrorTest()
         {
-            this.fixture.Logger.Info("************************ Recoverable100EventStreamsWith1NonTransientErrorTest *********************************");
+            this.fixture.Logger.LogInformation("************************ Recoverable100EventStreamsWith1NonTransientErrorTest *********************************");
             await runner.Recoverable100EventStreamsWith1NonTransientError(GenerateEvents,
                 ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.StreamNamespace,
                 TotalQueueCount,

--- a/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -60,14 +61,14 @@ namespace Tester.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task BatchedMemoryStreamProducerOnDroppedClientTest()
         {
-            this.fixture.Logger.Info("************************ BatchedMemoryStreamProducerOnDroppedClientTest *********************************");
+            this.fixture.Logger.LogInformation("************************ BatchedMemoryStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task BatchedMemoryStreamConsumerOnDroppedClientTest()
         {
-            this.fixture.Logger.Info("************************ BatchedMemoryStreamConsumerOnDroppedClientTest *********************************");
+            this.fixture.Logger.LogInformation("************************ BatchedMemoryStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace, output,
                     null, true);
         }

--- a/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -57,14 +58,14 @@ namespace Tester.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task MemoryStreamProducerOnDroppedClientTest()
         {
-            this.fixture.Logger.Info("************************ MemoryStreamProducerOnDroppedClientTest *********************************");
+            this.fixture.Logger.LogInformation("************************ MemoryStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task MemoryStreamConsumerOnDroppedClientTest()
         {
-            this.fixture.Logger.Info("************************ MemoryStreamConsumerOnDroppedClientTest *********************************");
+            this.fixture.Logger.LogInformation("************************ MemoryStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace, output,
                     null, true);
         }

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
@@ -282,7 +282,7 @@ namespace Tester.StreamingTests
                 numProduced += await p.GetNumberProduced();
             }
             var numConsumed = await consumer.GetNumberConsumed();
-            logger.Info("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
+            logger.LogInformation("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
             if (assertIsTrue)
             {
                 Assert.Equal(numProduced, numConsumed);

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -59,14 +60,14 @@ namespace Tester.StreamingTests
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSStreamProducerOnDroppedClientTest()
         {
-            logger.Info("************************ SMSStreamProducerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ SMSStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace);
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSStreamConsumerOnDroppedClientTest()
         {
-            logger.Info("************************ SMSStreamConsumerOnDroppedClientTest *********************************");
+            logger.LogInformation("************************ SMSStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace, output);
         }
     }

--- a/test/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/test/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -57,14 +58,14 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSDeactivationTest()
         {
-            logger.Info("************************ SMSDeactivationTest *********************************");
+            logger.LogInformation("************************ SMSDeactivationTest *********************************");
             await runner.DeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSDeactivationTest_ClientConsumer()
         {
-            logger.Info("************************ SMSDeactivationTest *********************************");
+            logger.LogInformation("************************ SMSDeactivationTest *********************************");
             await runner.DeactivationTest_ClientConsumer(Guid.NewGuid(), StreamNamespace);
         }
 

--- a/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -52,42 +53,42 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSMultipleSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ SMSMultipleSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ SMSMultipleSubscriptionTest *********************************");
             await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSAddAndRemoveSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ SMSAddAndRemoveSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ SMSAddAndRemoveSubscriptionTest *********************************");
             await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSResubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ SMSResubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ SMSResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSResubscriptionAfterDeactivationTest()
         {
-            this.fixture.Logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSActiveSubscriptionTest()
         {
-            this.fixture.Logger.Info("************************ SMSActiveSubscriptionTest *********************************");
+            this.fixture.Logger.LogInformation("************************ SMSActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task SMSSubscribeFromClientTest()
         {
-            this.fixture.Logger.Info("************************ SMSSubscribeFromClientTest *********************************");
+            this.fixture.Logger.LogInformation("************************ SMSSubscribeFromClientTest *********************************");
             await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
         }
     }

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT")]
         public async Task SampleStreamingTests_1()
         {
-            this.logger.Info("************************ SampleStreamingTests_1 *********************************");
+            this.logger.LogInformation("************************ SampleStreamingTests_1 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.fixture.HostedCluster);
             await runner.StreamingTests_Consumer_Producer(Guid.NewGuid());
         }
@@ -79,7 +79,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task SampleStreamingTests_2()
         {
-            this.logger.Info("************************ SampleStreamingTests_2 *********************************");
+            this.logger.LogInformation("************************ SampleStreamingTests_2 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.fixture.HostedCluster);
             await runner.StreamingTests_Producer_Consumer(Guid.NewGuid());
         }
@@ -87,7 +87,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task SampleStreamingTests_3()
         {
-            this.logger.Info("************************ SampleStreamingTests_3 *********************************");
+            this.logger.LogInformation("************************ SampleStreamingTests_3 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.fixture.HostedCluster);
             await runner.StreamingTests_Producer_InlineConsumer(Guid.NewGuid());
         }
@@ -95,7 +95,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task MultipleImplicitSubscriptionTest()
         {
-            this.logger.Info("************************ MultipleImplicitSubscriptionTest *********************************");
+            this.logger.LogInformation("************************ MultipleImplicitSubscriptionTest *********************************");
             var streamId = Guid.NewGuid();
             const int nRedEvents = 5, nBlueEvents = 3;
 
@@ -118,7 +118,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task FilteredImplicitSubscriptionGrainTest()
         {
-            this.logger.Info($"************************ {nameof(FilteredImplicitSubscriptionGrainTest)} *********************************");
+            this.logger.LogInformation($"************************ {nameof(FilteredImplicitSubscriptionGrainTest)} *********************************");
 
             var streamNamespaces = new[] { "red1", "red2", "blue3", "blue4" };
             var events = new[] { 3, 5, 2, 4 };
@@ -149,7 +149,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task FilteredImplicitSubscriptionWithExtensionGrainTest()
         {
-            logger.Info($"************************ {nameof(FilteredImplicitSubscriptionWithExtensionGrainTest)} *********************************");
+            logger.LogInformation($"************************ {nameof(FilteredImplicitSubscriptionWithExtensionGrainTest)} *********************************");
 
             var redEvents = new[] { 3, 5, 2, 4 };
             var blueEvents = new[] { 7, 3, 6 };
@@ -269,7 +269,7 @@ namespace UnitTests.StreamingTests
         {
             var numProduced = await producer.GetNumberProduced();
             var numConsumed = await consumer.GetNumberConsumed();
-            this.logger.Info("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
+            this.logger.LogInformation("CheckCounters: numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
             if (assertIsTrue)
             {
                 Assert.Equal(numProduced, numConsumed);

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -70,7 +70,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ValidateGeneratedStreamsTest()
         {
-            this.fixture.Logger.Info("************************ ValidateGeneratedStreamsTest *********************************");
+            this.fixture.Logger.LogInformation("************************ ValidateGeneratedStreamsTest *********************************");
             await TestingUtils.WaitUntilAsync(CheckCounters, Timeout);
         }
 

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -355,25 +355,25 @@ namespace UnitTests.StreamingTests
             {
                 if (numProduced <= 0)
                 {
-                    logger.Info("numProduced <= 0: Events were not produced");
+                    logger.LogInformation("numProduced <= 0: Events were not produced");
                 }
                 if (consumerCount != numConsumed.Count)
                 {
-                    logger.Info("consumerCount != numConsumed.Count: Incorrect number of consumers. consumerCount = {0}, numConsumed.Count = {1}",
+                    logger.LogInformation("consumerCount != numConsumed.Count: Incorrect number of consumers. consumerCount = {0}, numConsumed.Count = {1}",
                         consumerCount, numConsumed.Count);
                 }
                 foreach (var consumed in numConsumed)
                 {
                     if (numProduced != consumed.Value.Item1)
                     {
-                        logger.Info("numProduced != consumed: Produced and consumed counts do not match. numProduced = {0}, consumed = {1}",
+                        logger.LogInformation("numProduced != consumed: Produced and consumed counts do not match. numProduced = {0}, consumed = {1}",
                             numProduced, consumed.Key.HandleId + " -> " + consumed.Value);
                             //numProduced, Utils.DictionaryToString(numConsumed));
                     }
                 }
                 return false;
             }
-            logger.Info("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, 
+            logger.LogInformation("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, 
                 Utils.EnumerableToString(numConsumed, kvp => kvp.Key.HandleId.ToString() + "->" +  kvp.Value.ToString()));
             return true;
         }
@@ -392,16 +392,16 @@ namespace UnitTests.StreamingTests
             {
                 if (numProduced <= 0)
                 {
-                    logger.Info("numProduced <= 0: Events were not produced");
+                    logger.LogInformation("numProduced <= 0: Events were not produced");
                 }
                 if (numProduced != numConsumed)
                 {
-                    logger.Info("numProduced != numConsumed: Produced and consumed counts do not match. numProduced = {0}, consumed = {1}",
+                    logger.LogInformation("numProduced != numConsumed: Produced and consumed counts do not match. numProduced = {0}, consumed = {1}",
                         numProduced, numConsumed);
                 }
                 return false;
             }
-            logger.Info("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
+            logger.LogInformation("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
             return true;
         }
     }

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers;
@@ -62,7 +63,7 @@ namespace Tester.StreamingTests
         {
             const int streamCount = 100;
 
-            this.fixture.Logger.Info("************************ PersistentStreamingOverSingleGatewayTest *********************************");
+            this.fixture.Logger.LogInformation("************************ PersistentStreamingOverSingleGatewayTest *********************************");
 
             // generate stream Id's
             List<Guid> streamIds = Enumerable.Range(0, streamCount)

--- a/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -95,7 +95,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             var fullGrainTypeName = typeof(IdleActivationGcTestGrain1).FullName;
 
             List<Task> tasks = new List<Task>();
-            logger.Info("ActivationCollectorForceCollection: activating {0} grains.", grainCount);
+            logger.LogInformation("ActivationCollectorForceCollection: activating {0} grains.", grainCount);
             for (var i = 0; i < grainCount; ++i)
             {
                 IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
@@ -124,7 +124,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             var fullGrainTypeName = typeof(IdleActivationGcTestGrain1).FullName;
 
             List<Task> tasks = new List<Task>();
-            logger.Info("IdleActivationCollectorShouldCollectIdleActivations: activating {0} grains.", grainCount);
+            logger.LogInformation("IdleActivationCollectorShouldCollectIdleActivations: activating {0} grains.", grainCount);
             for (var i = 0; i < grainCount; ++i)
             {
                 IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
@@ -135,7 +135,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(grainCount, activationsCreated);
 
-            logger.Info("IdleActivationCollectorShouldCollectIdleActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("IdleActivationCollectorShouldCollectIdleActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
@@ -154,7 +154,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             List<Task> tasks0 = new List<Task>();
             List<IBusyActivationGcTestGrain1> busyGrains = new List<IBusyActivationGcTestGrain1>();
-            logger.Info("ActivationCollectorShouldNotCollectBusyActivations: activating {0} busy grains.", busyGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: activating {0} busy grains.", busyGrainCount);
             for (var i = 0; i < busyGrainCount; ++i)
             {
                 IBusyActivationGcTestGrain1 g = this.testCluster.GrainFactory.GetGrain<IBusyActivationGcTestGrain1>(Guid.NewGuid());
@@ -166,7 +166,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             Func<Task> busyWorker =
                 async () =>
                 {
-                    logger.Info("ActivationCollectorShouldNotCollectBusyActivations: busyWorker started");
+                    logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: busyWorker started");
                     List<Task> tasks1 = new List<Task>();
                     while (!quit[0])
                     {
@@ -177,7 +177,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 };
             Task.Run(busyWorker).Ignore();
 
-            logger.Info("ActivationCollectorShouldNotCollectBusyActivations: activating {0} idle grains.", idleGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: activating {0} idle grains.", idleGrainCount);
             tasks0.Clear();
             for (var i = 0; i < idleGrainCount; ++i)
             {
@@ -189,7 +189,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory, busyGrainTypeName);
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
-            logger.Info("ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
@@ -214,7 +214,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             List<Task> tasks0 = new List<Task>();
             List<IBusyActivationGcTestGrain1> busyGrains = new List<IBusyActivationGcTestGrain1>();
-            logger.Info("ManualCollectionShouldNotCollectBusyActivations: activating {0} busy grains.", busyGrainCount);
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {0} busy grains.", busyGrainCount);
             for (var i = 0; i < busyGrainCount; ++i)
             {
                 IBusyActivationGcTestGrain1 g = this.testCluster.GrainFactory.GetGrain<IBusyActivationGcTestGrain1>(Guid.NewGuid());
@@ -226,7 +226,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             Func<Task> busyWorker =
                 async () =>
                 {
-                    logger.Info("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
+                    logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
                     List<Task> tasks1 = new List<Task>();
                     while (!quit[0])
                     {
@@ -237,7 +237,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 };
             Task.Run(busyWorker).Ignore();
 
-            logger.Info("ManualCollectionShouldNotCollectBusyActivations: activating {0} idle grains.", idleGrainCount);
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {0} idle grains.", idleGrainCount);
             tasks0.Clear();
             for (var i = 0; i < idleGrainCount; ++i)
             {
@@ -249,16 +249,16 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory, busyGrainTypeName);
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
-            logger.Info("ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", shortIdleTimeout.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", shortIdleTimeout.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(shortIdleTimeout);
 
             TimeSpan everything = TimeSpan.FromMinutes(10);
-            logger.Info("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {0} sec).",  everything.TotalSeconds);
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {0} sec).",  everything.TotalSeconds);
             IManagementGrain mgmtGrain = this.testCluster.GrainFactory.GetGrain<IManagementGrain>(0);
             await mgmtGrain.ForceActivationCollection(everything);
             
 
-            logger.Info("ManualCollectionShouldNotCollectBusyActivations: waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
@@ -281,7 +281,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             var fullGrainTypeName = typeof(IdleActivationGcTestGrain2).FullName;
 
             List<Task> tasks = new List<Task>();
-            logger.Info("ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: activating {0} grains.", grainCount);
+            logger.LogInformation("ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: activating {0} grains.", grainCount);
             for (var i = 0; i < grainCount; ++i)
             {
                 IIdleActivationGcTestGrain2 g = this.testCluster.GrainFactory.GetGrain<IIdleActivationGcTestGrain2>(Guid.NewGuid());
@@ -292,7 +292,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(grainCount, activationsCreated);
 
-            logger.Info("ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
@@ -313,7 +313,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             List<Task> tasks0 = new List<Task>();
             List<IBusyActivationGcTestGrain2> busyGrains = new List<IBusyActivationGcTestGrain2>();
-            logger.Info("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {0} busy grains.", busyGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {0} busy grains.", busyGrainCount);
             for (var i = 0; i < busyGrainCount; ++i)
             {
                 IBusyActivationGcTestGrain2 g = this.testCluster.GrainFactory.GetGrain<IBusyActivationGcTestGrain2>(Guid.NewGuid());
@@ -325,7 +325,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             Func<Task> busyWorker =
                 async () =>
                 {
-                    logger.Info("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: busyWorker started");
+                    logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: busyWorker started");
                     List<Task> tasks1 = new List<Task>();
                     while (!quit[0])
                     {
@@ -336,7 +336,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 };
             Task.Run(busyWorker).Ignore();
 
-            logger.Info("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {0} idle grains.", idleGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {0} idle grains.", idleGrainCount);
             tasks0.Clear();
             for (var i = 0; i < idleGrainCount; ++i)
             {
@@ -348,7 +348,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory, busyGrainTypeName);
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
-            logger.Info("IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain2).
@@ -402,7 +402,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     await g.Delay(DEFAULT_IDLE_TIMEOUT.Divide(2));
                     // identify the activation and record whether it matches the activation ID last reported. it probably won't match in the beginning but should always converge on a match as other activations get collected.
                     string aid = await g.IdentifyActivation();
-                    logger.Info("ActivationCollectorShouldNotCollectBusyStatelessWorkers: identified {0}", aid);
+                    logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: identified {0}", aid);
                     matched[index] = aid == activationIds[index];
                     activationIds[index] = aid;
                 };
@@ -410,7 +410,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 async () =>
                 {
                     // (part of) 4. periodically send a message to each grain...
-                    logger.Info("ActivationCollectorShouldNotCollectBusyStatelessWorkers: busyWorker started");
+                    logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: busyWorker started");
 
                     List<Task> tasks1 = new List<Task>();
                     while (!quit[0])
@@ -433,7 +433,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             for (int i = 0; i < 2; ++i)
             {
                 // 2. activate a set of grains... 
-                this.logger.Info("ActivationCollectorShouldNotCollectBusyStatelessWorkers: activating {0} stateless worker grains (run #{1}).", grainCount, i);
+                this.logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: activating {0} stateless worker grains (run #{1}).", grainCount, i);
                 foreach (var g in grains)
                 {
                     for (int j = 0; j < burstLength; ++j)
@@ -450,11 +450,11 @@ namespace UnitTests.ActivationsLifeCycleTests
                 Assert.True(activationsCreated > grainCount, string.Format("more than {0} activations should have been created; got {1} instead", grainCount, activationsCreated));
 
                 // 4. periodically send a message to each grain...
-                this.logger.Info("ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; sending heartbeat to {0} stateless worker grains.", grainCount);
+                this.logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; sending heartbeat to {0} stateless worker grains.", grainCount);
                 Task workerTask = Task.Run(workerFunc);
 
                 // 5. wait long enough for idle activations to be collected.
-                this.logger.Info("ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+                this.logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
                 await Task.Delay(WAIT_TIME);
 
                 // 6. verify that only one activation is still active per grain.
@@ -488,7 +488,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             List<Task> tasks0 = new List<Task>();
             List<IBusyActivationGcTestGrain1> busyGrains = new List<IBusyActivationGcTestGrain1>();
-            logger.Info("ActivationCollectorShouldNotCauseMessageLoss: activating {0} busy grains.", busyGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCauseMessageLoss: activating {0} busy grains.", busyGrainCount);
             for (var i = 0; i < busyGrainCount; ++i)
             {
                 IBusyActivationGcTestGrain1 g = this.testCluster.GrainFactory.GetGrain<IBusyActivationGcTestGrain1>(Guid.NewGuid());
@@ -498,7 +498,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             await busyGrains[0].EnableBurstOnCollection(burstCount);
 
-            logger.Info("ActivationCollectorShouldNotCauseMessageLoss: activating {0} idle grains.", idleGrainCount);
+            logger.LogInformation("ActivationCollectorShouldNotCauseMessageLoss: activating {0} idle grains.", idleGrainCount);
             tasks0.Clear();
             for (var i = 0; i < idleGrainCount; ++i)
             {
@@ -510,7 +510,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory, busyGrainTypeName);
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
-            logger.Info("ActivationCollectorShouldNotCauseMessageLoss: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ActivationCollectorShouldNotCauseMessageLoss: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             await Task.Delay(WAIT_TIME);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
@@ -534,7 +534,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             var fullGrainTypeName = typeof(CollectionSpecificAgeLimitForTenSecondsActivationGcTestGrain).FullName;
 
             List<Task> tasks = new List<Task>();
-            logger.Info("ActivationCollectorShouldCollectByCollectionSpecificAgeLimit: activating {0} grains.", grainCount);
+            logger.LogInformation("ActivationCollectorShouldCollectByCollectionSpecificAgeLimit: activating {0} grains.", grainCount);
             for (var i = 0; i < grainCount; ++i)
             {
                 ICollectionSpecificAgeLimitForTenSecondsActivationGcTestGrain g = this.testCluster.GrainFactory.GetGrain<ICollectionSpecificAgeLimitForTenSecondsActivationGcTestGrain>(Guid.NewGuid());
@@ -545,7 +545,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(grainCount, activationsCreated);
 
-            logger.Info("ActivationCollectorShouldCollectByCollectionSpecificAgeLimit: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+            logger.LogInformation("ActivationCollectorShouldCollectByCollectionSpecificAgeLimit: grains activated; waiting {0} sec (activation GC idle timeout is {1} sec).", WAIT_TIME.TotalSeconds, DEFAULT_IDLE_TIMEOUT.TotalSeconds);
             
             // Some time is required for GC to collect all of the Grains)
             await Task.Delay(waitTime);

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -126,7 +126,7 @@ namespace UnitTests.StorageTests
             }
             catch (Exception exc)
             {
-                logger.Warn(0, "Injected error during ReadStateAsync for {0} {1} Exception = {2}", grainType, grainReference, exc);
+                logger.LogWarning(0, "Injected error during ReadStateAsync for {0} {1} Exception = {2}", grainType, grainReference, exc);
                 throw;
             }
         }
@@ -142,7 +142,7 @@ namespace UnitTests.StorageTests
             }
             catch (Exception exc)
             {
-                logger.Warn(0, "Injected error during WriteStateAsync for {0} {1} Exception = {2}", grainType, grainReference, exc);
+                logger.LogWarning(0, "Injected error during WriteStateAsync for {0} {1} Exception = {2}", grainType, grainReference, exc);
                 throw;
             }
         }

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -97,12 +97,12 @@ namespace UnitTests.StorageTests
         public void SetErrorInjection(ErrorInjectionBehavior errorInject)
         {
             ErrorInjection = errorInject;
-            logger.Info(0, "Set ErrorInjection to {0}", ErrorInjection);
+            logger.LogInformation(0, "Set ErrorInjection to {0}", ErrorInjection);
         }
         
         public async override Task Close()
         {
-            logger.Info(0, "Close ErrorInjection={0}", ErrorInjection);
+            logger.LogInformation(0, "Close ErrorInjection={0}", ErrorInjection);
             try
             {
                 SetErrorInjection(ErrorInjectionBehavior.None);
@@ -117,7 +117,7 @@ namespace UnitTests.StorageTests
 
         public async override Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            logger.Info(0, "ReadStateAsync for {0} {1} ErrorInjection={2}", grainType, grainReference, ErrorInjection);
+            logger.LogInformation(0, "ReadStateAsync for {0} {1} ErrorInjection={2}", grainType, grainReference, ErrorInjection);
             try
             {
                 ThrowIfMatches(ErrorInjectionPoint.BeforeRead);
@@ -133,7 +133,7 @@ namespace UnitTests.StorageTests
 
         public async override Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            logger.Info(0, "WriteStateAsync for {grainType} {grainReference} ErrorInjection={errorInjection}", grainType, grainReference, ErrorInjection);
+            logger.LogInformation(0, "WriteStateAsync for {grainType} {grainReference} ErrorInjection={errorInjection}", grainType, grainReference, ErrorInjection);
             try
             {
                 ThrowIfMatches(ErrorInjectionPoint.BeforeWrite);

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -110,7 +110,7 @@ namespace UnitTests.StorageTests
             }
             catch (Exception exc)
             {
-                logger.Error(0, "Unexpected error during Close", exc);
+                logger.LogError(0, exc, "Unexpected error during Close");
                 throw;
             }
         }

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -104,7 +105,7 @@ namespace UnitTests.General
                 VerificationScenario(PickKey(fail.SiloAddress)); // fail.SiloAddress.GetConsistentHashCode());
             }
 
-            logger.Info("FailureTest {0}, Code {1}, Stopping silos: {2}", numOfFailures, failCode, Utils.EnumerableToString(failures, handle => handle.SiloAddress.ToString()));
+            logger.LogInformation("FailureTest {0}, Code {1}, Stopping silos: {2}", numOfFailures, failCode, Utils.EnumerableToString(failures, handle => handle.SiloAddress.ToString()));
             List<uint> keysToTest = new List<uint>();
             foreach (SiloHandle fail in failures) // verify before failure
             {
@@ -136,7 +137,7 @@ namespace UnitTests.General
 
         private async Task JoinTest(int numOfJoins)
         {
-            logger.Info("JoinTest {0}", numOfJoins);
+            logger.LogInformation("JoinTest {0}", numOfJoins);
             await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos - numOfJoins);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
@@ -159,7 +160,7 @@ namespace UnitTests.General
             List<SiloHandle> joins = null;
 
             // kill a silo and join a new one in parallel
-            logger.Info("Killing silo {0} and joining a silo", failures[0].SiloAddress);
+            logger.LogInformation("Killing silo {0} and joining a silo", failures[0].SiloAddress);
             
             var tasks = new Task[2]
             {
@@ -189,7 +190,7 @@ namespace UnitTests.General
             List<SiloHandle> joins = null;
 
             // kill a silo and join a new one in parallel
-            logger.Info("Killing secondary silo {0} and joining a silo", fail.SiloAddress);
+            logger.LogInformation("Killing secondary silo {0} and joining a silo", fail.SiloAddress);
             var tasks = new Task[2]
             {
                 Task.Factory.StartNew(() => this.HostedCluster.StopSiloAsync(fail)),
@@ -356,10 +357,10 @@ namespace UnitTests.General
             {
                 ids.Add(siloHandle.SiloAddress.GetConsistentHashCode(), siloHandle.SiloAddress);
             }
-            logger.Info("{0} list of silos: ", msg);
+            logger.LogInformation("{0} list of silos: ", msg);
             foreach (var id in ids.Keys.ToList())
             {
-                logger.Info("{0} -> {1}", ids[id], id);
+                logger.LogInformation("{0} -> {1}", ids[id], id);
             }
         }
 

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -45,50 +46,50 @@ namespace UnitTests.General
         public async Task ElasticityTest_CatchingUp()
         {
 
-            logger.Info("\n\n\n----- Phase 1 -----\n\n");
+            logger.LogInformation("\n\n\n----- Phase 1 -----\n\n");
             AddTestGrains(perSilo).Wait();
             AddTestGrains(perSilo).Wait();
 
             var activationCounts = await GetPerSiloActivationCounts();
             LogCounts(activationCounts);
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             AssertIsInRange(activationCounts[this.HostedCluster.Primary], perSilo, leavy);
             AssertIsInRange(activationCounts[this.HostedCluster.SecondarySilos.First()], perSilo, leavy);
 
             SiloHandle silo3 = this.HostedCluster.StartAdditionalSilo();
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
-            logger.Info("\n\n\n----- Phase 2 -----\n\n");
+            logger.LogInformation("\n\n\n----- Phase 2 -----\n\n");
             await AddTestGrains(perSilo);
             await AddTestGrains(perSilo);
             await AddTestGrains(perSilo);
             await AddTestGrains(perSilo);
 
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             activationCounts = await GetPerSiloActivationCounts();
             LogCounts(activationCounts);
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             double expected = (6.0 * perSilo) / 3.0;
             AssertIsInRange(activationCounts[this.HostedCluster.Primary], expected, leavy);
             AssertIsInRange(activationCounts[this.HostedCluster.SecondarySilos.First()], expected, leavy);
             AssertIsInRange(activationCounts[silo3], expected, leavy);
 
-            logger.Info("\n\n\n----- Phase 3 -----\n\n");
+            logger.LogInformation("\n\n\n----- Phase 3 -----\n\n");
             await AddTestGrains(perSilo);
             await AddTestGrains(perSilo);
             await AddTestGrains(perSilo);
 
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             activationCounts = await GetPerSiloActivationCounts();
             LogCounts(activationCounts);
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             expected = (9.0 * perSilo) / 3.0;
             AssertIsInRange(activationCounts[this.HostedCluster.Primary], expected, leavy);
             AssertIsInRange(activationCounts[this.HostedCluster.SecondarySilos.First()], expected, leavy);
             AssertIsInRange(activationCounts[silo3], expected, leavy);
 
-            logger.Info("-----------------------------------------------------------------");
-            logger.Info("Test finished OK. Expected per silo = {0}", expected);
+            logger.LogInformation("-----------------------------------------------------------------");
+            logger.LogInformation("Test finished OK. Expected per silo = {0}", expected);
         }
 
         /// <summary>
@@ -108,9 +109,9 @@ namespace UnitTests.General
             await AddTestGrains(perSilo);
 
             var activationCounts = await GetPerSiloActivationCounts();
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             LogCounts(activationCounts);
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             AssertIsInRange(activationCounts[this.HostedCluster.Primary], perSilo, stopLeavy);
             AssertIsInRange(activationCounts[this.HostedCluster.SecondarySilos.First()], perSilo, stopLeavy);
             AssertIsInRange(activationCounts[runtimes[0]], perSilo, stopLeavy);
@@ -121,16 +122,16 @@ namespace UnitTests.General
             await InvokeAllGrains();
 
             activationCounts = await GetPerSiloActivationCounts();
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             LogCounts(activationCounts);
-            logger.Info("-----------------------------------------------------------------");
+            logger.LogInformation("-----------------------------------------------------------------");
             double expected = perSilo * 1.33;
             AssertIsInRange(activationCounts[this.HostedCluster.Primary], expected, stopLeavy);
             AssertIsInRange(activationCounts[this.HostedCluster.SecondarySilos.First()], expected, stopLeavy);
             AssertIsInRange(activationCounts[runtimes[1]], expected, stopLeavy);
 
-            logger.Info("-----------------------------------------------------------------");
-            logger.Info("Test finished OK. Expected per silo = {0}", expected);
+            logger.LogInformation("-----------------------------------------------------------------");
+            logger.LogInformation("Test finished OK. Expected per silo = {0}", expected);
         }
 
         /// <summary>
@@ -225,7 +226,7 @@ namespace UnitTests.General
             string assertMsg)
         {
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            logger.Info("********************** Starting the test {0} ******************************", name);
+            logger.LogInformation("********************** Starting the test {0} ******************************", name);
             var taintedSilo = this.HostedCluster.StartAdditionalSilo();
 
             const long sampleSize = 10;
@@ -251,7 +252,7 @@ namespace UnitTests.General
             finally
             {
                 // i don't know if this necessary but to be safe, i'll restore the silo's desirability.
-                logger.Info("********************** Finalizing the test {0} ******************************", name);
+                logger.LogInformation("********************** Finalizing the test {0} ******************************", name);
                 restore(taintedGrain).Wait();
             }
 
@@ -310,7 +311,7 @@ namespace UnitTests.General
                 activationCounts.TryGetValue(silo, out count);
                 sb.AppendLine($"{silo.Name}.ActivationCount = {count}");
             }
-            logger.Info(sb.ToString());
+            logger.LogInformation(sb.ToString());
         }
     }
 }

--- a/test/TesterInternal/General/GrainPlacementTests.cs
+++ b/test/TesterInternal/General/GrainPlacementTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -44,7 +45,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Placement"), TestCategory("Functional")]
         public async Task DefaultPlacementShouldBeRandom()
         {
-            logger.Info("********************** Starting the test DefaultPlacementShouldBeRandom ******************************");
+            logger.LogInformation("********************** Starting the test DefaultPlacementShouldBeRandom ******************************");
             TestSilosStarted(2);
 
             var actual = await GrainFactory.GetGrain<IDefaultPlacementGrain>(GetRandomGrainId()).GetDefaultPlacement();
@@ -55,10 +56,10 @@ namespace UnitTests.General
         public async Task RandomlyPlacedGrainShouldPlaceActivationsRandomly()
         {
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            logger.Info("********************** Starting the test RandomlyPlacedGrainShouldPlaceActivationsRandomly ******************************");
+            logger.LogInformation("********************** Starting the test RandomlyPlacedGrainShouldPlaceActivationsRandomly ******************************");
             TestSilosStarted(2);
 
-            logger.Info("********************** TestSilosStarted passed OK. ******************************");
+            logger.LogInformation("********************** TestSilosStarted passed OK. ******************************");
             
             var grains =
                 Enumerable.Range(0, 20).
@@ -77,7 +78,7 @@ namespace UnitTests.General
         //public void PreferLocalPlacedGrainShouldPlaceActivationsLocally_OneHop()
         //{
         //    HostedCluster.WaitForLivenessToStabilize();
-        //    logger.Info("********************** Starting the test PreferLocalPlacedGrainShouldPlaceActivationsLocally ******************************");
+        //    logger.LogInformation("********************** Starting the test PreferLocalPlacedGrainShouldPlaceActivationsLocally ******************************");
         //    TestSilosStarted(2);
 
         //    int numGrains = 20;
@@ -92,7 +93,7 @@ namespace UnitTests.General
         //    foreach (int key in Enumerable.Range(0, numGrains))
         //    {
         //        string preferLocal = preferLocalGrainPlaces.ElementAt(key);
-        //        logger.Info(preferLocal);
+        //        logger.LogInformation(preferLocal);
         //    }
         //}
 
@@ -100,7 +101,7 @@ namespace UnitTests.General
         public async Task PreferLocalPlacedGrainShouldPlaceActivationsLocally_TwoHops()
         {
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            logger.Info("********************** Starting the test PreferLocalPlacedGrainShouldPlaceActivationsLocally ******************************");
+            logger.LogInformation("********************** Starting the test PreferLocalPlacedGrainShouldPlaceActivationsLocally ******************************");
             TestSilosStarted(2);
 
             int numGrains = 20;
@@ -153,7 +154,7 @@ namespace UnitTests.General
         /*public async Task LocallyPlacedGrainShouldCreateSpecifiedNumberOfMultipleActivations()
         {
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            logger.Info("********************** Starting the test LocallyPlacedGrainShouldCreateSpecifiedNumberOfMultipleActivations ******************************");
+            logger.LogInformation("********************** Starting the test LocallyPlacedGrainShouldCreateSpecifiedNumberOfMultipleActivations ******************************");
             TestSilosStarted(2);
 
             // note: this amount should agree with both the specified minimum and maximum in the StatelessWorkerPlacement attribute
@@ -168,7 +169,7 @@ namespace UnitTests.General
         public async Task LocallyPlacedGrainShouldCreateActivationsOnLocalSilo()
         {
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            logger.Info("********************** Starting the test LocallyPlacedGrainShouldCreateActivationsOnLocalSilo ******************************");
+            logger.LogInformation("********************** Starting the test LocallyPlacedGrainShouldCreateActivationsOnLocalSilo ******************************");
             TestSilosStarted(2);
 
             const int sampleSize = 5;
@@ -296,7 +297,7 @@ namespace UnitTests.General
             Dictionary<SiloAddress, SiloStatus> statuses = mgmtGrain.GetHosts(onlyActive: true).Result;
             foreach (var pair in statuses)
             {
-                logger.Info("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
+                logger.LogInformation("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
                 Assert.Equal(
                     SiloStatus.Active,
                     pair.Value);

--- a/test/TesterInternal/General/LoadSheddingTest.cs
+++ b/test/TesterInternal/General/LoadSheddingTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -64,10 +65,10 @@ namespace UnitTests.General
         {
             ISimpleGrain grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), SimpleGrain.SimpleGrainNamePrefix);
 
-            this.fixture.Logger.Info("Acquired grain reference");
+            this.fixture.Logger.LogInformation("Acquired grain reference");
 
             await grain.SetA(1);
-            this.fixture.Logger.Info("First set succeeded");
+            this.fixture.Logger.LogInformation("First set succeeded");
 
             var latchPeriod = TimeSpan.FromSeconds(1);
             await this.HostedCluster.Client.GetTestHooks(this.HostedCluster.Primary).LatchIsOverloaded(true, latchPeriod);
@@ -78,13 +79,13 @@ namespace UnitTests.General
 
             await Task.Delay(latchPeriod.Multiply(1.1)); // wait for latch to reset
 
-            this.fixture.Logger.Info("Second set was shed");
+            this.fixture.Logger.LogInformation("Second set was shed");
 
             await this.HostedCluster.Client.GetTestHooks(this.HostedCluster.Primary).LatchIsOverloaded(false, latchPeriod);
 
             // Simple request after overload is cleared should succeed
             await grain.SetA(4);
-            this.fixture.Logger.Info("Third set succeeded");
+            this.fixture.Logger.LogInformation("Third set succeeded");
             await Task.Delay(latchPeriod.Multiply(1.1)); // wait for latch to reset
         }
     }

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.CodeGeneration;
 using Orleans.Configuration;
@@ -160,7 +161,7 @@ namespace UnitTests.General
         {
             var grain = this.fixture.GrainFactory.GetGrain<IRequestContextTaskGrain>(1);
             Tuple<string, string> requestContext = await grain.TestRequestContext();
-            this.fixture.Logger.Info("Request Context is: " + requestContext);
+            this.fixture.Logger.LogInformation("Request Context is: " + requestContext);
             Assert.Equal("binks",  requestContext.Item1);  // "Item1=" + requestContext.Item1
             Assert.Equal("binks",  requestContext.Item2);  // "Item2=" + requestContext.Item2
         }

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -53,7 +53,7 @@ namespace UnitTests.MembershipTests
 
             this.clusterId = "test-" + Guid.NewGuid();
 
-            logger.Info("ClusterId={0}", this.clusterId);
+            logger.LogInformation("ClusterId={0}", this.clusterId);
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
@@ -130,7 +130,7 @@ namespace UnitTests.MembershipTests
             var data = await membershipTable.ReadAll();
             Assert.NotNull(data);
 
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(0, data.Members.Count);
             Assert.NotNull(data.Version.VersionEtag);
@@ -162,7 +162,7 @@ namespace UnitTests.MembershipTests
         {
             MembershipTableData data = await membershipTable.ReadAll();
 
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(0, data.Members.Count);
 
@@ -200,7 +200,7 @@ namespace UnitTests.MembershipTests
             if (extendedProtocol)
                 Assert.Equal(newTableVersion.Version, data.Version.Version);
 
-            logger.Info("Membership.ReadRow returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadRow returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(1, data.Members.Count);
             Assert.NotNull(data.Version.VersionEtag);
@@ -211,7 +211,7 @@ namespace UnitTests.MembershipTests
             }
             var membershipEntry = data.Members[0].Item1;
             string eTag = data.Members[0].Item2;
-            logger.Info("Membership.ReadRow returned MembershipEntry ETag={0} Entry={1}", eTag, membershipEntry);
+            logger.LogInformation("Membership.ReadRow returned MembershipEntry ETag={0} Entry={1}", eTag, membershipEntry);
 
             Assert.NotNull(eTag);
             Assert.NotNull(membershipEntry);
@@ -220,7 +220,7 @@ namespace UnitTests.MembershipTests
         protected async Task MembershipTable_ReadAll_Insert_ReadAll(bool extendedProtocol = true)
         {
             MembershipTableData data = await membershipTable.ReadAll();
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(0, data.Members.Count);
 
@@ -232,7 +232,7 @@ namespace UnitTests.MembershipTests
             Assert.True(ok, "InsertRow failed");
 
             data = await membershipTable.ReadAll();
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(1, data.Members.Count);
             Assert.NotNull(data.Version.VersionEtag);
@@ -245,7 +245,7 @@ namespace UnitTests.MembershipTests
 
             var membershipEntry = data.Members[0].Item1;
             string eTag = data.Members[0].Item2;
-            logger.Info("Membership.ReadAll returned MembershipEntry ETag={0} Entry={1}", eTag, membershipEntry);
+            logger.LogInformation("Membership.ReadAll returned MembershipEntry ETag={0} Entry={1}", eTag, membershipEntry);
 
             Assert.NotNull(eTag);
             Assert.NotNull(membershipEntry);
@@ -272,7 +272,7 @@ namespace UnitTests.MembershipTests
 
                 TableVersion tableVersion = tableData.Version.Next();
 
-                logger.Info("Calling InsertRow with Entry = {0} TableVersion = {1}", siloEntry, tableVersion);
+                logger.LogInformation("Calling InsertRow with Entry = {0} TableVersion = {1}", siloEntry, tableVersion);
                 bool ok = await membershipTable.InsertRow(siloEntry, tableVersion);
 
                 Assert.True(ok, "InsertRow failed");
@@ -285,7 +285,7 @@ namespace UnitTests.MembershipTests
 
                 if (extendedProtocol)
                 {
-                    logger.Info("Calling UpdateRow with Entry = {0} correct eTag = {1} old version={2}", siloEntry,
+                    logger.LogInformation("Calling UpdateRow with Entry = {0} correct eTag = {1} old version={2}", siloEntry,
                                 etagBefore, tableVersion != null ? tableVersion.ToString() : "null");
                     ok = await membershipTable.UpdateRow(siloEntry, etagBefore, tableVersion);
                     Assert.False(ok, $"row update should have failed - Table Data = {tableData}");
@@ -294,14 +294,14 @@ namespace UnitTests.MembershipTests
 
                 tableVersion = tableData.Version.Next();
 
-                logger.Info("Calling UpdateRow with Entry = {0} correct eTag = {1} correct version={2}", siloEntry,
+                logger.LogInformation("Calling UpdateRow with Entry = {0} correct eTag = {1} correct version={2}", siloEntry,
                     etagBefore, tableVersion != null ? tableVersion.ToString() : "null");
 
                 ok = await membershipTable.UpdateRow(siloEntry, etagBefore, tableVersion);
 
                 Assert.True(ok, $"UpdateRow failed - Table Data = {tableData}");
 
-                logger.Info("Calling UpdateRow with Entry = {0} old eTag = {1} old version={2}", siloEntry,
+                logger.LogInformation("Calling UpdateRow with Entry = {0} old eTag = {1} old version={2}", siloEntry,
                     etagBefore, tableVersion != null ? tableVersion.ToString() : "null");
                 ok = await membershipTable.UpdateRow(siloEntry, etagBefore, tableVersion);
                 Assert.False(ok, $"row update should have failed - Table Data = {tableData}");
@@ -316,7 +316,7 @@ namespace UnitTests.MembershipTests
 
                 if (extendedProtocol)
                 {
-                    logger.Info("Calling UpdateRow with Entry = {0} correct eTag = {1} old version={2}", siloEntry,
+                    logger.LogInformation("Calling UpdateRow with Entry = {0} correct eTag = {1} old version={2}", siloEntry,
                                 etagAfter, tableVersion != null ? tableVersion.ToString() : "null");
 
                     ok = await membershipTable.UpdateRow(siloEntry, etagAfter, tableVersion);
@@ -407,7 +407,7 @@ namespace UnitTests.MembershipTests
         protected async Task MembershipTable_CleanupDefunctSiloEntries(bool extendedProtocol = true)
         {
             MembershipTableData data = await membershipTable.ReadAll();
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(0, data.Members.Count);
 
@@ -439,7 +439,7 @@ namespace UnitTests.MembershipTests
             Assert.True(ok, "InsertRow failed");
 
             data = await membershipTable.ReadAll();
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(3, data.Members.Count);
 
@@ -447,7 +447,7 @@ namespace UnitTests.MembershipTests
             await membershipTable.CleanupDefunctSiloEntries(oldEntryDead.IAmAliveTime.AddDays(3));
 
             data = await membershipTable.ReadAll();
-            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
+            logger.LogInformation("Membership.ReadAll returned VableVersion={0} Data={1}", data.Version, data);
 
             Assert.Equal(1, data.Members.Count);
         }

--- a/test/TesterInternal/MessageScheduling/DisabledCallChainReentrancyTestRunner.cs
+++ b/test/TesterInternal/MessageScheduling/DisabledCallChainReentrancyTestRunner.cs
@@ -49,7 +49,7 @@ namespace UnitTests
             {
                 Assert.True(timeout, "Non-reentrant grain should timeout");
             }
-            this.logger.Info("Reentrancy NonReentrantGrain Test finished OK.");
+            this.logger.LogInformation("Reentrancy NonReentrantGrain Test finished OK.");
         }
 
         public void NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsFalse(bool performDeadlockDetection)
@@ -82,7 +82,7 @@ namespace UnitTests
             {
                 Assert.True(timeout, "Non-reentrant grain should timeout on stream item delivery to itself when CanInterleave predicate returns false");
             }
-            this.logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsFalse Test finished OK.");
+            this.logger.LogInformation("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsFalse Test finished OK.");
         }
 
         public void NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateReturnsFalse(bool performDeadlockDetection)
@@ -115,7 +115,7 @@ namespace UnitTests
             {
                 Assert.True(timeout, "Non-reentrant grain should timeout when MayInterleave predicate returns false");
             }
-            this.logger.Info("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateReturnsFalse Test finished OK.");
+            this.logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateReturnsFalse Test finished OK.");
         }
 
         public void UnorderedNonReentrantGrain(bool performDeadlockDetection)
@@ -149,7 +149,7 @@ namespace UnitTests
                 Assert.True(timeout, "Non-reentrant grain should timeout");
             }
 
-            this.logger.Info("Reentrancy UnorderedNonReentrantGrain Test finished OK.");
+            this.logger.LogInformation("Reentrancy UnorderedNonReentrantGrain Test finished OK.");
         }
     }
 }

--- a/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Hosting;
 using Orleans;
 using Orleans.Runtime;
@@ -66,7 +67,7 @@ namespace UnitTests
             {
                 Assert.True(false, string.Format("Unexpected exception {0}: {1}", ex.Message, ex.StackTrace));
             }
-            this.fixture.Logger.Info("Reentrancy ReentrantGrain Test finished OK.");
+            this.fixture.Logger.LogInformation("Reentrancy ReentrantGrain Test finished OK.");
         }
         
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -82,7 +83,7 @@ namespace UnitTests
             {
                 Assert.True(false, string.Format("Unexpected exception {0}: {1}", ex.Message, ex.StackTrace));
             }
-            this.fixture.Logger.Info("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateReturnsTrue Test finished OK.");
+            this.fixture.Logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateReturnsTrue Test finished OK.");
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -98,7 +99,7 @@ namespace UnitTests
             {
                 Assert.True(false, string.Format("Unexpected exception {0}: {1}", ex.Message, ex.StackTrace));
             }
-            this.fixture.Logger.Info("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_StreamItemDelivery_WhenPredicateReturnsTrue Test finished OK.");
+            this.fixture.Logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_StreamItemDelivery_WhenPredicateReturnsTrue Test finished OK.");
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -118,7 +119,7 @@ namespace UnitTests
                 Assert.True(ex.GetBaseException().InnerException?.Message == "boom",
                     "Should fail with Orleans runtime exception having all of necessary details");
             }
-            this.fixture.Logger.Info("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateThrows Test finished OK.");
+            this.fixture.Logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleavePredicate_WhenPredicateThrows Test finished OK.");
         }
         
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -134,7 +135,7 @@ namespace UnitTests
             done.Add(grain2.Ping(15));
 
             Task.WhenAll(done).Wait();
-            this.fixture.Logger.Info("ReentrancyTest_Deadlock_1 OK - no deadlock.");
+            this.fixture.Logger.LogInformation("ReentrancyTest_Deadlock_1 OK - no deadlock.");
         }
 
         // TODO: [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -148,13 +149,13 @@ namespace UnitTests
             var grain2 = this.fixture.GrainFactory.GetGrain<INonReentrantSelfManagedGrain>(2);
             grain2.SetDestination(1).Wait();
 
-            this.fixture.Logger.Info("ReentrancyTest_Deadlock_2 is about to call grain1.Ping()");
+            this.fixture.Logger.LogInformation("ReentrancyTest_Deadlock_2 is about to call grain1.Ping()");
             done.Add(grain1.Ping(15));
-            this.fixture.Logger.Info("ReentrancyTest_Deadlock_2 is about to call grain2.Ping()");
+            this.fixture.Logger.LogInformation("ReentrancyTest_Deadlock_2 is about to call grain2.Ping()");
             done.Add(grain2.Ping(15));
 
             Task.WhenAll(done).Wait();
-            this.fixture.Logger.Info("ReentrancyTest_Deadlock_2 OK - no deadlock.");
+            this.fixture.Logger.LogInformation("ReentrancyTest_Deadlock_2 OK - no deadlock.");
         }
 
         [Fact, TestCategory("Failures"), TestCategory("Tasks"), TestCategory("Reentrancy")]

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -40,7 +40,7 @@ namespace UnitTests.RemindersTest
             var serviceId = Guid.NewGuid().ToString() + "/foo";
             var clusterId = "test-" + serviceId + "/foo2";
 
-            logger.Info("ClusterId={0}", clusterId);
+            logger.LogInformation("ClusterId={0}", clusterId);
             this.clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = serviceId });
 
             this.remindersTable = this.CreateRemindersTable();

--- a/test/TesterInternal/StreamingTests/MultipleStreamsTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/MultipleStreamsTestRunner.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Streaming
 
         private void Heading(string testName)
         {
-            logger.Info("\n\n************************ {0}_{1}_{2} ********************************* \n\n", streamProviderName, testNumber, testName);
+            logger.LogInformation("\n\n************************ {0}_{1}_{2} ********************************* \n\n", streamProviderName, testNumber, testName);
         }
 
         public async Task StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(Func<bool,SiloHandle> startSiloFunc = null, Action<SiloHandle> stopSiloFunc = null)
@@ -69,7 +69,7 @@ namespace UnitTests.Streaming
 
             if (stopSiloFunc != null)
             {
-                logger.Info("\n\n\nAbout to stop silo  {0} \n\n", silo.SiloAddress);
+                logger.LogInformation("\n\n\nAbout to stop silo  {0} \n\n", silo.SiloAddress);
 
                 stopSiloFunc(silo);
 

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -40,7 +41,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task RegisterConsumerFaultTest()
         {
-            this.fixture.Logger.Info("************************ RegisterConsumerFaultTest *********************************");
+            this.fixture.Logger.LogInformation("************************ RegisterConsumerFaultTest *********************************");
             var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
@@ -66,7 +67,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task UnregisterConsumerFaultTest()
         {
-            this.fixture.Logger.Info("************************ UnregisterConsumerFaultTest *********************************");
+            this.fixture.Logger.LogInformation("************************ UnregisterConsumerFaultTest *********************************");
             var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
@@ -112,7 +113,7 @@ namespace UnitTests.StreamingTests
         [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task RegisterProducerFaultTest()
         {
-            this.fixture.Logger.Info("************************ RegisterProducerFaultTest *********************************");
+            this.fixture.Logger.LogInformation("************************ RegisterProducerFaultTest *********************************");
             var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
@@ -142,7 +143,7 @@ namespace UnitTests.StreamingTests
         [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task UnregisterProducerFaultTest()
         {
-            this.fixture.Logger.Info("************************ UnregisterProducerFaultTest *********************************");
+            this.fixture.Logger.LogInformation("************************ UnregisterProducerFaultTest *********************************");
             var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -42,7 +42,7 @@ namespace UnitTests.StreamingTests
 
         private void Heading(string testName)
         {
-            logger.Info("\n\n************************ {0} {1}_{2} ********************************* \n\n", testNumber, streamProviderName, testName);
+            logger.LogInformation("\n\n************************ {0} {1}_{2} ********************************* \n\n", testNumber, streamProviderName, testName);
         }
 
         //------------------------ One to One ----------------------//
@@ -282,7 +282,7 @@ namespace UnitTests.StreamingTests
             await TestingUtils.WaitUntilAsync(lastTry => CheckGrainsDeactivated(null, consumer, false), _timeout);
             await TestingUtils.WaitUntilAsync(lastTry => CheckGrainsDeactivated(producer, null, false), _timeout);
 
-            logger.Info("\n\n\n*******************************************************************\n\n\n");
+            logger.LogInformation("\n\n\n*******************************************************************\n\n\n");
 
             this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
             this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
@@ -306,7 +306,7 @@ namespace UnitTests.StreamingTests
         //    await UnitTestBase.WaitUntilAsync(() => CheckGrainsDeactivated(null, consumer, assertAreEqual: false), _timeout);
         //    await UnitTestBase.WaitUntilAsync(() => CheckGrainsDeactivated(producer, null, assertAreEqual: false), _timeout);
 
-        //    logger.Info("*******************************************************************");
+        //    logger.LogInformation("*******************************************************************");
         //    //await BasicTestAsync(false);
         //    //await StopProxies();
         //}
@@ -319,9 +319,9 @@ namespace UnitTests.StreamingTests
             producer = await ProducerProxy.NewProducerClientObjectsAsync(streamGuid, streamProviderName, "TestNamespace1", logger, this.client);
             this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
-            logger.Info("\n** Starting Test {0}.\n", testNumber);
+            logger.LogInformation("\n** Starting Test {0}.\n", testNumber);
             var producerCount = await producer.ProducerCount;
-            logger.Info("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
+            logger.LogInformation("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
 
             Func<bool, Task<bool>> waitUntilFunc =
                 async lastTry =>
@@ -340,9 +340,9 @@ namespace UnitTests.StreamingTests
             this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client);
             this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
-            logger.Info("\n** Starting Test {0}.\n", testNumber);
+            logger.LogInformation("\n** Starting Test {0}.\n", testNumber);
             var producerCount = await producer.ProducerCount;
-            logger.Info("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
+            logger.LogInformation("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
 
             Func<bool, Task<bool>> waitUntilFunc =
                 async lastTry =>
@@ -362,9 +362,9 @@ namespace UnitTests.StreamingTests
             this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client);
             this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
-            logger.Info("\n** Starting Test {0}.\n", testNumber);
+            logger.LogInformation("\n** Starting Test {0}.\n", testNumber);
             var producerCount = await producer.ProducerCount;
-            logger.Info("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
+            logger.LogInformation("\n** Test {0} BasicTestAsync: producerCount={1}.\n", testNumber, producerCount);
 
             Func<bool, Task<bool>> waitUntilFunc =
                 async lastTry =>
@@ -429,10 +429,10 @@ namespace UnitTests.StreamingTests
 
         public async Task BasicTestAsync(bool fullTest = true)
         {
-            logger.Info("\n** Starting Test {0} BasicTestAsync.\n", testNumber);
+            logger.LogInformation("\n** Starting Test {0} BasicTestAsync.\n", testNumber);
             var producerCount = await producer.ProducerCount;
             var consumerCount = await consumer.ConsumerCount;
-            logger.Info("\n** Test {0} BasicTestAsync: producerCount={1}, consumerCount={2}.\n", testNumber, producerCount, consumerCount);
+            logger.LogInformation("\n** Test {0} BasicTestAsync: producerCount={1}, consumerCount={2}.\n", testNumber, producerCount, consumerCount);
 
             await producer.ProduceSequentialSeries(ItemCount);
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout);
@@ -465,7 +465,7 @@ namespace UnitTests.StreamingTests
             var numProduced = await producer.ExpectedItemsProduced;
             var expectConsumed = numProduced * consumerCount;
             var numConsumed = await consumer.ItemsConsumed;
-            logger.Info("Test {0} CheckCounters: numProduced = {1}, expectConsumed = {2}, numConsumed = {3}", testNumber, numProduced, expectConsumed, numConsumed);
+            logger.LogInformation("Test {0} CheckCounters: numProduced = {1}, expectConsumed = {2}, numConsumed = {3}", testNumber, numProduced, expectConsumed, numConsumed);
             if (assertAreEqual)
             {
                 Assert.Equal(expectConsumed,  numConsumed); // String.Format("expectConsumed = {0}, numConsumed = {1}", expectConsumed, numConsumed));
@@ -484,7 +484,7 @@ namespace UnitTests.StreamingTests
             {
                 var streamId = StreamId.Create(StreamTestsConstants.DefaultStreamNamespace, streamIdGuid);
                 var actualCount = await StreamTestUtils.GetStreamPubSub(this.client).ProducerCount(new InternalStreamId(providerName, streamId));
-                logger.Info("StreamingTestRunner.AssertProducerCount: expected={0} actual (SMSStreamRendezvousGrain.ProducerCount)={1} streamId={2}", expectedCount, actualCount, streamId);
+                logger.LogInformation("StreamingTestRunner.AssertProducerCount: expected={0} actual (SMSStreamRendezvousGrain.ProducerCount)={1} streamId={2}", expectedCount, actualCount, streamId);
                 Assert.Equal(expectedCount, actualCount);
             }
         }
@@ -511,7 +511,7 @@ namespace UnitTests.StreamingTests
                 activationCount = await consumer.GetNumActivations(this.client);
             }
             var expectActivationCount = 0;
-            logger.Info(
+            logger.LogInformation(
                 "Test {testNumber} CheckGrainsDeactivated: {type}ActivationCount = {activationCount}, Expected{type}ActivationCount = {expectActivationCount}", 
                 testNumber, 
                 str, 
@@ -529,7 +529,7 @@ namespace UnitTests.StreamingTests
 
 //public async Task AQ_1_ConsumerJoinsFirstProducerLater()
 //{
-//    logger.Info("\n\n ************************ AQ_1_ConsumerJoinsFirstProducerLater ********************************* \n\n");
+//    logger.LogInformation("\n\n ************************ AQ_1_ConsumerJoinsFirstProducerLater ********************************* \n\n");
 //    streamId = StreamId.NewRandomStreamId();
 //    streamProviderName = AQ_STREAM_PROVIDER_NAME;
 //    // consumer joins first, producer later
@@ -540,7 +540,7 @@ namespace UnitTests.StreamingTests
 
 //public async Task AQ_2_ProducerJoinsFirstConsumerLater()
 //{
-//    logger.Info("\n\n ************************ AQ_2_ProducerJoinsFirstConsumerLater ********************************* \n\n");
+//    logger.LogInformation("\n\n ************************ AQ_2_ProducerJoinsFirstConsumerLater ********************************* \n\n");
 //    streamId = StreamId.NewRandomStreamId();
 //    streamProviderName = AQ_STREAM_PROVIDER_NAME;
 //    // produce joins first, consumer later
@@ -552,7 +552,7 @@ namespace UnitTests.StreamingTests
 //[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_2_ProducerJoinsFirstConsumerLater()
 //{
-//    logger.Info("\n\n ************************ StreamTest_2_ProducerJoinsFirstConsumerLater ********************************* \n\n");
+//    logger.LogInformation("\n\n ************************ StreamTest_2_ProducerJoinsFirstConsumerLater ********************************* \n\n");
 //    streamId = Guid.NewGuid();
 //    streamProviderName = StreamTest_STREAM_PROVIDER_NAME;
 //    // produce joins first, consumer later
@@ -586,13 +586,13 @@ namespace UnitTests.StreamingTests
 
 //    await producer.ProduceSequentialSeries(0, ItemsPerSeries);
 //    var numProduced = await producer.NumberProduced;
-//    logger.Info("numProduced = " + numProduced);
+//    logger.LogInformation("numProduced = " + numProduced);
 //    Assert.Equal(numProduced, ItemsPerSeries);
 
 //    // note that the value returned from successive calls to Do...Production() methods is a cumulative total.
 //    await producer.ProduceParallelSeries(ItemsPerSeries, ItemsPerSeries);
 //    numProduced = await producer.NumberProduced;
-//    logger.Info("numProduced = " + numProduced);
+//    logger.LogInformation("numProduced = " + numProduced);
 //    Assert.Equal(numProduced, ItemsPerSeries * 2);
 //}
 
@@ -602,7 +602,7 @@ namespace UnitTests.StreamingTests
 //[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_Many_5_ManyProducerGrainsOneConsumerGrain()
 //{
-//    logger.Info("\n\n ************************ StreamTest_6_ManyProducerGrainsOneConsumerGrain ********************************* \n\n");
+//    logger.LogInformation("\n\n ************************ StreamTest_6_ManyProducerGrainsOneConsumerGrain ********************************* \n\n");
 //    streamId = Guid.NewGuid();
 //    this.streamProviderName = StreamTest_STREAM_PROVIDER_NAME;
 //    var consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, streamProviderName, logger);
@@ -613,7 +613,7 @@ namespace UnitTests.StreamingTests
 //[Fact, TestCategory("BVT"), TestCategory("Streaming")]
 //public async Task StreamTest_Many6_OneProducerGrainManyConsumerGrains()
 //{
-//    logger.Info("\n\n ************************ StreamTest_7_OneProducerGrainManyConsumerGrains ********************************* \n\n");
+//    logger.LogInformation("\n\n ************************ StreamTest_7_OneProducerGrainManyConsumerGrains ********************************* \n\n");
 //    streamId = Guid.NewGuid();
 //    this.streamProviderName = StreamTest_STREAM_PROVIDER_NAME;
 //    var consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, streamProviderName, logger, Many);

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -199,7 +199,7 @@ namespace UnitTests.StreamingTests
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
                 throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
-            logger.Info("ConsumerProxy.NewConsumerGrainsAsync: multiplexing {0} consumer grains for stream {1}.", grainCount, streamId);
+            logger.LogInformation("ConsumerProxy.NewConsumerGrainsAsync: multiplexing {0} consumer grains for stream {1}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ConsumerGrain>();
             var grainFullName = typeof(Streaming_ConsumerGrain).FullName;
@@ -230,7 +230,7 @@ namespace UnitTests.StreamingTests
             int grainCount = grainIds.Length;
             if (grainCount < 1)
                 throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
-            logger.Info("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {0} consumer grains for stream {1}.", grainCount, streamId);
+            logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {0} consumer grains for stream {1}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ConsumerGrain>();
             for (var i = 0; i < grainCount; ++i)
@@ -259,7 +259,7 @@ namespace UnitTests.StreamingTests
         {
             if (consumerCount < 1)
                 throw new ArgumentOutOfRangeException("consumerCount", "argument must be 1 or greater");
-            logger.Info("ConsumerProxy.NewConsumerClientObjectsAsync: multiplexing {0} consumer client objects for stream {1}.", consumerCount, streamId);
+            logger.LogInformation("ConsumerProxy.NewConsumerClientObjectsAsync: multiplexing {0} consumer client objects for stream {1}.", consumerCount, streamId);
             var objs = new IStreaming_ConsumerGrain[consumerCount];
             for (var i = 0; i < consumerCount; ++i)
                 objs[i] = Streaming_ConsumerClientObject.NewObserver(logger, client);
@@ -395,7 +395,7 @@ namespace UnitTests.StreamingTests
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
                 throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
-            logger.Info("ProducerProxy.NewProducerGrainsAsync: multiplexing {0} producer grains for stream {1}.", grainCount, streamId);
+            logger.LogInformation("ProducerProxy.NewProducerGrainsAsync: multiplexing {0} producer grains for stream {1}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ProducerGrain>();
             var producerGrainFullName = typeof(Streaming_ProducerGrain).FullName;
@@ -426,7 +426,7 @@ namespace UnitTests.StreamingTests
             int grainCount = grainIds.Length;
             if (grainCount < 1)
                 throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
-            logger.Info("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {0} producer grains for stream {1}.", grainCount, streamId);
+            logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {0} producer grains for stream {1}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ProducerGrain>();
             for (var i = 0; i < grainCount; ++i)
@@ -458,7 +458,7 @@ namespace UnitTests.StreamingTests
             var producers = new IStreaming_ProducerGrain[producersCount];
             for (var i = 0; i < producersCount; ++i)
                 producers[i] = Streaming_ProducerClientObject.NewObserver(logger, client);
-            logger.Info("ProducerProxy.NewProducerClientObjectsAsync: multiplexing {0} producer client objects for stream {1}.", producersCount, streamId);
+            logger.LogInformation("ProducerProxy.NewProducerClientObjectsAsync: multiplexing {0} producer client objects for stream {1}.", producersCount, streamId);
             return NewProducerProxy(producers, streamId, streamProvider, streamNamespace, logger);
         }
 

--- a/test/TesterInternal/StreamingTests/StreamTestUtils.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestUtils.cs
@@ -20,14 +20,14 @@ namespace UnitTests.StreamingTests
         {
             SiloAddress primSilo = siloHost.Primary?.SiloAddress;
             SiloAddress secSilo = siloHost.SecondarySilos.FirstOrDefault()?.SiloAddress;
-            logger.Info("\n\n**START********************** {0} ********************************* \n\n"
+            logger.LogInformation("\n\n**START********************** {0} ********************************* \n\n"
                         + "Running with initial silos Primary={1} Secondary={2} StreamId={3} StreamType={4} \n\n",
                 testName, primSilo, secSilo, streamId, streamProviderName);
         }
 
         internal static void LogEndTest(string testName, ILogger logger)
         {
-            logger.Info("\n\n--END------------------------ {0} --------------------------------- \n\n", testName);
+            logger.LogInformation("\n\n--END------------------------ {0} --------------------------------- \n\n", testName);
         }
 
         internal static IStreamPubSub GetStreamPubSub(IInternalClusterClient client)

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -76,11 +76,11 @@ namespace UnitTests.TimerTests
             }
             catch (Exception exc)
             {
-                log.Info("Couldn't remove {0}, as expected. Exception received = {1}", r1, exc);
+                log.LogInformation("Couldn't remove {0}, as expected. Exception received = {1}", r1, exc);
             }
 
             await grain.StopReminder(r2);
-            log.Info("Removed reminder2 successfully");
+            log.LogInformation("Removed reminder2 successfully");
 
             // trying to see if readreminder works
             _ = await grain.StartReminder(DR);
@@ -90,27 +90,27 @@ namespace UnitTests.TimerTests
 
             IGrainReminder r = await grain.GetReminderObject(DR);
             await grain.StopReminder(r);
-            log.Info("Removed got reminder successfully");
+            log.LogInformation("Removed got reminder successfully");
         }
 
         public async Task Test_Reminders_Basic_ListOps()
         {
             Guid id = Guid.NewGuid();
-            log.Info("Start Grain Id = {0}", id);
+            log.LogInformation("Start Grain Id = {0}", id);
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(id);
             const int count = 5;
             Task<IGrainReminder>[] startReminderTasks = new Task<IGrainReminder>[count];
             for (int i = 0; i < count; i++)
             {
                 startReminderTasks[i] = grain.StartReminder(DR + "_" + i);
-                log.Info("Started {0}_{1}", DR, i);
+                log.LogInformation("Started {0}_{1}", DR, i);
             }
 
             await Task.WhenAll(startReminderTasks);
             // do comparison on strings
             List<string> registered = (from reminder in startReminderTasks select reminder.Result.ReminderName).ToList();
 
-            log.Info("Waited");
+            log.LogInformation("Waited");
 
             List<IGrainReminder> remindersList = await grain.GetRemindersList();
             List<string> fetched = (from reminder in remindersList select reminder.ReminderName).ToList();
@@ -124,7 +124,7 @@ namespace UnitTests.TimerTests
             Assert.True(fetched.Count == 0, $"More than registered reminders. Extra: {Utils.EnumerableToString(fetched)}");
 
             // do some time tests as well
-            log.Info("Time tests");
+            log.LogInformation("Time tests");
             TimeSpan period = await grain.GetReminderPeriod(DR);
             Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
             for (int i = 0; i < count; i++)
@@ -155,7 +155,7 @@ namespace UnitTests.TimerTests
 
             Thread.Sleep(period.Multiply(5));
             // start another silo ... although it will take it a while before it stabilizes
-            log.Info("Starting another silo");
+            log.LogInformation("Starting another silo");
             await this.HostedCluster.StartAdditionalSilosAsync(1, true);
 
             //Block until all tasks complete.
@@ -176,7 +176,7 @@ namespace UnitTests.TimerTests
             // for churn cases, we do execute start and stop reminders with retries as we don't have the queue-ing 
             // functionality implemented on the LocalReminderService yet
             TimeSpan period = await g.GetReminderPeriod(DR);
-            this.log.Info("PerGrainMultiReminderTestChurn Period={0} Grain={1}", period, g);
+            this.log.LogInformation("PerGrainMultiReminderTestChurn Period={0} Grain={1}", period, g);
 
             // Start Default Reminder
             //g.StartReminder(DR, file + "_" + DR).Wait();
@@ -230,7 +230,7 @@ namespace UnitTests.TimerTests
         {
             TimeSpan period = await grain.GetReminderPeriod(DR);
 
-            this.log.Info("PerGrainFailureTest Period={0} Grain={1}", period, grain);
+            this.log.LogInformation("PerGrainFailureTest Period={0} Grain={1}", period, grain);
 
             await grain.StartReminder(DR);
             TimeSpan sleepFor = period.Multiply(failCheckAfter) + LEEWAY; // giving some leeway
@@ -252,7 +252,7 @@ namespace UnitTests.TimerTests
         {
             TimeSpan period = await g.GetReminderPeriod(DR);
 
-            this.log.Info("PerGrainMultiReminderTest Period={0} Grain={1}", period, g);
+            this.log.LogInformation("PerGrainMultiReminderTest Period={0} Grain={1}", period, g);
 
             // Each reminder is started 2 periods after the previous reminder
             // once all reminders have been started, stop them every 2 periods
@@ -321,7 +321,7 @@ namespace UnitTests.TimerTests
         {
             TimeSpan period = await grain.GetReminderPeriod(DR);
 
-            this.log.Info("PerCopyGrainFailureTest Period={0} Grain={1}", period, grain);
+            this.log.LogInformation("PerCopyGrainFailureTest Period={0} Grain={1}", period, grain);
 
             await grain.StartReminder(DR);
             Thread.Sleep(period.Multiply(failCheckAfter) + LEEWAY); // giving some leeway
@@ -349,7 +349,7 @@ namespace UnitTests.TimerTests
             sb.AppendFormat(
                 " -- Expecting value in the range between {0} and {1}, and got value {2}.",
                 lowerLimit, upperLimit, val);
-            this.log.Info(sb.ToString());
+            this.log.LogInformation(sb.ToString());
 
             bool tickCountIsInsideRange = lowerLimit <= val && val <= upperLimit;
 
@@ -412,7 +412,7 @@ namespace UnitTests.TimerTests
 
             if (ex is ReminderException)
             {
-                this.log.Info("Retriable operation failed on attempt {0}: {1}", i, ex.ToString());
+                this.log.LogInformation("Retriable operation failed on attempt {0}: {1}", i, ex.ToString());
                 Thread.Sleep(TimeSpan.FromMilliseconds(10)); // sleep a bit before retrying
                 return true;
             }

--- a/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
@@ -58,7 +58,7 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_MultipleReminders()
         {
-            //log.Info(TestContext.TestName);
+            //log.LogInformation(TestContext.TestName);
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             await PerGrainMultiReminderTest(grain);
         }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -74,7 +74,7 @@ namespace Orleans.Transactions.Azure.Tests
             }
             catch (Exception exc)
             {
-                logger.LogError("Error creating CloudTableCreationClient.", exc);
+                logger.LogError(exc, "Error creating CloudTableCreationClient.");
                 throw;
             }
         }

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -52,7 +52,7 @@ namespace Orleans.Transactions.Azure.Tests
                 bool didCreate = await tableRef.CreateIfNotExistsAsync();
 
 
-                logger.Info($"{(didCreate ? "Created" : "Attached to")} Azure storage table {tableName}", (didCreate ? "Created" : "Attached to"));
+                logger.LogInformation($"{(didCreate ? "Created" : "Attached to")} Azure storage table {tableName}", (didCreate ? "Created" : "Attached to"));
                 return tableRef;
             }
             catch (Exception exc)


### PR DESCRIPTION
Part of #7025.

This PR replaces usage of Orleans legacy logging wrappers with Microsoft.Logging.Extensions.

To ease review this PR doesn't try to change logging templates, introduce named arguments nor make templates compile time constant. It will be made in following PRs.

Internal extension classes are removed.
Public one is marked with `[Obsolete]` (BC involved).