### PR TITLE
Make `IGrainFactory.CreateObjectReference` and `IGrainFactory.DeleteObjectReference` synchronous

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -71,7 +71,7 @@ namespace Orleans
         /// </typeparam>
         /// <param name="obj">The reference being deleted.</param>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        Task DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
+        void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         /// <summary>
         /// A GetGrain overload that returns the runtime type of the grain interface and returns the grain cast to

--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -61,7 +61,7 @@ namespace Orleans
         /// </typeparam>
         /// <param name="obj">The object to create a reference to.</param>
         /// <returns>The reference to <paramref name="obj"/>.</returns>
-        Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
+        TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         /// <summary>
         /// Deletes the provided object reference.

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -111,7 +111,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithIntegerCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
 
         /// <inheritdoc />
-        public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver => ((IGrainFactory)_runtimeClient.InternalGrainFactory).CreateObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -115,7 +115,7 @@ namespace Orleans
             where TGrainObserverInterface : IGrainObserver => ((IGrainFactory)_runtimeClient.InternalGrainFactory).CreateObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />
-        public Task DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver => _runtimeClient.InternalGrainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
+        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver => _runtimeClient.InternalGrainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IAddressable obj)

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -82,10 +82,10 @@ namespace Orleans
 
 
         /// <inheritdoc />
-        public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver
         {
-            return Task.FromResult(this.CreateObjectReference<TGrainObserverInterface>((IAddressable)obj));
+            return this.CreateObjectReference<TGrainObserverInterface>((IAddressable)obj);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -89,11 +89,10 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public Task DeleteObjectReference<TGrainObserverInterface>(
+        public void DeleteObjectReference<TGrainObserverInterface>(
             IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
         {
             this.runtimeClient.DeleteObjectReference(obj);
-            return Task.CompletedTask;
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -69,9 +69,9 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        public Task DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
+        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
         {
-            return this.grainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
+            this.grainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -62,10 +62,10 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver
         {
-            return Task.FromResult(this.grainFactory.CreateObjectReference<TGrainObserverInterface>(obj));
+            return this.grainFactory.CreateObjectReference<TGrainObserverInterface>(obj);
         }
 
         /// <inheritdoc />

--- a/test/DefaultCluster.Tests/CodeGenTests/GeneratorGrainTest.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/GeneratorGrainTest.cs
@@ -204,7 +204,7 @@ namespace Tester.CodeGenTests
             var localObject = new ObserverWithGenericMethods();
 
             var grain = this.GrainFactory.GetGrain<IGrainWithGenericMethods>(Guid.NewGuid());
-            var observer = await this.GrainFactory.CreateObjectReference<IGrainObserverWithGenericMethods>(localObject);
+            var observer = this.GrainFactory.CreateObjectReference<IGrainObserverWithGenericMethods>(localObject);
             await grain.SetValueOnObserver(observer, "ToastedEnchiladas");
             Assert.Equal("ToastedEnchiladas", await localObject.ValueTask);
         }

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -161,7 +161,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.True(await handle.WaitForFinished(_timeout));
 
-            await client.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            client.DeleteObjectReference<ISimpleGrainObserver>(reference);
             Assert.NotNull(observer);
         }
 

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -154,7 +154,7 @@ namespace DefaultCluster.Tests.General
                 },
                 handle,
                 client.ServiceProvider.GetRequiredService<ILogger<ISimpleGrainObserver>>());
-            var reference = await client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            var reference = client.CreateObjectReference<ISimpleGrainObserver>(observer);
             await grain.Subscribe(reference);
             await grain.SetA(3);
             await grain.SetB(2);

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -52,7 +52,7 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_SimpleNotification_Callback, result, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
             await grain.Subscribe(reference);
             await grain.SetA(3);
             await grain.SetB(2);
@@ -70,7 +70,7 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_SimpleNotification_Callback, result, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             await grain.Subscribe(reference);
             await grain.SetA(3);
             await grain.SetB(2);
@@ -116,7 +116,7 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_DoubleSubscriptionSameReference_Callback, result, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             await grain.Subscribe(reference);
             await grain.SetA(1); // Use grain
             try
@@ -164,7 +164,7 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_SubscribeUnsubscribe_Callback, result, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             await grain.Subscribe(reference);
             await grain.SetA(5);
             Assert.True(await result.WaitForContinue(timeout), string.Format("Should not timeout waiting {0} for SetA", timeout));
@@ -196,7 +196,7 @@ namespace DefaultCluster.Tests.General
             TestInitialize();
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(null, null, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             try
             {
                 await grain.Unsubscribe(reference);
@@ -223,9 +223,9 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_DoubleSubscriptionDifferentReferences_Callback, result, this.Logger);
-            ISimpleGrainObserver reference1 = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference1 = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             this.observer2 = new SimpleGrainObserver(this.ObserverTest_DoubleSubscriptionDifferentReferences_Callback, result, this.Logger);
-            ISimpleGrainObserver reference2 = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer2);
+            ISimpleGrainObserver reference2 = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer2);
             await grain.Subscribe(reference1);
             await grain.Subscribe(reference2);
             grain.SetA(6).Ignore();
@@ -257,7 +257,7 @@ namespace DefaultCluster.Tests.General
 
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(this.ObserverTest_DeleteObject_Callback, result, this.Logger);
-            ISimpleGrainObserver reference = await this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
+            ISimpleGrainObserver reference = this.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer1);
             await grain.Subscribe(reference);
             await grain.SetA(5);
             Assert.True(await result.WaitForContinue(timeout), string.Format("Should not timeout waiting {0} for SetA", timeout));
