### PR TITLE
Respect ActivationTimeout option when activating a grain

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1099,7 +1099,7 @@ namespace Orleans.Runtime
         {
             if (!cancellationToken.HasValue)
             {
-                cancellationToken = new CancellationTokenSource(_shared.InternalRuntime.CollectionOptions.Value.DeactivationTimeout).Token;
+                cancellationToken = new CancellationTokenSource(_shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout).Token;
             }
 
             ScheduleOperation(new Command.Activate(requestContext, cancellationToken.Value));

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -303,7 +303,8 @@ namespace Orleans.Runtime
             else
             {
                 // Initialize the new activation asynchronously.
-                result.Activate(requestContextData, CancellationToken.None);
+                var cancellation = new CancellationTokenSource(collectionOptions.Value.ActivationTimeout);
+                result.Activate(requestContextData, cancellation.Token);
                 return result;
             }
         }


### PR DESCRIPTION
Replaced by #7503
Fixes #6384 by plumbing the `GrainCollectionOptions.ActivationTimeout` value through to grains.

TODO:

* [*] ~Consider moving `GrainCollectionOptions.ActivationTimeout` and `DeactivationTimeout` to a different class (perhaps `SiloMessagingOptions` or perhaps a new class).~ We decided to leave them in `GrainCollectionOptions` for now.
* [x] Add tests for grains which fail to activate before the timeout