### PR TITLE
Enable lifeguard improvements by default

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -133,11 +133,11 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets a value indicating whether to extend the effective <see cref="ProbeTimeout"/> value based upon current local health degradation.
         /// </summary>
-        public bool ExtendProbeTimeoutDuringDegradation { get; set; } = false;
+        public bool ExtendProbeTimeoutDuringDegradation { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable probing silos indirectly, via other silos.
         /// </summary>
-        public bool EnableIndirectProbes { get; set; } = false;
+        public bool EnableIndirectProbes { get; set; } = true;
     }
 }


### PR DESCRIPTION
This changes the defaults to enable two cluster membership stability improvements which were inspired by the lifeguard paper.
For more information, see #6745 and #6800.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7580)