### PR TITLE
Make ActivationId a struct backed by a Guid

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/ActivationAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ActivationAddress.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
         [Id(3)]
         public SiloAddress Silo { get; private set; }
 
-        public bool IsComplete => !Grain.IsDefault && Activation != null && Silo != null;
+        public bool IsComplete => !Grain.IsDefault && !Activation.IsDefault && Silo != null;
 
         private ActivationAddress(SiloAddress silo, GrainId grain, ActivationId activation)
         {
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
 
         public bool Equals(ActivationAddress other) => other != null && Matches(other) && (Silo?.Equals(other.Silo) ?? other.Silo is null);
 
-        public override int GetHashCode() => Grain.GetHashCode() ^ (Activation?.GetHashCode() ?? 0) ^ (Silo?.GetHashCode() ?? 0);
+        public override int GetHashCode() => Grain.GetHashCode() ^ Activation.GetHashCode() ^ (Silo?.GetHashCode() ?? 0);
 
         public override string ToString() => $"[{Silo} {Grain} {Activation}]";
 
@@ -55,9 +55,6 @@ namespace Orleans.Runtime
                     this.Activation.ToFullString());        // 2
         }
 
-        public bool Matches(ActivationAddress other)
-        {
-            return Grain.Equals(other.Grain) && (Activation?.Equals(other.Activation) ?? other.Activation is null);
-        }
+        public bool Matches(ActivationAddress other) => Grain.Equals(other.Grain) && Activation.Equals(other.Activation);
     }
 }

--- a/src/Orleans.Core.Abstractions/IDs/ActivationId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ActivationId.cs
@@ -1,89 +1,50 @@
 using System;
+using System.Buffers.Binary;
 using System.Runtime.Serialization;
 
 namespace Orleans.Runtime
 {
     [Serializable, Immutable]
     [GenerateSerializer]
-    [SuppressReferenceTracking]
-    public sealed class ActivationId : IEquatable<ActivationId>
+    public readonly struct ActivationId : IEquatable<ActivationId>
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        [DataMember]
-        [Id(1)]
-        internal readonly UniqueKey Key;
+        [DataMember(Order = 0)]
+        [Id(0)]
+        internal readonly Guid Key;
 
-        public bool IsSystem { get { return Key.IsSystemTargetKey; } }
+        public bool IsDefault => Equals(Zero);
 
-        private static readonly Interner<UniqueKey, ActivationId> legacyKeyInterner = new Interner<UniqueKey, ActivationId>(InternerConstants.SIZE_LARGE);
-        private static readonly Interner<GrainId, ActivationId> interner = new Interner<GrainId, ActivationId>(InternerConstants.SIZE_LARGE);
+        public static readonly ActivationId Zero = GetActivationId(Guid.Empty);
 
-        public static readonly ActivationId Zero = GetActivationId(UniqueKey.Empty);
+        private ActivationId(Guid key) => Key = key;
 
-        /// <summary>
-        /// Only used in Json serialization
-        /// DO NOT USE TO CREATE A RANDOM ACTIVATION ID
-        /// Use ActivationId.NewId to create new activation IDs.
-        /// </summary>
-        public ActivationId()
-        {
-        }
+        public static ActivationId NewId() => GetActivationId(Guid.NewGuid());
 
-        private ActivationId(UniqueKey key)
-        {
-            this.Key = key;
-        }
-
-        public static ActivationId NewId()
-        {
-            return GetActivationId(UniqueKey.NewKey());
-        }
-
-        // No need to encode SiloAddress in the activation address for system target. 
-        // System targets have unique grain ids and addressed to a concrete silo, so in fact we don't need ActivationId at all for System targets.
-        // Need to remove it all together. For now, just use grain id as activation id.
         public static ActivationId GetDeterministic(GrainId grain)
         {
-            return interner.FindOrCreate(grain, grainId =>
-            {
-                var a = (ulong)grainId.Type.GetHashCode();
-                var b = (ulong)grainId.Key.GetHashCode();
-                var key = UniqueKey.NewKey(a, b, UniqueKey.Category.KeyExtGrain, typeData: 0, keyExt: grainId.ToString());
-                return new ActivationId(key);
-            });
+            Span<byte> temp = stackalloc byte[16];
+            var a = (ulong)grain.Type.GetUniformHashCode();
+            var b = (ulong)grain.Key.GetUniformHashCode();
+            BinaryPrimitives.WriteUInt64LittleEndian(temp, a);
+            BinaryPrimitives.WriteUInt64LittleEndian(temp[8..], b);
+            var key = new Guid(temp);
+            return new ActivationId(key);
         }
 
-        internal static ActivationId GetActivationId(UniqueKey key)
-        {
-            return legacyKeyInterner.FindOrCreate(key, k => new ActivationId(k));
-        }
+        internal static ActivationId GetActivationId(Guid key) => new(key);
 
-        public override bool Equals(object obj)
-        {
-            var o = obj as ActivationId;
-            return o != null && Key.Equals(o.Key);
-        }
+        public override bool Equals(object obj) => obj is ActivationId other && Key.Equals(other.Key);
 
-        public bool Equals(ActivationId other)
-        {
-            return other != null && Key.Equals(other.Key);
-        }
+        public bool Equals(ActivationId other) => Key.Equals(other.Key);
 
-        public override int GetHashCode()
-        {
-            return Key.GetHashCode();
-        }
+        public override int GetHashCode() => Key.GetHashCode();
 
-        public override string ToString()
-        {
-            string idString = ((uint)Key.N1).ToString("x8");
-            return (IsSystem ? "@S" : "@") + idString;
-        }
+        public override string ToString() => $"@{Key:N}";
 
-        public string ToFullString()
-        {
-            string idString = Key.ToHexString();
-            return (IsSystem ? "@S" : "@") + idString;
-        }
+        public string ToFullString() => ToString();
+
+        public static bool operator ==(ActivationId left, ActivationId right) => left.Equals(right);
+
+        public static bool operator !=(ActivationId left, ActivationId right) => !(left == right);
     }
 }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -162,7 +162,7 @@ namespace Orleans.Runtime
             }
         }
 
