### PR TITLE
Fix SQL Server connection string

### DIFF
--- a/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -14,14 +14,13 @@ namespace UnitTests.General
 
         public override string DefaultConnectionString
         {
-            get { return @"Data Source = (localdb)\MSSQLLocalDB; Database = Master; Integrated Security = True; 
-                         Asynchronous Processing = True; Max Pool Size = 200; MultipleActiveResultSets = True"; }
+            get { return @"Data Source = (localdb)\MSSQLLocalDB; Database = Master; Integrated Security = True; Max Pool Size = 200; MultipleActiveResultSets = True"; }
         }
 
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
 
-        public override string CreateStreamTestTable { get { return "CREATE TABLE StreamingTest(Id INT NOT NULL, StreamData VARBINARY(MAX) NOT NULL);"; } }               
-               
+        public override string CreateStreamTestTable { get { return "CREATE TABLE StreamingTest(Id INT NOT NULL, StreamData VARBINARY(MAX) NOT NULL);"; } }
+
         protected override string[] SetupSqlScriptFileNames
         {
             get { return new[] {
@@ -39,12 +38,12 @@ namespace UnitTests.General
             {
                 return @"USE [Master];
                 DECLARE @fileName AS NVARCHAR(255) = CONVERT(NVARCHAR(255), SERVERPROPERTY('instancedefaultdatapath')) + N'{0}';
-                EXEC('CREATE DATABASE [{0}] ON PRIMARY 
+                EXEC('CREATE DATABASE [{0}] ON PRIMARY
                 (
-                    NAME = [{0}], 
-                    FILENAME =''' + @fileName + ''', 
-                    SIZE = 20MB, 
-                    MAXSIZE = 100MB, 
+                    NAME = [{0}],
+                    FILENAME =''' + @fileName + ''',
+                    SIZE = 20MB,
+                    MAXSIZE = 100MB,
                     FILEGROWTH = 5MB
                 )')";
             }
@@ -70,7 +69,7 @@ namespace UnitTests.General
         protected override IEnumerable<string> ConvertToExecutableBatches(string setupScript, string dataBaseName)
         {
             var batches = setupScript.Split(new[] {"GO"}, StringSplitOptions.RemoveEmptyEntries).ToList();
-            
+
             //This removes the use of recovery log in case of database crashes, which
             //improves performance to some degree, depending on usage. For non-performance testing only.
             batches.Add(string.Format("ALTER DATABASE [{0}] SET RECOVERY SIMPLE;", dataBaseName));


### PR DESCRIPTION
The newer SQL Server ADO.NET drivers do not accept
"asynchronous processing" as a parameter as it's on
by default and cannot be changed.