### PR TITLE
Fix serialization of exceptions with a null stack trace

### DIFF
--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -129,7 +129,10 @@ namespace Orleans.Serialization
             }
 
 #if NET6_0_OR_GREATER
-            ExceptionDispatchInfo.SetRemoteStackTrace(value, stackTrace);
+            if (stackTrace is not null)
+            {
+                ExceptionDispatchInfo.SetRemoteStackTrace(value, stackTrace);
+            }
 #endif
         }
 


### PR DESCRIPTION
#7513 was not as defensive as it should have been and there were some test failures as a result. I believe this was not caught because our build definitions were not updated to run .NET 6.0 tests yet.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7533)