### PR TITLE
Make IGrainState and IGrainStorage methods generic

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -186,7 +186,7 @@ namespace Orleans.Storage
             }
         }
 
-        private async Task WriteStateInternal(IGrainState grainState, GrainStateRecord record, bool clear = false)
+        private async Task WriteStateInternal<T>(IGrainState<T> grainState, GrainStateRecord record, bool clear = false)
         {
             var fields = new Dictionary<string, AttributeValue>();
             if (this.options.TimeToLive.HasValue)

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -148,9 +148,9 @@ namespace Orleans.Storage
 
             if (record != null)
             {
-                var loadedState = ConvertFromStorageFormat(record, grainState.Type);
+                var loadedState = ConvertFromStorageFormat<T>(record);
                 grainState.RecordExists = loadedState != null;
-                grainState.State = (T)(loadedState ?? Activator.CreateInstance(grainState.Type));
+                grainState.State = loadedState ?? Activator.CreateInstance<T>();
                 grainState.ETag = record.ETag.ToString();
             }
 
@@ -308,22 +308,22 @@ namespace Orleans.Storage
             return AWSUtils.ValidateDynamoDBPartitionKey(key);
         }
 
-        internal object ConvertFromStorageFormat(GrainStateRecord entity, Type stateType)
+        internal T ConvertFromStorageFormat<T>(GrainStateRecord entity)
         {
             var binaryData = entity.BinaryState;
             var stringData = entity.StringState;
 
-            object dataValue = null;
+            T dataValue = default;
             try
             {
                 if (binaryData?.Length > 0)
                 {
                     // Rehydrate
-                    dataValue = this.serializer.Deserialize<object>(binaryData);
+                    dataValue = this.serializer.Deserialize<T>(binaryData);
                 }
                 else if (!string.IsNullOrEmpty(stringData))
                 {
-                    dataValue = JsonConvert.DeserializeObject(stringData, stateType, this.jsonSettings);
+                    dataValue = JsonConvert.DeserializeObject<T>(stringData, this.jsonSettings);
                 }
 
                 // Else, no data found

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -117,7 +117,7 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync"/>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 
@@ -150,7 +150,7 @@ namespace Orleans.Storage
             {
                 var loadedState = ConvertFromStorageFormat(record, grainState.Type);
                 grainState.RecordExists = loadedState != null;
-                grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
+                grainState.State = (T)(loadedState ?? Activator.CreateInstance(grainState.Type));
                 grainState.ETag = record.ETag.ToString();
             }
 
@@ -159,7 +159,7 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 
@@ -253,7 +253,7 @@ namespace Orleans.Storage
         /// cleared by overwriting with default / null values.
         /// </remarks>
         /// <see cref="IGrainStorage.ClearStateAsync"/>
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -154,8 +154,8 @@ namespace Orleans.Storage
             lifecycle.Subscribe(OptionFormattingUtilities.Name<AdoNetGrainStorage>(this.name), this.options.InitStage, Init, Close);
         }
         /// <summary>Clear state data function for this storage provider.</summary>
-        /// <see cref="IGrainStorage.ClearStateAsync(string, GrainReference, IGrainState)"/>.
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainReference, IGrainState{T})"/>.
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown,
             //even if not as clear as when using explicitly checked parameters.
@@ -208,8 +208,8 @@ namespace Orleans.Storage
 
 
         /// <summary> Read state data function for this storage provider.</summary>
-        /// <see cref="IGrainStorage.ReadStateAsync(string, GrainReference, IGrainState)"/>.
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainReference, IGrainState{T})"/>.
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown, even if not as clear
             //as with explicitly checked parameters.
@@ -317,7 +317,7 @@ namespace Orleans.Storage
                     state = Activator.CreateInstance(grainState.Type);
                 }
 
-                grainState.State = state;
+                grainState.State = (T)state;
                 grainState.ETag = etag;
                 grainState.RecordExists = recordExists;
                 if (logger.IsEnabled(LogLevel.Trace))
@@ -335,7 +335,7 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider.</summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown, even if not as clear
             //as with explicitly checked parameters.

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -308,16 +308,16 @@ namespace Orleans.Storage
                     return Tuple.Create(storageState, version?.ToString(CultureInfo.InvariantCulture));
                 }, CancellationToken.None, commandBehavior).ConfigureAwait(false)).SingleOrDefault();
 
-                object state = readRecords != null ? readRecords.Item1 : null;
+                T state = readRecords != null ? (T) readRecords.Item1 : default;
                 string etag = readRecords != null ? readRecords.Item2 : null;
                 bool recordExists = readRecords != null;
                 if(state == null)
                 {
                     logger.Info((int)RelationalStorageProviderCodes.RelationalProviderNoStateFound, LogString("Null grain state read (default will be instantiated)", serviceId, this.name, grainState.ETag, baseGrainType, grainId.ToString()));
-                    state = Activator.CreateInstance(grainState.Type);
+                    state = Activator.CreateInstance<T>();
                 }
 
