### PR TITLE
Added token to DynamoDB client configuration.

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -22,9 +22,9 @@ namespace Orleans.Clustering.DynamoDB
         private readonly DynamoDBGatewayOptions options;
 
         public DynamoDBGatewayListProvider(
-            ILogger<DynamoDBGatewayListProvider> logger, 
+            ILogger<DynamoDBGatewayListProvider> logger,
             IOptions<DynamoDBGatewayOptions> options,
-            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<GatewayOptions> gatewayOptions)
         {
             this.logger = logger;
@@ -40,6 +40,7 @@ namespace Orleans.Clustering.DynamoDB
                 this.options.Service,
                 this.options.AccessKey,
                 this.options.SecretKey,
+                this.options.Token,
                 this.options.ReadCapacityUnits,
                 this.options.WriteCapacityUnits);
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -40,7 +40,7 @@ namespace Orleans.Clustering.DynamoDB
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,
@@ -545,7 +545,7 @@ namespace Orleans.Clustering.DynamoDB
                     { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(this.clusterId) },
                 };
                 var filter = $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}";
-                
+
                 var records = await this.storage.QueryAllAsync(this.options.TableName, keys, filter, item => new SiloInstanceRecord(item));
                 var defunctRecordKeys = records.Where(r => SiloIsDefunct(r, beforeDate)).Select(r => r.GetKeys());
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -85,7 +85,7 @@ namespace Orleans.Storage
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
                 this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
+                 this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -15,7 +15,7 @@ namespace Orleans.Reminders.DynamoDB
     /// Implementation for IReminderTable using DynamoDB as underlying storage.
     /// </summary>
     internal class DynamoDBReminderTable : IReminderTable
-    {   
+    {
         private const string GRAIN_REFERENCE_PROPERTY_NAME = "GrainReference";
         private const string REMINDER_NAME_PROPERTY_NAME = "ReminderName";
         private const string SERVICE_ID_PROPERTY_NAME = "ServiceId";
@@ -40,9 +40,9 @@ namespace Orleans.Reminders.DynamoDB
         /// <param name="clusterOptions"></param>
         /// <param name="storageOptions"></param>
         public DynamoDBReminderTable(
-            GrainReferenceKeyStringConverter grainReferenceConverter, 
-            ILoggerFactory loggerFactory, 
-            IOptions<ClusterOptions> clusterOptions, 
+            GrainReferenceKeyStringConverter grainReferenceConverter,
+            ILoggerFactory loggerFactory,
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<DynamoDBReminderStorageOptions> storageOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
@@ -55,7 +55,7 @@ namespace Orleans.Reminders.DynamoDB
         public Task Init()
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 
@@ -194,7 +194,7 @@ namespace Orleans.Reminders.DynamoDB
         }
 
         /// <summary>
-        /// Remove one row from the reminder table 
+        /// Remove one row from the reminder table
         /// </summary>
         /// <param name="grainRef"> specific grain ref to locate the row </param>
         /// <param name="reminderName"> reminder name to locate the row </param>
@@ -293,7 +293,7 @@ namespace Orleans.Reminders.DynamoDB
                 if (this.logger.IsEnabled(LogLevel.Debug)) this.logger.Debug("UpsertRow entry = {0}, etag = {1}", entry.ToString(), entry.ETag);
 
                 await this.storage.PutEntryAsync(this.options.TableName, fields);
-                
+
                 entry.ETag = fields[ETAG_PROPERTY_NAME].N;
                 return entry.ETag;
             }

--- a/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
+++ b/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
@@ -26,5 +26,10 @@ namespace Orleans.Reminders.DynamoDB
         /// DynamoDB Service name
         /// </summary>
         public string Service { get; set; }
+
+        /// <summary>
+        /// Token for DynamoDB storage
+        /// </summary>
+        public string Token { get; set; }
     }
 }

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -30,7 +30,7 @@ namespace Orleans.Transactions.DynamoDB
     internal class DynamoDBStorage
     {
         private string accessKey;
-
+        private string token;
         /// <summary> Secret key for this dynamoDB table </summary>
         protected string secretKey;
         private string service;
@@ -48,6 +48,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <param name="logger"></param>
         /// <param name="accessKey"></param>
         /// <param name="secretKey"></param>
+        /// <param name="token"></param>
         /// <param name="service"></param>
         /// <param name="readCapacityUnits"></param>
         /// <param name="writeCapacityUnits"></param>
@@ -57,6 +58,7 @@ namespace Orleans.Transactions.DynamoDB
             string service,
             string accessKey = "",
             string secretKey = "",
+            string token = "",
             int readCapacityUnits = DefaultReadCapacityUnits,
             int writeCapacityUnits = DefaultWriteCapacityUnits,
             bool useProvisionedThroughput = true)
@@ -64,6 +66,7 @@ namespace Orleans.Transactions.DynamoDB
             if (service == null) throw new ArgumentNullException(nameof(service));
             this.accessKey = accessKey;
             this.secretKey = secretKey;
+            this.token = token;
             this.service = service;
             this.readCapacityUnits = readCapacityUnits;
             this.writeCapacityUnits = writeCapacityUnits;
@@ -103,6 +106,12 @@ namespace Orleans.Transactions.DynamoDB
                 // Local DynamoDB instance (for testing)
                 var credentials = new BasicAWSCredentials("dummy", "dummyKey");
                 this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = this.service });
+            }
+            else if (!string.IsNullOrEmpty(this.accessKey) && !string.IsNullOrEmpty(this.secretKey) && !string.IsNullOrEmpty(this.token))
+            {
+                // AWS DynamoDB instance (auth via explicit credentials and token)
+                var credentials = new SessionAWSCredentials(this.accessKey, this.secretKey, this.token);
+                this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
             }
             else if (!string.IsNullOrEmpty(this.accessKey) && !string.IsNullOrEmpty(this.secretKey))
             {


### PR DESCRIPTION
As a follow up to https://github.com/dotnet/orleans/pull/7083, I'm introducing tokens in dynamodb client configuration. This resolves problems where authentication relies not only on:

* access key
* secret key

but also on tokens. At the moment:

* orleans documentation does not describe such situations: https://dotnet.github.io/orleans/docs/grains/grain_persistence/dynamodb_storage.html
* token-based dynamodb authentication is not supported

This change allows for both types of authentication credentials:

* access key & secret key
* access key & secret key & token

Usage:

```csharp
siloBuilder.AddDynamoDBGrainStorage(
  name: "profileStore",
  configureOptions: options =>
  {
      options.UseJson = true;
      options.AccessKey = "***";
      options.SecretKey = "***";
      options.Token = "***";
      options.Service = "***";
  });
```

`options.Token` can simply be omitted if not needed/not present.

More details in my draft PR https://github.com/dotnet/orleans/pull/7082