### PR TITLE
Improve StringComparer serialization for well-known comparers

### DIFF
--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -6,7 +6,10 @@ using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -20,6 +23,10 @@ namespace Orleans.Serialization.Codecs
         private readonly Type _ordinalType;
         private readonly Type _ordinalIgnoreCaseType;
         private readonly Type _defaultEqualityType;
+#if !NET6_0_OR_GREATER
+        private readonly StreamingContext _streamingContext;
+        private readonly FormatterConverter _formatterConverter;
+#endif
 
         public WellKnownStringComparerCodec()
         {
@@ -30,72 +37,208 @@ namespace Orleans.Serialization.Codecs
             _ordinalType = _ordinalComparer.GetType();
             _ordinalIgnoreCaseType = _ordinalIgnoreCaseComparer.GetType();
             _defaultEqualityType = _defaultEqualityComparer.GetType();
+#if !NET6_0_OR_GREATER
+            _streamingContext = new StreamingContext(StreamingContextStates.All);
+            _formatterConverter = new FormatterConverter();
+#endif
         }
 
-        public bool IsSupportedType(Type type) => CodecType == type || _defaultEqualityType == type || _ordinalType == type || _ordinalIgnoreCaseType == type;
+        public bool IsSupportedType(Type type) =>
+            type == CodecType
+            || type == _ordinalType
+            || type == _ordinalIgnoreCaseType
+            || type == _defaultEqualityType
+            || !type.IsAbstract && typeof(IEqualityComparer<string>).IsAssignableFrom(type) && type.Assembly.Equals(typeof(IEqualityComparer<string>).Assembly);
 
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            var value = reader.ReadUInt32(field.WireType);
-            if (value == 0)
+            uint type = default;
+            CompareOptions options = default;
+            int lcid = default;
+            uint fieldId = 0;
+            while (true)
+            {
+                var header = reader.ReadFieldHeader();
+                if (header.IsEndBaseOrEndObject)
+                {
+                    break;
+                }
+
+                fieldId += header.FieldIdDelta;
+                switch (fieldId)
+                {
+                    case 0:
+                        type = UInt32Codec.ReadValue(ref reader, header);
+                        break;
+                    case 1:
+                        options = (CompareOptions)UInt64Codec.ReadValue(ref reader, header);
+                        break;
+                    case 2:
+                        lcid = Int32Codec.ReadValue(ref reader, header);
+                        break;
+                    default:
+                        reader.ConsumeUnknownField(header);
+                        break;
+                }
+            }
+
+            if (type == 0)
             {
                 return null;
             }
-            else if (value == 1)
+            else if (type == 1)
             {
-                return _ordinalComparer;
+                if (options.HasFlag(CompareOptions.IgnoreCase))
+                {
+                    return StringComparer.OrdinalIgnoreCase;
+                }
+                else
+                {
+                    return StringComparer.Ordinal;
+                }
             }
-            else if (value == 2)
+            else if (type == 2)
             {
-                return _ordinalIgnoreCaseComparer;
-            }
-            else if (value == 3)
-            {
-                return _defaultEqualityComparer;
+                if (lcid == CultureInfo.InvariantCulture.LCID)
+                {
+                    if (options == CompareOptions.None)
+                    {
+                        return StringComparer.InvariantCulture;
+                    }
+                    else if (options == CompareOptions.IgnoreCase)
+                    {
+                        return StringComparer.InvariantCultureIgnoreCase;
+                    }
+
+                    // Otherwise, perhaps some other options were specified, in which case we fall-through to create a new comparer.
+                }
+
+                var cultureInfo = CultureInfo.GetCultureInfo(lcid);
+                var result = StringComparer.Create(cultureInfo, options);
+                return result;
             }
 
