### PR TITLE
Consider changing the .NET SDK value in `global.json`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "feature",
-    "version": "6.0.101"
+    "rollForward": "latestMinor",
+    "version": "6.0.0"
   }
 }


### PR DESCRIPTION
to help newcomers avoid having to change it or install
exact SDK versions to get Orleans and samples to build.

This change will still roll forward to `6.0.101` but will
also support folks running `6.0.0` to `6.0.100`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7558)