### PR TITLE
Merge HeadersContainer into Message

### DIFF
--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -5,7 +5,6 @@ using Orleans.Serialization.Invocation;
 
 namespace Orleans.Runtime
 {
-    [GenerateSerializer]
     [WellKnownId(101)]
     internal sealed class Message
     {
@@ -21,33 +20,42 @@ namespace Orleans.Runtime
         [NonSerialized]
         private int _retryCount;
 
-        public string TargetHistory
-        {
-            get { return _targetHistory; }
-            set { _targetHistory = value; }
-        }
-
-        public DateTime? QueuedTime
-        {
-            get { return _queuedTime; }
-            set { _queuedTime = value; }
-        }
-
-        public int RetryCount
-        {
-            get { return _retryCount; }
-            set { _retryCount = value; }
-        }
-
         // Cache values of TargetAddess and SendingAddress as they are used very frequently
-        [Id(0)]
-        private ActivationAddress targetAddress;
-        [Id(1)]
-        private ActivationAddress sendingAddress;
-        
-        static Message()
-        {
-        }
+        [NonSerialized]
+        private ActivationAddress _targetAddress;
+
+        [NonSerialized]
+        private ActivationAddress _sendingAddress;
+
+        // For statistical measuring of time spent in queues.
+        [NonSerialized]
+        private ITimeInterval _timeInterval;
+
+        public object BodyObject { get; set; }
+
+        public Categories _category;
+        public Directions? _direction;
+        public bool _isReadOnly;
+        public bool _isAlwaysInterleave;
+        public bool _isUnordered;
+        public CorrelationId _id;
+        public int _forwardCount;
+        public SiloAddress _targetSilo;
+        public GrainId _targetGrain;
+        public ActivationId _targetActivation;
+        public SiloAddress _sendingSilo;
+        public GrainId _sendingGrain;
+        public ActivationId _sendingActivation;
+        public ushort _interfaceVersion;
+        public ResponseTypes _result;
+        public GrainInterfaceType _interfaceType;
+        public TimeSpan? _timeToLive;
+        public List<ActivationAddress> _cacheInvalidationHeader;
+        public RejectionTypes _rejectionType;
+        public string _rejectionInfo;
+        public Dictionary<string, object> _requestContextData;
+        public CorrelationId _callChainId;
+        public readonly DateTime _localCreationTime = DateTime.UtcNow;
 
         [GenerateSerializer]
         public enum Categories
@@ -85,82 +93,13 @@ namespace Orleans.Runtime
             CacheInvalidation
         }
 
-        [Id(2)]
-        internal HeadersContainer Headers { get; set; } = new HeadersContainer();
-
-        public Categories Category
-        {
-            get { return Headers.Category; }
-            set { Headers.Category = value; }
-        }
-
         public Directions Direction
         {
-            get { return Headers.Direction ?? default(Directions); }
-            set { Headers.Direction = value; }
+            get => _direction ?? default;
+            set => _direction = value;
         }
 
-        public bool HasDirection => Headers.Direction.HasValue;
-
-        public bool IsReadOnly
-        {
-            get { return Headers.IsReadOnly; }
-            set { Headers.IsReadOnly = value; }
-        }
-
-        public bool IsAlwaysInterleave
-        {
-            get { return Headers.IsAlwaysInterleave; }
-            set { Headers.IsAlwaysInterleave = value; }
-        }
-
-        public bool IsUnordered
-        {
-            get { return Headers.IsUnordered; }
-            set { Headers.IsUnordered = value; }
-        }
-
-        public CorrelationId Id
-        {
-            get { return Headers.Id; }
-            set { Headers.Id = value; }
-        }
-
-        public int ForwardCount
-        {
-            get { return Headers.ForwardCount; }
-            set {  Headers.ForwardCount = value; }
-        }
-        
-        public SiloAddress TargetSilo
-        {
-            get { return Headers.TargetSilo; }
-            set
-            {
-                Headers.TargetSilo = value;
-                targetAddress = null;
-            }
-        }
-        
-        public GrainId TargetGrain
-        {
-            get { return Headers.TargetGrain; }
-            set
-            {
-                Headers.TargetGrain = value;
-                targetAddress = null;
-            }
-        }
-        
-        public ActivationId TargetActivation
-        {
-            get { return Headers.TargetActivation; }
-            set
-            {
-                Headers.TargetActivation = value;
-                targetAddress = null;
-            }
-        }
+        public bool HasDirection => _direction.HasValue;
 
         public bool IsFullyAddressed => TargetSilo is object && !TargetGrain.IsDefault && !TargetActivation.IsDefault;
 
@@ -168,10 +107,10 @@ namespace Orleans.Runtime
         {
             get
             {
-                if (targetAddress is object) return targetAddress;
+                if (_targetAddress is { } result) return result;
                 if (!TargetGrain.IsDefault)
                 {
-                    return targetAddress = ActivationAddress.GetAddress(TargetSilo, TargetGrain, TargetActivation);
+                    return _targetAddress = ActivationAddress.GetAddress(TargetSilo, TargetGrain, TargetActivation);
                 }
 
                 return null;
@@ -182,86 +121,20 @@ namespace Orleans.Runtime
                 TargetGrain = value.Grain;
                 TargetActivation = value.Activation;
                 TargetSilo = value.Silo;
-                targetAddress = value;
+                _targetAddress = value;
             }
         }
         
-        public SiloAddress SendingSilo
-        {
-            get { return Headers.SendingSilo; }
-            set
-            {
-                Headers.SendingSilo = value;
-                sendingAddress = null;
-            }
-        }
-        
-        public GrainId SendingGrain
-        {
-            get { return Headers.SendingGrain; }
-            set
-            {
-                Headers.SendingGrain = value;
-                sendingAddress = null;
-            }
-        }
-        
-        public ActivationId SendingActivation
-        {
-            get { return Headers.SendingActivation; }
-            set
-            {
-                Headers.SendingActivation = value;
-                sendingAddress = null;
-            }
-        }
-
-        public CorrelationId CallChainId
-        {
-            get { return Headers.CallChainId; }
-            set { Headers.CallChainId = value; }
-        }
-
         public ActivationAddress SendingAddress
         {
-            get { return sendingAddress ?? (sendingAddress = ActivationAddress.GetAddress(SendingSilo, SendingGrain, SendingActivation)); }
+            get => _sendingAddress ??= ActivationAddress.GetAddress(SendingSilo, SendingGrain, SendingActivation);
             set
             {
                 SendingGrain = value.Grain;
                 SendingActivation = value.Activation;
                 SendingSilo = value.Silo;
-                sendingAddress = value;
+                _sendingAddress = value;
             }
-        }
-        
-        public ushort InterfaceVersion
-        {
-            get { return Headers.InterfaceVersion; }
-            set
-            {
-                Headers.InterfaceVersion = value;
-            }
-        }
-
-        public GrainInterfaceType InterfaceType
-        {
-            get { return Headers.InterfaceType; }
-            set
-            {
-                Headers.InterfaceType = value;
-            }
-        }
-
-        public ResponseTypes Result
-        {
-            get { return Headers.Result; }
-            set {  Headers.Result = value; }
-        }
-
-        public TimeSpan? TimeToLive
-        {
-            get { return Headers.TimeToLive; }
-            set { Headers.TimeToLive = value; }
         }
 
         public bool IsExpired
@@ -269,10 +142,184 @@ namespace Orleans.Runtime
             get
             {
                 if (!TimeToLive.HasValue)
+                {
                     return false;
+                }
                 
                 return TimeToLive <= TimeSpan.Zero;
             }
+        }
+
+        public string TargetHistory
+        {
+            get => _targetHistory;
+            set => _targetHistory = value;
+        }
+
+        public DateTime? QueuedTime
+        {
+            get => _queuedTime;
+            set => _queuedTime = value;
+        }
+
+        public int RetryCount
+        {
+            get => _retryCount;
+            set => _retryCount = value;
+        }
+
+        public bool HasCacheInvalidationHeader => CacheInvalidationHeader is { Count: > 0 };
+
+        public TimeSpan Elapsed => _timeInterval == null ? TimeSpan.Zero : _timeInterval.Elapsed;
+
+        public Categories Category
+        {
+            get => _category;
+            set => _category = value;
+        }
+
+        public bool IsReadOnly
+        {
+            get => _isReadOnly;
+            set => _isReadOnly = value;
+        }
+
+        public bool IsAlwaysInterleave
+        {
+            get => _isAlwaysInterleave;
+            set => _isAlwaysInterleave = value;
+        }
+
+        public bool IsUnordered
+        {
+            get => _isUnordered;
+            set => _isUnordered = value;
+        }
+
+        public CorrelationId Id
+        {
+            get => _id;
+            set => _id = value;
+        }
+
+        public int ForwardCount
+        {
+            get => _forwardCount;
+            set => _forwardCount = value;
+        }
+
+        public SiloAddress TargetSilo
+        {
+            get => _targetSilo;
+            set
+            {
+                _targetSilo = value;
+                _targetAddress = null;
+            }
+        }
+
+        public GrainId TargetGrain
+        {
+            get => _targetGrain;
+            set
+            {
+                _targetGrain = value;
+                _targetAddress = null;
+            }
+        }
+
+        public ActivationId TargetActivation
+        {
+            get => _targetActivation;
+            set
+            {
+                _targetActivation = value;
+                _targetAddress = null;
+            }
+        }
+
+        public SiloAddress SendingSilo
+        {
+            get => _sendingSilo;
+            set
+            {
+                _sendingSilo = value;
+                _sendingAddress = null;
+            }
+        }
+
+        public GrainId SendingGrain
+        {
+            get => _sendingGrain;
+            set
+            {
+                _sendingGrain = value;
+                _sendingAddress = null;
+            }
+        }
+
+        public ActivationId SendingActivation
+        {
+            get => _sendingActivation;
+            set
+            {
+                _sendingActivation = value;
+                _sendingAddress = null;
+            }
+        }
+
+        public ushort InterfaceVersion
+        {
+            get => _interfaceVersion;
+            set => _interfaceVersion = value;
+        }
+
+        public ResponseTypes Result
+        {
+            get => _result;
+            set => _result = value;
+        }
+
+        public TimeSpan? TimeToLive
+        {
+            get => _timeToLive - (DateTime.UtcNow - _localCreationTime);
+            set => _timeToLive = value;
+        }
+
+        public List<ActivationAddress> CacheInvalidationHeader
+        {
+            get => _cacheInvalidationHeader;
+            set => _cacheInvalidationHeader = value;
+        }
+
+        public RejectionTypes RejectionType
+        {
+            get => _rejectionType;
+            set => _rejectionType = value;
+        }
+
+        public string RejectionInfo
+        {
+            get => _rejectionInfo ?? "";
+            set => _rejectionInfo = value;
+        }
+
+        public Dictionary<string, object> RequestContextData
+        {
+            get => _requestContextData;
+            set => _requestContextData = value;
+        }
+
+        public CorrelationId CallChainId
+        {
+            get => _callChainId;
+            set => _callChainId = value;
+        }
+
+        public GrainInterfaceType InterfaceType
+        {
+            get => _interfaceType;
+            set => _interfaceType = value;
         }
 
         public bool IsExpirableMessage(bool dropExpiredMessages)
