### PR TITLE
Expose deactivation reason to user code and flow timeouts for activation/deactivation

### DIFF
--- a/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
@@ -50,21 +50,39 @@ namespace Orleans.Runtime
         /// <param name="value">The component instance.</param>
         void SetComponent<TComponent>(TComponent value);
 
+        /// <summary>
+        /// Submits an incoming message to this instance.
+        /// </summary>
+        /// <param name="message">The message.</param>
         void ReceiveMessage(object message);
 
         IWorkItemScheduler Scheduler { get; }
-        PlacementStrategy PlacementStrategy { get; }
 
+        /// <summary>
+        /// Start activating this instance.
+        /// </summary>
+        /// <param name="requestContext">The request conext of the request which is causing this instance to be activated, if any.</param>
+        /// <param name="cancellationToken">A cancellation token which when cancelled, indicates that the process should complete prompty.</param>
         void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = default);
-        void Deactivate(CancellationToken? cancellationToken = default);
+
+        /// <summary>
+        /// Start deactivating this instance.
+        /// </summary>
+        /// <param name="deactivationReason">The reason for deactivation, for informational purposes.</param>
+        /// <param name="cancellationToken">A cancellation token which when cancelled, indicates that the process should complete prompty.</param>
+        void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = default);
+
+        /// <summary>
+        /// A task which completes when the grain has deactivated.
+        /// </summary>
         Task Deactivated { get; }
     }
 
     public static class GrainContextExtensions
     {
-        public static Task DeactivateAsync(this IGrainContext grainContext, CancellationToken? cancellationToken = default)
+        public static Task DeactivateAsync(this IGrainContext grainContext, DeactivationReason deactivationReason, CancellationToken? cancellationToken = default)
         {
-            grainContext.Deactivate(cancellationToken);
+            grainContext.Deactivate(deactivationReason, cancellationToken);
             return grainContext.Deactivated;
         }
     }
@@ -79,7 +97,7 @@ namespace Orleans.Runtime
         bool IsInactive { get; }
         bool IsStale();
         TimeSpan GetIdleness();
-        void StartDeactivating();
+        void StartDeactivating(DeactivationReason deactivationReason);
         void DelayDeactivation(TimeSpan timeSpan);
     }
 

--- a/src/Orleans.Core.Abstractions/Core/DeactivationReason.cs
+++ b/src/Orleans.Core.Abstractions/Core/DeactivationReason.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Represents a reason for initiating grain deactivation.
+    /// </summary>
+    public readonly struct DeactivationReason
+    {
+        public DeactivationReason(DeactivationReasonCode code, string text)
+        {
+            ReasonCode = code;
+            Description = text;
+            Exception = null;
+        }
+
+        public DeactivationReason(DeactivationReasonCode code, Exception exception, string text)
+        {
+            ReasonCode = code;
+            Description = text;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The descriptive reason for the deactivation.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// The reason for deactivation.
+        /// </summary>
+        public DeactivationReasonCode ReasonCode { get; }
+
+        /// <summary>
+        /// If not null, contains the exception thrown during activation.
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -11,20 +11,26 @@ namespace Orleans
     /// <summary>
     /// The abstract base class for all grain classes.
     /// </summary>
-    public abstract class Grain : IAddressable, ILifecycleParticipant<IGrainLifecycle>
+    public abstract class Grain : IGrainBase, IAddressable
     {
+        private readonly IGrainContext _grainContext;
+
         // Do not use this directly because we currently don't provide a way to inject it;
-        // any interaction with it will result in non unit-testable code. Any behaviour that can be accessed 
+        // any interaction with it will result in non unit-testable code. Any behaviour that can be accessed
         // from within client code (including subclasses of this class), should be exposed through IGrainRuntime.
         // The better solution is to refactor this interface and make it injectable through the constructor.
-        internal IActivationData Data;
-        public GrainReference GrainReference { get { return Data.GrainReference; } }
+        internal IActivationData Data => _grainContext as IActivationData;
+
+        IGrainContext IGrainBase.GrainContext => _grainContext;
+
+        public GrainReference GrainReference { get { return _grainContext.GrainReference; } }
 
         internal IGrainRuntime Runtime { get; }
+
         /// <summary>
         /// Gets an object which can be used to access other grains. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
         /// </summary>
-        protected IGrainFactory GrainFactory 
+        protected IGrainFactory GrainFactory
         {
             get { return Runtime?.GrainFactory; }
         }
@@ -32,12 +38,12 @@ namespace Orleans
         /// <summary>
         /// Gets the IServiceProvider managed by the runtime. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
         /// </summary>
-        protected internal IServiceProvider ServiceProvider 
+        protected internal IServiceProvider ServiceProvider
         {
-            get { return Data?.ActivationServices ?? Runtime?.ServiceProvider; }
+            get { return _grainContext?.ActivationServices ?? Runtime?.ServiceProvider; }
         }
 
-        internal GrainId GrainId => this.Data.GrainId;
+        internal GrainId GrainId => _grainContext.GrainId;
 
         /// <summary>
         /// This constructor should never be invoked. We expose it so that client code (subclasses of Grain) do not have to add a constructor.
@@ -57,7 +63,7 @@ namespace Orleans
                 return;
             }
 
-            this.Data = data;
+            _grainContext = data;
             this.Runtime = data.GrainRuntime;
         }
 
@@ -72,7 +78,7 @@ namespace Orleans
         /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
         /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
         /// </summary>
-        protected Grain(IGrainRuntime runtime) : this()
+        protected Grain(IGrainContext grainContext, IGrainRuntime runtime) : this()
         {
             Runtime = runtime;
         }
@@ -100,16 +106,16 @@ namespace Orleans
         /// If the grain is deactivated, then the timer will be discarded.
         /// </para>
         /// <para>
-        /// Until the Task returned from the asyncCallback is resolved, 
-        /// the next timer tick will not be scheduled. 
+        /// Until the Task returned from the asyncCallback is resolved,
+        /// the next timer tick will not be scheduled.
         /// That is to say, timer callbacks never interleave their turns.
         /// </para>
         /// <para>
-        /// The timer may be stopped at any time by calling the <c>Dispose</c> method 
+        /// The timer may be stopped at any time by calling the <c>Dispose</c> method
         /// on the timer handle returned from this call.
         /// </para>
         /// <para>
-        /// Any exceptions thrown by or faulted Task's returned from the asyncCallback 
+        /// Any exceptions thrown by or faulted Task's returned from the asyncCallback
         /// will be logged, but will not prevent the next timer tick from being queued.
         /// </para>
         /// </remarks>
@@ -121,11 +127,11 @@ namespace Orleans
         /// <seealso cref="IDisposable"/>
         protected IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            if (asyncCallback == null) 
+            if (asyncCallback == null)
                 throw new ArgumentNullException(nameof(asyncCallback));
 
             EnsureRuntime();
-            return Runtime.TimerRegistry.RegisterTimer(this, asyncCallback, state, dueTime, period);
+            return Runtime.TimerRegistry.RegisterTimer(_grainContext ?? RuntimeContext.Current, asyncCallback, state, dueTime, period);
         }
 
         /// <summary>
@@ -196,20 +202,20 @@ namespace Orleans
         protected void DeactivateOnIdle()
         {
             EnsureRuntime();
-            Runtime.DeactivateOnIdle(this);
+            Runtime.DeactivateOnIdle(_grainContext ?? RuntimeContext.Current);
         }
 
         /// <summary>
         /// Delay Deactivation of this activation at least for the specified time duration.
         /// A positive <c>timeSpan</c> value means “prevent GC of this activation for that time span”.
         /// A negative <c>timeSpan</c> value means “cancel the previous setting of the DelayDeactivation call and make this activation behave based on the regular Activation Garbage Collection settings”.
-        /// DeactivateOnIdle method would undo / override any current “keep alive” setting, 
+        /// DeactivateOnIdle method would undo / override any current “keep alive” setting,
         /// making this grain immediately available for deactivation.
         /// </summary>
         protected void DelayDeactivation(TimeSpan timeSpan)
         {
             EnsureRuntime();
-            Runtime.DelayDeactivation(this, timeSpan);
+            Runtime.DelayDeactivation(_grainContext ?? RuntimeContext.Current, timeSpan);
         }
 
         /// <summary>
@@ -217,18 +223,27 @@ namespace Orleans
         /// It is called before any messages have been dispatched to the grain.
         /// For grains with declared persistent state, this method is called after the State property has been populated.
         /// </summary>
-        public virtual Task OnActivateAsync()
-        {
-            return Task.CompletedTask;
-        }
+        /// <param name="cancellationToken">A cancellation token which signals when activation is being canceled.</param>
+        public virtual Task OnActivateAsync(CancellationToken cancellationToken) => OnActivateAsync();
+
+        /// <summary>
+        /// This method is called at the end of the process of activating a grain.
+        /// It is called before any messages have been dispatched to the grain.
+        /// For grains with declared persistent state, this method is called after the State property has been populated.
+        /// </summary>
+        public virtual Task OnActivateAsync() => Task.CompletedTask;
 
         /// <summary>
         /// This method is called at the beginning of the process of deactivating a grain.
         /// </summary>
