### PR TITLE
[3.x] Support Minimal API host builder

### DIFF
--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -43,7 +43,6 @@ namespace Orleans
             CreateHostingEnvironment();
             CreateHostBuilderContext();
             BuildAppConfiguration();
-            this.ConfigureApplicationParts(parts => parts.ConfigureDefaults());
 
             this.ConfigureServices(
                 services =>

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -74,11 +74,11 @@ namespace Orleans
 
             // Application parts
             var parts = builder.GetApplicationPartManager();
-            services.TryAddSingleton<IApplicationPartManager>(parts);
             parts.AddApplicationPart(new AssemblyPart(typeof(RuntimeVersion).Assembly) { IsFrameworkAssembly = true });
             parts.AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator());
             parts.AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainInterfaceFeature>());
             parts.AddFeatureProvider(new AssemblyAttributeFeatureProvider<SerializerFeature>());
+            services.TryAddSingleton<IApplicationPartManager>(sp => parts.ConfigureDefaults());
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
 
             services.TryAddSingleton(typeof(IKeyedServiceCollection<,>), typeof(KeyedServiceCollection<,>));

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -156,6 +156,7 @@ namespace Orleans.Hosting
                             options.SiloName ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
 
                     services.TryAddSingleton<Silo>();
+                    services.AddHostedService<SiloHostedService>();
                     DefaultSiloServices.AddDefaultServices(context.GetApplicationPartManager(), services);
 
                     context.Properties.Add("OrleansServicesAdded", true);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -281,13 +281,13 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ITransactionAgent, DisabledTransactionAgent>();
 
             // Application Parts
-            services.TryAddSingleton<IApplicationPartManager>(applicationPartManager);
             applicationPartManager.AddApplicationPart(new AssemblyPart(typeof(RuntimeVersion).Assembly) { IsFrameworkAssembly = true });
             applicationPartManager.AddApplicationPart(new AssemblyPart(typeof(Silo).Assembly) { IsFrameworkAssembly = true });
             applicationPartManager.AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator());
             applicationPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainInterfaceFeature>());
             applicationPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainClassFeature>());
             applicationPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<SerializerFeature>());
+            services.TryAddSingleton<IApplicationPartManager>(sp => applicationPartManager.ConfigureDefaults());
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
 
             //Add default option formatter if none is configured, for options which are required to be configured

--- a/src/Orleans.Runtime/Hosting/GenericHostExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/GenericHostExtensions.cs
@@ -30,17 +30,13 @@ namespace Microsoft.Extensions.Hosting
             {
                 siloBuilder = new SiloBuilder(hostBuilder);
                 hostBuilder.Properties.Add(siloBuilderKey, siloBuilder);
-                hostBuilder.ConfigureServices((context, services) =>
-                {
-                    siloBuilder.Build(context, services);
-                });
             }
             else
             {
                 siloBuilder = (SiloBuilder)hostBuilder.Properties[siloBuilderKey];
             }
 
-            siloBuilder.ConfigureSilo(configureDelegate);
+            siloBuilder.ConfigureServices((context, services) => configureDelegate(context, siloBuilder));
             return hostBuilder;
         }
 

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -49,10 +49,6 @@ namespace Orleans.TestingHost
 
             // Add the silo builder to the host builder so that it is executed during configuration time. 
             hostBuilder.Properties[nameof(SiloBuilder)] = siloBuilder;
-            hostBuilder.ConfigureServices((context, services) =>
-            {
-                siloBuilder.Build(context, services);
-            });
 
             siloBuilder
                 .Configure<ClusterOptions>(configuration)


### PR DESCRIPTION
The Minimal API host builder runs `ConfigureServices` delegates inline, whereas `HostBuilder` defers their execution until `Build()` is called. This difference causes an issue today and neither of the two options (passthru vs defer) will work in all cases:

1. If we pass-thru `ConfigureServices` calls in the `HostBuilder`, then the delegate passed to `UseOrleans(Action<HostBuilderContext, ISiloBuilder>)` will cause `HostBuilder` to throw when that delegate calls `ConfigureServices` itself (which is almost guaranteed to happen).
2. If we queue calls for later execution like we do today, then there is no opportunity for them to be invoked by the Minimal API builder, since there is no way to enqueue a delegate on it to be invoked when `Build` is called.

So the solution I've taken in this PR is to do both: we defer `ConfigureServices` calls until the `ConfigureServices` delegate in `SiloBuilder`'s constructor is called, after which point we pass them through. This works for both the Minimal API builder and the `HostBuilder`

cc @davidfowl

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7316)