### PR TITLE
Streaming: make PubSubStore configurable per provider

### DIFF
--- a/src/Orleans.Core.Abstractions/Providers/ProviderConstants.cs
+++ b/src/Orleans.Core.Abstractions/Providers/ProviderConstants.cs
@@ -1,9 +1,11 @@
-﻿namespace Orleans.Providers
+namespace Orleans.Providers
 {
     public static class ProviderConstants
     {
         public const string DEFAULT_STORAGE_PROVIDER_NAME = "Default";
 
         public const string DEFAULT_LOG_CONSISTENCY_PROVIDER_NAME = "Default";
+
+        public const string DEFAULT_PUBSUB_PROVIDER_NAME = "PubSubStore";
     }
 }

--- a/src/Orleans.Streaming.Abstractions/StreamId.cs
+++ b/src/Orleans.Streaming.Abstractions/StreamId.cs
@@ -128,6 +128,24 @@ namespace Orleans.Runtime
             return keyIndex == 0 ? "null/" + key : this.GetNamespace() + "/" + key;
         }
 
+        public static StreamId Parse(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                ThrowInvalidInternalStreamId(value);
+            }
+
+            var i = value.IndexOf('/');
+            if (i < 0)
+            {
+                ThrowInvalidInternalStreamId(value);
+            }
+
+            return Create(value.Substring(0, i), value.Substring(i + 1));
+        }
+
+        private static void ThrowInvalidInternalStreamId(string value) => throw new ArgumentException($"Unable to parse \"{value}\" as a stream id");
+
         public override int GetHashCode() => this.hash;
 
         public string GetKeyAsString() => Encoding.UTF8.GetString(fullKey, keyIndex, fullKey.Length - keyIndex);

--- a/src/Orleans.Streaming/Hosting/SiloBuilderStreamingExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/SiloBuilderStreamingExtensions.cs
@@ -29,6 +29,7 @@ namespace Orleans.Hosting
                 return;
             }
 
+            services.AddSingleton<PubSubGrainStateStorageFactory>();
             services.AddSingleton<SiloStreamProviderRuntime>();
             services.AddFromExisting<IStreamProviderRuntime, SiloStreamProviderRuntime>();
             services.AddSingleton<ImplicitStreamSubscriberTable>();

--- a/src/Orleans.Streaming/InternalStreamId.cs
+++ b/src/Orleans.Streaming/InternalStreamId.cs
@@ -59,6 +59,25 @@ namespace Orleans.Runtime
             return $"{ProviderName}/{StreamId.ToString()}";
         }
 
+        public static InternalStreamId Parse(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                ThrowInvalidInternalStreamId(value);
+            }
+
+            var i = value.IndexOf('/');
+            if (i < 0)
+            {
+                ThrowInvalidInternalStreamId(value);
+            }
+
+            return new InternalStreamId(value.Substring(0, i), StreamId.Parse(value.Substring(i + 1)));
+        }
+
+        private static void ThrowInvalidInternalStreamId(string value) => throw new ArgumentException($"Unable to parse \"{value}\" as a stream id");
+
+
         internal string GetNamespace() => StreamId.GetNamespace();
     }
 }

--- a/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
@@ -25,11 +25,11 @@ namespace Orleans.Hosting
             var pubsubOptions = services.GetOptionsByName<StreamPubSubOptions>(this.streamProviderName);
             if (pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedAndImplicit || pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedOnly)
             {
-                var pubsubStore = services.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
+                var pubsubStore = services.GetServiceByName<IGrainStorage>(this.streamProviderName) ?? services.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
                 if (pubsubStore == null)
                     throw new OrleansConfigurationException(
-                        $" Streams with pubsub type {StreamPubSubType.ExplicitGrainBasedAndImplicit} and {StreamPubSubType.ExplicitGrainBasedOnly} requires a grain storage named {ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME} " +
-                        $"to be configured with silo. Please configure one for your stream {streamProviderName}.");
+                        $" Streams with pubsub type {StreamPubSubType.ExplicitGrainBasedAndImplicit} and {StreamPubSubType.ExplicitGrainBasedOnly} requires a grain storage named " +
+                        $"{ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME} or {this.streamProviderName} to be configured with silo. Please configure one for your stream {streamProviderName}.");
             }
         }
 