-                grainState.State = (T)state;
+                grainState.State = state;
                 grainState.ETag = etag;
                 grainState.RecordExists = recordExists;
                 if (logger.IsEnabled(LogLevel.Trace))

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -258,7 +258,7 @@ namespace Orleans.Storage
                         {
                             using(var downloadStream = streamSelector.GetStream(binaryColumnPositionInSelect, Storage))
                             {
-                                storageState = choice.Deserializer.Deserialize(downloadStream, grainState.Type);
+                                storageState = choice.Deserializer.Deserialize(downloadStream, typeof(T));
                             }
                         }
 
@@ -266,7 +266,7 @@ namespace Orleans.Storage
                         {
                             using(var downloadStream = streamSelector.GetTextReader(xmlColumnPositionInSelect))
                             {
-                                storageState = choice.Deserializer.Deserialize(downloadStream, grainState.Type);
+                                storageState = choice.Deserializer.Deserialize(downloadStream, typeof(T));
                             }
                         }
 
@@ -274,7 +274,7 @@ namespace Orleans.Storage
                         {
                             using(var downloadStream = streamSelector.GetTextReader(jsonColumnPositionInSelect))
                             {
-                                storageState = choice.Deserializer.Deserialize(downloadStream, grainState.Type);
+                                storageState = choice.Deserializer.Deserialize(downloadStream, typeof(T));
                             }
                         }
 
@@ -299,7 +299,7 @@ namespace Orleans.Storage
 
                         if(payload != null)
                         {
-                            storageState = choice.Deserializer.Deserialize(payload, grainState.Type);
+                            storageState = choice.Deserializer.Deserialize(payload, typeof(T));
                         }
 
                         version = selector.GetNullableInt32("Version");

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/IStorageHashPicker.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/IStorageHashPicker.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System.Collections.Generic;
 
 
@@ -23,6 +23,6 @@ namespace Orleans.Storage
         /// <param name="grainState">The grain state.</param>
         /// <param name="tag">An optional tag parameter that might be used by the storage parameter for "out-of-band" contracts.</param>
         /// <returns>A serializer or <em>null</em> if not match was found.</returns>
-        IHasher PickHasher(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null);
+        IHasher PickHasher<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null);
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/IStorageSerializationPicker.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/IStorageSerializationPicker.cs
@@ -78,7 +78,7 @@ namespace Orleans.Storage
         /// <param name="grainState">The grain state.</param>
         /// <param name="tag">An optional tag parameter that might be used by the storage parameter for "out-of-band" contracts.</param>
         /// <returns>A serializer or <em>null</em> if not match was found.</returns>
-        SerializationChoice PickDeserializer(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null);
+        SerializationChoice PickDeserializer<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null);
 
         /// <summary>Picks a serializer using the given parameters.</summary>
         /// <param name="serviceId">The ID of the current service.</param>
@@ -88,6 +88,6 @@ namespace Orleans.Storage
         /// <param name="grainState">The grain state.</param>
         /// <param name="tag">An optional tag parameter that might be used by the storage parameter for "out-of-band" contracts.</param>
         /// <returns>A deserializer or <em>null</em> if not match was found.</returns>
-        SerializationChoice PickSerializer(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null);
+        SerializationChoice PickSerializer<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null);
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/StorageHasherPicker.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/StorageHasherPicker.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -34,9 +34,9 @@ namespace Orleans.Storage
 
 
         /// <summary>
-        /// <see cref="IStorageHasherPicker.PickHasher(string, string, string, GrainReference, IGrainState, string)"/>.
+        /// <see cref="IStorageHasherPicker.PickHasher{T}"/>.
         /// </summary>
-        public IHasher PickHasher(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null)
+        public IHasher PickHasher<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null)
         {
             return HashProviders.FirstOrDefault();
         }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/StorageSerializationPicker.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/StorageSerializationPicker.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -53,7 +53,7 @@ namespace Orleans.Storage
         /// Picks a deserializer using the given parameters.
         /// <see cref="IStorageSerializationPicker.PickDeserializer"/>
         /// </summary>
