### PR TITLE
Improve performance for `ValueTask` methods

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -304,6 +304,12 @@ namespace Orleans.Runtime
             var request = (RequestBase)body;
             return this.Runtime.InvokeMethodAsync<T>(this, body, request.Options);
         }
+
+        protected ValueTask InvokeAsync(IInvokable body)
+        {
+            var request = (RequestBase)body;
+            return this.Runtime.InvokeMethodAsync(this, body, request.Options);
+        }
     }
 
     [GenerateSerializer]

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -156,6 +156,11 @@ namespace Orleans.Runtime
     /// <summary>
     /// This is the base class for all typed grain references.
     /// </summary>
+    [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
+    [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
+    [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]
+    [DefaultInvokableBaseType(typeof(Task), typeof(TaskRequest))]
+    [DefaultInvokableBaseType(typeof(void), typeof(VoidRequest))]
     public class GrainReference : IAddressable, IEquatable<GrainReference>
     {
         [NonSerialized]
@@ -265,14 +270,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Implemented in generated code.
         /// </summary>
-        public virtual ushort InterfaceVersion
-        {
-            get
-            {
-                throw new InvalidOperationException("Should be overridden by subclass");
-            }
-        }
-
+        public ushort InterfaceVersion => Shared.InterfaceVersion;
 
         /// <summary>
         /// Return the name of the interface for this GrainReference.
@@ -298,20 +296,6 @@ namespace Orleans.Runtime
         {
             return this.Runtime.InvokeMethodAsync<T>(this, methodId, arguments, options | _shared.InvokeMethodOptions);
         }
-    }
-
-    [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
-    [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
-    [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]
-    [DefaultInvokableBaseType(typeof(Task), typeof(TaskRequest))]
-    [DefaultInvokableBaseType(typeof(void), typeof(VoidRequest))]
-    public abstract class NewGrainReference : GrainReference
-    {
-        protected NewGrainReference(GrainReferenceShared shared, IdSpan key) : base(shared, key)
-        {
-        }
-
-        public override ushort InterfaceVersion => Shared.InterfaceVersion;
 
         protected TInvokable GetInvokable<TInvokable>() => ActivatorUtilities.GetServiceOrCreateInstance<TInvokable>(Shared.ServiceProvider);
 

--- a/src/Orleans.Core.Abstractions/Runtime/IAddressable.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IAddressable.cs
@@ -3,7 +3,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Marker interface for addressable endpoints, such as grains, observers, and other system-internal addressable endpoints
     /// </summary>
-    [GenerateMethodSerializers(typeof(NewGrainReference))]
+    [GenerateMethodSerializers(typeof(GrainReference))]
     public interface IAddressable
     {
     }

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainExtension.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainExtension.cs
@@ -3,7 +3,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Marker interface for grain extensions, used by internal runtime extension endpoints
     /// </summary>
-    [GenerateMethodSerializers(typeof(NewGrainReference), isExtension: true)]
+    [GenerateMethodSerializers(typeof(GrainReference), isExtension: true)]
     public interface IGrainExtension : IAddressable
     {
     }

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
@@ -29,6 +29,8 @@ namespace Orleans.Runtime
 
         ValueTask<T> InvokeMethodAsync<T>(GrainReference reference, IInvokable request, InvokeMethodOptions options);
 
+        ValueTask InvokeMethodAsync(GrainReference reference, IInvokable request, InvokeMethodOptions options);
+
         /// <summary>
         /// Converts the provided <paramref name="grain"/> to the provided <paramref name="interfaceType"/>.
         /// </summary>

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -49,7 +49,7 @@ namespace Orleans
             services.TryAddSingleton<GrainFactory>();
             services.TryAddSingleton<GrainInterfaceTypeToGrainTypeResolver>();
             services.TryAddSingleton<GrainReferenceActivator>();
-            services.AddSingleton<IGrainReferenceActivatorProvider, NewGrainReferenceActivatorProvider>();
+            services.AddSingleton<IGrainReferenceActivatorProvider, GrainReferenceActivatorProvider>();
             services.AddSingleton<IGrainReferenceActivatorProvider, UntypedGrainReferenceActivatorProvider>();
             services.TryAddSingleton<NewRpcProvider>();
             services.TryAddSingleton<GrainReferenceKeyStringConverter>();

--- a/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
+++ b/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
@@ -215,7 +215,7 @@ namespace Orleans.GrainReferences
         }
     }
 
-    internal class NewGrainReferenceActivatorProvider : IGrainReferenceActivatorProvider
+    internal class GrainReferenceActivatorProvider : IGrainReferenceActivatorProvider
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly GrainPropertiesResolver _propertiesResolver;
@@ -223,7 +223,7 @@ namespace Orleans.GrainReferences
         private readonly GrainVersionManifest _grainVersionManifest;
         private IGrainReferenceRuntime _grainReferenceRuntime;
 
-        public NewGrainReferenceActivatorProvider(
+        public GrainReferenceActivatorProvider(
             IServiceProvider serviceProvider,
             GrainPropertiesResolver propertiesResolver,
             NewRpcProvider rpcProvider,
@@ -256,16 +256,16 @@ namespace Orleans.GrainReferences
             var invokeMethodOptions = unordered ? InvokeMethodOptions.Unordered : InvokeMethodOptions.None;
             var runtime = _grainReferenceRuntime ??= _serviceProvider.GetRequiredService<IGrainReferenceRuntime>();
             var shared = new GrainReferenceShared(grainType, interfaceType, interfaceVersion, runtime, invokeMethodOptions, _serviceProvider);
-            activator = new NewGrainReferenceActivator(proxyType, shared);
+            activator = new GrainReferenceActivator(proxyType, shared);
             return true;
         }
 
-        private class NewGrainReferenceActivator : IGrainReferenceActivator
+        private class GrainReferenceActivator : IGrainReferenceActivator
         {
             private readonly Type _referenceType;
             private readonly GrainReferenceShared _shared;
 
-            public NewGrainReferenceActivator(Type referenceType, GrainReferenceShared shared)
+            public GrainReferenceActivator(Type referenceType, GrainReferenceShared shared)
             {
                 _referenceType = referenceType;
                 _shared = shared;

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -108,21 +108,8 @@ namespace Orleans.Runtime
                     // Finally call the root-level invoker.
                     stage++;
                     var responseCompletionSource = ResponseCompletionSourcePool.Get();
-                    try
-                    {
-                        this.sendRequest(this.grainReference, responseCompletionSource, this.request, this.options);
-                        this.Response = await responseCompletionSource.AsValueTask();
-
-                        // Rethrow exceptions for filters to optionally handle.
-                        if (this.Response.Exception is { } exception)
-                        {
-                            ExceptionDispatchInfo.Capture(exception).Throw();
-                        }
-                    }
-                    finally
-                    {
-                        ResponseCompletionSourcePool.Return(responseCompletionSource);
-                    }
+                    this.sendRequest(this.grainReference, responseCompletionSource, this.request, this.options);
+                    this.Response = await responseCompletionSource.AsValueTask();
 
                     return;
                 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -107,7 +107,7 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<IInternalGrainFactory, GrainFactory>();
             services.TryAddSingleton<IGrainReferenceRuntime, GrainReferenceRuntime>();
             services.TryAddSingleton<GrainReferenceActivator>();
-            services.AddSingleton<IGrainReferenceActivatorProvider, NewGrainReferenceActivatorProvider>();
+            services.AddSingleton<IGrainReferenceActivatorProvider, GrainReferenceActivatorProvider>();
             services.AddSingleton<IGrainReferenceActivatorProvider, UntypedGrainReferenceActivatorProvider>();
             services.AddSingleton<IConfigureGrainContextProvider, MayInterleaveConfiguratorProvider>();
             services.AddSingleton<IConfigureGrainTypeComponents, ReentrantSharedComponentsConfigurator>();

--- a/src/Orleans.Serialization/Invocation/Response.cs
+++ b/src/Orleans.Serialization/Invocation/Response.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.ExceptionServices;
+using Orleans.Serialization.Activators;
 
 namespace Orleans.Serialization.Invocation
 {
@@ -15,7 +16,7 @@ namespace Orleans.Serialization.Invocation
             return result;
         }
 
-        public static Response Completed { get; } = new CompletedResponse();
+        public static Response Completed => CompletedResponse.Instance;
 
         public abstract object Result { get; set; }
 
@@ -44,8 +45,11 @@ namespace Orleans.Serialization.Invocation
 
     [GenerateSerializer]
     [Immutable]
+    [UseActivator]
     public sealed class CompletedResponse : Response
     {
+        public static CompletedResponse Instance { get; } = new CompletedResponse();
+
         public override object Result { get => null; set => throw new InvalidOperationException($"Type {nameof(CompletedResponse)} is read-only"); } 
 
         public override Exception Exception { get => null; set => throw new InvalidOperationException($"Type {nameof(CompletedResponse)} is read-only"); }
@@ -55,6 +59,12 @@ namespace Orleans.Serialization.Invocation
         public override void Dispose() { }
 
         public override string ToString() => "[Completed]";
+    }
+
+    [RegisterActivator]
+    public sealed class CompletedResponseActivator : IActivator<CompletedResponse>
+    {
+        public CompletedResponse Create() => CompletedResponse.Instance;
     }
 
     [GenerateSerializer]

--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -50,7 +50,7 @@ namespace Orleans.Serialization.Invocation
             {
                 if (isValid)
                 {
-                    _core.Reset();
+                    Reset();
                 }
             }
         }
@@ -66,7 +66,7 @@ namespace Orleans.Serialization.Invocation
             {
                 if (isValid)
                 {
-                    _core.Reset();
+                    Reset();
                 }
             }
         }
@@ -186,7 +186,7 @@ namespace Orleans.Serialization.Invocation
             {
                 if (isValid)
                 {
-                    _core.Reset();
+                    Reset();
                 }
             }
         }

--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -14,10 +14,10 @@ namespace Orleans
     /// The TransactionAttribute attribute is used to mark methods that start and join transactions.
     /// </summary>
     [InvokableCustomInitializer("SetTransactionOptions")]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(ValueTask), typeof(TransactionRequest))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(ValueTask<>), typeof(TransactionRequest<>))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(Task), typeof(TransactionTaskRequest))]
