### PR TITLE
Use Ordinal comparisons instead of culture sensitive comparisons

### DIFF
--- a/src/AdoNet/Shared/Storage/AdoNetFormatProvider.cs
+++ b/src/AdoNet/Shared/Storage/AdoNetFormatProvider.cs
@@ -43,7 +43,7 @@ namespace Orleans.Tests.SqlUtils
 
                 if(arg is string)
                 {
-                    return "N'" + ((string)arg).Replace("'", "''") + "'";
+                    return "N'" + ((string)arg).Replace("'", "''", StringComparison.Ordinal) + "'";
                 }
 
                 if(arg is DateTime)

--- a/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/Hosting/ServiceRuntimeWrapper.cs
@@ -175,7 +175,7 @@ namespace Orleans.Runtime.Host
         private void Initialize()
         {
             assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(
-                a => a.FullName.StartsWith("Microsoft.WindowsAzure.ServiceRuntime"));
+                a => a.FullName.StartsWith("Microsoft.WindowsAzure.ServiceRuntime", StringComparison.Ordinal));
 
             // If we are runing within a worker role Microsoft.WindowsAzure.ServiceRuntime should already be loaded
             if (assembly == null)
@@ -220,7 +220,7 @@ namespace Orleans.Runtime.Host
 
         private static string ExtractInstanceName(string instanceId, string deploymentId)
         {
-            return instanceId.Length > deploymentId.Length && instanceId.StartsWith(deploymentId)
+            return instanceId.Length > deploymentId.Length && instanceId.StartsWith(deploymentId, StringComparison.Ordinal)
                 ? instanceId.Substring(deploymentId.Length + 1)
                 : instanceId;
         }