-        public virtual Task OnDeactivateAsync()
-        {
-            return Task.CompletedTask;
-        }
+        /// <param name="reason">The reason for deactivation. Informational only.</param>
+        /// <param name="cancellationToken">A cancellation token which signals when deactivation should complete promptly.</param>
+        public virtual Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken) => OnDeactivateAsync();
+
+        /// <summary>
+        /// This method is called at the beginning of the process of deactivating a grain.
+        /// </summary>
+        public virtual Task OnDeactivateAsync() => Task.CompletedTask;
 
         private void EnsureRuntime()
         {
@@ -237,18 +252,13 @@ namespace Orleans
                 throw new InvalidOperationException("Grain was created outside of the Orleans creation process and no runtime was specified.");
             }
         }
-
-        public virtual void Participate(IGrainLifecycle lifecycle)
-        {
-            lifecycle.Subscribe(this.GetType().FullName, GrainLifecycleStage.Activate, ct => OnActivateAsync(), ct => OnDeactivateAsync());
-        }
     }
 
     /// <summary>
     /// Base class for a Grain with declared persistent state.
     /// </summary>
     /// <typeparam name="TGrainState">The class of the persistent state object</typeparam>
-    public class Grain<TGrainState> : Grain
+    public class Grain<TGrainState> : Grain, ILifecycleParticipant<IGrainLifecycle>
     {
         private IStorage<TGrainState> storage;
 
@@ -271,7 +281,7 @@ namespace Orleans
         }
 
         /// <summary>
-        /// Strongly typed accessor for the grain state 
+        /// Strongly typed accessor for the grain state
         /// </summary>
         protected TGrainState State
         {
@@ -298,9 +308,8 @@ namespace Orleans
             return storage.ReadStateAsync();
         }
 
-        public override void Participate(IGrainLifecycle lifecycle)
+        public virtual void Participate(IGrainLifecycle lifecycle)
         {
-            base.Participate(lifecycle);
             lifecycle.Subscribe(this.GetType().FullName, GrainLifecycleStage.SetupState, OnSetupState);
         }
 
@@ -308,7 +317,7 @@ namespace Orleans
         {
             if (ct.IsCancellationRequested)
                 return Task.CompletedTask;
-            this.storage = this.Runtime.GetStorage<TGrainState>(this);
+            this.storage = this.Runtime.GetStorage<TGrainState>(Data);
             return this.ReadStateAsync();
         }
     }

--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Interface for grain implementations
+    /// </summary>
+    public interface IGrainBase
+    {
+        IGrainContext GrainContext { get; }
+        Task OnActivateAsync(CancellationToken token) => default;
+        Task OnDeactivateAsync(DeactivationReason reason, CancellationToken token) => default;
+    }
+
+    /// <summary>
+    /// Helper methods for <see cref="IGrainBase"/> implementations.
+    /// </summary>
+    public static class GrainBaseExtensions
+    {
+        /// <summary>
+        /// Deactivate this activation of the grain after the current grain method call is completed.
+        /// This call will mark this activation of the current grain to be deactivated and removed at the end of the current method.
+        /// The next call to this grain will result in a different activation to be used, which typical means a new activation will be created automatically by the runtime.
+        /// </summary>
+        public static void DeactivateOnIdle(this IGrainBase grain) => 
+            grain.GrainContext.Deactivate(new(DeactivationReasonCode.ApplicationRequested, $"{nameof(DeactivateOnIdle)} was called."));
+    }
+
+    /// <summary>
+    /// An informational reason code for deactivation.
+    /// </summary>
+    [GenerateSerializer]
+    public enum DeactivationReasonCode : byte
+    {
+        None,
+
+        /// <summary>
+        /// The process is currently shutting down.
+        /// </summary>
+        ShuttingDown,
+
+        /// <summary>
+        /// Activation of the grain failed.
+        /// </summary>
+        ActivationFailed,
+
+        /// <summary>
+        /// This activation is affected by an internal failure.
+        /// </summary>
+        /// <remarks>
+        /// This could be caused by the failure of a process hosting this activation's grain directory partition, for example.
+        /// </remarks>
+        InternalFailure,
+
+        /// <summary>
+        /// This activation is idle.
+        /// </summary>
+        ActivationIdle,
+
+        /// <summary>
+        /// This activation is unresponsive to commands or requests.
+        /// </summary>
+        ActivationUnresponsive,
+
+        /// <summary>
+        /// Another instance of this grain has been activated.
+        /// </summary>
+        DuplicateActivation,
+
+        /// <summary>
+        /// This activation received a request which cannot be handled by the locally running process.
+        /// </summary>
+        IncompatibleRequest,
+
+        /// <summary>
+        /// An application error occurred.
+        /// </summary>
+        ApplicationError,
+
+        /// <summary>
+        /// The application requested that this activation deactivate.
+        /// </summary>
+        ApplicationRequested,
+    }
+}

--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -11,8 +11,8 @@ namespace Orleans
     public interface IGrainBase
     {
         IGrainContext GrainContext { get; }
-        Task OnActivateAsync(CancellationToken token) => default;
-        Task OnDeactivateAsync(DeactivationReason reason, CancellationToken token) => default;
+        Task OnActivateAsync(CancellationToken token) => Task.CompletedTask;
+        Task OnDeactivateAsync(DeactivationReason reason, CancellationToken token) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
@@ -25,10 +25,10 @@ namespace Orleans.Runtime
 
         IServiceProvider ServiceProvider { get; }
 
-        void DeactivateOnIdle(Grain grain);
+        void DeactivateOnIdle(IGrainContext grainContext);
 
-        void DelayDeactivation(Grain grain, TimeSpan timeSpan);
+        void DelayDeactivation(IGrainContext grainContext, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain);
+        IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grainContext);
     }
 }

--- a/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
+++ b/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
 namespace Orleans.Timers
 {
     public interface ITimerRegistry
     {
-        IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
+        IDisposable RegisterTimer(IGrainContext grainContext, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
     }
 }

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -151,7 +151,7 @@ namespace Orleans
         }
 
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
-        public void Deactivate(CancellationToken? cancellationToken = null) { }
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -343,7 +343,7 @@ namespace Orleans
             }
 
             public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
-            public void Deactivate(CancellationToken? cancellationToken = null) { }
+            public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
             public Task Deactivated => Task.CompletedTask;
         }
     }

--- a/src/Orleans.Core/SystemTargetInterfaces/ICatalog.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/ICatalog.cs
@@ -13,7 +13,9 @@ namespace Orleans.Runtime
         /// Delete activations from this silo
         /// </summary>
         /// <param name="activationAddresses"></param>
+        /// <param name="reasonCode"></param>
+        /// <param name="reasonText"></param>
         /// <returns></returns>
-        Task DeleteActivations(List<GrainAddress> activationAddresses);
+        Task DeleteActivations(List<GrainAddress> activationAddresses, DeactivationReasonCode reasonCode, string reasonText);
     }
 }

--- a/src/Orleans.EventSourcing/Hosting/LogStorageSiloBuilderExtensions.cs
+++ b/src/Orleans.EventSourcing/Hosting/LogStorageSiloBuilderExtensions.cs
@@ -29,9 +29,9 @@ namespace Orleans.Hosting
 
         internal static IServiceCollection AddLogStorageBasedLogConsistencyProvider(this IServiceCollection services, string name)
         {
-            services.TryAddSingleton<Factory<Grain, ILogConsistencyProtocolServices>>(serviceProvider =>
+            services.TryAddSingleton<Factory<IGrainContext, ILogConsistencyProtocolServices>>(serviceProvider =>
             {
-                var factory = ActivatorUtilities.CreateFactory(typeof(ProtocolServices), new[] { typeof(Grain) });
+                var factory = ActivatorUtilities.CreateFactory(typeof(ProtocolServices), new[] { typeof(IGrainContext) });
                 return arg1 => (ILogConsistencyProtocolServices)factory(serviceProvider, new object[] { arg1 });
             });
             services.TryAddSingleton<ILogViewAdaptorFactory>(sp => sp.GetServiceByName<ILogViewAdaptorFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));

--- a/src/Orleans.EventSourcing/JournaledGrain.cs
+++ b/src/Orleans.EventSourcing/JournaledGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Storage;
 
@@ -169,7 +170,7 @@ namespace Orleans.EventSourcing
         /// view from storage. Subclasses can override this behavior,
         /// and skip the wait if desired.
         /// </summary>
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return LogViewAdaptor.Synchronize();
         }

--- a/src/Orleans.EventSourcing/LogConsistency/ILogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/ILogViewAdaptor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.EventSourcing
@@ -18,13 +19,13 @@ namespace Orleans.EventSourcing
           ILogConsistencyDiagnostics
         where TLogView : new()
     {
-        /// <summary>Called during activation, right before the user-defined <see cref="Grain.OnActivateAsync"/>.</summary>
+        /// <summary>Called during activation, right before the user-defined <see cref="Grain.OnActivateAsync(CancellationToken)"/>.</summary>
         Task PreOnActivate();
 
-        /// <summary>Called during activation, right after the user-defined <see cref="Grain.OnActivateAsync"/>..</summary>
+        /// <summary>Called during activation, right after the user-defined <see cref="Grain.OnActivateAsync(CancellationToken)"/>..</summary>
         Task PostOnActivate();
 
-        /// <summary>Called during deactivation, right after the user-defined <see cref="Grain.OnDeactivateAsync"/>.</summary>
+        /// <summary>Called during deactivation, right after the user-defined <see cref="Grain.OnDeactivateAsync(DeactivationReason, CancellationToken)"/>.</summary>
         Task PostOnDeactivate();
     }
 

