### PR TITLE
Support ILBasedSerializer as a fallback only after trying the configured fallback

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -65,12 +65,8 @@ namespace Orleans
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();
-            services.AddSingleton<BinaryFormatterISerializableSerializer>();
-            services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
-#pragma warning disable CS0618 // Type or member is obsolete
-            services.TryAddSingleton<ILBasedSerializer>();
-            services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
-#pragma warning restore CS0618 // Type or member is obsolete
+            services.AddSingleton<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
+            services.AddSingleton<IKeyedSerializer, ILBasedSerializer>();
 
             // Application parts
             var parts = builder.GetApplicationPartManager();

--- a/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace Orleans.Serialization
@@ -34,5 +34,8 @@ namespace Orleans.Serialization
 
         /// <inheritdoc />
         public KeyedSerializerId SerializerId => KeyedSerializerId.BinaryFormatterISerializable;
+
+        /// <inheritdoc />
+        public bool IsFallbackOnly => true;
     }
 }

--- a/src/Orleans.Core/Serialization/IKeyedSerializer.cs
+++ b/src/Orleans.Core/Serialization/IKeyedSerializer.cs
@@ -11,7 +11,7 @@ namespace Orleans.Serialization
         KeyedSerializerId SerializerId { get; }
 
         /// <summary>
-        /// Returns <see langword="true"/> if is serializer should only be used for fallback scenarios, <see langword="false"/> otherwise.
+        /// Returns <see langword="true"/> if this serializer should only be used for fallback scenarios, <see langword="false"/> otherwise.
         /// </summary>
         bool IsFallbackOnly { get; }
     }

--- a/src/Orleans.Core/Serialization/IKeyedSerializer.cs
+++ b/src/Orleans.Core/Serialization/IKeyedSerializer.cs
@@ -9,5 +9,10 @@ namespace Orleans.Serialization
         /// Gets the identifier for this serializer.
         /// </summary>
         KeyedSerializerId SerializerId { get; }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if is serializer should only be used for fallback scenarios, <see langword="false"/> otherwise.
+        /// </summary>
+        bool IsFallbackOnly { get; }
     }
 }

--- a/src/Orleans.Core/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans.Core/Serialization/ILBasedExceptionSerializer.cs
@@ -4,6 +4,7 @@ using Orleans.Utilities;
 namespace Orleans.Serialization
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Reflection;
 
