### PR TITLE
Add c#9 record support to serializer

### DIFF
--- a/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
@@ -775,7 +775,7 @@ namespace Orleans.CodeGenerator.Generators
             /// <summary>
             /// Gets a value indicating whether or not this field represents a property with an accessible, non-obsolete setter. 
             /// </summary>
-            public bool IsSettableProperty => this.Property?.SetMethod != null && this.model.IsAccessible(0, this.Property.SetMethod) && !this.IsObsolete;
+            public bool IsSettableProperty => Property?.SetMethod is { } setMethod && model.IsAccessible(0, setMethod) && !setMethod.IsInitOnly && !IsObsolete;
 
             /// <summary>
             /// Gets syntax representing the type of this field.

--- a/test/DefaultCluster.Tests/SerializationTests/RoundTripSerializerTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/RoundTripSerializerTests.cs
@@ -14,6 +14,14 @@ namespace UnitTests.SerializerTests
         }
 
         [Fact]
+        public async Task Serialize_TestMethodResultRecord()
+        {
+            var grain = this.GrainFactory.GetGrain<IRoundtripSerializationGrain>(GetRandomGrainId());
+            RetVal retVal = await grain.GetRetValForParamVal(new ParamVal(42));
+            Assert.Equal(42, retVal.Value);
+        }
+
+        [Fact]
         public async Task Serialize_TestMethodResultEnum()
         {
             var grain = this.GrainFactory.GetGrain<IRoundtripSerializationGrain>(GetRandomGrainId());

--- a/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
@@ -144,7 +144,13 @@ namespace UnitTests.GrainInterfaces
         Task<CampaignEnemyTestType> GetEnemyType();
 
         Task<object> GetClosedGenericValue();
+
+        Task<RetVal> GetRetValForParamVal(ParamVal param);
     }
+
+    public record ParamVal(int Value);
+
+    public record RetVal(int Value);
 
     [Serializable]
     [Immutable]

--- a/test/Grains/TestGrainInterfaces/IsExternalInit.cs
+++ b/test/Grains/TestGrainInterfaces/IsExternalInit.cs
@@ -1,0 +1,5 @@
+namespace System.Runtime.CompilerServices
+{
+    // required for record serialization support for downlevel
+    internal static class IsExternalInit {}
+}

--- a/test/Grains/TestGrains/RoundtripSerializationGrain.cs
+++ b/test/Grains/TestGrains/RoundtripSerializationGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -20,5 +20,8 @@ namespace UnitTests.Grains
             var result = new List<ImmutableList<HashSet<Tuple<int, string>>>>();
             return Task.FromResult((object)result);
         }
+
+        // test record support
+        public Task<RetVal> GetRetValForParamVal(ParamVal param) => Task.FromResult(new RetVal(param.Value));
     }
 }


### PR DESCRIPTION
Enables support for serialization of c# 9 records for grain method return values and parameters. 

Thanks to @ReubenBond for the guiding hand. 