### PR TITLE
Facilitate attaching debugger to Orleans.TestingHost

### DIFF
--- a/src/Orleans.TestingHost/StandaloneSiloHandle.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHandle.cs
@@ -44,6 +44,13 @@ namespace Orleans.TestingHost
             }
 
             Name = siloName;
+
+            // If the debugger is attached to this process, give it an opportunity to attach to the remote process.
+            if (Debugger.IsAttached)
+            {
+                configuration["AttachDebugger"] = "true";
+            }
+
             var serializedConfiguration = TestClusterHostFactory.SerializeConfiguration(configuration);
 
             Process = new Process();

--- a/src/Orleans.TestingHost/StandaloneSiloHost.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHost.cs
@@ -28,6 +28,11 @@ namespace Orleans.TestingHost
             var monitorProcessId = int.Parse(args[0], NumberStyles.Integer, CultureInfo.InvariantCulture);
             var serializedConfiguration = args[1];
             var configuration = TestClusterHostFactory.DeserializeConfiguration(serializedConfiguration);
+            if (string.Equals(configuration["AttachDebugger"], "true", StringComparison.OrdinalIgnoreCase))
+            {
+                Debugger.Launch();
+            }
+
             var name = configuration["SiloName"];
             using var host = TestClusterHostFactory.CreateSiloHost(name, configuration);
             try


### PR DESCRIPTION
When a debugger is attached to the main process, we should prompt for the developer to attach it to a newly spawned Orleans.TestingHost process to facilitate debugging.