### PR TITLE
Avoid rejecting pending messages when an InconsistentStateException occurs

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -315,7 +315,7 @@ namespace Orleans.Runtime
 
                         var msg = $"Deactivating {target} due to inconsistent state.";
                         this.invokeExceptionLogger.Info(msg);
-                        target.Deactivate(new DeactivationReason(DeactivationReasonCode.ApplicationError, invocationException, invocationException.Message));
+                        target.Deactivate(new DeactivationReason(DeactivationReasonCode.ApplicationError, LogFormatter.PrintException(invocationException)));
                     }
                 }
 

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -84,15 +84,14 @@ namespace UnitTests.StorageTests
             SetErrorInjection(ErrorInjectionBehavior.None);
         }
 
-        public static void SetErrorInjection(string providerName, ErrorInjectionBehavior errorInjectionBehavior, IGrainFactory grainFactory)
+        public static async Task SetErrorInjection(string providerName, ErrorInjectionBehavior errorInjectionBehavior, IGrainFactory grainFactory)
         {
             IManagementGrain mgmtGrain = grainFactory.GetGrain<IManagementGrain>(0);
-            mgmtGrain.SendControlCommandToProvider(
+            await mgmtGrain.SendControlCommandToProvider(
                 typeof(ErrorInjectionStorageProvider).FullName,
                 providerName, 
                 (int)Commands.SetErrorInjection,
-                errorInjectionBehavior)
-                .Wait();
+                errorInjectionBehavior);
         }
 
         public ErrorInjectionBehavior ErrorInjection { get; private set; }


### PR DESCRIPTION
... and forward them instead.

The current behavior is to deactivate a grain when an `InconsistentStateException` is allowed to propagate from a request.
When this occurs, we're setting a `DeactivationException`, which is then propagated to all pending calls until the grain completes deactivation.

This PR changes that by not setting the exception, and therefore fixes the flaky `Persistence_Provider_InconsistentStateException_DeactivatesOnlyCurrentGrain` & `Persistence_Provider_InconsistentStateException_DeactivatesGrain` tests.

As a drive-by, it also removes some synchronous blocking from test code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7640)