### PR TITLE
AddDynamoDBGrainStorage - support for tokens and non-default profile names.

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -22,9 +22,9 @@ namespace Orleans.Clustering.DynamoDB
         private readonly DynamoDBGatewayOptions options;
 
         public DynamoDBGatewayListProvider(
-            ILogger<DynamoDBGatewayListProvider> logger, 
+            ILogger<DynamoDBGatewayListProvider> logger,
             IOptions<DynamoDBGatewayOptions> options,
-            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<GatewayOptions> gatewayOptions)
         {
             this.logger = logger;
@@ -40,6 +40,8 @@ namespace Orleans.Clustering.DynamoDB
                 this.options.Service,
                 this.options.AccessKey,
                 this.options.SecretKey,
+                this.options.Token,
+                this.options.ProfileName,
                 this.options.ReadCapacityUnits,
                 this.options.WriteCapacityUnits);
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -39,8 +39,15 @@ namespace Orleans.Clustering.DynamoDB
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(
+                this.logger,
+                this.options.Service,
+                this.options.AccessKey,
+                this.options.SecretKey,
+                this.options.Token,
+                this.options.ProfileName,
+                this.options.ReadCapacityUnits,
+                this.options.WriteCapacityUnits);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,
@@ -545,7 +552,7 @@ namespace Orleans.Clustering.DynamoDB
                     { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(this.clusterId) },
                 };
                 var filter = $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}";
-                
+
                 var records = await this.storage.QueryAllAsync(this.options.TableName, keys, filter, item => new SiloInstanceRecord(item));
                 var defunctRecordKeys = records.Where(r => SiloIsDefunct(r, beforeDate)).Select(r => r.GetKeys());
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
@@ -16,8 +16,12 @@ namespace Orleans.Configuration
         [Redact]
         public string SecretKey { get; set; }
 
+        public string Token { get; set; }
+
+        public string ProfileName { get; set; }
+
         /// <summary>
-        /// DynamoDB Service name 
+        /// DynamoDB Service name
         /// </summary>
         public string Service { get; set; }
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
@@ -14,8 +14,12 @@ namespace Orleans.Configuration
         /// </summary>
         public string SecretKey { get; set; }
 
+        public string Token { get; set; }
+
+        public string ProfileName { get; set; }
+
         /// <summary>
-        /// DynamoDB Service name 
+        /// DynamoDB Service name
         /// </summary>
         public string Service { get; set; }
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -24,6 +24,10 @@ namespace Orleans.Configuration
         [Redact]
         public string SecretKey { get; set; }
 
+        public string Token { get; set; }
+
+        public string ProfileName { get; set; }
+
         /// <summary>
         /// DynamoDB Service name
         /// </summary>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -84,8 +84,16 @@ namespace Orleans.Storage
 
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
-                this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
+                this.storage = new DynamoDBStorage(
+                    this.logger,
+                    this.options.Service,
+                    this.options.AccessKey,
+                    this.options.SecretKey,
+                    this.options.Token,
+                    this.options.ProfileName,
+                    this.options.ReadCapacityUnits,
+                    this.options.WriteCapacityUnits,
+                    this.options.UseProvisionedThroughput);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -15,7 +15,7 @@ namespace Orleans.Reminders.DynamoDB
     /// Implementation for IReminderTable using DynamoDB as underlying storage.
     /// </summary>
     internal class DynamoDBReminderTable : IReminderTable