@@ -14,6 +15,22 @@ namespace Orleans.Serialization
     {
         private static readonly Type ExceptionType = typeof(Exception);
 
+        private HashSet<string> SkippedProperties { get; } = new HashSet<string>
+            {
+                "Message",
+                "StackTraceString",
+                "InnerException",
+                "ClassName",
+                "Data",
+                "HelpURL",
+                "RemoteStackTraceString",
+                "RemoteStackIndex",
+                "ExceptionMethod",
+                "HResult",
+                "Source",
+                "WatsonBuckets",
+            };
+
         /// <summary>
         /// The collection of serializers.
         /// </summary>
@@ -21,18 +38,13 @@ namespace Orleans.Serialization
             new CachedReadConcurrentDictionary<Type, SerializerMethods>();
 
         /// <summary>
-        /// The field filter used for generating serializers for subclasses of <see cref="Exception"/>.
-        /// </summary>
-        private readonly Func<FieldInfo, bool> exceptionFieldFilter;
-
-        /// <summary>
         /// The serializer used as a fallback when the concrete exception type is unavailable.
         /// </summary>
         /// <remarks>
-        /// This serializer operates on <see cref="RemoteNonDeserializableException"/> instances, however it 
+        /// This serializer operates on <see cref="ExceptionBaseProperties"/> instances, however it 
         /// includes only fields from <see cref="Exception"/> and no sub-class fields.
         /// </remarks>
-        private readonly SerializerMethods fallbackBaseExceptionSerializer;
+        private readonly SerializerMethods propsSerializer;
         
         /// <summary>
         /// The serializer generator.
@@ -40,45 +52,61 @@ namespace Orleans.Serialization
         private readonly ILSerializerGenerator generator;
 
         private readonly TypeSerializer typeSerializer;
+        private readonly StreamingContext _streamingContext;
+        private readonly FormatterConverter _formatterConverter;
+        private readonly SerializationConstructorFactory _constructorFactory;
+        private readonly Func<Type, Action<object, SerializationInfo, StreamingContext>> _createConstructorDelegate;
+        private readonly Action<object, SerializationInfo, StreamingContext> _baseExceptionConstructor;
 
         public ILBasedExceptionSerializer(ILSerializerGenerator generator, TypeSerializer typeSerializer)
         {
+            _streamingContext = new StreamingContext(StreamingContextStates.All);
+            _formatterConverter = new FormatterConverter();
+            _constructorFactory = new SerializationConstructorFactory();
+            _createConstructorDelegate = _constructorFactory.GetSerializationConstructorDelegate;
+            _baseExceptionConstructor = _createConstructorDelegate(typeof(Exception));
+
             this.generator = generator;
             this.typeSerializer = typeSerializer;
 
-            // Exceptions are a special type in .NET because of the way they are handled by the runtime.
-            // Only certain fields can be safely serialized.
-            this.exceptionFieldFilter = field =>
-            {
-                // Any field defined below Exception is acceptable.
-                if (field.DeclaringType != ExceptionType) return true;
-
-                // Certain fields from the Exception base class are acceptable.
-                return field.FieldType == typeof(string) || field.FieldType == ExceptionType;
-            };
-
             // When serializing the fallback type, only the fields declared on Exception are included.
             // Other fields are manually serialized.
-            this.fallbackBaseExceptionSerializer = this.generator.GenerateSerializer(
-                typeof(RemoteNonDeserializableException),
-                field =>
-                {
-                    // Only serialize base-class fields.
-                    if (field.DeclaringType != ExceptionType) return false;
-
-                    // Certain fields from the Exception base class are acceptable.
-                    return field.FieldType == typeof(string) || field.FieldType == ExceptionType;
-                },
-                fieldComparer: ExceptionFieldInfoComparer.Instance);
+            this.propsSerializer = this.generator.GenerateSerializer(typeof(ExceptionBaseProperties));
 
             // Ensure that the fallback serializer only ever has its base exception fields serialized.
-            this.serializers[typeof(RemoteNonDeserializableException)] = this.fallbackBaseExceptionSerializer;
+            this.serializers[typeof(ExceptionBaseProperties)] = this.propsSerializer;
         }
+
+        public SerializationInfo GetObjectData(Exception value)
+        {
+            var info = new SerializationInfo(value.GetType(), _formatterConverter);
+            value.GetObjectData(info, _streamingContext);
+            return info;
+        }
+
+        private static Dictionary<object, object> GetDataProperty(Exception exception)
+        {
+            if (exception.Data is null or { Count: 0 })
+            {
+                return null;
+            }
+
+            var tmp = new Dictionary<object, object>(exception.Data.Count);
+            var enumerator = exception.Data.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var entry = enumerator.Entry;
+                tmp[entry.Key] = entry.Value;
+            }
+
+            return tmp;
+        }
+
 
         public void Serialize(object item, ISerializationContext outerContext, Type expectedType)
         {
             var outerWriter = outerContext.StreamWriter;
-            
+
             var actualType = item.GetType();
 
             // To support loss-free serialization where possible, instances of the fallback exception type are serialized in a
@@ -86,21 +114,53 @@ namespace Orleans.Serialization
             var fallbackException = item as RemoteNonDeserializableException;
             if (fallbackException != null)
             {
-                this.ReserializeFallback(fallbackException, outerContext);
-                return;
+                // Write the type name directly.
+                var key = new TypeSerializer.TypeKey(fallbackException.OriginalTypeName);
+                TypeSerializer.WriteTypeKey(key, outerWriter);
             }
-            
-            // Write the concrete type directly.
-            this.typeSerializer.WriteNamedType(actualType, outerWriter);
+            else
+            {
+                // Write the concrete type directly.
+                this.typeSerializer.WriteNamedType(actualType, outerWriter);
+            }
 
             // Create a nested context which will be written to the outer context at an int-length offset from the current position.
             // This is because the inner context will be copied with a length prefix to the outer context.
             var innerWriter = new BinaryTokenStreamWriter();
             var innerContext = outerContext.CreateNestedContext(position: outerContext.CurrentOffset + sizeof(int), writer: innerWriter);
 
-            // Serialize the exception itself.
-            var methods = this.GetSerializerMethods(actualType);
-            methods.Serialize(item, innerContext, null);
+            var typedValue = (Exception)item;
+            var props = new ExceptionBaseProperties
+            {
+                Message = typedValue.Message,
+                StackTrace = typedValue.StackTrace,
+                InnerException = typedValue.InnerException,
+                HResult = typedValue.HResult,
+                Data = GetDataProperty(typedValue),
+            };
+
+            var data = GetObjectData(typedValue);
+            var serializationManager = innerContext.GetSerializationManager();
+            if (fallbackException is { })
+            {
+                props.AdditionalData = fallbackException.AdditionalData;
+            }
+            else
+            {
+                // Build up the additional data by enumerating the populated serialization info.
+                props.AdditionalData = new();
+                foreach (var pair in data)
+                {
+                    if (SkippedProperties.Contains(pair.Name)) continue;
+
+                    var bytes = serializationManager.SerializeToByteArray(pair.Value);
+                    var type = pair.Value?.GetType() ?? pair.ObjectType ?? typeof(object);
+                    var typeName = typeSerializer.GetNameFromType(type);
+                    props.AdditionalData[pair.Name] = (typeName, bytes);
+                }
+            }
+
+            innerContext.SerializeInner(props, typeof(ExceptionBaseProperties));
 
             // Write the serialized exception to the output stream.
             outerContext.StreamWriter.Write(innerWriter.CurrentOffset);
@@ -124,44 +184,80 @@ namespace Orleans.Serialization
             var innerBytes = outerReader.ReadBytes(length);
             
             var innerContext = outerContext.CreateNestedContext(position: position, reader: new BinaryTokenStreamReader(innerBytes));
-            object result;
 
             // If the concrete type is available and the exception is valid for reconstruction,
             // reconstruct the original exception type.
             var actualType = this.typeSerializer.GetTypeFromTypeKey(typeKey, throwOnError: false);
-            if (actualType != null)
+            var props = (ExceptionBaseProperties)innerContext.DeserializeInner(typeof(ExceptionBaseProperties));
+
+            var resultType = actualType ?? typeof(RemoteNonDeserializableException);
+            var result = (Exception)FormatterServices.GetUninitializedObject(resultType);
+
+            var info = new SerializationInfo(resultType, _formatterConverter);
+            info.AddValue("Message", props.Message, typeof(string));
+            info.AddValue("StackTraceString", null, typeof(string));
+            info.AddValue("InnerException", props.InnerException, typeof(Exception));
+            info.AddValue("ClassName", result.GetType().ToString(), typeof(string));
+            info.AddValue("Data", null, typeof(IDictionary));
+            info.AddValue("HelpURL", null, typeof(string));
+            info.AddValue("RemoteStackTraceString", props.StackTrace, typeof(string));
+            info.AddValue("RemoteStackIndex", 0, typeof(int));
+            info.AddValue("ExceptionMethod", null, typeof(string));
+            info.AddValue("HResult", props.HResult);
+            info.AddValue("Source", null, typeof(string));
+            info.AddValue("WatsonBuckets", null, typeof(byte[]));
+
+            var serializationManager = innerContext.GetSerializationManager();
+            if (props.AdditionalData is not null)
             {
-                // Deserialize into the concrete type.
-                var methods = this.GetSerializerMethods(actualType);
-                result = methods.Deserialize(null, innerContext);
+                foreach (var pair in props.AdditionalData)
+                {
+                    if (SkippedProperties.Contains(pair.Key)) continue;
+
+                    try
+                    {
+                        var pairTypeKey = new TypeSerializer.TypeKey(pair.Value.Item1);
+                        var valueType = this.typeSerializer.GetTypeFromTypeKey(pairTypeKey, throwOnError: false);
+                        if (valueType is not null)
+                        {
+                            var value = serializationManager.DeserializeFromByteArray(pair.Value.Item2, valueType);
+                            info.AddValue(pair.Key, value, valueType);
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore and skip.
+                    }
+                }
+            }
+
+            if (resultType == typeof(RemoteNonDeserializableException))
+            {
+                info.AddValue(nameof(RemoteNonDeserializableException.OriginalTypeName), typeKey.GetTypeName());
+                info.AddValue(nameof(RemoteNonDeserializableException.AdditionalData), props.AdditionalData);
+            }
+
+            // Find the most suitable constructor
+            Action<object, SerializationInfo, StreamingContext> ctor;
+            if (SerializationConstructorFactory.HasSerializationConstructor(resultType))
+            {
+                ctor = _constructorFactory.GetSerializationConstructorDelegate(resultType);
             }
             else
             {
-                // Since the concrete type is unavailable, deserialize into the fallback type.
-
-                // Read the Exception fields.
-                var exception = (RemoteNonDeserializableException)this.fallbackBaseExceptionSerializer.Deserialize(null, innerContext);
-                exception.OriginalTypeName = typeKey.GetTypeName();
-
-                // If there is additional data, store it for later serialization.
-                var additionalDataLength = length - innerContext.StreamReader.CurrentPosition;
-                if (additionalDataLength > 0)
-                {
-                    exception.AdditionalData = innerContext.StreamReader.ReadBytes(additionalDataLength);
-                }
-
-                // If a particular type is expected, but the actual type is not available, throw an exception to avoid 
-                if (expectedType != null && !expectedType.IsAssignableFrom(typeof(RemoteNonDeserializableException)))
-                {
-                    throw new SerializationException(
-                        $"Unable to deserialize exception of unavailable type {exception.OriginalTypeName} into expected type {expectedType}. " +
-                        $" See {nameof(Exception.InnerException)} for recovered information.",
-                        exception);
-                }
-
-                result = exception;
+                ctor = _baseExceptionConstructor;
             }
-            
+
+            ctor(result, info, _streamingContext);
+
+            if (props.Data is { } data && result.Data is not null)
+            {
+                foreach (var pair in data)
+                {
+                    result.Data[pair.Key] = pair.Value;
+                }
+            }
+
             return result;
         }
 
@@ -175,71 +271,16 @@ namespace Orleans.Serialization
         {
             return original;
         }
+    }
 
