### PR TITLE
Fix generation number generation race condition in LocalSiloDetails

### DIFF
--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -21,7 +21,8 @@ namespace Orleans.Runtime
             this.DnsHostName = Dns.GetHostName();
 
             var endpointOptions = siloEndpointOptions.Value;
-            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.GetPublicSiloEndpoint(), SiloAddress.AllocateNewGeneration()));
+            var generation = SiloAddress.AllocateNewGeneration();
+            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.GetPublicSiloEndpoint(), generation));
             this.gatewayAddressLazy = new Lazy<SiloAddress>(() =>
             {
                 var publicProxyEndpoint = endpointOptions.GetPublicProxyEndpoint();


### PR DESCRIPTION
In Orleans, a silo is identified with:
- its IP address
- silo-to-silo port number
- **a generation number**

The generation number is basically based on ticks, and is used to detect previous instance(s) of silos running on the same machine.

The address is generated and stored in `LocalSiloDetails`. The value of `LocalSiloDetails.SiloAddress` is computed lazily, **including the generation number**.

Bacause of that, in some cases, it's possible to produce two addresses with different generation number: for example, in the membership table generation `123` will be stored, but the `SiloConnection` will have generation `134`... And this will cause some weird issues, like in the following logs:

```
info: ProcessTableUpdate (called from TryUpdateMyStatusGlobalOnce) membership table: 2 silos, 1 are Active, 0 are Dead, 1 are Joining, Version=<3, W/"datetime'2021-11-19T09%3A54%3A41.5411184Z'">. All silos: [SiloAddress=S192.168.1.90:11111:375011678 SiloName=load01-d3946 Status=Active, SiloAddress=S192.168.1.91:11111:375011679 SiloName=load02-bb521 Status=Joining]
 Orleans.Runtime.OrleansMessageRejectionException: The target silo is no longer active: target was S192.168.1.90:11111:375011678, but this silo is S192.168.1.90:11111:375006184. The rejected message is  Request [S192.168.1.91:11111:375011679 sys.client/hosted-192.168.1.91:11111@375011679 @7eedc39f30b6a6f8c07cdacc4d8e999e]->[S192.168.1.90:11111:375011678 sys.svc.manifest/192.168.1.90:11111@375011678 @f3c70d20000000002f2f0cfa00000000]
warn: Orleans.Runtime.ISiloManifestSystemTargetOrleans.Runtime.ISiloManifestSystemTarget.GetSiloManifest() #2.
         at Orleans.Serialization.Invocation.ResponseCompletionSource`1.GetResult(Int16 token) in C:\src\orleans\src\Orleans.Serialization\Invocation\ResponseCompletionSource.cs:line 167
         at Orleans.Runtime.Metadata.ClusterManifestProvider.<>c__DisplayClass18_0.<<UpdateManifest>g__GetManifest|0>d.MoveNext() in C:\src\orleans\src\Orleans.Runtime\Manifest\ClusterManifestProvider.cs:line 156
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7399)