--- a/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
@@ -12,7 +12,6 @@ namespace Orleans.Hosting
     public class PersistentStreamStorageConfigurationValidator : IConfigurationValidator
     {
         private IServiceProvider services;
-        private const string pubsubStoreName = "PubSubStore";
         private string streamProviderName;
 
         private PersistentStreamStorageConfigurationValidator(IServiceProvider services, string streamProviderName)
@@ -26,10 +25,10 @@ namespace Orleans.Hosting
             var pubsubOptions = services.GetOptionsByName<StreamPubSubOptions>(this.streamProviderName);
             if (pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedAndImplicit || pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedOnly)
             {
-                var pubsubStore = services.GetServiceByName<IGrainStorage>(pubsubStoreName);
+                var pubsubStore = services.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
                 if (pubsubStore == null)
                     throw new OrleansConfigurationException(
-                        $" Streams with pubsub type {StreamPubSubType.ExplicitGrainBasedAndImplicit} and {StreamPubSubType.ExplicitGrainBasedOnly} requires a grain storage named {pubsubStoreName} " +
+                        $" Streams with pubsub type {StreamPubSubType.ExplicitGrainBasedAndImplicit} and {StreamPubSubType.ExplicitGrainBasedOnly} requires a grain storage named {ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME} " +
                         $"to be configured with silo. Please configure one for your stream {streamProviderName}.");
             }
         }

--- a/test/Tester/StreamingTests/MemoryProgrammaticSubcribeTests.cs
+++ b/test/Tester/StreamingTests/MemoryProgrammaticSubcribeTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.TestingHost;
+using Tester.StreamingTests;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.StreamingTests
+{
+    [TestCategory("BVT"), TestCategory("Streaming")]
+    public class MemoryProgrammaticSubcribeTests : ProgrammaticSubcribeTestsRunner, IClassFixture<MemoryProgrammaticSubcribeTests.Fixture>
+    {
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<TestClusterConfigurator>();
+                builder.AddClientBuilderConfigurator<TestClusterConfigurator>();
+            }
+
+            private class TestClusterConfigurator : ISiloConfigurator, IClientBuilderConfigurator
+            {
+                public void Configure(ISiloBuilder hostBuilder)
+                {
+                    // Do use "PubSubStore" in this test
+
+                    hostBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName);
+                    hostBuilder.AddMemoryGrainStorage(StreamProviderName);
+
+                    hostBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName2);
+                    hostBuilder.AddMemoryGrainStorage(StreamProviderName2);
+                }
+
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder.AddStreaming();
+            }
+        }
+
+        public MemoryProgrammaticSubcribeTests(Fixture fixture) : base(fixture)
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+}

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -25,7 +25,9 @@ namespace UnitTests.StreamingTests
             {
                 public void Configure(ISiloBuilder hostBuilder)
                 {
-                    hostBuilder.AddFaultInjectionMemoryStorage("PubSubStore");
+                    hostBuilder
+                        .AddFaultInjectionMemoryStorage("PubSubStore")
+                        .Services.AddSiloStreaming();
                 }
             }
         }


### PR DESCRIPTION
Issue #7474

Instead of relying on the state of `Grain<T>`, we can pass in the constructor of `PubSubRendezvousGrain` a storage factory or locator, that will try to return, in this order, a storage provider named:

- Like the stream provider (if the stream provider configured is "MyStreamingProvider" it will try to find a storage provider named "MyStreamingProvider"
- Otherwise it will fallback to the default "PubSubStore".

Initial storage read will be done during `OnActivateAsync`.

The solution isn't ideal since we rely on parsing the key of  `PubSubRendezvousGrain` to extract the provider name, but the benefit of this solution is that it can be easily backported in 3.x if needed.

In the future we could change the key of `PubSubRendezvousGrain` so user could inject their own logic to choose a storage provider.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7551)