### PR TITLE
Add TelemetryConfiguration support for AITelemetryConsumer

### DIFF
--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumer.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Runtime;
@@ -21,12 +22,20 @@ namespace Orleans.TelemetryConsumers.AI
         /// <param name="options">The instrumentation key for ApplicationInsights.</param>
         public AITelemetryConsumer(IOptions<ApplicationInsightsTelemetryConsumerOptions> options)
         {
+            var telemetryConfiguration = options.Value.TelemetryConfiguration;
             var instrumentationKey = options.Value.InstrumentationKey;
-            this._client = instrumentationKey != null
-                ? new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration { InstrumentationKey = instrumentationKey })
+            if (telemetryConfiguration != null)
+            {
+                this._client = new TelemetryClient(telemetryConfiguration);
+            }
+            else
+            {
+                this._client = instrumentationKey != null
+                    ? new TelemetryClient(new TelemetryConfiguration { InstrumentationKey = instrumentationKey })
 #pragma warning disable CS0618 // Type or member is obsolete
                 : new TelemetryClient(Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.Active);
 #pragma warning restore CS0618 // Type or member is obsolete
+            }
         }
 
         /// <inheritdoc />

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
@@ -22,7 +22,6 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="hostBuilder"></param>
         /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
-
         public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, TelemetryConfiguration telemetryConfiguration)
         {
             return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, null));

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
@@ -11,22 +11,42 @@ namespace Orleans.Hosting
         /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/>.
         /// </summary>
         /// <param name="hostBuilder"></param>
-        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
         /// <param name="instrumentationKey">The Application Insights instrumentation key.</param>
-        public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, TelemetryConfiguration telemetryConfiguration = null, string instrumentationKey = null)
+
+        public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, string instrumentationKey = null)
         {
-            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, instrumentationKey));
+            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, null, instrumentationKey));
+        }
+
+        /// <summary>
+        /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/> using a predefined <see cref="TelemetryConfiguration"/>.
+        /// </summary>
+        /// <param name="hostBuilder"></param>
+        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
+
+        public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, TelemetryConfiguration telemetryConfiguration)
+        {
+            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, null));
         }
 
         /// <summary>
         /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/>.
         /// </summary>
         /// <param name="clientBuilder"></param>
-        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
         /// <param name="instrumentationKey">The Application Insights instrumentation key.</param>
-        public static IClientBuilder AddApplicationInsightsTelemetryConsumer(this IClientBuilder clientBuilder, TelemetryConfiguration telemetryConfiguration = null, string instrumentationKey = null)
+        public static IClientBuilder AddApplicationInsightsTelemetryConsumer(this IClientBuilder clientBuilder, string instrumentationKey = null)
         {
-            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, instrumentationKey));
+            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, null, instrumentationKey));
+        }
+
+        /// <summary>
+        /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/> using a predefined <see cref="TelemetryConfiguration"/>.
+        /// </summary>
+        /// <param name="clientBuilder"></param>
+        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
+        public static IClientBuilder AddApplicationInsightsTelemetryConsumer(this IClientBuilder clientBuilder, TelemetryConfiguration telemetryConfiguration)
+        {
+            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, null));
         }
 
         private static void ConfigureServices(Microsoft.Extensions.Hosting.HostBuilderContext context, IServiceCollection services, TelemetryConfiguration telemetryConfiguration, string instrumentationKey)
@@ -34,9 +54,13 @@ namespace Orleans.Hosting
             services.ConfigureFormatter<ApplicationInsightsTelemetryConsumerOptions>();
             services.Configure<TelemetryOptions>(options => options.AddConsumer<AITelemetryConsumer>());
             if (telemetryConfiguration != null)
+            {
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.TelemetryConfiguration = telemetryConfiguration);
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            }
+            else if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            {
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.InstrumentationKey = instrumentationKey);
+            }
         }
 
         private static void ConfigureServices(HostBuilderContext context, IServiceCollection services, TelemetryConfiguration telemetryConfiguration, string instrumentationKey)
