### PR TITLE
CodeGenerator: support implicit using directives

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,7 +71,7 @@
 
     <!-- Microsoft packages -->
     <MicrosoftBuildVersion>16.4.0</MicrosoftBuildVersion>
-    <MicrosoftCodeAnalysisVersion>3.9.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>3.11.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftWin32RegistryVersion>4.7.0</MicrosoftWin32RegistryVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesVersion>

--- a/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Orleans.Analyzers
         private const string AlwaysInterleaveAttributeName = "Orleans.Concurrency.AlwaysInterleaveAttribute";
 
         public const string DiagnosticId = "ORLEANS0001";
-        public const string Title = "[AlwaysInterleave] must only be used on the grain interface method and not the grain class method.";
+        public const string Title = "[AlwaysInterleave] must only be used on the grain interface method and not the grain class method";
         public const string MessageFormat = Title;
         public const string Category = "Usage";
 

--- a/src/Orleans.CodeGenerator.MSBuild/Program.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/Program.cs
@@ -67,11 +67,12 @@ namespace Microsoft.Orleans.CodeGenerator.MSBuild
                     {
                         case "WaitForDebugger":
                             var i = 0;
+                            var process = Process.GetCurrentProcess();
                             while (!Debugger.IsAttached)
                             {
                                 if (i++ % 50 == 0)
                                 {
-                                    Console.WriteLine("Waiting for debugger to attach.");
+                                    Console.WriteLine($"Waiting for debugger to attach to process {process.ProcessName} with PID {process.Id}");
                                 }
 
                                 Thread.Sleep(100);

--- a/src/Orleans.CodeGenerator/Analysis/CompilationAnalyzer.cs
+++ b/src/Orleans.CodeGenerator/Analysis/CompilationAnalyzer.cs
@@ -9,6 +9,7 @@ using Orleans.CodeGenerator.Utilities;
 
 namespace Orleans.CodeGenerator.Analysis
 {
+#pragma warning disable RS1024 // Compare symbols correctly
     internal class CompilationAnalyzer
     {
         private readonly ILogger log;
@@ -22,22 +23,22 @@ namespace Orleans.CodeGenerator.Analysis
         /// <summary>
         /// Assemblies whose declared types are all considered serializable.
         /// </summary>
-        private readonly HashSet<IAssemblySymbol> assembliesWithForcedSerializability = new HashSet<IAssemblySymbol>();
+        private readonly HashSet<IAssemblySymbol> assembliesWithForcedSerializability = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
 
         /// <summary>
         /// Types whose sub-types are all considered serializable.
         /// </summary>
-        private readonly HashSet<INamedTypeSymbol> knownBaseTypes = new HashSet<INamedTypeSymbol>();
+        private readonly HashSet<INamedTypeSymbol> knownBaseTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
         /// <summary>
         /// Types which were observed in a grain interface.
         /// </summary>
-        private readonly HashSet<ITypeSymbol> dependencyTypes = new HashSet<ITypeSymbol>();
+        private readonly HashSet<ITypeSymbol> dependencyTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
 
-        private readonly HashSet<INamedTypeSymbol> grainInterfacesToProcess = new HashSet<INamedTypeSymbol>();
-        private readonly HashSet<INamedTypeSymbol> grainClassesToProcess = new HashSet<INamedTypeSymbol>();
-        private readonly HashSet<INamedTypeSymbol> serializationTypesToProcess = new HashSet<INamedTypeSymbol>();
-        private readonly HashSet<INamedTypeSymbol> fieldOfSerializableType = new HashSet<INamedTypeSymbol>();
+        private readonly HashSet<INamedTypeSymbol> grainInterfacesToProcess = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        private readonly HashSet<INamedTypeSymbol> grainClassesToProcess = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        private readonly HashSet<INamedTypeSymbol> serializationTypesToProcess = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        private readonly HashSet<INamedTypeSymbol> fieldOfSerializableType = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
         public CompilationAnalyzer(ILogger log, WellKnownTypes wellKnownTypes, Compilation compilation)
         {
@@ -50,33 +51,33 @@ namespace Orleans.CodeGenerator.Analysis
             this.compilation = compilation;
         }
 
-        public HashSet<INamedTypeSymbol> CodeGenerationRequiredTypes { get; } = new HashSet<INamedTypeSymbol>();
+        public HashSet<INamedTypeSymbol> CodeGenerationRequiredTypes { get; } = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
         /// <summary>
         /// All assemblies referenced by this compilation.
         /// </summary>
-        public HashSet<IAssemblySymbol> ReferencedAssemblies = new HashSet<IAssemblySymbol>();
+        public HashSet<IAssemblySymbol> ReferencedAssemblies = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
 
         /// <summary>
         /// Assemblies which should be excluded from code generation (eg, because they already contain generated code).
         /// </summary>
-        public HashSet<IAssemblySymbol> AssembliesExcludedFromCodeGeneration = new HashSet<IAssemblySymbol>();
+        public HashSet<IAssemblySymbol> AssembliesExcludedFromCodeGeneration = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
 
         /// <summary>
         /// Assemblies which should be excluded from metadata generation.
         /// </summary>
-        public HashSet<IAssemblySymbol> AssembliesExcludedFromMetadataGeneration = new HashSet<IAssemblySymbol>();
+        public HashSet<IAssemblySymbol> AssembliesExcludedFromMetadataGeneration = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
 
-        public HashSet<IAssemblySymbol> KnownAssemblies { get; } = new HashSet<IAssemblySymbol>();
-        public HashSet<INamedTypeSymbol> KnownTypes { get; } = new HashSet<INamedTypeSymbol>();
+        public HashSet<IAssemblySymbol> KnownAssemblies { get; } = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
+        public HashSet<INamedTypeSymbol> KnownTypes { get; } = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
         public (IEnumerable<INamedTypeSymbol> grainClasses, IEnumerable<INamedTypeSymbol> grainInterfaces, IEnumerable<INamedTypeSymbol> types) GetTypesToProcess() =>
             (this.grainClassesToProcess, this.grainInterfacesToProcess, this.GetSerializationTypesToProcess());
 
         private IEnumerable<INamedTypeSymbol> GetSerializationTypesToProcess()
         {
-            var done = new HashSet<INamedTypeSymbol>();
-            var remaining = new HashSet<INamedTypeSymbol>();
+            var done = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var remaining = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             while (done.Count != this.serializationTypesToProcess.Count)
             {
                 remaining.Clear();
@@ -234,7 +235,7 @@ namespace Orleans.CodeGenerator.Analysis
 
         private static IEnumerable<ITypeSymbol> ExpandType(ITypeSymbol symbol)
         {
-            return ExpandTypeInternal(symbol, new HashSet<ITypeSymbol>());
+            return ExpandTypeInternal(symbol, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
             IEnumerable<ITypeSymbol> ExpandTypeInternal(ITypeSymbol s, HashSet<ITypeSymbol> emitted)
             {
                 if (!emitted.Add(s)) yield break;
@@ -431,4 +432,5 @@ namespace Orleans.CodeGenerator.Analysis
             this.dependencyTypes.Add(type);
         }
     }
+#pragma warning restore RS1024 // Compare symbols correctly
 }

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -69,7 +69,8 @@ namespace Orleans.CodeGenerator
             var types = this.compilationAnalyzer
                 .KnownAssemblies.SelectMany(a => a.GetDeclaredTypes())
                 .Concat(this.compilationAnalyzer.KnownTypes)
-                .Distinct()
+                .Distinct(SymbolEqualityComparer.Default)
+                .OfType<INamedTypeSymbol>()
                 .ToList();
 
             var model = new AggregatedModel();
@@ -142,7 +143,9 @@ namespace Orleans.CodeGenerator
 
         private CompilationUnitSyntax GenerateSyntax(AggregatedModel model)
         {
-            var namespaceGroupings = new Dictionary<INamespaceSymbol, List<MemberDeclarationSyntax>>();
+#pragma warning disable RS1024 // Compare symbols correctly
+            var namespaceGroupings = new Dictionary<INamespaceSymbol, List<MemberDeclarationSyntax>>(SymbolEqualityComparer.Default);
+#pragma warning restore RS1024 // Compare symbols correctly
 
             // Pass the relevant elements of the model to each of the code generators.
             foreach (var grainInterface in model.GrainInterfaces)

--- a/src/Orleans.CodeGenerator/Generators/GrainMethodInvokerGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainMethodInvokerGenerator.cs
@@ -292,9 +292,11 @@ namespace Orleans.CodeGenerator.Generators
         /// </summary>
         private Dictionary<IMethodSymbol, GenericInvokerField> GenerateGenericInvokerFields(WellKnownTypes wellKnownTypes, List<GrainMethodDescription> methodDescriptions)
         {
-            if (!(wellKnownTypes.GenericMethodInvoker is WellKnownTypes.Some genericMethodInvoker)) return new Dictionary<IMethodSymbol, GenericInvokerField>();
+#pragma warning disable RS1024 // Compare symbols correctly
+            if (!(wellKnownTypes.GenericMethodInvoker is WellKnownTypes.Some genericMethodInvoker)) return new Dictionary<IMethodSymbol, GenericInvokerField>(SymbolEqualityComparer.Default);
 
-            var result = new Dictionary<IMethodSymbol, GenericInvokerField>(methodDescriptions.Count);
+            var result = new Dictionary<IMethodSymbol, GenericInvokerField>(methodDescriptions.Count, SymbolEqualityComparer.Default);
+#pragma warning restore RS1024 // Compare symbols correctly
             foreach (var description in methodDescriptions)
             {
                 var method = description.Method;

--- a/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/GrainReferenceGenerator.cs
@@ -322,7 +322,9 @@ namespace Orleans.CodeGenerator.Generators
                 var enumType = wellKnownTypes.TransactionOption;
                 var txRequirement = (int)attr.ConstructorArguments.First().Value;
                 var values = enumType.GetMembers().OfType<IFieldSymbol>().ToList();
+#pragma warning disable RS1024 // Compare symbols correctly
                 var mapping = values.ToDictionary(m => (int)m.ConstantValue, m => m.Name);
+#pragma warning restore RS1024 // Compare symbols correctly
                 if (!mapping.TryGetValue(txRequirement, out var value))
                 {
                     throw new NotSupportedException(

--- a/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/Generators/SerializerGenerator.cs
@@ -60,7 +60,9 @@ namespace Orleans.CodeGenerator.Generators
             this.wellKnownTypes = wellKnownTypes;
         }
 
-        private readonly ConcurrentDictionary<ITypeSymbol, bool> ShallowCopyableTypes = new ConcurrentDictionary<ITypeSymbol, bool>();
+#pragma warning disable RS1024 // Compare symbols correctly
+        private readonly ConcurrentDictionary<ITypeSymbol, bool> ShallowCopyableTypes = new ConcurrentDictionary<ITypeSymbol, bool>(SymbolEqualityComparer.Default);
+#pragma warning restore RS1024 // Compare symbols correctly
 
         /// <summary>
         /// Returns the name of the generated class for the provided type.

--- a/src/Orleans.CodeGenerator/Model/SerializationTypeDescriptions.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializationTypeDescriptions.cs
@@ -41,7 +41,7 @@ namespace Orleans.CodeGenerator.Model
 
             public int GetHashCode(SerializerTypeDescription obj)
             {
-                return obj.Target != null ? obj.Target.GetHashCode() : 0;
+                return obj.Target != null ? SymbolEqualityComparer.Default.GetHashCode(obj.target) : 0;
             }
         }
     }
@@ -74,7 +74,7 @@ namespace Orleans.CodeGenerator.Model
             {
                 unchecked
                 {
-                    return ((obj.Type != null ? obj.Type.GetHashCode() : 0) * 397);
+                    return ((obj.Type != null ? SymbolEqualityComparer.Default.GetHashCode(obj.Type) : 0) * 397);
                 }
             }
         }

--- a/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
@@ -252,7 +252,7 @@ namespace Orleans.CodeGenerator.Utilities
         public static IMethodSymbol Method(this ITypeSymbol type, string name, Func<IMethodSymbol, bool> predicate = null) => type.Member(name, predicate);
 
         public static IMethodSymbol Method(this ITypeSymbol type, string name, params INamedTypeSymbol[] parameters) =>
-            type.Member<IMethodSymbol>(name, m => m.Parameters.Select(p => p.Type).SequenceEqual(parameters));
+            type.Member<IMethodSymbol>(name, m => m.Parameters.Select(p => p.Type).SequenceEqual(parameters, SymbolEqualityComparer.Default));
 
         public static IPropertySymbol Property(this ITypeSymbol type, string name) => type.Member<IPropertySymbol>(name);
 


### PR DESCRIPTION
Currently, the MSBuild code generator does not support the new `<ImplicitUsings>enable</ImplicitUsings>` feature which is coming in .NET 6. When a developer creates a new .NET 6 project in VS or via templates, this feature is enabled by default and that breaks the build with an error message similar to this:

```
  Orleans.CodeGeneration.Build -> C:\dev\orleans\src\Orleans.CodeGeneration.Build\bin\Debug\publish\netcoreapp3.1\
  fail: Orleans.CodeGenerator[0]
        Grain interface BenchmarkGrainInterfaces.Ping.ILoadGrain has method BenchmarkGrainInterfaces.Ping.ILoadGrain.Generate(int, int) which returns a non-awaitable type Task. All grain interface methods must return awaitable types. Did you mean to return Task<Task>?
  -- Code Generation FAILED --

  Exc level 0: System.InvalidOperationException: Grain interface BenchmarkGrainInterfaces.Ping.ILoadGrain has method BenchmarkGrainInterfaces.Ping.ILoadGrain.Generate(int, int) which returns a non-awaitable type Task. All grain interface methods must return awaitable types. Did you mean to return Task<Task>?
     at Orleans.CodeGenerator.Analysis.CompilationAnalyzer.InspectGrainInterface(INamedTypeSymbol type) in C:\dev\orleans\src\Orleans.CodeGenerator\Analysis\CompilationAnalyzer.cs:line 193
     at Orleans.CodeGenerator.Analysis.CompilationAnalyzer.InspectType(INamedTypeSymbol type) in C:\dev\orleans\src\Orleans.CodeGenerator\Analysis\CompilationAnalyzer.cs:line 264
     at Orleans.CodeGenerator.CodeGenerator.AnalyzeCompilation() in C:\dev\orleans\src\Orleans.CodeGenerator\CodeGenerator.cs:line 78
     at Orleans.CodeGenerator.CodeGenerator.GenerateCode(CancellationToken cancellationToken) in C:\dev\orleans\src\Orleans.CodeGenerator\CodeGenerator.cs:line 53
     at Orleans.CodeGenerator.MSBuild.CodeGeneratorCommand.Execute(CancellationToken cancellationToken) in C:\dev\orleans\src\Orleans.CodeGenerator.MSBuild\CodeGeneratorCommand.cs:line 154
     at Microsoft.Orleans.CodeGenerator.MSBuild.Program.SourceToSource(String[] args) in C:\dev\orleans\src\Orleans.CodeGenerator.MSBuild\Program.cs:line 142
     at Microsoft.Orleans.CodeGenerator.MSBuild.Program.Main(String[] args) in C:\dev\orleans\src\Orleans.CodeGenerator.MSBuild\Program.cs:line 26
C:\dev\orleans\src\Orleans.CodeGenerator.MSBuild\build\Microsoft.Orleans.CodeGenerator.MSBuild.targets(126,5): error MSB3073: The command ""dotnet" "C:\dev\orleans\src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/bin/Debug/publish/Orleans.CodeGenerator.MSBuild.Bootstrap.dll" SourceToSource "C:\dev\orleans\test\Grains\BenchmarkGrainInterfaces\obj\Debug\netstandard2.0\BenchmarkGrainInterfaces.orleans.g.args.txt"" exited with code 3. [C:\dev\orleans\test\Grains\BenchmarkGrainInterfaces\BenchmarkGrainInterfaces.csproj]
```

This PR fixes that by upgrading the Roslyn version used, which subsequently required making some code changes to suppress a Roslyn analyzer

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7310)