### PR TITLE
Add ObjectSerializer to support serialization of known types without generics

### DIFF
--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -92,6 +92,11 @@ namespace Orleans.Serialization.Cloning
 
         public T Copy<T>(T value)
         {
+            if (!typeof(T).IsValueType)
+            {
+                if (value is null) return default;
+            }
+
             var copier = _copierProvider.GetDeepCopier(value.GetType());
             return (T)copier.DeepCopy(value, this);
         }

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ namespace Orleans.Serialization
                 services.AddSingleton<IGeneralizedBaseCodec>(sp => sp.GetRequiredService<ExceptionCodec>());
 
                 // Serializer
+                services.TryAddSingleton<ObjectSerializer>();
                 services.TryAddSingleton<Serializer>();
                 services.TryAddSingleton(typeof(Serializer<>));
                 services.TryAddSingleton(typeof(ValueSerializer<>));


### PR DESCRIPTION
This adds `ObjectSerializer`, which has `Serialize` and `Deserialize` methods which accept a `Type` as a parameter. The `Type` parameter is the *expected* type of the value being serialized/deserialized.
In cases where the type exactly matches the type which was serialized, Orleans will not write full type information to the payload, and can instead set a flag in the payload indicating that the value is the *expected* type.
This means that the `Serialize` and `Deserialize` calls must have the same exact `Type` value or the deserialization may not know how to deserialize the value.

This complements the existing classes:
* `Serializer`, which has generic `Serialize<T>` and `Deserialize<T>` methods, where `T` is the expected type.
* `Serializer<T>`, which has `Serialize` and `Deserialize` methods which use the class' `T` as the expected type.