### PR TITLE
[3.x] Implement GetGrainId() for SystemTargets & GrainService

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
@@ -109,6 +109,11 @@ namespace Orleans
                 return grainBase.Data.GrainId;
             }
 
+            if (grain is ISystemTargetBase systemTarget)
+            {
+                return systemTarget.GrainId;
+            }
+
             throw new ArgumentException(String.Format("GetGrainId has been called on an unexpected type: {0}.", grain.GetType().FullName), "grain");
         }
 

--- a/test/Tester/GrainServiceTests/TestGrainService.cs
+++ b/test/Tester/GrainServiceTests/TestGrainService.cs
@@ -56,11 +56,13 @@ namespace Tester
     {
         private readonly IGrainIdentity id;
         private TestGrainServiceOptions config;
+        private ILogger<TestGrainService> log;
 
         public TestGrainService(IGrainIdentity id, Silo silo, ILoggerFactory loggerFactory, IOptions<TestGrainServiceOptions> options) : base(id, silo, loggerFactory)
         {
             this.id = id;
             this.config = options.Value;
+            this.log = loggerFactory.CreateLogger<TestGrainService>();
         }
 
         private bool started = false;
@@ -69,44 +71,53 @@ namespace Tester
 
         public async override Task Init(IServiceProvider serviceProvider)
         {
+            this.log.LogInformation("Calling Init on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             await base.Init(serviceProvider);
             init = true;
         }
 
         public override Task Start()
         {
+            this.log.LogInformation("Calling Start on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             started = true;
             return base.Start();
         }
 
         public Task<string> GetHelloWorldUsingCustomService(GrainReference reference)
         {
+            this.log.LogInformation("Calling GetHelloWorldUsingCustomService on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             return Task.FromResult("Hello World from Test Grain Service");
         }
 
         protected override Task StartInBackground()
         {
+            this.log.LogInformation("Calling StartInBackground on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             startedInBackground = true;
             return Task.CompletedTask;
         }
 
         public Task<bool> HasStarted()
         {
+            this.log.LogInformation("Calling HasStarted on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             return Task.FromResult(started);
         }
 
         public Task<bool> HasStartedInBackground()
         {
+            this.log.LogInformation("Calling HasStartedInBackground on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             return Task.FromResult(startedInBackground);
         }
 
         public Task<bool> HasInit()
         {
+            var id = this.GetPrimaryKeyLong(out _);
+            this.log.LogInformation("Calling HasInit on grain service with id {GrainServiceId}", id);
             return Task.FromResult(init);
         }
 
         public Task<string> GetServiceConfigProperty()
         {
+            this.log.LogInformation("Calling GetServiceConfigProperty on grain service with id {GrainServiceId}", this.GetPrimaryKeyLong(out _));
             return Task.FromResult(config.ConfigProperty);
         }
     }


### PR DESCRIPTION
Fixes #7055 by adding support for calling `GetPrimaryKey` variants from classes which inherit from `jSystemTarget`, such as `GrainService` implementations.

Note that this targets the `3.x` branch, which is currently even with `3.5.0`