--- a/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/ProtocolServices.cs
@@ -14,10 +14,10 @@ namespace Orleans.Runtime.LogConsistency
     {
         private readonly ILogger log;
         private readonly DeepCopier deepCopier;
-        private readonly Grain grain;   // links to the grain that owns this service object
+        private readonly IGrainContext grain;   // links to the grain that owns this service object
 
         public ProtocolServices(
-            Grain gr,
+            IGrainContext gr,
             ILoggerFactory loggerFactory,
             DeepCopier deepCopier,
             ILocalSiloDetails siloDetails)

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1099,7 +1099,7 @@ namespace Orleans.Runtime
         {
             if (!cancellationToken.HasValue)
             {
-                cancellationToken = new CancellationTokenSource(_shared.InternalRuntime.CollectionOptions.Value.DeactivationTimeout).Token;
+                cancellationToken = new CancellationTokenSource(_shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout).Token;
             }
 
             ScheduleOperation(new Command.Activate(requestContext, cancellationToken.Value));

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1350,7 +1350,7 @@ namespace Orleans.Runtime
 
                 StopAllTimers();
 
-                // Wait timers and call OnDeactivateAsync()
+                // Wait timers and call OnDeactivateAsync(reason, cancellationToken)
                 await WaitForAllTimersToFinish(cancellationToken);
                 await CallGrainDeactivate(cancellationToken);
 
@@ -1410,7 +1410,7 @@ namespace Orleans.Runtime
                 try
                 {
                     // Note: This call is being made from within Scheduler.Queue wrapper, so we are already executing on worker thread
-                    if (_shared.Logger.IsEnabled(LogLevel.Debug)) _shared.Logger.Debug(ErrorCode.Catalog_BeforeCallingDeactivate, "About to call {1} grain's OnDeactivateAsync() method {0}", this, GrainInstance?.GetType().FullName);
+                    if (_shared.Logger.IsEnabled(LogLevel.Debug)) _shared.Logger.Debug(ErrorCode.Catalog_BeforeCallingDeactivate, "About to call {1} grain's OnDeactivateAsync(...) method {0}", this, GrainInstance?.GetType().FullName);
 
                     // Call OnDeactivateAsync inline, but within try-catch wrapper to safely capture any exceptions thrown from called function
                     try
@@ -1427,12 +1427,12 @@ namespace Orleans.Runtime
                             await Lifecycle.OnStop(ct).WithCancellation(ct, "Timed out waiting for grain lifecycle to complete deactivation");
                         }
 
-                        if (_shared.Logger.IsEnabled(LogLevel.Debug)) _shared.Logger.Debug(ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync() method {0}", this, GrainInstance?.GetType().FullName);
+                        if (_shared.Logger.IsEnabled(LogLevel.Debug)) _shared.Logger.Debug(ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync(...) method {0}", this, GrainInstance?.GetType().FullName);
                     }
                     catch (Exception exc)
                     {
                         _shared.Logger.Error(ErrorCode.Catalog_ErrorCallingDeactivate,
-                            string.Format("Error calling grain's OnDeactivateAsync() method - Grain type = {1} Activation = {0}", this, GrainInstance?.GetType().FullName), exc);
+                            string.Format("Error calling grain's OnDeactivateAsync(...) method - Grain type = {1} Activation = {0}", this, GrainInstance?.GetType().FullName), exc);
                     }
                 }
                 catch (Exception exc)

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -303,7 +303,8 @@ namespace Orleans.Runtime
             else
             {
                 // Initialize the new activation asynchronously.
-                result.Activate(requestContextData, CancellationToken.None);
+                var cancellation = new CancellationTokenSource(collectionOptions.Value.ActivationTimeout);
+                result.Activate(requestContextData, cancellation.Token);
                 return result;
             }
         }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -260,7 +260,7 @@ namespace Orleans.Runtime
             GrainAddress address,
             Dictionary<string, object> requestContextData)
         {
-            if (TryGetActivationData(address.GrainId, out var result))
+            if (TryGetGrainContext(address.GrainId, out var result))
             {
                 return result;
             }
@@ -268,7 +268,7 @@ namespace Orleans.Runtime
             // Lock over all activations to try to prevent multiple instances of the same activation being created concurrently.
             lock (activations)
             {
-                if (TryGetActivationData(address.GrainId, out result))
+                if (TryGetGrainContext(address.GrainId, out result))
                 {
                     return result;
                 }
@@ -328,7 +328,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Try to get runtime data for an activation
         /// </summary>
-        public bool TryGetActivationData(GrainId grainId, out IGrainContext data)
+        public bool TryGetGrainContext(GrainId grainId, out IGrainContext data)
         {
             data = activations.FindTarget(grainId);
             return data != null;
@@ -339,16 +339,27 @@ namespace Orleans.Runtime
         /// complete and commit outstanding transactions before deleting it.
         /// To be called not from within Activation context, so can be awaited.
         /// </summary>
-        /// <param name="list"></param>
-        /// <returns></returns>
-        internal async Task DeactivateActivations(List<IGrainContext> list)
+        internal async Task DeactivateActivations(DeactivationReason reason, List<IGrainContext> list)
         {
             if (list == null || list.Count == 0) return;
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("DeactivateActivations: {0} activations.", list.Count);
 
             var timeoutTokenSource = new CancellationTokenSource(this.collectionOptions.Value.DeactivationTimeout);
-            await Task.WhenAll(list.Select(activation => activation.DeactivateAsync(timeoutTokenSource.Token)));
+            await Task.WhenAll(list.Select(activation => activation.DeactivateAsync(reason, timeoutTokenSource.Token)));
+        }
+
+        internal void StartDeactivatingActivations(DeactivationReason reason, List<IGrainContext> list)
+        {
+            if (list == null || list.Count == 0) return;
+
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("DeactivateActivations: {0} activations.", list.Count);
+
+            var timeoutTokenSource = new CancellationTokenSource(this.collectionOptions.Value.DeactivationTimeout);
+            foreach (var activation in list)
+            {
+                activation.DeactivateAsync(reason, timeoutTokenSource.Token);
+            }
         }
 
         public Task DeactivateAllActivations()
@@ -366,7 +377,8 @@ namespace Orleans.Runtime
                 activationsToShutdown.Add(activation);
             }
 
-            return DeactivateActivations(activationsToShutdown);
+            var reason = new DeactivationReason(DeactivationReasonCode.ShuttingDown, "This process is terminating");
+            return DeactivateActivations(reason, activationsToShutdown);
         }
 
         public SiloStatus LocalSiloStatus
@@ -377,28 +389,19 @@ namespace Orleans.Runtime
             }
         }
 
-        public Task DeleteActivations(List<GrainAddress> addresses)
+        public Task DeleteActivations(List<GrainAddress> addresses, DeactivationReasonCode reasonCode, string reasonText)
         {
-            List<IGrainContext> TryGetActivationDatas(List<GrainAddress> addresses)
-            {
-                var datas = new List<IGrainContext>(addresses.Count);
-                foreach (var activationAddress in addresses)
-                {
-                    IGrainContext data;
-                    if (TryGetActivationData(activationAddress.GrainId, out data))
-                    {
-                        datas.Add(data);
-                    }
-                }
-                return datas;
-            }
-
             var timeoutTokenSource = new CancellationTokenSource(this.collectionOptions.Value.DeactivationTimeout);
             var tasks = new List<Task>(addresses.Count);
-            foreach (var activationData in TryGetActivationDatas(addresses))
+            var deactivationReason = new DeactivationReason(reasonCode, reasonText);
+            foreach (var activationAddress in addresses)
             {
-                tasks.Add(activationData.DeactivateAsync(timeoutTokenSource.Token));
+                if (TryGetGrainContext(activationAddress.GrainId, out var grainContext))
+                {
+                    tasks.Add(grainContext.DeactivateAsync(deactivationReason, timeoutTokenSource.Token));
+                }
             }
+
             return Task.WhenAll(tasks);
         }
 
@@ -429,7 +432,9 @@ namespace Orleans.Runtime
                         try
                         {
                             var activationData = activation.Value;
-                            if (!activationData.PlacementStrategy.IsUsingGrainDirectory || grainDirectoryResolver.HasNonDefaultDirectory(activationData.GrainId.Type)) continue;
+                            var placementStrategy = activationData.GetComponent<PlacementStrategy>();
+                            var isUsingGrainDirectory = placementStrategy is { IsUsingGrainDirectory: true };
+                            if (!isUsingGrainDirectory || grainDirectoryResolver.HasNonDefaultDirectory(activationData.GrainId.Type)) continue;
                             if (!updatedSilo.Equals(directory.GetPrimaryForGrain(activationData.GrainId))) continue;
 
                             activationsToShutdown.Add(activationData);
@@ -455,7 +460,9 @@ namespace Orleans.Runtime
                 // outside the lock.
                 if (activationsToShutdown.Count > 0)
                 {
-                    DeactivateActivations(activationsToShutdown).Ignore();
+                    var reasonText = $"This activation is being deactivated due to a failure of server {updatedSilo}, since it was responsible for this activation's grain directory registration.";
+                    var reason = new DeactivationReason(DeactivationReasonCode.InternalFailure, reasonText);
+                    StartDeactivatingActivations(reason, activationsToShutdown);
                 }
             }
         }

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -342,7 +342,7 @@ namespace Orleans.Runtime
 
         public TTarget GetTarget<TTarget>() => throw new NotImplementedException();
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
-        public void Deactivate(CancellationToken? cancellationToken = null) { }
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -313,8 +313,9 @@ namespace Orleans.Runtime
                         // Mark the exception so that it doesn't deactivate any other activations.
                         ise.IsSourceActivation = false;
 
