### PR TITLE
Fix grain level call filter not invoked without global filters

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -271,7 +271,7 @@ namespace Orleans.Runtime
                             {
                                 invokable.SetTarget(target);
                                 CancellationSourcesExtension.RegisterCancellationTokens(target, invokable);
-                                if (GrainCallFilters is { Count: > 0 } || target is IIncomingGrainCallFilter)
+                                if (GrainCallFilters is { Count: > 0 } || target.GrainInstance is IIncomingGrainCallFilter)
                                 {
                                     var invoker = new GrainMethodInvoker(target, invokable, GrainCallFilters, this.interfaceToImplementationMapping, this.responseCopier);
                                     await invoker.Invoke();

--- a/test/Tester/GrainLevelCallFilterTests.cs
+++ b/test/Tester/GrainLevelCallFilterTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using Xunit;
+using Orleans.Hosting;
+using Orleans.Serialization;
+
+namespace UnitTests.General
+{
+    [TestCategory("BVT"), TestCategory("GrainLevelCallFilter")]
+    public class GrainLevelCallFilterTests : OrleansTestingBase, IClassFixture<GrainLevelCallFilterTests.Fixture>
+    {
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
+            }
+        }
+
+        private readonly Fixture fixture;
+
+        public GrainLevelCallFilterTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        /// <summary>
+        /// Tests filters on just the grain level when there are no global grain call filters
+        /// </summary>
+        [Fact]
+        public async Task GrainCallFilter_Incoming_GrainLevel_Without_Global_Filter_Test()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(0);
+            var result = await grain.One();
+            Assert.Equal("intercepted one with no args", result);
+
+            result = await grain.Echo("stao erom tae");
+            Assert.Equal("eat more oats", result);// Grain interceptors should receive the MethodInfo of the implementation, not the interface.
+
+            result = await grain.NotIntercepted();
+            Assert.Equal("not intercepted", result);
+
+            result = await grain.SayHello();
+            Assert.Equal("Hello", result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7618 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7619)