-    [InvokableBaseType(typeof(NewGrainReference), typeof(Task<>), typeof(TransactionTaskRequest<>))]
+    [InvokableBaseType(typeof(GrainReference), typeof(ValueTask), typeof(TransactionRequest))]
+    [InvokableBaseType(typeof(GrainReference), typeof(ValueTask<>), typeof(TransactionRequest<>))]
+    [InvokableBaseType(typeof(GrainReference), typeof(Task), typeof(TransactionTaskRequest))]
+    [InvokableBaseType(typeof(GrainReference), typeof(Task<>), typeof(TransactionTaskRequest<>))]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TransactionAttribute : Attribute
     {

--- a/test/Benchmarks/Ping/ConcurrentLoadGenerator.cs
+++ b/test/Benchmarks/Ping/ConcurrentLoadGenerator.cs
@@ -21,7 +21,7 @@ namespace Benchmarks.Ping
         }
 
         private Channel<WorkBlock> completedBlocks;
-        private readonly Func<TState, Task> issueRequest;
+        private readonly Func<TState, ValueTask> issueRequest;
         private readonly Func<int, TState> getStateForWorker;
         private readonly bool logIntermediateResults;
         private readonly Task[] tasks;
@@ -34,7 +34,7 @@ namespace Benchmarks.Ping
             int maxConcurrency,
             int blocksPerWorker,
             int requestsPerBlock,
