### PR TITLE
Serialization: make reference-tracking opt-in, not opt-out

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -49,7 +49,7 @@ namespace Orleans.CodeGenerator
                 RegisterActivatorAttribute = Type("Orleans.RegisterActivatorAttribute"),
                 RegisterCopierAttribute = Type("Orleans.RegisterCopierAttribute"),
                 UseActivatorAttribute = Type("Orleans.UseActivatorAttribute"),
-                SuppressReferenceTrackingAttribute = Type("Orleans.SuppressReferenceTrackingAttribute"),
+                EnableReferenceTrackingAttribute = Type("Orleans.EnableReferenceTrackingAttribute"),
                 OmitDefaultMemberValuesAttribute = Type("Orleans.OmitDefaultMemberValuesAttribute"),
                 Int32 = compilation.GetSpecialType(SpecialType.System_Int32),
                 UInt32 = compilation.GetSpecialType(SpecialType.System_UInt32),
@@ -265,7 +265,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol RegisterSerializerAttribute { get; private set; }
         public INamedTypeSymbol RegisterActivatorAttribute { get; private set; }
         public INamedTypeSymbol UseActivatorAttribute { get; private set; }
-        public INamedTypeSymbol SuppressReferenceTrackingAttribute { get; private set; }
+        public INamedTypeSymbol EnableReferenceTrackingAttribute { get; private set; }
         public INamedTypeSymbol OmitDefaultMemberValuesAttribute { get; private set; }
         public INamedTypeSymbol CopyContext { get; private set; }
         public Compilation Compilation { get; private set; }

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -186,7 +186,7 @@ namespace Orleans.CodeGenerator
 
         public bool UseActivator => Type.HasAttribute(_libraryTypes.UseActivatorAttribute) || !IsEmptyConstructable || HasActivatorConstructor;
 
-        public bool TrackReferences => !IsValueType && !Type.HasAttribute(_libraryTypes.SuppressReferenceTrackingAttribute);
+        public bool TrackReferences => !IsValueType && Type.HasAttribute(_libraryTypes.EnableReferenceTrackingAttribute);
         public bool OmitDefaultMemberValues => Type.HasAttribute(_libraryTypes.OmitDefaultMemberValuesAttribute);
 
         public List<INamedTypeSymbol> SerializationHooks { get; }

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
@@ -8,7 +8,6 @@ namespace Orleans.Runtime
 {
     [Serializable, Immutable]
     [GenerateSerializer]
-    [SuppressReferenceTracking]
     public sealed class UniqueKey : IComparable<UniqueKey>, IEquatable<UniqueKey>
     {
         /// <summary>

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -20,7 +20,6 @@ namespace Orleans.Runtime
     [Serializable, Immutable]
     [JsonConverter(typeof(SiloAddressConverter))]
     [DebuggerDisplay("SiloAddress {ToString()}")]
-    [SuppressReferenceTracking]
     public sealed class SiloAddress : IEquatable<SiloAddress>, IComparable<SiloAddress>, IComparable
     {
         [NonSerialized]

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -399,13 +399,13 @@ namespace Orleans
     }
 
     /// <summary>
-    /// When applied to a type, indicates that generated serializers for the type should not track references to the type.
+    /// When applied to a type, indicates that generated serializers for the type should track references to the type.
     /// </summary>
     /// <remarks>
     /// Reference tracking allows a serializable type to participate in a cyclic object graph.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-    public sealed class SuppressReferenceTrackingAttribute : Attribute
+    public sealed class EnableReferenceTrackingAttribute : Attribute
     {
     }
 

--- a/src/Orleans.Serialization/Invocation/PooledResponse.cs
+++ b/src/Orleans.Serialization/Invocation/PooledResponse.cs
@@ -8,7 +8,6 @@ namespace Orleans.Serialization.Invocation
     /// </summary>
     /// <typeparam name="TResult">The underlying result type.</typeparam>
     [GenerateSerializer]
-    [SuppressReferenceTracking]
     public class PooledResponse<TResult> : Response<TResult>
     {
         [Id(0)]


### PR DESCRIPTION
Currently, all custom types can participate in reference cycles and any objects of any type will only be serialized once per message.
Reference tracking in our serializer scales well, offering very good performance with small object graphs (<64 object) and scaling up to hundreds of thousands (thanks to some early internal adopters).

The `[SuppressReferenceTracking]` attribute can be used to disable reference tracking on a per-type basis. Because this influences how code generation happens, and because code is generated at build time, you cannot opt-in or opt-out of reference tracking at runtime - only build time.

This PR reverses things and makes reference tracking opt-in instead of opt-out, thus turning `[SuppressReferenceTracking]` into `[EnableReferenceTracking]`. The idea is that if a developer has a type which may participate in a reference cycle or will frequently appear many times in a serialized payload, then they should explicitly opt-in to reference tracking.

I'm not certain that we should go down this route, but I wanted to experiment, so here we are.

### TODO:

* [ ] Consider implementing a max depth option in `SerializerSession` to prevent a lack of reference tracking from causing a stack overflow

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7595)