@@ -285,15 +332,6 @@ namespace Orleans.Runtime
             // don't set expiration for one way, system target and system grain messages.
             return Direction != Directions.OneWay && !id.IsSystemTarget();
         }
-
-        public List<ActivationAddress> CacheInvalidationHeader
-        {
-            get { return Headers.CacheInvalidationHeader; }
-            set { Headers.CacheInvalidationHeader = value; }
-        }
-
-        public bool HasCacheInvalidationHeader => this.CacheInvalidationHeader != null
-                                                  && this.CacheInvalidationHeader.Count > 0;
         
         internal void AddToCacheInvalidationHeader(ActivationAddress address)
         {
@@ -307,80 +345,44 @@ namespace Orleans.Runtime
             CacheInvalidationHeader = list;
         }
         
-        public RejectionTypes RejectionType
-        {
-            get { return Headers.RejectionType; }
-            set { Headers.RejectionType = value; }
-        }
-
-        public string RejectionInfo
-        {
-            get { return GetNotNullString(Headers.RejectionInfo); }
-            set { Headers.RejectionInfo = value; }
-        }
-
-        public Dictionary<string, object> RequestContextData
-        {
-            get { return Headers.RequestContextData; }
-            set { Headers.RequestContextData = value; }
-        }
-
-        [Id(3)]
-        public object BodyObject { get; set; }
-
         public void ClearTargetAddress()
         {
-            targetAddress = null;
+            _targetAddress = null;
         }
 
