### PR TITLE
Fix minor typo in comment in Postgres persistence setup

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql
@@ -85,7 +85,7 @@ AS $function$
     END IF;
 
     -- The grain state has not been read. The following locks rather pessimistically
-    -- to ensure only on INSERT succeeds.
+    -- to ensure only one INSERT succeeds.
     IF _GrainStateVersion IS NULL
     THEN
         INSERT INTO OrleansStorage


### PR DESCRIPTION
This fixes a minor typo in the comment

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7356)