### PR TITLE
Fix: Orleans.Hosting.KubernetesHosting: System.MissingMethodException

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <ZooKeeperNetExVersion>3.4.12.4</ZooKeeperNetExVersion>
     <StackExchangeRedisVersion>2.0.601</StackExchangeRedisVersion>
-    <KubernetesClientVersion>4.0.5</KubernetesClientVersion>
+    <KubernetesClientVersion>6.0.19</KubernetesClientVersion>
 
     <!-- Test related packages -->
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -62,8 +62,7 @@ namespace Orleans.Hosting
                 {
                     var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
                     return config.CreateDefaultHttpClientHandler();
-                })
-                .AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);
+                });
 
             return services;
         }


### PR DESCRIPTION
Due to https://github.com/kubernetes-client/csharp/pull/681 in C# Kubernetes clients newer than 6.0.2 (e.g. when using [KubeOps](https://github.com/buehler/dotnet-operator-sdk/) in conjunction with Orleans in the same app), the following error is thrown when using `Orleans.Hosting.KubernetesHosting`:

```
System.MissingMethodException: Method not found: 'System.Net.Http.DelegatingHandler k8s.KubernetesClientConfiguration.CreateWatchHandler()'.
    at Orleans.Hosting.KubernetesHostingExtensions.UseKubernetesHosting(IServiceCollection services, Action`1 configureOptions)
```

This fixes the issue by removing the offending line, which is no longer needed, and upgrading the referenced Kubernetes client.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7346)