-        private void ReserializeFallback(RemoteNonDeserializableException fallbackException, ISerializationContext outerContext)
-        {
-            var outerWriter = outerContext.StreamWriter;
-
-            // Write the type name directly.
-            var key = new TypeSerializer.TypeKey(fallbackException.OriginalTypeName);
-            TypeSerializer.WriteTypeKey(key, outerWriter);
-
-            // Create a nested context which will be written to the outer context at an int-length offset from the current position.
-            // This is because the inner context will be copied with a length prefix to the outer context.
-            var innerWriter = new BinaryTokenStreamWriter();
-            var innerContext = outerContext.CreateNestedContext(sizeof(int), innerWriter);
-
-            // Serialize the only accepted fields from the base Exception class.
-            this.fallbackBaseExceptionSerializer.Serialize(fallbackException, innerContext, null);
-
-            // Write the length of the serialized exception, then write the serialized bytes.
-            var additionalDataLength = fallbackException.AdditionalData?.Length ?? 0;
-            outerWriter.Write(innerWriter.CurrentOffset + additionalDataLength);
-            outerWriter.Write(innerWriter.ToBytes());
-            
-            if (additionalDataLength > 0)
-            {
-                outerWriter.Write(fallbackException.AdditionalData);
-            }
-        }
-
-        private SerializerMethods GetSerializerMethods(Type actualType)
-        {
-            SerializerMethods methods;
-            if (!this.serializers.TryGetValue(actualType, out methods))
-            {
-                methods = this.generator.GenerateSerializer(
-                    actualType,
-                    this.exceptionFieldFilter,
-                    fieldComparer: ExceptionFieldInfoComparer.Instance);
-                this.serializers.TryAdd(actualType, methods);
-            }
-
-            return methods;
-        }
-
-        /// <summary>
-        /// Field comparer which sorts fields on the Exception class higher than fields on sub classes.
-        /// </summary>
-        private class ExceptionFieldInfoComparer : IComparer<FieldInfo>
-        {
-            /// <summary>
-            /// Gets the singleton instance of this class.
-            /// </summary>
-            public static ExceptionFieldInfoComparer Instance { get; } = new ExceptionFieldInfoComparer();
-
-            public int Compare(FieldInfo left, FieldInfo right)
-            {
-                var l = left?.DeclaringType == ExceptionType ? 1 : 0;
-                var r = right?.DeclaringType == ExceptionType ? 1 : 0;
-
-                // First compare based on whether or not the field is from the Exception base class.
-                var compareBaseClass = r - l;
-                if (compareBaseClass != 0) return compareBaseClass;
-
-                // Secondarily compare the field names.
-                return string.Compare(left?.Name, right?.Name, StringComparison.Ordinal);
-            }
-        }
+    [Serializable]
+    internal sealed class ExceptionBaseProperties
+    {
+        public string Message { get; set; }
+        public string StackTrace { get; set; }
+        public Exception InnerException { get; set; }
+        public int HResult { get; set; }
+        public Dictionary<object, object> Data { get; set; }
+        public Dictionary<string, (string, byte[])> AdditionalData { get; set; }
     }
 }

