### PR TITLE
Support custom grain directory cache implementations

### DIFF
--- a/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
@@ -1,5 +1,6 @@
 
 using System;
+using Orleans.Runtime.GrainDirectory;
 
 namespace Orleans.Configuration
 {
@@ -15,7 +16,9 @@ namespace Orleans.Configuration
             /// <summary>Standard fixed-size LRU.</summary>
             LRU,
             /// <summary>Adaptive caching with fixed maximum size and refresh. This option should be used in production.</summary>
-            Adaptive
+            Adaptive,
+            /// <summary>Custom cache implementation, configured by registering an <see cref="IGrainDirectoryCache"/> implementation in the dependency injection container.</summary>
+            Custom
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -1,24 +1,29 @@
+using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal static class GrainDirectoryCacheFactory
+    public static class GrainDirectoryCacheFactory
     {
-        internal static IGrainDirectoryCache CreateGrainDirectoryCache(GrainDirectoryOptions options)
+        public static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
         {
             if (options.CacheSize <= 0)
                 return new NullGrainDirectoryCache();
-            
+
             switch (options.CachingStrategy)
             {
                 case GrainDirectoryOptions.CachingStrategyType.None:
                     return new NullGrainDirectoryCache();
                 case GrainDirectoryOptions.CachingStrategyType.LRU:
                     return new LRUBasedGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL);
-                default:
+                case GrainDirectoryOptions.CachingStrategyType.Adaptive:
                     return new AdaptiveGrainDirectoryCache(options.InitialCacheTTL, options.MaximumCacheTTL, options.CacheTTLExtensionFactor, options.CacheSize);
+                case GrainDirectoryOptions.CachingStrategyType.Custom:
+                default:
+                    return services.GetRequiredService<IGrainDirectoryCache>();
             }
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryCache.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    interface IGrainDirectoryCache
+    public interface IGrainDirectoryCache
     {
         /// <summary>
         /// Adds a new entry with the given version into the cache: key (grain) --> value

--- a/test/Tester/Properties/IsExternalInit.cs
+++ b/test/Tester/Properties/IsExternalInit.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}

--- a/test/Tester/TestDirectoryCache.cs
+++ b/test/Tester/TestDirectoryCache.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+
+namespace UnitTests.General
+{
+    public class TestDirectoryCache : IGrainDirectoryCache
+    {
+        public TestDirectoryCache(IServiceProvider serviceProvider)
+        {
+            var options = new GrainDirectoryOptions();
+            InnerCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, options);
+        }
+
+        public IGrainDirectoryCache InnerCache { get; }
+
+        public ConcurrentQueue<CacheOperation> Operations { get; } = new();
+
+        public IEnumerable<(ActivationAddress ActivationAddress, int Version)> KeyValues => InnerCache.KeyValues;
+
+        public void AddOrUpdate(ActivationAddress value, int version)
+        {
+            InnerCache.AddOrUpdate(value, version);
+            Operations.Enqueue(new CacheOperation.AddOrUpdate(value, version));
+        }
+
+        public void Clear()
+        {
+            InnerCache.Clear();
+            Operations.Enqueue(new CacheOperation.Clear());
+        }
+
+        public bool LookUp(GrainId key, out ActivationAddress result, out int version)
+        {
+            var exists = InnerCache.LookUp(key, out result, out version);
+            Operations.Enqueue(new CacheOperation.Lookup(key, (exists, result, version)));
+            return exists;
+        }
+
+        public bool Remove(GrainId key)
+        {
+            var exists = InnerCache.Remove(key);
+            Operations.Enqueue(new CacheOperation.Remove(key, exists));
+            return exists;
+        }
+
+        /// <summary>
+        /// Removes an entry from the cache given its key
+        /// </summary>
+        /// <param name="key">key to remove</param>
+        /// <returns>True if the entry was in the cache and the removal was successful</returns>
+        public bool Remove(ActivationAddress key)
+        {
+            var exists = InnerCache.Remove(key);
+            Operations.Enqueue(new CacheOperation.RemoveActivation(key, exists));
+            return exists;
+        }
+
+        public record CacheOperation()
+        {
+            public record RemoveActivation(ActivationAddress Key, bool Result) : CacheOperation;
+            public record Remove(GrainId Key, bool Result) : CacheOperation;
+            public record Lookup(GrainId Key, (bool Exists, ActivationAddress Address, int Version) Result) : CacheOperation;
+            public record AddOrUpdate(ActivationAddress value, int version) : CacheOperation;
+            public record Clear() : CacheOperation;
+        }
+    }
+}


### PR DESCRIPTION
This PR opens up the ability for developers to add custom implementations of `IGrainDirectoryCache` within the in-cluster grain directory. This does not support custom cache implementations for other `IGrainLocator`/`IGrainDirectory` implementations.
I don't see this as being something which many developers will need to do, but it may be useful in some specialized situations and it is useful for tests like the one included in this PR.
