### PR TITLE
#7309 - add support for generic constraints on grain methods

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.400"
+    "version": "5.0.400",
+    "rollForward": "patch"
   }
 }

--- a/test/CodeGeneration/CodeGenerator.Tests/GenericMethodInvokerTests.cs
+++ b/test/CodeGeneration/CodeGenerator.Tests/GenericMethodInvokerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.CodeGeneration;
@@ -5,6 +6,22 @@ using Xunit;
 
 namespace CodeGenerator.Tests
 {
+    public interface IAnimal
+    {
+    }
+
+    public class Cat : IAnimal
+    {
+    }
+
+    public interface ICar
+    {
+    }
+
+    public class Toyota : ICar
+    {
+    }
+
     public interface IDummyGrain : IGrainWithGuidKey
     {
         Task<int> Method<T>(int x);
@@ -16,6 +33,8 @@ namespace CodeGenerator.Tests
         ValueTask Method<T>(string s1, string s2);
         ValueTask<int> Method<T>(string s);
         ValueTask<object> Method<T>(int x, int y);
+        Task<int> ConstrainedMethod<T>(int a) where T : IAnimal;
+        Task<int> ConstrainedMethod<T>(int a, string b) where T : ICar;
     }
 
     public class FooGrain : IDummyGrain
@@ -37,22 +56,77 @@ namespace CodeGenerator.Tests
         public ValueTask<object> Method<T>(int x, int y) => new(7);
 
         public ValueTask<int> Method<T>(string s) => new(8);
+
+        public Task<int> ConstrainedMethod<T>(int a) where T : IAnimal => Task.FromResult(1);
+
+        public Task<int> ConstrainedMethod<T>(int a, string b) where T : ICar => Task.FromResult(2);
     }
 
     public class GenericMethodInvokerTests
     {
         [Fact]
+        public async Task Constraint_Compliant_Animal_Int_Argument()
+        {
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.ConstrainedMethod), 1);
+            var mock = new FooGrain();
+
+            // Act<Cat>(42)
+            var result = await invoker.Invoke(mock, new object[] { typeof(Cat), typeof(int), 42 });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task Constraint_Compliant_Car_Int_String_Arguments()
+        {
+
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.ConstrainedMethod), 1);
+            var mock = new FooGrain();
+
+            // Act<Toyota>(42, "b")
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(Toyota), typeof(int), typeof(string), 42, "b" });
+
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public async Task Constraint_Animal_Wrong_Type_Parameter_Type()
+        {
+
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.ConstrainedMethod), 1);
+            var mock = new FooGrain();
+
+            // Act<Toyota>("c") -- violates IAnimal constraint
+            await Assert.ThrowsAsync<ArgumentException>(async () => await invoker.Invoke(mock,
+                new object[] { typeof(Toyota), typeof(string), "c" }));
+        }
+
+        [Fact]
+        public async Task Constraint_Animal_Wrong_Argument_Type()
+        {
+
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.ConstrainedMethod), 1);
+            var mock = new FooGrain();
+
+            // Act<Cat>("c") -- string overload does not exist for IAnimal constrained
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await invoker.Invoke(mock,
+                    new object[] { typeof(Cat), typeof(string), "c" }));
+        }
+
+        [Fact]
         public async Task Overload_Int()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
 
             var mock = new FooGrain();
 
             var result = await invoker.Invoke(mock, new object[]
             {
-                typeof(bool),   // type parameter(s)
-                typeof(int),    // argument type(s)
-                42              // argument(s)
+                typeof(bool), // type parameter(s)
+                typeof(int), // argument type(s)
+                42 // argument(s)
             });
 
             Assert.Equal(1, result);
@@ -61,15 +135,11 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_Int_String()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(int), typeof(string),
-                42, "bar"
-            });
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(bool), typeof(int), typeof(string), 42, "bar" });
 
             Assert.Equal(2, result);
         }
@@ -77,15 +147,11 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_Int_String_T()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(int), typeof(string), typeof(bool),
-                42, "bar", true
-            });
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(bool), typeof(int), typeof(string), typeof(bool), 42, "bar", true });
 
             Assert.Equal(3, result);
         }
@@ -93,15 +159,11 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_T_string_string()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(bool), typeof(string), typeof(string),
-                false, "bar", "foo"
-            });
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(bool), typeof(bool), typeof(string), typeof(string), false, "bar", "foo" });
 
             Assert.Equal(4, result);
         }
@@ -109,15 +171,11 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_object_array_covariant_arg()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(string[]),
-                new [] {"a","b","c"}
-            });
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(bool), typeof(string[]), new[] { "a", "b", "c" } });
 
             Assert.Equal(5, result);
         }
@@ -125,15 +183,15 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_multiple_type_parameters()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 2);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 2);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(string[]), typeof(double),
-                typeof(string[]), typeof(double),
-                new [] {"a","b","c"}, 0.5d
-            });
+            var result = await invoker.Invoke(mock,
+                new object[]
+                {
+                    typeof(string[]), typeof(double), typeof(string[]), typeof(double), new[] { "a", "b", "c" },
+                    0.5d
+                });
 
             Assert.Equal(6, result);
         }
@@ -141,15 +199,11 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_invoke_with_null()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 2);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 2);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(string[]), typeof(double),
-                typeof(string[]), typeof(double),
-                null, 0.5d
-            });
+            var result = await invoker.Invoke(mock,
+                new object[] { typeof(string[]), typeof(double), typeof(string[]), typeof(double), null, 0.5d });
 
             Assert.Equal(6, result);
         }
@@ -157,15 +211,10 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_invoke_ValueTask_return()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            _ = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(string),typeof(string),
-                "foo","bar"
-            });
+            _ = await invoker.Invoke(mock, new object[] { typeof(bool), typeof(string), typeof(string), "foo", "bar" });
 
             Assert.True(true);
         }
@@ -173,15 +222,10 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_invoke_ValueTaskObject_return()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(int),typeof(int),
-                42,43
-            });
+            var result = await invoker.Invoke(mock, new object[] { typeof(bool), typeof(int), typeof(int), 42, 43 });
 
             Assert.Equal(7, result);
         }
@@ -189,17 +233,13 @@ namespace CodeGenerator.Tests
         [Fact]
         public async Task Overload_invoke_ValueTaskInt_return()
         {
-            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), "Method", 1);
+            var invoker = new GenericMethodInvoker(typeof(IDummyGrain), nameof(IDummyGrain.Method), 1);
             var mock = new FooGrain();
 
-            var result = await invoker.Invoke(mock, new object[]
-            {
-                typeof(bool),
-                typeof(string),
-                "foo"
-            });
+            var result = await invoker.Invoke(mock, new object[] { typeof(bool), typeof(string), "foo" });
 
             Assert.Equal(8, result);
         }
     }
 }
+


### PR DESCRIPTION
 - add support for generic overloads with constraints on grain methods
 - add tests 

Closes https://github.com/dotnet/orleans/issues/7309


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7325)