--- a/src/Orleans.Core/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans.Core/Serialization/ILBasedSerializer.cs
@@ -7,7 +7,6 @@ namespace Orleans.Serialization
     /// <summary>
     /// Fallback serializer to be used when other serializers are unavailable.
     /// </summary>
-    [Obsolete("Obsolete in favor of other serializers.")]
     public class ILBasedSerializer : IKeyedSerializer
     {
         private static readonly Type ExceptionType = typeof(Exception);
@@ -189,5 +188,8 @@ namespace Orleans.Serialization
 
         /// <inheritdoc />
         KeyedSerializerId IKeyedSerializer.SerializerId => KeyedSerializerId.ILBasedSerializer;
+
+        /// <inheritdoc />
+        public bool IsFallbackOnly => true;
     }
 }

--- a/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.Serialization;
+using System.Security;
 using Orleans.Runtime;
 
 namespace Orleans.Serialization

--- a/src/Orleans.Core/Serialization/RemoteNonDeserializableException.cs
+++ b/src/Orleans.Core/Serialization/RemoteNonDeserializableException.cs
@@ -1,9 +1,10 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using Orleans.Runtime;
 
 namespace Orleans.Serialization
 {
     using System;
+    using System.Collections.Generic;
     using System.Text;
 
     /// <summary>
@@ -22,7 +23,7 @@ namespace Orleans.Serialization
         /// <summary>
         /// Gets or sets the additional data deserialized alongside this instance, for example, exception subclass fields.
         /// </summary>
-        public byte[] AdditionalData { get; internal set; }
+        public Dictionary<string, (string, byte[])> AdditionalData { get; internal set; }
 
         /// <summary>
         /// Returns a <see cref="string"/> representation of this instance.
@@ -55,7 +56,7 @@ namespace Orleans.Serialization
             : base(info, context)
         {
             this.OriginalTypeName = info.GetString(nameof(this.OriginalTypeName));
-            this.AdditionalData = (byte[]) info.GetValue(nameof(this.AdditionalData), typeof(byte[]));
+            this.AdditionalData = (Dictionary<string, (string, byte[])>) info.GetValue(nameof(this.AdditionalData), typeof(Dictionary<string, (string, byte[])>));
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Serialization/SerializationConstructorFactory.cs
+++ b/src/Orleans.Core/Serialization/SerializationConstructorFactory.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// Creates delegates for calling ISerializable-conformant constructors.
+    /// </summary>
+    internal class SerializationConstructorFactory
+    {
+        private static readonly Type[] SerializationConstructorParameterTypes = { typeof(SerializationInfo), typeof(StreamingContext) };
+        private readonly Func<Type, object> _createConstructorDelegate;
+        private readonly ConcurrentDictionary<Type, object> _constructors = new();
+
+        [SecurityCritical]
+        public SerializationConstructorFactory()
+        {
+            _createConstructorDelegate =
+                GetSerializationConstructorInvoker<object, Action<object, SerializationInfo, StreamingContext>>;
+        }
+
+        [SecurityCritical]
+        public static bool HasSerializationConstructor(Type type) => GetSerializationConstructor(type) != null;
+
+        [SecurityCritical]
+        public Action<object, SerializationInfo, StreamingContext> GetSerializationConstructorDelegate(Type type) => (Action<object, SerializationInfo, StreamingContext>)_constructors.GetOrAdd(
+                type,
+                _createConstructorDelegate);
+
+        [SecurityCritical]
+        public TConstructor GetSerializationConstructorDelegate<TOwner, TConstructor>() => (TConstructor)_constructors.GetOrAdd(
+                typeof(TOwner),
+                type => (object)GetSerializationConstructorInvoker<TOwner, TConstructor>(type));
+
+        [SecurityCritical]
+        private static ConstructorInfo GetSerializationConstructor(Type type) => type.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                SerializationConstructorParameterTypes,
+                null);
+
+        [SecurityCritical]
+        private static TConstructor GetSerializationConstructorInvoker<TOwner, TConstructor>(Type type)
+        {
+            var constructor = GetSerializationConstructor(type) ?? (typeof(Exception).IsAssignableFrom(type) ? GetSerializationConstructor(typeof(Exception)) : null);
+            if (constructor is null)
+            {
+                throw new SerializationException($"{nameof(ISerializable)} constructor not found on type {type}.");
+            }
+
+            Type[] parameterTypes;
+            if (typeof(TOwner).IsValueType)
+            {
+                parameterTypes = new[] { typeof(TOwner).MakeByRefType(), typeof(SerializationInfo), typeof(StreamingContext) };
+            }
+            else
+            {
+                parameterTypes = new[] { typeof(object), typeof(SerializationInfo), typeof(StreamingContext) };
+            }
+
+            var method = new DynamicMethod($"{type}_serialization_ctor", null, parameterTypes, typeof(TOwner), skipVisibility: true);
+            var il = method.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);
+            if (type != typeof(TOwner))
+            {
+                il.Emit(OpCodes.Castclass, type);
+            }
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, constructor);
+            il.Emit(OpCodes.Ret);
+
+            object result = method.CreateDelegate(typeof(TConstructor));
+            return (TConstructor)result;
+        }
+    }
+}

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1546,6 +1546,14 @@ namespace Orleans.Serialization
             return result;
         }
 