-            ThrowNotSupported(field, value);
+            ThrowNotSupported(field, type);
             return null;
         }
 
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
         {
-            uint encoded;
+            uint type;
+            CompareOptions compareOptions = default;
+            CompareInfo compareInfo = default;
             if (value is null)
             {
-                encoded = 0;
-            }
-            else if (_ordinalComparer.Equals(value))
-            {
-                encoded = 1;
-            }
-            else if (_ordinalIgnoreCaseComparer.Equals(value))
-            {
-                encoded = 2;
-            }
-            else if (_defaultEqualityComparer.Equals(value))
-            {
-                encoded = 3;
+                type = 0;
             }
             else
             {
-                ThrowNotSupported(value.GetType());
-                return;
+#if NET6_0_OR_GREATER
+                var comparer = (IEqualityComparer<string>)value;
+                if (StringComparer.IsWellKnownOrdinalComparer(comparer, out var ignoreCase))
+                {
+                    // Ordinal. This also handles EqualityComparer<string>.Default.
+                    type = 1;
+                    if (ignoreCase)
+                    {
+                        compareOptions = CompareOptions.IgnoreCase;
+                    }
+                }
+                else if (StringComparer.IsWellKnownCultureAwareComparer(comparer, out compareInfo, out compareOptions))
+                {
+                    type = 2;
+                }
+                else
+                {
+                    ThrowNotSupported(value.GetType());
+                    return;
+                }
+#else
+                var isOrdinal = _ordinalComparer.Equals(value) || _defaultEqualityComparer.Equals(value);
+                var isOrdinalIgnoreCase = _ordinalIgnoreCaseComparer.Equals(value);
+                if (isOrdinal)
+                {
+                    type = 1;
+                }
+                else if (isOrdinalIgnoreCase)
+                {
+                    type = 1;
+                    compareOptions = CompareOptions.IgnoreCase;
+                }
+                else if (TryGetWellKnownCultureAwareComparerInfo(value, out compareInfo, out compareOptions, out var ignoreCase))
+                {
+                    type = 2;
+                    if (ignoreCase)
+                    {
+                        compareOptions |= CompareOptions.IgnoreCase;
+                    }
+                }
+                else
+                {
+                    ThrowNotSupported(value.GetType());
+                    return;
+                }
+#endif
             }
 
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(WellKnownStringComparerCodec), WireType.VarInt);
-            writer.WriteVarUInt32(encoded);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(WellKnownStringComparerCodec), WireType.TagDelimited);
+
+            UInt32Codec.WriteField(ref writer, 0, typeof(int), type);
+            UInt64Codec.WriteField(ref writer, 1, typeof(ulong), (ulong)compareOptions);
+
+            if (compareInfo is not null)
+            {
+                Int32Codec.WriteField(ref writer, 1, typeof(int), compareInfo.LCID);
+            }
+
+            writer.WriteEndObject();
         }
 
+#if !NET6_0_OR_GREATER
+        private bool TryGetWellKnownCultureAwareComparerInfo(object value, out CompareInfo compareInfo, out CompareOptions compareOptions, out bool ignoreCase)
+        {
+            compareInfo = default;
+            compareOptions = default;
+            ignoreCase = default;
+            if (value is ISerializable serializable)
+            {
+                var info = new SerializationInfo(value.GetType(), _formatterConverter);
+                serializable.GetObjectData(info, _streamingContext);
+                foreach (var entry in info)
+                {
+                    switch (entry.Name)
+                    {
+                        case "_compareInfo":
+                            compareInfo = entry.Value as CompareInfo;
+                            break;
+                        case "_options":
+                            compareOptions = (CompareOptions)entry.Value;
+                            break;
+                        case "_ignoreCase":
+                            ignoreCase = (bool)entry.Value;
+                            break;
+                    }
+                }
+
+                return compareInfo is not null;
+            }
+
+            return false;
+        }
+#endif
+
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for OrdinalComparer fields. {field}");
 
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotSupported(Field field, uint value) => throw new NotSupportedException($"Values of type {field.FieldType} are not supported. Value: {value}");
 
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotSupported(Type type) => throw new NotSupportedException($"Values of type {type} are not supported");
     }

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -1547,7 +1547,7 @@ namespace Orleans.Serialization.UnitTests
             StringComparer.OrdinalIgnoreCase,
             EqualityComparer<string>.Default,
 #endif
-#if NET6_0
+#if NET6_0_OR_GREATER
             StringComparer.InvariantCulture,
             StringComparer.InvariantCultureIgnoreCase,
             StringComparer.CurrentCulture,


### PR DESCRIPTION
We added method in .NET 6.0 to read the properties of well-known string comparers (see https://github.com/dotnet/runtime/pull/50312). This PR makes use of those where available to enhance how string comparers are serialized.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7514)