### PR TITLE
Reduce indirection in RuntimeContext

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -45,7 +45,7 @@ namespace Orleans
         /// </summary>
         protected Grain()
         {
-            var context = RuntimeContext.CurrentGrainContext;
+            var context = RuntimeContext.Current;
             if (context is null)
             {
                 return;

--- a/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
@@ -3,38 +3,30 @@ using System.Runtime.CompilerServices;
 
 namespace Orleans.Runtime
 {
-    internal class RuntimeContext
+    internal static class RuntimeContext
     {
-        public IGrainContext GrainContext { get; private set; }
-
         [ThreadStatic]
-        private static RuntimeContext threadLocalContext;
+        private static IGrainContext _threadLocalContext;
 
-        public static RuntimeContext Current => threadLocalContext;
-
-        internal static IGrainContext CurrentGrainContext { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => threadLocalContext?.GrainContext; }
+        public static IGrainContext Current => _threadLocalContext;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetExecutionContext(IGrainContext newContext)
         {
-            var ctx = threadLocalContext ??= new RuntimeContext();
-            ctx.GrainContext = newContext;
+            _threadLocalContext = newContext;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetExecutionContext(IGrainContext newContext, out IGrainContext existingContext)
         {
-            var ctx = threadLocalContext ??= new RuntimeContext();
-            existingContext = ctx.GrainContext;
-            ctx.GrainContext = newContext;
+            existingContext = _threadLocalContext;
+            _threadLocalContext = newContext;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ResetExecutionContext()
         {
-            threadLocalContext.GrainContext = null;
+            _threadLocalContext = null;
         }
-
-        public override string ToString() => $"RuntimeContext: GrainContext={GrainContext?.ToString() ?? "null"}";
     }
 }

--- a/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime
 
         internal static void OnDispatcherMessageReceive(Message msg)
         {
-            var context = RuntimeContext.CurrentGrainContext;
+            var context = RuntimeContext.Current;
             dispatcherMessagesProcessingReceivedPerDirection[(int)msg.Direction].Increment();
             dispatcherMessagesReceivedTotal.Increment();
             if (context == null)

--- a/src/Orleans.Runtime/Activation/GrainContextAccessor.cs
+++ b/src/Orleans.Runtime/Activation/GrainContextAccessor.cs
@@ -9,6 +9,6 @@ namespace Orleans.Runtime
             _hostedClient = hostedClient;
         }
 
-        public IGrainContext GrainContext => RuntimeContext.CurrentGrainContext ?? _hostedClient;
+        public IGrainContext GrainContext => RuntimeContext.Current ?? _hostedClient;
     }
 }

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -92,7 +92,7 @@ namespace Orleans.Runtime
 
         public static void CheckRuntimeContext()
         {
-            var context = RuntimeContext.CurrentGrainContext;
+            var context = RuntimeContext.Current;
 
             if (context is null)
             {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -130,7 +130,7 @@ namespace Orleans.Runtime
             if (message.SendingSilo == null)
                 message.SendingSilo = MySilo;
 
-            IGrainContext sendingActivation = RuntimeContext.CurrentGrainContext;
+            IGrainContext sendingActivation = RuntimeContext.Current;
 
             if (sendingActivation == null)
             {
@@ -499,7 +499,7 @@ namespace Orleans.Runtime
             }
         }
 
-        public string CurrentActivationIdentity => RuntimeContext.CurrentGrainContext?.Address.ToString() ?? this.HostedClient.ToString();
+        public string CurrentActivationIdentity => RuntimeContext.Current?.Address.ToString() ?? this.HostedClient.ToString();
 
         /// <inheritdoc />
         public TimeSpan GetResponseTimeout() => this.sharedCallbackData.ResponseTimeout;
@@ -509,13 +509,13 @@ namespace Orleans.Runtime
 
         public IAddressable CreateObjectReference(IAddressable obj)
         {
-            if (RuntimeContext.CurrentGrainContext is null) return this.HostedClient.CreateObjectReference(obj);
+            if (RuntimeContext.Current is null) return this.HostedClient.CreateObjectReference(obj);
             throw new InvalidOperationException("Cannot create a local object reference from a grain.");
         }
 
         public void DeleteObjectReference(IAddressable obj)
         {
-            if (RuntimeContext.CurrentGrainContext is null)
+            if (RuntimeContext.Current is null)
             {
                 this.HostedClient.DeleteObjectReference(obj);
             }

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -162,7 +162,7 @@ namespace Orleans.Runtime
         /// </summary>
         internal IGrainTimer RegisterGrainTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period, string name = null)
         {
-            var ctxt = RuntimeContext.CurrentGrainContext;
+            var ctxt = RuntimeContext.Current;
             name = name ?? ctxt.GrainId + "Timer";
 
             var timer = GrainTimer.FromTaskCallback(this.timerLogger, asyncCallback, state, dueTime, period, name);

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -68,8 +68,8 @@ namespace Orleans.Runtime.Scheduler
         /// <param name="taskWasPreviouslyQueued">A Boolean denoting whether or not task has previously been queued. If this parameter is True, then the task may have been previously queued (scheduled); if False, then the task is known not to have been queued, and this call is being made in order to execute the task inline without queuing it.</param>
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
-            RuntimeContext ctx = RuntimeContext.Current;
-            bool canExecuteInline = ctx != null && object.Equals(ctx.GrainContext, workerGroup.GrainContext);
+            var currentContext = RuntimeContext.Current;
+            bool canExecuteInline = currentContext != null && object.Equals(currentContext, workerGroup.GrainContext);
 
 #if DEBUG
             if (logger.IsEnabled(LogLevel.Trace))

--- a/src/Orleans.Runtime/Scheduler/SchedulerExtensions.cs
+++ b/src/Orleans.Runtime/Scheduler/SchedulerExtensions.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime.Scheduler
         internal static Task<T> RunOrQueueTask<T>(this IGrainContext targetContext, Func<Task<T>> taskFunc) => targetContext.Scheduler.RunOrQueueTask(taskFunc, targetContext);
         private static Task<T> RunOrQueueTask<T>(this IWorkItemScheduler scheduler, Func<Task<T>> taskFunc, IGrainContext targetContext)
         {
-            var currentContext = RuntimeContext.CurrentGrainContext;
+            var currentContext = RuntimeContext.Current;
             if (currentContext is object && currentContext.Equals(targetContext))
             {
                 try
@@ -90,7 +90,7 @@ namespace Orleans.Runtime.Scheduler
         internal static Task RunOrQueueTask(this IGrainContext targetContext, Func<Task> taskFunc) => targetContext.Scheduler.RunOrQueueTask(taskFunc, targetContext);
         private static Task RunOrQueueTask(this IWorkItemScheduler scheduler, Func<Task> taskFunc, IGrainContext targetContext)
         {
-            var currentContext = RuntimeContext.CurrentGrainContext;
+            var currentContext = RuntimeContext.Current;
             if (currentContext is object && currentContext.Equals(targetContext))
             {
                 try

--- a/src/Orleans.Runtime/Services/GrainServiceClient.cs
+++ b/src/Orleans.Runtime/Services/GrainServiceClient.cs
@@ -48,7 +48,7 @@ namespace Orleans.Runtime.Services
         /// <summary>
         /// Resolves the Grain Reference invoking this request.
         /// </summary>
-        protected GrainReference CallingGrainReference => RuntimeContext.CurrentGrainContext?.GrainReference;
+        protected GrainReference CallingGrainReference => RuntimeContext.Current?.GrainReference;
 
         /// <summary>
         /// Moved from InsideRuntimeClient.cs

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime
 
         private GrainTimer(IGrainContext activationData, ILogger logger, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period, string name)
         {
-            var ctxt = RuntimeContext.CurrentGrainContext;
+            var ctxt = RuntimeContext.Current;
             if (ctxt is null)
             {
                 throw new InvalidSchedulingContextException(

--- a/src/Orleans.Streaming/Providers/SiloProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloProviderRuntime.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime.Providers
         /// <inheritdoc />
         public StreamDirectory GetStreamDirectory()
         {
-            if (RuntimeContext.CurrentGrainContext is { } activation)
+            if (RuntimeContext.Current is { } activation)
             {
                 var directory = activation.GetComponent<StreamDirectory>();
                 if (directory is null)

--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Hosting;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
-using Orleans.Metadata;
 
 namespace Benchmarks.Ping
 {
@@ -40,10 +39,6 @@ namespace Benchmarks.Ping
                     if (i == 0 && grainsOnSecondariesOnly)
                     {
                         siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
-                        siloBuilder.ConfigureServices(services =>
-                        {
-                            services.Remove(services.First(s => s.ImplementationType?.Name == "ApplicationPartValidator"));
-                        });
                     }
                 });
 

--- a/test/Benchmarks/Serialization/MessageBenchmark.cs
+++ b/test/Benchmarks/Serialization/MessageBenchmark.cs
@@ -16,15 +16,15 @@ namespace Benchmarks
     [Config(typeof(BenchmarkConfig))]
     public class MessageBenchmark
     {
-        private static readonly Serializer<Message.HeadersContainer> Serializer;
+        private static readonly Serializer<BenchmarkMessage.HeadersContainer> Serializer;
         private static readonly byte[] Input;
         private static readonly SerializerSession Session;
-        private static readonly Message.HeadersContainer Value;
+        private static readonly BenchmarkMessage.HeadersContainer Value;
 
         static MessageBenchmark()
         {
             var body = new Response("yess!");
-            Value = (new Message
+            Value = (new BenchmarkMessage
             {
                 TargetActivation = ActivationId.NewId(),
                 TargetSilo = SiloAddress.New(IPEndPoint.Parse("210.50.4.44:40902"), 5423123),
@@ -42,7 +42,7 @@ namespace Benchmarks
             var services = new ServiceCollection()
                 .AddSerializer()
                 .BuildServiceProvider();
-            Serializer = services.GetRequiredService<Serializer<Message.HeadersContainer>>();
+            Serializer = services.GetRequiredService<Serializer<BenchmarkMessage.HeadersContainer>>();
             var bytes = new byte[4000];
             Session = services.GetRequiredService<SerializerSessionPool>().GetSession();
             var writer = new SingleSegmentBuffer(bytes).CreateWriter(Session);

--- a/test/Benchmarks/Serialization/Models/Orleans/BenchmarkActivationAddress.cs
+++ b/test/Benchmarks/Serialization/Models/Orleans/BenchmarkActivationAddress.cs
@@ -6,7 +6,7 @@ namespace FakeFx.Runtime
     [Serializable, Immutable]
     [GenerateSerializer]
     [SuppressReferenceTracking]
-    public sealed class ActivationAddress : IEquatable<ActivationAddress>
+    public sealed class BenchmarkActivationAddress : IEquatable<BenchmarkActivationAddress>
     {
         [Id(1)]
         public GrainId Grain { get; private set; }
@@ -17,20 +17,20 @@ namespace FakeFx.Runtime
 
         public bool IsComplete => !Grain.IsDefault && Activation != null && Silo != null;
 
-        private ActivationAddress(SiloAddress silo, GrainId grain, ActivationId activation)
+        private BenchmarkActivationAddress(SiloAddress silo, GrainId grain, ActivationId activation)
         {
             Silo = silo;
             Grain = grain;
             Activation = activation;
         }
 
-        public static ActivationAddress NewActivationAddress(SiloAddress silo, GrainId grain)
+        public static BenchmarkActivationAddress NewActivationAddress(SiloAddress silo, GrainId grain)
         {
             var activation = ActivationId.NewId();
             return GetAddress(silo, grain, activation);
         }
 
-        public static ActivationAddress GetAddress(SiloAddress silo, GrainId grain, ActivationId activation)
+        public static BenchmarkActivationAddress GetAddress(SiloAddress silo, GrainId grain, ActivationId activation)
         {
             // Silo part is not mandatory
             if (grain.IsDefault)
@@ -38,12 +38,12 @@ namespace FakeFx.Runtime
                 throw new ArgumentNullException("grain");
             }
 
-            return new ActivationAddress(silo, grain, activation);
+            return new BenchmarkActivationAddress(silo, grain, activation);
         }
 
-        public override bool Equals(object obj) => Equals(obj as ActivationAddress);
+        public override bool Equals(object obj) => Equals(obj as BenchmarkActivationAddress);
 
-        public bool Equals(ActivationAddress other) => other != null && Matches(other) && (Silo?.Equals(other.Silo) ?? other.Silo is null);
+        public bool Equals(BenchmarkActivationAddress other) => other != null && Matches(other) && (Silo?.Equals(other.Silo) ?? other.Silo is null);
 
         public override int GetHashCode() => Grain.GetHashCode() ^ (Activation?.GetHashCode() ?? 0) ^ (Silo?.GetHashCode() ?? 0);
 
@@ -59,7 +59,7 @@ namespace FakeFx.Runtime
                     this.Activation.ToFullString());        // 2
         }
 
-        public bool Matches(ActivationAddress other)
+        public bool Matches(BenchmarkActivationAddress other)
         {
             return Grain.Equals(other.Grain) && (Activation?.Equals(other.Activation) ?? other.Activation is null);
         }

--- a/test/Benchmarks/Serialization/Models/Orleans/BenchmarkMessage.cs
+++ b/test/Benchmarks/Serialization/Models/Orleans/BenchmarkMessage.cs
@@ -7,7 +7,7 @@ namespace FakeFx.Runtime
 {
     [WellKnownId(9902)]
     [GenerateSerializer]
-    internal sealed class Message
+    internal sealed class BenchmarkMessage
     {
         public const int LENGTH_HEADER_SIZE = 8;
         public const int LENGTH_META_HEADER = 4;
@@ -40,10 +40,10 @@ namespace FakeFx.Runtime
         }
         
         // Cache values of TargetAddess and SendingAddress as they are used very frequently
-        internal ActivationAddress targetAddress;
-        internal ActivationAddress sendingAddress;
+        internal BenchmarkActivationAddress targetAddress;
+        internal BenchmarkActivationAddress sendingAddress;
         
-        static Message()
+        static BenchmarkMessage()
         {
         }
 
@@ -171,7 +171,7 @@ namespace FakeFx.Runtime
             }
         }
 
-        public ActivationAddress TargetAddress
+        public BenchmarkActivationAddress TargetAddress
         {
             get
             {
@@ -182,7 +182,7 @@ namespace FakeFx.Runtime
 
                 if (!TargetGrain.IsDefault)
                 {
-                    return targetAddress = ActivationAddress.GetAddress(TargetSilo, TargetGrain, TargetActivation);
+                    return targetAddress = BenchmarkActivationAddress.GetAddress(TargetSilo, TargetGrain, TargetActivation);
                 }
 
                 return null;
@@ -238,9 +238,9 @@ namespace FakeFx.Runtime
             set { Headers.TraceContext = value; }
         }
 
-        public ActivationAddress SendingAddress
+        public BenchmarkActivationAddress SendingAddress
         {
-            get { return sendingAddress ?? (sendingAddress = ActivationAddress.GetAddress(SendingSilo, SendingGrain, SendingActivation)); }
+            get { return sendingAddress ?? (sendingAddress = BenchmarkActivationAddress.GetAddress(SendingSilo, SendingGrain, SendingActivation)); }
             set
             {
                 SendingGrain = value.Grain;
@@ -299,7 +299,7 @@ namespace FakeFx.Runtime
             set { Headers.TransactionInfo = value; }
         }
 
-        public List<ActivationAddress> CacheInvalidationHeader
+        public List<BenchmarkActivationAddress> CacheInvalidationHeader
         {
             get { return Headers.CacheInvalidationHeader; }
             set { Headers.CacheInvalidationHeader = value; }
@@ -308,9 +308,9 @@ namespace FakeFx.Runtime
         public bool HasCacheInvalidationHeader => this.CacheInvalidationHeader != null
                                                   && this.CacheInvalidationHeader.Count > 0;
         
-        internal void AddToCacheInvalidationHeader(ActivationAddress address)
+        internal void AddToCacheInvalidationHeader(BenchmarkActivationAddress address)
         {
-            var list = new List<ActivationAddress>();
+            var list = new List<BenchmarkActivationAddress>();
             if (CacheInvalidationHeader != null)
             {
                 list.AddRange(CacheInvalidationHeader);
@@ -355,7 +355,7 @@ namespace FakeFx.Runtime
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        public bool IsDuplicate(Message other)
+        public bool IsDuplicate(BenchmarkMessage other)
         {
             return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
         }
@@ -391,7 +391,7 @@ namespace FakeFx.Runtime
             return sb.ToString();
         }
         
-        internal void AppendIfExists(HeadersContainer.Headers header, StringBuilder sb, Func<Message, object> valueProvider)
+        internal void AppendIfExists(HeadersContainer.Headers header, StringBuilder sb, Func<BenchmarkMessage, object> valueProvider)
         {
             // used only under log3 level
             if ((Headers.GetHeadersMask() & header) != HeadersContainer.Headers.NONE)
@@ -434,13 +434,13 @@ namespace FakeFx.Runtime
                 $"{(ForwardCount > 0 ? "[ForwardCount=" + ForwardCount + "]" : "")}";
         }
 
-        public static Message CreatePromptExceptionResponse(Message request, Exception exception)
+        public static BenchmarkMessage CreatePromptExceptionResponse(BenchmarkMessage request, Exception exception)
         {
             return new()
             {
                 Category = request.Category,
-                Direction = Message.Directions.Response,
-                Result = Message.ResponseTypes.Error,
+                Direction = BenchmarkMessage.Directions.Response,
+                Result = BenchmarkMessage.ResponseTypes.Error,
                 BodyObject = Response.ExceptionResponse(exception)
             };
         }
@@ -530,7 +530,7 @@ namespace FakeFx.Runtime
             public ResponseTypes _result;
             public object _transactionInfo;
             public TimeSpan? _timeToLive;
-            public List<ActivationAddress> _cacheInvalidationHeader;
+            public List<BenchmarkActivationAddress> _cacheInvalidationHeader;
             public RejectionTypes _rejectionType;
             public string _rejectionInfo;
             public Dictionary<string, object> _requestContextData;
@@ -724,7 +724,7 @@ namespace FakeFx.Runtime
                 }
             }
 
-            public List<ActivationAddress> CacheInvalidationHeader
+            public List<BenchmarkActivationAddress> CacheInvalidationHeader
             {
                 get { return _cacheInvalidationHeader; }
                 set
@@ -857,7 +857,7 @@ namespace FakeFx.Runtime
                     && _result == container._result
                     && EqualityComparer<object>.Default.Equals(_transactionInfo, container._transactionInfo)
                     && EqualityComparer<TimeSpan?>.Default.Equals(_timeToLive, container._timeToLive)
-                    && EqualityComparer<List<ActivationAddress>>.Default.Equals(_cacheInvalidationHeader, container._cacheInvalidationHeader)
+                    && EqualityComparer<List<BenchmarkActivationAddress>>.Default.Equals(_cacheInvalidationHeader, container._cacheInvalidationHeader)
                     && _rejectionType == container._rejectionType
                     && _rejectionInfo == container._rejectionInfo
                     && EqualityComparer<CorrelationId>.Default.Equals(_callChainId, container._callChainId)

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -127,7 +127,7 @@ namespace DefaultCluster.Tests.General
             var observer = new ObserverTests.SimpleGrainObserver(
                 (a, b, result) =>
                 {
-                    Assert.Null(RuntimeContext.CurrentGrainContext);
+                    Assert.Null(RuntimeContext.Current);
                     callbackCounter[0]++;
 
                     if (a == 3 && b == 0)

--- a/test/Grains/TestInternalGrains/ErrorGrain.cs
+++ b/test/Grains/TestInternalGrains/ErrorGrain.cs
@@ -186,10 +186,10 @@ namespace UnitTests.Grains
 
         public async Task<bool> ExecuteDelayed(TimeSpan delay)
         {
-            object ctxBefore = RuntimeContext.CurrentGrainContext;
+            object ctxBefore = RuntimeContext.Current;
 
             await Task.Delay(delay);
-            object ctxInside = RuntimeContext.CurrentGrainContext;
+            object ctxInside = RuntimeContext.Current;
             return ReferenceEquals(ctxBefore, ctxInside);
         }
     }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -715,7 +715,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            _context = RuntimeContext.CurrentGrainContext;
+            _context = RuntimeContext.Current;
             _scheduler = TaskScheduler.Current;
             executing = false;
             return base.OnActivateAsync();
@@ -860,7 +860,7 @@ namespace UnitTests.Grains
                 //Environment.Exit(1);
             }
 
-            if (RuntimeContext.CurrentGrainContext == null)
+            if (RuntimeContext.Current == null)
             {
                 var errorMsg = "Found RuntimeContext.Current == null.\n" + TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment();
                 this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
@@ -868,7 +868,7 @@ namespace UnitTests.Grains
                 //Environment.Exit(1);
             }
 
-            var context = RuntimeContext.CurrentGrainContext;
+            var context = RuntimeContext.Current;
             var scheduler = TaskScheduler.Current;
 
             executing = true;

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -32,7 +32,7 @@ namespace UnitTestGrains
         public override Task OnActivateAsync()
         {
             ThrowIfDeactivating();
-            context = RuntimeContext.CurrentGrainContext;
+            context = RuntimeContext.Current;
             defaultTimer = this.RegisterTimer(Tick, DefaultTimerName, period, period);
             allTimers = new Dictionary<string, IDisposable>();
             return Task.CompletedTask;
@@ -50,7 +50,7 @@ namespace UnitTestGrains
             logger.Info(data.ToString() + " Tick # " + counter + " RuntimeContext = " + RuntimeContext.Current?.ToString());
 
             // make sure we run in the right activation context.
-            if(!Equals(context, RuntimeContext.CurrentGrainContext))
+            if(!Equals(context, RuntimeContext.Current))
                 logger.Error((int)ErrorCode.Runtime_Error_100146, "grain not running in the right activation context");
 
             string name = (string)data;
@@ -150,7 +150,7 @@ namespace UnitTestGrains
 
         public override Task OnActivateAsync()
         {
-            context = RuntimeContext.CurrentGrainContext;
+            context = RuntimeContext.Current;
             activationTaskScheduler = TaskScheduler.Current;
             return Task.CompletedTask;
         }
@@ -231,12 +231,12 @@ namespace UnitTestGrains
 
         private void CheckRuntimeContext(string what)
         {
-            if (RuntimeContext.CurrentGrainContext == null 
-                || !RuntimeContext.CurrentGrainContext.Equals(context))
+            if (RuntimeContext.Current == null 
+                || !RuntimeContext.Current.Equals(context))
             {
                 throw new InvalidOperationException(
                     string.Format("{0} in timer callback with unexpected activation context: Expected={1} Actual={2}",
-                                  what, context, RuntimeContext.CurrentGrainContext));
+                                  what, context, RuntimeContext.Current));
             }
             if (TaskScheduler.Current.Equals(activationTaskScheduler) && TaskScheduler.Current is ActivationTaskScheduler)
             {

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -53,14 +53,14 @@ namespace UnitTests.SchedulerTests
                 {
                     for (int i = 0; i < 10; i++)
                     {
-                        Task.Factory.StartNew(() => 
+                        Task.Factory.StartNew(() =>
                         {
                             // ReSharper disable AccessToModifiedClosure
-                            this.output.WriteLine("Starting " + i + " in Context=" + RuntimeContext.Current); 
+                            this.output.WriteLine("Starting " + i + " in Context=" + RuntimeContext.Current);
                             Assert.False(insideTask, $"Starting new task when I am already inside task of iteration {n}");
                             insideTask = true;
-                            int k = n; 
-                            Thread.Sleep(100); 
+                            int k = n;
+                            Thread.Sleep(100);
                             n = k + 1;
                             insideTask = false;
                             // ReSharper restore AccessToModifiedClosure
@@ -686,8 +686,8 @@ namespace UnitTests.SchedulerTests
         private static void CheckRuntimeContext(IGrainContext context)
         {
             Assert.NotNull(RuntimeContext.Current); // Runtime context should not be null
-            Assert.NotNull(RuntimeContext.CurrentGrainContext); // Activation context should not be null
-            Assert.Equal(context, RuntimeContext.CurrentGrainContext);  // "Activation context"
+            Assert.NotNull(RuntimeContext.Current); // Activation context should not be null
+            Assert.Equal(context, RuntimeContext.Current);  // "Activation context"
         }
     }
 }


### PR DESCRIPTION
Reduces the indirection in `RuntimeContext` so that instead of a `[ThreadStatic]` pointing to an object with an `IGrainContext` property on it, the `[ThreadStatic]` points directly to the `IGrainContext`