### PR TITLE
Support Npgsql 6.0 for clustering and reminders

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
@@ -2,7 +2,7 @@
 CREATE TABLE OrleansMembershipVersionTable
 (
     DeploymentId varchar(150) NOT NULL,
-    Timestamp timestamp(3) NOT NULL DEFAULT (now() at time zone 'utc'),
+    Timestamp timestamptz(3) NOT NULL DEFAULT now(),
     Version integer NOT NULL DEFAULT 0,
 
     CONSTRAINT PK_OrleansMembershipVersionTable_DeploymentId PRIMARY KEY(DeploymentId)
@@ -20,8 +20,8 @@ CREATE TABLE OrleansMembershipTable
     Status integer NOT NULL,
     ProxyPort integer NULL,
     SuspectTimes varchar(8000) NULL,
-    StartTime timestamp(3) NOT NULL,
-    IAmAliveTime timestamp(3) NOT NULL,
+    StartTime timestamptz(3) NOT NULL,
+    IAmAliveTime timestamptz(3) NOT NULL,
 
     CONSTRAINT PK_MembershipTable_DeploymentId PRIMARY KEY(DeploymentId, Address, Port, Generation),
     CONSTRAINT FK_MembershipTable_MembershipVersionTable_DeploymentId FOREIGN KEY (DeploymentId) REFERENCES OrleansMembershipVersionTable (DeploymentId)
@@ -155,7 +155,7 @@ BEGIN
 
         UPDATE OrleansMembershipVersionTable
         SET
-            Timestamp = (now() at time zone 'utc'),
+            Timestamp = now(),
             Version = Version + 1
         WHERE
             DeploymentId = DeploymentIdArg AND DeploymentIdArg IS NOT NULL
@@ -215,7 +215,7 @@ BEGIN
 
     UPDATE OrleansMembershipVersionTable
     SET
-        Timestamp = (now() at time zone 'utc'),
+        Timestamp = now(),
         Version = Version + 1
     WHERE
         DeploymentId = DeploymentIdArg AND DeploymentIdArg IS NOT NULL

--- a/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql
@@ -4,7 +4,7 @@ CREATE TABLE OrleansRemindersTable
     ServiceId varchar(150) NOT NULL,
     GrainId varchar(150) NOT NULL,
     ReminderName varchar(150) NOT NULL,
-    StartTime timestamp(3) NOT NULL,
+    StartTime timestamptz(3) NOT NULL,
     Period bigint NOT NULL,
     GrainHash integer NOT NULL,
     Version integer NOT NULL,


### PR DESCRIPTION
Starting with Npgsql 6.0, date-time handling got more strict (https://www.npgsql.org/doc/types/datetime.html#timestamps-and-timezones). Using Npgsql 6.0 with Orleans broke some clustering queries, in particular when trying to mark previous versions of the same silo as dead when the previous version did not shutdown gracefully.

The issue is that when loading current cluster members, the DateTimes were loaded with type `unspecified`, because the table uses `datetime without time zone`. Then when reusing those date objects for update queries, Npgsql would not allow this anymore.

My solution is to follow the general advice for Postgres to always use `timestamp with time zone` (`timestamptz`) for storing date-times. By doing so, the membership DateTime gets loaded with type `utc`, and everything keeps working.

For consistency I also updated the date columns for reminders, and verified everything still works.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7402)