-        public SerializationChoice PickDeserializer(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null)
+        public SerializationChoice PickDeserializer<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null)
         {
             //If the tag has been given, try to pick that one and if not found, take the first on the list. This arrangement allows one to switch storage format more easily.
             var deserializer = Deserializers.FirstOrDefault(i => i.Tag == tag);
@@ -65,7 +65,7 @@ namespace Orleans.Storage
         /// Picks a serializer using the given parameters.
         /// <see cref="IStorageSerializationPicker.PickSerializer"/>
         /// </summary>
-        public SerializationChoice PickSerializer(string servideId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null)
+        public SerializationChoice PickSerializer<T>(string servideId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null)
         {
             var serializer = Serializers.FirstOrDefault(i => i.Tag == tag);
             return new SerializationChoice(false, null, serializer ?? Serializers.FirstOrDefault());

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -91,8 +91,8 @@ namespace Orleans.Storage
                     grainState.RecordExists = true;
                 }
 
-                var loadedState = this.ConvertFromStorageFormat(contents, grainState.Type);
-                grainState.State = (T) (loadedState ?? Activator.CreateInstance(grainState.Type));
+                var loadedState = this.ConvertFromStorageFormat<T>(contents);
+                grainState.State = loadedState ?? Activator.CreateInstance<T>();
 
                 if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
@@ -277,23 +277,22 @@ namespace Orleans.Storage
         /// Deserialize from the configured storage format, either binary or JSON.
         /// </summary>
         /// <param name="contents">The serialized contents.</param>
-        /// <param name="stateType">The state type.</param>
         /// <remarks>
         /// See:
         /// http://msdn.microsoft.com/en-us/library/system.web.script.serialization.javascriptserializer.aspx
         /// for more on the JSON serializer.
         /// </remarks>
-        private object ConvertFromStorageFormat(byte[] contents, Type stateType)
+        private T ConvertFromStorageFormat<T>(byte[] contents)
         {
-            object result;
+            T result;
             if (this.options.UseJson)
             {
                 var str = Encoding.UTF8.GetString(contents);
-                result = JsonConvert.DeserializeObject(str, stateType, this.jsonSettings);
+                result = JsonConvert.DeserializeObject<T>(str, this.jsonSettings);
             }
             else
             {
-                result = this.serializer.Deserialize<object>(contents);
+                result = this.serializer.Deserialize<T>(contents);
             }
 
             return result;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -52,7 +52,7 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync"/>
-        public async Task ReadStateAsync(string grainType, GrainReference grainId, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
             if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading, "Reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
@@ -92,7 +92,7 @@ namespace Orleans.Storage
                 }
 
                 var loadedState = this.ConvertFromStorageFormat(contents, grainState.Type);
-                grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
+                grainState.State = (T) (loadedState ?? Activator.CreateInstance(grainState.Type));
 
                 if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
@@ -113,7 +113,7 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainId, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
             try
@@ -140,7 +140,7 @@ namespace Orleans.Storage
 
         /// <summary> Clear / Delete state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ClearStateAsync"/>
-        public async Task ClearStateAsync(string grainType, GrainReference grainId, IGrainState grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
             try

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -175,7 +175,7 @@ namespace Orleans.Storage
             }
         }
 
-        private async Task WriteStateAndCreateContainerIfNotExists(string grainType, GrainReference grainId, IGrainState grainState, byte[] contents, string mimeType, BlobClient blob)
+        private async Task WriteStateAndCreateContainerIfNotExists<T>(string grainType, GrainReference grainId, IGrainState<T> grainState, byte[] contents, string mimeType, BlobClient blob)
         {
             try
             {

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -65,7 +65,7 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync"/>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
@@ -81,7 +81,7 @@ namespace Orleans.Storage
                 {
                     var loadedState = ConvertFromStorageFormat(entity, grainState.Type);
                     grainState.RecordExists = loadedState != null;
-                    grainState.State = loadedState ?? Activator.CreateInstance(grainState.Type);
+                    grainState.State = (T) (loadedState ?? Activator.CreateInstance(grainState.Type));
                     grainState.ETag = record.ETag;
                 }
             }
@@ -91,7 +91,7 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
@@ -124,7 +124,7 @@ namespace Orleans.Storage
         /// cleared by overwriting with default / null values.
         /// </remarks>
         /// <see cref="IGrainStorage.ClearStateAsync"/>
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 

--- a/src/Orleans.Core/CodeGeneration/IGrainState.cs
+++ b/src/Orleans.Core/CodeGeneration/IGrainState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Orleans
 {
@@ -17,16 +17,22 @@ namespace Orleans
         bool RecordExists { get; set; }
     }
 
+    /// <summary>Defines the state of a grain</summary>
+    public interface IGrainState<T> : IGrainState
+    {
+        public new T State { get; set; }
+    }
+
     /// <summary>
-    /// Typed default implementation of <see cref="IGrainState"/>.
+    /// Default implementation of <see cref="IGrainState{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of application level payload.</typeparam>
     [Serializable]
     [GenerateSerializer]
-    public class GrainState<T> : IGrainState
+    public class GrainState<T> : IGrainState<T>
     {
         [Id(1)]
-        public T State;
+        public T State { get; set; }
 
         object IGrainState.State
         {

--- a/src/Orleans.Core/CodeGeneration/IGrainState.cs
+++ b/src/Orleans.Core/CodeGeneration/IGrainState.cs
@@ -3,10 +3,9 @@ using System;
 namespace Orleans
 {
     /// <summary>Defines the state of a grain</summary>
-    public interface IGrainState
+    public interface IGrainState<T>
     {
-        /// <summary>The application level payload that is the actual state.</summary>
-        object State { get; set; }
+        T State { get; set; }
 
         /// <summary>Type of the grain state</summary>
         Type Type { get; }
@@ -15,12 +14,6 @@ namespace Orleans
         string ETag { get; set; }
 
         bool RecordExists { get; set; }
-    }
-
-    /// <summary>Defines the state of a grain</summary>
-    public interface IGrainState<T> : IGrainState
-    {
-        public new T State { get; set; }
     }
 
     /// <summary>
@@ -33,12 +26,6 @@ namespace Orleans
     {
         [Id(1)]
         public T State { get; set; }
-
-        object IGrainState.State
-        {
-            get => State;
-            set => State = (T)value;
-        }
 
         /// <inheritdoc />
         public Type Type => typeof(T);

--- a/src/Orleans.Core/CodeGeneration/IGrainState.cs
+++ b/src/Orleans.Core/CodeGeneration/IGrainState.cs
@@ -7,9 +7,6 @@ namespace Orleans
     {
         T State { get; set; }
 
-        /// <summary>Type of the grain state</summary>
-        Type Type { get; }
-
         /// <summary>An e-tag that allows optimistic concurrency checks at the storage provider level.</summary>
         string ETag { get; set; }
 
@@ -26,9 +23,6 @@ namespace Orleans
     {
         [Id(1)]
         public T State { get; set; }
-
-        /// <inheritdoc />
-        public Type Type => typeof(T);
 
         /// <inheritdoc />
         [Id(2)]

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -16,21 +16,21 @@ namespace Orleans.Storage
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be populated for this grain.</param>
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
-        Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState);
+        Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState);
 
         /// <summary>Write data function for this storage instance.</summary>
         /// <param name="grainType">Type of this grain [fully qualified class name]</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be written for this grain.</param>
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
-        Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState);
+        Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState);
 
         /// <summary>Delete / Clear data function for this storage instance.</summary>
         /// <param name="grainType">Type of this grain [fully qualified class name]</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">Copy of last-known state data object for this grain.</param>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
-        Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState);
+        Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState);
     }
 
     /// <summary>

--- a/src/Orleans.Core/Providers/IMemoryStorageGrain.cs
+++ b/src/Orleans.Core/Providers/IMemoryStorageGrain.cs
@@ -11,19 +11,19 @@ namespace Orleans.Storage
         /// <param name="stateStore">The name of the store that is used to store this grain state.</param>
         /// <param name="grainStoreKey">Store key for this grain.</param>
         /// <returns>Value promise for the currently stored grain state for the specified grain.</returns>
-        Task<IGrainState> ReadStateAsync(string stateStore, string grainStoreKey);
+        Task<IGrainState<T>> ReadStateAsync<T>(string stateStore, string grainStoreKey);
 
         /// <summary>Async method to cause update of the specified grain state data into memory store.</summary>
         /// <param name="grainType">Type of the grain</param>
         /// <param name="grainId">Grain ID.</param>
         /// <param name="grainState">New state data to be stored for this grain.</param>
         /// <returns>Completion promise with new eTag for the update operation for stored grain state for the specified grain.</returns>
-        Task<string> WriteStateAsync(string grainType, string grainId, IGrainState grainState);
+        Task<string> WriteStateAsync<T>(string grainType, string grainId, IGrainState<T> grainState);
         
         /// <param name="stateStore">The name of the store that is used to store this grain state.</param>
         /// <param name="grainStoreKey">Store key for this grain.</param>
         /// <param name="eTag">The previous etag that was read.</param>
         /// <returns>Completion promise for the update operation for stored grain state for the specified grain.</returns>
-        Task DeleteStateAsync(string stateStore, string grainStoreKey, string eTag);
+        Task DeleteStateAsync<T>(string stateStore, string grainStoreKey, string eTag);
     }
 }

