### PR TITLE
Add selector for the client

### DIFF
--- a/src/Orleans.Connections.Security/Security/TlsClientAuthenticationOptions.cs
+++ b/src/Orleans.Connections.Security/Security/TlsClientAuthenticationOptions.cs
@@ -5,6 +5,8 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Orleans.Connections.Security
 {
+    public delegate X509Certificate ClientCertificateSelectionCallback(object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] acceptableIssuers);
+
     public class TlsClientAuthenticationOptions
     {
         internal SslClientAuthenticationOptions Value { get; } = new SslClientAuthenticationOptions
@@ -14,6 +16,12 @@ namespace Orleans.Connections.Security
                 OrleansApplicationProtocol.Orleans1
             }
         };
+
+        public ClientCertificateSelectionCallback LocalCertificateSelectionCallback
+        {
+            get => Value.LocalCertificateSelectionCallback is null ? null : new ClientCertificateSelectionCallback(Value.LocalCertificateSelectionCallback);
+            set => Value.LocalCertificateSelectionCallback = value is null ? null : new System.Net.Security.LocalCertificateSelectionCallback(value);
+        }
 
         public X509CertificateCollection ClientCertificates
         {

--- a/src/Orleans.Connections.Security/Security/TlsOptions.cs
+++ b/src/Orleans.Connections.Security/Security/TlsOptions.cs
@@ -41,6 +41,16 @@ namespace Orleans.Connections.Security
         public Func<ConnectionContext, string, X509Certificate2> LocalServerCertificateSelector { get; set; }
 
         /// <summary>
+        /// <para>
+        /// A callback that will be invoked to dynamically select a local client certificate. This is higher priority than LocalCertificate.
+        /// </para>
+        /// <para>
+        /// If the certificate has an Extended Key Usage extension, the usages must include Client Authentication (OID 1.3.6.1.5.5.7.3.2).
+        /// </para>
+        /// </summary>
+        public Func<object, string, X509CertificateCollection, X509Certificate, string[], X509Certificate2> LocalClientCertificateSelector { get; set; }
+
+        /// <summary>
         /// Specifies the remote endpoint certificate requirements for a TLS connection. Defaults to <see cref="RemoteCertificateMode.RequireCertificate"/>.
         /// </summary>
         public RemoteCertificateMode RemoteCertificateMode { get; set; } = RemoteCertificateMode.RequireCertificate;


### PR DESCRIPTION
Adds the ability to use a certificate selector for client connections. See issue #7143 .