### PR TITLE
Add a catch block in Azure DeleteQueueMessage for 404 error (#7461)

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -308,6 +308,13 @@ namespace Orleans.AzureUtils
                 await client.DeleteMessageAsync(message.MessageId, message.PopReceipt);
 
             }
+            catch (RequestFailedException exc)
+            {
+                if (exc.Status != (int)HttpStatusCode.NotFound)
+                {
+                    ReportErrorAndRethrow(exc, "DeleteMessage", AzureQueueErrorCode.AzureQueue_11);
+                }
+            }
             catch (Exception exc)
             {
                 ReportErrorAndRethrow(exc, "DeleteMessage", AzureQueueErrorCode.AzureQueue_11);


### PR DESCRIPTION
Addresses unhandled intermittent 404 failure in DeleteQueueMessage as described in https://github.com/dotnet/orleans/issues/7461#issue-1093743910.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7508)