### PR TITLE
Upgrade to .NET 6.0.101 SDK, add .NET 6.0 target, fix packaging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,12 +14,21 @@
     <PackageIcon>logo_128.png</PackageIcon>
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/dotnet/Orleans</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/orleans</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-    <LangVersion>9.0</LangVersion>
+    <PrivateRepositoryUrl>$(RepositoryUrl)</PrivateRepositoryUrl>
+    <LangVersion>latest</LangVersion>
     <Features>strict</Features>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
+    <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSource>false</IncludeSource>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,7 +39,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);1591;2003</NoWarn>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <!-- FSharp SDK overrides -->
@@ -42,84 +50,95 @@
   <!-- Shared Package Versions -->
   <PropertyGroup>
     <!-- System packages -->
-    <SystemDiagnosticsPerformanceCounterVersion>5.0.0</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>6.0.0</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>6.0.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemNetNameResolutionVersion>4.3.0</SystemNetNameResolutionVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.6</MicrosoftDotNetPlatformAbstractionsVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
-    <SystemIoPipelinesVersion>5.0.0</SystemIoPipelinesVersion>
+    <SystemIoPipelinesVersion>6.0.1</SystemIoPipelinesVersion>
     <SystemMemoryData>1.0.1</SystemMemoryData>
 
     <!-- Microsoft packages -->
-    <MicrosoftBuildVersion>16.9.0</MicrosoftBuildVersion>
-    <MicrosoftCodeAnalysisVersion>3.9.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftBuildVersion>17.0.0</MicrosoftBuildVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
 
-    <MicrosoftAspNetCoreConnectionsAbstractionsVersion>5.0.2</MicrosoftAspNetCoreConnectionsAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>5.0.0</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>5.0.0</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyModelVersion>5.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsLoggingVersion>5.0.0</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsObjectPoolVersion>5.0.2</MicrosoftExtensionsObjectPoolVersion>
-    <MicrosoftExtensionsOptionsVersion>5.0.0</MicrosoftExtensionsOptionsVersion>
-    <MicrosoftExtensionsHttpVersion>5.0.0</MicrosoftExtensionsHttpVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>5.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
-    <MicrosoftExtensionsHostingVersion>5.0.0</MicrosoftExtensionsHostingVersion>
+    <MicrosoftAspNetCoreConnectionsAbstractionsVersion>6.0.1</MicrosoftAspNetCoreConnectionsAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>6.0.0</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsObjectPoolVersion>6.0.1</MicrosoftExtensionsObjectPoolVersion>
+    <MicrosoftExtensionsOptionsVersion>6.0.0</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsHttpVersion>6.0.0</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>6.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsHostingVersion>6.0.0</MicrosoftExtensionsHostingVersion>
 
-    <MicrosoftApplicationInsightsVersion>2.16.0</MicrosoftApplicationInsightsVersion>
-    <AzureDataTablesVersion>12.2.0</AzureDataTablesVersion>
-    <AzureCoreVersion>1.19.0</AzureCoreVersion>
-    <AzureMessagingEventHubs>5.6.1</AzureMessagingEventHubs>
+    <MicrosoftApplicationInsightsVersion>2.20.0</MicrosoftApplicationInsightsVersion>
+    <AzureDataTablesVersion>12.4.0</AzureDataTablesVersion>
+    <AzureCoreVersion>1.22.0</AzureCoreVersion>
+    <AzureMessagingEventHubs>5.6.2</AzureMessagingEventHubs>
     <AzureStorageBlobsVersion>12.10.0</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.8.0</AzureStorageQueuesVersion>
     <MicrosoftServiceFabricServicesVersion>4.1.456</MicrosoftServiceFabricServicesVersion>
 
     <!-- 3rd party packages -->
-    <AWSSDKDynamoDBv2Version>3.3.102.2</AWSSDKDynamoDBv2Version>
-    <AWSSDKSQSVersion>3.3.2.7</AWSSDKSQSVersion>
+    <AWSSDKDynamoDBv2Version>3.7.2.12</AWSSDKDynamoDBv2Version>
+    <AWSSDKSQSVersion>3.7.2.14</AWSSDKSQSVersion>
     <BondCoreCSharpVersion>5.3.1</BondCoreCSharpVersion>
-    <ConsulVersion>0.7.2.3</ConsulVersion>
+    <ConsulVersion>1.6.10.4</ConsulVersion>
     <GoogleCloudPubSubV1Version>1.0.0-beta13</GoogleCloudPubSubV1Version>
-    <GoogleProtobufVersion>3.4.0</GoogleProtobufVersion>
-    <ProtobufNetVersion>3.0.73</ProtobufNetVersion>
-    <NewRelicAgentApiVersion>8.0.0.0</NewRelicAgentApiVersion>
+    <GoogleProtobufVersion>3.19.3</GoogleProtobufVersion>
+    <ProtobufNetVersion>3.0.101</ProtobufNetVersion>
+    <NewRelicAgentApiVersion>9.4.0</NewRelicAgentApiVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <ZooKeeperNetExVersion>3.4.12.4</ZooKeeperNetExVersion>
-    <StackExchangeRedisVersion>2.0.601</StackExchangeRedisVersion>
-    <KubernetesClientVersion>6.0.19</KubernetesClientVersion>
+    <StackExchangeRedisVersion>2.2.88</StackExchangeRedisVersion>
+    <KubernetesClientVersion>7.0.7</KubernetesClientVersion>
 
     <!-- Test related packages -->
-    <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
+    <FluentAssertionsVersion>6.4.0</FluentAssertionsVersion>
     <MoqVersion>4.16.0</MoqVersion>
-    <MicrosoftTestSdkVersion>16.9.4</MicrosoftTestSdkVersion>
-    <BenchmarkDotNetVersion>0.12.1</BenchmarkDotNetVersion>
+    <MicrosoftTestSdkVersion>17.0.0</MicrosoftTestSdkVersion>
+    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
     <XunitSkippableFactVersion>1.4.13</XunitSkippableFactVersion>
     <xUnitVersion>2.4.1</xUnitVersion>