+        public object DeserializeFromByteArray(byte[] data, Type expectedType)
+        {
+            var context = new DeserializationContext(this);
+            context.StreamReader = new BinaryTokenStreamReader(data);
+            var result = DeserializeInner(expectedType, context);
+            return result;
+        }
+
         internal static void SerializeMessageHeaders(Message.HeadersContainer headers, SerializationContext context)
         {
             var sm = context.SerializationManager;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -270,12 +270,8 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
             services.TryAddSingleton<IFieldUtils, FieldUtils>();
             services.AddSingleton<BinaryFormatterSerializer>();
-            services.AddSingleton<BinaryFormatterISerializableSerializer>();
-            services.AddFromExisting<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
-#pragma warning disable CS0618 // Type or member is obsolete
-            services.AddSingleton<ILBasedSerializer>();
-            services.AddFromExisting<IKeyedSerializer, ILBasedSerializer>();
-#pragma warning restore CS0618 // Type or member is obsolete
+            services.AddSingleton<IKeyedSerializer, BinaryFormatterISerializableSerializer>();
+            services.AddSingleton<IKeyedSerializer, ILBasedSerializer>();
 
             // Transactions
             services.TryAddSingleton<ITransactionAgent, DisabledTransactionAgent>();

--- a/test/Benchmarks/Serialization/SerializationBenchmarks.cs
+++ b/test/Benchmarks/Serialization/SerializationBenchmarks.cs
@@ -31,9 +31,7 @@ namespace Benchmarks.Serialization
                 case SerializerToUse.Default:
                     break;
                 case SerializerToUse.IlBasedFallbackSerializer:
-#pragma warning disable CS0618 // Type or member is obsolete
                     fallback = typeof(ILBasedSerializer);
-#pragma warning restore CS0618 // Type or member is obsolete
                     break;
                 case SerializerToUse.BinaryFormatterFallbackSerializer:
                     fallback = typeof(BinaryFormatterSerializer);

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1215,7 +1216,7 @@ namespace UnitTests.Serialization
         }
 
         [Serializable]