-        private static string GetNotNullString(string s)
-        {
-            return s ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Tell whether two messages are duplicates of one another
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        public bool IsDuplicate(Message other)
-        {
-            return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
-        }
-                
         // For testing and logging/tracing
         public string ToLongString()
         {
             var sb = new StringBuilder();
 
-            AppendIfExists(HeadersContainer.Headers.CACHE_INVALIDATION_HEADER, sb, (m) => m.CacheInvalidationHeader);
-            AppendIfExists(HeadersContainer.Headers.CATEGORY, sb, (m) => m.Category);
-            AppendIfExists(HeadersContainer.Headers.DIRECTION, sb, (m) => m.Direction);
-            AppendIfExists(HeadersContainer.Headers.TIME_TO_LIVE, sb, (m) => m.TimeToLive);
-            AppendIfExists(HeadersContainer.Headers.FORWARD_COUNT, sb, (m) => m.ForwardCount);
-            AppendIfExists(HeadersContainer.Headers.CORRELATION_ID, sb, (m) => m.Id);
-            AppendIfExists(HeadersContainer.Headers.ALWAYS_INTERLEAVE, sb, (m) => m.IsAlwaysInterleave);
-            AppendIfExists(HeadersContainer.Headers.READ_ONLY, sb, (m) => m.IsReadOnly);
-            AppendIfExists(HeadersContainer.Headers.IS_UNORDERED, sb, (m) => m.IsUnordered);
-            AppendIfExists(HeadersContainer.Headers.REJECTION_INFO, sb, (m) => m.RejectionInfo);
-            AppendIfExists(HeadersContainer.Headers.REJECTION_TYPE, sb, (m) => m.RejectionType);
-            AppendIfExists(HeadersContainer.Headers.REQUEST_CONTEXT, sb, (m) => m.RequestContextData);
-            AppendIfExists(HeadersContainer.Headers.RESULT, sb, (m) => m.Result);
-            AppendIfExists(HeadersContainer.Headers.SENDING_ACTIVATION, sb, (m) => m.SendingActivation);
-            AppendIfExists(HeadersContainer.Headers.SENDING_GRAIN, sb, (m) => m.SendingGrain);
-            AppendIfExists(HeadersContainer.Headers.SENDING_SILO, sb, (m) => m.SendingSilo);
-            AppendIfExists(HeadersContainer.Headers.TARGET_ACTIVATION, sb, (m) => m.TargetActivation);
-            AppendIfExists(HeadersContainer.Headers.TARGET_GRAIN, sb, (m) => m.TargetGrain);
-            AppendIfExists(HeadersContainer.Headers.CALL_CHAIN_ID, sb, (m) => m.CallChainId);
-            AppendIfExists(HeadersContainer.Headers.TARGET_SILO, sb, (m) => m.TargetSilo);
+            AppendIfExists(Headers.CACHE_INVALIDATION_HEADER, sb, (m) => m.CacheInvalidationHeader);
+            AppendIfExists(Headers.CATEGORY, sb, (m) => m.Category);
+            AppendIfExists(Headers.DIRECTION, sb, (m) => m.Direction);
+            AppendIfExists(Headers.TIME_TO_LIVE, sb, (m) => m.TimeToLive);
+            AppendIfExists(Headers.FORWARD_COUNT, sb, (m) => m.ForwardCount);
+            AppendIfExists(Headers.CORRELATION_ID, sb, (m) => m.Id);
+            AppendIfExists(Headers.ALWAYS_INTERLEAVE, sb, (m) => m.IsAlwaysInterleave);
+            AppendIfExists(Headers.READ_ONLY, sb, (m) => m.IsReadOnly);
+            AppendIfExists(Headers.IS_UNORDERED, sb, (m) => m.IsUnordered);
+            AppendIfExists(Headers.REJECTION_INFO, sb, (m) => m.RejectionInfo);
+            AppendIfExists(Headers.REJECTION_TYPE, sb, (m) => m.RejectionType);
+            AppendIfExists(Headers.REQUEST_CONTEXT, sb, (m) => m.RequestContextData);
+            AppendIfExists(Headers.RESULT, sb, (m) => m.Result);
+            AppendIfExists(Headers.SENDING_ACTIVATION, sb, (m) => m.SendingActivation);
+            AppendIfExists(Headers.SENDING_GRAIN, sb, (m) => m.SendingGrain);
+            AppendIfExists(Headers.SENDING_SILO, sb, (m) => m.SendingSilo);
+            AppendIfExists(Headers.TARGET_ACTIVATION, sb, (m) => m.TargetActivation);
+            AppendIfExists(Headers.TARGET_GRAIN, sb, (m) => m.TargetGrain);
+            AppendIfExists(Headers.CALL_CHAIN_ID, sb, (m) => m.CallChainId);
+            AppendIfExists(Headers.TARGET_SILO, sb, (m) => m.TargetSilo);
 
             return sb.ToString();
         }
         
-        private void AppendIfExists(HeadersContainer.Headers header, StringBuilder sb, Func<Message, object> valueProvider)
+        private void AppendIfExists(Headers header, StringBuilder sb, Func<Message, object> valueProvider)
         {
             // used only under log3 level
-            if ((Headers.GetHeadersMask() & header) != HeadersContainer.Headers.NONE)
+            if ((GetHeadersMask() & header) != Headers.NONE)
             {
                 sb.AppendFormat("{0}={1};", header, valueProvider(this));
                 sb.AppendLine();
@@ -443,27 +445,21 @@ namespace Orleans.Runtime
             return history.ToString();
         }
 
-        // For statistical measuring of time spent in queues.
-        [Id(4)]
-        private ITimeInterval timeInterval;
-
         public void Start()
         {
-            timeInterval = TimeIntervalFactory.CreateTimeInterval(true);
-            timeInterval.Start();
+            _timeInterval = TimeIntervalFactory.CreateTimeInterval(true);
+            _timeInterval.Start();
         }
 
         public void Stop()
         {
-            timeInterval.Stop();
+            _timeInterval.Stop();
         }
 
         public void Restart()
         {
-            timeInterval.Restart();
+            _timeInterval.Restart();
         }
-
-        public TimeSpan Elapsed => timeInterval == null ? TimeSpan.Zero : timeInterval.Elapsed;
 
         public static Message CreatePromptExceptionResponse(Message request, Exception exception)
         {
@@ -476,313 +472,92 @@ namespace Orleans.Runtime
             };
         }
 
-        [Serializable]
-        public class HeadersContainer
+        [Flags]
+        public enum Headers
         {
-            [Flags]
-            public enum Headers
+            NONE = 0,
+            ALWAYS_INTERLEAVE = 1 << 0,
+            CACHE_INVALIDATION_HEADER = 1 << 1,
+            CATEGORY = 1 << 2,
+            CORRELATION_ID = 1 << 3,
+            DEBUG_CONTEXT = 1 << 4, // No longer used
+            DIRECTION = 1 << 5,
+            TIME_TO_LIVE = 1 << 6,
+            FORWARD_COUNT = 1 << 7,
+            NEW_GRAIN_TYPE = 1 << 8,
+            GENERIC_GRAIN_TYPE = 1 << 9,
+            RESULT = 1 << 10,
+            REJECTION_INFO = 1 << 11,
+            REJECTION_TYPE = 1 << 12,
+            READ_ONLY = 1 << 13,
+            RESEND_COUNT = 1 << 14, // Support removed. Value retained for backwards compatibility.
+            SENDING_ACTIVATION = 1 << 15,
+            SENDING_GRAIN = 1 << 16,
+            SENDING_SILO = 1 << 17,
+            //IS_NEW_PLACEMENT = 1 << 18,
+
+            TARGET_ACTIVATION = 1 << 19,
+            TARGET_GRAIN = 1 << 20,
+            TARGET_SILO = 1 << 21,
+            TARGET_OBSERVER = 1 << 22,
+            IS_UNORDERED = 1 << 23,
+            REQUEST_CONTEXT = 1 << 24,
+            INTERFACE_VERSION = 1 << 26,
+
+            CALL_CHAIN_ID = 1 << 29,
+
+            INTERFACE_TYPE = 1 << 31
+            // Do not add over int.MaxValue of these.
+        }
+
+        internal Headers GetHeadersMask()
+        {
+            var headers = Headers.NONE;
+            if (Category != default)
             {
-                NONE = 0,
-                ALWAYS_INTERLEAVE = 1 << 0,
-                CACHE_INVALIDATION_HEADER = 1 << 1,
-                CATEGORY = 1 << 2,
-                CORRELATION_ID = 1 << 3,
-                DEBUG_CONTEXT = 1 << 4, // No longer used
-                DIRECTION = 1 << 5,
-                TIME_TO_LIVE = 1 << 6,
-                FORWARD_COUNT = 1 << 7,
-                NEW_GRAIN_TYPE = 1 << 8,
-                GENERIC_GRAIN_TYPE = 1 << 9,
-                RESULT = 1 << 10,
-                REJECTION_INFO = 1 << 11,
-                REJECTION_TYPE = 1 << 12,
-                READ_ONLY = 1 << 13,
-                RESEND_COUNT = 1 << 14, // Support removed. Value retained for backwards compatibility.
-                SENDING_ACTIVATION = 1 << 15,
-                SENDING_GRAIN = 1 << 16,
-                SENDING_SILO = 1 << 17,
-                //IS_NEW_PLACEMENT = 1 << 18,
-
-                TARGET_ACTIVATION = 1 << 19,
-                TARGET_GRAIN = 1 << 20,
-                TARGET_SILO = 1 << 21,
-                TARGET_OBSERVER = 1 << 22,
-                IS_UNORDERED = 1 << 23,
-                REQUEST_CONTEXT = 1 << 24,
-                INTERFACE_VERSION = 1 << 26,
-
-                CALL_CHAIN_ID = 1 << 29,
-
-                INTERFACE_TYPE = 1 << 31
-                // Do not add over int.MaxValue of these.
+                headers |= Headers.CATEGORY;
             }
 
-            public Categories _category;
-            public Directions? _direction;
-            public bool _isReadOnly;
-            public bool _isAlwaysInterleave;
-            public bool _isUnordered;
-            public CorrelationId _id;
-            public int _forwardCount;
-            public SiloAddress _targetSilo;
-            public GrainId _targetGrain;
-            public ActivationId _targetActivation;
-            public SiloAddress _sendingSilo;
-            public GrainId _sendingGrain;
-            public ActivationId _sendingActivation;
-            public ushort _interfaceVersion;
-            public ResponseTypes _result;
-            public GrainInterfaceType interfaceType;
-            public TimeSpan? _timeToLive;
-            public List<ActivationAddress> _cacheInvalidationHeader;
-            public RejectionTypes _rejectionType;
-            public string _rejectionInfo;
-            public Dictionary<string, object> _requestContextData;
-            public CorrelationId _callChainId;
-            public readonly DateTime _localCreationTime;
+            headers = _direction == null ? headers & ~Headers.DIRECTION : headers | Headers.DIRECTION;
 
-            public HeadersContainer()
+            if (IsReadOnly)
             {
-                _localCreationTime = DateTime.UtcNow;
+                headers |= Headers.READ_ONLY;
             }
 
-            public Categories Category
+            if (IsAlwaysInterleave)
             {
-                get { return _category; }
-                set
-                {
-                    _category = value;
-                }
+                headers |= Headers.ALWAYS_INTERLEAVE;
             }
 
-            public Directions? Direction
+            if (IsUnordered)
             {
-                get { return _direction; }
-                set
-                {
-                    _direction = value;
-                }
+                headers |= Headers.IS_UNORDERED;
             }
 
-            public bool IsReadOnly
+            headers = _id.ToInt64() == 0 ? headers & ~Headers.CORRELATION_ID : headers | Headers.CORRELATION_ID;
+
+            if (_forwardCount != default(int))
             {
-                get { return _isReadOnly; }
-                set
-                {
-                    _isReadOnly = value;
-                }
+                headers |= Headers.FORWARD_COUNT;
             }
 
-            public bool IsAlwaysInterleave
-            {
-                get { return _isAlwaysInterleave; }
-                set
-                {
-                    _isAlwaysInterleave = value;
-                }
-            }
-
-            public bool IsUnordered
-            {
-                get { return _isUnordered; }
-                set
-                {
-                    _isUnordered = value;
-                }
-            }
-
-            public CorrelationId Id
-            {
-                get { return _id; }
-                set
-                {
-                    _id = value;
-                }
-            }
-
-            public int ForwardCount
-            {
-                get { return _forwardCount; }
-                set
-                {
-                    _forwardCount = value;
-                }
-            }
-
-            public SiloAddress TargetSilo
-            {
-                get { return _targetSilo; }
-                set
-                {
-                    _targetSilo = value;
-                }
-            }
-
-            public GrainId TargetGrain
-            {
-                get { return _targetGrain; }
-                set
-                {
-                    _targetGrain = value;
-                }
-            }
-
-            public ActivationId TargetActivation
-            {
-                get { return _targetActivation; }
-                set
-                {
-                    _targetActivation = value;
-                }
-            }
-
-            public SiloAddress SendingSilo
-            {
-                get { return _sendingSilo; }
-                set
-                {
-                    _sendingSilo = value;
-                }
-            }
-
-            public GrainId SendingGrain
-            {
-                get { return _sendingGrain; }
-                set
-                {
-                    _sendingGrain = value;
-                }
-            }
-
-            public ActivationId SendingActivation
-            {
-                get { return _sendingActivation; }
-                set
-                {
-                    _sendingActivation = value;
-                }
-            }
-
-            public ushort InterfaceVersion
-            {
-                get { return _interfaceVersion; }
-                set
-                {
-                    _interfaceVersion = value;
-                }
-            }
-
-            public ResponseTypes Result
-            {
-                get { return _result; }
-                set
-                {
-                    _result = value;
-                }
-            }
-
-            public TimeSpan? TimeToLive
-            {
-                get
-                {
-                    return _timeToLive - (DateTime.UtcNow - _localCreationTime);
-                }
-                set
-                {
-                    _timeToLive = value;
-                }
-            }
-
-            public List<ActivationAddress> CacheInvalidationHeader
-            {
-                get { return _cacheInvalidationHeader; }
-                set
-                {
-                    _cacheInvalidationHeader = value;
-                }
-            }
-
-            public RejectionTypes RejectionType
-            {
-                get { return _rejectionType; }
-                set
-                {
-                    _rejectionType = value;
-                }
-            }
-
-            public string RejectionInfo
-            {
-                get { return _rejectionInfo; }
-                set
-                {
-                    _rejectionInfo = value;
-                }
-            }
-
-            public Dictionary<string, object> RequestContextData
-            {
-                get { return _requestContextData; }
-                set
-                {
-                    _requestContextData = value;
-                }
-            }
-
-            public CorrelationId CallChainId
-            {
-                get { return _callChainId; }
-                set
-                {
-                    _callChainId = value;
-                }
-            }
-
-            public GrainInterfaceType InterfaceType
-            {
-                get { return interfaceType; }
-                set
-                {
-                    interfaceType = value;
-                }
-            }
-
-            internal Headers GetHeadersMask()
-            {
-                Headers headers = Headers.NONE;
-                if (Category != default(Categories))
-                    headers = headers | Headers.CATEGORY;
-
-                headers = _direction == null ? headers & ~Headers.DIRECTION : headers | Headers.DIRECTION;
-                if (IsReadOnly)
-                    headers = headers | Headers.READ_ONLY;
-                if (IsAlwaysInterleave)
-                    headers = headers | Headers.ALWAYS_INTERLEAVE;
-                if (IsUnordered)
-                    headers = headers | Headers.IS_UNORDERED;
-
-                headers = _id.ToInt64() == 0 ? headers & ~Headers.CORRELATION_ID : headers | Headers.CORRELATION_ID;
-
-                if (_forwardCount != default(int))
-                    headers = headers | Headers.FORWARD_COUNT;
-
-                headers = _targetSilo == null ? headers & ~Headers.TARGET_SILO : headers | Headers.TARGET_SILO;
-                headers = _targetGrain.IsDefault ? headers & ~Headers.TARGET_GRAIN : headers | Headers.TARGET_GRAIN;
-                headers = _targetActivation.IsDefault ? headers & ~Headers.TARGET_ACTIVATION : headers | Headers.TARGET_ACTIVATION;
-                headers = _sendingSilo is null ? headers & ~Headers.SENDING_SILO : headers | Headers.SENDING_SILO;
-                headers = _sendingGrain.IsDefault ? headers & ~Headers.SENDING_GRAIN : headers | Headers.SENDING_GRAIN;
-                headers = _sendingActivation.IsDefault ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
-                headers = _interfaceVersion == 0 ? headers & ~Headers.INTERFACE_VERSION : headers | Headers.INTERFACE_VERSION;
-                headers = _result == default(ResponseTypes) ? headers & ~Headers.RESULT : headers | Headers.RESULT;
-                headers = _timeToLive == null ? headers & ~Headers.TIME_TO_LIVE : headers | Headers.TIME_TO_LIVE;
-                headers = _cacheInvalidationHeader == null || _cacheInvalidationHeader.Count == 0 ? headers & ~Headers.CACHE_INVALIDATION_HEADER : headers | Headers.CACHE_INVALIDATION_HEADER;
-                headers = _rejectionType == default(RejectionTypes) ? headers & ~Headers.REJECTION_TYPE : headers | Headers.REJECTION_TYPE;
-                headers = string.IsNullOrEmpty(_rejectionInfo) ? headers & ~Headers.REJECTION_INFO : headers | Headers.REJECTION_INFO;
-                headers = _requestContextData == null || _requestContextData.Count == 0 ? headers & ~Headers.REQUEST_CONTEXT : headers | Headers.REQUEST_CONTEXT;
-                headers = _callChainId.ToInt64() == 0 ? headers & ~Headers.CALL_CHAIN_ID : headers | Headers.CALL_CHAIN_ID;
-                headers = interfaceType.IsDefault ? headers & ~Headers.INTERFACE_TYPE : headers | Headers.INTERFACE_TYPE;
-                return headers;
-            }
+            headers = _targetSilo == null ? headers & ~Headers.TARGET_SILO : headers | Headers.TARGET_SILO;
+            headers = _targetGrain.IsDefault ? headers & ~Headers.TARGET_GRAIN : headers | Headers.TARGET_GRAIN;
+            headers = _targetActivation.IsDefault ? headers & ~Headers.TARGET_ACTIVATION : headers | Headers.TARGET_ACTIVATION;
+            headers = _sendingSilo is null ? headers & ~Headers.SENDING_SILO : headers | Headers.SENDING_SILO;
+            headers = _sendingGrain.IsDefault ? headers & ~Headers.SENDING_GRAIN : headers | Headers.SENDING_GRAIN;
+            headers = _sendingActivation.IsDefault ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
+            headers = _interfaceVersion == 0 ? headers & ~Headers.INTERFACE_VERSION : headers | Headers.INTERFACE_VERSION;
+            headers = _result == default(ResponseTypes) ? headers & ~Headers.RESULT : headers | Headers.RESULT;
+            headers = _timeToLive == null ? headers & ~Headers.TIME_TO_LIVE : headers | Headers.TIME_TO_LIVE;
+            headers = _cacheInvalidationHeader == null || _cacheInvalidationHeader.Count == 0 ? headers & ~Headers.CACHE_INVALIDATION_HEADER : headers | Headers.CACHE_INVALIDATION_HEADER;
+            headers = _rejectionType == default(RejectionTypes) ? headers & ~Headers.REJECTION_TYPE : headers | Headers.REJECTION_TYPE;
+            headers = string.IsNullOrEmpty(_rejectionInfo) ? headers & ~Headers.REJECTION_INFO : headers | Headers.REJECTION_INFO;
+            headers = _requestContextData == null || _requestContextData.Count == 0 ? headers & ~Headers.REQUEST_CONTEXT : headers | Headers.REQUEST_CONTEXT;
+            headers = _callChainId.ToInt64() == 0 ? headers & ~Headers.CALL_CHAIN_ID : headers | Headers.CALL_CHAIN_ID;
+            headers = _interfaceType.IsDefault ? headers & ~Headers.INTERFACE_TYPE : headers | Headers.INTERFACE_TYPE;
+            return headers;
         }
     }
 }

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Networking.Shared;
 using static Orleans.Runtime.Message;
