### PR TITLE
Add and use `ConcurrentObjectPool` instead of `DefaultObjectPool`

### DIFF
--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Threading;
+using Orleans.Serialization.Invocation;
 
 namespace Orleans.Serialization.Cloning
 {
@@ -224,19 +225,19 @@ namespace Orleans.Serialization.Cloning
 
     public sealed class CopyContextPool 
     {
-        private readonly ObjectPool<CopyContext> _pool;
+        private readonly ConcurrentObjectPool<CopyContext, PoolPolicy> _pool;
 
         public CopyContextPool(CodecProvider codecProvider)
         {
             var sessionPoolPolicy = new PoolPolicy(codecProvider, Return);
-            _pool = new DefaultObjectPool<CopyContext>(sessionPoolPolicy);
+            _pool = new ConcurrentObjectPool<CopyContext, PoolPolicy>(sessionPoolPolicy);
         }
 
         public CopyContext GetContext() => _pool.Get();
 
         private void Return(CopyContext session) => _pool.Return(session);
 
-        private class PoolPolicy : IPooledObjectPolicy<CopyContext>
+        private readonly struct PoolPolicy : IPooledObjectPolicy<CopyContext>
         {
             private readonly CodecProvider _codecProvider;
             private readonly Action<CopyContext> _onDisposed;

--- a/src/Orleans.Serialization/Invocation/Pools/ConcurrentObjectPool.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/ConcurrentObjectPool.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Orleans.Serialization.Invocation
+{
+    internal sealed class ConcurrentObjectPool<T> : ConcurrentObjectPool<T, DefaultConcurrentObjectPoolPolicy<T>> where T : class, new()
+    {
+        public ConcurrentObjectPool() : base(new())
+        {
+        }
+    }
+
+    internal class ConcurrentObjectPool<T, TPoolPolicy> : ObjectPool<T> where T : class where TPoolPolicy : IPooledObjectPolicy<T>
+    {
+        private readonly ThreadLocal<Stack<T>> _objects = new(() => new());
+
+        private readonly TPoolPolicy _policy;
+
+        public ConcurrentObjectPool(TPoolPolicy policy) => _policy = policy;
+
+        public int MaxPoolSize { get; set; } = int.MaxValue;
+
+        public override T Get()
+        {
+            var stack = _objects.Value;
+            if (stack.TryPop(out var result))
+            {
+                return result;
+            }
+
+            return _policy.Create();
+        }
+
+        public override void Return(T obj)
+        {
+            if (_policy.Return(obj))
+            {
+                var stack = _objects.Value;
+                if (stack.Count < MaxPoolSize)
+                {
+                    stack.Push(obj);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Serialization/Invocation/Pools/DefaultConcurrentObjectPoolPolicy.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/DefaultConcurrentObjectPoolPolicy.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.ObjectPool;
+
+namespace Orleans.Serialization.Invocation
+{
+    internal readonly struct DefaultConcurrentObjectPoolPolicy<T> : IPooledObjectPolicy<T> where T : class, new()
+    {
+        public T Create() => new();
+
+        public bool Return(T obj) => true;
+    }
+}

--- a/src/Orleans.Serialization/Invocation/Pools/InvokablePool.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/InvokablePool.cs
@@ -10,7 +10,7 @@ namespace Orleans.Serialization.Invocation
 
         private static class TypedPool<T> where T : class, IInvokable, new()
         {
-            public static readonly DefaultObjectPool<T> Pool = new DefaultObjectPool<T>(new DefaultPooledObjectPolicy<T>());
+            public static readonly ConcurrentObjectPool<T> Pool = new();
         }
     }
 }

--- a/src/Orleans.Serialization/Invocation/Pools/ResponseCompletionSourcePool.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/ResponseCompletionSourcePool.cs
@@ -1,10 +1,8 @@
-using Microsoft.Extensions.ObjectPool;
-
 namespace Orleans.Serialization.Invocation
 {
     public static class ResponseCompletionSourcePool
     {
-        public static readonly DefaultObjectPool<ResponseCompletionSource> UntypedPool = new(new DefaultPooledObjectPolicy<ResponseCompletionSource>());
+        internal static readonly ConcurrentObjectPool<ResponseCompletionSource, DefaultConcurrentObjectPoolPolicy<ResponseCompletionSource>> UntypedPool = new(new());
 
         public static ResponseCompletionSource<T> Get<T>() => TypedPool<T>.Pool.Get();
         public static void Return<T>(ResponseCompletionSource<T> obj) => TypedPool<T>.Pool.Return(obj);
@@ -14,7 +12,7 @@ namespace Orleans.Serialization.Invocation
 
         private static class TypedPool<T>
         {
-            public static readonly DefaultObjectPool<ResponseCompletionSource<T>> Pool = new(new DefaultPooledObjectPolicy<ResponseCompletionSource<T>>());
+            public static readonly ConcurrentObjectPool<ResponseCompletionSource<T>, DefaultConcurrentObjectPoolPolicy<ResponseCompletionSource<T>>> Pool = new(new());
         }
     }
 }

--- a/src/Orleans.Serialization/Invocation/Pools/ResponsePool.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/ResponsePool.cs
@@ -10,7 +10,7 @@ namespace Orleans.Serialization.Invocation
 
         private static class TypedPool<T>
         {
-            public static readonly DefaultObjectPool<PooledResponse<T>> Pool = new DefaultObjectPool<PooledResponse<T>>(new DefaultPooledObjectPolicy<PooledResponse<T>>());
+            public static readonly ConcurrentObjectPool<PooledResponse<T>> Pool = new();
         }
     }
 }

--- a/src/Orleans.Serialization/Session/SerializerSessionPool.cs
+++ b/src/Orleans.Serialization/Session/SerializerSessionPool.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ObjectPool;
+using Orleans.Serialization.Invocation;
 using System;
 
 namespace Orleans.Serialization.Session
@@ -11,14 +12,14 @@ namespace Orleans.Serialization.Session
         public SerializerSessionPool(IServiceProvider serviceProvider)
         {
             var sessionPoolPolicy = new SerializerSessionPoolPolicy(serviceProvider, ReturnSession);
-            _sessionPool = new DefaultObjectPool<SerializerSession>(sessionPoolPolicy);
+            _sessionPool = new ConcurrentObjectPool<SerializerSession, SerializerSessionPoolPolicy>(sessionPoolPolicy);
         }
 
         public SerializerSession GetSession() => _sessionPool.Get();
 
         private void ReturnSession(SerializerSession session) => _sessionPool.Return(session);
 
-        private class SerializerSessionPoolPolicy : IPooledObjectPolicy<SerializerSession>
+        private readonly struct SerializerSessionPoolPolicy : IPooledObjectPolicy<SerializerSession>
         {
             private readonly IServiceProvider _serviceProvider;
             private readonly ObjectFactory _factory;


### PR DESCRIPTION
In local benchmarks, `DefaultObjectPool` became a dominator. This implementation improved TPS by 20% in one scenario (in-proc messaging) by relying on thread-local stacks.