--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -18,7 +18,7 @@ namespace Orleans.Analyzers
         {
             var name = attributeSyntax.GetTypeName();
             return string.Equals(name, attributeName, StringComparison.Ordinal)
-                || (name.StartsWith(attributeName) && name.EndsWith(nameof(Attribute)) && name.Length == attributeName.Length + nameof(Attribute).Length);
+                || (name.StartsWith(attributeName, StringComparison.Ordinal) && name.EndsWith(nameof(Attribute), StringComparison.Ordinal) && name.Length == attributeName.Length + nameof(Attribute).Length);
         }
 
         public static bool HasAttribute(this MemberDeclarationSyntax member, string attributeName)

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -107,7 +107,7 @@ namespace Orleans.CodeGenerator
                 List<IPropertySymbol> dataMembers = new();
                 foreach (var property in symbol.GetDeclaredInstanceMembers<IPropertySymbol>())
                 {
-                    if (!property.Name.StartsWith("Item"))
+                    if (!property.Name.StartsWith("Item", System.StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/src/Orleans.Core/Configuration/ConfigUtilities.cs
+++ b/src/Orleans.Core/Configuration/ConfigUtilities.cs
@@ -25,12 +25,12 @@ namespace Orleans.Runtime.Configuration
                 unitSize = 10000;
                 numberInput = trimmedInput.Remove(trimmedInput.Length - 2).Trim();
             }
-            else if (trimmedInput.EndsWith("s", StringComparison.Ordinal))
+            else if (trimmedInput.EndsWith('s'))
             {
                 unitSize = 1000 * 10000;
                 numberInput = trimmedInput.Remove(trimmedInput.Length - 1).Trim();
             }
-            else if (trimmedInput.EndsWith("m", StringComparison.Ordinal))
+            else if (trimmedInput.EndsWith('m'))
             {
                 unitSize = 60 * 1000 * 10000;
                 numberInput = trimmedInput.Remove(trimmedInput.Length - 1).Trim();

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using System;
 using System.Buffers;
@@ -123,7 +123,7 @@ namespace Orleans.Serialization
 
             foreach (var lib in dependencyContext.RuntimeLibraries)
             {
-                if (!lib.Name.Contains("Orleans.Serialization") && !lib.Dependencies.Any(dep => dep.Name.Contains("Orleans.Serialization")))
+                if (!lib.Name.Contains("Orleans.Serialization", StringComparison.Ordinal) && !lib.Dependencies.Any(dep => dep.Name.Contains("Orleans.Serialization", StringComparison.Ordinal)))
                 {
                     continue;
                 }

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -201,7 +201,7 @@ namespace Orleans.Serialization
                 return false;
             }
 
-            if (typeof(Exception).IsAssignableFrom(type) && type.Namespace is { } ns && (ns.StartsWith("System") || ns.StartsWith("Microsoft")))
+            if (typeof(Exception).IsAssignableFrom(type) && type.Namespace is { } ns && (ns.StartsWith("System", StringComparison.Ordinal) || ns.StartsWith("Microsoft", StringComparison.Ordinal)))
             {
                 return true;
             }

--- a/src/Orleans.Serialization/TypeSystem/DefaultTypeFilter.cs
+++ b/src/Orleans.Serialization/TypeSystem/DefaultTypeFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Orleans.Serialization.TypeSystem
 {
@@ -9,29 +9,29 @@ namespace Orleans.Serialization.TypeSystem
     {
         public bool? IsTypeNameAllowed(string typeName, string assemblyName)
         {
-            if (assemblyName is { } && assemblyName.Contains("Orleans.Serialization"))
+            if (assemblyName is { } && assemblyName.Contains("Orleans.Serialization", StringComparison.Ordinal))
             {
                 return true;
             }
 
-            if (typeName.EndsWith(nameof(Exception)))
+            if (typeName.EndsWith(nameof(Exception), StringComparison.Ordinal))
             {
                 return true;
             }
 
-            if (typeName.StartsWith("System."))
+            if (typeName.StartsWith("System.", StringComparison.Ordinal))
             {
-                if (typeName.EndsWith("Comparer"))
+                if (typeName.EndsWith("Comparer", StringComparison.Ordinal))
                 {
                     return true;
                 }
 
-                if (typeName.StartsWith("System.Collections."))
+                if (typeName.StartsWith("System.Collections.", StringComparison.Ordinal))
                 {
                     return true;
                 }
 
-                if (typeName.StartsWith("System.Net.IP"))
+                if (typeName.StartsWith("System.Net.IP", StringComparison.Ordinal))
                 {
                     return true;
                 }

--- a/src/Orleans.TestingHost/StandaloneSiloHandle.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHandle.cs
@@ -73,15 +73,15 @@ namespace Orleans.TestingHost
                     // Read standard output from the process for status updates.
                     if (!_startedEvent.Task.IsCompleted)
                     {
-                        if (e.Data.StartsWith(StandaloneSiloHost.SiloAddressLog))
+                        if (e.Data.StartsWith(StandaloneSiloHost.SiloAddressLog, StringComparison.Ordinal))
                         {
                             SiloAddress = Orleans.Runtime.SiloAddress.FromParsableString(e.Data.Substring(StandaloneSiloHost.SiloAddressLog.Length));
                         }
-                        else if (e.Data.StartsWith(StandaloneSiloHost.GatewayAddressLog))
+                        else if (e.Data.StartsWith(StandaloneSiloHost.GatewayAddressLog, StringComparison.Ordinal))
                         {
                             GatewayAddress = Orleans.Runtime.SiloAddress.FromParsableString(e.Data.Substring(StandaloneSiloHost.GatewayAddressLog.Length));
                         }
-                        else if (e.Data.StartsWith(StandaloneSiloHost.StartedLog))
+                        else if (e.Data.StartsWith(StandaloneSiloHost.StartedLog, StringComparison.Ordinal))
                         {
                             _startedEvent.TrySetResult(true);
                         }

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatistics.cs
@@ -264,7 +264,7 @@ namespace Orleans.Statistics
                 string line;
                 while ((line = await r.ReadLineAsync()) != null)
                 {
-                    if (line.StartsWith(lineStartsWith))
+                    if (line.StartsWith(lineStartsWith, StringComparison.Ordinal))
                         return line;
                 }
             }


### PR DESCRIPTION
`StartsWith` and `EndsWith` use the culture-culture to compare strings. It is slower and may lead to unexpected results.

I did not change methods that use `Ordinal` by default such as `Contains`. If you want, I can change them in this PR or in another PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7426)