--- a/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
@@ -25,11 +25,6 @@ namespace Orleans.EventSourcing.LogStorage
         [Id(1)]
         public string ETag { get; set; }
 
-        /// <summary>
-        /// Gets Type
-        /// </summary>
-        public Type Type => typeof(LogStateWithMetaData<TEntry>);
-
         [Id(2)]
         public bool RecordExists { get; set; }
 

--- a/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
@@ -30,18 +30,6 @@ namespace Orleans.EventSourcing.LogStorage
         /// </summary>
         public Type Type => typeof(LogStateWithMetaData<TEntry>);
 
-        object IGrainState.State
-        {
-            get
-            {
-                return StateAndMetaData;
-            }
-            set
-            {
-                StateAndMetaData = (LogStateWithMetaData<TEntry>)value;
-            }
-        }
-
         [Id(2)]
         public bool RecordExists { get; set; }
 

--- a/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogStateWithMetaData.cs
@@ -11,7 +11,7 @@ namespace Orleans.EventSourcing.LogStorage
     /// <typeparam name="TEntry">The type used for log entries</typeparam>
     [Serializable]
     [GenerateSerializer]
-    public class LogStateWithMetaDataAndETag<TEntry> : IGrainState where TEntry : class
+    public class LogStateWithMetaDataAndETag<TEntry> : IGrainState<LogStateWithMetaData<TEntry>> where TEntry : class
     {
         /// <summary>
         /// Gets and Sets StateAndMetaData
@@ -44,6 +44,8 @@ namespace Orleans.EventSourcing.LogStorage
 
         [Id(2)]
         public bool RecordExists { get; set; }
+
+        public LogStateWithMetaData<TEntry> State { get => StateAndMetaData; set => StateAndMetaData = value; }
 
         /// <summary>
         /// Initializes a new instance of GrainStateWithMetaDataAndETag class

--- a/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.EventSourcing.Common;
+using Orleans.EventSourcing.Common;
 using System;
 
 namespace Orleans.EventSourcing.StateStorage
@@ -10,7 +10,7 @@ namespace Orleans.EventSourcing.StateStorage
     /// <typeparam name="TView">The type used for log view</typeparam>
     [Serializable]
     [GenerateSerializer]
-    public class GrainStateWithMetaDataAndETag<TView> : IGrainState where TView : class, new()
+    public class GrainStateWithMetaDataAndETag<TView> : IGrainState<GrainStateWithMetaData<TView>> where TView : class, new()
     {
         /// <summary>
         /// Gets and Sets StateAndMetaData
@@ -43,6 +43,8 @@ namespace Orleans.EventSourcing.StateStorage
 
         [Id(2)]
         public bool RecordExists { get; set; }
+
+        public GrainStateWithMetaData<TView> State { get => StateAndMetaData; set => StateAndMetaData = value; }
 
         /// <summary>
         /// Initialize a new instance of GrainStateWithMetaDataAndETag class with an initialView

--- a/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -24,11 +24,6 @@ namespace Orleans.EventSourcing.StateStorage
         [Id(1)]
         public string ETag { get; set; }
 
-        /// <summary>
-        /// Gets Type
-        /// </summary>
-        public Type Type => typeof(GrainStateWithMetaData<TView>);
-
         [Id(2)]
         public bool RecordExists { get; set; }
 

--- a/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -29,18 +29,6 @@ namespace Orleans.EventSourcing.StateStorage
         /// </summary>
         public Type Type => typeof(GrainStateWithMetaData<TView>);
 
-        object IGrainState.State
-        {
-            get
-            {
-                return StateAndMetaData;
-            }
-            set
-            {
-                StateAndMetaData = (GrainStateWithMetaData<TView>)value;
-            }
-        }
-
         [Id(2)]
         public bool RecordExists { get; set; }
 

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -67,7 +67,7 @@ namespace Orleans.Storage
 
             string id = HierarchicalKeyStore.MakeStoreKey(keys);
             IMemoryStorageGrain storageGrain = GetStorageGrain(id);
-            var state = await storageGrain.ReadStateAsync(STATE_STORE_NAME, id);
+            var state = await storageGrain.ReadStateAsync<T>(STATE_STORE_NAME, id);
             if (state != null)
             {
                 grainState.ETag = state.ETag;
@@ -105,7 +105,7 @@ namespace Orleans.Storage
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
             try
             {
-                await storageGrain.DeleteStateAsync(STATE_STORE_NAME, key, grainState.ETag);
+                await storageGrain.DeleteStateAsync<T>(STATE_STORE_NAME, key, grainState.ETag);
                 grainState.ETag = null;
                 grainState.RecordExists = false;
             }

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -59,7 +59,7 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync"/>
-        public virtual async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             var keys = MakeKeys(grainType, grainReference);
 
@@ -71,14 +71,14 @@ namespace Orleans.Storage
             if (state != null)
             {
                 grainState.ETag = state.ETag;
-                grainState.State = state.State;
+                grainState.State = (T)state.State;
                 grainState.RecordExists = true;
             }
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public virtual async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             var keys = MakeKeys(grainType, grainReference);
             string key = HierarchicalKeyStore.MakeStoreKey(keys);
@@ -97,7 +97,7 @@ namespace Orleans.Storage
 
         /// <summary> Delete / Clear state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ClearStateAsync"/>
-        public virtual async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             var keys = MakeKeys(grainType, grainReference);
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Delete Keys={Keys} Etag={Etag}", StorageProviderUtils.PrintKeys(keys), grainState.ETag);

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
@@ -25,7 +25,7 @@ namespace Orleans.Storage
         {
             if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebug("ReadStateAsync for {StateStore} grain: {GrainStoreKey}", stateStore, grainStoreKey);
             _store.TryGetValue((stateStore, grainStoreKey), out var entry);
-            return Task.FromResult((IGrainState<T>) (entry is DeletedState ? null : entry));
+            return Task.FromResult((IGrainState<T>)entry);
         }
 
         public Task<string> WriteStateAsync<T>(string stateStore, string grainStoreKey, IGrainState<T> grainState)
@@ -53,7 +53,7 @@ namespace Orleans.Storage
             }
 
             ValidateEtag(currentETag, etag, grainId, "Delete");
-            _store[(grainType, grainId)] = deleted;
+            _store.Remove((grainType, grainId));
             return Task.CompletedTask;
         }
 
@@ -85,17 +85,5 @@ namespace Orleans.Storage
 
             throw new MemoryStorageEtagMismatchException(currentETag, receivedEtag);
         }
