### PR TITLE
Enhance `IGrainCallContext` for distributed tracing

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
@@ -33,15 +33,39 @@ namespace Orleans
     public interface IGrainCallContext
     {
         /// <summary>
+        /// Gets the request.
+        /// </summary>
+        IInvokable Request { get; }
+
+        /// <summary>
         /// Gets the grain being invoked.
         /// </summary>
         object Grain { get; }
 
         /// <summary>
-        /// Gets the <see cref="MethodInfo"/> of the method being invoked.
+        /// Gets the identity of the source, if available.
         /// </summary>
-        [Obsolete("Use InterfaceMethod or IIncomingGrainCallContext.ImplementationMethod instead.")]
-        MethodInfo Method { get; }
+        GrainId? SourceId { get; }
+
+        /// <summary>
+        /// Gets the identity of the target.
+        /// </summary>
+        GrainId TargetId { get; }
+
+        /// <summary>
+        /// Gets the type of the interface being invoked.
+        /// </summary>
+        GrainInterfaceType InterfaceType { get; }
+
+        /// <summary>
+        /// Gets the name of the interface being invoked.
+        /// </summary>
+        string InterfaceName { get; }
+
+        /// <summary>
+        /// Gets the name of the method being invoked.
+        /// </summary>
+        string MethodName { get; }
 
         /// <summary>
         /// Gets the <see cref="MethodInfo"/> for the interface method being invoked.
@@ -78,6 +102,11 @@ namespace Orleans
     public interface IIncomingGrainCallContext : IGrainCallContext
     {
         /// <summary>
+        /// Gets the grain context of the target.
+        /// </summary>
+        public IGrainContext TargetContext { get; }
+
+        /// <summary>
         /// Gets the <see cref="MethodInfo"/> for the implementation method being invoked.
         /// </summary>
         MethodInfo ImplementationMethod { get; }
@@ -88,6 +117,10 @@ namespace Orleans
     /// </summary>
     public interface IOutgoingGrainCallContext : IGrainCallContext
     {
+        /// <summary>
+        /// Gets the grain context of the sender.
+        /// </summary>
+        public IGrainContext SourceContext { get; }
     }
 
     /// <summary>

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -42,6 +42,8 @@ namespace Orleans.Runtime
             this.grainReference = grain;
             this.filters = filters;
             this.stages = filters.Length;
+            SourceContext = RuntimeContext.Current;
+
             if (request is IOutgoingGrainCallFilter requestFilter)
             {
                 this.requestFilter = requestFilter;
@@ -49,25 +51,18 @@ namespace Orleans.Runtime
             }
         }
 
-        /// <inheritdoc />
+        public IInvokable Request => this.request;
+
         public object Grain => this.grainReference;
 
-        /// <inheritdoc />
-        public MethodInfo Method => request.Method;
+        public MethodInfo InterfaceMethod => request.Method;
 
-        /// <inheritdoc />
-        public MethodInfo InterfaceMethod => this.Method;
-
-        /// <inheritdoc />
         public IMethodArguments Arguments => this;
 
-        /// <inheritdoc />
         public object Result { get => TypedResult; set => TypedResult = (TResult)value; }
 
-        /// <inheritdoc />
         public Response Response { get; set; }
 
-        /// <inheritdoc />
         public TResult TypedResult { get => Response.GetResult<TResult>(); set => Response = Response.FromResult(value); }
 
         object IMethodArguments.this[int index]
@@ -82,7 +77,18 @@ namespace Orleans.Runtime
 
         int IMethodArguments.Length => request.ArgumentCount;
 
-        /// <inheritdoc />
+        public IGrainContext SourceContext { get; }
+
+        public GrainId? SourceId => SourceContext is { } source ? source.GrainId : null;
+
+        public GrainId TargetId => grainReference.GrainId;
+
+        public GrainInterfaceType InterfaceType => grainReference.InterfaceType;
+
+        public string InterfaceName => request.InterfaceName;
+
+        public string MethodName => request.MethodName;
+
         public async Task Invoke()
         {
             try

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -273,7 +273,7 @@ namespace Orleans.Runtime
                                 CancellationSourcesExtension.RegisterCancellationTokens(target, invokable);
                                 if (GrainCallFilters is { Count: > 0 } || target.GrainInstance is IIncomingGrainCallFilter)
                                 {
-                                    var invoker = new GrainMethodInvoker(target, invokable, GrainCallFilters, this.interfaceToImplementationMapping, this.responseCopier);
+                                    var invoker = new GrainMethodInvoker(message, target, invokable, GrainCallFilters, this.interfaceToImplementationMapping, this.responseCopier);
                                     await invoker.Invoke();
                                     response = invoker.Response;
                                 }


### PR DESCRIPTION
This PR enhances `IGrainCallContext` with some extra information which is useful for many cases, including distributed tracing and higher-performance filtering scenarios, etc.

The following details are added:

`IGrainCallContext`:
* The request object (`IInvokable`)
* `InterfaceType` (`GrainInterfaceType`)
* `InterfaceName` (`string`)
* `MethodName` (`string`)
* `SourceId` (`GrainId?`) - it may not be available, so it's nullable
* `TargetId` (`GrainId`)

`IIncomingGrainCallContext`:
* `TargetContext` (`IGrainContext`)

`IOutgoingGrainCallContext`:
* `SourceContext` (`IGrainContext`) - might be `null` if the call was not made from a grain (a plain old background task for example).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7646)