### PR TITLE
Support configuring ILBasedSerializer and BinaryFormatterISerializableSerializer as pre-fallback serializers

### DIFF
--- a/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
@@ -1,8 +1,20 @@
 using System;
 using System.Runtime.Serialization;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Serialization
 {
+    /// <summary>
+    /// Options for <see cref="BinaryFormatterISerializableSerializer"/>.
+    /// </summary>
+    public class BinaryFormatterISerializableSerializerOptions
+    {
+        /// <summary>
+        /// Whether to use the <see cref="BinaryFormatterISerializableSerializer"/> serializer only as a fallback
+        /// </summary>
+        public bool IsFallbackOnly { get; set; } = true;
+    }
+
     /// <summary>
     /// A wrapper around <see cref="BinaryFormatterSerializer"/> which only serializes ISerializable types.
     /// </summary>
@@ -11,10 +23,12 @@ namespace Orleans.Serialization
         private static readonly Type SerializableType = typeof(ISerializable);
         
         private readonly BinaryFormatterSerializer serializer;
+        private readonly BinaryFormatterISerializableSerializerOptions options;
 
-        public BinaryFormatterISerializableSerializer(BinaryFormatterSerializer serializer)
+        public BinaryFormatterISerializableSerializer(BinaryFormatterSerializer serializer, IOptions<BinaryFormatterISerializableSerializerOptions> options)
         {
             this.serializer = serializer;
+            this.options = options.Value;
         }
 
         /// <inheritdoc />
@@ -36,6 +50,6 @@ namespace Orleans.Serialization
         public KeyedSerializerId SerializerId => KeyedSerializerId.BinaryFormatterISerializable;
 
         /// <inheritdoc />
-        public bool IsFallbackOnly => true;
+        public bool IsFallbackOnly => options.IsFallbackOnly;
     }
 }

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1717,7 +1717,7 @@ namespace Orleans.Serialization
                 }
                 else
                 {
-                    serializer = new ILBasedSerializer(serviceProvider.GetRequiredService<ITypeResolver>());
+                    serializer = new ILBasedSerializer(serviceProvider.GetRequiredService<ITypeResolver>(), serviceProvider.GetRequiredService<IOptions<ILBasedSerializerOptions>>());
                 }
             }
 

--- a/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using TestExtensions;
@@ -210,7 +211,7 @@ namespace UnitTests.Serialization
 
         private T SerializerLoop<T>(T input)
         {
-            var serializer = new ILBasedSerializer(new CachedTypeResolver());
+            var serializer = new ILBasedSerializer(new CachedTypeResolver(), Options.Create(new ILBasedSerializerOptions()));
             Assert.True(serializer.IsSupportedType(input.GetType()));
 
             var writer = new BinaryTokenStreamWriter();


### PR DESCRIPTION
This allows a developer to configure `ILBasedSerializerOptions` or `BinaryFormatterISerializableSerializerOptions` and set their respective `IsFallbackOnly` properties to `false` to revert serializer behavior to pre-3.5.0.

The optimum solution if you are considering this is to add `[Serializable]` to your types and ensure that the code generator is generating code for your types, but this PR gives you an alternative route.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7384)