-    {   
+    {
         private const string GRAIN_REFERENCE_PROPERTY_NAME = "GrainReference";
         private const string REMINDER_NAME_PROPERTY_NAME = "ReminderName";
         private const string SERVICE_ID_PROPERTY_NAME = "ServiceId";
@@ -40,9 +40,9 @@ namespace Orleans.Reminders.DynamoDB
         /// <param name="clusterOptions"></param>
         /// <param name="storageOptions"></param>
         public DynamoDBReminderTable(
-            GrainReferenceKeyStringConverter grainReferenceConverter, 
-            ILoggerFactory loggerFactory, 
-            IOptions<ClusterOptions> clusterOptions, 
+            GrainReferenceKeyStringConverter grainReferenceConverter,
+            ILoggerFactory loggerFactory,
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<DynamoDBReminderStorageOptions> storageOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
@@ -54,8 +54,15 @@ namespace Orleans.Reminders.DynamoDB
         /// <summary>Initialize current instance with specific global configuration and logger</summary>
         public Task Init()
         {
-            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(
+                this.logger,
+                this.options.Service,
+                this.options.AccessKey,
+                this.options.SecretKey,
+                this.options.Token,
+                this.options.ProfileName,
+                this.options.ReadCapacityUnits,
+                this.options.WriteCapacityUnits);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 
@@ -194,7 +201,7 @@ namespace Orleans.Reminders.DynamoDB
         }
 
         /// <summary>
-        /// Remove one row from the reminder table 
+        /// Remove one row from the reminder table
         /// </summary>
         /// <param name="grainRef"> specific grain ref to locate the row </param>
         /// <param name="reminderName"> reminder name to locate the row </param>
@@ -293,7 +300,7 @@ namespace Orleans.Reminders.DynamoDB
                 if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("UpsertRow entry = {0}, etag = {1}", entry.ToString(), entry.ETag);
 
                 await this.storage.PutEntryAsync(this.options.TableName, fields);
-                
+
                 entry.ETag = fields[ETAG_PROPERTY_NAME].N;
                 return entry.ETag;
             }

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
@@ -19,8 +19,12 @@ namespace Orleans.Configuration
         [Redact]
         public string SecretKey { get; set; }
 
+        public string Token { get; set; }
+
+        public string ProfileName { get; set; }
+
         /// <summary>
-        /// DynamoDB Service name 
+        /// DynamoDB Service name
         /// </summary>
         public string Service { get; set; }
 

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Amazon.Runtime.CredentialManagement;
 
 #if CLUSTERING_DYNAMODB
 namespace Orleans.Clustering.DynamoDB
@@ -33,6 +34,9 @@ namespace Orleans.Transactions.DynamoDB
 
         /// <summary> Secret key for this dynamoDB table </summary>
         protected string secretKey;
+
+        private readonly string token;
+        private readonly string profileName;
         private string service;
         public const int DefaultReadCapacityUnits = 10;
         public const int DefaultWriteCapacityUnits = 5;
@@ -48,6 +52,8 @@ namespace Orleans.Transactions.DynamoDB
         /// <param name="logger"></param>
         /// <param name="accessKey"></param>
         /// <param name="secretKey"></param>
+        /// <param name="token"></param>
+        /// <param name="profileName"></param>
         /// <param name="service"></param>
         /// <param name="readCapacityUnits"></param>
         /// <param name="writeCapacityUnits"></param>
@@ -57,6 +63,8 @@ namespace Orleans.Transactions.DynamoDB
             string service,
             string accessKey = "",
             string secretKey = "",
+            string token = "",
+            string profileName = "",
             int readCapacityUnits = DefaultReadCapacityUnits,
             int writeCapacityUnits = DefaultWriteCapacityUnits,
             bool useProvisionedThroughput = true)
@@ -64,6 +72,8 @@ namespace Orleans.Transactions.DynamoDB
             if (service == null) throw new ArgumentNullException(nameof(service));
             this.accessKey = accessKey;
             this.secretKey = secretKey;
+            this.token = token;
+            this.profileName = profileName;
             this.service = service;
             this.readCapacityUnits = readCapacityUnits;
             this.writeCapacityUnits = writeCapacityUnits;
@@ -104,11 +114,33 @@ namespace Orleans.Transactions.DynamoDB
                 var credentials = new BasicAWSCredentials("dummy", "dummyKey");
                 this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = this.service });
             }
+            else if (!string.IsNullOrEmpty(this.accessKey) && !string.IsNullOrEmpty(this.secretKey) && !string.IsNullOrEmpty(this.token))
+            {
+                // AWS DynamoDB instance (auth via explicit credentials and token)
+                var credentials = new SessionAWSCredentials(this.accessKey, this.secretKey, this.token);
+                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+            }
             else if (!string.IsNullOrEmpty(this.accessKey) && !string.IsNullOrEmpty(this.secretKey))
             {
                 // AWS DynamoDB instance (auth via explicit credentials)
                 var credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
                 this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+            }
+            else if (!string.IsNullOrEmpty(this.profileName))
+            {
+                // AWS DynamoDB instance (auth via explicit credentials and token found in a named profile)
+                var chain = new CredentialProfileStoreChain();
+                if (chain.TryGetAWSCredentials(this.profileName, out var credentials))
+                {
+                    var immutableCredentials = credentials.GetCredentials();
+                    var sessionCredentials = new SessionAWSCredentials(immutableCredentials.AccessKey, immutableCredentials.SecretKey, immutableCredentials.Token);
+                    this.ddbClient = new AmazonDynamoDBClient(sessionCredentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"AWS named profile '{this.profileName}' provided, but credentials could not be retrieved");
+                }
             }
             else
             {


### PR DESCRIPTION
In response to https://github.com/dotnet/orleans/issues/7077 I'm introducing two changes:

* fix which corrects situations where callers have a token accompanying:
  * `AccessKey`
  * `SecretKey`

  For more details, see: https://dotnet.github.io/orleans/docs/grains/grain_persistence/dynamodb_storage.html.

  In those cases, providing only `AccessKey` and `SecretKey` (and not the token) results in an exception. Please refer to the linked issue for more details.

  Before:

  ```csharp
  siloBuilder.AddDynamoDBGrainStorage(
    name: "profileStore",
    configureOptions: options =>
    {
        options.UseJson = true;
        options.AccessKey = "***";
        options.SecretKey = "***";
        options.Service = "***";
    });
  ```

  After:

  ```csharp
  siloBuilder.AddDynamoDBGrainStorage(
    name: "profileStore",
    configureOptions: options =>
    {
        options.UseJson = true;
        options.AccessKey = "***";
        options.SecretKey = "***";
        options.Token = "***";
        options.Service = "***";
    });
  ```

  The fix still supports scenarios where the token is not required. Then, it can simply be omitted.

* Support for non-default profile names stored in `~/.aws/credentials`. When AWS credentials are not provided either through environment variables or explicitly via options, AWS SDK falls back on credentials stored under the `default` `~/.aws/credentials` profile. In case people chose not to have the default profile in that file or use multiple profiles, using Orleans DynamoDB connectivity could be tricky. My change adds a profile name from which the credentials can be retrieved. Sample credentials file storing multiple profiles can look like this:

  ```
  [default]
  aws_access_key_id = ***
  aws_secret_access_key = ***
  aws_security_token = ***
  aws_session_expiration = ***
  aws_session_token = ***

  [sts]
  aws_access_key_id = ***
  aws_secret_access_key = ***
  aws_security_token = ***
  aws_session_expiration = ***
  aws_session_token = ***
  ```