### PR TITLE
Use Orleans.Serialization for the default IGrainStorageSerializer

### DIFF
--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -344,7 +344,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ITimerManager, TimerManagerImpl>();
 
             // persistent state facet support
-            services.TryAddSingleton<IGrainStorageSerializer, JsonGrainStorageSerializer>();
+            services.TryAddSingleton<IGrainStorageSerializer, OrleansGrainStorageSerializer>();
             services.TryAddSingleton<IPersistentStateFactory, PersistentStateFactory>();
             services.TryAddSingleton(typeof(IAttributeToFactoryMapper<PersistentStateAttribute>), typeof(PersistentStateAttributeMapper));
 


### PR DESCRIPTION
The JSON serializer is not yet able to serialize `StreamSubscriptionHandleImpl<T>` yet, so we have decided to temporarily switch the default serializer to one which uses *Orleans.Serialziation* (the in-built binary serializer) instead, for 4.0.0-preview1.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7542)