-using static Orleans.Runtime.Message.HeadersContainer;
 using Orleans.Serialization;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.Codecs;
@@ -91,23 +90,18 @@ namespace Orleans.Runtime.Messaging
                 var body = input.Slice(bodyOffset, bodyLength);
 
                 // build message
-                HeadersContainer headersContainer;
                 if (header.IsSingleSegment)
                 {
                     var headersReader = Reader.Create(header.First.Span, _deserializationSession);
-                    headersContainer = DeserializeFast(ref headersReader);
+                    message = DeserializeFast(ref headersReader);
                 }
                 else
                 {
                     var headersReader = Reader.Create(header, _deserializationSession);
-                    headersContainer = DeserializeFast(ref headersReader);
+                    message = DeserializeFast(ref headersReader);
                 }
 
                 _deserializationSession.PartialReset();
-                message = new Message
-                {
-                    Headers = headersContainer
-                };
 
                 // Body deserialization is more likely to fail than header deserialization.
                 // Separating the two allows for these kinds of errors to be propagated back to the caller.
@@ -143,7 +137,7 @@ namespace Orleans.Runtime.Messaging
                 Span<byte> lengthFields = stackalloc byte[FramingLength];
 
                 var headerWriter = Writer.Create(buffer, _serializationSession);
-                SerializeFast(ref headerWriter, message.Headers);
+                SerializeFast(ref headerWriter, message);
                 headerWriter.Commit();
 
                 var headerLength = bufferWriter.CommittedBytes;
