### PR TITLE
Fix `Response.ToString()`

### DIFF
--- a/src/Orleans.Serialization/Invocation/Response.cs
+++ b/src/Orleans.Serialization/Invocation/Response.cs
@@ -26,7 +26,7 @@ namespace Orleans.Serialization.Invocation
 
         public abstract void Dispose();
 
-        public virtual object GetResultOrDefault() => Exception is { } ? Result : default;
+        public virtual object GetResultOrDefault() => Exception switch { null => Result, _ => default };
 
         public override string ToString()
         {


### PR DESCRIPTION
`Response.ToString()` would throw since the logic in `GetValueOrDefault()` was wrong