-    <NodaTimeVersion>3.0.5</NodaTimeVersion>
-    <AutofacExtensionsDependencyInjectionVersion>7.1.0</AutofacExtensionsDependencyInjectionVersion>
+    <xUnitRunnerVersion>2.4.3</xUnitRunnerVersion>
+    <NodaTimeVersion>3.0.9</NodaTimeVersion>
+    <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
     <StructureMapMicrosoftDependencyInjectionVersion>2.0.0</StructureMapMicrosoftDependencyInjectionVersion>
-    <SystemCodeDomVersion>5.0.0</SystemCodeDomVersion>
-    <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesVersion>
-    <AzureIdentityVersion>1.3.0</AzureIdentityVersion>
+    <SystemCodeDomVersion>6.0.0</SystemCodeDomVersion>
+    <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesVersion>
+    <AzureIdentityVersion>1.5.0</AzureIdentityVersion>
     <AzureKeyVaultVersion>4.2.0</AzureKeyVaultVersion>
-    <FSharpCoreVersion>4.7.0</FSharpCoreVersion>
-    <NSubstituteVersion>4.2.2</NSubstituteVersion>
-    <NSubstituteAnalyzersCSharpVersion>1.0.14</NSubstituteAnalyzersCSharpVersion>
+    <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
+    <NSubstituteVersion>4.3.0</NSubstituteVersion>
+    <NSubstituteAnalyzersCSharpVersion>1.0.15</NSubstituteAnalyzersCSharpVersion>
     <CoverletVersion>3.0.3</CoverletVersion>
-    <CsCheckVersion>1.1.3</CsCheckVersion>
+    <CsCheckVersion>2.4.2</CsCheckVersion>
     <DotnetReportGeneratorCliVersion>4.3.0</DotnetReportGeneratorCliVersion>
+    <SystemDataSqlClientVersion>4.8.3</SystemDataSqlClientVersion>
+    <NpgsqlVersion>6.0.2</NpgsqlVersion>
+    <MySqlDataVersion>8.0.28</MySqlDataVersion>
+    <MicrosoftExtensionsConfigurationAzureKeyVaultVersion>3.1.22</MicrosoftExtensionsConfigurationAzureKeyVaultVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21308.1</SystemCommandLineVersion>
     <CrankVersion>0.2.0-alpha.21457.1</CrankVersion>
+    <MessagePackVersion>2.3.85</MessagePackVersion>
+    <ZeroFormatterVersion>1.6.4</ZeroFormatterVersion>
+    <Utf8JsonVersion>1.3.7</Utf8JsonVersion>
+    <SpanJsonVersion>3.2.0</SpanJsonVersion>
+    <HyperionVersion>0.12.0</HyperionVersion>
+    <GrpcToolsVersion>2.43.0</GrpcToolsVersion>
 
     <!-- Tooling related packages -->
-    <SourceLinkVersion>2.8.3</SourceLinkVersion>
+    <SourceLinkVersion>1.1.1</SourceLinkVersion>
   </PropertyGroup>
 
   <!-- Versioning properties -->
   <PropertyGroup>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">3.0.0</VersionPrefix>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">4.0.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,8 +13,8 @@
   <PropertyGroup Condition=" '$(OrleansBuildTimeCodeGen)' == 'msbuild' ">
     <DotNetHost Condition="'$(DotNetHost)' == ''">dotnet</DotNetHost>
     <Asm>Orleans.CodeGenerator.MSBuild.Bootstrap</Asm>
-    <OrleansCodeGenCoreAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net5.0/$(Asm).dll</OrleansCodeGenCoreAssembly>
-    <OrleansCodeGenTasksAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net5.0/Orleans.CodeGenerator.MSBuild.Tasks.dll</OrleansCodeGenTasksAssembly>
+    <OrleansCodeGenCoreAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net6.0/$(Asm).dll</OrleansCodeGenCoreAssembly>
+    <OrleansCodeGenTasksAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net6.0/Orleans.CodeGenerator.MSBuild.Tasks.dll</OrleansCodeGenTasksAssembly>
     <OrleansBootstrapBuildProject>$(MSBuildThisFileDirectory)src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj</OrleansBootstrapBuildProject>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
       <Project>{CB36EF45-6E90-443F-AEE4-394677068147}</Project>
       <Name>Orleans.CodeGenerator.MSBuild.Bootstrap</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <AssetTargetFallback>net5.0</AssetTargetFallback>
+      <AssetTargetFallback>net6.0</AssetTargetFallback>
       <Visible>false</Visible>
       <!-- Workaround. See: https://github.com/dotnet/sdk/issues/939#issuecomment-284641613 -->
       <!-- This causes the 'Dependency' node in VS to show a warning icon. See https://github.com/dotnet/project-system/issues/2928 -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "feature",
-    "version": "5.0.400"
+    "version": "6.0.101"
   }
 }

--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build;PostBuildPublish">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,8 +6,8 @@
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
   <PropertyGroup>
-    <StandardTargetFrameworks>netcoreapp3.1;net5.0</StandardTargetFrameworks>
-    <MultiTargetFrameworks>netcoreapp3.1;net5.0</MultiTargetFrameworks>
+    <StandardTargetFrameworks>netcoreapp3.1;net5.0;net6.0</StandardTargetFrameworks>
+    <MultiTargetFrameworks>netcoreapp3.1;net5.0;net6.0</MultiTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,6 +6,7 @@
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
 
   <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and '$(IncludeBuildOutput)'=='true'">
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="$(SourceLinkVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(SourceLinkVersion)" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Orleans.Analyzers
         private const string AlwaysInterleaveAttributeName = "Orleans.Concurrency.AlwaysInterleaveAttribute";
 
         public const string DiagnosticId = "ORLEANS0001";
