### PR TITLE
Support unmanaged and notnull constraints for grain interfaces

### DIFF
--- a/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Orleans.Analyzers
 
         private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword))
+            if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
             {
                 if (declaration.TryGetAttribute(Constants.GenerateSerializerAttributeName, out var attribute))
                 {
@@ -65,7 +65,7 @@ namespace Orleans.Analyzers
 
         private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword))
+            if (context.Node is TypeDeclarationSyntax declaration && !declaration.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
             {
                 if (declaration.TryGetAttribute(Constants.SerializableAttributeName, out var attribute) && !declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
                 {

--- a/src/Orleans.Analyzers/SerializationAttributesHelper.cs
+++ b/src/Orleans.Analyzers/SerializationAttributesHelper.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
@@ -9,7 +10,7 @@ namespace Orleans.Analyzers
     {
         public static bool ShouldGenerateSerializer(TypeDeclarationSyntax declaration)
         {
-            if (!declaration.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword) && declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
+            if (!declaration.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)) && declaration.HasAttribute(Constants.GenerateSerializerAttributeName))
             {
                 return true;
             }

--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
@@ -60,7 +61,7 @@ namespace Orleans.Analyzers
         {
             if (member is PropertyDeclarationSyntax property)
             {
-                return property.ChildTokens().FirstOrDefault(token => token.Kind() == SyntaxKind.IdentifierToken).ValueText;
+                return property.ChildTokens().FirstOrDefault(token => token.IsKind(SyntaxKind.IdentifierToken)).ValueText;
             }
             else if (member is FieldDeclarationSyntax field)
             {

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SyntaxFactoryUtility.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SyntaxFactoryUtility.cs
@@ -78,14 +78,22 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             foreach (var (name, tp) in typeParameter)
             {
                 var constraints = new List<TypeParameterConstraintSyntax>();
-                if (tp.HasReferenceTypeConstraint)
-                {
-                    constraints.Add(ClassOrStructConstraint(SyntaxKind.ClassConstraint));
-                }
 
-                if (tp.HasValueTypeConstraint)
+                if (tp.HasUnmanagedTypeConstraint)
+                {
+                    constraints.Add(TypeConstraint(IdentifierName("unmanaged")));
+                }
+                else if (tp.HasValueTypeConstraint)
                 {
                     constraints.Add(ClassOrStructConstraint(SyntaxKind.StructConstraint));
+                }
+                else if (tp.HasNotNullConstraint)
+                {
+                    constraints.Add(TypeConstraint(IdentifierName("notnull")));
+                }
+                else if (tp.HasReferenceTypeConstraint)
+                {
+                    constraints.Add(ClassOrStructConstraint(SyntaxKind.ClassConstraint));
                 }
 
                 foreach (var c in tp.ConstraintTypes)

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -8,6 +8,7 @@ using Orleans.Runtime;
 using TestExtensions;
 using TestGrainInterfaces;
 using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
 using Xunit;
 
 namespace DefaultCluster.Tests.General
@@ -672,6 +673,22 @@ namespace DefaultCluster.Tests.General
             await grain.Add(42);
             result = await grain.GetCount();
             Assert.Equal(1, result);
+
+            var unmanagedGrain = this.GrainFactory.GetGrain<IUnmanagedArgGrain<DateTime>>(Guid.NewGuid());
+            {
+                var echoInput = DateTime.UtcNow;
+                var echoOutput = await unmanagedGrain.Echo(echoInput);
+                Assert.Equal(echoInput, echoOutput);
+                echoOutput = await unmanagedGrain.EchoValue(echoInput);
+                Assert.Equal(echoInput, echoOutput);
+            }
+            {
+                var echoInput = "hello";
+                var echoOutput = await unmanagedGrain.EchoNonNullable(echoInput);
+                Assert.Equal(echoInput, echoOutput);
+                echoOutput = await unmanagedGrain.EchoReference(echoInput);
+                Assert.Equal(echoInput, echoOutput);
+            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Persistence")]

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -800,6 +800,22 @@ namespace UnitTests.Grains
         public Task<int> Handle(int prevState, Reducer2Action act) => Task.FromResult(prevState + act.ToString().Length);
     }
 
+    public interface IUnmanagedArgGrain<T> : IGrainWithGuidKey where T : unmanaged
+    {
+        ValueTask<T> Echo(T value);
+        ValueTask<U> EchoNonNullable<U>(U value) where U : notnull;
+        ValueTask<U> EchoReference<U>(U value) where U : class;
+        ValueTask<U> EchoValue<U>(U value) where U : struct;
+    }
+
+    public class UnmanagedArgGrain<T> : IUnmanagedArgGrain<T> where T : unmanaged
+    {
+        public ValueTask<T> Echo(T value) => new(value);
+        public ValueTask<U> EchoNonNullable<U>(U value)  where U : notnull => new(value);
+        public ValueTask<U> EchoReference<U>(U value) where U : class => new(value);
+        public ValueTask<U> EchoValue<U>(U value) where U : struct => new(value);
+    }
+
     public interface IReducerGameGrain<TState, TAction> : IGrainWithStringKey
     {
         Task<TState> Go(TState prevState, TAction act);

--- a/test/Grains/TestGrains/TestGrains.csproj
+++ b/test/Grains/TestGrains/TestGrains.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <NoWarn>$(NoWarn);1591;1591;618</NoWarn>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #7039

Adds support for grains with the new constraints, `unmanaged` and `notnull`

Example:
``` C#
public interface IUnmanagedArgGrain<T> : IGrainWithGuidKey where T : unmanaged
{
    ValueTask<T> Echo(T value);
    ValueTask<U> EchoNonNullable<U>(U value) where U : notnull;
    ValueTask<U> EchoReference<U>(U value) where U : class;
    ValueTask<U> EchoValue<U>(U value) where U : struct;
}
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7587)