### PR TITLE
[WIP] Reminders V2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "feature",
-    "version": "6.0.101"
+    "rollForward": "latestFeature",
+    "version": "6.0.200"
   }
 }

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainRuntime.cs
@@ -36,6 +36,11 @@ namespace Orleans.Runtime
         IReminderRegistry ReminderRegistry { get; }
 
         /// <summary>
+        /// Gets the reminder registry.
+        /// </summary>
+        IReminderV2Registry ReminderV2Registry { get; }
+
+        /// <summary>
         /// Gets the service provider.
         /// </summary>
         IServiceProvider ServiceProvider { get; }

--- a/src/Orleans.Core.Abstractions/SystemTargetInterfaces/IReminderServiceV2.cs
+++ b/src/Orleans.Core.Abstractions/SystemTargetInterfaces/IReminderServiceV2.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Services;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Functionality for managing reminders V2.
+    /// </summary>
+    public interface IReminderServiceV2 : IGrainService
+    {
+        /// <summary>
+        /// Starts the service.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task Start();
+
+        /// <summary>
+        /// Stops the service.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task Stop();
+
+        /// <summary>
+        /// Registers a new reminder or updates an existing one.
+        /// </summary>
+        /// <param name="grainRef">A reference to the grain which the reminder is being registered or updated on behalf of.</param>
+        /// <param name="reminderName">The reminder name.</param>
+        /// <param name="dueTime">The amount of time to delay before firing the reminder initially.</param>
+        /// <param name="period">The time interval between invocations of the reminder.</param>
+        /// <returns>The reminder.</returns>
+        Task<IGrainReminderV2> RegisterOrUpdateReminder(GrainReference grainRef, string reminderName, TimeSpan dueTime, TimeSpan period);
+
+        /// <summary>
+        /// Unregisters the specified reminder.
+        /// </summary>
+        /// <param name="reminder">The reminder.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task UnregisterReminder(IGrainReminderV2 reminder);
+
+        /// <summary>
+        /// Gets the reminder registered to the specified grain with the provided name.
+        /// </summary>
+        /// <param name="grainRef">A reference to the grain which the reminder is registered on.</param>
+        /// <param name="reminderName">The name of the reminder.</param>
+        /// <returns>The reminder.</returns>
+        Task<IGrainReminderV2> GetReminder(GrainReference grainRef, string reminderName);
+
+        /// <summary>
+        /// Gets all reminders registered for the specified grain.
+        /// </summary>
+        /// <param name="grainRef">A reference to the grain.</param>
+        /// <returns>A list of all registered reminders for the specified grain.</returns>
+        Task<List<IGrainReminderV2>> GetReminders(GrainReference grainRef);
+    }
+}

--- a/src/Orleans.Core.Abstractions/Timers/IRemindableV2.cs
+++ b/src/Orleans.Core.Abstractions/Timers/IRemindableV2.cs
@@ -7,7 +7,7 @@ namespace Orleans
     /// <summary>
     /// Callback interface that grains must implement in order to be able to register and receive Reminders.
     /// </summary>
