### PR TITLE
Remove closures when using ConcurrentDictionary

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -243,7 +243,7 @@ namespace Orleans.ServiceBus.Providers
 
         private EventHubAdapterReceiver GetOrCreateReceiver(QueueId queueId)
         {
-            return this.receivers.GetOrAdd(queueId, q => MakeReceiver(queueId));
+            return this.receivers.GetOrAdd(queueId, (q, instance) => instance.MakeReceiver(q), this);
         }
 
         protected virtual void InitEventHubClient()

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
@@ -27,7 +27,7 @@ namespace Orleans.Serialization
 
         [SecurityCritical]
         public SerializationCallbacks<TDelegate> GetValueTypeCallbacks<TOwner, TDelegate>(Type type) => (
-            SerializationCallbacks<TDelegate>)_cache.GetOrAdd(type, t => (object)CreateTypedCallbacks<TOwner, TDelegate>(type));
+            SerializationCallbacks<TDelegate>)_cache.GetOrAdd(type, t => CreateTypedCallbacks<TOwner, TDelegate>(t));
 
         [SecurityCritical]
         private static SerializationCallbacks<TDelegate> CreateTypedCallbacks<TOwner, TDelegate>(Type type)

--- a/src/Orleans.Serialization/TypeSystem/CachedTypeResolver.cs
+++ b/src/Orleans.Serialization/TypeSystem/CachedTypeResolver.cs
@@ -71,7 +71,7 @@ namespace Orleans.Serialization.TypeSystem
 
         private void AddTypeToCache(string name, Type type)
         {
-            var entry = _typeCache.GetOrAdd(name, _ => type);
+            var entry = _typeCache.GetOrAdd(name, type);
             if (!ReferenceEquals(entry, type))
             {
                 throw new InvalidOperationException("inconsistent type name association");

--- a/src/Orleans.Streaming/Internal/StreamDirectory.cs
+++ b/src/Orleans.Streaming/Internal/StreamDirectory.cs
@@ -16,7 +16,7 @@ namespace Orleans.Streams
 
         internal IAsyncStream<T> GetOrAddStream<T>(InternalStreamId streamId, Func<IAsyncStream<T>> streamCreator)
         {
-            var stream = allStreams.GetOrAdd(streamId, _ => streamCreator());
+            var stream = allStreams.GetOrAdd(streamId, (_, streamCreator) => streamCreator(), streamCreator);
             var streamOfT = stream as IAsyncStream<T>;
             if (streamOfT == null)
             {

--- a/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
@@ -243,7 +243,7 @@ namespace Orleans.Providers
         /// <returns></returns>
         private IMemoryStreamQueueGrain GetQueueGrain(QueueId queueId)
         {
-            return queueGrains.GetOrAdd(queueId, id => grainFactory.GetGrain<IMemoryStreamQueueGrain>(GenerateDeterministicGuid(id)));
+            return queueGrains.GetOrAdd(queueId, (id, arg) => arg.grainFactory.GetGrain<IMemoryStreamQueueGrain>(arg.instance.GenerateDeterministicGuid(id)), (instance: this, grainFactory));
         }
 
         public static MemoryAdapterFactory<TSerializer> Create(IServiceProvider services, string name)


### PR DESCRIPTION
Remove closures by using the `factoryArgument` parameter. This reduces allocations and is slightly faster.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7425)