### PR TITLE
Avoid excessive locking on grainBucketUpdateLock in ClientMessageCenter

### DIFF
--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -15,7 +15,6 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionManager connectionManager;
         private readonly ConnectionOptions connectionOptions;
         private readonly ConnectionPreambleHelper connectionPreambleHelper;
-        private readonly SiloAddress remoteSiloAddress;
 
         public ClientOutboundConnection(
             SiloAddress remoteSiloAddress,
@@ -32,10 +31,12 @@ namespace Orleans.Runtime.Messaging
             this.connectionManager = connectionManager;
             this.connectionOptions = connectionOptions;
             this.connectionPreambleHelper = connectionPreambleHelper;
-            this.remoteSiloAddress = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));
-            this.MessageReceivedCounter = MessagingStatisticsGroup.GetMessageReceivedCounter(this.remoteSiloAddress);
-            this.MessageSentCounter = MessagingStatisticsGroup.GetMessageSendCounter(this.remoteSiloAddress);
+            this.RemoteSiloAddress = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));
+            this.MessageReceivedCounter = MessagingStatisticsGroup.GetMessageReceivedCounter(this.RemoteSiloAddress);
+            this.MessageSentCounter = MessagingStatisticsGroup.GetMessageSendCounter(this.RemoteSiloAddress);
         }
+
+        public SiloAddress RemoteSiloAddress { get; }
 
         protected override ConnectionDirection ConnectionDirection => ConnectionDirection.ClientToGateway;
 
@@ -79,7 +80,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                this.connectionManager.OnConnectionTerminated(this.remoteSiloAddress, this, error);
+                this.connectionManager.OnConnectionTerminated(this.RemoteSiloAddress, this, error);
                 this.messageCenter.OnGatewayConnectionClosed();
             }
         }
@@ -98,7 +99,7 @@ namespace Orleans.Runtime.Messaging
 
             if (msg.TargetSilo != null) return true;
 
-            msg.TargetSilo = this.remoteSiloAddress;
+            msg.TargetSilo = this.RemoteSiloAddress;
             if (msg.TargetGrain.IsSystemTarget())
                 msg.TargetActivation = ActivationId.GetDeterministic(msg.TargetGrain);
 

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -29,7 +29,6 @@ namespace Orleans.Runtime.Messaging
         };
 
         private static readonly ObjectPool<MessageHandler> MessageHandlerPool = ObjectPool.Create(new MessageHandlerPoolPolicy());
-        private readonly MemoryPool<byte> memoryPool = MemoryPool<byte>.Shared;
         private readonly ConnectionCommon shared;
         private readonly ConnectionDelegate middleware;
         private readonly Channel<Message> outgoingMessages;


### PR DESCRIPTION
The crucial line is this one:

``` diff
- && gatewayManager.IsGatewayAvailable(msg.TargetSilo))
+ && gatewayManager.IsGatewayAvailable(existingConnection.RemoteSiloAddress))
```

Essentially, TargetSilo was almost always un-set (since clients don't know where each grain is active), and so it was always going through ConnectionManager and subsequently UpdateBucket (taking a lock)