-
-        /// <summary>
-        /// Marker to record deleted state so we can detect the difference between deleted state and state that never existed.
-        /// </summary>
-        private sealed class DeletedState : IGrainState<object>
-        {
-            public object State { get; set; }
-            public string ETag { get; set; } = string.Empty;
-            public bool RecordExists { get; set; }
-        }
-
-        private readonly IGrainState<object> deleted = new DeletedState();
     }
 }

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
@@ -13,7 +13,7 @@ namespace Orleans.Storage
     [KeepAlive]
     internal class MemoryStorageGrain : Grain, IMemoryStorageGrain
     {
-        private readonly Dictionary<(string, string), object> _store = new(); // BPETIT TODO
+        private readonly Dictionary<(string, string), object> _store = new(); 
         private readonly ILogger _logger;
 
         public MemoryStorageGrain(ILogger<MemoryStorageGrain> logger)

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageGrain.cs
@@ -92,7 +92,6 @@ namespace Orleans.Storage
         private sealed class DeletedState : IGrainState<object>
         {
             public object State { get; set; }
-            public Type Type => typeof(object);
             public string ETag { get; set; } = string.Empty;
             public bool RecordExists { get; set; }
         }

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -51,21 +51,21 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync"/>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             await MakeFixedLatencyCall(() => baseGranStorage.ReadStateAsync(grainType, grainReference, grainState));
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
            await MakeFixedLatencyCall(() => baseGranStorage.WriteStateAsync(grainType, grainReference, grainState));
         }
 
         /// <summary> Delete / Clear state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ClearStateAsync"/>
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             await MakeFixedLatencyCall(() => baseGranStorage.ClearStateAsync(grainType, grainReference, grainState));
         }

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -52,7 +52,7 @@ namespace Orleans.TestingHost
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be populated for this grain.</param>
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
@@ -74,7 +74,7 @@ namespace Orleans.TestingHost
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be written for this grain.</param>
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
@@ -96,7 +96,7 @@ namespace Orleans.TestingHost
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">Copy of last-known state data object for this grain.</param>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try

