### PR TITLE
Use ExceptionDispatchInfo.SetRemoteStackTrace API in .NET 6.0 builds

### DIFF
--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -10,6 +10,7 @@ using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 
 namespace Orleans.Serialization
@@ -107,7 +108,11 @@ namespace Orleans.Serialization
             info.AddValue("ClassName", value.GetType().ToString(), typeof(string));
             info.AddValue("Data", null, typeof(IDictionary));
             info.AddValue("HelpURL", null, typeof(string));
+#if NET6_0_OR_GREATER
+            info.AddValue("RemoteStackTraceString", null, typeof(string));
+#else
             info.AddValue("RemoteStackTraceString", stackTrace, typeof(string));
+#endif
             info.AddValue("RemoteStackIndex", 0, typeof(int));
             info.AddValue("ExceptionMethod", null, typeof(string));
             info.AddValue("HResult", hResult);
@@ -122,6 +127,10 @@ namespace Orleans.Serialization
                     value.Data[pair.Key] = pair.Value;
                 }
             }
+
+#if NET6_0_OR_GREATER
+            ExceptionDispatchInfo.SetRemoteStackTrace(value, stackTrace);
+#endif
         }
 
         public Dictionary<object, object> GetDataProperty(Exception exception)

--- a/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
@@ -55,7 +55,7 @@ namespace Orleans.Serialization.UnitTests
 
             var result = RoundTripToExpectedType<Exception, InvalidOperationException>(exception);
             Assert.Equal(exception.Message, result.Message);
-            Assert.Equal(exception.StackTrace, result.StackTrace);
+            Assert.Contains(exception.StackTrace, result.StackTrace);
             Assert.Equal(exception.InnerException, result.InnerException);
             Assert.NotNull(result.Data);
             var data = result.Data;
@@ -64,7 +64,7 @@ namespace Orleans.Serialization.UnitTests
 
             var agResult = RoundTripToExpectedType<Exception, AggregateException>(aggregateException);
             Assert.Equal(aggregateException.Message, agResult.Message);
-            Assert.Equal(aggregateException.StackTrace, agResult.StackTrace);
+            Assert.Contains(aggregateException.StackTrace, agResult.StackTrace);
             var inner = Assert.IsType<InvalidOperationException>(agResult.InnerException);
             Assert.Equal(exception.Message, inner.Message);
         }


### PR DESCRIPTION
We added an API in .NET 6.0 which allows us to set the RemoteStackTrace on Exception objects (see https://github.com/dotnet/runtime/pull/50392). This PR makes use of that where supported.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7513)