### PR TITLE
Create missing OrleansQuery table in pg sql script.

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
@@ -49,6 +49,14 @@ BEGIN
 END
 $func$ LANGUAGE plpgsql;
 
+-- Predefined Orleans queries.
+CREATE TABLE OrleansQuery
+(
+    QueryKey varchar(50) NOT NULL,
+    QueryText varchar NOT NULL,
+    CONSTRAINT PK_OrleansQuery_QueryKey PRIMARY KEY(QueryKey)
+);
+
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (


### PR DESCRIPTION
Creation of missing table OrleansQuery was added to the pg sql script.