### PR TITLE
Do not add application parts from dependency context by default

### DIFF
--- a/src/Orleans.Core/ApplicationParts/ApplicationPartManagerExtensions.cs
+++ b/src/Orleans.Core/ApplicationParts/ApplicationPartManagerExtensions.cs
@@ -46,7 +46,6 @@ namespace Orleans
                 .Any(part => !part.IsFrameworkAssembly);
             if (!hasApplicationParts)
             {
-                applicationPartsManager.AddFromDependencyContext();
                 applicationPartsManager.AddFromAppDomain();
                 applicationPartsManager.AddFromApplicationBaseDirectory();
             }


### PR DESCRIPTION
This is a workaround for #6898 / #7172