--- a/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
+++ b/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
@@ -136,8 +136,6 @@ namespace DefaultCluster.Tests.StorageTests
             [Id(0)]
             public object State { get; set; }
 
-            public Type Type => typeof(int);
-
             [Id(1)]
             public string ETag { get; set; }
 

--- a/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
+++ b/test/DefaultCluster.Tests/MemoryStorageProviderTests.cs
@@ -65,10 +65,10 @@ namespace DefaultCluster.Tests.StorageTests
             var memoryStorageGrain = this.GrainFactory.GetGrain<IMemoryStorageGrain>(random.Next());
 
             // Delete grain state from empty grain, should be safe.
-            await memoryStorageGrain.DeleteStateAsync("stateStore", "grainStoreKey", "eTag");
+            await memoryStorageGrain.DeleteStateAsync<object>("stateStore", "grainStoreKey", "eTag");
 
             // Read grain state from empty grain, should be safe, but return nothing.
-            IGrainState grainState = await memoryStorageGrain.ReadStateAsync("stateStore", "grainStoreKey");
+            var grainState = await memoryStorageGrain.ReadStateAsync<object>("stateStore", "grainStoreKey");
             Assert.Null(grainState);
 
             // write state with etag, when there is nothing in storage.  Most storage should fail this, but memory storage should succeed.
@@ -89,20 +89,20 @@ namespace DefaultCluster.Tests.StorageTests
             Assert.NotNull(latestEtag);
 
             // try delete state with null etag
-            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", null));
+            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync<object>("grain", "id", null));
 
             // try delete state with wrong etag
-            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag+"a"));
+            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync<object>("grain", "id", latestEtag+"a"));
 
             // delete state
-            await memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag);
+            await memoryStorageGrain.DeleteStateAsync<object>("grain", "id", latestEtag);
 
             // Read grain deleted grain state, should be safe, but return nothing.
-            grainState = await memoryStorageGrain.ReadStateAsync("grain", "id");
+            grainState = await memoryStorageGrain.ReadStateAsync<object>("grain", "id");
             Assert.Null(grainState);
 
             // try delete already deleted grain state