-    public interface IRemindable : IGrain
+    public interface IRemindableV2 : IGrain
     {
         /// <summary>
         /// Receive a new Reminder.
@@ -23,7 +23,7 @@ namespace Orleans
         /// <summary>
         /// Handle for a persistent Reminder.
         /// </summary>
-        public interface IGrainReminder
+        public interface IGrainReminderV2
         {
             /// <summary>
             /// Gets the name of this reminder.
@@ -41,7 +41,7 @@ namespace Orleans
         /// </summary>
         [Serializable]
         [GenerateSerializer]
-        public struct TickStatus
+        public struct TickStatusV2
         {
             /// <summary>
             /// Gets the time at which the first tick of this reminder is due, or was triggered.
@@ -62,17 +62,17 @@ namespace Orleans
             public DateTime CurrentTickTime { get; private set; }
 
             /// <summary>
-            /// Creates a new <see cref="TickStatus"/> instance.
+            /// Creates a new <see cref="TickStatusV2"/> instance.
             /// </summary>
             /// <param name="firstTickTime">The time at which the first tick of the reminder is due.</param>
             /// <param name="period">The period of the reminder.</param>
             /// <param name="timeStamp">The time when delivery of the current tick was initiated.</param>
             /// <returns></returns>
-            public static TickStatus Create(DateTime firstTickTime, TimeSpan period, DateTime timeStamp)
+            public static TickStatusV2 Create(DateTime firstTickTime, TimeSpan period, DateTime timeStamp)
             {
                 return
-                    new TickStatus
-                        {
+                    new TickStatusV2
+                    {
                             FirstTickTime = firstTickTime,
                             Period = period,
                             CurrentTickTime = timeStamp
@@ -89,21 +89,21 @@ namespace Orleans
         [Serializable]
         [GenerateSerializer]
 #pragma warning disable RCS1194 // Implement exception constructors.
-        public class ReminderException : OrleansException
+        public class ReminderV2Exception : OrleansException
 #pragma warning restore RCS1194 // Implement exception constructors.
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="ReminderException"/> class.
             /// </summary>
             /// <param name="message">The message.</param>
-            public ReminderException(string message) : base(message) { }
+            public ReminderV2Exception(string message) : base(message) { }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ReminderException"/> class.
             /// </summary>
             /// <param name="info">The serialization info.</param>
             /// <param name="context">The context.</param>
-            public ReminderException(SerializationInfo info, StreamingContext context)
+            public ReminderV2Exception(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
             }

--- a/src/Orleans.Core.Abstractions/Timers/IReminderV2Registry.cs
+++ b/src/Orleans.Core.Abstractions/Timers/IReminderV2Registry.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Services;
+
+namespace Orleans.Timers
+{
+    /// <summary>
+    /// Functionality for managing reminders.
+    /// </summary>
+    public interface IReminderV2Registry : IGrainServiceClient<IReminderService>
+    {
+        /// <summary>
+        /// Register or update the reminder with the specified name for the currently active grain.
+        /// </summary>
+        /// <param name="reminderName">The reminder name.</param>
+        /// <param name="dueTime">The amount of time to delay before initially invoking the reminder.</param>
+        /// <param name="period">The time interval between invocations of the reminder.</param>
+        /// <returns>The reminder.</returns>
+        Task<IGrainReminderV2> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period);
+
+        /// <summary>
+        /// Unregisters a reminder from the currently active grain.
+        /// </summary>
+        /// <param name="reminder">The reminder to unregister.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task UnregisterReminder(IGrainReminderV2 reminder);
+
+        /// <summary>
+        /// Gets the reminder with the specified name which is registered to the currently active grain.
+        /// </summary>
+        /// <param name="reminderName">The reminder name.</param>
+        /// <returns>The reminder.</returns>
+        Task<IGrainReminderV2> GetReminder(string reminderName);
+
+        /// <summary>
+        /// Gets all reminders which are currently registered to the active grain.
+        /// </summary>
+        /// <returns>All reminders which are currently registered to the active grain.</returns>
+        Task<List<IGrainReminderV2>> GetReminders();
+    }
+}

--- a/src/Orleans.Core/Configuration/Options/ReminderV2Options.cs
+++ b/src/Orleans.Core/Configuration/Options/ReminderV2Options.cs
@@ -1,0 +1,60 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Options for the reminder service.
+    /// </summary>
+    public class ReminderV2Options
+    {
+        /// <summary>
+        /// Gets or sets the minimum period for reminders.
+        /// </summary>
+        /// <remarks>
+        /// High-frequency reminders are dangerous for production systems.
+        /// </remarks>
+        public TimeSpan MinimumReminderPeriod { get; set; } = Constants.MinReminderPeriod;
+    }
+
+    /// <summary>
+    /// Validator for <see cref="ReminderV2Options"/>.
+    /// </summary>
+    internal class ReminderV2OptionsValidator : IConfigurationValidator
+    {
+        private readonly ILogger<ReminderV2OptionsValidator> _logger;
+        private readonly ReminderV2Options _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReminderV2OptionsValidator"/> class.
+        /// </summary>
+        /// <param name="logger">
+        /// The logger.
+        /// </param>
+        /// <param name="ReminderV2Options">
+        /// The reminder options.
+        /// </param>
+        public ReminderV2OptionsValidator(ILogger<ReminderV2OptionsValidator> logger, IOptions<ReminderV2Options> ReminderV2Options)
+        {
+            _logger = logger;
+            _options = ReminderV2Options.Value;
+        }
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            if (_options.MinimumReminderPeriod < TimeSpan.Zero)
+            {
+                throw new OrleansConfigurationException($"{nameof(ReminderV2Options)}.{nameof(ReminderV2Options.MinimumReminderPeriod)} must not be less than {TimeSpan.Zero}");
+            }
+
+            if (_options.MinimumReminderPeriod < Constants.MinReminderPeriod)
+            {
+                _logger.LogWarning((int)ErrorCode.RS_FastReminderInterval,
+                        $"{nameof(ReminderV2Options)}.{nameof(ReminderV2Options.MinimumReminderPeriod)} is {_options.MinimumReminderPeriod:g} (default {Constants.MinReminderPeriod:g}. High-Frequency reminders are unsuitable for production use.");
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/SystemTargetInterfaces/IReminderV2Table.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IReminderV2Table.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Interface for implementations of the underlying storage for reminder data:
+    /// Azure Table, SQL, development emulator grain, and a mock implementation.
+    /// Defined as a grain interface for the development emulator grain case.
+    /// </summary>  
+    public interface IReminderV2Table
+    {
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        /// <returns>A Task representing the work performed.</returns>
+        Task Init();
+
+        /// <summary>
+        /// Reads the reminder table entries associated with the specified grain.
+        /// </summary>
+        /// <param name="key">The grain.</param>
+        /// <returns>The reminder table entries associated with the specified grain.</returns>
+        Task<ReminderV2TableData> ReadRows(GrainReference key);
+
+        /// <summary>
+        /// Return all rows that have their GrainReference's.GetUniformHashCode() in the range (start, end]
+        /// </summary>
+        /// <param name="begin">The exclusive lower bound.</param>
+        /// <param name="end">The inclusive upper bound.</param>
+        /// <returns>The reminder table entries which fall within the specified range.</returns>
+        Task<ReminderV2TableData> ReadRows(uint begin, uint end);
+
+        /// <summary>
+        /// Reads a specifie entry.
+        /// </summary>
+        /// <param name="grainRef">The grain reference.</param>
+        /// <param name="reminderName">Name of the reminder.</param>
+        /// <returns>The reminder table entry.</returns>
+        Task<ReminderV2Entry> ReadRow(GrainReference grainRef, string reminderName);
+
+        /// <summary>
+        /// Upserts the specified entry.
+        /// </summary>
+        /// <param name="entry">The entry.</param>
+        /// <returns>The row's new ETag.</returns>
+        Task<string> UpsertRow(ReminderV2Entry entry);
+
+        /// <summary>
+        /// Removes a row from the table.
+        /// </summary>
+        /// <param name="grainRef">The grain reference.</param>
+        /// <param name="reminderName">The reminder name.</param>
+        /// /// <param name="eTag">The ETag.</param>
+        /// <returns>true if a row with <paramref name="grainRef"/> and <paramref name="reminderName"/> existed and was removed successfully, false otherwise</returns>
+        Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag);
+
+        /// <summary>
+        /// Clears the table.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task TestOnlyClearTable();
+    }
+
+    /// <summary>
+    /// Reminder table interface for grain based implementation.
+    /// </summary>
+    [Unordered]
+    internal interface IReminderV2TableGrain : IGrainWithIntegerKey
+    {
+        Task<ReminderV2TableData> ReadRows(GrainReference key);
+
+        Task<ReminderV2TableData> ReadRows(uint begin, uint end);
+
+        Task<ReminderV2Entry> ReadRow(GrainReference grainRef, string reminderName);
+
+        Task<string> UpsertRow(ReminderV2Entry entry);
+
+        Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag);
+
+        Task TestOnlyClearTable();
+    }
+
+    /// <summary>
+    /// Represents a collection of reminder table entries.
+    /// </summary>
+    [Serializable]
+    [GenerateSerializer]
+    public class ReminderV2TableData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReminderV2TableData"/> class.
+        /// </summary>
+        /// <param name="list">The entries.</param>
+        public ReminderV2TableData(IEnumerable<ReminderV2Entry> list)
+        {
+            Reminders = new List<ReminderV2Entry>(list);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReminderV2TableData"/> class.
+        /// </summary>
+        /// <param name="entry">The entry.</param>
+        public ReminderV2TableData(ReminderV2Entry entry)
+        {
+            Reminders = new List<ReminderV2Entry> { entry };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReminderV2TableData"/> class.
+        /// </summary>
+        public ReminderV2TableData()
+        {
+            Reminders = new List<ReminderV2Entry>();
+        }
+
+        /// <summary>
+        /// Gets the reminders.
+        /// </summary>
+        /// <value>The reminders.</value>
+        [Id(0)]
+        public IList<ReminderV2Entry> Reminders { get; private set; }
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        public override string ToString()
+        {
+            return string.Format("[{0} reminders: {1}.", Reminders.Count,
+                Utils.EnumerableToString(Reminders, e => e.ToString()));
+        }
+    }
+
+    /// <summary>
+    /// Represents a reminder table entry.
+    /// </summary>
+    [Serializable]
+    [GenerateSerializer]
+    public class ReminderV2Entry
+    {
+        /// <summary>
+        /// Gets or sets the grain reference of the grain that created the reminder. Forms the reminder
+        /// primary key together with <see cref="ReminderName"/>.
+        /// </summary>
+        [Id(1)]
+        public GrainReference GrainRef { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the reminder. Forms the reminder primary key together with 
+        /// <see cref="GrainRef"/>.
+        /// </summary>
+        [Id(2)]
+        public string ReminderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time when the reminder was supposed to tick in the first time
+        /// </summary>
+        [Id(3)]
+        public DateTime StartAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time period for the reminder
+        /// </summary>
+        [Id(4)]
+        public TimeSpan Period { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ETag.
+        /// </summary>
+        /// <value>The ETag.</value>
+        [Id(5)]
+        public string ETag { get; set; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return string.Format("<GrainRef={0} ReminderName={1} Period={2}>", GrainRef.ToString(), ReminderName, Period);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IGrainReminderV2"/> representing the data in this instance.
+        /// </summary>
+        /// <returns>The <see cref="IGrainReminderV2"/>.</returns>
+        internal IGrainReminderV2 ToIGrainReminderV2()
+        {
+            return new ReminderV2Data(GrainRef, ReminderName, ETag);
+        }
+    }
+
+    [Serializable]
+    [GenerateSerializer]
+    internal class ReminderV2Data : IGrainReminderV2
+    {
+        [Id(1)]
+        public GrainReference GrainRef { get; private set; }
+        [Id(2)]
+        public string ReminderName { get; private set; }
+        [Id(3)]
+        public string ETag { get; private set; }
+
+        internal ReminderV2Data(GrainReference grainRef, string reminderName, string eTag)
+        {
+            GrainRef = grainRef;
+            ReminderName = reminderName;
+            ETag = eTag;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("<IOrleansReminder: GrainRef={0} ReminderName={1} ETag={2}>", GrainRef.ToString(), ReminderName, ETag);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Configuration/Options/MockReminderV2TableOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/MockReminderV2TableOptions.cs
@@ -1,0 +1,21 @@
+
+using System;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Settings for the mock reminder V2 service.
+    /// </summary>
+    public class MockReminderV2TableOptions
+    {
+        /// <summary>
+        /// Gets or sets the delay inserted before every operation completes.
+        /// </summary>
+        public TimeSpan OperationDelay { get; set; } = DEFAULT_MOCK_REMINDER_TABLE_DELAY;
+
+        /// <summary>
+        /// The default value for <see cref="MockReminderV2TableOptions"/>.
+        /// </summary>
+        public static readonly TimeSpan DEFAULT_MOCK_REMINDER_TABLE_DELAY = TimeSpan.FromMilliseconds(50);
+    }
+}

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -62,6 +62,15 @@ namespace Orleans.Runtime
             }
         }
 
+        public IReminderV2Registry ReminderV2Registry
+        {
+            get
+            {
+                CheckRuntimeContext(RuntimeContext.Current);
+                return this.ReminderV2Registry;
+            }
+        }
+
         public IServiceProvider ServiceProvider
         {
             get

--- a/src/Orleans.Runtime/ReminderServiceV2/InMemoryReminderV2Table.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/InMemoryReminderV2Table.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.ReminderServiceV2
+{
+    internal class InMemoryReminderV2Table : IReminderTable, ILifecycleParticipant<ISiloLifecycle>
+    {
+        internal const long ReminderTableGrainId = 12345;
+        private readonly IReminderTableGrain reminderTableGrain;
+        private bool isAvailable;
+
+        public InMemoryReminderV2Table(IGrainFactory grainFactory)
+        {
+            this.reminderTableGrain = grainFactory.GetGrain<IReminderTableGrain>(ReminderTableGrainId);
+        }
+
+        public Task Init() => Task.CompletedTask;
+
+        public Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
+        {
+            this.ThrowIfNotAvailable();
+            return this.reminderTableGrain.ReadRow(grainRef, reminderName);
+        }
+
+        public Task<ReminderTableData> ReadRows(GrainReference key)
+        {
+            this.ThrowIfNotAvailable();
+            return this.reminderTableGrain.ReadRows(key);
+        }
+
+        public Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            return this.isAvailable ? this.reminderTableGrain.ReadRows(begin, end) : Task.FromResult(new ReminderTableData());
+        }
+
+        public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
+        {
+            this.ThrowIfNotAvailable();
+            return this.reminderTableGrain.RemoveRow(grainRef, reminderName, eTag);
+        }
+
+        public Task TestOnlyClearTable()
+        {
+            this.ThrowIfNotAvailable();
+            return this.reminderTableGrain.TestOnlyClearTable();
+        }
+
+        public Task<string> UpsertRow(ReminderEntry entry)
+        {
+            this.ThrowIfNotAvailable();
+            return this.reminderTableGrain.UpsertRow(entry);
+        }
+
+        private void ThrowIfNotAvailable()
+        {
+            if (!this.isAvailable) throw new InvalidOperationException("The reminder service is not currently available.");
+        }
+
+        void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
+        {
+            Task OnApplicationServicesStart(CancellationToken ct)
+            {
+                this.isAvailable = true;
+                return Task.CompletedTask;
+            }
+
+            Task OnApplicationServicesStop(CancellationToken ct)
+            {
+                this.isAvailable = false;
+                return Task.CompletedTask;
+            }
+
+            lifecycle.Subscribe(
+                nameof(InMemoryReminderV2Table),
+                ServiceLifecycleStage.ApplicationServices,
+                OnApplicationServicesStart,
+                OnApplicationServicesStop);
+        }
+    }
+}

--- a/src/Orleans.Runtime/ReminderServiceV2/LocalReminderV2Service.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/LocalReminderV2Service.cs
@@ -1,0 +1,681 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.CodeGeneration;
+using Orleans.Internal;
+
+namespace Orleans.Runtime.ReminderServiceV2
+{
+    internal sealed class LocalReminderV2Service : GrainService, IReminderServiceV2
+    {
+        private const int InitialReadRetryCountBeforeFastFailForUpdates = 2;
+        private static readonly TimeSpan InitialReadMaxWaitTimeForUpdates = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan InitialReadRetryPeriod = TimeSpan.FromSeconds(30);
+        private readonly ILogger logger;
+        private readonly Dictionary<ReminderV2Identity, LocalReminderV2Data> localReminders = new();
+        private readonly IReminderV2Table reminderTable;
+        private readonly TaskCompletionSource<bool> startedTask;
+        private readonly AverageTimeSpanStatistic tardinessStat;
+        private readonly CounterStatistic ticksDeliveredStat;
+        private readonly TimeSpan initTimeout;
+        private readonly IAsyncTimerFactory asyncTimerFactory;
+        private readonly IAsyncTimer listRefreshTimer; // timer that refreshes our list of reminders to reflect global reminder table
+        private long localTableSequence;
+        private uint initialReadCallCount = 0;
+        private Task runTask;
+
+        internal LocalReminderV2Service(
+            Silo silo,
+            IReminderV2Table reminderTable,
+            TimeSpan initTimeout,
+            ILoggerFactory loggerFactory,
+            IAsyncTimerFactory asyncTimerFactory)
+            : base(SystemTargetGrainId.CreateGrainServiceGrainId(GrainInterfaceUtils.GetGrainClassTypeCode(typeof(IReminderServiceV2)), null, silo.SiloAddress), silo, loggerFactory)
+        {
+            this.reminderTable = reminderTable;
+            this.initTimeout = initTimeout;
+            this.asyncTimerFactory = asyncTimerFactory;
+            tardinessStat = AverageTimeSpanStatistic.FindOrCreate(StatisticNames.REMINDERS_AVERAGE_TARDINESS_SECONDS);
+            IntValueStatistic.FindOrCreate(StatisticNames.REMINDERS_NUMBER_ACTIVE_REMINDERS, () => localReminders.Count);
+            ticksDeliveredStat = CounterStatistic.FindOrCreate(StatisticNames.REMINDERS_COUNTERS_TICKS_DELIVERED);
+            startedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            logger = loggerFactory.CreateLogger<LocalReminderV2Service>();
+            listRefreshTimer = asyncTimerFactory.Create(Constants.RefreshReminderList, "ReminderService.ReminderListRefresher");
+        }
+
+        /// <summary>
+        /// Attempt to retrieve reminders, that are my responsibility, from the global reminder table when starting this silo (reminder service instance)
+        /// </summary>
+        /// <returns></returns>
+        public override async Task Start()
+        {
+            // confirm that it can access the underlying store, as after this the ReminderService will load in the background, without the opportunity to prevent the Silo from starting
+            await reminderTable.Init().WithTimeout(initTimeout, $"ReminderTable Initialization failed due to timeout {initTimeout}");
+
+            await base.Start();
+        }
+
+        public async override Task Stop()
+        {
+            await base.Stop();
+
+            if (listRefreshTimer != null)
+            {
+                listRefreshTimer.Dispose();
+                if (runTask is Task task)
+                {
+                    await task;
+                }
+            }
+
+            foreach (var r in localReminders.Values)
+            {
+                r.StopReminder();
+            }
+
+            // for a graceful shutdown, also handover reminder responsibilities to new owner, and update the ReminderTable
+            // currently, this is taken care of by periodically reading the reminder table
+        }
+
+        public async Task<IGrainReminderV2> RegisterOrUpdateReminder(GrainReference grainRef, string reminderName, TimeSpan dueTime, TimeSpan period)
+        {
+            var entry = new ReminderV2Entry
+            {
+                GrainRef = grainRef,
+                ReminderName = reminderName,
+                StartAt = DateTime.UtcNow.Add(dueTime),
+                Period = period,
+            };
+
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_RegisterOrUpdate, "RegisterOrUpdateReminder: {0}", entry.ToString());
+            await DoResponsibilitySanityCheck(grainRef, "RegisterReminder");
+            var newEtag = await reminderTable.UpsertRow(entry);
+
+            if (newEtag != null)
+            {
+                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Registered reminder {0} in table, assigned localSequence {1}", entry, localTableSequence);
+                entry.ETag = newEtag;
+                StartAndAddTimer(entry);
+                if (logger.IsEnabled(LogLevel.Trace)) PrintReminders();
+                return new ReminderData(grainRef, reminderName, newEtag) as IGrainReminderV2;
+            }
+
+            var msg = string.Format("Could not register reminder {0} to reminder table due to a race. Please try again later.", entry);
+            logger.Error(ErrorCode.RS_Register_TableError, msg);
+            throw new ReminderException(msg);
+        }
+
+        /// <summary>
+        /// Stop the reminder locally, and remove it from the external storage system
+        /// </summary>
+        /// <param name="reminder"></param>
+        /// <returns></returns>
+        public async Task UnregisterReminder(IGrainReminderV2 reminder)
+        {
+            var remData = (ReminderData)reminder;
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_Unregister, "UnregisterReminder: {0}, LocalTableSequence: {1}", remData, localTableSequence);
+
+            var grainRef = remData.GrainRef;
+            var reminderName = remData.ReminderName;
+            var eTag = remData.ETag;
+
+            await DoResponsibilitySanityCheck(grainRef, "RemoveReminder");
+
+            // it may happen that we dont have this reminder locally ... even then, we attempt to remove the reminder from the reminder
+            // table ... the periodic mechanism will stop this reminder at any silo's LocalReminderService that might have this reminder locally
+
+            // remove from persistent/memory store
+            var success = await reminderTable.RemoveRow(grainRef, reminderName, eTag);
+            if (success)
+            {
+                var removed = TryStopPreviousTimer(grainRef, reminderName);
+                if (removed)
+                {
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_Stop, "Stopped reminder {0}", reminder);
+                    if (logger.IsEnabled(LogLevel.Trace)) PrintReminders(string.Format("After removing {0}.", reminder));
+                }
+                else
+                {
+                    // no-op
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_RemoveFromTable, "Removed reminder from table which I didn't have locally: {0}.", reminder);
+                }
+            }
+            else
+            {
+                var msg = string.Format("Could not unregister reminder {0} from the reminder table, due to tag mismatch. You can retry.", reminder);
+                logger.Error(ErrorCode.RS_Unregister_TableError, msg);
+                throw new ReminderException(msg);
+            }
+        }
+
+        public async Task<IGrainReminderV2> GetReminder(GrainReference grainRef, string reminderName)
+        {
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_GetReminder, "GetReminder: GrainReference={0} ReminderName={1}", grainRef.ToString(), reminderName);
+            var entry = await reminderTable.ReadRow(grainRef, reminderName);
+            return entry == null ? null : entry.ToIGrainReminderV2();
+        }
+
+        public async Task<List<IGrainReminderV2>> GetReminders(GrainReference grainRef)
+        {
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_GetReminders, "GetReminders: GrainReference={0}", grainRef.ToString());
+            var tableData = await reminderTable.ReadRows(grainRef);
+            return tableData.Reminders.Select(entry => entry.ToIGrainReminderV2()).ToList();
+        }
+
+        /// <summary>
+        /// Attempt to retrieve reminders from the global reminder table
+        /// </summary>
+        private Task ReadAndUpdateReminders()
+        {
+            if (StoppedCancellationTokenSource.IsCancellationRequested) return Task.CompletedTask;
+
+            RemoveOutOfRangeReminders();
+
+            // try to retrieve reminders from all my subranges
+            var rangeSerialNumberCopy = RangeSerialNumber;
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace($"My range= {RingRange}, RangeSerialNumber {RangeSerialNumber}. Local reminders count {localReminders.Count}");
+            var acks = new List<Task>();
+            foreach (var range in RangeFactory.GetSubRanges(RingRange))
+            {
+                acks.Add(ReadTableAndStartTimers(range, rangeSerialNumberCopy));
+            }
+            var task = Task.WhenAll(acks);
+            if (logger.IsEnabled(LogLevel.Trace)) task.ContinueWith(_ => PrintReminders(), TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+            return task;
+        }
+
+        private void RemoveOutOfRangeReminders()
+        {
+            var remindersOutOfRange = localReminders.Where(r => !RingRange.InRange(r.Key.GrainRef)).Select(r => r.Value).ToArray();
+
+            foreach (var reminder in remindersOutOfRange)
+            {
+                if (logger.IsEnabled(LogLevel.Trace))
+                    logger.Trace("Not in my range anymore, so removing. {0}", reminder);
+                // remove locally
+                reminder.StopReminder();
+                localReminders.Remove(reminder.Identity);
+            }
+
+            if (logger.IsEnabled(LogLevel.Information) && remindersOutOfRange.Length > 0) logger.Info($"Removed {remindersOutOfRange.Length} local reminders that are now out of my range.");
+        }
+
+        public override Task OnRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
+        {
+            _ = base.OnRangeChange(oldRange, newRange, increased);
+            if (Status == GrainServiceStatus.Started)
+                return ReadAndUpdateReminders();
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Ignoring range change until ReminderService is Started -- Current status = {0}", Status);
+            return Task.CompletedTask;
+        }
+
+        private async Task RunAsync()
+        {
+            TimeSpan? overrideDelay = ThreadSafeRandom.NextTimeSpan(InitialReadRetryPeriod);
+            while (await listRefreshTimer.NextTick(overrideDelay))
+            {
+                try
+                {
+                    overrideDelay = null;
+                    switch (Status)
+                    {
+                        case GrainServiceStatus.Booting:
+                            await DoInitialReadAndUpdateReminders();
+                            break;
+                        case GrainServiceStatus.Started:
+                            await ReadAndUpdateReminders();
+                            break;
+                        default:
+                            listRefreshTimer.Dispose();
+                            return;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    logger.LogWarning(exception, "Exception while reading reminders: {Exception}", exception);
+                    overrideDelay = ThreadSafeRandom.NextTimeSpan(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
+                }
+            }
+        }
+
+        protected override async Task StartInBackground()
+        {
+            await DoInitialReadAndUpdateReminders();
+            runTask = RunAsync();
+        }
+
+        private async Task DoInitialReadAndUpdateReminders()
+        {
+            try
+            {
+                if (StoppedCancellationTokenSource.IsCancellationRequested) return;
+
+                initialReadCallCount++;
+                await ReadAndUpdateReminders();
+                Status = GrainServiceStatus.Started;
+                startedTask.TrySetResult(true);
+            }
+            catch (Exception ex)
+            {
+                if (StoppedCancellationTokenSource.IsCancellationRequested) return;
+
+                if (initialReadCallCount <= InitialReadRetryCountBeforeFastFailForUpdates)
+                {
+                    logger.Warn(
+                        ErrorCode.RS_ServiceInitialLoadFailing,
+                        string.Format("ReminderService failed initial load of reminders and will retry. Attempt #{0}", initialReadCallCount),
+                        ex);
+                }
+                else
+                {
+                    const string baseErrorMsg = "ReminderService failed initial load of reminders and cannot guarantee that the service will be eventually start without manual intervention or restarting the silo.";
+                    var logErrorMessage = string.Format(baseErrorMsg + " Attempt #{0}", initialReadCallCount);
+                    logger.Error(ErrorCode.RS_ServiceInitialLoadFailed, logErrorMessage, ex);
+                    startedTask.TrySetException(new OrleansException(baseErrorMsg, ex));
+                }
+            }
+        }
+
+        private async Task ReadTableAndStartTimers(IRingRange range, int rangeSerialNumberCopy)
+        {
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Reading rows from {0}", range.ToString());
+            localTableSequence++;
+            var cachedSequence = localTableSequence;
+
+            try
+            {
+                var srange = range as ISingleRange;
+                if (srange == null)
+                    throw new InvalidOperationException("LocalReminderService must be dealing with SingleRange");
+
+                var table = await reminderTable.ReadRows(srange.Begin, srange.End); // get all reminders, even the ones we already have
+
+                if (rangeSerialNumberCopy < RangeSerialNumber)
+                {
+                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug($"My range changed while reading from the table, ignoring the results. Another read has been started. RangeSerialNumber {RangeSerialNumber}, RangeSerialNumberCopy {rangeSerialNumberCopy}.");
+                    return;
+                }
+                if (StoppedCancellationTokenSource.IsCancellationRequested) return;
+
+                // if null is a valid value, it means that there's nothing to do.
+                if (null == table && reminderTable is MockReminderV2Table) return;
+
+                var remindersNotInTable = localReminders.Where(r => range.InRange(r.Key.GrainRef)).ToDictionary(r => r.Key, r => r.Value); // shallow copy
+                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("For range {0}, I read in {1} reminders from table. LocalTableSequence {2}, CachedSequence {3}", range.ToString(), table.Reminders.Count, localTableSequence, cachedSequence);
+
+                foreach (var entry in table.Reminders)
+                {
+                    var key = new ReminderV2Identity(entry.GrainRef, entry.ReminderName);
+                    LocalReminderV2Data localRem;
+                    if (localReminders.TryGetValue(key, out localRem))
+                    {
+                        if (cachedSequence > localRem.LocalSequenceNumber) // info read from table is same or newer than local info
+                        {
+                            if (localRem.IsRunning) // if ticking
+                            {
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Old, & Ticking {0}", localRem);
+                                // it might happen that our local reminder is different than the one in the table, i.e., eTag is different
+                                // if so, stop the local timer for the old reminder, and start again with new info
+                                if (!localRem.ETag.Equals(entry.ETag))
+                                // this reminder needs a restart
+                                {
+                                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("{0} Needs a restart", localRem);
+                                    localRem.StopReminder();
+                                    localReminders.Remove(localRem.Identity);
+                                    StartAndAddTimer(entry);
+                                }
+                            }
+                            else // if not ticking
+                            {
+                                // no-op
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Old, & Not Ticking {0}", localRem);
+                            }
+                        }
+                        else // cachedSequence < localRem.LocalSequenceNumber ... // info read from table is older than local info
+                        {
+                            if (localRem.IsRunning) // if ticking
+                            {
+                                // no-op
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Newer, & Ticking {0}", localRem);
+                            }
+                            else // if not ticking
+                            {
+                                // no-op
+                                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, In local, Newer, & Not Ticking {0}", localRem);
+                            }
+                        }
+                    }
+                    else // exists in table, but not locally
+                    {
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("In table, Not in local, {0}", entry);
+                        // create and start the reminder
+                        StartAndAddTimer(entry);
+                    }
+                    // keep a track of extra reminders ... this 'reminder' is useful, so remove it from extra list
+                    remindersNotInTable.Remove(key);
+                } // foreach reminder read from table
+
+                var remindersCountBeforeRemove = localReminders.Count;
+
+                // foreach reminder that is not in global table, but exists locally
+                foreach (var reminder in remindersNotInTable.Values)
+                {
+                    if (cachedSequence < reminder.LocalSequenceNumber)
+                    {
+                        // no-op
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Not in table, In local, Newer, {0}", reminder);
+                    }
+                    else // cachedSequence > reminder.LocalSequenceNumber
+                    {
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Not in table, In local, Old, so removing. {0}", reminder);
+                        // remove locally
+                        reminder.StopReminder();
+                        localReminders.Remove(reminder.Identity);
+                    }
+                }
+                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug($"Removed {localReminders.Count - remindersCountBeforeRemove} reminders from local table");
+            }
+            catch (Exception exc)
+            {
+                logger.Error(ErrorCode.RS_FailedToReadTableAndStartTimer, "Failed to read rows from table.", exc);
+                throw;
+            }
+        }
+
+        private void StartAndAddTimer(ReminderV2Entry entry)
+        {
+            // it might happen that we already have a local reminder with a different eTag
+            // if so, stop the local timer for the old reminder, and start again with new info
+            // Note: it can happen here that we restart a reminder that has the same eTag as what we just registered ... its a rare case, and restarting it doesn't hurt, so we don't check for it
+            var key = new ReminderV2Identity(entry.GrainRef, entry.ReminderName);
+            LocalReminderV2Data prevReminder;
+            if (localReminders.TryGetValue(key, out prevReminder)) // if found locally
+            {
+                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_LocalStop, "Locally stopping reminder {0} as it is different than newly registered reminder {1}", prevReminder, entry);
+                prevReminder.StopReminder();
+                localReminders.Remove(prevReminder.Identity);
+            }
+
+            var newReminder = new LocalReminderV2Data(entry, this);
+            localTableSequence++;
+            newReminder.LocalSequenceNumber = localTableSequence;
+            localReminders.Add(newReminder.Identity, newReminder);
+            newReminder.StartTimer();
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.RS_Started, "Started reminder {0}.", entry.ToString());
+        }
+
+        // stop without removing it. will remove later.
+        private bool TryStopPreviousTimer(GrainReference grainRef, string reminderName)
+        {
+            // we stop the locally running timer for this reminder
+            var key = new ReminderV2Identity(grainRef, reminderName);
+            LocalReminderV2Data localRem;
+            if (!localReminders.TryGetValue(key, out localRem)) return false;
+
+            // if we have it locally
+            localTableSequence++; // move to next sequence
+            localRem.LocalSequenceNumber = localTableSequence;
+            localRem.StopReminder();
+            return true;
+        }
+
+        private Task DoResponsibilitySanityCheck(GrainReference grainRef, string debugInfo)
+        {
+            switch (Status)
+            {
+                case GrainServiceStatus.Booting:
+                    // if service didn't finish the initial load, it could still be loading normally or it might have already 
+                    // failed a few attempts and callers should not be hold waiting for it to complete
+                    var task = startedTask.Task;
+                    if (task.IsCompleted)
+                    {
+                        // task at this point is already Faulted
+                        task.GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        return WaitForInitCompletion();
+                        async Task WaitForInitCompletion()
+                        {
+                            try
+                            {
+                                // wait for the initial load task to complete (with a timeout)
+                                await task.WithTimeout(InitialReadMaxWaitTimeForUpdates);
+                            }
+                            catch (TimeoutException ex)
+                            {
+                                throw new OrleansException("Reminder Service is still initializing and it is taking a long time. Please retry again later.", ex);
+                            }
+                            CheckRange();
+                        }
+                    }
+                    break;
+                case GrainServiceStatus.Started:
+                    break;
+                case GrainServiceStatus.Stopped:
+                    throw new OperationCanceledException("ReminderService has been stopped.");
+                default:
+                    throw new InvalidOperationException("status");
+            }
+            CheckRange();
+            return Task.CompletedTask;
+
+            void CheckRange()
+            {
+                if (!RingRange.InRange(grainRef))
+                {
+                    logger.Warn(ErrorCode.RS_NotResponsible, "I shouldn't have received request '{0}' for {1}. It is not in my responsibility range: {2}",
+                        debugInfo, grainRef.ToString(), RingRange);
+                    // For now, we still let the caller proceed without throwing an exception... the periodical mechanism will take care of reminders being registered at the wrong silo
+                    // otherwise, we can either reject the request, or re-route the request
+                }
+            }
+        }
+
+        // Note: The list of reminders can be huge in production!
+        private void PrintReminders(string msg = null)
+        {
+            if (!logger.IsEnabled(LogLevel.Trace)) return;
+
+            var str = string.Format("{0}{1}{2}", msg ?? "Current list of reminders:", Environment.NewLine,
+                Utils.EnumerableToString(localReminders, null, Environment.NewLine));
+            logger.Trace(str);
+        }
+
+        private class LocalReminderV2Data
+        {
+            private readonly IRemindableV2 remindable;
+            private readonly DateTime firstTickTime; // time for the first tick of this reminder
+            private readonly TimeSpan period;
+            private readonly LocalReminderV2Service reminderService;
+            private readonly IAsyncTimer timer;
+
+            private ValueStopwatch stopwatch;
+            private Task runTask;
+
+            internal LocalReminderV2Data(ReminderV2Entry entry, LocalReminderV2Service reminderService)
+            {
+                Identity = new ReminderV2Identity(entry.GrainRef, entry.ReminderName);
+                firstTickTime = entry.StartAt;
+                period = entry.Period;
+                remindable = entry.GrainRef.Cast<IRemindableV2>();
+                ETag = entry.ETag;
+                LocalSequenceNumber = -1;
+                this.reminderService = reminderService;
+                timer = reminderService.asyncTimerFactory.Create(period, "");
+            }
+
+            public ReminderV2Identity Identity { get; }
+
+            public string ETag { get; }
+
+            /// <summary>
+            /// Locally, we use this for resolving races between the periodic table reader, and any concurrent local register/unregister requests
+            /// </summary>
+            public long LocalSequenceNumber { get; set; }
+
+            /// <summary>
+            /// Gets a value indicating whether this instance is running.
+            /// </summary>
+            public bool IsRunning => runTask is Task task && !task.IsCompleted;
+
+            public void StartTimer()
+            {
+                if (runTask is null)
+                {
+                    runTask = RunAsync();
+                }
+                else
+                {
+                    throw new InvalidOperationException($"{nameof(StartTimer)} may only be called once per instance and has already been called on this instance.");
+                }
+            }
+
+            public void StopReminder()
+            {
+                timer.Dispose();
+            }
+
+            private async Task RunAsync()
+            {
+                TimeSpan? dueTimeSpan = CalculateDueTime();
+                while (await timer.NextTick(dueTimeSpan))
+                {
+                    try
+                    {
+                        await OnTimerTick();
+                        reminderService.ticksDeliveredStat.Increment();
+                    }
+                    catch (Exception exception)
+                    {
+                        reminderService.logger.LogWarning(
+                            exception,
+                            "Exception firing reminder \"{ReminderName}\" for grain {GrainId}: {Exception}",
+                            Identity.ReminderName,
+                            Identity.GrainRef?.GrainId,
+                            exception);
+                    }
+
+                    dueTimeSpan = CalculateDueTime();
+                }
+            }
+
+            private TimeSpan CalculateDueTime()
+            {
+                TimeSpan dueTimeSpan;
+                var now = DateTime.UtcNow;
+                if (now < firstTickTime) // if the time for first tick hasn't passed yet
+                {
+                    dueTimeSpan = firstTickTime.Subtract(now); // then duetime is duration between now and the first tick time
+                }
+                else // the first tick happened in the past ... compute duetime based on the first tick time, and period
+                {
+                    // formula used:
+                    // due = period - 'time passed since last tick (==sinceLast)'
+                    // due = period - ((Now - FirstTickTime) % period)
+                    // explanation of formula:
+                    // (Now - FirstTickTime) => gives amount of time since first tick happened
+                    // (Now - FirstTickTime) % period => gives amount of time passed since the last tick should have triggered
+                    var sinceFirstTick = now.Subtract(firstTickTime);
+                    var sinceLastTick = TimeSpan.FromTicks(sinceFirstTick.Ticks % period.Ticks);
+                    dueTimeSpan = period.Subtract(sinceLastTick);
+                    // in corner cases, dueTime can be equal to period ... so, take another mod
+                    dueTimeSpan = TimeSpan.FromTicks(dueTimeSpan.Ticks % period.Ticks);
+                }
+                return dueTimeSpan;
+            }
+
+            public async Task OnTimerTick()
+            {
+                var before = DateTime.UtcNow;
+                var status = TickStatus.Create(firstTickTime, period, before);
+
+                var logger = reminderService.logger;
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    logger.Trace("Triggering tick for {0}, status {1}, now {2}", ToString(), status, before);
+                }
+
+                try
+                {
+                    if (stopwatch.IsRunning)
+                    {
+                        stopwatch.Stop();
+                        var tardiness = stopwatch.Elapsed - period;
+                        reminderService.tardinessStat.AddSample(Math.Max(0, tardiness.Ticks));
+                    }
+
+                    await remindable.ReceiveReminder(Identity.ReminderName, status);
+
+                    stopwatch.Restart();
+
+                    var after = DateTime.UtcNow;
+                    if (logger.IsEnabled(LogLevel.Trace))
+                    {
+                        logger.Trace("Tick triggered for {0}, dt {1} sec, next@~ {2}", ToString(), (after - before).TotalSeconds,
+                              // the next tick isn't actually scheduled until we return control to
+                              // AsyncSafeTimer but we can approximate it by adding the period of the reminder
+                              // to the after time.
+                              after + period);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    var after = DateTime.UtcNow;
+                    logger.Error(
+                        ErrorCode.RS_Tick_Delivery_Error,
+                        string.Format("Could not deliver reminder tick for {0}, next {1}.", ToString(), after + period),
+                            exc);
+                    // What to do with repeated failures to deliver a reminder's ticks?
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Format("[{0}, {1}, {2}, {3}, {4}, {5}, {6}]",
+                                        Identity.ReminderName,
+                                        Identity.GrainRef?.ToString(),
+                                        period,
+                                        LogFormatter.PrintDate(firstTickTime),
+                                        ETag,
+                                        LocalSequenceNumber,
+                                        timer == null ? "Not_ticking" : "Ticking");
+            }
+        }
+
+        private readonly struct ReminderV2Identity : IEquatable<ReminderV2Identity>
+        {
+            public readonly GrainReference GrainRef { get; }
+            public readonly string ReminderName { get; }
+
+            public ReminderV2Identity(GrainReference grainRef, string reminderName)
+            {
+                if (grainRef == null)
+                    throw new ArgumentNullException("grainRef");
+
+                if (string.IsNullOrWhiteSpace(reminderName))
+                    throw new ArgumentException("The reminder name is either null or whitespace.", "reminderName");
+
+                GrainRef = grainRef;
+                ReminderName = reminderName;
+            }
+
+            public readonly bool Equals(ReminderV2Identity other)
+            {
+                return GrainRef.Equals(other.GrainRef) && ReminderName.Equals(other.ReminderName);
+            }
+
+            public override readonly bool Equals(object other)
+            {
+                return other is ReminderV2Identity && Equals((ReminderV2Identity)other);
+            }
+
+            public override readonly int GetHashCode()
+            {
+                return unchecked((int)((uint)GrainRef.GetHashCode() + (uint)ReminderName.GetHashCode()));
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/ReminderServiceV2/MockReminderV2Table.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/MockReminderV2Table.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+
+namespace Orleans.Runtime.ReminderServiceV2
+{
+    internal class MockReminderV2Table : IReminderTable
+    {
+        private const string MOCK_E_TAG = "MockETag";
+        private readonly TimeSpan delay;
+
+        public MockReminderV2Table(IOptions<MockReminderV2TableOptions> options)
+        {
+            this.delay = options.Value.OperationDelay;
+        }
+
+        public Task Init()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task<ReminderTableData> ReadRows(GrainReference key)
+        {
+            await Task.Delay(delay);
+            return null;
+        }
+
+        public async Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            await Task.Delay(delay);
+            return null;
+        }
+
+        public async Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
+        {
+            await Task.Delay(delay);
+            return null;
+        }
+
+        public async Task<string> UpsertRow(ReminderEntry entry)
+        {
+            await Task.Delay(delay);
+            return MOCK_E_TAG;
+        }
+
+        public async Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
+        {
+            await Task.Delay(delay);
+            return true;
+        }
+
+        public Task TestOnlyClearTable()
+        {
+            return Task.Delay(delay);
+        }
+    }
+}

--- a/src/Orleans.Runtime/ReminderServiceV2/ReminderV2Registry.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/ReminderV2Registry.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime.Services;
+using Orleans.Timers;
+
+namespace Orleans.Runtime.ReminderServiceV2
+{
+    internal class ReminderV2Registry : GrainServiceClient<IReminderServiceV2>, IReminderV2Registry
+    {
+        private const string ReminderServiceNotConfigured =
+           "The reminder service has not been configured. Reminders can be configured using extension methods from the following packages:"
+           + "\n  * Microsoft.Orleans.Reminders.AzureStorage via ISiloBuilder.UseAzureTableReminderService(...)"
+           + "\n  * Microsoft.Orleans.Reminders.AdoNet via ISiloBuilder.UseAdoNetReminderService(...)"
+           + "\n  * Microsoft.Orleans.Reminders.DynamoDB via via ISiloBuilder.UseDynamoDBReminderService(...)"
+           + "\n  * Microsoft.Orleans.OrleansRuntime via ISiloBuilder.UseInMemoryReminderService(...) (Note: for development purposes only)"
+           + "\n  * Others, see: https://www.nuget.org/packages?q=Microsoft.Orleans.Reminders.";
+
+        private const uint MaxSupportedTimeout = 0xfffffffe;
+        private readonly IServiceProvider serviceProvider;
+        private bool reminderServiceRegistered;
+
+        public ReminderV2Registry(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        public Task<IGrainReminderV2> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
+        {
+            this.EnsureReminderServiceRegistered();
+
+            // Perform input volatility checks that are consistent with System.Threading.Timer
+            // http://referencesource.microsoft.com/#mscorlib/system/threading/timer.cs,c454f2afe745d4d3,references
+            var dueTm = (long) dueTime.TotalMilliseconds;
+            if (dueTm < -1)
+                throw new ArgumentOutOfRangeException(nameof(dueTime), "Cannot use negative dueTime to create a reminder");
+            if (dueTm > MaxSupportedTimeout)
+                throw new ArgumentOutOfRangeException(
+                    nameof(dueTime),
+                    $"Cannot use value larger than {MaxSupportedTimeout}ms for dueTime when creating a reminder");
+
+            var periodTm = (long) period.TotalMilliseconds;
+            if (periodTm < -1)
+                throw new ArgumentOutOfRangeException(nameof(period), "Cannot use negative period to create a reminder");
+            if (periodTm > MaxSupportedTimeout)
+                throw new ArgumentOutOfRangeException(
+                    nameof(period),
+                    $"Cannot use value larger than {MaxSupportedTimeout}ms for period when creating a reminder");
+
+            var reminderOptions = serviceProvider.GetService<IOptions<ReminderOptions>>();
+            var minReminderPeriod = reminderOptions.Value.MinimumReminderPeriod;
+
+            if (period < minReminderPeriod)
+            {
+                var msg =
+                    string.Format(
+                        "Cannot register reminder {0} as requested period ({1}) is less than minimum allowed reminder period ({2})",
+                        reminderName,
+                        period,
+                        minReminderPeriod);
+                throw new ArgumentException(msg);
+            }
+            if (string.IsNullOrEmpty(reminderName))
+            {
+                throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
+            }
+
+            return GrainService.RegisterOrUpdateReminder(CallingGrainReference, reminderName, dueTime, period);
+        }
+
+        public Task UnregisterReminder(IGrainReminderV2 reminder)
+        {
+            this.EnsureReminderServiceRegistered();
+            return GrainService.UnregisterReminder(reminder);
+        }
+
+        public Task<IGrainReminderV2> GetReminder(string reminderName)
+        {
+            this.EnsureReminderServiceRegistered();
+            if (string.IsNullOrEmpty(reminderName))
+            {
+                throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
+            }
+
+            return GrainService.GetReminder(CallingGrainReference, reminderName);
+        }
+
+        public Task<List<IGrainReminderV2>> GetReminders()
+        {
+            this.EnsureReminderServiceRegistered();
+            return GrainService.GetReminders(CallingGrainReference);
+        }
+
+        private void EnsureReminderServiceRegistered()
+        {
+            if (this.reminderServiceRegistered) return;
+            var reminderTable = this.serviceProvider.GetService<IReminderTable>();
+            if (reminderTable == null)
+            {
+                throw new OrleansConfigurationException(ReminderServiceNotConfigured);
+            }
+
+            this.reminderServiceRegistered = true;
+        }
+    }
+}

--- a/src/Orleans.Runtime/ReminderServiceV2/ReminderV2TableGrain.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/ReminderV2TableGrain.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Concurrency;
+
+namespace Orleans.Runtime.ReminderServiceV2
+{
+    [Reentrant]
+    [KeepAlive]
+    internal class ReminderV2TableGrain : Grain, IReminderV2TableGrain
+    {
+        private readonly Dictionary<GrainReference, Dictionary<string, ReminderV2Entry>> reminderTable = new Dictionary<GrainReference, Dictionary<string, ReminderV2Entry>>();
+        private readonly ILogger logger;
+
+        public ReminderV2TableGrain(ILogger<ReminderV2TableGrain> logger)
+        {
+            this.logger = logger;
+        }
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Activated");
+            base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation virtually indefinitely.
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Deactivated");
+            return Task.CompletedTask;
+        }
+
+        public Task TestOnlyClearTable()
+        {
+            logger.LogInformation("TestOnlyClearTable");
+            reminderTable.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task<ReminderV2TableData> ReadRows(GrainReference grainRef)
+        {
+            Dictionary<string, ReminderV2Entry> reminders;
+            reminderTable.TryGetValue(grainRef, out reminders);
+            var result = reminders == null ? new ReminderV2TableData() : new ReminderV2TableData(reminders.Values.ToList());
+            return Task.FromResult(result);
+        }
+
+        public Task<ReminderV2TableData> ReadRows(uint begin, uint end)
+        {
+            var range = RangeFactory.CreateRange(begin, end);
+
+            var list = reminderTable.Where(e => range.InRange(e.Key)).SelectMany(e => e.Value.Values).ToList();
+
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace(
+                    "Selected {SelectCount} out of {TotalCount} reminders from memory for {Range}. Selected: {Reminders}",
+                    list.Count,
+                    reminderTable.Values.Sum(r => r.Count),
+                    range.ToString(),
+                    Utils.EnumerableToString(list, e => e.ToString()));
+            }
+
+            var result = new ReminderV2TableData(list);
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Read {ReminderCount} reminders from memory: {Reminders}", result.Reminders.Count, Utils.EnumerableToString(result.Reminders));
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task<ReminderV2Entry> ReadRow(GrainReference grainRef, string reminderName)
+        {
+            ReminderV2Entry result = null;
+            Dictionary<string, ReminderV2Entry> reminders;
+            if (reminderTable.TryGetValue(grainRef, out reminders))
+            {
+                reminders.TryGetValue(reminderName, out result);
+            }
+
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                if (result is null)
+                {
+                    logger.LogTrace("Reminder not found for grain {Grain} reminder {ReminderName} ", grainRef, reminderName);
+                }
+                else
+                {
+                    logger.LogTrace("Read for grain {Grain} reminder {ReminderName} row {Reminder}", grainRef, reminderName, result.ToString());
+                }
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task<string> UpsertRow(ReminderV2Entry entry)
+        {
+            entry.ETag = Guid.NewGuid().ToString();
+            Dictionary<string, ReminderV2Entry> d;
+            if (!reminderTable.TryGetValue(entry.GrainRef, out d))
+            {
+                d = new Dictionary<string, ReminderV2Entry>();
+                reminderTable.Add(entry.GrainRef, d);
+            }
+
+            ReminderV2Entry old; // tracing purposes only
+            d.TryGetValue(entry.ReminderName, out old); // tracing purposes only
+                                                        // add or over-write
+            d[entry.ReminderName] = entry;
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Upserted entry {Updated}, replaced {Replaced}", entry, old);
+            }
+
+            return Task.FromResult(entry.ETag);
+        }
+
+        public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("RemoveRow Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}", grainRef, reminderName, eTag);
+            }
+
+            if (reminderTable.TryGetValue(grainRef, out var data)
+                && data.TryGetValue(reminderName, out var e)
+                && e.ETag == eTag)
+            {
+                if (data.Count > 1)
+                {
+                    data.Remove(reminderName);
+                }
+                else
+                {
+                    reminderTable.Remove(grainRef);
+                }
+
+                return Task.FromResult(true);
+            }
+
+            logger.LogWarning(
+                (int)ErrorCode.RS_Table_Remove,
+                "RemoveRow failed for Grain = {Grain}, ReminderName = {ReminderName}, eTag = {ETag}. Table now is: {3}",
+                grainRef,
+                reminderName,
+                eTag,
+                Utils.EnumerableToString(reminderTable.Values.SelectMany(x => x.Values)));
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Orleans.Runtime/ReminderServiceV2/SiloBuilderReminderV2Extensions.cs
+++ b/src/Orleans.Runtime/ReminderServiceV2/SiloBuilderReminderV2Extensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration.Internal;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderServiceV2;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extensions to <see cref="ISiloBuilder"/> for configuring reminder storage.
+    /// </summary>
+    public static class SiloBuilderReminderV2Extensions
+    {
+        /// <summary>
+        /// Configures reminder storage using an in-memory, non-persistent store.
+        /// </summary>
+        /// <remarks>
+        /// Note that this is for development and testing scenarios only and should not be used in production.
+        /// </remarks>
+        /// <param name="builder">The silo host builder.</param>
+        /// <returns>The provided <see cref="ISiloBuilder"/>, for chaining.</returns>
+        public static ISiloBuilder UseInMemoryReminderV2Service(this ISiloBuilder builder)
+        {
+            // The reminder table is a reference to a singleton IReminderTableGrain.
+            builder.ConfigureServices(services => services.UseInMemoryReminderV2Service());
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures reminder storage using an in-memory, non-persistent store.
+        /// </summary>
+        /// <remarks>
+        /// Note that this is for development and testing scenarios only and should not be used in production.
+        /// </remarks>
+        /// <param name="services">The service collection.</param>
+        /// <returns>The provided <see cref="IServiceCollection"/>, for chaining.</returns>
+        internal static IServiceCollection UseInMemoryReminderV2Service(this IServiceCollection services)
+        {
+            services.AddSingleton<InMemoryReminderV2Table>();
+            services.AddFromExisting<IReminderTable, InMemoryReminderV2Table>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, InMemoryReminderV2Table>();
+            return services;
+        }
+    }
+}

--- a/src/Orleans.Runtime/Services/GrainServiceClient.cs
+++ b/src/Orleans.Runtime/Services/GrainServiceClient.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime.Services
         }
 
         /// <summary>
-        /// Gets a reference to the the currently executing grain.
+        /// Gets a reference to the currently executing grain.
         /// </summary>
         protected GrainReference CallingGrainReference => RuntimeContext.Current?.GrainReference;
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -404,7 +404,7 @@ namespace Orleans.Runtime
         {
             var stopWatch = Stopwatch.StartNew();
 
-            if (this.reminderService != null)
+            if (this.reminderServiceV2 != null)
             {
                 await StartAsyncTaskWithPerfAnalysis("Start reminder V2 service", StartReminderV2Service, stopWatch);
 

--- a/test/DefaultCluster.Tests/ReminderV2Test.cs
+++ b/test/DefaultCluster.Tests/ReminderV2Test.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests
+{
+    public class ReminderV2Test : HostedTestClusterEnsureDefaultStarted
+    {
+        public ReminderV2Test(DefaultClusterFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Reminders")]
+        public async Task SimpleGrainGetGrain()
+        {
+            IReminderV2TestGrain grain = this.GrainFactory.GetGrain<IReminderV2TestGrain>(GetRandomGrainId());
+            bool notExists = await grain.IsReminderExists("not exists");
+            Assert.False(notExists);
+
+            await grain.AddReminder("dummy");
+            Assert.True(await grain.IsReminderExists("dummy"));
+
+            await grain.RemoveReminder("dummy");
+            Assert.False(await grain.IsReminderExists("dummy"));
+        }
+    }
+}

--- a/test/Grains/TestGrainInterfaces/IReminderV2TestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IReminderV2TestGrain.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IReminderV2TestGrain : IGrainWithIntegerKey
+    {
+        Task<bool> IsReminderExists(string reminderName);
+        Task AddReminder(string reminderName);
+        Task RemoveReminder(string reminderName);
+    }
+}

--- a/test/Grains/TestGrainInterfaces/IReminderV2TestGrain2.cs
+++ b/test/Grains/TestGrainInterfaces/IReminderV2TestGrain2.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IReminderV2TestGrain2 : IGrainWithGuidKey
+    {
+        Task<IGrainReminderV2> StartReminder(string reminderName, TimeSpan? period = null, bool validate = false);
+
+        Task StopReminder(string reminderName);
+        Task StopReminder(IGrainReminderV2 reminder);
+
+        Task<TimeSpan> GetReminderPeriod(string reminderName);
+        Task<long> GetCounter(string name);
+        Task<IGrainReminderV2> GetReminderObject(string reminderName);
+        Task<List<IGrainReminderV2>> GetRemindersList();
+
+        Task EraseReminderTable();
+    }
+
+    // to test reminders for different grain types
+    public interface IReminderV2TestCopyGrain : IGrainWithGuidKey
+    {
+        Task<IGrainReminderV2> StartReminder(string reminderName, TimeSpan? period = null, bool validate = false);
+        Task StopReminder(string reminderName);
+
+        Task<TimeSpan> GetReminderPeriod(string reminderName);
+        Task<long> GetCounter(string name);
+    }
+
+    public interface IReminderV2GrainWrong : IGrainWithIntegerKey
+    // since it doesnt implement IRemindable, we should get an error at run time
+    // we need a way to let the user know at compile time if s/he doesn't implement IRemindable yet tries to register a reminder
+    {
+        Task<bool> StartReminder(string reminderName);
+    }
+}
+

--- a/test/Grains/TestGrains/ReminderV2TestGrain.cs
+++ b/test/Grains/TestGrains/ReminderV2TestGrain.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    internal class ReminderV2TestGrain : Grain, IReminderV2TestGrain, IRemindable
+    {
+        public async Task<bool> IsReminderExists(string reminderName)
+        {
+            var reminder = await this.GetReminder(reminderName);
+            return reminder != null;
+        }
+
+        public Task AddReminder(string reminderName) => RegisterOrUpdateReminder(reminderName, TimeSpan.FromDays(1), TimeSpan.FromDays(1));
+
+        public async Task RemoveReminder(string reminderName)
+        {
+            var r = await GetReminder(reminderName) ?? throw new Exception("Reminder not found");
+            await UnregisterReminder(r);
+        }
+
+        public Task ReceiveReminder(string reminderName, Orleans.Runtime.TickStatus status) => throw new NotSupportedException();
+    }
+}

--- a/test/Grains/TestInternalGrains/ReminderV2TestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderV2TestGrain2.cs
@@ -1,0 +1,447 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.Services;
+using Orleans.Timers;
+using UnitTests.GrainInterfaces;
+
+
+#pragma warning disable 612,618
+namespace UnitTests.Grains
+{
+    // NOTE: if you make any changes here, copy them to ReminderTestCopyGrain
+    public class ReminderV2TestGrain2 : Grain, IReminderV2TestGrain2, IRemindable
+    {
+        private readonly IReminderV2Table reminderTable;
+
+        private readonly IReminderV2Registry unvalidatedReminderRegistry;
+        Dictionary<string, IGrainReminderV2> allReminders;
+        Dictionary<string, long> sequence;
+        private TimeSpan period;
+
+        private static long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
+
+        private IOptions<ReminderOptions> reminderOptions;
+
+        private ILogger logger;
+        private string _id; // used to distinguish during debugging between multiple activations of the same grain
+
+        private string filePrefix;
+
+        public ReminderV2TestGrain2(IServiceProvider services, IReminderV2Table reminderTable, ILoggerFactory loggerFactory)
+        {
+            this.reminderTable = reminderTable;
+            this.unvalidatedReminderRegistry = new UnvalidatedReminderV2Registry(services);
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+            this.reminderOptions = services.GetService<IOptions<ReminderOptions>>();
+        }
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            this._id = Guid.NewGuid().ToString();
+            this.allReminders = new Dictionary<string, IGrainReminderV2>();
+            this.sequence = new Dictionary<string, long>();
+            this.period = GetDefaultPeriod(this.logger);
+            this.logger.Info("OnActivateAsync.");
+            this.filePrefix = "g" + this.GrainId.ToString().Replace('/', '_') + "_";
+            return GetMissingReminders();
+        }
+
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+        {
+            this.logger.Info("OnDeactivateAsync");
+            return Task.CompletedTask;
+        }
+
+        public async Task<IGrainReminderV2> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
+        {
+            TimeSpan usePeriod = p ?? this.period;
+            this.logger.Info("Starting reminder {0}.", reminderName);
+            TimeSpan dueTime;
+            if (reminderOptions.Value.MinimumReminderPeriod < TimeSpan.FromSeconds(2))
+                dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimumReminderPeriod;
+            else dueTime = usePeriod - TimeSpan.FromSeconds(2);
+
+            IGrainReminderV2 r;
+            if (validate)
+                r = await RegisterOrUpdateReminderV2(reminderName, dueTime, usePeriod);
+            else
+                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(reminderName, dueTime, usePeriod);
+
+            this.allReminders[reminderName] = r;
+            this.sequence[reminderName] = 0;
+
+            string fileName = GetFileName(reminderName);
+            File.Delete(fileName); // if successfully started, then remove any old data
+            this.logger.Info("Started reminder {0}", r);
+            return r;
+        }
+
+        public Task ReceiveReminder(string reminderName, TickStatus status)
+        {
+            // it can happen that due to failure, when a new activation is created,
+            // it doesn't know which reminders were registered against the grain
+            // hence, this activation may receive a reminder that it didn't register itself, but
+            // the previous activation (incarnation of the grain) registered... so, play it safe
+            if (!this.sequence.ContainsKey(reminderName))
+            {
+                // allReminders.Add(reminderName, r); // not using allReminders at the moment
+                //counters.Add(reminderName, 0);
+                this.sequence.Add(reminderName, 0); // we'll get upto date to the latest sequence number while processing this tick
+            }
+
+            // calculating tick sequence number
+
+            // we do all arithmetics on DateTime by converting into long because we dont have divide operation on DateTime
+            // using dateTime.Ticks is not accurate as between two invocations of ReceiveReminder(), there maybe < period.Ticks
+            // if # of ticks between two consecutive ReceiveReminder() is larger than period.Ticks, everything is fine... the problem is when its less
+            // thus, we reduce our accuracy by ACCURACY ... here, we are preparing all used variables for the given accuracy
+            long now = status.CurrentTickTime.Ticks / aCCURACY; //DateTime.UtcNow.Ticks / ACCURACY;
+            long first = status.FirstTickTime.Ticks / aCCURACY;
+            long per = status.Period.Ticks / aCCURACY;
+            long sequenceNumber = 1 + ((now - first) / per);
+
+            // end of calculating tick sequence number
+
+            // do switch-ing here
+            if (sequenceNumber < this.sequence[reminderName])
+            {
+                this.logger.Info("ReceiveReminder: {0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
+                return Task.CompletedTask;
+            }
+
+            this.sequence[reminderName] = sequenceNumber;
+            this.logger.Info("ReceiveReminder: {0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
+
+            string fileName = GetFileName(reminderName);
+            string counterValue = this.sequence[reminderName].ToString(CultureInfo.InvariantCulture);
+            File.WriteAllText(fileName, counterValue);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task StopReminder(string reminderName)
+        {
+            this.logger.Info("Stopping reminder {0}.", reminderName);
+            // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
+            //return UnregisterReminder(allReminders[reminderName]);
+            IGrainReminderV2 reminder;
+            if (this.allReminders.TryGetValue(reminderName, out reminder))
+            {
+                await UnregisterReminder(reminder);
+            }
+            else
+            {
+                // during failures, there may be reminders registered by an earlier activation that we dont have cached locally
+                // therefore, we need to update our local cache
+                await GetMissingReminders();
+                if (this.allReminders.TryGetValue(reminderName, out reminder))
+                {
+                    await UnregisterReminder(reminder);
+                }
+                else
+                {
+                    //var reminders = await this.GetRemindersList();
+                    throw new OrleansException(string.Format(
+                        "Could not find reminder {0} in grain {1}", reminderName, this.IdentityString));
+                }
+            }
+        }
+
+        private async Task GetMissingReminders()
+        {
+            List<IGrainReminderV2> reminders = await base.GetRemindersV2();
+            this.logger.Info("Got missing reminders {0}", Utils.EnumerableToString(reminders));
+            foreach (IGrainReminderV2 l in reminders)
+            {
+                if (!this.allReminders.ContainsKey(l.ReminderName))
+                {
+                    this.allReminders.Add(l.ReminderName, l);
+                }
+            }
+        }
+
+
+        public async Task StopReminder(IGrainReminderV2 reminder)
+        {
+            this.logger.Info("Stopping reminder (using ref) {0}.", reminder);
+            // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
+            await UnregisterReminder(reminder);
+        }
+
+        public Task<TimeSpan> GetReminderPeriod(string reminderName)
+        {
+            return Task.FromResult(this.period);
+        }
+
+        public Task<long> GetCounter(string name)
+        {
+            string fileName = GetFileName(name);
+            string data = File.ReadAllText(fileName);
+            long counterValue = long.Parse(data);
+            return Task.FromResult(counterValue);
+        }
+
+        public Task<IGrainReminderV2> GetReminderObject(string reminderName)
+        {
+            return base.GetReminderV2(reminderName);
+        }
+        public async Task<List<IGrainReminderV2>> GetRemindersList()
+        {
+            return await base.GetRemindersV2();
+        }
+
+        private string GetFileName(string reminderName)
+        {
+            return string.Format("{0}{1}", this.filePrefix, reminderName);
+        }
+
+        public static TimeSpan GetDefaultPeriod(ILogger log)
+        {
+            int period = 12; // Seconds
+            var reminderPeriod = TimeSpan.FromSeconds(period);
+            log.Info("Using reminder period of {0} in ReminderTestGrain", reminderPeriod);
+            return reminderPeriod;
+        }
+
+        public async Task EraseReminderTable()
+        {
+            await this.reminderTable.TestOnlyClearTable();
+        }
+    }
+
+    // NOTE: do not make changes here ... this is a copy of ReminderV2TestGrain
+    // changes to make when copying:
+    //      1. rename logger to ReminderCopyGrain
+    //      2. filePrefix should start with "gc", instead of "g"
+    public class ReminderV2TestCopyGrain : Grain, IReminderV2TestCopyGrain, IRemindable
+    {
+        private readonly IReminderV2Registry unvalidatedReminderRegistry;
+        Dictionary<string, IGrainReminderV2> allReminders;
+        Dictionary<string, long> sequence;
+        private TimeSpan period;
+
+        private static long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
+
+        private ILogger logger;
+        private long myId; // used to distinguish during debugging between multiple activations of the same grain
+
+        private string filePrefix;
+
+        public ReminderV2TestCopyGrain(IServiceProvider services, ILoggerFactory loggerFactory)
+        {
+            this.unvalidatedReminderRegistry = new UnvalidatedReminderV2Registry(services); ;
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+        }
+
+        public override async Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            this.myId = new Random().Next();
+            this.allReminders = new Dictionary<string, IGrainReminderV2>();
+            this.sequence = new Dictionary<string, long>();
+            this.period = ReminderTestGrain2.GetDefaultPeriod(this.logger);
+            this.logger.Info("OnActivateAsync.");
+            this.filePrefix = "gc" + this.GrainId.Key + "_";
+            await GetMissingReminders();
+        }
+
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+        {
+            this.logger.Info("OnDeactivateAsync.");
+            return Task.CompletedTask;
+        }
+
+        public async Task<IGrainReminderV2> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
+        {
+            TimeSpan usePeriod = p ?? this.period;
+            this.logger.Info("Starting reminder {0} for {1}", reminderName, this.GrainId);
+            IGrainReminderV2 r;
+            if (validate)
+                r = await RegisterOrUpdateReminderV2(reminderName, /*TimeSpan.FromSeconds(3)*/usePeriod - TimeSpan.FromSeconds(2), usePeriod);
+            else
+                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(
+                    reminderName,
+                    usePeriod - TimeSpan.FromSeconds(2),
+                    usePeriod);
+            if (this.allReminders.ContainsKey(reminderName))
+            {
+                this.allReminders[reminderName] = r;
+                this.sequence[reminderName] = 0;
+            }
+            else
+            {
+                this.allReminders.Add(reminderName, r);
+                this.sequence.Add(reminderName, 0);
+            }
+
+            File.Delete(GetFileName(reminderName)); // if successfully started, then remove any old data
+            this.logger.Info("Started reminder {0}.", r);
+            return r;
+        }
+
+        public Task ReceiveReminder(string reminderName, TickStatus status)
+        {
+            // it can happen that due to failure, when a new activation is created,
+            // it doesn't know which reminders were registered against the grain
+            // hence, this activation may receive a reminder that it didn't register itself, but
+            // the previous activation (incarnation of the grain) registered... so, play it safe
+            if (!this.sequence.ContainsKey(reminderName))
+            {
+                // allReminders.Add(reminderName, r); // not using allReminders at the moment
+                //counters.Add(reminderName, 0);
+                this.sequence.Add(reminderName, 0); // we'll get upto date to the latest sequence number while processing this tick
+            }
+
+            // calculating tick sequence number
+
+            // we do all arithmetics on DateTime by converting into long because we dont have divide operation on DateTime
+            // using dateTime.Ticks is not accurate as between two invocations of ReceiveReminder(), there maybe < period.Ticks
+            // if # of ticks between two consecutive ReceiveReminder() is larger than period.Ticks, everything is fine... the problem is when its less
+            // thus, we reduce our accuracy by ACCURACY ... here, we are preparing all used variables for the given accuracy
+            long now = status.CurrentTickTime.Ticks / aCCURACY; //DateTime.UtcNow.Ticks / ACCURACY;
+            long first = status.FirstTickTime.Ticks / aCCURACY;
+            long per = status.Period.Ticks / aCCURACY;
+            long sequenceNumber = 1 + ((now - first) / per);
+
+            // end of calculating tick sequence number
+
+            // do switch-ing here
+            if (sequenceNumber < this.sequence[reminderName])
+            {
+                this.logger.Info("{0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, this.sequence[reminderName], sequenceNumber, status);
+                return Task.CompletedTask;
+            }
+
+            this.sequence[reminderName] = sequenceNumber;
+            this.logger.Info("{0} Sequence # {1} with status {2}.", reminderName, this.sequence[reminderName], status);
+
+            File.WriteAllText(GetFileName(reminderName), this.sequence[reminderName].ToString());
+
+            return Task.CompletedTask;
+        }
+
+        public async Task StopReminder(string reminderName)
+        {
+            this.logger.Info("Stopping reminder {0}.", reminderName);
+            // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
+            //return UnregisterReminder(allReminders[reminderName]);
+            IGrainReminderV2 reminder;
+            if (this.allReminders.TryGetValue(reminderName, out reminder))
+            {
+                await UnregisterReminder(reminder);
+            }
+            else
+            {
+                // during failures, there may be reminders registered by an earlier activation that we dont have cached locally
+                // therefore, we need to update our local cache
+                await GetMissingReminders();
+                await UnregisterReminder(this.allReminders[reminderName]);
+            }
+        }
+
+        private async Task GetMissingReminders()
+        {
+            List<IGrainReminderV2> reminders = await base.GetRemindersV2();
+            foreach (IGrainReminderV2 l in reminders)
+            {
+                if (!this.allReminders.ContainsKey(l.ReminderName))
+                {
+                    this.allReminders.Add(l.ReminderName, l);
+                }
+            }
+        }
+
+        public async Task StopReminder(IGrainReminderV2 reminder)
+        {
+            this.logger.Info("Stopping reminder (using ref) {0}.", reminder);
+            // we dont reset counter as we want the test methods to be able to read it even after stopping the reminder
+            await UnregisterReminder(reminder);
+        }
+
+        public Task<TimeSpan> GetReminderPeriod(string reminderName)
+        {
+            return Task.FromResult(this.period);
+        }
+
+        public Task<long> GetCounter(string name)
+        {
+            return Task.FromResult(long.Parse(File.ReadAllText(GetFileName(name))));
+        }
+
+        public async Task<IGrainReminderV2> GetReminderObject(string reminderName)
+        {
+            return await base.GetReminderV2(reminderName);
+        }
+        public async Task<List<IGrainReminderV2>> GetRemindersList()
+        {
+            return await base.GetRemindersV2();
+        }
+
+        private string GetFileName(string reminderName)
+        {
+            return string.Format("{0}{1}", this.filePrefix, reminderName);
+        }
+    }
+
+    public class WrongReminderV2Grain : Grain, IReminderV2GrainWrong
+    {
+        private ILogger logger;
+
+        public WrongReminderV2Grain(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+        }
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            this.logger.Info("OnActivateAsync.");
+            return Task.CompletedTask;
+        }
+
+        public async Task<bool> StartReminder(string reminderName)
+        {
+            this.logger.Info("Starting reminder {0}.", reminderName);
+            IGrainReminderV2 r = await RegisterOrUpdateReminderV2(reminderName, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+            this.logger.Info("Started reminder {0}. It shouldn't have succeeded!", r);
+            return true;
+        }
+    }
+
+
+    internal class UnvalidatedReminderV2Registry : GrainServiceClient<IReminderServiceV2>, IReminderV2Registry
+    {
+        public UnvalidatedReminderV2Registry(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        public Task<IGrainReminderV2> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
+        {
+            return this.GrainService.RegisterOrUpdateReminder(this.CallingGrainReference, reminderName, dueTime, period);
+        }
+
+        public Task UnregisterReminder(IGrainReminderV2 reminder)
+        {
+            return this.GrainService.UnregisterReminder(reminder);
+        }
+
+        public Task<IGrainReminderV2> GetReminder(string reminderName)
+        {
+            return this.GrainService.GetReminder(this.CallingGrainReference, reminderName);
+        }
+
+        public Task<List<IGrainReminderV2>> GetReminders()
+        {
+            return this.GrainService.GetReminders(this.CallingGrainReference);
+        }
+    }
+}
+#pragma warning restore 612,618

--- a/test/TestInfrastructure/TestExtensions/DefaultClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/DefaultClusterFixture.cs
@@ -61,6 +61,7 @@ namespace TestExtensions
                 hostBuilder
                     .Configure<SiloMessagingOptions>(o => o.ClientGatewayShutdownNotificationTimeout = default)
                     .UseInMemoryReminderService()
+                    .UseInMemoryReminderV2Service()
                     .AddMemoryGrainStorageAsDefault()
                     .AddMemoryGrainStorage("MemoryStore");
             }

--- a/test/Tester/MinimalReminderV2Tests.cs
+++ b/test/Tester/MinimalReminderV2Tests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.CatalogTests
+{
+    public class MinimalReminderV2Tests : IClassFixture<MinimalReminderTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<SiloConfiguration>();
+            }
+        }
+
+        public class SiloConfiguration : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder siloBuilder)
+            {
+                siloBuilder.Configure<ReminderV2Options>(options =>
+                        options.MinimumReminderPeriod = TimeSpan.FromMilliseconds(100))
+                    .UseInMemoryReminderV2Service();
+            }
+        }
+
+        public MinimalReminderV2Tests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact, TestCategory("Catalog"), TestCategory("Functional")]
+        public async Task MinimalReminderInterval()
+        {
+            var grainGuid = Guid.NewGuid();
+            const string reminderName = "minimal_reminder";
+
+            var reminderGrain = this.fixture.GrainFactory.GetGrain<IReminderTestGrain2>(grainGuid);
+            _ = await reminderGrain.StartReminder(reminderName, TimeSpan.FromMilliseconds(100), true);
+
+            var r = await reminderGrain.GetReminderObject(reminderName);
+            await reminderGrain.StopReminder(r);
+
+        }
+    }
+}

--- a/test/Tester/MinimalReminderV2Tests.cs
+++ b/test/Tester/MinimalReminderV2Tests.cs
@@ -42,7 +42,7 @@ namespace UnitTests.CatalogTests
             var grainGuid = Guid.NewGuid();
             const string reminderName = "minimal_reminder";
 
-            var reminderGrain = this.fixture.GrainFactory.GetGrain<IReminderTestGrain2>(grainGuid);
+            var reminderGrain = this.fixture.GrainFactory.GetGrain<IReminderV2TestGrain2>(grainGuid);
             _ = await reminderGrain.StartReminder(reminderName, TimeSpan.FromMilliseconds(100), true);
 
             var r = await reminderGrain.GetReminderObject(reminderName);

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -38,7 +38,8 @@ namespace UnitTests.General
             {
                 hostBuilder.AddMemoryGrainStorage("MemoryStore")
                     .AddMemoryGrainStorageAsDefault()
-                    .UseInMemoryReminderService();
+                    .UseInMemoryReminderService()
+                    .UseInMemoryReminderV2Service();
             }
 
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
@@ -276,7 +277,7 @@ namespace UnitTests.General
             List<SiloHandle> failures = new List<SiloHandle>();
             int count = 0;
 
-            // Figure out the primary directory partition and the silo hosting the ReminderTableGrain.
+            // Figure out the primary directory partition and the silo hosting the ReminderV2TableGrain.
             var tableGrain = this.GrainFactory.GetGrain<IReminderTableGrain>(InMemoryReminderTable.ReminderTableGrainId);
 
             // Ping the grain to make sure it is active.
@@ -296,7 +297,7 @@ namespace UnitTests.General
                 {
                     continue;
                 }
-                // Don't fail primary directory partition and the silo hosting the ReminderTableGrain.
+                // Don't fail primary directory partition and the silo hosting the ReminderV2TableGrain.
                 if (siloAddress.Equals(reminderTableGrainPrimaryDirectoryAddress) || siloAddress.Equals(reminderGrainActivation.SiloAddress))
                 {
                     continue;

--- a/test/TesterInternal/RemindersV2Test/ReminderV2TableTestsBase.cs
+++ b/test/TesterInternal/RemindersV2Test/ReminderV2TableTestsBase.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using TestExtensions;
+using UnitTests.MembershipTests;
+using Xunit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.TestingHost.Utils;
+using Orleans.Internal;
+
+namespace UnitTests.RemindersV2Test
+{
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    public abstract class ReminderV2TableTestsBase : IAsyncLifetime, IClassFixture<ConnectionStringFixture>
+    {
+        protected readonly TestEnvironmentFixture ClusterFixture;
+        private readonly ILogger logger;
+
+        private readonly IReminderV2Table remindersTable;
+        protected ILoggerFactory loggerFactory;
+        protected IOptions<ClusterOptions> clusterOptions;
+
+        protected ConnectionStringFixture connectionStringFixture;
+
+        protected const string testDatabaseName = "OrleansReminderV2Test";//for relational storage
+
+        protected ReminderV2TableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture, LoggerFilterOptions filters)
+        {
+            connectionStringFixture = fixture;
+            fixture.InitializeConnectionStringAccessor(GetConnectionString);
+            loggerFactory = TestingUtils.CreateDefaultLoggerFactory($"{GetType()}.log", filters);
+            ClusterFixture = clusterFixture;
+            logger = loggerFactory.CreateLogger<ReminderV2TableTestsBase>();
+            var serviceId = Guid.NewGuid().ToString() + "/foo";
+            var clusterId = "test-" + serviceId + "/foo2";
+
+            logger.Info("ClusterId={0}", clusterId);
+            clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = serviceId });
+
+            remindersTable = CreateRemindersTable();
+        }
+
+        public virtual async Task InitializeAsync()
+        {
+            await remindersTable.Init().WithTimeout(TimeSpan.FromMinutes(1));
+        }
+
+        public virtual async Task DisposeAsync()
+        {
+            if (remindersTable != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
+            {
+                await remindersTable.TestOnlyClearTable();
+            }
+        }
+
+        protected abstract IReminderV2Table CreateRemindersTable();
+        protected abstract Task<string> GetConnectionString();
+
+        protected virtual string GetAdoInvariant()
+        {
+            return null;
+        }
+
+        protected async Task RemindersParallelUpsert()
+        {
+            var upserts = await Task.WhenAll(Enumerable.Range(0, 5).Select(i =>
+            {
+                var reminder = CreateReminder(MakeTestGrainReference(), i.ToString());
+                return Task.WhenAll(Enumerable.Range(1, 5).Select(j =>
+                {
+                    return RetryHelper.RetryOnExceptionAsync(5, RetryOperation.Sigmoid, async () =>
+                    {
+                        return await remindersTable.UpsertRow(reminder);
+                    });
+                }));
+            }));
+            Assert.DoesNotContain(upserts, i => i.Distinct().Count() != 5);
+        }
+
+        protected async Task ReminderSimple()
+        {
+            var reminder = CreateReminder(MakeTestGrainReference(), "foo/bar\\#b_a_z?");
+            await remindersTable.UpsertRow(reminder);
+
+            var readReminder = await remindersTable.ReadRow(reminder.GrainRef, reminder.ReminderName);
+
+            var etagTemp = reminder.ETag = readReminder.ETag;
+
+            Assert.Equal(readReminder.ETag, reminder.ETag);
+            Assert.Equal(readReminder.GrainRef.GrainId, reminder.GrainRef.GrainId);
+            Assert.Equal(readReminder.Period, reminder.Period);
+            Assert.Equal(readReminder.ReminderName, reminder.ReminderName);
+            Assert.Equal(readReminder.StartAt, reminder.StartAt);
+            Assert.NotNull(etagTemp);
+
+            reminder.ETag = await remindersTable.UpsertRow(reminder);
+
+            var removeRowRes = await remindersTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, etagTemp);
+            Assert.False(removeRowRes, "should have failed. Etag is wrong");
+            removeRowRes = await remindersTable.RemoveRow(reminder.GrainRef, "bla", reminder.ETag);
+            Assert.False(removeRowRes, "should have failed. reminder name is wrong");
+            removeRowRes = await remindersTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, reminder.ETag);
+            Assert.True(removeRowRes, "should have succeeded. Etag is right");
+            removeRowRes = await remindersTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, reminder.ETag);
+            Assert.False(removeRowRes, "should have failed. reminder shouldn't exist");
+        }
+
+        protected async Task RemindersRange(int iterations = 1000)
+        {
+            await Task.WhenAll(Enumerable.Range(1, iterations).Select(async i =>
+            {
+                var grainRef = MakeTestGrainReference();
+
+                await RetryHelper.RetryOnExceptionAsync(10, RetryOperation.Sigmoid, async () =>
+                {
+                    await remindersTable.UpsertRow(CreateReminder(grainRef, i.ToString()));
+                    return Task.CompletedTask;
+                });
+            }));
+
+            var rows = await remindersTable.ReadRows(0, uint.MaxValue);
+
+            Assert.Equal(rows.Reminders.Count, iterations);
+
+            rows = await remindersTable.ReadRows(0, 0);
+
+            Assert.Equal(rows.Reminders.Count, iterations);
+
+            var remindersHashes = rows.Reminders.Select(r => r.GrainRef.GetUniformHashCode()).ToArray();
+
+            await Task.WhenAll(Enumerable.Range(0, iterations).Select(i =>
+                TestRemindersHashInterval(remindersTable, (uint)ThreadSafeRandom.Next(int.MinValue, int.MaxValue), (uint)ThreadSafeRandom.Next(int.MinValue, int.MaxValue),
+                    remindersHashes)));
+        }
+
+        private async Task TestRemindersHashInterval(IReminderV2Table reminderTable, uint beginHash, uint endHash,
+            uint[] remindersHashes)
+        {
+            var rowsTask = reminderTable.ReadRows(beginHash, endHash);
+            var expectedHashes = beginHash < endHash
+                ? remindersHashes.Where(r => r > beginHash && r <= endHash)
+                : remindersHashes.Where(r => r > beginHash || r <= endHash);
+
+            var expectedSet = new HashSet<uint>(expectedHashes);
+            var returnedHashes = (await rowsTask).Reminders.Select(r => r.GrainRef.GetUniformHashCode());
+            var returnedSet = new HashSet<uint>(returnedHashes);
+
+            Assert.True(returnedSet.SetEquals(expectedSet));
+        }
+
+        private static ReminderV2Entry CreateReminder(GrainReference grainRef, string reminderName)
+        {
+            var now = DateTime.UtcNow;
+            now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+            return new ReminderV2Entry
+            {
+                GrainRef = grainRef,
+                Period = TimeSpan.FromMinutes(1),
+                StartAt = now,
+                ReminderName = reminderName
+            };
+        }
+
+        private GrainReference MakeTestGrainReference()
+        {
+            GrainId regularGrainId = LegacyGrainId.GetGrainId(12345, Guid.NewGuid(), "foo/bar\\#baz?");
+            var grainRef = (GrainReference)ClusterFixture.InternalGrainFactory.GetGrain(regularGrainId);
+            return grainRef;
+        }
+    }
+}

--- a/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
@@ -29,6 +29,7 @@ namespace UnitTests.TimerTests
                 public void Configure(ISiloBuilder hostBuilder)
                 {
                     hostBuilder.UseInMemoryReminderService();
+                    hostBuilder.UseInMemoryReminderV2Service();
                 }
             }
         }


### PR DESCRIPTION
This is currently a WIP.

Fixes #7573.

## Plan
I'm starting by cloning V1 into V2 and getting all tests to pass; once this happens, things will start to diverge.

## Reminder Persistence
I intend to attempt to eliminate the Reminder Tables aspect and have reminders use regular grain storage. This should eliminate the need for separate reminder storage providers. 

**Problem**: This also means we don't have a way to enumerate. 
**Solution**: None yet. Possibly extend Storage provider to provide enumeration similar to how `ReminderTable` and `ReminderEntry` work, as the work is basically done for enumeration, just requires adapting to grain storage schemas.

This approach may have to be abandoned in favor of modifying the existing `ReminderTable` and `ReminderEntry` for simplicity in this pass.

## Middleware Pipeline
Implement a basic synchronous middleware pipeline with shared state via property bag.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7599)