@@ -183,7 +177,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        private HeadersContainer SerializeFast<TBufferWriter>(ref Writer<TBufferWriter> writer, HeadersContainer value) where TBufferWriter : IBufferWriter<byte>
+        private Message SerializeFast<TBufferWriter>(ref Writer<TBufferWriter> writer, Message value) where TBufferWriter : IBufferWriter<byte>
         {
             var headers = value.GetHeadersMask();
             writer.WriteVarUInt32((uint)headers);
@@ -286,10 +280,10 @@ namespace Orleans.Runtime.Messaging
             return value;
         }
 
-        private HeadersContainer DeserializeFast<TInput>(ref Reader<TInput> reader)
+        private Message DeserializeFast<TInput>(ref Reader<TInput> reader)
         {
             var headers = (Headers)reader.ReadVarUInt32();
-            var result = new HeadersContainer();
+            var result = new Message();
 
             if ((headers & Headers.CACHE_INVALIDATION_HEADER) != Headers.NONE)
             {

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -423,7 +423,7 @@ namespace Orleans.Runtime.Messaging
                 this.LocalEndPoint);
 
             // If deserialization completely failed, rethrow the exception so that it can be handled at another level.
-            if (message?.Headers is null)
+            if (message is null)
             {
                 // Returning false here informs the caller that the exception should not be caught.
                 return false;

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -170,7 +170,7 @@ namespace Orleans.Runtime.Messaging
 
         protected override void OnSendMessageFailure(Message message, string error)
         {
-            if (message?.Headers != null && message.IsPing())
+            if (message != null && message.IsPing())
             {
                 this.Log.LogWarning("Failed to send ping message {Message}", message);
             }
@@ -311,7 +311,7 @@ namespace Orleans.Runtime.Messaging
 
         public void FailMessage(Message msg, string reason)
         {
-            if (msg?.Headers != null && msg.IsPing())
+            if (msg != null && msg.IsPing())
             {
                 this.Log.LogWarning("Failed ping message {Message}", msg);
             }
@@ -347,7 +347,7 @@ namespace Orleans.Runtime.Messaging
         {
             if (msg == null) return;
 
-            if (msg?.Headers != null && msg.IsPing())
+            if (msg != null && msg.IsPing())
             {
                 this.Log.LogWarning("Retrying ping message {Message}", msg);
             }


### PR DESCRIPTION
This PR merges the `HeadersContainer` class into the `Message` class.
The two types have identical lifetimes and are never used separately.
The benefit of merging them are:
* Less code
* Improved performance due to fewer allocations and less indirection.