-        public const string Title = "[AlwaysInterleave] must only be used on the grain interface method and not the grain class method.";
+        public const string Title = "[AlwaysInterleave] must only be used on the grain interface method and not the grain class method";
         public const string MessageFormat = Title;
         public const string Category = "Usage";
 

--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <PackageDescription>Code generator for projects using Orleans.Serialization with MSBuild</PackageDescription>
     <OutputType>Exe</OutputType>

--- a/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -18,7 +18,7 @@
 
     <!-- Specify the assembly containing the code generator. -->
     <Orleans_GeneratorAssembly Condition="'$(OrleansCodeGenCoreAssembly)' != ''">$(OrleansCodeGenCoreAssembly)</Orleans_GeneratorAssembly>
-    <Orleans_GeneratorAssembly Condition="'$(Orleans_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net5.0\Orleans.CodeGenerator.MSBuild.dll</Orleans_GeneratorAssembly>
+    <Orleans_GeneratorAssembly Condition="'$(Orleans_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net6.0\Orleans.CodeGenerator.MSBuild.dll</Orleans_GeneratorAssembly>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
@@ -163,6 +163,7 @@ namespace Orleans.Connections.Security
             return _reader.CopyToAsync(destination, cancellationToken);
         }
 
+#if !NET6_0_OR_GREATER
         private static void ValidateBufferArguments(byte[] buffer, int offset, int size)
         {
             if (buffer == null)
@@ -178,6 +179,7 @@ namespace Orleans.Connections.Security
                 throw new ArgumentOutOfRangeException(nameof(size));
             }
         }
