### PR TITLE
Fix: Orleans.Hosting.KubernetesHosting: System.MissingMethodExceptio

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -119,6 +119,7 @@
     <NSubstituteAnalyzersCSharpVersion>1.0.10</NSubstituteAnalyzersCSharpVersion>
     <ZooKeeperNetExVersion>3.4.12.1</ZooKeeperNetExVersion>
     <StackExchangeRedis>2.0.601</StackExchangeRedis>
+    <Netstandard20KubernetesClientVersion>4.0.5</Netstandard20KubernetesClientVersion>
     <KubernetesClientVersion>6.0.19</KubernetesClientVersion>
 
     <!-- Test related packages -->

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -62,7 +62,12 @@ namespace Orleans.Hosting
                 {
                     var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
                     return config.CreateDefaultHttpClientHandler();
-                });
+                })
+#if NETSTANDARD2_0
+                .AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);
+#else
+                ;
+#endif
 
             return services;
         }

--- a/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
+++ b/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
@@ -5,16 +5,23 @@
     <Title>Microsoft Orleans Hosting for Kubernetes</Title>
     <Description>Microsoft Orleans hosting support for Kubernetes</Description>
     <PackageTags>$(PackageTags) Kubernetes k8s</PackageTags>
-    <TargetFrameworks>$(StandardTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(MultiTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="KubernetesClient" Version="$(Netstandard20KubernetesClientVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of #7346

This need multi-targeting, since recent  C# Kubernetes clients do not support netstandard 2.0

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7364)