### PR TITLE
Allow passing a CancellationToken to LockAsync

### DIFF
--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -54,9 +54,9 @@ namespace Orleans
             semaphore = new SemaphoreSlim(1);
         }
 
-        public Task<IDisposable> LockAsync()
+        public Task<IDisposable> LockAsync(CancellationToken cancellation = default)
         {
-            Task wait = semaphore.WaitAsync();
+            Task wait = semaphore.WaitAsync(cancellation);
             if (wait.IsCompleted)
                 return Task.FromResult((IDisposable)new LockReleaser(this));
             else


### PR DESCRIPTION
This allows the calling process to potentially abort the lock operation 
if (say) it takes too long, or if it's no longer necessary for whatever reason.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7311)