### PR TITLE
Support opting in to IKeyedSerializer implementations on a per-type basis using an attribute

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -46,6 +46,7 @@ namespace Orleans.ServiceBus.Providers
 
         private Body GetPayload() => payload ?? (payload = this.serializationManager.DeserializeFromByteArray<Body>(eventHubMessage.Payload));
 
+        [EnableKeyedSerializer(typeof(ILBasedSerializer))]
         [Serializable]
         private class Body
         {

--- a/src/Orleans.Core/Serialization/IKeyedSerializer.cs
+++ b/src/Orleans.Core/Serialization/IKeyedSerializer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Orleans.Serialization
 {
     /// <summary>
@@ -11,8 +13,11 @@ namespace Orleans.Serialization
         KeyedSerializerId SerializerId { get; }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this serializer should only be used for fallback scenarios, <see langword="false"/> otherwise.
+        /// Returns true if the provided type should be serialized by this serializer.
         /// </summary>
-        bool IsFallbackOnly { get; }
+        /// <param name="type">The type.</param>
+        /// <param name="isFallback">Whether this is the last chance for this serializer to opt-in to serializing the provided type.</param>
+        /// <returns><see langword="true"/> if the provided type should be serialized by this serializer, <see langword="false"/> otherwise.</returns>
+        bool IsSupportedType(Type type, bool isFallback);
     }
 }

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -930,7 +930,7 @@ namespace Orleans.Serialization
                 return;
             }
 
-            if (sm.fallbackSerializer.IsSupportedType(t))
+            if (sm.fallbackSerializer.IsSupportedType(t) || sm.fallbackSerializer is IKeyedSerializer keyed && keyed.IsSupportedType(t, isFallback: true))
             {
                 sm.FallbackSerializer(obj, context, expected);
                 return;
@@ -944,7 +944,7 @@ namespace Orleans.Serialization
                 return;
             }
 
-            if (obj is Exception && !sm.fallbackSerializer.IsSupportedType(t))
+            if (obj is Exception)
             {
                 // Exceptions should always be serializable, and thus handled by the prior if.
                 // In case someone creates a non-serializable exception, though, we don't want to 
@@ -1645,8 +1645,7 @@ namespace Orleans.Serialization
 
             foreach (var keyedSerializer in this.orderedKeyedSerializers)
             {
-                var canUseSerializer = !keyedSerializer.IsFallbackOnly || fallback;
-                if (canUseSerializer && keyedSerializer.IsSupportedType(type))
+                if (keyedSerializer.IsSupportedType(type, isFallback: fallback))
                 {
                     this.typeToKeyedSerializer[type] = keyedSerializer;
                     serializer = keyedSerializer;

--- a/src/Orleans.Core/Serialization/UseExternalSerializerAttribute.cs
+++ b/src/Orleans.Core/Serialization/UseExternalSerializerAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Orleans.Serialization
+{
+    /// <summary>
+    /// Allows a type to specify the serializer type to use for this class in the event that no other serializer claims responsibility.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class EnableKeyedSerializerAttribute : Attribute
+    {
+        public EnableKeyedSerializerAttribute(Type serializerType)
+        {
+            SerializerType = serializerType ?? throw new ArgumentNullException(nameof(serializerType));
+            if (!typeof(IExternalSerializer).IsAssignableFrom(serializerType)) throw new ArgumentException($"Type {serializerType} does not implement {typeof(IKeyedSerializer)}");
+        }
+
+        /// <summary>
+        /// The serializer type to use for this class in the event that no other serializer claims responsibility.
+        /// </summary>
+        public Type SerializerType { get; set; }
+    }
+}

--- a/src/Orleans.Core/Streams/QueueAdapters/BatchContainerBatch.cs
+++ b/src/Orleans.Core/Streams/QueueAdapters/BatchContainerBatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
@@ -8,6 +9,7 @@ namespace Orleans.Streams
     /// A batch of batch containers, that if configured (see StreamPullingAgentOptions), will be the data pulled by the
     /// PersistenStreamPullingAgent from it's underlying cache
     /// </summary>
+    [EnableKeyedSerializer(typeof(ILBasedSerializer))]
     class BatchContainerBatch : IBatchContainerBatch
     {
         /// <summary>

--- a/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
@@ -212,7 +212,7 @@ namespace UnitTests.Serialization
         private T SerializerLoop<T>(T input)
         {
             var serializer = new ILBasedSerializer(new CachedTypeResolver(), Options.Create(new ILBasedSerializerOptions()));
-            Assert.True(serializer.IsSupportedType(input.GetType()));
+            Assert.True(serializer.IsSupportedType(input.GetType(), isFallback: true));
 
             var writer = new BinaryTokenStreamWriter();
             var serializationContext =


### PR DESCRIPTION
Supersedes #7385

This PR allows types to add an `[EnableKeyedSerializer(typeof(MyKeyedSerializer))]` attribute in order to configure the specified `IKeyedSerializer` implementation as the serializer to try before the fallback serializer is used.

It is not intended for end-users, since `IKeyedSerializer` is currently `internal`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7438)