### PR TITLE
[3.5.0] Upgrade Azure EventHubs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -93,9 +93,9 @@
 
     <MicrosoftApplicationInsightsVersion>2.4.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftAzureCosmosTableVersion>1.0.5</MicrosoftAzureCosmosTableVersion>
-    <AzureCoreVersion>1.3.0</AzureCoreVersion>
-    <AzureIdentityVersion>1.4.0</AzureIdentityVersion>
-    <AzureMessagingEventHubs>5.1.0</AzureMessagingEventHubs>
+    <AzureCoreVersion>1.18.0</AzureCoreVersion>
+    <AzureIdentityVersion>1.4.1</AzureIdentityVersion>
+    <AzureMessagingEventHubs>5.6.0</AzureMessagingEventHubs>
     <AzureStorageBlobsVersion>12.4.4</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.3.2</AzureStorageQueuesVersion>
     <MicrosoftDataSQLiteVersion>3.1.0</MicrosoftDataSQLiteVersion>


### PR DESCRIPTION
This fixes some incompatibility issues on .NET 5 with Azure Event Hubs
Fixes #7057