-            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag));
+            ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.DeleteStateAsync<object>("grain", "id", latestEtag));
 
             // try to write state to deleted state.
             ex = await Assert.ThrowsAsync<MemoryStorageEtagMismatchException>(() => memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(latestEtag)));
@@ -113,9 +113,9 @@ namespace DefaultCluster.Tests.StorageTests
 
         [Serializable]
         [GenerateSerializer]
-        public class TestGrainState : IGrainState
+        public class TestGrainState : IGrainState<object>
         {
-            public static IGrainState CreateRandom()
+            public static IGrainState<object> CreateRandom()
             {
                 return new TestGrainState
                 {
@@ -124,7 +124,7 @@ namespace DefaultCluster.Tests.StorageTests
                 };
             }
 
-            public static IGrainState CreateWithEtag(string eTag)
+            public static IGrainState<object> CreateWithEtag(string eTag)
             {
                 return new TestGrainState
                 {

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -156,7 +156,7 @@ namespace AWSUtils.Tests.StorageTests
 
             storage.ConvertToStorageFormat(initialState, entity);
 
-            var convertedState = (TestStoreGrainState)storage.ConvertFromStorageFormat(entity, initialState.GetType());
+            var convertedState = storage.ConvertFromStorageFormat<TestStoreGrainState>(entity);
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.A, convertedState.A);
             Assert.Equal(initialState.B, convertedState.B);

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -139,7 +139,7 @@ namespace AWSUtils.Tests.StorageTests
             var storage = await InitDynamoDBTableStorageProvider(
                 this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
-            var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
+            var convertedState = storage.ConvertFromStorageFormat<GrainStateContainingGrainReferences>(entity);
             Assert.NotNull(convertedState); // Converted state
             Assert.Equal(initialState.Grain, convertedState.Grain);  // "Grain"
         }
@@ -165,7 +165,7 @@ namespace AWSUtils.Tests.StorageTests
                 await InitDynamoDBTableStorageProvider(
                     this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
-            var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity, initialState.GetType());
+            var convertedState = storage.ConvertFromStorageFormat<GrainStateContainingGrainReferences>(entity);
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.GrainList.Count, convertedState.GrainList.Count);  // "GrainList size"
             Assert.Equal(initialState.GrainDict.Count, convertedState.GrainDict.Count);  // "GrainDict size"

--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Storage;
+using Orleans.Storage;
 using System;
 using System.Globalization;
 using System.Text;
@@ -25,7 +25,7 @@ namespace UnitTests.StorageTests.Relational
             Parallel.For(0, 1000000, i =>
             {
                 //These parameters can be null in this test.
-                int grainTypeHash = adonetDefaultHasher.PickHasher(null, null, null, null, null, null).Hash(Encoding.UTF8.GetBytes(grainType));
+                int grainTypeHash = adonetDefaultHasher.PickHasher<object>(null, null, null, null, null, null).Hash(Encoding.UTF8.GetBytes(grainType));
                 Assert.Equal(TestGrainHash, grainTypeHash);
             });
         }

--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/StreamingTestRelationalStoragePicker.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/StreamingTestRelationalStoragePicker.cs
@@ -1,4 +1,4 @@
-﻿using Orleans;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Storage;
 using System;
@@ -47,7 +47,7 @@ namespace UnitTests.StorageTests.Relational.TestDataSets
         /// Picks a deserializer using the given parameters.
         /// <see cref="IStorageSerializationPicker.PickDeserializer"/>
         /// </summary>
-        public SerializationChoice PickDeserializer(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null)
+        public SerializationChoice PickDeserializer<T>(string serviceId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null)
         {
             //If the tag has been given, try to pick that one and if not found, take the first on the list. This arrangement allows one to switch storage format more easily.
             var deserializer = Deserializers.FirstOrDefault(i => i.Tag == tag);
@@ -59,7 +59,7 @@ namespace UnitTests.StorageTests.Relational.TestDataSets
         /// Picks a serializer using the given parameters.
         /// <see cref="IStorageSerializationPicker.PickSerializer"/>
         /// </summary>
-        public SerializationChoice PickSerializer(string servideId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState grainState, string tag = null)
+        public SerializationChoice PickSerializer<T>(string servideId, string storageProviderInstanceName, string grainType, GrainReference grainReference, IGrainState<T> grainState, string tag = null)
         {
             var serializer = Serializers.FirstOrDefault(i => i.Tag == tag);
             return new SerializationChoice(true, null, serializer ?? Serializers.FirstOrDefault());

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -191,7 +191,7 @@ namespace Tester.AzureUtils.Persistence
 
             storage.ConvertToStorageFormat(initialState, entity);
 
-            var convertedState = (TestStoreGrainState)storage.ConvertFromStorageFormat(entity, typeof(TestStoreGrainState));
+            var convertedState = storage.ConvertFromStorageFormat<TestStoreGrainState>(entity);
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.A, convertedState.A);
             Assert.Equal(initialState.B, convertedState.B);
@@ -211,7 +211,7 @@ namespace Tester.AzureUtils.Persistence
 
             storage.ConvertToStorageFormat(initialState, entity);
 
-            var convertedState = (TestStoreGrainStateWithCustomJsonProperties)storage.ConvertFromStorageFormat(entity, typeof(TestStoreGrainStateWithCustomJsonProperties));
+            var convertedState = storage.ConvertFromStorageFormat<TestStoreGrainStateWithCustomJsonProperties>(entity);
             Assert.NotNull(convertedState);
             Assert.Equal(initialState.String, convertedState.String);
         }