@@ -44,9 +68,13 @@ namespace Orleans.Hosting
             services.ConfigureFormatter<ApplicationInsightsTelemetryConsumerOptions>();
             services.Configure<TelemetryOptions>(options => options.AddConsumer<AITelemetryConsumer>());
             if (telemetryConfiguration != null)
+            {
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.TelemetryConfiguration = telemetryConfiguration);
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            }
+            else if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            {
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.InstrumentationKey = instrumentationKey);
+            }
         }
     }
 }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
@@ -12,7 +12,6 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="hostBuilder"></param>
         /// <param name="instrumentationKey">The Application Insights instrumentation key.</param>
-
         public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, string instrumentationKey = null)
         {
             return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, null, instrumentationKey));

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/AITelemetryConsumerConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.TelemetryConsumers.AI;
@@ -10,34 +11,40 @@ namespace Orleans.Hosting
         /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/>.
         /// </summary>
         /// <param name="hostBuilder"></param>
+        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
         /// <param name="instrumentationKey">The Application Insights instrumentation key.</param>
-        public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, string instrumentationKey = null)
+        public static ISiloBuilder AddApplicationInsightsTelemetryConsumer(this ISiloBuilder hostBuilder, TelemetryConfiguration telemetryConfiguration = null, string instrumentationKey = null)
         {
-            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, instrumentationKey));
+            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, instrumentationKey));
         }
 
         /// <summary>
         /// Adds a metrics telemetric consumer provider of type <see cref="AITelemetryConsumer"/>.
         /// </summary>
         /// <param name="clientBuilder"></param>
+        /// <param name="telemetryConfiguration">The Application Insights TelemetryConfiguration.</param>
         /// <param name="instrumentationKey">The Application Insights instrumentation key.</param>
-        public static IClientBuilder AddApplicationInsightsTelemetryConsumer(this IClientBuilder clientBuilder, string instrumentationKey = null)
+        public static IClientBuilder AddApplicationInsightsTelemetryConsumer(this IClientBuilder clientBuilder, TelemetryConfiguration telemetryConfiguration = null, string instrumentationKey = null)
         {
-            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, instrumentationKey));
+            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, telemetryConfiguration, instrumentationKey));
         }
 
-        private static void ConfigureServices(Microsoft.Extensions.Hosting.HostBuilderContext context, IServiceCollection services, string instrumentationKey)
+        private static void ConfigureServices(Microsoft.Extensions.Hosting.HostBuilderContext context, IServiceCollection services, TelemetryConfiguration telemetryConfiguration, string instrumentationKey)
         {
             services.ConfigureFormatter<ApplicationInsightsTelemetryConsumerOptions>();
             services.Configure<TelemetryOptions>(options => options.AddConsumer<AITelemetryConsumer>());
+            if (telemetryConfiguration != null)
+                services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.TelemetryConfiguration = telemetryConfiguration);
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.InstrumentationKey = instrumentationKey);
         }
 
-        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services, string instrumentationKey)
+        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services, TelemetryConfiguration telemetryConfiguration, string instrumentationKey)
         {
             services.ConfigureFormatter<ApplicationInsightsTelemetryConsumerOptions>();
             services.Configure<TelemetryOptions>(options => options.AddConsumer<AITelemetryConsumer>());
+            if (telemetryConfiguration != null)
+                services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.TelemetryConfiguration = telemetryConfiguration);
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
                 services.Configure<ApplicationInsightsTelemetryConsumerOptions>(options => options.InstrumentationKey = instrumentationKey);
         }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
