### PR TITLE
Support serialization of manual (non-auto) properties

### DIFF
--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
@@ -17,7 +17,6 @@
     <SourceDir>$(MSBuildThisFileDirectory)..\..\Orleans.CodeGenerator.MSBuild\</SourceDir>
     <OrleansBuildTimeCodeGen>false</OrleansBuildTimeCodeGen>
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-    <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -31,12 +31,12 @@ namespace Orleans.Analyzers
         {
             if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword))
             {
-                if (declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
+                if (declaration.TryGetAttribute(Constants.GenerateSerializerAttributeName, out var attribute))
                 {
-                    var (serializableMembers, nextId) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
+                    var (serializableMembers, _, nextId) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
                     if (serializableMembers.Count > 0)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, attribute.GetLocation()));
                     }
                 }
             }
@@ -67,9 +67,61 @@ namespace Orleans.Analyzers
         {
             if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword))
             {
-                if (declaration.HasAttribute(Constants.SerializableAttributeName) && !declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
+                if (declaration.TryGetAttribute(Constants.SerializableAttributeName, out var attribute) && !declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, attribute.GetLocation()));
+                }
+            }
+        }
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AbstractPropertiesCannotBeSerializedAnalyzer : DiagnosticAnalyzer
+    {
+        public const string RuleId = "ORLEANS0006";
+        private const string Category = "Usage";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AbstractOrStaticMembersCannotBeSerializedTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AbstractOrStaticMembersCannotBeSerializedMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+        internal static DiagnosticDescriptor Rule { get; } = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.RegisterSyntaxNodeAction(CheckSyntaxNode, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration);
+        }
+
+        private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is TypeDeclarationSyntax declaration && SerializationAttributesHelper.ShouldGenerateSerializer(declaration))
+            {
+                var (_, members, _) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
+                foreach (var member in members)
+                {
+                    string modifier = null;
+                    if (member.IsAbstract())
+                    {
+                        modifier = "abstract";
+                    }
+                    else if (member.IsStatic())
+                    {
+                        modifier = "static";
+                    }
+
+                    if (modifier is not null)
+                    {
+                        var location = member.GetLocation();
+                        if (member.TryGetAttribute(Constants.IdAttributeName, out var attribute))
+                        {
+                            location = attribute.GetLocation();
+                        }
+
+                        var name = member.GetMemberNameOrDefault();
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, location, name, modifier));
+                    }
                 }
             }
         }

