### PR TITLE
Fix: wrong parameter used when throwing QueueCacheMissException (#7295)

### DIFF
--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -221,7 +221,7 @@ namespace Orleans.Providers.Streams.Common
                 }
                 else
                 {
-                    throw new QueueCacheMissException(cursor.SequenceToken,
+                    throw new QueueCacheMissException(sequenceToken,
                         messageBlocks.Last.Value.GetOldestSequenceToken(cacheDataAdapter),
                         messageBlocks.First.Value.GetNewestSequenceToken(cacheDataAdapter));
                 }


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7306)