@@ -6,7 +6,7 @@ namespace Orleans.Configuration
     {
         /// <summary>
         /// Instrumentation Key of the Application Insights instance.
-        /// Will be ignored if <see cref="TelemetryClient" /> is provided.
+        /// Will be ignored if <see cref="TelemetryConfiguration" /> is provided.
         /// </summary>
         [Redact]
         public string InstrumentationKey { get; set; }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
@@ -1,9 +1,19 @@
-﻿
+using Microsoft.ApplicationInsights.Extensibility;
+
 namespace Orleans.Configuration
 {
     public class ApplicationInsightsTelemetryConsumerOptions
     {
+        /// <summary>
+        /// Instrumentation Key of the App Insights instance.
+        /// Will be ignored if TelemetryClient is provided.
+        /// </summary>
         [Redact]
         public string InstrumentationKey { get; set; }
+
+        /// <summary>
+        /// The TelemetryClient instance.
+        /// </summary>
+        public TelemetryConfiguration TelemetryConfiguration  { get; set; }
     }
 }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
@@ -12,7 +12,7 @@ namespace Orleans.Configuration
         public string InstrumentationKey { get; set; }
 
         /// <summary>
-        /// The TelemetryClient instance.
+        /// The <see cref="TelemetryConfiguration" /> instance.
         /// </summary>
         public TelemetryConfiguration TelemetryConfiguration  { get; set; }
     }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
@@ -6,7 +6,7 @@ namespace Orleans.Configuration
     {
         /// <summary>
         /// Instrumentation Key of the Application Insights instance.
-        /// Will be ignored if TelemetryClient is provided.
+        /// Will be ignored if <see cref="TelemetryClient" /> is provided.
         /// </summary>
         [Redact]
         public string InstrumentationKey { get; set; }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.AI/ApplicationInsightsTelemetryConsumerOptions.cs
@@ -5,7 +5,7 @@ namespace Orleans.Configuration
     public class ApplicationInsightsTelemetryConsumerOptions
     {
         /// <summary>
-        /// Instrumentation Key of the App Insights instance.
+        /// Instrumentation Key of the Application Insights instance.
         /// Will be ignored if TelemetryClient is provided.
         /// </summary>
         [Redact]


### PR DESCRIPTION
This PR fixes a current gap in AITelemetryConsumer, which no longer picks up a TelemetryConfiguration that was registered via Dependency Injection. This means custom configurations through TelemetryInitializers, TelemetryProcessors, or TelemetrySinks will not be applied to Orleans metrics. Today, AITelemetryConsumer uses a configuration built by default by TelemetryConfiguration.Active, which is not recommended by the AppInsights team.

This behavior changed because as of 2.15.0-beta3 of Application Insights, a preconfigured TelemetryConfiguration through DI is no longer copied over to the TelemetryConfiguration.Active singleton, and it now requires a feature flag. It is unclear how long this feature flag will be supported in future versions of the AppInsights SDK
microsoft/ApplicationInsights-dotnet#1886

To address this issue, this PR allows users to add TelemetryConfiguration directly using:

```csharp
var siloHostBuilder = new SiloHostBuilder();
var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
//configure the silo with AITelemetryConsumer
siloHostBuilder.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);
```

```csharp
var clientBuilder = new ClientBuilder();
var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
//configure the clientBuilder with AITelemetryConsumer
clientBuilder.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);
```

While the examples above use the simplified TelemetryConfiguration.CreateDefault(), users will be able to pull their own TelemetryConfiguration from their ServiceCollection and pass it to Orleans for consuming metrics.

This PR is back compatible with existing orleans configuration code, and does not attempt to remove the obselete reference to TelemetryConfiguration.Active. This is because there may still be users that are relying on TelemetryConfiguration.Active from .NET Framework, or possibly .NET Core users who may still be using the provided feature flag to leverage the obselete feature:
```csharp
      services.AddApplicationInsightsTelemetry()
      .Configure<ApplicationInsightsServiceOptions>(options =>
      {
          options.EnableActiveTelemetryConfigurationSetup = true;
      })
```

Eventually, TelemetryConfiguration.Active should be deprecated from AITelemetryConsumer and replaced with `new TelemetryClient(TelemetryConfiguration.CreateDefault());`