### PR TITLE
Add Google.Protobuf to benchmarks

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="SpanJson" Version="3.1.0" />
     <PackageReference Include="Hyperion" Version="0.9.16" />
+    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.40.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,6 +34,10 @@
     <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\Grains\BenchmarkGrains\BenchmarkGrains.csproj" />
     <ProjectReference Include="..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Serialization\Models\ProtoIntClass.proto" />
   </ItemGroup>
 
 </Project>

--- a/test/Benchmarks/Serialization/Comparison/ClassDeserializeBenchmark.cs
+++ b/test/Benchmarks/Serialization/Comparison/ClassDeserializeBenchmark.cs
@@ -11,6 +11,7 @@ using Xunit;
 using SerializerSession = Orleans.Serialization.Session.SerializerSession;
 using Utf8JsonNS = Utf8Json;
 using Hyperion;
+using System.Buffers;
 
 namespace Benchmarks.Comparison
 {
@@ -21,6 +22,8 @@ namespace Benchmarks.Comparison
     public class ClassDeserializeBenchmark
     {
         private static readonly MemoryStream ProtoInput;
+
+        private static readonly ReadOnlySequence<byte> GoogleProtoInput;
 
         private static readonly byte[] MsgPackInput = MessagePack.MessagePackSerializer.Serialize(IntClass.Create());
 
@@ -46,6 +49,9 @@ namespace Benchmarks.Comparison
         {
             ProtoInput = new MemoryStream();
             ProtoBuf.Serializer.Serialize(ProtoInput, IntClass.Create());
+
+            ProtoInput = new MemoryStream();
+            GoogleProtoInput = new ReadOnlySequence<byte>(Google.Protobuf.MessageExtensions.ToByteArray(ProtoIntClass.Create()));
 
             HyperionInput = new MemoryStream();
             HyperionSession = HyperionSerializer.GetDeserializerSession();
@@ -83,6 +89,16 @@ namespace Benchmarks.Comparison
                    result.MyProperty8 +
                    result.MyProperty9;
 
+        private static int SumResult(ProtoIntClass result) => result.MyProperty1 +
+                   result.MyProperty2 +
+                   result.MyProperty3 +
+                   result.MyProperty4 +
+                   result.MyProperty5 +
+                   result.MyProperty6 +
+                   result.MyProperty7 +
+                   result.MyProperty8 +
+                   result.MyProperty9;
+
         [Fact]
         [Benchmark(Baseline = true)]
         public int Orleans()
@@ -106,6 +122,12 @@ namespace Benchmarks.Comparison
         {
             ProtoInput.Position = 0;
             return SumResult(ProtoBuf.Serializer.Deserialize<IntClass>(ProtoInput));
+        }
+
+        [Benchmark]
+        public int GoogleProtobuf()
+        {
+            return SumResult(ProtoIntClass.Parser.ParseFrom(GoogleProtoInput));
         }
 
         [Benchmark]

--- a/test/Benchmarks/Serialization/Comparison/ClassSerializeBenchmark.cs
+++ b/test/Benchmarks/Serialization/Comparison/ClassSerializeBenchmark.cs
@@ -13,6 +13,8 @@ using SerializerSession = Orleans.Serialization.Session.SerializerSession;
 using Utf8JsonNS = Utf8Json;
 using Hyperion;
 using ZeroFormatter;
+using System.Buffers;
+using Google.Protobuf;
 
 namespace Benchmarks.Comparison
 {
@@ -23,6 +25,7 @@ namespace Benchmarks.Comparison
     {
         private static readonly IntClass Input = IntClass.Create();
         private static readonly VirtualIntsClass ZeroFormatterInput = VirtualIntsClass.Create();
+        private static readonly IBufferMessage ProtoInput = ProtoIntClass.Create();
 
         private static readonly Hyperion.Serializer HyperionSerializer = new(new SerializerOptions(knownTypes: new[] { typeof(IntClass) }));
         private static readonly Hyperion.SerializerSession HyperionSession;
@@ -33,6 +36,8 @@ namespace Benchmarks.Comparison
         private static readonly SerializerSession Session;
 
         private static readonly MemoryStream ProtoBuffer = new();
+
+        private static readonly ClassSingleSegmentBuffer ProtoSegmentBuffer;
 
         private static readonly MemoryStream Utf8JsonOutput = new();
         private static readonly Utf8JsonNS.IJsonFormatterResolver Utf8JsonResolver = Utf8JsonNS.Resolvers.StandardResolver.Default;
@@ -53,6 +58,8 @@ namespace Benchmarks.Comparison
             HyperionSession = HyperionSerializer.GetSerializerSession();
 
             SystemTextJsonWriter = new Utf8JsonWriter(SystemTextJsonOutput);
+
+            ProtoSegmentBuffer = new ClassSingleSegmentBuffer(Data);
         }
 
         [Fact]
@@ -93,6 +100,14 @@ namespace Benchmarks.Comparison
             ProtoBuffer.Position = 0;
             ProtoBuf.Serializer.Serialize(ProtoBuffer, Input);
             return ProtoBuffer.Length;
+        }
+
+        [Benchmark]
+        public long GoogleProtobuf()
+        {
+            ProtoSegmentBuffer.Reset();
+            ProtoInput.WriteTo(ProtoSegmentBuffer);
+            return ProtoSegmentBuffer.Length;
         }
 
         [Benchmark]

--- a/test/Benchmarks/Serialization/Models/ProtoIntClass.cs
+++ b/test/Benchmarks/Serialization/Models/ProtoIntClass.cs
@@ -1,0 +1,15 @@
+namespace Benchmarks.Models
+{
+    public partial class ProtoIntClass
+    {
+        public static ProtoIntClass Create()
+        {
+            var result = new ProtoIntClass();
+            result.Initialize();
+            return result;
+        }
+
+        public void Initialize() => MyProperty1 = MyProperty2 =
+            MyProperty3 = MyProperty4 = MyProperty5 = MyProperty6 = MyProperty7 = MyProperty8 = MyProperty9 = 10;
+    }
+}

--- a/test/Benchmarks/Serialization/Models/ProtoIntClass.proto
+++ b/test/Benchmarks/Serialization/Models/ProtoIntClass.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package Benchmarks.Models;
+
+message ProtoIntClass {
+  int32 my_property_1 = 1;
+  int32 my_property_2 = 2;
+  int32 my_property_3 = 3;
+  int32 my_property_4 = 4;
+  int32 my_property_5 = 5;
+  int32 my_property_6 = 6;
+  int32 my_property_7 = 7;
+  int32 my_property_8 = 8;
+  int32 my_property_9 = 9;
+}

--- a/test/Benchmarks/Serialization/Utilities/ClassSingleSegmentBuffer.cs
+++ b/test/Benchmarks/Serialization/Utilities/ClassSingleSegmentBuffer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Buffers;
+using System.Diagnostics.Contracts;
+using System.Text;
+
+namespace Benchmarks.Utilities
+{
+    public class ClassSingleSegmentBuffer : IBufferWriter<byte>
+    {
+        private readonly byte[] _buffer;
+        private int _written;
+
+        public ClassSingleSegmentBuffer(byte[] buffer)
+        {
+            _buffer = buffer;
+            _written = 0;
+        }
+
+        public void Advance(int bytes) => _written += bytes;
+
+        [Pure]
+        public Memory<byte> GetMemory(int sizeHint = 0) => _buffer.AsMemory(_written);
+
+        [Pure]
+        public Span<byte> GetSpan(int sizeHint) => _buffer.AsSpan(_written);
+
+        public byte[] ToArray() => _buffer.AsSpan(0, _written).ToArray();
+
+        public void Reset() => _written = 0;
+
+        [Pure]
+        public int Length => _written;
+
+        [Pure]
+        public ReadOnlySequence<byte> GetReadOnlySequence() => new(_buffer, 0, _written);
+
+        public override string ToString() => Encoding.UTF8.GetString(_buffer.AsSpan(0, _written).ToArray());
+    }
+}


### PR DESCRIPTION
Serialization

```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated | Payload |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|--------:|
|           Orleans |   107.32 ns |  1.256 ns |  1.114 ns |  1.00 |    0.00 |      - |     - |     - |         - |    20 B |
|          Utf8Json |   253.17 ns |  4.734 ns |  4.428 ns |  2.36 |    0.05 |      - |     - |     - |         - |   154 B |
|    SystemTextJson |   732.74 ns |  5.409 ns |  4.517 ns |  6.83 |    0.10 |      - |     - |     - |         - |   154 B |
| MessagePackCSharp |   269.47 ns |  3.489 ns |  3.093 ns |  2.51 |    0.04 | 0.0005 |     - |     - |      40 B |    10 B |
|       ProtobufNet |   413.53 ns |  2.093 ns |  1.748 ns |  3.85 |    0.04 |      - |     - |     - |         - |    18 B |
|    GoogleProtobuf |    92.70 ns |  0.858 ns |  0.803 ns |  0.86 |    0.01 |      - |     - |     - |         - |    18 B |
|          Hyperion |   208.75 ns |  3.031 ns |  2.687 ns |  1.95 |    0.03 |      - |     - |     - |         - |    39 B |
|    NewtonsoftJson | 2,766.01 ns | 39.935 ns | 35.401 ns | 25.77 |    0.42 | 0.0267 |     - |     - |    2024 B |   154 B |
|          SpanJson |   220.39 ns |  4.271 ns |  3.995 ns |  2.05 |    0.04 | 0.0024 |     - |     - |     184 B |   154 B |
```

Deserialization

```
|            Method |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|           Orleans |   147.6 ns |  2.20 ns |  1.83 ns |  1.00 |    0.00 | 0.0007 |     - |     - |      56 B |
|          Utf8Json |   881.0 ns | 11.15 ns |  9.31 ns |  5.97 |    0.06 |      - |     - |     - |      56 B |
|    SystemTextJson | 1,760.5 ns | 34.45 ns | 32.22 ns | 11.92 |    0.26 |      - |     - |     - |      56 B |
| MessagePackCSharp |   188.3 ns |  3.79 ns |  5.79 ns |  1.28 |    0.04 | 0.0007 |     - |     - |      56 B |
|       ProtobufNet |   232.7 ns |  4.53 ns |  3.78 ns |  1.58 |    0.03 | 0.0007 |     - |     - |      56 B |
|    GoogleProtobuf |   166.5 ns |  3.27 ns |  3.06 ns |  1.13 |    0.02 | 0.0007 |     - |     - |      64 B |
|          Hyperion |   211.4 ns |  4.17 ns |  6.11 ns |  1.45 |    0.06 | 0.0007 |     - |     - |      56 B |
|    NewtonsoftJson | 5,465.4 ns | 81.28 ns | 93.61 ns | 36.99 |    0.73 | 0.0381 |     - |     - |    2856 B |
|          SpanJson |   463.1 ns |  9.30 ns | 14.76 ns |  3.21 |    0.11 | 0.0005 |     - |     - |      56 B |
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7329)