### PR TITLE
Add `CoarseStopwatch` using `Environment.TickCount64` and use on hot paths

### DIFF
--- a/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
@@ -77,8 +77,8 @@ namespace Orleans.Runtime
         DateTime KeepAliveUntil { get; }
         DateTime CollectionTicket { get; set; }
         bool IsInactive { get; }
-        bool IsStale(DateTime now);
-        TimeSpan GetIdleness(DateTime now);
+        bool IsStale();
+        TimeSpan GetIdleness();
         void StartDeactivating();
         void DelayDeactivation(TimeSpan timeSpan);
     }

--- a/src/Orleans.Core/Networking/SocketDirection.cs
+++ b/src/Orleans.Core/Networking/SocketDirection.cs
@@ -1,6 +1,6 @@
 namespace Orleans.Messaging
 {
-    internal enum ConnectionDirection
+    internal enum ConnectionDirection : byte
     {
         SiloToSilo,
         ClientToGateway,

--- a/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/MessagingProcessingStatisticsGroup.cs
@@ -23,19 +23,19 @@ namespace Orleans.Runtime
             dispatcherMessagesProcessedOkPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                dispatcherMessagesProcessedOkPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
+                dispatcherMessagesProcessedOkPerDirection[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_OK_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
             dispatcherMessagesProcessedErrorsPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                dispatcherMessagesProcessedErrorsPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
+                dispatcherMessagesProcessedErrorsPerDirection[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_ERRORS_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
             dispatcherMessagesProcessingReceivedPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                dispatcherMessagesProcessingReceivedPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
+                dispatcherMessagesProcessingReceivedPerDirection[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_DISPATCHER_RECEIVED_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
             dispatcherMessagesProcessedTotal = CounterStatistic.FindOrCreate(StatisticNames.MESSAGING_DISPATCHER_PROCESSED_TOTAL);
@@ -57,7 +57,7 @@ namespace Orleans.Runtime
         internal static void OnDispatcherMessageReceive(Message msg)
         {
             var context = RuntimeContext.Current;
-            dispatcherMessagesProcessingReceivedPerDirection[(int)msg.Direction].Increment();
+            dispatcherMessagesProcessingReceivedPerDirection[(byte)msg.Direction].Increment();
             dispatcherMessagesReceivedTotal.Increment();
             if (context == null)
             {
@@ -71,13 +71,13 @@ namespace Orleans.Runtime
 
         internal static void OnDispatcherMessageProcessedOk(Message msg)
         {
-            dispatcherMessagesProcessedOkPerDirection[(int)msg.Direction].Increment();
+            dispatcherMessagesProcessedOkPerDirection[(byte)msg.Direction].Increment();
             dispatcherMessagesProcessedTotal.Increment();
         }
 
         internal static void OnDispatcherMessageProcessedError(Message msg)
         {
-            dispatcherMessagesProcessedErrorsPerDirection[(int)msg.Direction].Increment();
+            dispatcherMessagesProcessedErrorsPerDirection[(byte)msg.Direction].Increment();
             dispatcherMessagesProcessedTotal.Increment();
         }
 

--- a/src/Orleans.Core/Statistics/MessagingStatisticsGroup.cs
+++ b/src/Orleans.Core/Statistics/MessagingStatisticsGroup.cs
@@ -88,7 +88,7 @@ namespace Orleans.Runtime
             MessagesSentPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                MessagesSentPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
+                MessagesSentPerDirection[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_SENT_MESSAGES_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
 
@@ -96,7 +96,7 @@ namespace Orleans.Runtime
             MessagesReceivedPerDirection ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                MessagesReceivedPerDirection[(int)direction] = CounterStatistic.FindOrCreate(
+                MessagesReceivedPerDirection[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_RECEIVED_MESSAGES_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
 
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
             ReroutedMessages ??= new CounterStatistic[Enum.GetValues(typeof(Message.Directions)).Length];
             foreach (var direction in Enum.GetValues(typeof(Message.Directions)))
             {
-                ReroutedMessages[(int)direction] = CounterStatistic.FindOrCreate(
+                ReroutedMessages[(byte)direction] = CounterStatistic.FindOrCreate(
                     new StatisticName(StatisticNames.MESSAGING_REROUTED_PER_DIRECTION, Enum.GetName(typeof(Message.Directions), direction)));
             }
 
@@ -154,13 +154,13 @@ namespace Orleans.Runtime
         {
             Debug.Assert(numTotalBytes >= 0, $"OnMessageSend(numTotalBytes={numTotalBytes})");
             MessagesSentTotal.Increment();
-            MessagesSentPerDirection[(int)msg.Direction].Increment();
+            MessagesSentPerDirection[(byte)msg.Direction].Increment();
 
             TotalBytesSent.IncrementBy(numTotalBytes);
             HeaderBytesSent.IncrementBy(headerBytes);
             sentMsgSizeHistogram.AddData(numTotalBytes);
             messageSendCounter?.Increment();
-            perSocketDirectionStatsSend[(int)connectionDirection].OnMessage(1, numTotalBytes);
+            perSocketDirectionStatsSend[(byte)connectionDirection].OnMessage(1, numTotalBytes);
         }
 
         private static CounterStatistic FindCounter(ConcurrentDictionary<string, CounterStatistic> counters, StatisticName name, CounterStorage storage)
@@ -184,12 +184,12 @@ namespace Orleans.Runtime
         internal static void OnMessageReceive(CounterStatistic messageReceivedCounter, Message msg, int numTotalBytes, int headerBytes, ConnectionDirection connectionDirection)
         {
             MessagesReceived.Increment();
-            MessagesReceivedPerDirection[(int)msg.Direction].Increment();
+            MessagesReceivedPerDirection[(byte)msg.Direction].Increment();
             totalBytesReceived.IncrementBy(numTotalBytes);
             headerBytesReceived.IncrementBy(headerBytes);
             receiveMsgSizeHistogram.AddData(numTotalBytes);
             messageReceivedCounter?.Increment();
-            perSocketDirectionStatsReceive[(int)connectionDirection].OnMessage(1, numTotalBytes);
+            perSocketDirectionStatsReceive[(byte)connectionDirection].OnMessage(1, numTotalBytes);
         }
 
         internal static void OnMessageExpired(Phase phase)
@@ -237,7 +237,7 @@ namespace Orleans.Runtime
         internal static void OnFailedSentMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
-            int direction = (int)msg.Direction;
+            int direction = (byte)msg.Direction;
             if (FailedSentMessages[direction] == null)
             {
                 FailedSentMessages[direction] = CounterStatistic.FindOrCreate(
@@ -249,7 +249,7 @@ namespace Orleans.Runtime
         internal static void OnDroppedSentMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
-            int direction = (int)msg.Direction;
+            int direction = (byte)msg.Direction;
             if (DroppedSentMessages[direction] == null)
             {
                 DroppedSentMessages[direction] = CounterStatistic.FindOrCreate(
@@ -261,7 +261,7 @@ namespace Orleans.Runtime
         internal static void OnRejectedMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
-            int direction = (int)msg.Direction;
+            int direction = (byte)msg.Direction;
             if (RejectedMessages[direction] == null)
             {
                 RejectedMessages[direction] = CounterStatistic.FindOrCreate(
@@ -272,7 +272,7 @@ namespace Orleans.Runtime
 
         internal static void OnMessageReRoute(Message msg)
         {
-            ReroutedMessages[(int)msg.Direction].Increment();
+            ReroutedMessages[(byte)msg.Direction].Increment();
         }
     }
 }

--- a/src/Orleans.Core/Timers/CheapStopwatch.cs
+++ b/src/Orleans.Core/Timers/CheapStopwatch.cs
@@ -1,0 +1,135 @@
+using System;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Cheap, non-allocating stopwatch for timing durations with an accuracy within tens of milliseconds.
+    /// </summary>
+    internal struct CoarseStopwatch
+    {
+        private long _value;
+
+        /// <summary>
+        /// Starts a new instance.
+        /// </summary>
+        /// <returns>A new, running stopwatch.</returns>
+        public static CoarseStopwatch StartNew() => new(GetTimestamp());
+        
+        private CoarseStopwatch(long timestamp)
+        {
+            _value = timestamp;
+        }
+
+        /// <summary>
+        /// Returns true if this instance is running or false otherwise.
+        /// </summary>
+        public bool IsRunning => _value > 0;
+        
+        /// <summary>
+        /// Returns the elapsed time.
+        /// </summary>
+        public TimeSpan Elapsed => TimeSpan.FromMilliseconds(ElapsedMilliseconds);
+
+        /// <summary>
+        /// Returns the elapsed ticks.
+        /// </summary>
+        public long ElapsedMilliseconds
+        {
+            get
+            {
+                // A positive timestamp value indicates the start time of a running stopwatch,
+                // a negative value indicates the negative total duration of a stopped stopwatch.
+                var timestamp = _value;
+                
+                long delta;
+                if (IsRunning)
+                {
+                    // The stopwatch is still running.
+                    var start = timestamp;
+                    var end = GetTimestamp();
+                    delta = end - start;
+                }
+                else
+                {
+                    // The stopwatch has been stopped.
+                    delta = -timestamp;
+                }
+
+                return delta;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of ticks in the timer mechanism.
+        /// </summary>
+        /// <returns>The number of ticks in the timer mechanism</returns>
+        public static long GetTimestamp() => Environment.TickCount64;
+
+        /// <summary>
+        /// Returns a new, stopped <see cref="CoarseStopwatch"/> with the provided start and end timestamps.
+        /// </summary>
+        /// <param name="start">The start timestamp.</param>
+        /// <param name="end">The end timestamp.</param>
+        /// <returns>A new, stopped <see cref="CoarseStopwatch"/> with the provided start and end timestamps.</returns>
+        public static CoarseStopwatch FromTimestamp(long start, long end) => new(-(end - start));
+
+        /// <summary>
+        /// Gets the raw counter value for this instance.
+        /// </summary>
+        /// <remarks> 
+        /// A positive timestamp value indicates the start time of a running stopwatch,
+        /// a negative value indicates the negative total duration of a stopped stopwatch.
+        /// </remarks>
+        /// <returns>The raw counter value.</returns>
+        public long GetRawTimestamp() => _value;
+
+        /// <summary>
+        /// Starts the stopwatch.
+        /// </summary>
+        public void Start()
+        {
+            var timestamp = _value;
+            
+            // If already started, do nothing.
+            if (IsRunning) return;
+
+            // Stopwatch is stopped, therefore value is zero or negative.
+            // Add the negative value to the current timestamp to start the stopwatch again.
+            var newValue = GetTimestamp() + timestamp;
+            if (newValue == 0) newValue = 1;
+            _value = newValue;
+        }
+
+        /// <summary>
+        /// Restarts this stopwatch, beginning from zero time elapsed.
+        /// </summary>
+        public void Restart() => _value = GetTimestamp();
+
+        /// <summary>
+        /// Resets this stopwatch into a stopped state with no elapsed duration.
+        /// </summary>
+        public void Reset() => _value = 0;
+
+        /// <summary>
+        /// Stops this stopwatch.
+        /// </summary>
+        public void Stop()
+        {
+            var timestamp = _value;
+
+            // If already stopped, do nothing.
+            if (!IsRunning) return;
+
+            var end = GetTimestamp();
+            var delta = end - timestamp;
+
+            _value = -delta;
+        }
+
+        public override bool Equals(object obj) => obj is CoarseStopwatch stopwatch && _value == stopwatch._value;
+        public bool Equals(CoarseStopwatch other) => _value == other._value;
+        public override int GetHashCode() => HashCode.Combine(_value);
+        public static bool operator== (CoarseStopwatch left, CoarseStopwatch right) => left.Equals(right);
+        public static bool operator!= (CoarseStopwatch left, CoarseStopwatch right) => !left.Equals(right);
+    }
+}

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -214,7 +214,7 @@ namespace Orleans.Runtime
                             var timeout = TimeSpan.FromTicks(Math.Max(keepAliveDuration.Ticks, activation.CollectionAgeLimit.Ticks));
                             ScheduleCollection(activation, timeout);
                         }
-                        else if (!activation.IsInactive || !activation.IsStale(now))
+                        else if (!activation.IsInactive || !activation.IsStale())
                         {
                             ScheduleCollection(activation, activation.CollectionAgeLimit);
                         }
@@ -262,7 +262,7 @@ namespace Orleans.Runtime
                         }
                         else
                         {
-                            if (activation.GetIdleness(now) >= ageLimit)
+                            if (activation.GetIdleness() >= ageLimit)
                             {
                                 if (bucket.TryRemove(activation))
                                 {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -26,16 +26,16 @@ namespace Orleans.Runtime
         private readonly GrainTypeSharedContext _shared;
         private readonly IServiceScope serviceScope;
         private readonly WorkItemGroup _workItemGroup;
-        private readonly List<Message> _waitingRequests = new();
-        private readonly Dictionary<Message, DateTime> _runningRequests = new();
+        private readonly List<(Message Message, CoarseStopwatch QueuedTime)> _waitingRequests = new();
+        private readonly Dictionary<Message, CoarseStopwatch> _runningRequests = new();
         private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = true };
         private readonly GrainLifecycle lifecycle;
         private List<object> _pendingOperations;
         private Message _blockingRequest;
         private Dictionary<Type, object> _components;
         private bool isInWorkingSet;
-        private DateTime currentRequestStartTime;
-        private DateTime becameIdle;
+        private CoarseStopwatch _busyDuration;
+        private CoarseStopwatch _idleDuration;
         private GrainReference _selfReference;
 
         // Values which are needed less frequently and do not warrant living directly on activation for object size reasons.
@@ -330,7 +330,7 @@ namespace Orleans.Runtime
         {
             lock (this)
             {
-                var tmp = _waitingRequests.ToList();
+                var tmp = _waitingRequests.Select(m => m.Item1).ToList();
                 _waitingRequests.Clear();
                 return tmp;
             }
@@ -339,20 +339,12 @@ namespace Orleans.Runtime
         /// <summary>
         /// Returns how long this activation has been idle.
         /// </summary>
-        public TimeSpan GetIdleness(DateTime now)
-        {
-            if (now == default)
-            {
-                throw new ArgumentException("default(DateTime) is not allowed; Use DateTime.UtcNow instead.", "now");
-            }
-
-            return now - becameIdle;
-        }
+        public TimeSpan GetIdleness() => _idleDuration.Elapsed;
 
         /// <summary>
         /// Returns whether this activation has been idle long enough to be collected.
         /// </summary>
-        public bool IsStale(DateTime now) => GetIdleness(now) >= _shared.CollectionAgeLimit;
+        public bool IsStale() => GetIdleness() >= _shared.CollectionAgeLimit;
 
         public void DelayDeactivation(TimeSpan timespan)
         {
@@ -408,7 +400,7 @@ namespace Orleans.Runtime
         private void DeactivateStuckActivation()
         {
             IsStuckProcessingMessage = true;
-            var msg = $"Activation {this} has been processing request {_blockingRequest} since {currentRequestStartTime} and is likely stuck";
+            var msg = $"Activation {this} has been processing request {_blockingRequest} since {_busyDuration} and is likely stuck";
             DeactivationReason = new(DeactivationReasonCode.StuckProcessingMessage, msg);
 
             // Mark the grain as deactivating so that messages are forwarded instead of being invoked
@@ -502,8 +494,13 @@ namespace Orleans.Runtime
                 if (_blockingRequest is object)
                 {
                     var message = _blockingRequest;
-                    var timeSinceQueued = now - message.QueuedTime;
-                    var executionTime = now - currentRequestStartTime;
+                    TimeSpan? timeSinceQueued = default;
+                    if (_runningRequests.TryGetValue(message, out var waitTime))
+                    {
+                        timeSinceQueued = waitTime.Elapsed;
+                    }
+                    
+                    var executionTime = _busyDuration.Elapsed;
                     if (executionTime >= slowRunningRequestDuration)
                     {
                         GetStatusList(ref diagnostics);
@@ -524,11 +521,11 @@ namespace Orleans.Runtime
                 foreach (var running in _runningRequests)
                 {
                     var message = running.Key;
-                    var startTime = running.Value;
+                    var runDuration = running.Value;
                     if (ReferenceEquals(message, _blockingRequest)) continue;
 
                     // Check how long they've been executing.
-                    var executionTime = now - startTime;
+                    var executionTime = runDuration.Elapsed;
                     if (executionTime >= slowRunningRequestDuration)
                     {
                         // Interleaving message X has been executing for a long time
@@ -544,16 +541,17 @@ namespace Orleans.Runtime
                 }
 
                 var queueLength = 1;
-                foreach (var message in _waitingRequests)
+                foreach (var pair in _waitingRequests)
                 {
-                    var waitTime = now - message.QueuedTime;
-                    if (waitTime >= longQueueTimeDuration)
+                    var message = pair.Message;
+                    var queuedTime = pair.QueuedTime.Elapsed;
+                    if (queuedTime >= longQueueTimeDuration)
                     {
                         // Message X has been enqueued on the target grain for Y and is currently position QueueLength in queue for processing.
                         GetStatusList(ref diagnostics);
                         var messageDiagnostics = new List<string>(diagnostics)
                         {
-                           $"Message {message} has been enqueued on the target grain for {waitTime} and is currently position {queueLength} in queue for processing."
+                           $"Message {message} has been enqueued on the target grain for {queuedTime} and is currently position {queueLength} in queue for processing."
                         };
 
                         var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: false, isWaiting: true, messageDiagnostics);
@@ -593,7 +591,7 @@ namespace Orleans.Runtime
                 return
                     $"[Activation: {Address.Silo.ToLongString()}/{GrainId.ToString()}{ActivationId} {GetActivationInfoString()} "
                     + $"State={State} NonReentrancyQueueSize={WaitingCount} NumRunning={_runningRequests.Count} "
-                    + $"IdlenessTimeSpan={GetIdleness(DateTime.UtcNow)} CollectionAgeLimit={_shared.CollectionAgeLimit}"
+                    + $"IdlenessTimeSpan={GetIdleness()} CollectionAgeLimit={_shared.CollectionAgeLimit}"
                     + $"{((includeExtraDetails && _blockingRequest != null) ? " CurrentlyExecuting=" + _blockingRequest : "")}]";
             }
         }
@@ -743,7 +741,7 @@ namespace Orleans.Runtime
                             break;
                         }
 
-                        message = _waitingRequests[i];
+                        message = _waitingRequests[i].Message;
                         if (!MayInvokeRequest(message))
                         {
                             // The activation is not able to process this message right now, so try the next message.
@@ -751,7 +749,7 @@ namespace Orleans.Runtime
 
                             if (_blockingRequest != null)
                             {
-                                var currentRequestActiveTime = DateTime.UtcNow - currentRequestStartTime;
+                                var currentRequestActiveTime = _busyDuration.Elapsed;
                                 if (currentRequestActiveTime > _shared.MaxRequestProcessingTime && !IsStuckProcessingMessage)
                                 {
                                     DeactivateStuckActivation();
@@ -796,15 +794,15 @@ namespace Orleans.Runtime
 
                         void RecordRunning(Message message, bool isInterleavable)
                         {
-                            var now = DateTime.UtcNow;
-                            _runningRequests.Add(message, now);
+                            var stopwatch = CoarseStopwatch.StartNew();
+                            _runningRequests.Add(message, stopwatch);
 
                             if (_blockingRequest != null || isInterleavable) return;
 
                             // This logic only works for non-reentrant activations
                             // Consider: Handle long request detection for reentrant activations.
                             _blockingRequest = message;
-                            currentRequestStartTime = now;
+                            _busyDuration = stopwatch;
                         }
                     }
 
@@ -969,7 +967,7 @@ namespace Orleans.Runtime
 
                 if (_runningRequests.Count == 0)
                 {
-                    becameIdle = DateTime.UtcNow;
+                    _idleDuration = CoarseStopwatch.StartNew();
                 }
 
                 if (!isInWorkingSet)
@@ -982,7 +980,7 @@ namespace Orleans.Runtime
                 if (_blockingRequest is null || message.Equals(_blockingRequest))
                 {
                     _blockingRequest = null;
-                    currentRequestStartTime = DateTime.MinValue;
+                    _busyDuration = default;
                 }
             }
 
@@ -1047,12 +1045,8 @@ namespace Orleans.Runtime
             {
                 state = State;
                 blockingMessage = _blockingRequest;
-                if (!message.QueuedTime.HasValue)
-                {
-                    message.QueuedTime = DateTime.UtcNow;
-                }
 
-                _waitingRequests.Add(message);
+                _waitingRequests.Add((message, CoarseStopwatch.StartNew()));
             }
 
             _workSignal.Signal();


### PR DESCRIPTION
We currently use our custom `ValueStopwatch` struct in many places where we want a non-allocating stopwatch to measure durations with high precision. `ValueStopwatch` is suitable for measuring very short durations infrequently, but it can be expensive on hot paths because it uses `Stopwatch.GetTimestamp()`, which involves a system call.

`CoarseStopwatch` uses `Environment.TickCount64` ("milliseconds since the system started") instead, which is much cheaper but has the downside of being less accurate and less precise. It's more suitable for use on hot paths when timing longer running events where accuracy is not critical. For example, LRU cache ages, message age/queueing duration, and activation idleness.

Note that this PR is should be merged after #7245, since both make changes to `Message`.