@@ -297,17 +297,17 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact, TestCategory("BVT")]
-        public async Task ObserverTest_CreateObjectReference_ThrowsForInvalidArgumentTypes()
+        public void ObserverTest_CreateObjectReference_ThrowsForInvalidArgumentTypes()
         {
             TestInitialize();
 
             // Attempt to create an object reference to a Grain class.
-            await Assert.ThrowsAsync<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(new DummyObserverGrain()));
+            Assert.Throws<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(new DummyObserverGrain()));
 
             // Attempt to create an object reference to an existing GrainReference.
             var observer = new DummyObserver();
-            var reference = await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
-            await Assert.ThrowsAsync<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(reference));
+            var reference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            Assert.Throws<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(reference));
         }
 
         public class DummyObserverGrain : Grain, ISimpleGrainObserver

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -59,7 +59,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.True(await result.WaitForFinished(timeout));
 
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
         [Fact, TestCategory("BVT")]
@@ -77,7 +77,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.True(await result.WaitForFinished(timeout));
 
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
         void ObserverTest_SimpleNotification_Callback(int a, int b, AsyncResultHandle result)
@@ -142,7 +142,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.False(await result.WaitForFinished(timeout), string.Format("Should timeout waiting {0} for SetA(2)", timeout));
 
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
         void ObserverTest_DoubleSubscriptionSameReference_Callback(int a, int b, AsyncResultHandle result)
@@ -174,7 +174,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.False(await result.WaitForFinished(timeout), string.Format("Should timeout waiting {0} for SetB", timeout));
 
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
         void ObserverTest_SubscribeUnsubscribe_Callback(int a, int b, AsyncResultHandle result)
@@ -201,7 +201,7 @@ namespace DefaultCluster.Tests.General
             {
                 await grain.Unsubscribe(reference);
 
-                await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+                this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
             }
             catch (TimeoutException)
             {
@@ -232,8 +232,8 @@ namespace DefaultCluster.Tests.General
 
             Assert.True(await result.WaitForFinished(timeout), string.Format("Should not timeout waiting {0} for SetA", timeout));
 
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference1);
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference2);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference1);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference2);
         }
 
         void ObserverTest_DoubleSubscriptionDifferentReferences_Callback(int a, int b, AsyncResultHandle result)
@@ -261,7 +261,7 @@ namespace DefaultCluster.Tests.General
             await grain.Subscribe(reference);
             await grain.SetA(5);
             Assert.True(await result.WaitForContinue(timeout), string.Format("Should not timeout waiting {0} for SetA", timeout));
-            await this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
             await grain.SetB(3);
 
             Assert.False(await result.WaitForFinished(timeout), string.Format("Should timeout waiting {0} for SetB", timeout));

--- a/test/DefaultCluster.Tests/OneWayCallTests.cs
+++ b/test/DefaultCluster.Tests/OneWayCallTests.cs
@@ -18,7 +18,7 @@ namespace DefaultCluster.Tests.General
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
 
             var observer = new SimpleGrainObserver();
-            var task = grain.Notify(await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            var task = grain.Notify(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
             Assert.True(task.Status == TaskStatus.RanToCompletion, "Task should be synchronously completed.");
             await observer.ReceivedValue.WithTimeout(TimeSpan.FromSeconds(10));
             var count = await grain.GetCount();
@@ -36,7 +36,7 @@ namespace DefaultCluster.Tests.General
             var otherGrain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
 
             var observer = new SimpleGrainObserver();
-            var observerReference = await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
             var completedSynchronously = await grain.NotifyOtherGrain(otherGrain, observerReference);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
             await observer.ReceivedValue.WithTimeout(TimeSpan.FromSeconds(10));
@@ -50,7 +50,7 @@ namespace DefaultCluster.Tests.General
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
 
             var observer = new SimpleGrainObserver();
-            var task = grain.NotifyValueTask(await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            var task = grain.NotifyValueTask(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
             Assert.True(task.IsCompleted, "ValueTask should be synchronously completed.");
             await observer.ReceivedValue.WithTimeout(TimeSpan.FromSeconds(10));
             var count = await grain.GetCount();
@@ -68,7 +68,7 @@ namespace DefaultCluster.Tests.General
             var otherGrain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
 
             var observer = new SimpleGrainObserver();
-            var observerReference = await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
             var completedSynchronously = await grain.NotifyOtherGrainValueTask(otherGrain, observerReference);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
             await observer.ReceivedValue.WithTimeout(TimeSpan.FromSeconds(10));

--- a/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -54,7 +54,7 @@ namespace UnitTests.MembershipTests
             // Ensure the client entry is on Silo2 partition and get a grain that live on Silo3
             var grain = await SetupTestAndPickGrain<ISimpleObserverableGrain>(g => g.GetRuntimeInstanceId());
             var observer = new Observer();
-            var reference = await this.hostedCluster.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer);
+            var reference = this.hostedCluster.GrainFactory.CreateObjectReference<ISimpleGrainObserver>(observer);
 
             await grain.Subscribe(reference);
 


### PR DESCRIPTION
Related issue #7528

Make `IGrainFactory.CreateObjectReference` and `IGrainFactory.DeleteObjectReference` synchronous

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7552)