-            Func<TState, Task> issueRequest,
+            Func<TState, ValueTask> issueRequest,
             Func<int, TState> getStateForWorker,
             bool logIntermediateResults = false)
         {

--- a/test/Grains/BenchmarkGrainInterfaces/Ping/IPingGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/Ping/IPingGrain.cs
@@ -6,11 +6,11 @@ namespace BenchmarkGrainInterfaces.Ping
 {
     public interface IPingGrain : IGrainWithIntegerKey
     {
-        Task Run();
+        ValueTask Run();
 
         [AlwaysInterleave]
-        Task PingPongInterleave(IPingGrain other, int count);
+        ValueTask PingPongInterleave(IPingGrain other, int count);
 
-        Task<int> GetSiloPort();
+        ValueTask<int> GetSiloPort();
     }
 }

--- a/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
+++ b/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
@@ -50,11 +50,11 @@ namespace BenchmarkGrains.Ping
             {
                 if(all)
                 {
-                    await Task.WhenAll(pendingWork.Select(p => p.PendingCall).Where(t => t!=null));
+                    await Task.WhenAll(pendingWork.Where(t => !t.PendingCall.IsCompletedSuccessfully).Select(p => p.PendingCall.AsTask()));
                 }
                 else
                 {
-                    await Task.WhenAny(pendingWork.Select(p => p.PendingCall).Where(t => t != null));
+                    await Task.WhenAny(pendingWork.Where(t => !t.PendingCall.IsCompletedSuccessfully).Select(p => p.PendingCall.AsTask()));
                 }
             } catch (Exception) {}
             foreach (Pending pending in pendingWork.Where(p => p.PendingCall != null))
@@ -62,12 +62,12 @@ namespace BenchmarkGrains.Ping
                 if (pending.PendingCall.IsFaulted || pending.PendingCall.IsCanceled)
                 {
                     report.Failed++;
-                    pending.PendingCall = null;
+                    pending.PendingCall = default;
                 }
                 else if (pending.PendingCall.IsCompleted)
                 {
                     report.Succeeded++;
-                    pending.PendingCall = null;
+                    pending.PendingCall = default;
                 }
             }
         }
