### PR TITLE
[Dependencies] Updating Event Hubs SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,8 +67,8 @@
 
     <MicrosoftApplicationInsightsVersion>2.16.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftAzureCosmosTableVersion>1.0.5</MicrosoftAzureCosmosTableVersion>
-    <AzureCoreVersion>1.9.0</AzureCoreVersion>
-    <AzureMessagingEventHubs>5.3.0</AzureMessagingEventHubs>
+    <AzureCoreVersion>1.19.0</AzureCoreVersion>
+    <AzureMessagingEventHubs>5.6.1</AzureMessagingEventHubs>
     <AzureStorageBlobsVersion>12.4.4</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.3.2</AzureStorageQueuesVersion>
     <MicrosoftServiceFabricServicesVersion>4.1.456</MicrosoftServiceFabricServicesVersion>


### PR DESCRIPTION
# Summary 

The focus of these changes is to update the Event Hubs and Azure.Core package references. The currently referenced versions are roughly ~8 months old, during which time each has received a number of improvements.  The current generation of Azure SDKs has a strong commitment to avoid breaking changes; there should be no cascading changes needed.

# References and Resources

- [Event Hubs Changelog](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)
- [Azure.Core Changelog](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/CHANGELOG.md)