-                        this.invokeExceptionLogger.Info($"Deactivating {target} due to inconsistent state.");
-                        this.DeactivateOnIdle(target.GrainId);
+                        var msg = $"Deactivating {target} due to inconsistent state.";
+                        this.invokeExceptionLogger.Info(msg);
+                        target.Deactivate(new DeactivationReason(DeactivationReasonCode.ApplicationError, invocationException, invocationException.Message));
                     }
                 }
 
@@ -523,12 +524,6 @@ namespace Orleans.Runtime
             {
                 throw new InvalidOperationException("Cannot delete a local object reference from a grain.");
             }
-        }
-
-        public void DeactivateOnIdle(GrainId id)
-        {
-            if (!Catalog.TryGetActivationData(id, out var data)) return; // already gone
-            _ = data.DeactivateAsync();
         }
 
         private Task OnRuntimeInitializeStop(CancellationToken tc)

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -275,7 +275,7 @@ namespace Orleans.Runtime
 
         public TTarget GetTarget<TTarget>() => (TTarget)(object)this;
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
-        public void Deactivate(CancellationToken? cancellationToken = null) { }
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -319,7 +319,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
 
                     var remoteCatalog = this.grainFactory.GetSystemTarget<ICatalog>(Constants.CatalogType, pair.Key);
-                    await remoteCatalog.DeleteActivations(pair.Value);
+                    await remoteCatalog.DeleteActivations(pair.Value, DeactivationReasonCode.DuplicateActivation, "This grain has been activated elsewhere");
                 }
 
                 duplicates.Remove(pair.Key);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -241,11 +241,14 @@ namespace Orleans.Hosting
             services.TryAddSingleton<GrainContextActivator>();
             services.AddSingleton<IConfigureGrainTypeComponents, ConfigureDefaultGrainActivator>();
             services.TryAddSingleton<GrainReferenceActivator>();
-            services.TryAddSingleton<IGrainContextActivatorProvider, ActivationDataActivatorProvider>();
-            services.TryAddSingleton<IGrainContextAccessor, GrainContextAccessor>();
+            services.AddSingleton<IGrainContextActivatorProvider, ActivationDataActivatorProvider>();
+            services.AddSingleton<IGrainContextAccessor, GrainContextAccessor>();
             services.AddSingleton<IncomingRequestMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, IncomingRequestMonitor>();
             services.AddFromExisting<IActivationWorkingSetObserver, IncomingRequestMonitor>();
+
+            // Scoped to a grain activation
+            services.AddScoped<IGrainContext>(sp => RuntimeContext.Current);
 
             services.TryAddSingleton<IConsistentRingProvider>(
                 sp =>

--- a/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/Orleans.Runtime/ReminderService/GrainBasedReminderTable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
@@ -19,14 +20,14 @@ namespace Orleans.Runtime.ReminderService
             this.logger = logger;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.LogInformation("Activated");
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation virtually indefinitely.
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.LogInformation("Deactivated");
             return Task.CompletedTask;

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -19,13 +19,13 @@ namespace Orleans.Core
         {
             get
             {
-                GrainRuntime.CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
                 return grainState.State;
             }
 
             set
             {
-                GrainRuntime.CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
                 grainState.State = value;
             }
         }
@@ -58,7 +58,7 @@ namespace Orleans.Core
             Stopwatch sw = Stopwatch.StartNew();
             try
             {
-                GrainRuntime.CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 await store.ReadStateAsync(name, grainRef, grainState);
 
@@ -90,7 +90,7 @@ namespace Orleans.Core
             const string what = "WriteState";
             try
             {
-                GrainRuntime.CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 Stopwatch sw = Stopwatch.StartNew();
                 await store.WriteStateAsync(name, grainRef, grainState);
@@ -119,7 +119,7 @@ namespace Orleans.Core
             const string what = "ClearState";
             try
             {
-                GrainRuntime.CheckRuntimeContext();
+                GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 Stopwatch sw = Stopwatch.StartNew();
                 // Clear (most likely Delete) state from external storage

--- a/src/Orleans.Runtime/Timers/TimerRegistry.cs
+++ b/src/Orleans.Runtime/Timers/TimerRegistry.cs
@@ -13,10 +13,10 @@ namespace Orleans.Timers
             this.timerLogger = loggerFactory.CreateLogger<GrainTimer>();
         }
 
-        public IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+        public IDisposable RegisterTimer(IGrainContext grainContext, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            var timer = GrainTimer.FromTaskCallback(this.timerLogger, asyncCallback, state, dueTime, period, activationData: grain?.Data);
-            grain?.Data.GetComponent<IGrainTimerRegistry>().OnTimerCreated(timer);
+            var timer = GrainTimer.FromTaskCallback(this.timerLogger, asyncCallback, state, dueTime, period, grainContext: grainContext);
+            grainContext?.GetComponent<IGrainTimerRegistry>().OnTimerCreated(timer);
             timer.Start();
             return timer;
         }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Providers;
@@ -48,13 +49,13 @@ namespace Orleans.Streams
             this.logger = logger;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             LogPubSubCounts("OnActivateAsync");
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             LogPubSubCounts("OnDeactivateAsync");
             return Task.CompletedTask;

--- a/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -1,10 +1,11 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 
 namespace Orleans.TestingHost
 {
@@ -23,9 +24,9 @@ namespace Orleans.TestingHost
         /// It is called before any messages have been dispatched to the grain.
         /// For grains with declared persistent state, this method is called after the State property has been populated.
         /// </summary>
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
             logger = this.ServiceProvider.GetService<ILoggerFactory>().CreateLogger($"{typeof (StorageFaultGrain).FullName}-{IdentityString}-{RuntimeIdentity}");
             readFaults = new Dictionary<GrainReference, Exception>();
             writeFaults = new Dictionary<GrainReference, Exception>();

--- a/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
+++ b/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
@@ -42,7 +42,7 @@ namespace Orleans.Transactions.TestKit
             var result = await this.tm.PrepareAndCommit(transactionId, accessCount, timeStamp, writeParticipants, totalParticipants);
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepareAndCommit && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} PrepareAndCommit");
             }
             this.faultInjectionControl.Reset();
@@ -56,7 +56,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepared
                 && this.faultInjectionControl?.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepared");
             }
             this.faultInjectionControl.Reset();
@@ -69,7 +69,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPing
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Ping");
             }
             this.faultInjectionControl.Reset();
@@ -105,7 +105,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCommitReadOnly
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} CommitReadOnly");
             }
 
@@ -120,7 +120,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterAbort
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} abort");
             }
             this.faultInjectionControl.Reset();
@@ -133,7 +133,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCancel
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} cancel");
             }
             this.faultInjectionControl.Reset();
@@ -155,7 +155,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterConfirm
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Confirm");
             }
             this.faultInjectionControl.Reset();
@@ -179,7 +179,7 @@ namespace Orleans.Transactions.TestKit
             if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepare
                 && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
             {
-                this.grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+                this.grainRuntime.DeactivateOnIdle(context);
                 this.logger.Info($"Grain {this.context.GrainInstance} deactivating after transaction {transactionId} Prepare");
             }
             this.faultInjectionControl.Reset();

--- a/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/SingleStateDeactivatingTransactionalGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/FaultInjection/ControlledInjection/SingleStateDeactivatingTransactionalGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Transactions.Abstractions;
 
@@ -34,12 +35,12 @@ namespace Orleans.Transactions.TestKit
             this.loggerFactory = loggerFactory;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger = this.loggerFactory.CreateLogger(this.GetGrainId().ToString());
             this.logger.LogInformation($"GrainId : {this.GetPrimaryKey()}.");
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task Set(int newValue)

--- a/src/Orleans.Transactions.TestKitBase/Grains/MultiStateTransactionalBitArrayGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/Grains/MultiStateTransactionalBitArrayGrain.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -216,12 +217,12 @@ namespace Orleans.Transactions.TestKit.Correctnesss
             this.loggerFactory = loggerFactory;
         }
         
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger = this.loggerFactory.CreateLogger(this.GetGrainId().ToString());
             this.logger.LogTrace($"GrainId : {this.GetPrimaryKey()}.");
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task Ping()

--- a/src/Orleans.Transactions.TestKitBase/Grains/MultiStateTransactionalGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/Grains/MultiStateTransactionalGrain.cs
@@ -3,6 +3,7 @@ using Orleans.Transactions.Abstractions;
 using System;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Transactions.TestKit
@@ -74,10 +75,10 @@ namespace Orleans.Transactions.TestKit
             this.loggerFactory = loggerFactory;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger = this.loggerFactory.CreateLogger(this.GetGrainId().ToString());
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public async Task Set(int newValue)
@@ -120,7 +121,7 @@ namespace Orleans.Transactions.TestKit
                     return state.Value;
                 });
             }
-            return result;              
+            return result;
         }
 
         public async Task AddAndThrow(int numberToAdd)

--- a/src/Orleans.Transactions.TestKitBase/Grains/TransactionCommitterTestGrain.cs
+++ b/src/Orleans.Transactions.TestKitBase/Grains/TransactionCommitterTestGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Transactions.Abstractions;
 
