### PR TITLE
Fix some test code crashes caused by logging from unawaited background tasks

### DIFF
--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -824,7 +824,7 @@ namespace UnitTests.Grains
 
         public async Task Task_Delay(bool doStart)
         {
-            var wrapper = new Task(async () =>
+            var wrapper = new Task<Task>(async () =>
             {
                 logger.Info("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(1);
@@ -838,7 +838,7 @@ namespace UnitTests.Grains
                 wrapper.Start(); // THIS IS THE KEY STEP!
             }
 
-            await wrapper;
+            await wrapper.Unwrap();
         }
 
         private async Task DoDelay(int i)
@@ -958,7 +958,7 @@ namespace UnitTests.Grains
 
         public async Task Task_Delay(bool doStart)
         {
-            var wrapper = new Task(async () =>
+            var wrapper = new Task<Task>(async () =>
             {
                 logger.Info("Before Task.Delay #1 TaskScheduler.Current=" + TaskScheduler.Current);
                 await DoDelay(1);
@@ -972,7 +972,7 @@ namespace UnitTests.Grains
                 wrapper.Start(); // THIS IS THE KEY STEP!
             }
 
-            await wrapper;
+            await wrapper.Unwrap();
         }
 
         private async Task DoDelay(int i)

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -505,7 +505,7 @@ namespace UnitTests.SchedulerTests
             using var workItemGroup = SchedulingHelper.CreateWorkItemGroupForTesting(context, loggerFactory);
             TaskScheduler scheduler = workItemGroup.TaskScheduler;
 
-            Task wrapper = new Task(async () =>
+            Task<Task> wrapper = new Task<Task>(async () =>
             {
                 Assert.Equal(scheduler, TaskScheduler.Current);
                 await DoDelay(1);
@@ -515,7 +515,7 @@ namespace UnitTests.SchedulerTests
             });
             wrapper.Start(scheduler);
 
-            await wrapper;
+            await wrapper.Unwrap();
         }
 
         private async Task DoDelay(int i)


### PR DESCRIPTION
I see a test run for #7443 crashed with [this output](https://orleans.visualstudio.com/GitHub%20-%20PR%20Builds/_build/results?buildId=48989&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=64c999b4-06f1-59fa-9b80-6eac5fccdd35):
```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. 
System.InvalidOperationException: There is no currently active test.
    + CategoryInfo          : NotSpecified: (The active test...ly active test.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
    + PSComputerName        : localhost
 
   at Xunit.Sdk.TestOutputHelper.GuardInitialized() in C:\Dev\xunit\xunit\src\xunit.execution\Sd
k\Frameworks\TestOutputHelper.cs:line 51
   at Xunit.Sdk.TestOutputHelper.QueueTestOutput(String output) in 
C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\TestOutputHelper.cs:line 66
   at UnitTests.SchedulerTests.OrleansTaskSchedulerAdvancedTests_Set2.DoDelay(Int32 i) in 
C:\agent\_work\2\s\test\NonSilo.Tests\SchedulerTests\OrleansTaskSchedulerAdvancedTests_Set2.cs:line 527
   at UnitTests.SchedulerTests.OrleansTaskSchedulerAdvancedTests_Set2.<>c__DisplayClass17_0.<<ActivationSched_Task_Dela
y>b__0>d.MoveNext() in 
C:\agent\_work\2\s\test\NonSilo.Tests\SchedulerTests\OrleansTaskSchedulerAdvancedTests_Set2.cs:line 511
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__140_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

The reason is an attempt to log to the xUnit test output from a background task which is not awaited. It seems to me that these tasks should be properly awaited.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7446)