### PR TITLE
Clarify comment on disabling workload analysis and log unknown status updates as debug

### DIFF
--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -369,12 +369,12 @@ namespace Orleans
                 }
                 else
                 {
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Information))
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Debug))
                     {
                         var diagnosticsString = string.Join("\n", status.Diagnostics);
                         using (response.SetThreadActivityId())
                         {
-                            this.logger.LogInformation("Received status update for unknown request. Message: {StatusMessage}. Status: {Diagnostics}", response, diagnosticsString);
+                            this.logger.LogDebug("Received status update for unknown request. Message: {StatusMessage}. Status: {Diagnostics}", response, diagnosticsString);
                         }
                     }
                 }

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime
     /// </summary>
     internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>
     {
-        private static readonly TimeSpan DefaultAnalysisPeriod = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan DisabledAnalysisRefreshPeriod = TimeSpan.FromSeconds(10);
         private static readonly TimeSpan InactiveGrainIdleness = TimeSpan.FromMinutes(1);
         private readonly IAsyncTimer _scanPeriodTimer;
         private readonly IMessageCenter _messageCenter;
@@ -67,7 +67,7 @@ namespace Orleans.Runtime
         {
             var options = _messagingOptions.CurrentValue;
             var optionsPeriod = options.GrainWorkloadAnalysisPeriod;
-            TimeSpan nextDelay = optionsPeriod > TimeSpan.Zero ? optionsPeriod : DefaultAnalysisPeriod;
+            TimeSpan nextDelay = optionsPeriod > TimeSpan.Zero ? optionsPeriod : DisabledAnalysisRefreshPeriod;
 
             while (await _scanPeriodTimer.NextTick(nextDelay))
             {
@@ -77,7 +77,7 @@ namespace Orleans.Runtime
                 if (optionsPeriod <= TimeSpan.Zero)
                 {
                     // Scanning is disabled. Wake up and check again soon.
-                    nextDelay = DefaultAnalysisPeriod;
+                    nextDelay = DisabledAnalysisRefreshPeriod;
                     if (_enabled)
                     {
                         _enabled = false;

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -109,7 +109,10 @@ namespace Orleans.Configuration
         /// <summary>
         /// The period of time between analyzing currently executing activation workloads.
         /// </summary>
-        public TimeSpan GrainWorkloadAnalysisPeriod { get; set; } = TimeSpan.FromSeconds(5);
+        /// <remarks>
+        /// Note: A negative value disables periodic analysis.
+        /// </remarks>
+        public TimeSpan GrainWorkloadAnalysisPeriod { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// The period after which a currently executing request is deemed to be slow.


### PR DESCRIPTION
Fixes #7330

Removes some log chattiness, increases the scan duration, and adds a doc comment on disabling the scan.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7358)