### PR TITLE
Fix SonarQube's "Any() should be used to test for emptiness" / Code S…

### DIFF
--- a/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -84,7 +84,7 @@ namespace Tester.AzureUtils
             AzureQueueDataManager manager = await GetTableManager(queueName);
 
             IEnumerable<QueueMessage> msgs = await manager.GetQueueMessages();
-            Assert.True(msgs == null || msgs.Count() == 0);
+            Assert.True(msgs == null || !msgs.Any());
 
             int numMsgs = 10;
             List<Task> promises = new List<Task>();

--- a/test/Grains/TestGrains/EventSourcing/ChatFormat.cs
+++ b/test/Grains/TestGrains/EventSourcing/ChatFormat.cs
@@ -18,7 +18,7 @@ namespace TestGrains
     {
         public static void Initialize(this XDocument document, DateTime timestamp, string origin)
         {
-            if (document.Nodes().Count() == 0)
+            if (!document.Nodes().Any())
             {
                 document.Add(new XComment($"This chat room was created by {origin}"));
                 document.Add(new XElement("root",

--- a/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
@@ -109,7 +109,7 @@ namespace Tester.EventSourcingTests
 
         private bool HasRunThisFirstAttribute(ITestCase testcase)
         {
-            return testcase.TestMethod.Method.GetCustomAttributes(attrname).Count() > 0;
+            return testcase.TestMethod.Method.GetCustomAttributes(attrname).Any();
         }
 
         public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "'Any()' should be used to test for emptiness" [rule](https://rules.sonarsource.com/csharp/RSPEC-1155)  in SonarQube.

Let me know if you are interested in similar contributions.

Best,
Martin