+#endif
 
         /// <summary>
         /// Provides support for efficiently using Tasks to implement the APM (Begin/End) pattern.

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -416,7 +416,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             string result;
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             if (reader.TryReadBytes(length, out var span))
             {
                 result = Encoding.UTF8.GetString(span);
@@ -440,7 +440,7 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             var numBytes = Encoding.UTF8.GetByteCount(value);
             writer.WriteVarInt32(numBytes);
             if (numBytes < 512)
@@ -502,7 +502,7 @@ namespace Orleans.Runtime.Messaging
             {
                 return null;
             }
-#if NET5_0
+#if NET5_0_OR_GREATER
             if (reader.TryReadBytes(length, out var bytes))
             {
                 ip = new IPAddress(bytes);
@@ -512,7 +512,7 @@ namespace Orleans.Runtime.Messaging
 #endif
                 var addressBytes = reader.ReadBytes((uint)length);
                 ip = new IPAddress(addressBytes);
-#if NET5_0
+#if NET5_0_OR_GREATER
             }
 #endif
             var port = (int)reader.ReadVarUInt32();
@@ -530,7 +530,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             var ep = value.Endpoint;
-#if NET5_0
+#if NET5_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[64];
             if (ep.Address.TryWriteBytes(buffer, out var length))
             {

--- a/src/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -160,10 +160,10 @@ return 0
 
         #region Logging
         private void LogConnectionRestored(object sender, ConnectionFailedEventArgs e)
-            => this.logger.LogInformation(e.Exception, "Connection to {EndPoint) failed: {FailureType}", e.EndPoint, e.FailureType);
+            => this.logger.LogInformation(e.Exception, "Connection to {EndPoint} failed: {FailureType}", e.EndPoint, e.FailureType);
 
         private void LogConnectionFailed(object sender, ConnectionFailedEventArgs e)
-            => this.logger.LogError(e.Exception, "Connection to {EndPoint) failed: {FailureType}", e.EndPoint, e.FailureType);
+            => this.logger.LogError(e.Exception, "Connection to {EndPoint} failed: {FailureType}", e.EndPoint, e.FailureType);
 
         private void LogErrorMessage(object sender, RedisErrorEventArgs e)
             => this.logger.LogError(e.Message);

--- a/src/Orleans.Serialization.Abstractions/Orleans.Serialization.Abstractions.csproj
+++ b/src/Orleans.Serialization.Abstractions/Orleans.Serialization.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization.Abstractions</PackageId>
     <Title>Microsoft Orleans Serialization Abstractions</Title>
-    <Description>Serialization abstractions library of Microsoft Orleans</Description>
+    <Description>Serialization abstractions for Microsoft Orleans</Description>
     <TargetFrameworks>$(MultiTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Orleans</RootNamespace>

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -2,13 +2,13 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.IO;
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
 using System.Numerics;
 #endif
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Orleans.Serialization.Session;
-#if !NETCOREAPP
+#if !NETCOREAPP3_1_OR_GREATER
 using Orleans.Serialization.Utilities;
 #endif
 
@@ -59,7 +59,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override void ReadBytes(in Span<byte> destination)
         {
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             var count = _stream.Read(destination);
             if (count < destination.Length)
             {
@@ -97,12 +97,12 @@ namespace Orleans.Serialization.Buffers
             }
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [SkipLocalsInit]
 #endif
         public override uint ReadUInt32()
         {
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             Span<byte> buffer = stackalloc byte[sizeof(uint)];
             ReadBytes(buffer);
             return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
@@ -113,12 +113,12 @@ namespace Orleans.Serialization.Buffers
 #endif
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [SkipLocalsInit]
 #endif
         public override ulong ReadUInt64()
         {
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             Span<byte> buffer = stackalloc byte[sizeof(ulong)];
             ReadBytes(buffer);
             return BinaryPrimitives.ReadUInt64LittleEndian(buffer);

--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.IO;
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
 using System.Numerics;
 #else
 using Orleans.Serialization.Utilities;

--- a/src/Orleans.Serialization/Codecs/FloatCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FloatCodec.cs
@@ -57,7 +57,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
         public static float ReadFloatRaw<TInput>(ref Reader<TInput> reader) => BitConverter.Int32BitsToSingle(reader.ReadInt32());
 #else
         public static float ReadFloatRaw<TInput>(ref Reader<TInput> reader) => BitConverter.ToSingle(BitConverter.GetBytes(reader.ReadInt32()), 0);
@@ -117,7 +117,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
         public static double ReadDoubleRaw<TInput>(ref Reader<TInput> reader) => BitConverter.Int64BitsToDouble(reader.ReadInt64());
 #else
         public static double ReadDoubleRaw<TInput>(ref Reader<TInput> reader) => BitConverter.ToDouble(BitConverter.GetBytes(reader.ReadInt64()), 0);

--- a/src/Orleans.Serialization/Codecs/GuidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GuidCodec.cs
@@ -19,7 +19,7 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Guid), WireType.LengthPrefixed);
             writer.WriteVarUInt32(Width);
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             writer.EnsureContiguous(Width);
             if (value.TryWriteBytes(writer.WritableSpan))
             {
@@ -47,7 +47,7 @@ namespace Orleans.Serialization.Codecs
                 throw new UnexpectedLengthPrefixValueException(nameof(Guid), Width, length);
             }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             if (reader.TryReadBytes(Width, out var readOnly))
             {
                 return new Guid(readOnly);

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -22,7 +22,7 @@ namespace Orleans.Serialization.Codecs
 
             var length = reader.ReadVarUInt32();
             IPAddress result;
-#if NET5_0
+#if NET5_0_OR_GREATER
             if (reader.TryReadBytes((int)length, out var bytes))
             {
                 result = new IPAddress(bytes);
@@ -32,7 +32,7 @@ namespace Orleans.Serialization.Codecs
 #endif
                 var addressBytes = reader.ReadBytes(length);
                 result = new IPAddress(addressBytes);
-#if NET5_0
+#if NET5_0_OR_GREATER
             }
 #endif
 
@@ -53,7 +53,7 @@ namespace Orleans.Serialization.Codecs
             }
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
-#if NET5_0
+#if NET5_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[64];
             if (value.TryWriteBytes(buffer, out var length))
             {

--- a/src/Orleans.Serialization/Codecs/StringCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StringCodec.cs
@@ -31,7 +31,7 @@ namespace Orleans.Serialization.Codecs
             var length = reader.ReadVarUInt32();
 
             string result;
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             if (reader.TryReadBytes((int) length, out var span))
             {
                 result = Encoding.UTF8.GetString(span);
@@ -58,7 +58,7 @@ namespace Orleans.Serialization.Codecs
             }
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             var numBytes = Encoding.UTF8.GetByteCount(value);
             writer.WriteVarUInt32((uint)numBytes);
             if (numBytes < 512)

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -20,7 +20,7 @@ namespace Orleans.Serialization
 
             AddFromDependencyContext(parts);
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             AddFromAssemblyLoadContext(parts);
 #endif
 
@@ -58,7 +58,7 @@ namespace Orleans.Serialization
             }
         }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
         public static void AddFromAssemblyLoadContext(HashSet<Assembly> parts, AssemblyLoadContext context)
         {
             if (context is null)
@@ -115,7 +115,7 @@ namespace Orleans.Serialization
                 return;
             }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             var assemblyContext = assembly is not null
                 ? AssemblyLoadContext.GetLoadContext(assembly) ?? AssemblyLoadContext.Default
                 : AssemblyLoadContext.Default;
@@ -130,7 +130,7 @@ namespace Orleans.Serialization
 
                 try
                 {
-#if NET5_0
+#if NET5_0_OR_GREATER
                     var name = lib.GetRuntimeAssemblyNames(dependencyContext, System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier).FirstOrDefault();
                     if (name is null)
                     {
@@ -145,7 +145,7 @@ namespace Orleans.Serialization
                         continue;
                     }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
                     var asm = assemblyContext.LoadFromAssemblyName(name);
 #else
                     var asm = Assembly.Load(name);

--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -126,7 +126,7 @@ namespace Orleans.Serialization.Invocation
         private void SetInvalidCastException(object result)
         {
             var exception = new InvalidCastException($"Cannot cast object of type {result.GetType()} to {typeof(TResult)}");
-#if NET5_0
+#if NET5_0_OR_GREATER
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.SetCurrentStackTrace(exception);
             SetException(exception);
 #else

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -153,7 +153,7 @@ namespace Orleans.Serialization.TypeSystem
                 // The generic arity is additive, so that a generic class nested in a generic class has an arity
                 // equal to the sum of specified arity values. For example, "C`1+N`2" has an arity of 3.
                 var aritySlice = s.Input.Slice(genericArityStart, s.Index - genericArityStart);
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
                 var arity = int.Parse(aritySlice);
 #else
                 var arity = int.Parse(aritySlice.ToString());

--- a/src/Orleans.Serialization/Utilities/BitOperations.cs
+++ b/src/Orleans.Serialization/Utilities/BitOperations.cs
@@ -1,6 +1,6 @@
 namespace Orleans.Serialization.Utilities
 {
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
 #else
     /// <summary>
     /// BitOperations polyfill.

--- a/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
@@ -1,5 +1,5 @@
 using System.Buffers;
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
 using System.Numerics;
 #endif
 using System.Runtime.CompilerServices;

--- a/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKitBase/Consistency/ConsistencyTestHarness.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using Orleans.TestingHost;
 using System;
 using System.Collections.Generic;
@@ -93,7 +93,7 @@ namespace Orleans.Transactions.TestKit.Consistency
 
                         foreach (var tuple in result)
                         {
-                            tuple.ExecutingTx.ShouldBeEquivalentTo(id); // all effects of this transaction must have same id
+                            tuple.ExecutingTx.Should().BeEquivalentTo(id); // all effects of this transaction must have same id
                             lock (tuples)
                             {
                                 if (!tuples.TryGetValue(tuple.Grain, out var versions))

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/ConsistencyTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/ConsistencyTransactionTestRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Orleans.Transactions.TestKit.Consistency;
@@ -43,7 +43,7 @@ namespace Orleans.Transactions.TestKit
                 && avoidDeadlocks
                 && (readwrite == ReadWriteDetermination.PerGrain || readwrite == ReadWriteDetermination.PerTransaction))
             {
-                harness.NumAborted.ShouldBeEquivalentTo(0);
+                harness.NumAborted.Should().Be(0);
             }
 
             // then, analyze the history results

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -19,10 +19,10 @@ namespace Orleans.Transactions.TestKit
             IFaultInjectionTransactionTestGrain grain = grainFactory.GetGrain<IFaultInjectionTransactionTestGrain>(Guid.NewGuid());
             await grain.Set(expected);
             int actual = await grain.Get();
-            actual.ShouldBeEquivalentTo(expected);
+            actual.Should().Be(expected);
             await grain.Deactivate();
             actual = await grain.Get();
-            actual.ShouldBeEquivalentTo(expected);
+            actual.Should().Be(expected);
         }
         
         public virtual async Task SingleGrainWriteTransaction()
@@ -34,7 +34,7 @@ namespace Orleans.Transactions.TestKit
             await grain.Deactivate();
             int expected = original + delta;
             int actual = await grain.Get();
-            actual.ShouldBeEquivalentTo(expected);
+            actual.Should().Be(expected);
         }
 
         public virtual async Task MultiGrainWriteTransaction_FaultInjection(TransactionFaultInjectPhase injectionPhase, FaultInjectionType injectionType)
@@ -85,7 +85,7 @@ namespace Orleans.Transactions.TestKit
                     {
                         this.testOutput($"Retry failed with OrleansCascadingAbortException: {e}, retrying without fault");
                         // should only encounter this when faulting after storage write
-                        injectionType.ShouldBeEquivalentTo(FaultInjectionType.ExceptionAfterStore);
+                        injectionType.Should().Be(FaultInjectionType.ExceptionAfterStore);
                         // only allow one retry
                         firstAttempt.Should().BeTrue();
                         // add delay prevent castcading abort.
@@ -99,7 +99,7 @@ namespace Orleans.Transactions.TestKit
             foreach (var grain in grains)
             {
                 int actual = await grain.Get();
-                actual.ShouldBeEquivalentTo(expected);
+                actual.Should().Be(expected);
             }
         }
     }

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/DisabledTransactionsTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/DisabledTransactionsTestRunner.cs
@@ -16,7 +16,7 @@ namespace Orleans.Transactions.TestKit
             const int delta = 5;
             ITransactionTestGrain grain = RandomTestGrain(transactionTestGrainClassName);
             Func<Task> task = ()=>grain.Set(delta);
-            var response = task.ShouldThrow<OrleansTransactionsDisabledException>();
+            var response = task.Should().ThrowAsync<OrleansTransactionsDisabledException>();
         }
 
         public virtual void MultiTransactionGrainsThrowWhenTransactions(string transactionTestGrainClassName)
@@ -31,7 +31,7 @@ namespace Orleans.Transactions.TestKit
             ITransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
 
             Func<Task> task = () => coordinator.MultiGrainSet(grains, delta);
-            var response = task.ShouldThrow<OrleansTransactionsDisabledException>();
+            var response = task.Should().ThrowAsync<OrleansTransactionsDisabledException>();
         }
     }
 }

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/GoldenPathTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/GoldenPathTransactionTestRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,7 +20,7 @@ namespace Orleans.Transactions.TestKit
             //each transaction state should all be 0 since no operation was applied yet
             foreach (var actual in actualResults)
             {
-                actual.ShouldBeEquivalentTo(expected);
+                actual.Should().Be(expected);
             }
         }
 
