### PR TITLE
Added AWS profile name support to DynamoDBStorage.

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -41,6 +41,7 @@ namespace Orleans.Clustering.DynamoDB
                 this.options.AccessKey,
                 this.options.SecretKey,
                 this.options.Token,
+                this.options.ProfileName,
                 this.options.ReadCapacityUnits,
                 this.options.WriteCapacityUnits);
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -40,7 +40,7 @@ namespace Orleans.Clustering.DynamoDB
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                this.options.Token, this.options.ProfileName, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -85,7 +85,7 @@ namespace Orleans.Storage
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
                 this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
+                 this.options.Token, this.options.ProfileName, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -55,7 +55,7 @@ namespace Orleans.Reminders.DynamoDB
         public Task Init()
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                this.options.Token, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                this.options.Token, this.options.ProfileName, this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 

--- a/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
+++ b/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
@@ -31,5 +31,10 @@ namespace Orleans.Reminders.DynamoDB
         /// Token for DynamoDB storage
         /// </summary>
         public string Token { get; set; }
+
+        /// <summary>
+        /// AWS profile name.
+        /// </summary>
+        public string ProfileName { get; set; }
     }
 }

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -129,13 +129,8 @@ namespace Orleans.Transactions.DynamoDB
                 var chain = new CredentialProfileStoreChain();
                 if (chain.TryGetAWSCredentials(this.profileName, out var credentials))
                 {
-                    var immutableCredentials = credentials.GetCredentials();
-                    var sessionCredentials = new SessionAWSCredentials(
-                        immutableCredentials.AccessKey,
-                        immutableCredentials.SecretKey,
-                        immutableCredentials.Token);
                     this.ddbClient = new AmazonDynamoDBClient(
-                        sessionCredentials,
+                        credentials,
                         new AmazonDynamoDBConfig
                         {
                             RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Amazon.Runtime.CredentialManagement;
 
 #if CLUSTERING_DYNAMODB
 namespace Orleans.Clustering.DynamoDB
@@ -30,6 +31,7 @@ namespace Orleans.Transactions.DynamoDB
     {
         private string accessKey;
         private string token;
+        private string profileName;
         /// <summary> Secret key for this dynamoDB table </summary>
         protected string secretKey;
         private string service;
@@ -48,6 +50,7 @@ namespace Orleans.Transactions.DynamoDB
         /// <param name="accessKey"></param>
         /// <param name="secretKey"></param>
         /// <param name="token"></param>
+        /// <param name="profileName"></param>
         /// <param name="service"></param>
         /// <param name="readCapacityUnits"></param>
         /// <param name="writeCapacityUnits"></param>
@@ -58,6 +61,7 @@ namespace Orleans.Transactions.DynamoDB
             string accessKey = "",
             string secretKey = "",
             string token = "",
+            string profileName = "",
             int readCapacityUnits = DefaultReadCapacityUnits,
             int writeCapacityUnits = DefaultWriteCapacityUnits,
             bool useProvisionedThroughput = true)
@@ -66,6 +70,7 @@ namespace Orleans.Transactions.DynamoDB
             this.accessKey = accessKey;
             this.secretKey = secretKey;
             this.token = token;
+            this.profileName = profileName;
             this.service = service;
             this.readCapacityUnits = readCapacityUnits;
             this.writeCapacityUnits = writeCapacityUnits;
@@ -117,6 +122,30 @@ namespace Orleans.Transactions.DynamoDB
                 // AWS DynamoDB instance (auth via explicit credentials)
                 var credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
                 this.ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig {RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)});
+            }
+            else if (!string.IsNullOrEmpty(this.profileName))
+            {
+                // AWS DynamoDB instance (auth via explicit credentials and token found in a named profile)
+                var chain = new CredentialProfileStoreChain();
+                if (chain.TryGetAWSCredentials(this.profileName, out var credentials))
+                {
+                    var immutableCredentials = credentials.GetCredentials();
+                    var sessionCredentials = new SessionAWSCredentials(
+                        immutableCredentials.AccessKey,
+                        immutableCredentials.SecretKey,
+                        immutableCredentials.Token);
+                    this.ddbClient = new AmazonDynamoDBClient(
+                        sessionCredentials,
+                        new AmazonDynamoDBConfig
+                        {
+                            RegionEndpoint = AWSUtils.GetRegionEndpoint(this.service)
+                        });
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"AWS named profile '{this.profileName}' provided, but credentials could not be retrieved");
+                }
             }
             else
             {


### PR DESCRIPTION
This is third and last PR of a series of changes resulting from an issue I reported in May:

https://github.com/dotnet/orleans/issues/7077

Previous PRs: 

1. groundwork refactoring: https://github.com/dotnet/orleans/pull/7083
2. add aws credentials token: https://github.com/dotnet/orleans/pull/7104

In this PR I'm taking the dynamodb client options one step further allowing for non-default aws profile names (like e.g. `sts`, which I've been using myself for a while). This change should enrich the spectrum of dynamodb connectivity options further for more people.

Depending on the feedback this PR receives, a follow-up documentation change will have to be made:

https://dotnet.github.io/orleans/docs/grains/grain_persistence/dynamodb_storage.html

which I'm happy to do.