--- a/src/Orleans.Analyzers/GenerateSerializationAttributesCodeFix.cs
+++ b/src/Orleans.Analyzers/GenerateSerializationAttributesCodeFix.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -59,7 +59,7 @@ namespace Orleans.Analyzers
         private static async Task<Document> AddSerializationAttributes(TypeDeclarationSyntax declaration, CodeFixContext context, CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
-            var (serializableMembers, nextId) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
+            var (serializableMembers, _, nextId) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
 
             foreach (var member in serializableMembers)
             {
@@ -76,7 +76,7 @@ namespace Orleans.Analyzers
         private static async Task<Document> AddNonSerializedAttributes(SyntaxNode root, TypeDeclarationSyntax declaration, CodeFixContext context, CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
-            var (serializableMembers, _) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
+            var (serializableMembers, _, _) = SerializationAttributesHelper.AnalyzeTypeDeclaration(declaration);
 
             var insertUsingDirective = true;
             var ns = root.DescendantNodesAndSelf()

--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Analyzers</PackageId>
     <Title>Microsoft Orleans Analyzers</Title>
@@ -19,6 +19,21 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Analyzers/Resources.Designer.cs
+++ b/src/Orleans.Analyzers/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Orleans.Analyzers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,24 @@ namespace Orleans.Analyzers {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The member &quot;{0}&quot; is marked as {1} and therefore cannot be serialized..
+        /// </summary>
+        internal static string AbstractOrStaticMembersCannotBeSerializedMessageFormat {
+            get {
+                return ResourceManager.GetString("AbstractOrStaticMembersCannotBeSerializedMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Members which are static or abstract cannot be serialized..
+        /// </summary>
+        internal static string AbstractOrStaticMembersCannotBeSerializedTitle {
+            get {
+                return ResourceManager.GetString("AbstractOrStaticMembersCannotBeSerializedTitle", resourceCulture);
             }
         }
         

--- a/src/Orleans.Analyzers/Resources.resx
+++ b/src/Orleans.Analyzers/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AbstractOrStaticMembersCannotBeSerializedMessageFormat" xml:space="preserve">
+    <value>The member "{0}" is marked as {1} and therefore cannot be serialized.</value>
+  </data>
+  <data name="AbstractOrStaticMembersCannotBeSerializedTitle" xml:space="preserve">
+    <value>Members which are static or abstract cannot be serialized.</value>
+  </data>
   <data name="AddGenerateSerializerAttributeDescription" xml:space="preserve">
     <value>Add the [GenerateSerializer] attribute.</value>
   </data>

--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Orleans.Analyzers
@@ -52,6 +53,38 @@ namespace Orleans.Analyzers
             }
 
             attribute = default;
+            return false;
+        }
+
+        public static string GetMemberNameOrDefault(this MemberDeclarationSyntax member)
+        {
+            if (member is PropertyDeclarationSyntax property)
+            {
+                return property.ChildTokens().FirstOrDefault(token => token.Kind() == SyntaxKind.IdentifierToken).ValueText;
+            }
+            else if (member is FieldDeclarationSyntax field)
+            {
+                return field.ChildNodes().OfType<VariableDeclarationSyntax>().FirstOrDefault()?.ChildNodes().OfType<VariableDeclaratorSyntax>().FirstOrDefault()?.Identifier.ValueText;
+            }
+
+            return null;
+        }
+        
+        public static bool IsAbstract(this MemberDeclarationSyntax member) => member.HasModifier(SyntaxKind.AbstractKeyword);
+
+        public static bool IsStatic(this MemberDeclarationSyntax member) => member.HasModifier(SyntaxKind.StaticKeyword);
+
+        public static bool HasModifier(this MemberDeclarationSyntax member, SyntaxKind modifierKind)
+        {
+            foreach (var modifier in member.Modifiers)
+            {
+                var kind = modifier.Kind();
+                if (kind == modifierKind) 
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -30,9 +30,9 @@ namespace Orleans.CodeGenerator
                 {
                     members.Add(serializable);
                 }
-                else if (member is IFieldDescription field)
+                else if (member is IFieldDescription or IPropertyDescription)
                 {
-                    members.Add(new SerializableMember(libraryTypes, type, field, members.Count));
+                    members.Add(new SerializableMember(libraryTypes, type, member, members.Count));
                 }
                 else if (member is MethodParameterFieldDescription methodParameter)
                 {

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -695,13 +695,16 @@ namespace Orleans.CodeGenerator
                 }
 
                 FieldTypeSyntax = TypeSyntax;
+                Symbol = parameter;
             }
 
+            public ISymbol Symbol { get; }
             public MethodDescription Method { get; }
             public int ParameterOrdinal => Parameter.Ordinal;
             public ushort FieldId { get; }
             public ISymbol Member => Parameter;
             public ITypeSymbol Type => FieldType;
+            public INamedTypeSymbol ContainingType => Parameter.ContainingType;
             public TypeSyntax TypeSyntax { get; }
             public IParameterSymbol Parameter { get; }
             public override bool IsSerializable => true;

--- a/src/Orleans.CodeGenerator/Model/FieldDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/FieldDescription.cs
@@ -8,11 +8,12 @@ namespace Orleans.CodeGenerator
 {
     internal class FieldDescription : IFieldDescription
     {
-        public FieldDescription(ushort fieldId, IFieldSymbol member, ITypeSymbol type)
+        public FieldDescription(ushort fieldId, IFieldSymbol member)
         {
             FieldId = fieldId;
             Field = member;
-            Type = type;
+            Type = member.Type;
+            ContainingType = member.ContainingType;
 
             if (Type.TypeKind == TypeKind.Dynamic)
             {
@@ -24,9 +25,11 @@ namespace Orleans.CodeGenerator
             }
         }
 
+        public ISymbol Symbol => Field;
         public IFieldSymbol Field { get; }
         public ushort FieldId { get; }
         public ITypeSymbol Type { get; }
+        public INamedTypeSymbol ContainingType { get; }
         public TypeSyntax TypeSyntax { get; }
 
         public string AssemblyName => Type.ContainingAssembly.ToDisplayName();

--- a/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
@@ -8,7 +8,9 @@ namespace Orleans.CodeGenerator
     internal interface IMemberDescription
     {
         ushort FieldId { get; }
+        ISymbol Symbol { get; }
         ITypeSymbol Type { get; }
+        INamedTypeSymbol ContainingType { get; }
         string AssemblyName { get; }
         string TypeName { get; }
         TypeSyntax TypeSyntax { get; }

--- a/src/Orleans.CodeGenerator/Model/PropertyDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/PropertyDescription.cs
@@ -6,7 +6,11 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Orleans.CodeGenerator
 {
-    internal class PropertyDescription : IMemberDescription
+    internal interface IPropertyDescription : IMemberDescription 
+    {
+    }
+
+    internal class PropertyDescription : IPropertyDescription
     {
         public PropertyDescription(ushort fieldId, IPropertySymbol property)
         {
@@ -23,8 +27,9 @@ namespace Orleans.CodeGenerator
         }
 
         public ushort FieldId { get; }
-        public ISymbol Member => Property;
+        public ISymbol Symbol => Property;
         public ITypeSymbol Type => Property.Type;
+        public INamedTypeSymbol ContainingType => Property.ContainingType;
         public IPropertySymbol Property { get; }
 
         public TypeSyntax TypeSyntax { get; }

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -32,9 +32,9 @@ namespace Orleans.CodeGenerator
                 {
                     members.Add(serializable);
                 }
-                else if (member is IFieldDescription field)
+                else if (member is IFieldDescription or IPropertyDescription)
                 {
-                    members.Add(new SerializableMember(libraryTypes, type, field, members.Count));
+                    members.Add(new SerializableMember(libraryTypes, type, member, members.Count));
                 }
                 else if (member is MethodParameterFieldDescription methodParameter)
                 {
@@ -1170,37 +1170,37 @@ namespace Orleans.CodeGenerator
             private readonly SemanticModel _model;
             private readonly LibraryTypes _libraryTypes;
             private IPropertySymbol _property;
-            private readonly IFieldDescription _fieldDescription;
+            private readonly IMemberDescription _member;
 
             /// <summary>
             /// The ordinal assigned to this field.
             /// </summary>
             private readonly int _ordinal;
 
-            public SerializableMember(LibraryTypes libraryTypes, ISerializableTypeDescription type, IFieldDescription member, int ordinal)
+            public SerializableMember(LibraryTypes libraryTypes, ISerializableTypeDescription type, IMemberDescription member, int ordinal)
             {
                 _libraryTypes = libraryTypes;
                 _model = type.SemanticModel;
                 _ordinal = ordinal;
-                _fieldDescription = member;
+                _member = member;
             }
 
-            public bool IsShallowCopyable => _libraryTypes.IsShallowCopyable(_fieldDescription.Type) || (Property is { } prop && prop.HasAnyAttribute(_libraryTypes.ImmutableAttributes)) || _fieldDescription.Field.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
+            public bool IsShallowCopyable => _libraryTypes.IsShallowCopyable(_member.Type) || (Property is { } prop && prop.HasAnyAttribute(_libraryTypes.ImmutableAttributes)) || _member.Symbol.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
 
             public bool IsValueType => Type.IsValueType;
 
-            public IMemberDescription Member => _fieldDescription;
+            public IMemberDescription Member => _member;
 
             /// <summary>
             /// Gets the underlying <see cref="Field"/> instance.
             /// </summary>
-            private IFieldSymbol Field => _fieldDescription.Field;
+            private IFieldSymbol Field => (_member as IFieldDescription)?.Field;
 
-            public ITypeSymbol Type => _fieldDescription.Type;
+            public ITypeSymbol Type => _member.Type;
 
-            public INamedTypeSymbol ContainingType => _fieldDescription.Field.ContainingType;
+            public INamedTypeSymbol ContainingType => _member.ContainingType;
 
-            public string FieldName => _fieldDescription.Field.Name;
+            public string MemberName => Field?.Name ?? Property?.Name;
 
             /// <summary>
             /// Gets the name of the getter field.
@@ -1213,44 +1213,43 @@ namespace Orleans.CodeGenerator
             private string SetterFieldName => "setField" + _ordinal;
 
             /// <summary>
-            /// Gets a value indicating whether or not this field represents a property with an accessible, non-obsolete getter. 
+            /// Gets a value indicating whether or not this member represents an accessible field. 
             /// </summary>
-            private bool IsGettableProperty => Property?.GetMethod != null && _model.IsAccessible(0, Property.GetMethod) && !IsObsolete;
+            private bool IsGettableField => Field is { } field && _model.IsAccessible(0, field) && !IsObsolete;
 
             /// <summary>
-            /// Gets a value indicating whether or not this field represents a property with an accessible, non-obsolete setter. 
+            /// Gets a value indicating whether or not this member represents an accessible, mutable field. 
+            /// </summary>
+            private bool IsSettableField => Field is { } field && IsGettableField && !field.IsReadOnly;
+
+            /// <summary>
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete getter. 
+            /// </summary>
+            private bool IsGettableProperty => Property?.GetMethod is { } getMethod && _model.IsAccessible(0, getMethod) && !IsObsolete;
+
+            /// <summary>
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete setter. 
             /// </summary>
             private bool IsSettableProperty => Property?.SetMethod is { } setMethod && _model.IsAccessible(0, setMethod) && !setMethod.IsInitOnly && !IsObsolete;
 
             /// <summary>
             /// Gets syntax representing the type of this field.
             /// </summary>
-            public TypeSyntax TypeSyntax => Field.Type.TypeKind == TypeKind.Dynamic
+            public TypeSyntax TypeSyntax => Member.Type.TypeKind == TypeKind.Dynamic
                 ? PredefinedType(Token(SyntaxKind.ObjectKeyword)) 
-                : _fieldDescription.GetTypeSyntax(Field.Type);
+                : _member.GetTypeSyntax(Member.Type);
 
 
             /// <summary>
             /// Gets the <see cref="Property"/> which this field is the backing property for, or
             /// <see langword="null" /> if this is not the backing field of an auto-property.
             /// </summary>
-            private IPropertySymbol Property
-            {
-                get
-                {
-                    if (_property != null)
-                    {
-                        return _property;
-                    }
-
-                    return _property = PropertyUtility.GetMatchingProperty(Field);
-                }
-            }
+            private IPropertySymbol Property => _property ??= _property = Member.Symbol as IPropertySymbol ?? PropertyUtility.GetMatchingProperty(Field);
 
             /// <summary>
             /// Gets a value indicating whether or not this field is obsolete.
             /// </summary>
-            private bool IsObsolete => Field.HasAttribute(_libraryTypes.ObsoleteAttribute) ||
+            private bool IsObsolete => Member.Symbol.HasAttribute(_libraryTypes.ObsoleteAttribute) ||
                                        Property != null && Property.HasAttribute(_libraryTypes.ObsoleteAttribute);
 
             /// <summary>
@@ -1266,7 +1265,7 @@ namespace Orleans.CodeGenerator
                 {
                     result = instance.Member(Property.Name);
                 }
-                else if (Field.DeclaredAccessibility == Accessibility.Public && _model.IsAccessible(0, Field))
+                else if (IsGettableField)
                 {
                     result = instance.Member(Field.Name);
                 }
@@ -1298,16 +1297,17 @@ namespace Orleans.CodeGenerator
                         value);
                 }
 
-                if (!Field.IsReadOnly && IsDeclaredAccessible(Field) && _model.IsAccessible(0, Field))
+                if (IsSettableField)
                 {
                     return AssignmentExpression(
                         SyntaxKind.SimpleAssignmentExpression,
                         instance.Member(Field.Name),
+
                         value);
                 }
 
                 var instanceArg = Argument(instance);
-                if (Field.ContainingType != null && Field.ContainingType.IsValueType)
+                if (ContainingType != null && ContainingType.IsValueType)
                 {
                     instanceArg = instanceArg.WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword));
                 }
@@ -1317,19 +1317,15 @@ namespace Orleans.CodeGenerator
                         .AddArgumentListArguments(instanceArg, Argument(value));
             }
 
-            private static bool IsDeclaredAccessible(ISymbol symbol) => symbol.DeclaredAccessibility switch
-            {
-                Accessibility.Public => true,
-                _ => false,
-            };
-
             public GetterFieldDescription GetGetterFieldDescription()
             {
-                var getterType = _libraryTypes.Func_2.ToTypeSyntax(_fieldDescription.GetTypeSyntax(ContainingType), TypeSyntax);
+                if (IsGettableField || IsGettableProperty) return null;
+
+                var getterType = _libraryTypes.Func_2.ToTypeSyntax(_member.GetTypeSyntax(ContainingType), TypeSyntax);
 
                 // Generate syntax to initialize the field in the constructor
                 var fieldAccessorUtility = AliasQualifiedName("global", IdentifierName("Orleans.Serialization")).Member("Utilities").Member("FieldAccessor");
-                var fieldInfo = GetGetFieldInfoExpression(ContainingType, FieldName);
+                var fieldInfo = GetGetFieldInfoExpression(ContainingType, MemberName);
                 var accessorInvoke = CastExpression(
                     getterType,
                     InvocationExpression(fieldAccessorUtility.Member("GetGetter")).AddArgumentListArguments(Argument(fieldInfo)));
@@ -1341,19 +1337,21 @@ namespace Orleans.CodeGenerator
 
             public SetterFieldDescription GetSetterFieldDescription()
             {
+                if (IsSettableField || IsSettableProperty) return null;
+
                 TypeSyntax fieldType;
                 if (ContainingType != null && ContainingType.IsValueType)
                 {
-                    fieldType = _libraryTypes.ValueTypeSetter_2.ToTypeSyntax(_fieldDescription.GetTypeSyntax(ContainingType), TypeSyntax);
+                    fieldType = _libraryTypes.ValueTypeSetter_2.ToTypeSyntax(_member.GetTypeSyntax(ContainingType), TypeSyntax);
                 }
                 else
                 {
-                    fieldType = _libraryTypes.Action_2.ToTypeSyntax(_fieldDescription.GetTypeSyntax(ContainingType), TypeSyntax);
+                    fieldType = _libraryTypes.Action_2.ToTypeSyntax(_member.GetTypeSyntax(ContainingType), TypeSyntax);
                 }
 
                 // Generate syntax to initialize the field in the constructor
                 var fieldAccessorUtility = AliasQualifiedName("global", IdentifierName("Orleans.Serialization")).Member("Utilities").Member("FieldAccessor");
-                var fieldInfo = GetGetFieldInfoExpression(ContainingType, FieldName);
+                var fieldInfo = GetGetFieldInfoExpression(ContainingType, MemberName);
                 var isContainedByValueType = ContainingType != null && ContainingType.IsValueType;
                 var accessorMethod = isContainedByValueType ? "GetValueSetter" : "GetReferenceSetter";
                 var accessorInvoke = CastExpression(
@@ -1378,19 +1376,6 @@ namespace Orleans.CodeGenerator
                             .AddArgumentListArguments(
                                 Argument(fieldName.GetLiteralExpression()),
                                 Argument(bindingFlags));
-            }
-
-            /// <summary>
-            /// A comparer for <see cref="SerializableMember"/> which compares by name.
-            /// </summary>
-            public class Comparer : IComparer<SerializableMember>
-            {
-                /// <summary>
-                /// Gets the singleton instance of this class.
-                /// </summary>
-                public static Comparer Instance { get; } = new();
-
-                public int Compare(SerializableMember x, SerializableMember y) => string.Compare(x?.Field.Name, y?.Field.Name, StringComparison.Ordinal);
             }
         }
     }

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -171,6 +171,8 @@ namespace Orleans.CodeGenerator
 
                 public INamedTypeSymbol ContainingType => _property.ContainingType;
 
+                public ISymbol Symbol => _property;
+
                 public string FieldName => _property.Name.ToLowerInvariant(); 
 
                 /// <summary>
@@ -302,6 +304,8 @@ namespace Orleans.CodeGenerator
                 public IMemberDescription Member => this;
 
                 public ITypeSymbol Type => _property.Type;
+
+                public ISymbol Symbol => _property;
 
                 public INamedTypeSymbol ContainingType => _property.ContainingType;
 

--- a/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
+++ b/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Core.Abstractions</PackageId>
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <RootNamespace>Orleans</RootNamespace>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Core/Runtime/RingRange.cs
+++ b/src/Orleans.Core/Runtime/RingRange.cs
@@ -206,7 +206,6 @@ namespace Orleans.Runtime
         private readonly List<SingleRange> ranges;
         [Id(2)]
         private readonly long rangeSize;
-        [Id(3)]
 
         internal List<SingleRange> Ranges => ranges;
 

--- a/src/Orleans.Streaming.Abstractions/Core/StreamSequenceToken.cs
+++ b/src/Orleans.Streaming.Abstractions/Core/StreamSequenceToken.cs
@@ -14,13 +14,11 @@ namespace Orleans.Streams
         /// <summary>
         /// Number of event batches in stream prior to this event batch
         /// </summary>
-        [Id(1)]
         public abstract long SequenceNumber { get; protected set;  }
 
         /// <summary>
         /// Number of events in batch prior to this event
         /// </summary>
-        [Id(2)]
         public abstract int EventIndex { get; protected set; }
 
         public abstract bool Equals(StreamSequenceToken other);

--- a/src/Orleans.Streaming.Abstractions/Core/StreamSubscriptionHandle.cs
+++ b/src/Orleans.Streaming.Abstractions/Core/StreamSubscriptionHandle.cs
@@ -13,16 +13,13 @@ namespace Orleans.Streams
     [GenerateSerializer]
     public abstract class StreamSubscriptionHandle<T> : IEquatable<StreamSubscriptionHandle<T>>
     {
-        [Id(1)]
         public abstract StreamId StreamId { get; }
 
-        [Id(2)]
         public abstract string ProviderName { get; }
 
         /// <summary>
         /// Unique identifier for this StreamSubscriptionHandle
         /// </summary>
-        [Id(3)]
         public abstract Guid HandleId { get; }
 
         /// <summary>

--- a/test/Grains/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -205,7 +205,6 @@ namespace UnitTests.GrainInterfaces
         [NonSerialized]
         private int nonSerializedIntField;
 
-        [Id(0)]
         public abstract int Int { get; set; }
 
         [Id(1)]

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -231,6 +231,36 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal(original.Uri, result.Uri);
         }
 
+        [Fact]
+        public void ClassWithManualSerializablePropertyRoundTrip()
+        {
+            var original = new ClassWithManualSerializableProperty
+            {
+                GuidProperty = Guid.NewGuid(),
+            };
+
+            var result = RoundTripThroughCodec(original);
+            Assert.Equal(original.GuidProperty, result.GuidProperty);
+            Assert.Equal(original.StringProperty, result.StringProperty);
+
+            var guidValue = Guid.NewGuid();
+            original.StringProperty = guidValue.ToString("N");
+            result = RoundTripThroughCodec(original);
+
+            Assert.Equal(guidValue, result.GuidProperty);
+            Assert.Equal(original.GuidProperty, result.GuidProperty);
+
+            Assert.Equal(guidValue.ToString("N"), result.StringProperty);
+            Assert.Equal(original.StringProperty, result.StringProperty);
+
+            original.StringProperty = "bananas";
+            result = RoundTripThroughCodec(original);
+ 
+            Assert.Equal(default(Guid), result.GuidProperty);
+            Assert.Equal(original.GuidProperty, result.GuidProperty);
+            Assert.Equal("bananas", result.StringProperty);
+        }
+
         public void Dispose() => _serviceProvider?.Dispose();
 
         private T RoundTripThroughCodec<T>(T original)

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -172,4 +172,28 @@ namespace Orleans.Serialization.UnitTests
         [Id(1)]
         public Uri Uri;
     }
+
+    [GenerateSerializer]
+    public class ClassWithManualSerializableProperty
+    {
+        private string _stringPropertyValue;
+
+        [Id(0)]
+        public Guid GuidProperty { get; set; }
+
+        [Id(1)]
+        public string StringProperty
+        {
+            get
+            {
+                return _stringPropertyValue ?? GuidProperty.ToString("N");
+            }
+
+            set
+            {
+                _stringPropertyValue = value;
+                GuidProperty = Guid.TryParse(value, out var guidValue) ? guidValue : default;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/ReubenBond/Hagar/issues/192, but for Orleans

This PR allows non-auto properties to be serialized like auto properties and fields. This allows developers to implement migration and other logic by adding properties with logic, as @Normanator did in https://github.com/ReubenBond/Hagar/issues/192.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7435)