-        public class LocalClass : ISerializable
+        public class LocalClass : ISerializable, IEquatable<LocalClass>
         {
             public LocalClass()
             {
@@ -1228,6 +1229,10 @@ namespace UnitTests.Serialization
 
             public string Foo { get; set; }
 
+            public bool Equals(LocalClass other) => other != null && string.Equals(Foo, other.Foo, StringComparison.Ordinal);
+
+            public override bool Equals(object obj) => obj is LocalClass other && Equals(other);
+            public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Foo);
             public void GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 info.AddValue("LocalClass.Foo", Foo);
@@ -1282,7 +1287,7 @@ namespace UnitTests.Serialization
             Assert.NotNull(result.Local.Foo);
             Assert.Equal(local.Foo, result.Local.Foo);
 
-            Assert.Same(result.Local, result.Local2);
+            Assert.Equal(result.Local, result.Local2);
         }
 
         [Serializable]

--- a/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedExceptionSerializerTests.cs
@@ -16,9 +16,7 @@ namespace UnitTests.Serialization
 
         public ILBasedExceptionSerializerTests()
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             this.environment = SerializationTestEnvironment.Initialize(null, typeof(ILBasedSerializer));
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
@@ -210,9 +210,7 @@ namespace UnitTests.Serialization
 
         private T SerializerLoop<T>(T input)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             var serializer = new ILBasedSerializer(new CachedTypeResolver());
-#pragma warning restore CS0618 // Type or member is obsolete
             Assert.True(serializer.IsSupportedType(input.GetType()));
 
             var writer = new BinaryTokenStreamWriter();


### PR DESCRIPTION
Fixes #7328

We should not use ILBasedSerializer preferentially to the configured fallback serializer. This PR deprioritizes it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7357)