### PR TITLE
Initial yaml pipeline for PR build/tests

### DIFF
--- a/.azure/pipelines/pr.yaml
+++ b/.azure/pipelines/pr.yaml
@@ -1,0 +1,65 @@
+pool: 'GitHub PR'
+
+trigger: none
+
+parameters:
+  - name: build_configuration
+    displayName: Build configuration
+    type: string
+    default: Release
+    values:
+    - Release
+    - Debug
+  - name: frameworks
+    displayName: Frameworks
+    type: object
+    default:
+    - netcoreapp3.1
+    - net5.0
+    - net6.0
+  - name: tests_categories
+    displayName: Test categories
+    type: object
+    default:
+    - BVT
+    - SlowBVT
+    - Functional
+
+variables:
+  build_flags: ' /m /v:m' 
+  solution: 'Orleans.sln'
+
+jobs:
+- job: Build
+  displayName: Build and create NuGet packages
+  steps:
+  - checkout: self
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      command: build
+      arguments: '$(build_flags) /bl:${{parameters.build_configuration}}-Build.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
+  - task: CmdLine@2
+    displayName: Pack
+    inputs:
+      script: 'dotnet pack --no-build --no-restore $(build_flags) /bl:${{parameters.build_configuration}}-Pack.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
+- ${{ each category in parameters.tests_categories }}:
+  - ${{ each framework in parameters.frameworks }}:
+    - job:
+      displayName: ${{category}} on ${{framework}}
+      dependsOn: Build
+      steps:
+      - checkout: self
+      - task: DotNetCoreCLI@2
+        displayName: Build
+        inputs:
+          command: build
+          arguments: '$(build_flags) /bl:${{parameters.build_configuration}}-Build.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
+      - task: DotNetCoreCLI@2
+        displayName: Test
+        inputs:
+          command: 'test'
+          testRunTitle: ${{category}} on ${{framework}}
+          arguments: '--no-build --framework ${{framework}} --configuration "${{parameters.build_configuration}}" --filter Category=${{category}} -- -parallel none -noshadow'
+
+  


### PR DESCRIPTION
Currently we use the "classic" azure pipelines, that call the `build.ps1` and the `tests.ps1` scripts.

Switching to the yaml format will be easier to maintain, and allow us to run tests that target different framework in parallel.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7611)