@@ -32,7 +32,7 @@ namespace Orleans.Transactions.TestKit
             await grain.Add(delta);
             var expected = original.Select(value => value + delta).ToArray();
             var actual = await grain.Get();
-            actual.ShouldBeEquivalentTo(expected);
+            actual.Should().BeEquivalentTo(expected);
         }
 
         public virtual async Task MultiGrainWriteTransaction(string grainStates, int grainCount)
@@ -53,7 +53,7 @@ namespace Orleans.Transactions.TestKit
                 var actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
         }
@@ -79,7 +79,7 @@ namespace Orleans.Transactions.TestKit
                 foreach (var actual in actualValues)
                 {
                     if (expected != actual) this.testOutput($"{grain} - failed");
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
         }
@@ -111,7 +111,7 @@ namespace Orleans.Transactions.TestKit
                     foreach (var actual in actualValues)
                     {
                         if (expected != actual) this.testOutput($"{grain} - failed");
-                        actual.ShouldBeEquivalentTo(expected);
+                        actual.Should().Be(expected);
                     }
                 }
             }
@@ -133,7 +133,7 @@ namespace Orleans.Transactions.TestKit
             int[] actualValues = await grains[0].Get();
             foreach (var actual in actualValues)
             {
-                actual.ShouldBeEquivalentTo(expected);
+                actual.Should().Be(expected);
             }
         }
 
@@ -157,7 +157,7 @@ namespace Orleans.Transactions.TestKit
                 foreach (var actual in actualValues)
                 {
                     if (expected != actual) this.testOutput($"{grain} - failed");
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
         }
@@ -182,7 +182,7 @@ namespace Orleans.Transactions.TestKit
                 foreach (var actual in actualValues)
                 {
                     if (expected != actual) this.testOutput($"{grain} - failed");
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
         }

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/GrainFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/GrainFaultTransactionTestRunner.cs
@@ -21,14 +21,14 @@ namespace Orleans.Transactions.TestKit
 
             await coordinator.MultiGrainSet(new List<ITransactionTestGrain> { grain }, expected);
             Func<Task> task = () => coordinator.AddAndThrow(grain, expected);