@@ -18,10 +19,10 @@ namespace Orleans.Transactions.TestKit
             this.loggerFactory = loggerFactory;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger = this.loggerFactory.CreateLogger(this.GetGrainId().ToString());
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task Commit(ITransactionCommitOperation<IRemoteCommitService> operation)

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -206,7 +206,7 @@ namespace Orleans.Transactions
             ITransactionalStateStorage<TState> storage = storageFactory.Create<TState>(this.config.StorageName, this.config.StateName);
 
             // setup transaction processing pipe
-            Action deactivate = () => grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+            Action deactivate = () => grainRuntime.DeactivateOnIdle(context);
             var options = this.context.ActivationServices.GetRequiredService<IOptions<TransactionalStateOptions>>();
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
             var timerManager = this.context.ActivationServices.GetRequiredService<ITimerManager>();

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -129,7 +129,7 @@ namespace Orleans.Transactions
             ITransactionalStateStorage<OperationState> storage = storageFactory.Create<OperationState>(this.config.StorageName, this.config.ServiceName);
 
             // setup transaction processing pipe
-            Action deactivate = () => grainRuntime.DeactivateOnIdle((Grain)context.GrainInstance);
+            Action deactivate = () => grainRuntime.DeactivateOnIdle(context);
             var options = this.context.ActivationServices.GetRequiredService<IOptions<TransactionalStateOptions>>();
             var clock = this.context.ActivationServices.GetRequiredService<IClock>();
             TService service = this.context.ActivationServices.GetRequiredServiceByName<TService>(this.config.ServiceName);

--- a/test/Grains/BenchmarkGrains/MapReduce/TransformGrain.cs
+++ b/test/Grains/BenchmarkGrains/MapReduce/TransformGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
@@ -91,11 +91,11 @@ namespace BenchmarkGrains.MapReduce
             this._processingStarted = true;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this._proccessingStopped = true;
             this._processingStarted = false;
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public Task<List<TOutput>> ReceiveAll()

