### PR TITLE
Fix equality comparer used in ReferencedObjectCollection's overflow dictionary

### DIFF
--- a/src/Orleans.Core/Utils/ReferenceEqualsComparer.cs
+++ b/src/Orleans.Core/Utils/ReferenceEqualsComparer.cs
@@ -3,12 +3,12 @@ using System.Runtime.CompilerServices;
 
 namespace Orleans
 {
-    internal class ReferenceEqualsComparer : EqualityComparer<object>
+    internal class ReferenceEqualsComparer : IEqualityComparer<object>
     {
         /// <summary>
         /// Gets an instance of this class.
         /// </summary>
-        public static ReferenceEqualsComparer Instance { get; } = new ReferenceEqualsComparer();
+        public static ReferenceEqualsComparer Default { get; } = new ReferenceEqualsComparer();
 
         /// <summary>
         /// Defines object equality by reference equality (eq, in LISP).
@@ -17,23 +17,17 @@ namespace Orleans
         /// true if the specified objects are equal; otherwise, false.
         /// </returns>
         /// <param name="x">The first object to compare.</param><param name="y">The second object to compare.</param>
-        public override bool Equals(object x, object y)
-        {
-            return object.ReferenceEquals(x, y);
-        }
+        public new bool Equals(object x, object y) => object.ReferenceEquals(x, y);
 
-        public override int GetHashCode(object obj)
-        {
-            return obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
-        }
+        public int GetHashCode(object obj) => obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
     }
 
-    internal class ReferenceEqualsComparer<T> : EqualityComparer<T> where T : class
+    internal class ReferenceEqualsComparer<T> : IEqualityComparer<T> where T : class
     {
         /// <summary>
         /// Gets an instance of this class.
         /// </summary>
-        public static ReferenceEqualsComparer<T> Instance { get; } = new ReferenceEqualsComparer<T>();
+        public static ReferenceEqualsComparer<T> Default { get; } = new ReferenceEqualsComparer<T>();
 
         /// <summary>
         /// Defines object equality by reference equality (eq, in LISP).
@@ -42,14 +36,8 @@ namespace Orleans
         /// true if the specified objects are equal; otherwise, false.
         /// </returns>
         /// <param name="x">The first object to compare.</param><param name="y">The second object to compare.</param>
-        public override bool Equals(T x, T y)
-        {
-            return object.ReferenceEquals(x, y);
-        }
+        public bool Equals(T x, T y) => object.ReferenceEquals(x, y);
 
-        public override int GetHashCode(T obj)
-        {
-            return obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
-        }
+        public int GetHashCode(T obj) => obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
         private readonly IServiceProvider _serviceProvider;
         private readonly MessageFactory _messageFactory;
         private readonly IOptionsMonitor<SiloMessagingOptions> _messagingOptions;
-        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, bool>(ReferenceEqualsComparer<ActivationData>.Instance);
+        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, bool>(ReferenceEqualsComparer<ActivationData>.Default);
         private bool _enabled = true;
         private Task _runTask;
 

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly IConnectionListenerFactory listenerFactory;
         private readonly ConnectionManager connectionManager;
-        protected readonly ConcurrentDictionary<Connection, object> connections = new(ReferenceEqualsComparer.Instance);
+        protected readonly ConcurrentDictionary<Connection, object> connections = new(ReferenceEqualsComparer.Default);
         private readonly ConnectionCommon connectionShared;
         private Task acceptLoopTask;
         private IConnectionListener listener;

--- a/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
@@ -123,6 +123,7 @@ namespace Orleans.Serialization.Session
             return -1;
         }
 
+
         private void AddToReferenceToIdMap(object value, uint reference)
         {
             if (_objectToReferenceOverflow is { } overflow)

--- a/src/Orleans.Serialization/Utilities/ReferenceEqualsComparer.cs
+++ b/src/Orleans.Serialization/Utilities/ReferenceEqualsComparer.cs
@@ -1,11 +1,15 @@
-﻿using System.Collections.Generic;
+using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Utilities
 {
-    internal sealed class ReferenceEqualsComparer : EqualityComparer<object>
+    internal sealed class ReferenceEqualsComparer : IEqualityComparer<object>, IEqualityComparer
     {
-        public override bool Equals(object x, object y) => ReferenceEquals(x, y);
-        public override int GetHashCode(object obj) => obj is null ? 0 : RuntimeHelpers.GetHashCode(obj);
+        public static ReferenceEqualsComparer Default { get; } = new();
+
+        public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => obj is null ? 0 : RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -177,14 +177,14 @@ namespace Orleans.Serialization.UnitTests
         {
             var concurrentQueueField = new ConcurrentQueue<int>();
             concurrentQueueField.Enqueue(4);
-            
+
             var concurrentQueueProperty = new ConcurrentQueue<int>();
             concurrentQueueProperty.Enqueue(5);
             concurrentQueueProperty.Enqueue(6);
-            
+
             var concurrentDictField = new ConcurrentDictionary<string, int>();
             _ = concurrentDictField.TryAdd("nine", 9);
-            
+
             var concurrentDictProperty = new ConcurrentDictionary<string, int>();
             _ = concurrentDictProperty.TryAdd("ten", 10);
             _ = concurrentDictProperty.TryAdd("eleven", 11);
@@ -212,6 +212,24 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal(original.ConcurrentDictProperty["eleven"], result.ConcurrentDictProperty["eleven"]);
         }
 
+        [Fact]
+        public void ClassWithLargeCollectionAndUriRoundTrip()
+        {
+            var largeCollection = new List<string>(200);
+            for (int i = 0; i < 200; i++)
+            {
+                largeCollection.Add(i.ToString());
+            }
+
+            var original = new ClassWithLargeCollectionAndUri
+            {
+                LargeCollection = largeCollection,
+                Uri = new($"http://www.{Guid.NewGuid()}.com/")
+            };
+
+            var result = RoundTripThroughCodec(original);
+            Assert.Equal(original.Uri, result.Uri);
+        }
 
         public void Dispose() => _serviceProvider?.Dispose();
 

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Orleans;
@@ -160,5 +161,15 @@ namespace Orleans.Serialization.UnitTests
 
         [Id(5)]
         public ConcurrentDictionary<string, int> ConcurrentDictProperty { get; set; }
+    }
+
+    [GenerateSerializer]
+    public class ClassWithLargeCollectionAndUri
+    {
+        [Id(0)]
+        public List<string> LargeCollection;
+
+        [Id(1)]
+        public Uri Uri;
     }
 }


### PR DESCRIPTION
`ReferencedObjectCollection` uses a hybrid approach to storing object references: an array is used for tracking the first 64 reference objects and a `Dictionary<object, uint>` is used for subsequent objects.

That dictionary uses `ReferenceEqualsComparer.Default` to check for equality. `ReferenceEqualsComparer` doesn't explicitly define a `Default` property, though, instead it inherits from `EqualityComparer<object>`. This was the mistake: the `Default` property was returning the default equality comparer which means we do not have reference equality. Eg, It can tell you that a `Uri` and `string` are equal, as it was in the test case which @mcm2020 provided.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7433)