-            task.ShouldThrow<OrleansTransactionAbortedException>();
+            await task.Should().ThrowAsync<OrleansTransactionAbortedException>();
 
             await TestAfterDustSettles(async () =>
             {
                 int[] actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             });
         }
@@ -51,7 +51,7 @@ namespace Orleans.Transactions.TestKit
             {
                 throwGrain
             }, grains, expected);
-            task.ShouldThrow<OrleansTransactionAbortedException>();
+            await task.Should().ThrowAsync<OrleansTransactionAbortedException>();
             grains.Add(throwGrain);
 
             await TestAfterDustSettles(async () =>
@@ -61,7 +61,7 @@ namespace Orleans.Transactions.TestKit
                     int[] actualValues = await grain.Get();
                     foreach (var actual in actualValues)
                     {
-                        actual.ShouldBeEquivalentTo(expected);
+                        actual.Should().Be(expected);
                     }
                 }
             });
@@ -99,7 +99,7 @@ namespace Orleans.Transactions.TestKit
             }
 
             Func<Task> task = () => InnerExceptionCheck();
-            task.ShouldThrow<OrleansTransactionAbortedException>();
+            await task.Should().ThrowAsync<OrleansTransactionAbortedException>();
 
             grains.AddRange(throwGrains);
 
@@ -110,7 +110,7 @@ namespace Orleans.Transactions.TestKit
                     int[] actualValues = await grain.Get();
                     foreach (var actual in actualValues)
                     {
-                        actual.ShouldBeEquivalentTo(expected);
+                        actual.Should().Be(expected);
                     }
                 }
             });
@@ -125,7 +125,7 @@ namespace Orleans.Transactions.TestKit
 
             await grain.Set(expected);
             Func<Task> task = () => coordinator.OrphanCallTransaction(grain);
-            task.ShouldThrow<OrleansOrphanCallException>();
+            await task.Should().ThrowAsync<OrleansOrphanCallException>();
 
             //await Task.Delay(20000); // give time for GC
 
@@ -134,7 +134,7 @@ namespace Orleans.Transactions.TestKit
                 int[] actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             });
         }

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/TOCGoldenPathTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/TOCGoldenPathTestRunner.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +30,7 @@ namespace Orleans.Transactions.TestKit
                 var actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
 

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/TocFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/TocFaultTransactionTestRunner.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,14 +27,14 @@ namespace Orleans.Transactions.TestKit
             await coordinator.MultiGrainAdd(committer, new PassOperation("pass"), grains, expected);
 
             Func<Task> task = () => coordinator.MultiGrainAdd(committer, new FailOperation("fail"), grains, expected);
-            task.ShouldThrow<OrleansTransactionAbortedException>();
+            await task.Should().ThrowAsync<OrleansTransactionAbortedException>();
 
             foreach (var grain in grains)
             {
                 var actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
 
@@ -56,14 +56,14 @@ namespace Orleans.Transactions.TestKit
             await coordinator.MultiGrainAdd(committer, new PassOperation("pass"), grains, expected);
 
             Func<Task> task = () => coordinator.MultiGrainAdd(committer, new ThrowOperation("throw"), grains, expected);
-            task.ShouldThrow<OrleansTransactionInDoubtException>();
+            await task.Should().ThrowAsync<OrleansTransactionInDoubtException>();
 
             foreach (var grain in grains)
             {
                 var actualValues = await grain.Get();
                 foreach (var actual in actualValues)
                 {
-                    actual.ShouldBeEquivalentTo(expected);
+                    actual.Should().Be(expected);
                 }
             }
 

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionConcurrencyTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionConcurrencyTestRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -33,11 +33,11 @@ namespace Orleans.Transactions.TestKit
                 coordinator2.MultiGrainAdd(transaction2Members, expected));
 
             int[] actual = await grain1.Get();
-            expected.ShouldBeEquivalentTo(actual.FirstOrDefault());
+            expected.Should().Be(actual.FirstOrDefault());
             actual = await grain2.Get();
-            expected.ShouldBeEquivalentTo(actual.FirstOrDefault());
+            expected.Should().Be(actual.FirstOrDefault());
             actual = await sharedGrain.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected * 2);
+            actual.FirstOrDefault().Should().Be(expected * 2);
         }
 
         /// <summary>
@@ -70,15 +70,15 @@ namespace Orleans.Transactions.TestKit
                 coordinator4.MultiGrainAdd(transaction4Members, expected));
 
             int[] actual = await grain1.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected);
+            actual.FirstOrDefault().Should().Be(expected);
             actual = await grain2.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected*2);
+            actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain3.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected*2);
+            actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain4.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected*2);
+            actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain5.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected);
+            actual.FirstOrDefault().Should().Be(expected);
         }
 
         /// <summary>
@@ -107,13 +107,13 @@ namespace Orleans.Transactions.TestKit
                 coordinator3.MultiGrainAdd(transaction3Members, expected));
 
             int[] actual = await grain1.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected);
+            actual.FirstOrDefault().Should().Be(expected);
             actual = await grain2.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected*2);
+            actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain3.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected*2);
+            actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain4.Get();
-            actual.FirstOrDefault().ShouldBeEquivalentTo(expected);
+            actual.FirstOrDefault().Should().Be(expected);
         }
     }
 }

--- a/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKitBase/TestRunners/TransactionalStateStorageTestRunner.cs
@@ -142,9 +142,9 @@ namespace Orleans.Transactions.TestKit
         private void AssertTState(TState actual, TState expected)
         {
             if(assertConfig == null)
-                actual.ShouldBeEquivalentTo(expected);
+                actual.Should().BeEquivalentTo(expected);
             else
-                actual.ShouldBeEquivalentTo(expected, assertConfig);
+                actual.Should().BeEquivalentTo(expected, assertConfig);
         }
 
         private PendingTransactionState<TState> MakePendingState(long seqno, TState val, bool tm)

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.NewRelic/NRTelemetryConsumer.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.NewRelic/NRTelemetryConsumer.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -81,10 +81,12 @@ namespace Orleans.TelemetryConsumers.NewRelic
         {
             if (metrics != null)
             {
-                metrics.AsParallel().ForAll(m =>
-                   {
-                       NRClient.AddCustomParameter(m.Key, m.Value);
-                   });
+                var agent = NRClient.GetAgent();
+                var transaction = agent.CurrentTransaction;
+                foreach (var metric in metrics)
+                {
+                   transaction.AddCustomAttribute(metric.Key, metric.Value);
+                }
             }
         }
 
