### PR TITLE
Fix: wrong parameter used when throwing QueueCacheMissException

### DIFF
--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -219,7 +219,7 @@ namespace Orleans.Providers.Streams.Common
                 }
                 else
                 {
-                    throw new QueueCacheMissException(cursor.SequenceToken,
+                    throw new QueueCacheMissException(sequenceToken,
                         messageBlocks.Last.Value.GetOldestSequenceToken(cacheDataAdapter),
                         messageBlocks.First.Value.GetNewestSequenceToken(cacheDataAdapter));
                 }


### PR DESCRIPTION
Fix for #7294 