### PR TITLE
Ensure that `EventHubBatchContainer.Body` has a generated serializer

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -47,7 +47,7 @@ namespace Orleans.ServiceBus.Providers
         private Body GetPayload() => payload ?? (payload = this.serializationManager.DeserializeFromByteArray<Body>(eventHubMessage.Payload));
 
         [Serializable]
-        private class Body
+        internal class Body
         {
             public List<object> Events { get; set; }
             public Dictionary<string, object> RequestContext { get; set; }


### PR DESCRIPTION
The code generator cannot generate code for private types since they cannot be referenced in C# outside of the containing type. The `EventHubBatchContainer` type contains a private `Body` type which it serializes. This PR fixes the mistake of that class being marked as private.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7385)