@@ -92,10 +94,12 @@ namespace Orleans.TelemetryConsumers.NewRelic
         {
             if (properties != null)
             {
-                properties.AsParallel().ForAll(p =>
+                var agent = NRClient.GetAgent();
+                var transaction = agent.CurrentTransaction;
+                foreach (var property in properties)
                 {
-                    NRClient.AddCustomParameter(p.Key, p.Value);
-                });
+                   transaction.AddCustomAttribute(property.Key, property.Value);
+                }
             }
         }
 

--- a/test/Analyzers.Tests/Analyzers.Tests.csproj
+++ b/test/Analyzers.Tests/Analyzers.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Benchmarks</RootNamespace>
     <AssemblyName>Benchmarks</AssemblyName>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <DebugSymbols>true</DebugSymbols>
     <ServerGarbageCollection>true</ServerGarbageCollection>
@@ -12,25 +12,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" />
     <!-- Temporarily kept to resolve a conflict between Microsoft.Azure.DocumentDB.Core's dependencies -->
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
-    <PackageReference Include="MessagePack" Version="2.3.85" />
-    <PackageReference Include="ZeroFormatter" Version="1.6.4" />
-    <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="SpanJson" Version="3.1.0" />
-    <PackageReference Include="Hyperion" Version="0.11.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
+    <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
+    <PackageReference Include="ZeroFormatter" Version="$(ZeroFormatterVersion)" />
+    <PackageReference Include="Utf8Json" Version="$(Utf8JsonVersion)" />
+    <PackageReference Include="SpanJson" Version="$(SpanJsonVersion)" />
+    <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\Azure\Orleans.Transactions.AzureStorage\Orleans.Transactions.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\src\AdoNet\Orleans.Persistence.AdoNet\Orleans.Persistence.AdoNet.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Azure\Orleans.Transactions.AzureStorage\Orleans.Transactions.AzureStorage.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\Orleans.Persistence.AdoNet.csproj" />
     <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\Grains\BenchmarkGrains\BenchmarkGrains.csproj" />
     <ProjectReference Include="..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />

--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -137,15 +137,18 @@ namespace Benchmarks.Ping
 
         public async Task Shutdown()
         {
-            await this.clientHost.StopAsync();
-            if (clientHost is IAsyncDisposable asyncDisposable) await asyncDisposable.DisposeAsync();
-            else clientHost.Dispose();
+            if (clientHost is { } client)
+            {
+                await client.StopAsync();
+                if (client is IAsyncDisposable asyncDisposable) await asyncDisposable.DisposeAsync();
+                else client.Dispose();
+            }
 
             this.hosts.Reverse();
-            foreach (var h in this.hosts)
+            foreach (var host in this.hosts)
             {
-                await h.StopAsync();
-                h.Dispose();
+                await host.StopAsync();
+                host.Dispose();
             }
         }
 

--- a/test/Benchmarks/Properties/launchSettings.json
+++ b/test/Benchmarks/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Benchmarks": {
       "commandName": "Project",
-      "commandLineArgs": "ConcurrentPing_HostedClient"
+      "commandLineArgs": "ConcurrentPing"
     }
   }
 }

--- a/test/Benchmarks/run_test.cmd
+++ b/test/Benchmarks/run_test.cmd
@@ -1,3 +1,3 @@
 git log -n 1
 git --no-pager diff
-dotnet run -c Release -f net5.0 -- ConcurrentPing
+dotnet run -c Release -- ConcurrentPing

--- a/test/DependencyInjection.Tests/DependencyInjection.Tests.csproj
+++ b/test/DependencyInjection.Tests/DependencyInjection.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="$(AutofacExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="$(StructureMapMicrosoftDependencyInjectionVersion)" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -14,7 +14,7 @@
 
   <!-- For test project we still need to target various desktop .Net versions instead of .Net Standard -->
   <PropertyGroup>
-    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net5.0;netcoreapp3.1</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net5.0;net6.0;netcoreapp3.1</TestTargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DistributedTests/DistributedTests.Client/DistributedTests.Client.csproj
+++ b/test/DistributedTests/DistributedTests.Client/DistributedTests.Client.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <Content Include="..\secrets.json" Link="secrets.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/test/DistributedTests/DistributedTests.Common/DistributedTests.Common.csproj
+++ b/test/DistributedTests/DistributedTests.Common/DistributedTests.Common.csproj
@@ -6,14 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\..\src\Orleans.Streaming.Abstractions\Orleans.Streaming.Abstractions.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Streaming.Abstractions\Orleans.Streaming.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="$(AzureKeyVaultVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.19" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="$(MicrosoftExtensionsConfigurationAzureKeyVaultVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>

--- a/test/DistributedTests/DistributedTests.Server/DistributedTests.Server.csproj
+++ b/test/DistributedTests/DistributedTests.Server/DistributedTests.Server.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <Content Include="..\secrets.json" Link="secrets.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/test/Extensions/TestServiceFabric/TestServiceFabric.csproj
+++ b/test/Extensions/TestServiceFabric/TestServiceFabric.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>

--- a/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
+++ b/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
@@ -8,10 +8,10 @@
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />-->
     <!--<PackageReference Include="MySqlConnector" Version="1.2.1" />-->
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <!--<PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.2" />-->
-    <PackageReference Include="Npgsql" Version="5.0.3" />
-    <PackageReference Include="MySql.Data" Version="8.0.23" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageReference Include="MySql.Data" Version="$(MySqlDataVersion)" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>