-        public bool IsFullyAddressed => TargetSilo is object && !TargetGrain.IsDefault && TargetActivation is object;
+        public bool IsFullyAddressed => TargetSilo is object && !TargetGrain.IsDefault && !TargetActivation.IsDefault;
 
         public ActivationAddress TargetAddress
         {
@@ -431,7 +431,7 @@ namespace Orleans.Runtime
             {
                 history.Append(TargetGrain).Append(":");
             }
-            if (TargetActivation is object)
+            if (!TargetActivation.IsDefault)
             {
                 history.Append(TargetActivation);
             }
@@ -768,10 +768,10 @@ namespace Orleans.Runtime
 
                 headers = _targetSilo == null ? headers & ~Headers.TARGET_SILO : headers | Headers.TARGET_SILO;
                 headers = _targetGrain.IsDefault ? headers & ~Headers.TARGET_GRAIN : headers | Headers.TARGET_GRAIN;
-                headers = _targetActivation is null ? headers & ~Headers.TARGET_ACTIVATION : headers | Headers.TARGET_ACTIVATION;
+                headers = _targetActivation.IsDefault ? headers & ~Headers.TARGET_ACTIVATION : headers | Headers.TARGET_ACTIVATION;
                 headers = _sendingSilo is null ? headers & ~Headers.SENDING_SILO : headers | Headers.SENDING_SILO;
                 headers = _sendingGrain.IsDefault ? headers & ~Headers.SENDING_GRAIN : headers | Headers.SENDING_GRAIN;
-                headers = _sendingActivation is null ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
+                headers = _sendingActivation.IsDefault ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
                 headers = _interfaceVersion == 0 ? headers & ~Headers.INTERFACE_VERSION : headers | Headers.INTERFACE_VERSION;
                 headers = _result == default(ResponseTypes) ? headers & ~Headers.RESULT : headers | Headers.RESULT;
                 headers = _timeToLive == null ? headers & ~Headers.TIME_TO_LIVE : headers | Headers.TIME_TO_LIVE;

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -53,7 +53,7 @@ namespace Orleans.Runtime
             if (!request.SendingGrain.IsDefault)
             {
                 response.TargetGrain = request.SendingGrain;
-                if (request.SendingActivation != null)
+                if (!request.SendingActivation.IsDefault)
                 {
                     response.TargetActivation = request.SendingActivation;
                 }
@@ -63,7 +63,7 @@ namespace Orleans.Runtime
             if (!request.TargetGrain.IsDefault)
             {
                 response.SendingGrain = request.TargetGrain;
-                if (request.TargetActivation != null)
+                if (!request.TargetActivation.IsDefault)
                 {
                     response.SendingActivation = request.TargetActivation;
                 }

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -368,7 +368,7 @@ namespace Orleans.Runtime.Messaging
                         exception,
                         "Exception while processing messages to remote endpoint {EndPoint}",
                         this.RemoteEndPoint);
-                (serializer as IDisposable)?.Dispose();
+                    (serializer as IDisposable)?.Dispose();
                 }
 
                 error = exception;

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -580,7 +580,7 @@ namespace Orleans.Runtime
         {
             return string.Format("[Activation: {0}/{1}{2}{3} State={4}]",
                  Address.Silo,
-                 GrainId,
+                 GrainId.ToString(),
                  ActivationId,
                  GetActivationInfoString(),
                  State);

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -227,7 +227,7 @@ namespace Orleans.Runtime.GrainDirectory
             return ActivationAddress.GetAddress(
                     addr.SiloAddress,
                     addr.GrainId,
-                    ActivationId.GetActivationId(UniqueKey.Parse(addr.ActivationId.AsSpan())));
+                    ActivationId.GetActivationId(Guid.Parse(addr.ActivationId.AsSpan())));
         }
 
         public static GrainAddress ToGrainAddress(this ActivationAddress addr)