@@ -75,7 +75,7 @@ namespace BenchmarkGrains.Ping
         private class Pending
         {
             public IPingGrain Grain { get; set; }
-            public Task PendingCall { get; set; }
+            public ValueTask PendingCall { get; set; }
         }
     }
 }

--- a/test/Grains/BenchmarkGrains/Ping/PingGrain.cs
+++ b/test/Grains/BenchmarkGrains/Ping/PingGrain.cs
@@ -7,25 +7,22 @@ namespace BenchmarkGrains.Ping
 {
     public class PingGrain : Grain, IPingGrain
     {
-        private IPingGrain self;
+        private IPingGrain _self;
 
         public override Task OnActivateAsync()
         {
-            this.self = this.AsReference<IPingGrain>();
+            _self = this.AsReference<IPingGrain>();
             return base.OnActivateAsync();
         }
 
-        public Task Run()
+        public ValueTask Run() => default;
+
+        public ValueTask PingPongInterleave(IPingGrain other, int count)
         {
-            return Task.CompletedTask;
+            if (count == 0) return default;
+            return other.PingPongInterleave(_self, count - 1);
         }
 
-        public Task PingPongInterleave(IPingGrain other, int count)
-        {
-            if (count == 0) return Task.CompletedTask;
-            return other.PingPongInterleave(this.self, count - 1);
-        }
-
-        public Task<int> GetSiloPort() => Task.FromResult(((ILocalSiloDetails)this.ServiceProvider.GetService(typeof(ILocalSiloDetails))).SiloAddress.Endpoint.Port);
+        public ValueTask<int> GetSiloPort() => new(((ILocalSiloDetails)ServiceProvider.GetService(typeof(ILocalSiloDetails))).SiloAddress.Endpoint.Port);
     }
 }

--- a/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.GrainInterfaces
         Task<Nullable<DateTime>> EchoNullable(Nullable<DateTime> value);
     }
 
-    [GenerateMethodSerializers(typeof(NewGrainReference))]
+    [GenerateMethodSerializers(typeof(GrainReference))]
     public interface IEchoTaskGrain : IGrainWithGuidKey
     {
         Task<int> GetMyIdAsync();

--- a/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
+++ b/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
@@ -24,10 +24,9 @@ namespace Orleans.Serialization.UnitTests
         
         protected TInvokable GetInvokable<TInvokable>() where TInvokable : class, IInvokable, new() => InvokablePool.Get<TInvokable>();
 
-        protected ValueTask<T> InvokeAsync<T>(IInvokable body)
-        {
-            return default;
-        }
+        protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
+
+        protected ValueTask InvokeAsync(IInvokable body) => default;
     }
 
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
@@ -43,10 +42,9 @@ namespace Orleans.Serialization.UnitTests
 
         protected TInvokable GetInvokable<TInvokable>() where TInvokable : class, IInvokable, new() => InvokablePool.Get<TInvokable>();
 
-        protected ValueTask<T> InvokeAsync<T>(IInvokable request)
-        {
-            return default;
-        }
+        protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
+
+        protected ValueTask InvokeAsync(IInvokable body) => default;
     }
 
     [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]


### PR DESCRIPTION
Currently, `ValueTask` returning methods incur unnecessary memory allocations internally compared with `ValueTask<T>` and return types which necessarily allocate, such as `Task`/`Task<T>`.

This PR removes those unnecessary allocations by adding explicit support for non-value returning methods in the runtime.