--- a/test/Grains/BenchmarkGrains/Ping/PingGrain.cs
+++ b/test/Grains/BenchmarkGrains/Ping/PingGrain.cs
@@ -2,6 +2,7 @@ using Orleans;
 using BenchmarkGrainInterfaces.Ping;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using System.Threading;
 
 namespace BenchmarkGrains.Ping
 {
@@ -9,10 +10,10 @@ namespace BenchmarkGrains.Ping
     {
         private IPingGrain _self;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _self = this.AsReference<IPingGrain>();
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public ValueTask Run() => default;

--- a/test/Grains/TestGrainInterfaces/IStuckGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStuckGrain.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -11,6 +12,8 @@ namespace UnitTests.GrainInterfaces
         Task NonBlockingCall();
 
         Task<int> GetNonBlockingCallCounter();
+
+        Task<bool> DidActivationTryToStart(GrainId id);
 
         Task BlockingDeactivation();
     }

--- a/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
+++ b/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.SqlUtils.StorageProvider.GrainInterfaces;
@@ -11,9 +12,9 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
     {
         private readonly Random _random = new Random();
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
         }
 
         public Task<string> IntroduceSelf()

--- a/test/Grains/TestGrains/CatalogTestGrain.cs
+++ b/test/Grains/TestGrains/CatalogTestGrain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
@@ -8,7 +9,7 @@ namespace UnitTests.Grains
 {
     public class CatalogTestGrain : Grain, ICatalogTestGrain
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.Delay(TimeSpan.FromMilliseconds(50));
         }

--- a/test/Grains/TestGrains/CircularStateTestGrain.cs
+++ b/test/Grains/TestGrains/CircularStateTestGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
 using Orleans;
 using TestGrainInterfaces;
 
@@ -6,7 +7,7 @@ namespace TestGrains
 {
     public class CircularStateTestGrain : Grain<CircularStateTestState>, ICircularStateTestGrain
     {
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var c1 = new CircularTest1();
             var c2 = new CircularTest2();

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -46,20 +47,20 @@ namespace UnitTests.Grains
             }
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger.Info("Consumer.OnActivateAsync");
             _numConsumedItems = 0;
             _subscriptionHandle = null;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("Consumer.OnDeactivateAsync");
             await StopConsuming();
             _numConsumedItems = 0;
-            await base.OnDeactivateAsync();
+            await base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public async Task BecomeConsumer(Guid streamId, string providerToUse)

--- a/test/Grains/TestGrains/EventSourcing/ChatGrain.cs
+++ b/test/Grains/TestGrains/EventSourcing/ChatGrain.cs
@@ -1,6 +1,7 @@
 using Orleans.EventSourcing;
 using Orleans.Providers;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using TestGrainInterfaces;
@@ -10,13 +11,13 @@ namespace TestGrains
     /// <summary>
     /// An example of a journaled grain implementing a chat.
     /// The state of the grain is an XML document (System.Xml.Linq.XDocument).
-    /// 
+    ///
     /// Configured to use the default storage provider.
     /// Configured to use the LogStorage consistency provider.
-    /// 
-    /// This means we persist all events; since events are replayed when a grain is loaded 
+    ///
+    /// This means we persist all events; since events are replayed when a grain is loaded
     /// we can change the XML schema later
-    /// 
+    ///
     /// </summary>
 
     [StorageProvider(ProviderName = "Default")]
@@ -25,10 +26,10 @@ namespace TestGrains
     {
         // we want to ensure chats are correctly initialized when first used
         // so we override the default activation, to insert a creation event if needed
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             // first, wait for all events to be loaded from storage so we are caught up with the latest version
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
 
             // if the chat has not been initialized, do that now
             if (Version == 0)
@@ -44,7 +45,7 @@ namespace TestGrains
         }
 
         /// <summary>
-        /// in order to apply events correctly to the grain state, we 
+        /// in order to apply events correctly to the grain state, we
         /// must override the transition function
         /// (because an XDocument object does not have an Apply function)
         /// </summary>
@@ -57,7 +58,7 @@ namespace TestGrains
         {
             return Task.FromResult(TentativeState);
         }
- 
+
         public Task Post(Guid guid, string user, string text)
         {
             RaiseEvent(new PostedEvent() { Guid = guid, User = user, Text = text, Timestamp = DateTime.UtcNow });

--- a/test/Grains/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/Grains/TestGrains/EventSourcing/CountersGrain.cs
@@ -2,6 +2,7 @@ using Orleans;
 using Orleans.EventSourcing;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using TestGrainInterfaces;
 
@@ -68,8 +69,7 @@ namespace TestGrains
         {
         }
 
-        
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             // on activation, we load lazily (do not wait until the current state is loaded).
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -19,7 +20,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{nameof(FilteredImplicitSubscriptionGrain)} {IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             var streamProvider = this.GetStreamProvider("SMSProvider");

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -18,7 +19,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{nameof(FilteredImplicitSubscriptionWithExtensionGrain)} {IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             var streamProvider = this.GetStreamProvider("SMSProvider");

--- a/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
@@ -1,6 +1,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -27,7 +28,7 @@ namespace TestGrains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -19,12 +20,12 @@ namespace TestGrains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 
             reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task ReportResult(Guid streamGuid, string streamProvider, string streamNamespace, int count)

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -200,11 +201,11 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class GrainWithListFields : Grain<IGrainWithListFieldsState>, IGrainWithListFields
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (State.Items == null)
                 State.Items = new List<string>();
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task AddItem(string item)
@@ -230,12 +231,12 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class GenericGrainWithListFields<T> : Grain<GenericGrainWithListFieldsState<T>>, IGenericGrainWithListFields<T>
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (State.Items == null)
                 State.Items = new List<T>();
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task AddItem(T item)
@@ -597,13 +598,13 @@ namespace UnitTests.Grains
             DeactivateOnIdle();
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger.LogDebug("***Activating*** {0}", this.GetPrimaryKey());
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.LogDebug("***Deactivating*** {0}", this.GetPrimaryKey());
             return Task.CompletedTask;
@@ -718,7 +719,7 @@ namespace UnitTests.Grains
     {
         private A collection;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             collection = new A();
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -19,7 +20,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{nameof(ImplicitSubscriptionCounterGrain)} {this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger.LogInformation("OnActivateAsync");
 

--- a/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -36,7 +37,7 @@ namespace TestGrains
             this.logger = loggerFactory.CreateLogger("RecoverableStreamCollectorGrain " + base.IdentityString);
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 

--- a/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -28,7 +29,7 @@ namespace TestGrains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 

--- a/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -79,7 +80,7 @@ namespace TestGrains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 

--- a/test/Grains/TestGrains/LivenessTestGrain.cs
+++ b/test/Grains/TestGrains/LivenessTestGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -18,7 +19,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (this.GetPrimaryKeyLong() == -2)
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
@@ -27,13 +28,13 @@ namespace UnitTests.Grains
             label = this.GetPrimaryKeyLong().ToString();
             logger.Info("OnActivateAsync");
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("!!! OnDeactivateAsync");
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public Task<string> GetLabel()

--- a/test/Grains/TestGrains/LogTestGrain.cs
+++ b/test/Grains/TestGrains/LogTestGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.EventSourcing;
 using UnitTests.GrainInterfaces;
@@ -71,7 +72,7 @@ namespace TestGrains
     public abstract class LogTestGrain : JournaledGrain<MyGrainState,object>, UnitTests.GrainInterfaces.ILogTestGrain
     {
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask; // do not wait for initial load
         }

--- a/test/Grains/TestGrains/LogTestGrainVariations.cs
+++ b/test/Grains/TestGrains/LogTestGrainVariations.cs
@@ -2,6 +2,7 @@ using Orleans;
 using Orleans.Providers;
 using Orleans.Serialization;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
@@ -83,7 +84,7 @@ namespace TestGrains
 
         // simulate an async call during activation. This caused deadlock in earlier version,
         // so I add it here to catch regressions.
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             await Task.Run(async () =>
             {

--- a/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -22,7 +23,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger("MultipleImplicitSubscriptionGrain " + base.IdentityString);
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
 

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -37,7 +38,7 @@ namespace UnitTests.Grains
             }
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             return Task.CompletedTask;
@@ -144,7 +145,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -19,18 +20,18 @@ namespace UnitTests.Grains
             _logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger.Info("Producer.OnActivateAsync");
             _numProducedItems = 0;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("Producer.OnDeactivateAsync");
             _numProducedItems = 0;
-            await base.OnDeactivateAsync();
+            await base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public Task BecomeProducer(Guid streamId, string providerToUse)

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
@@ -5,6 +5,7 @@ using Orleans.Streams;
 using Orleans.Streams.Core;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
@@ -22,7 +23,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             onAddCalledCount = 0;
@@ -59,7 +60,7 @@ namespace UnitTests.Grains
             consumerObservers.Clear();
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -85,7 +86,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -5,6 +5,7 @@ using Orleans.Streams;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
@@ -24,7 +25,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             numProducedItems = 0;
@@ -102,7 +103,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             logger.Info("{0} (item={1})", caller, numProducedItems);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -45,10 +46,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<string> One()
@@ -191,7 +192,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -238,7 +239,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -286,7 +287,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -406,7 +407,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -524,7 +525,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -562,7 +563,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/SampleStreamingGrain.cs
+++ b/test/Grains/TestGrains/SampleStreamingGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -52,7 +53,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             numProducedItems = 0;
@@ -112,7 +113,7 @@ namespace UnitTests.Grains
             logger.Info("{0} (item={1})", caller, numProducedItems);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -132,7 +133,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             numConsumedItems = 0;
@@ -164,7 +165,7 @@ namespace UnitTests.Grains
             return Task.FromResult(numConsumedItems);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -183,7 +184,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info( "OnActivateAsync" );
             numConsumedItems = 0;
@@ -234,7 +235,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/SimpleDIGrain.cs
+++ b/test/Grains/TestGrains/SimpleDIGrain.cs
@@ -6,6 +6,7 @@ using UnitTests.GrainInterfaces;
 using Orleans.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace UnitTests.Grains
 {
@@ -31,10 +32,10 @@ namespace UnitTests.Grains
             this.grainContextAccessor = grainContextAccessor;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.originalGrainContext = this.grainContextAccessor.GrainContext;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<long> GetLongValue()

--- a/test/Grains/TestGrains/SimpleGrain.cs
+++ b/test/Grains/TestGrains/SimpleGrain.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -24,7 +25,7 @@ namespace UnitTests.Grains
         protected int A { get; set; }
         protected int B { get; set; }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("Activate.");
             return Task.CompletedTask;
@@ -64,7 +65,7 @@ namespace UnitTests.Grains
             return Task.FromResult(A);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync.");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/SimpleObserverableGrain.cs
+++ b/test/Grains/TestGrains/SimpleObserverableGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -23,7 +24,7 @@ namespace UnitTests.Grains
             this.Observers = new ObserverManager<ISimpleGrainObserver>(TimeSpan.FromMinutes(5), logger, "observers");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("Activate.");
             return Task.CompletedTask;

--- a/test/Grains/TestGrains/SimplePersistentGrain.cs
+++ b/test/Grains/TestGrains/SimplePersistentGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -31,11 +32,11 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("Activate.");
             version = Guid.NewGuid();
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
         public Task SetA(int a)
         {

--- a/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
+++ b/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
@@ -3,6 +3,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
@@ -22,7 +23,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             ConsumerHandle = null;

--- a/test/Grains/TestGrains/StatelessWorkerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             activationGuid = Guid.NewGuid();
             logger.Info("Activate.");

--- a/test/Grains/TestGrains/StreamInterceptionGrain.cs
+++ b/test/Grains/TestGrains/StreamInterceptionGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Orleans;
 using Orleans.Streams;
 using UnitTests.GrainInterfaces;
@@ -10,7 +11,7 @@ namespace UnitTests.Grains
     {
         private int lastStreamValue;
         
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var streams = this.GetStreamProvider("SMSProvider");
             var stream = streams.GetStream<int>(this.GetPrimaryKey(), "InterceptedStream");
@@ -20,7 +21,7 @@ namespace UnitTests.Grains
                     this.lastStreamValue = value;
                     return Task.CompletedTask;
                 });
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
         }
 
         public Task<int> GetLastStreamValue() => Task.FromResult(this.lastStreamValue);

--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -109,7 +109,7 @@ namespace UnitTests.Grains
                 }
             }
 
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
         }
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
@@ -127,7 +127,7 @@ namespace UnitTests.Grains
             {
                 tcss.Remove(key);
             }
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
     }
 

--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -1,7 +1,11 @@
-﻿using System;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans;
+using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
 
@@ -9,10 +13,17 @@ namespace UnitTests.Grains
 {
     public class StuckGrain : Grain, IStuckGrain
     {
+        private static ConcurrentDictionary<GrainId, bool> ActivationCalls = new();
         private static Dictionary<Guid, TaskCompletionSource<bool>> tcss = new Dictionary<Guid, TaskCompletionSource<bool>>();
         private static Dictionary<Guid, int> counters = new Dictionary<Guid, int>();
         private static HashSet<Guid> grains = new HashSet<Guid>();
+        private readonly ILogger<StuckGrain> _log;
         private bool isDeactivatingBlocking = false;
+
+        public StuckGrain(ILogger<StuckGrain> log)
+        {
+            _log = log;
+        }
 
         public static bool Release(Guid key)
         {
@@ -58,6 +69,11 @@ namespace UnitTests.Grains
             return Task.FromResult(counters[this.GetPrimaryKey()]);
         }
 
+        public Task<bool> DidActivationTryToStart(GrainId id)
+        {
+            return Task.FromResult(ActivationCalls.TryGetValue(id, out _));
+        }
+
         public Task BlockingDeactivation()
         {
             isDeactivatingBlocking = true;
@@ -65,22 +81,41 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
+            ActivationCalls[this.GetGrainId()] = true;
+
+            _log.LogInformation("Activating");
             var key = this.GetPrimaryKey();
             lock (grains)
             {
                 grains.Add(key);
             }
+
             lock (counters)
             {
                 counters[key] = 0;
             }
-            return base.OnActivateAsync();
+
+            if (RequestContext.Get("block_activation_seconds") is int blockActivationSeconds && blockActivationSeconds > 1)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(blockActivationSeconds), cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    _log.LogInformation(exception, "Error while waiting");
+                }
+            }
+
+            await base.OnActivateAsync();
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
+            _log.LogInformation(reason.Exception, "Deactivating ReasonCode: {ReasonCode} Description: {ReasonText}", reason.ReasonCode, reason.Description);
+
             if (isDeactivatingBlocking) return RunForever();
 
             var key = this.GetPrimaryKey();

--- a/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
@@ -36,7 +36,7 @@ namespace UnitTests.Grains
             doingActivate = false;
         }
 
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             Assert.False(doingActivate, "Activate method should have finished");
@@ -79,7 +79,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
@@ -95,7 +95,7 @@ namespace UnitTests.Grains
                 });
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             Assert.False(doingActivate, "Activate method should have finished");
@@ -142,7 +142,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
 
@@ -176,7 +176,7 @@ namespace UnitTests.Grains
             doingActivate = false;
         }
 
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
 
@@ -227,7 +227,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             Assert.NotNull(TaskScheduler.Current);
             Assert.NotEqual(TaskScheduler.Current, TaskScheduler.Default);
@@ -284,7 +284,7 @@ namespace UnitTests.Grains
             await awaitMe;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             Task.Factory.StartNew(() => logger.Info("OnDeactivateAsync"));
 
@@ -332,13 +332,13 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             throw new ApplicationException("Thrown from Application-OnActivateAsync");
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             throw new ApplicationException("Thrown from Application-OnDeactivateAsync");
@@ -365,14 +365,14 @@ namespace UnitTests.Grains
             throw new ApplicationException("Thrown from Constructor");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             throw new NotImplementedException("OnActivateAsync should not have been called");
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException("OnDeactivateAsync() should not have been called");
+            throw new NotImplementedException("OnDeactivateAsync(...) should not have been called");
         }
 
         public Task<string> DoSomething()
@@ -390,14 +390,14 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             this.DeactivateOnIdle();
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -422,7 +422,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             grain = GrainFactory.GetGrain<ITestGrain>(1);
             logger.Info("OnActivateAsync");

--- a/test/Grains/TestInternalGrains/CollectionTestGrain.cs
+++ b/test/Grains/TestInternalGrains/CollectionTestGrain.cs
@@ -11,12 +11,18 @@ namespace UnitTests.Grains
 {
     public class CollectionTestGrain : Grain, ICollectionTestGrain
     {
+        protected readonly IGrainContext _grainContext;
         private DateTime activated;
 
         private ICollectionTestGrain other;
         private ILogger logger;
         private int counter;
         private static int staticCounter;
+
+        public CollectionTestGrain(IGrainContext grainContext)
+        {
+            _grainContext = grainContext;
+        }
 
         protected virtual ILogger Logger()
         {
@@ -26,7 +32,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
-                .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, Data.ActivationId, RuntimeIdentity));
+                .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, _grainContext.ActivationId, RuntimeIdentity));
             logger.Info("OnActivateAsync.");
             activated = DateTime.UtcNow;
             counter = 0;