@@ -236,7 +236,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 SiloAddress = addr.Silo,
                 GrainId = addr.Grain,
-                ActivationId = (addr.Activation.Key.ToHexString())
+                ActivationId = (addr.Activation.Key.ToString("N"))
             };
         }
     }

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -76,7 +76,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     // the grain entry either does not exist in the local partition (curGen = -1) or has not been updated
 
-                    result.Add(new AddressAndTag { Address = ActivationAddress.GetAddress(null, tuple.GrainId, null), VersionTag = curGen });
+                    result.Add(new AddressAndTag { Address = ActivationAddress.GetAddress(null, tuple.GrainId, default), VersionTag = curGen });
                 }
                 else
                 {
@@ -89,7 +89,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
                     else
                     {
-                        result.Add(new AddressAndTag { Address = ActivationAddress.GetAddress(null, tuple.GrainId, null), VersionTag = GrainInfo.NO_ETAG });
+                        result.Add(new AddressAndTag { Address = ActivationAddress.GetAddress(null, tuple.GrainId, default), VersionTag = GrainInfo.NO_ETAG });
                     }
                 }
             }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -54,7 +54,7 @@ namespace Orleans.Runtime.Messaging
             // so every GW needs to behave as a different "activation" with a different ActivationId (its not enough that they have different SiloAddress)
             string stringToHash = clientId.ToString() + siloAddress.Endpoint + siloAddress.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);
             Guid hash = Utils.CalculateGuidHash(stringToHash);
-            var activationId = ActivationId.GetActivationId(UniqueKey.NewKey(hash));
+            var activationId = ActivationId.GetActivationId(hash);
             return ActivationAddress.GetAddress(siloAddress, clientId, activationId);
         }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -383,11 +383,10 @@ namespace Orleans.Runtime.Messaging
         private void ResendMessageImpl(Message message, ActivationAddress forwardingAddress = null)
         {
             if (log.IsEnabled(LogLevel.Debug)) log.Debug("Resend {0}", message);
-            message.TargetHistory = message.GetTargetHistory();
 
             if (message.TargetGrain.IsSystemTarget())
             {
-                this.PrepareSystemTargetMessage(message);
+                PrepareSystemTargetMessage(message);
                 SendMessage(message);
             }
             else if (forwardingAddress != null)
@@ -400,7 +399,7 @@ namespace Orleans.Runtime.Messaging
                 message.TargetActivation = default;
                 message.TargetSilo = null;
                 message.ClearTargetAddress();
-                _ = this.AddressAndSendMessage(message);
+                _ = AddressAndSendMessage(message);
             }
         }
 
@@ -483,7 +482,7 @@ namespace Orleans.Runtime.Messaging
                 message.TargetSilo = _siloAddress;
             }
 
-            if (message.TargetActivation is null)
+            if (message.TargetActivation.IsDefault)
             {
                 message.TargetActivation = ActivationId.GetDeterministic(message.TargetGrain);
             }

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -287,7 +287,7 @@ namespace UnitTests.Directory
             return new GrainAddress
             {
                 GrainId = GrainId.Create(GrainType.Create("test"), GrainIdKeyExtensions.CreateGuidKey(Guid.NewGuid())),
-                ActivationId = ActivationId.NewId().Key.ToHexString(),
+                ActivationId = ActivationId.NewId().Key.ToString("N"),
                 SiloAddress = siloAddress ?? GenerateSiloAddress(),
                 MembershipVersion = this.mockMembershipService.CurrentVersion,
             };

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -156,12 +156,12 @@ namespace UnitTests.Serialization
             var addr = ActivationAddress.GetAddress(null, grain, default);
             object deserialized = OrleansSerializationLoop(environment.Serializer, environment.DeepCopier, addr, false);
             Assert.IsAssignableFrom<ActivationAddress>(deserialized);
-            Assert.Null(((ActivationAddress)deserialized).Activation); //Activation no longer null after copy
+            Assert.True(((ActivationAddress)deserialized).Activation.IsDefault); //Activation no longer null after copy
             Assert.Null(((ActivationAddress)deserialized).Silo); //Silo no longer null after copy
             Assert.Equal(grain, ((ActivationAddress)deserialized).Grain); //Grain different after copy
             deserialized = OrleansSerializationLoop(environment.Serializer, environment.DeepCopier, addr);
             Assert.IsAssignableFrom<ActivationAddress>(deserialized); //ActivationAddress full serialization loop as wrong type
-            Assert.Null(((ActivationAddress)deserialized).Activation); //Activation no longer null after full serialization loop
+            Assert.True(((ActivationAddress)deserialized).Activation.IsDefault); //Activation no longer null after full serialization loop
             Assert.Null(((ActivationAddress)deserialized).Silo); //Silo no longer null after full serialization loop
             Assert.Equal(grain, ((ActivationAddress)deserialized).Grain); //Grain different after copy
         }


### PR DESCRIPTION
This PR makes `ActivationId` a simple `Guid`-backed struct, rather than a class backed by the (rather large) `UniqueKey` class.