### PR TITLE
Change equality for IdSpan so that empty and null values are identical

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/IdSpan.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IdSpan.cs
@@ -208,7 +208,16 @@ namespace Orleans.Runtime
         public bool Equals(IdSpan obj)
         {
             if (object.ReferenceEquals(_value, obj._value)) return true;
-            if (_value is null || obj._value is null) return false;
+            if (_value is null || obj._value is null)
+            {
+                if (_value is { Length: 0 } || obj._value is { Length: 0 })
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
             return _value.AsSpan().SequenceEqual(obj._value);
         }
 


### PR DESCRIPTION
This aligns `.Equals(other)` with `.IsDefault`, which treats null backing arrays as equal to empty backing arrays