@@ -112,6 +118,10 @@ namespace UnitTests.Grains
         private int counter;
         private static int staticCounter;
 
+        public ReentrantCollectionTestGrain(IGrainContext grainContext) : base(grainContext)
+        {
+        }
+
         protected override ILogger Logger()
         {
             return logger;
@@ -120,7 +130,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
-                .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, Data.ActivationId, RuntimeIdentity));
+                .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, _grainContext.ActivationId, RuntimeIdentity));
             logger.Info("OnActivateAsync.");
             counter = 0;
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/CollectionTestGrain.cs
+++ b/test/Grains/TestInternalGrains/CollectionTestGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -29,7 +30,7 @@ namespace UnitTests.Grains
             return logger;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, _grainContext.ActivationId, RuntimeIdentity));
@@ -39,7 +40,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             Logger().Info("OnDeactivateAsync.");
             return Task.CompletedTask;
@@ -127,7 +128,7 @@ namespace UnitTests.Grains
             return logger;
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, _grainContext.ActivationId, RuntimeIdentity));
@@ -136,7 +137,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             Logger().Info("OnDeactivateAsync.");
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/Grains/TestInternalGrains/EchoTaskGrain.cs
@@ -34,10 +34,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(GetType().FullName + " created");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<string> GetLastEcho()
@@ -77,10 +77,10 @@ namespace UnitTests.Grains
         public Task<int> GetMyIdAsync() { return Task.FromResult(State.MyId); } 
         public Task<string> GetLastEchoAsync() { return Task.FromResult(State.LastEcho); }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(GetType().FullName + " created");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<string> EchoAsync(string data)
@@ -217,10 +217,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(GetType().FullName + " created");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<int> GetMyId()
@@ -310,10 +310,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(GetType().FullName + " created");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<int> GetMyId()

--- a/test/Grains/TestInternalGrains/ErrorGrain.cs
+++ b/test/Grains/TestInternalGrains/ErrorGrain.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Grains
         {
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("Activate.");
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/ExtensionTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ExtensionTestGrain.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
@@ -9,11 +10,11 @@ namespace UnitTests.Grains
         public string ExtensionProperty { get; private set; }
         private TestExtension extender;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             ExtensionProperty = "";
             extender = null;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task InstallExtension(string name)
@@ -33,11 +34,11 @@ namespace UnitTests.Grains
         public T ExtensionProperty { get; private set; }
         private GenericTestExtension<T> extender;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             ExtensionProperty = default(T);
             extender = null;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task InstallExtension(T name)
@@ -60,7 +61,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
         
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (extender == null)
             {
@@ -68,7 +69,7 @@ namespace UnitTests.Grains
                 this.Data.SetComponent<ISimpleExtension>(extender);
             }
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
     }
 }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -73,7 +73,7 @@ namespace UnitTests.Grains
     [Orleans.Providers.StorageProvider(ProviderName = "test1")]
     public class PersistenceTestGrain : Grain<PersistenceTestGrainState>, IPersistenceTestGrain
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -136,7 +136,7 @@ namespace UnitTests.Grains
     {
         private readonly string _id = Guid.NewGuid().ToString();
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -229,7 +229,7 @@ namespace UnitTests.Grains
     [Orleans.Providers.StorageProvider(ProviderName = "test1")]
     public class PersistenceErrorGrain : Grain<PersistenceTestGrainState>, IPersistenceErrorGrain
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -277,7 +277,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger.Warn(1, "OnActivateAsync");
             return Task.CompletedTask;
@@ -301,7 +301,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger.Info(1, "OnActivateAsync");
             return Task.CompletedTask;
@@ -333,7 +333,7 @@ namespace UnitTests.Grains
     public class GrainStorageTestGrain : Grain<PersistenceTestGrainState>,
         IGrainStorageTestGrain, IGrainStorageTestGrain_LongKey
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -365,7 +365,7 @@ namespace UnitTests.Grains
     public class GrainStorageGenericGrain<T> : Grain<PersistenceGenericGrainState<T>>,
         IGrainStorageGenericGrain<T>
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -397,7 +397,7 @@ namespace UnitTests.Grains
     public class GrainStorageTestGrainExtendedKey : Grain<PersistenceTestGrainState>,
         IGrainStorageTestGrain_GuidExtendedKey, IGrainStorageTestGrain_LongExtendedKey
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -438,7 +438,7 @@ namespace UnitTests.Grains
     {
         private readonly string _id = Guid.NewGuid().ToString();
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -472,7 +472,7 @@ namespace UnitTests.Grains
     public class AWSStorageGenericGrain<T> : Grain<PersistenceGenericGrainState<T>>,
         IAWSStorageGenericGrain<T>
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -504,7 +504,7 @@ namespace UnitTests.Grains
     public class AWSStorageTestGrainExtendedKey : Grain<PersistenceTestGrainState>,
         IAWSStorageTestGrain_GuidExtendedKey, IAWSStorageTestGrain_LongExtendedKey
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -544,7 +544,7 @@ namespace UnitTests.Grains
     public class MemoryStorageTestGrain : Grain<MemoryStorageTestGrain.NestedPersistenceTestGrainState>,
         IMemoryStorageTestGrain
     {
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -713,12 +713,12 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _context = RuntimeContext.Current;
             _scheduler = TaskScheduler.Current;
             executing = false;
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         // When reentrant grain is doing WriteStateAsync, etag violations are posssible due to concurent writes.
@@ -889,7 +889,7 @@ namespace UnitTests.Grains
         private static int _counter = 1;
         private int _id;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _id = _counter++;
             var loggerFactory = this.ServiceProvider?.GetService<ILoggerFactory>();
@@ -901,7 +901,7 @@ namespace UnitTests.Grains
             executing = false;
             Log("--> OnActivateAsync");
             Log("<-- OnActivateAsync");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         private async Task SetOne(int iter, int level)
@@ -1067,10 +1067,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<int> GetValue()

--- a/test/Grains/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/Grains/TestInternalGrains/PlacementTestGrain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -212,7 +213,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
             DelayDeactivation(TimeSpan.MaxValue);   // make sure this activation is not collected.
@@ -242,10 +243,10 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info("OnActivateAsync");
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
         public Task<string> GetRuntimeInstanceId()

--- a/test/Grains/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/Grains/TestInternalGrains/PlacementTestGrain.cs
@@ -26,14 +26,16 @@ namespace UnitTests.Grains
         private readonly OverloadDetector overloadDetector;
 
         private readonly TestHooksHostEnvironmentStatistics hostEnvironmentStatistics;
-        
+        private readonly IGrainContext _grainContext;
         private readonly LoadSheddingOptions loadSheddingOptions;
 
         public PlacementTestGrainBase(
             OverloadDetector overloadDetector,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
-            IOptions<LoadSheddingOptions> loadSheddingOptions)
+            IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IGrainContext grainContext)
         {
+            _grainContext = grainContext;
             this.overloadDetector = overloadDetector;
             this.hostEnvironmentStatistics = hostEnvironmentStatistics;
             this.loadSheddingOptions = loadSheddingOptions.Value;
@@ -41,7 +43,7 @@ namespace UnitTests.Grains
 
         public Task<IPEndPoint> GetEndpoint()
         {
-            return Task.FromResult(Data.Address.SiloAddress.Endpoint);
+            return Task.FromResult(_grainContext.Address.SiloAddress.Endpoint);
         }
 
         public Task<string> GetRuntimeInstanceId()
@@ -130,8 +132,7 @@ namespace UnitTests.Grains
 
         public Task<SiloAddress> GetLocation()
         {
-            SiloAddress siloAddress = Data.Address.SiloAddress;
-            return Task.FromResult(siloAddress);
+            return Task.FromResult(_grainContext.Address.SiloAddress);
         }
     }
 
@@ -141,8 +142,9 @@ namespace UnitTests.Grains
         public RandomPlacementTestGrain(
             OverloadDetector overloadDetector,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
-            IOptions<LoadSheddingOptions> loadSheddingOptions)
-            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions)
+            IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IGrainContext grainContext)
+            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions, grainContext)
         {
         }
     }
@@ -153,8 +155,9 @@ namespace UnitTests.Grains
         public PreferLocalPlacementTestGrain(
             OverloadDetector overloadDetector,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
-            IOptions<LoadSheddingOptions> loadSheddingOptions)
-            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions)
+            IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IGrainContext grainContext)
+            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions, grainContext)
         {
         }
     }
@@ -165,8 +168,9 @@ namespace UnitTests.Grains
         public LocalPlacementTestGrain(
             OverloadDetector overloadDetector,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
-            IOptions<LoadSheddingOptions> loadSheddingOptions)
-            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions)
+            IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IGrainContext grainContext)
+            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions, grainContext)
         {
         }
     }
@@ -177,8 +181,9 @@ namespace UnitTests.Grains
         public ActivationCountBasedPlacementTestGrain(
             OverloadDetector overloadDetector,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
-            IOptions<LoadSheddingOptions> loadSheddingOptions)
-            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions)
+            IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IGrainContext grainContext)
+            : base(overloadDetector, hostEnvironmentStatistics, loadSheddingOptions, grainContext)
         {
         }
     }

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,7 +45,7 @@ namespace UnitTests.Grains
             this.reminderOptions = services.GetService<IOptions<ReminderOptions>>();
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this._id = Guid.NewGuid().ToString();
             this.allReminders = new Dictionary<string, IGrainReminder>();