--- a/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
+++ b/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
@@ -171,7 +171,7 @@ namespace UnitTests.StorageTests
             return (T) LastState;
         }
 
-        private object GetLastState(string grainType, GrainReference grainReference, IGrainState grainState)
+        private object GetLastState<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             lock (StateStore)
             {

--- a/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
+++ b/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
@@ -197,7 +197,7 @@ namespace UnitTests.StorageTests
             return Task.CompletedTask;
         }
 
-        public virtual Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             logger.Info(0, "ReadStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref readCount);
@@ -205,12 +205,12 @@ namespace UnitTests.StorageTests
             {
                 var storedState = GetLastState(grainType, grainReference, grainState);
                 grainState.RecordExists = storedState != null;
-                grainState.State = this.copier.Copy(storedState); // Read current state data
+                grainState.State = (T)this.copier.Copy(storedState); // Read current state data
             }
             return Task.CompletedTask;
         }
 
-        public virtual Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             logger.Info(0, "WriteStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref writeCount);
@@ -227,7 +227,7 @@ namespace UnitTests.StorageTests
             return Task.CompletedTask;
         }
 
-        public virtual Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public virtual Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             logger.Info(0, "ClearStateAsync for {0} {1}", grainType, grainReference);
             Interlocked.Increment(ref deleteCount);

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -120,7 +120,7 @@ namespace UnitTests.StorageTests
             }
         }
 
-        public async override Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async override Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             logger.Info(0, "ReadStateAsync for {0} {1} ErrorInjection={2}", grainType, grainReference, ErrorInjection);
             try
@@ -136,7 +136,7 @@ namespace UnitTests.StorageTests
             }
         }
 
-        public async override Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async override Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             logger.Info(0, "WriteStateAsync for {grainType} {grainReference} ErrorInjection={errorInjection}", grainType, grainReference, ErrorInjection);
             try

--- a/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
+++ b/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
@@ -116,7 +116,7 @@ namespace Samples.StorageProviders
         /// http://msdn.microsoft.com/en-us/library/system.web.script.serialization.javascriptserializer.aspx
         /// for more on the JSON serializer.
         /// </remarks>
-        protected static string ConvertToStorageFormat(IGrainState grainState)
+        protected static string ConvertToStorageFormat<T>(IGrainState<T> grainState)
         {
             return JsonConvert.SerializeObject(grainState.State);
         }
@@ -126,9 +126,9 @@ namespace Samples.StorageProviders
         /// </summary>
         /// <param name="grainState">Grain state to be populated for storage.</param>
         /// <param name="entityData">JSON storage format representation of the grain state.</param>
-        protected static void ConvertFromStorageFormat(IGrainState grainState, string entityData)
+        protected static void ConvertFromStorageFormat<T>(IGrainState<T> grainState, string entityData)
         {
-            object data = JsonConvert.DeserializeObject(entityData, grainState.State.GetType());
+            var data = JsonConvert.DeserializeObject<T>(entityData);
             grainState.State = data;
         }
     }

--- a/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
+++ b/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
@@ -66,7 +66,7 @@ namespace Samples.StorageProviders
         /// <param name="grainReference">Represents the long-lived identity of the grain.</param>
         /// <param name="grainState">A reference to an object to hold the persisted state of the grain.</param>
         /// <returns>Completion promise for this operation.</returns>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
             var entityData = await DataManager.Read(grainState.GetType().Name, grainReference.ToKeyString());
@@ -84,7 +84,7 @@ namespace Samples.StorageProviders
         /// <param name="grainReference">Represents the long-lived identity of the grain.</param>
         /// <param name="grainState">A reference to an object holding the persisted state of the grain.</param>
         /// <returns>Completion promise for this operation.</returns>
-        public Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public Task WriteStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
             var entityData = ConvertToStorageFormat(grainState);
@@ -99,7 +99,7 @@ namespace Samples.StorageProviders
         /// <param name="grainReference">Represents the long-lived identity of the grain.</param>
         /// <param name="grainState">An object holding the persisted state of the grain.</param>
         /// <returns></returns>
-        public Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        public Task ClearStateAsync<T>(string grainType, GrainReference grainReference, IGrainState<T> grainState)
         {
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
             DataManager.Delete(grainState.GetType().Name, grainReference.ToKeyString());


### PR DESCRIPTION
Avoid `typeof` call where possible and will simplify some serialization calls