### PR TITLE
Remove NewGrainReference

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -156,6 +156,11 @@ namespace Orleans.Runtime
     /// <summary>
     /// This is the base class for all typed grain references.
     /// </summary>
+    [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
+    [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
+    [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]
+    [DefaultInvokableBaseType(typeof(Task), typeof(TaskRequest))]
+    [DefaultInvokableBaseType(typeof(void), typeof(VoidRequest))]
     public class GrainReference : IAddressable, IEquatable<GrainReference>
     {
         [NonSerialized]
@@ -265,14 +270,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Implemented in generated code.
         /// </summary>
-        public virtual ushort InterfaceVersion
-        {
-            get
-            {
-                throw new InvalidOperationException("Should be overridden by subclass");
-            }
-        }
-
+        public ushort InterfaceVersion => Shared.InterfaceVersion;
 
         /// <summary>
         /// Return the name of the interface for this GrainReference.
@@ -298,20 +296,6 @@ namespace Orleans.Runtime
         {
             return this.Runtime.InvokeMethodAsync<T>(this, methodId, arguments, options | _shared.InvokeMethodOptions);
         }
-    }
-
-    [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
-    [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
-    [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]
-    [DefaultInvokableBaseType(typeof(Task), typeof(TaskRequest))]
-    [DefaultInvokableBaseType(typeof(void), typeof(VoidRequest))]
-    public abstract class NewGrainReference : GrainReference
-    {
-        protected NewGrainReference(GrainReferenceShared shared, IdSpan key) : base(shared, key)
-        {
-        }
-
-        public override ushort InterfaceVersion => Shared.InterfaceVersion;
 
         protected TInvokable GetInvokable<TInvokable>() => ActivatorUtilities.GetServiceOrCreateInstance<TInvokable>(Shared.ServiceProvider);
 

--- a/src/Orleans.Core.Abstractions/Runtime/IAddressable.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IAddressable.cs
@@ -3,7 +3,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Marker interface for addressable endpoints, such as grains, observers, and other system-internal addressable endpoints
     /// </summary>
-    [GenerateMethodSerializers(typeof(NewGrainReference))]
+    [GenerateMethodSerializers(typeof(GrainReference))]
     public interface IAddressable
     {
     }

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainExtension.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainExtension.cs
@@ -3,7 +3,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Marker interface for grain extensions, used by internal runtime extension endpoints
     /// </summary>
-    [GenerateMethodSerializers(typeof(NewGrainReference), isExtension: true)]
+    [GenerateMethodSerializers(typeof(GrainReference), isExtension: true)]
     public interface IGrainExtension : IAddressable
     {
     }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -49,7 +49,7 @@ namespace Orleans
             services.TryAddSingleton<GrainFactory>();
             services.TryAddSingleton<GrainInterfaceTypeToGrainTypeResolver>();
             services.TryAddSingleton<GrainReferenceActivator>();
-            services.AddSingleton<IGrainReferenceActivatorProvider, NewGrainReferenceActivatorProvider>();
+            services.AddSingleton<IGrainReferenceActivatorProvider, GrainReferenceActivatorProvider>();
             services.AddSingleton<IGrainReferenceActivatorProvider, UntypedGrainReferenceActivatorProvider>();
             services.TryAddSingleton<NewRpcProvider>();
             services.TryAddSingleton<GrainReferenceKeyStringConverter>();

--- a/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
+++ b/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
@@ -215,7 +215,7 @@ namespace Orleans.GrainReferences
         }
     }
 
-    internal class NewGrainReferenceActivatorProvider : IGrainReferenceActivatorProvider
+    internal class GrainReferenceActivatorProvider : IGrainReferenceActivatorProvider
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly GrainPropertiesResolver _propertiesResolver;
@@ -223,7 +223,7 @@ namespace Orleans.GrainReferences
         private readonly GrainVersionManifest _grainVersionManifest;
         private IGrainReferenceRuntime _grainReferenceRuntime;
 
-        public NewGrainReferenceActivatorProvider(
+        public GrainReferenceActivatorProvider(
             IServiceProvider serviceProvider,
             GrainPropertiesResolver propertiesResolver,
             NewRpcProvider rpcProvider,
@@ -256,16 +256,16 @@ namespace Orleans.GrainReferences
             var invokeMethodOptions = unordered ? InvokeMethodOptions.Unordered : InvokeMethodOptions.None;
             var runtime = _grainReferenceRuntime ??= _serviceProvider.GetRequiredService<IGrainReferenceRuntime>();
             var shared = new GrainReferenceShared(grainType, interfaceType, interfaceVersion, runtime, invokeMethodOptions, _serviceProvider);
-            activator = new NewGrainReferenceActivator(proxyType, shared);
+            activator = new GrainReferenceActivator(proxyType, shared);
             return true;
         }
 
-        private class NewGrainReferenceActivator : IGrainReferenceActivator
+        private class GrainReferenceActivator : IGrainReferenceActivator
         {
             private readonly Type _referenceType;
             private readonly GrainReferenceShared _shared;
 
-            public NewGrainReferenceActivator(Type referenceType, GrainReferenceShared shared)
+            public GrainReferenceActivator(Type referenceType, GrainReferenceShared shared)
             {
                 _referenceType = referenceType;
                 _shared = shared;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -107,7 +107,7 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<IInternalGrainFactory, GrainFactory>();
             services.TryAddSingleton<IGrainReferenceRuntime, GrainReferenceRuntime>();
             services.TryAddSingleton<GrainReferenceActivator>();
-            services.AddSingleton<IGrainReferenceActivatorProvider, NewGrainReferenceActivatorProvider>();
+            services.AddSingleton<IGrainReferenceActivatorProvider, GrainReferenceActivatorProvider>();
             services.AddSingleton<IGrainReferenceActivatorProvider, UntypedGrainReferenceActivatorProvider>();
             services.AddSingleton<IConfigureGrainContextProvider, MayInterleaveConfiguratorProvider>();
             services.AddSingleton<IConfigureGrainTypeComponents, ReentrantSharedComponentsConfigurator>();

--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -14,10 +14,10 @@ namespace Orleans
     /// The TransactionAttribute attribute is used to mark methods that start and join transactions.
     /// </summary>
     [InvokableCustomInitializer("SetTransactionOptions")]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(ValueTask), typeof(TransactionRequest))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(ValueTask<>), typeof(TransactionRequest<>))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(Task), typeof(TransactionTaskRequest))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(Task<>), typeof(TransactionTaskRequest<>))]
+    [InvokableBaseType(typeof(GrainReference), typeof(ValueTask), typeof(TransactionRequest))]
+    [InvokableBaseType(typeof(GrainReference), typeof(ValueTask<>), typeof(TransactionRequest<>))]
+    [InvokableBaseType(typeof(GrainReference), typeof(Task), typeof(TransactionTaskRequest))]
+    [InvokableBaseType(typeof(GrainReference), typeof(Task<>), typeof(TransactionTaskRequest<>))]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TransactionAttribute : Attribute
     {

--- a/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.GrainInterfaces
         Task<Nullable<DateTime>> EchoNullable(Nullable<DateTime> value);
     }
 
-    [GenerateMethodSerializers(typeof(NewGrainReference))]
+    [GenerateMethodSerializers(typeof(GrainReference))]
     public interface IEchoTaskGrain : IGrainWithGuidKey
     {
         Task<int> GetMyIdAsync();


### PR DESCRIPTION
`NewGrainReference` was intended as a temporary class in the `GrainReference` hierarchy while works were ongoing. This PR removes it by flattening it into `GrainReference`.