@@ -55,7 +56,7 @@ namespace UnitTests.Grains
             return GetMissingReminders();
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -242,7 +243,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.myId = new Random().Next();
             this.allReminders = new Dictionary<string, IGrainReminder>();
@@ -253,7 +254,7 @@ namespace UnitTests.Grains
             await GetMissingReminders();
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.Info("OnDeactivateAsync.");
             return Task.CompletedTask;
@@ -400,7 +401,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.logger.Info("OnActivateAsync.");
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -169,7 +170,7 @@ namespace UnitTests.Grains
 
         protected IDictionary<StreamSubscriptionHandle<int>, MyStreamObserver<int>> Observers { get; set; }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnActivateAsync");
 
@@ -199,7 +200,7 @@ namespace UnitTests.Grains
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Not conected to stream yet.");
             }
         }
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnDeactivateAsync");
             await RecordDeactivate();
@@ -287,7 +288,7 @@ namespace UnitTests.Grains
         {
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnActivateAsync");
 
@@ -302,7 +303,8 @@ namespace UnitTests.Grains
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Not connected to stream yet.");
             }
         }
-        public override async Task OnDeactivateAsync()
+
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnDeactivateAsync");
             await RecordDeactivate();

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -78,7 +79,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));
@@ -114,10 +115,10 @@ namespace UnitTests.Grains
             }
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("OnDeactivateAsync");
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public Task<int> GetConsumerCount()
@@ -360,7 +361,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             logger.Info(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -487,7 +488,7 @@ namespace UnitTests.Grains
         protected List<IProducerObserver> _producers;
         private InterlockedFlag _cleanedUpFlag;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");
@@ -496,7 +497,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -598,9 +599,9 @@ namespace UnitTests.Grains
     {
         private ILogger _logger;
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");
             if (State.Producers == null)
@@ -618,10 +619,10 @@ namespace UnitTests.Grains
             }
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public override async Task BecomeProducer(Guid streamId, string providerToUse, string streamNamespace)
@@ -666,7 +667,7 @@ namespace UnitTests.Grains
         protected List<IConsumerObserver> _observers;
         private string _providerToUse;
         
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");    
@@ -674,7 +675,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -724,9 +725,9 @@ namespace UnitTests.Grains
     {
         private ILogger _logger;
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");
 
@@ -745,10 +746,10 @@ namespace UnitTests.Grains
             }
         }
 
-        public override async Task OnDeactivateAsync()
+        public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
-            await base.OnDeactivateAsync();
+            await base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public override async Task BecomeConsumer(Guid streamId, string providerToUse, string streamNamespace)
@@ -772,11 +773,11 @@ namespace UnitTests.Grains
     {
         private ILogger _logger;
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_Reentrant_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId) ;
             _logger.Info("OnActivateAsync");
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
         }
     }
 
@@ -787,13 +788,13 @@ namespace UnitTests.Grains
         private ConsumerObserver _consumer;
         private string _providerToUseForConsumer;
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");
             return Task.CompletedTask;
         }
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;
@@ -897,7 +898,7 @@ namespace UnitTests.Grains
         private ILogger _logger;
         private Dictionary<string, IConsumerObserver> _observers;
         
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ImplicitConsumerGrain1 " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("{0}.OnActivateAsync", GetType().FullName);    
@@ -911,7 +912,7 @@ namespace UnitTests.Grains
             await Task.WhenAll(activeStreamProviders.Select(stream => BecomeConsumer(this.GetPrimaryKey(), stream, "TestNamespace1")));
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             _logger.Info("OnDeactivateAsync");
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/StressTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StressTestGrain.cs
@@ -9,6 +9,7 @@ using UnitTests.GrainInterfaces;
 using Orleans.Runtime.Configuration;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
+using System.Threading;
 
 namespace UnitTests.Grains
 {
@@ -23,7 +24,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (this.GetPrimaryKeyLong() == -2)
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
@@ -120,7 +121,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.label = this.GetPrimaryKeyLong().ToString();
             this.logger.Info("OnActivateAsync");
@@ -277,7 +278,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.label = this.GetPrimaryKeyLong().ToString();
             this.logger.Info("OnActivateAsync");

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,7 +24,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             if (this.GetPrimaryKeyLong() == -2)
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
@@ -31,13 +32,13 @@ namespace UnitTests.Grains
             label = this.GetPrimaryKeyLong().ToString();
             logger.Info("OnActivateAsync");
 
-            return base.OnActivateAsync();
+            return base.OnActivateAsync(cancellationToken);
         }
 
-        public override Task OnDeactivateAsync()
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             logger.Info("!!! OnDeactivateAsync");
-            return base.OnDeactivateAsync();
+            return base.OnDeactivateAsync(reason, cancellationToken);
         }
 
         public Task<long> GetKey()
@@ -67,7 +68,7 @@ namespace UnitTests.Grains
         {
             logger.Info("StartTimer.");
             timer = base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
-            
+
             return Task.CompletedTask;
         }
 
@@ -141,14 +142,14 @@ namespace UnitTests.Grains
         {
         }
 
-        public override async Task OnActivateAsync()
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             await Task.Delay(TimeSpan.FromSeconds(3));
 
             if (this.GetPrimaryKeyLong() == -2)
                 throw new ArgumentException("Primary key cannot be -2 for this test case");
 
-            await base.OnActivateAsync();
+            await base.OnActivateAsync(cancellationToken);
         }
 
         public Task<long> GetKey()
@@ -169,7 +170,7 @@ namespace UnitTests.Grains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             //if (this.GetPrimaryKeyLong() == -2)
             //    throw new ArgumentException("Primary key cannot be -2 for this test case");

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTestGrains
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             ThrowIfDeactivating();
             context = RuntimeContext.Current;
@@ -148,7 +148,7 @@ namespace UnitTestGrains
         public Task<int> GetTickCount() { return Task.FromResult(tickCount); }
         public Task<Exception> GetException() { return Task.FromResult(tickException); }
 
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             context = RuntimeContext.Current;
             activationTaskScheduler = TaskScheduler.Current;

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -693,7 +693,7 @@ namespace UnitTests.SchedulerTests
             };
             var grain = new NonReentrentStressGrainWithoutState();
 
-            await Task.Factory.StartNew(() => grain.OnActivateAsync(), CancellationToken.None, TaskCreationOptions.None, scheduler).Unwrap();
+            await Task.Factory.StartNew(() => grain.OnActivateAsync(CancellationToken.None), CancellationToken.None, TaskCreationOptions.None, scheduler).Unwrap();
 
             Task wrapped = null;
             var wrapperDone = new TaskCompletionSource<bool>();

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 using Orleans.TestingHost.Utils;
 using Orleans.Internal;
 using System.Collections.Generic;
+using Orleans;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -39,10 +40,8 @@ namespace UnitTests.SchedulerTests
 
         public PlacementStrategy PlacementStrategy => throw new NotImplementedException();
 
-        IAddressable IGrainContext.GrainInstance => throw new NotImplementedException();
-
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = default) => throw new NotImplementedException();
-        public void Deactivate(CancellationToken? cancellationToken = default) { }
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = default) { }
         public Task Deactivated => Task.CompletedTask;
         public void Dispose() => (Scheduler as IDisposable)?.Dispose();
         public TComponent GetComponent<TComponent>() => throw new NotImplementedException();

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
@@ -4,6 +4,7 @@ using Orleans.Runtime;
 using Orleans.Streams;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tester.StreamingTests
@@ -28,7 +29,7 @@ namespace Tester.StreamingTests
         private static readonly DateTime UnAssignedLeaseTime = DateTime.MinValue;
         private Dictionary<QueueId, DateTime> queueLeaseToRenewTimeMap;
         private ISiloStatusOracle siloStatusOracle;
-        public override Task OnActivateAsync()
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             this.siloStatusOracle = base.ServiceProvider.GetRequiredService<ISiloStatusOracle>();
             this.queueLeaseToRenewTimeMap = new Dictionary<QueueId, DateTime>();


### PR DESCRIPTION
Replaces #7261
Fixes #6384
Fixes #7324

Exposes the reason for a grain being deactivated to the developer via an optional overload on the grain implementation.
It also adds an overload of `OnActivateAsync` which accepts a `CancellationToken`.

``` C#
public interface IGrainBase
{
    IGrainContext GrainContext { get; }
    Task OnActivateAsync(CancellationToken token) => default;
    Task OnDeactivateAsync(DeactivationReason reason, CancellationToken token) => default;
}
```

`DeactivationReason` contains 3 properties:
* `Exception`, which is usually null since most exceptions which would cause deactivation happen during activation but `OnDeactivateAsync` is only called if activation was successful. It is provided in the case of `InconsistentStateException`.
* `ReasonCode`, an enum with values `None`, `ShuttingDown`, `ActivationFailed`, `InternalFailure`, `ActivationIdle`, `ActivationUnresponsive`, `DuplicateActivation`, `ApplicationError`, `ApplicationRequested` (for explicit `DeactivateOnIdle` calls))
* `Description`, a textual description

The methods were added on a new interface, `IGrainBase` in preparation for POCO grains (#7360). `Grain` implements `IGrainBase`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7503)