### PR TITLE
Fix unhandled exception on k8s watcher background task

### DIFF
--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -45,9 +45,19 @@ namespace Orleans.Hosting.Kubernetes
 
             _ = Task.Run(async () =>
             {
-                await channel.Reader.Completion.ConfigureAwait(false);
-                watcher[0].Dispose();
-                cancellationRegistration.Dispose();
+                try
+                {
+                    await channel.Reader.Completion.ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Suppress exception set by channel writer and re-thrown by Completion task
+                }
+                finally
+                {
+                    watcher[0].Dispose();
+                    cancellationRegistration.Dispose();
+                }
             });
 
 

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -52,7 +52,7 @@ namespace Orleans.Hosting.Kubernetes
                 }
                 catch (Exception)
                 {
-                    // Suppress exception set by channel writer and re-thrown by Completion task
+                    // suppress exception set by channel writer and re-thrown by Completion task
                 }
                 finally
                 {

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -1,5 +1,6 @@
 using k8s;
 using Microsoft.Rest;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;


### PR DESCRIPTION
Fix unawaited background task to suppress any exception from the ChannelReader's Completion task.

The channel reader's Completion task would re-raise the exception set on the channel writer and cause an unhandled exception in the unawaited task and crash silo.

We have witnessed multiple cases when the HTTPS connection between the k8s watcher and the k8s API was lost, and it caused a silo crash. The investigation led to this unawaited background task. (See attached exception.)

```
[12:04:14 FTL] An unhandled exception occurred during the execution of ***-silo on ******.svc.cluster.local <s:******.Platform.Hosting.UnhandledExceptionHandler>
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Unable to read data from the transport connection: Connection reset by peer.)
 ---> System.IO.IOException: Unable to read data from the transport connection: Connection reset by peer.
 ---> System.Net.Sockets.SocketException (104): Connection reset by peer
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.GetResult(Int16 token)
   at System.Net.Security.SslStream.<FillBufferAsync>g__InternalFillBufferAsync|215_0[TReadAdapter](TReadAdapter adap, ValueTask`1 task, Int32 min, Int32 initial)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Net.Http.HttpConnection.FillAsync()
   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.ReadAsyncCore(Memory`1 buffer, CancellationToken cancellationToken)
   at k8s.WatcherDelegatingHandler.CancelableStream.ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at System.IO.StreamReader.ReadBufferAsync(CancellationToken cancellationToken)
   at System.IO.StreamReader.ReadLineAsyncInternal()
   at k8s.Watcher`1.WatcherLoop(CancellationToken cancellationToken)
   at Orleans.Hosting.Kubernetes.KubernetesClientExtensions.<>c__DisplayClass0_0`2.<<WatchAsync>b__4>d.MoveNext()
   --- End of inner exception stack trace ---
```