### PR TITLE
Fix default name for CustomStorage log-consistency provider

### DIFF
--- a/src/Orleans.EventSourcing/Hosting/CustomStorageSiloBuilderExtensions.cs
+++ b/src/Orleans.EventSourcing/Hosting/CustomStorageSiloBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Orleans.Hosting
         /// <summary>
         /// Adds a custom storage log consistency provider"/>
         /// </summary>
-        public static ISiloBuilder AddCustomStorageBasedLogConsistencyProvider(this ISiloBuilder builder, string name = "LogStorage", string primaryCluster = null)
+        public static ISiloBuilder AddCustomStorageBasedLogConsistencyProvider(this ISiloBuilder builder, string name = "CustomStorage", string primaryCluster = null)
         {
             return builder.ConfigureServices(services => services.AddCustomStorageBasedLogConsistencyProvider(name, primaryCluster));
         }


### PR DESCRIPTION
This seems to be a simple typo.