--- a/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
+++ b/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
+++ b/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
+++ b/test/Grains/BenchmarkGrains/GrainStorage/PersistentGrain.cs
@@ -45,14 +45,12 @@ namespace BenchmarkGrains.GrainStorage
                 this.persistentState.State.Payload[index] = (byte)(this.persistentState.State.Payload[index] + 1);
                 await this.persistentState.WriteStateAsync();
                 sw.Stop();
-                object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
-                logger.LogInformation("Grain {GrainId} took {WriteTimeMs}ms to set state.", args);
+                logger.LogInformation("Grain {GrainId} took {WriteTimeMs}ms to set state.", this.GetPrimaryKey(), sw.ElapsedMilliseconds);
                 success = true;
             } catch(Exception ex)
             {
                 sw.Stop();
-                object[] args = { this.GetPrimaryKey(), sw.ElapsedMilliseconds };
-                this.logger.LogError(ex, "Grain {GrainId} failed to set state in {WriteTimeMs}ms to set state.", args);
+                this.logger.LogError(ex, "Grain {GrainId} failed to set state in {WriteTimeMs}ms to set state.",  this.GetPrimaryKey(), sw.ElapsedMilliseconds );
                 success = false;
             }
 

--- a/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
+++ b/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
@@ -32,7 +32,7 @@ namespace BenchmarkGrains.Ping
             Stopwatch sw = Stopwatch.StartNew();
             while (!this.end)
             {
-                foreach(Pending pending in pendingWork.Where(t => t.PendingCall == null))
+                foreach(Pending pending in pendingWork.Where(t => t.PendingCall == default))
                 {
                     pending.PendingCall = pending.Grain.Run();
                 }
@@ -57,7 +57,7 @@ namespace BenchmarkGrains.Ping
                     await Task.WhenAny(pendingWork.Where(t => !t.PendingCall.IsCompletedSuccessfully).Select(p => p.PendingCall.AsTask()));
                 }
             } catch (Exception) {}
-            foreach (Pending pending in pendingWork.Where(p => p.PendingCall != null))
+            foreach (Pending pending in pendingWork.Where(p => p.PendingCall != default))
             {
                 if (pending.PendingCall.IsFaulted || pending.PendingCall.IsCanceled)
                 {

--- a/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Configuration;
+using System.Reflection;
 using Orleans.Hosting;
 using TestExtensions;
 using Xunit;
@@ -26,7 +27,7 @@ namespace UnitTests.Serialization
             this.environment = SerializationTestEnvironment.InitializeWithDefaults(
                 builder => builder.ConfigureServices(services =>
                 {
-                    services.AddSingleton<IGeneralizedCodec>(new NewtonsoftJsonCodec(isSupportedFunc: type => type.HasAttribute<JsonTypeAttribute>()));
+                    services.AddSingleton<IGeneralizedCodec>(new NewtonsoftJsonCodec(isSupportedFunc: type => type.GetCustomAttribute<JsonTypeAttribute>() != null));
                 }));
         }
 
@@ -48,7 +49,7 @@ namespace UnitTests.Serialization
                     .ConfigureServices(
                     services =>
                     {
-                        services.AddSingleton<IGeneralizedCodec>(new NewtonsoftJsonCodec(isSupportedFunc: type => type.HasAttribute<JsonTypeAttribute>()));
+                        services.AddSingleton<IGeneralizedCodec>(new NewtonsoftJsonCodec(isSupportedFunc: type => type.GetCustomAttribute<JsonTypeAttribute>() != null));
                     });
                 })
                 .Build();

--- a/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.csproj
+++ b/test/Orleans.Connections.Security.Tests/Orleans.Connections.Security.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -1542,7 +1542,7 @@ namespace Orleans.Serialization.UnitTests
         private IEqualityComparer<string>[] _comparers = new IEqualityComparer<string>[]
         {
             new CaseInsensitiveEqualityComparer(),
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             StringComparer.Ordinal,
             StringComparer.OrdinalIgnoreCase,
             EqualityComparer<string>.Default,

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CsCheck" Version="$(CsCheckVersion)" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -82,7 +82,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var files = Directory.GetFiles(directory, VersionTestBinaryName, SearchOption.AllDirectories)
                 .Where(f => !f.Contains(Path.DirectorySeparatorChar + "ref" + Path.DirectorySeparatorChar))
                 .Where(f => f.Contains("publish"))
-#if NET5_0
+#if NET5_0_OR_GREATER
                 .Where(f => f.Contains("net5"))
 #else
                 .Where(f => f.Contains("netcoreapp"))

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>
 

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -30,7 +30,7 @@ namespace Orleans.Transactions.Azure.Tests
         private const string tableName = "StateStorageTests";
         private const string partition = "testpartition";
         public AzureTransactionalStateStorageTests(TestFixture fixture, ITestOutputHelper testOutput)
-            :base(()=>StateStorageFactory(fixture), (seed)=>new TestState(){State = seed}, fixture.GrainFactory, testOutput)
+            : base(() => StateStorageFactory(fixture), (seed) => new TestState() { State = seed }, fixture.GrainFactory, testOutput)
         {
         }
 

--- a/test/Transactions/Orleans.Transactions.Tests/Orleans.Transactions.Tests.csproj
+++ b/test/Transactions/Orleans.Transactions.Tests/Orleans.Transactions.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitRunnerVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSdkVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
* Upgrade build SDK to .NET 6.0.100
* Add .NET 6.0 build target
* Enable reproducible builds for packages
* Enable SourceLink
* Remove NuGet symbol packages & sources
* Upgrade all dependencies (except for Google.Cloud.PubSub.V1: https://github.com/dotnet/orleans/issues/7509)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7511)