### PR TITLE
Consolidated DynamoDBClientOptions

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
@@ -2,25 +2,8 @@
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBClusteringOptions
+    public class DynamoDBClusteringOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
         /// <summary>
         /// Read capacity unit for DynamoDB storage
         /// </summary>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
@@ -2,23 +2,8 @@
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBGatewayOptions
+    public class DynamoDBGatewayOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
         /// <summary>
         /// Read capacity unit for DynamoDB storage
         /// </summary>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
   </ItemGroup>
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -5,29 +5,12 @@ using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBStorageOptions
+    public class DynamoDBStorageOptions : DynamoDBClientOptions
     {
         /// <summary>
         /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment.
         /// </summary>
         public string ServiceId { get; set; } = string.Empty;
-
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name
-        /// </summary>
-        public string Service { get; set; }
 
         /// <summary>
         /// Use Provisioned Throughput for tables

--- a/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Storage\DynamoDBStorage.cs" Link="Storage\DynamoDBStorage.cs" />
+    <Compile Include="..\Shared\Storage\DynamoDBClientOptions.cs" Link="Storage\DynamoDBClientOptions.cs" />
     <Compile Include="..\Shared\AWSUtils.cs" Link="AWSUtils.cs" />
   </ItemGroup>
 

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
@@ -5,25 +5,8 @@ namespace Orleans.Configuration
     /// <summary>
     /// Configuration for Amazon DynamoDB reminder storage.
     /// </summary>
-    public class DynamoDBReminderStorageOptions
+    public class DynamoDBReminderStorageOptions : DynamoDBClientOptions
     {
-        /// <summary>
-        /// AccessKey string for DynamoDB Storage
-        /// </summary>
-        [Redact]
-        public string AccessKey { get; set; }
-
-        /// <summary>
-        /// Secret key for DynamoDB storage
-        /// </summary>
-        [Redact]
-        public string SecretKey { get; set; }
-
-        /// <summary>
-        /// DynamoDB Service name 
-        /// </summary>
-        public string Service { get; set; }
-
         /// <summary>
         /// Read capacity unit for DynamoDB storage
         /// </summary>

--- a/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
+++ b/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
@@ -1,0 +1,30 @@
+#if CLUSTERING_DYNAMODB
+namespace Orleans.Clustering.DynamoDB
+#elif PERSISTENCE_DYNAMODB
+namespace Orleans.Persistence.DynamoDB
+#elif REMINDERS_DYNAMODB
+namespace Orleans.Reminders.DynamoDB
+#else
+// No default namespace intentionally to cause compile errors if something is not defined
+#endif
+{
+    public class DynamoDBClientOptions
+    {
+        /// <summary>
+        /// AccessKey string for DynamoDB Storage
+        /// </summary>
+        [Redact]
+        public string AccessKey { get; set; }
+
+        /// <summary>
+        /// Secret key for DynamoDB storage
+        /// </summary>
+        [Redact]
+        public string SecretKey { get; set; }
+
+        /// <summary>
+        /// DynamoDB Service name
+        /// </summary>
+        public string Service { get; set; }
+    }
+}


### PR DESCRIPTION
In preparation for https://github.com/dotnet/orleans/pull/7082, as a result of feedback I received https://github.com/dotnet/orleans/pull/7082#pullrequestreview-659888375 and inspired by the PR referenced in the feedback: https://github.com/dotnet/orleans/pull/7019 I am first consolidating all `DynamoDBClientOptions` in order not to repeat reused properties.

In order to complete https://github.com/dotnet/orleans/pull/7082 my goal is to eventually extend `DynamoDBClientOptions` with two more properties:

* `string Token` (holding one's AWS authentication token) - this is to support DynamoDB connections requiring not only access key and secret key, but also a token. This is not supported today.
* `string ProfileName` (name of one's named profile used to authenticate with AWS) - this is to support non-default named profiles while authenticating DynamoDB clients.