### PR TITLE
Enhance distributed tracing support

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -474,6 +474,9 @@ namespace Orleans.Runtime
         public abstract string InterfaceName { get; }
 
         /// <inheritdoc/>
+        public abstract string ActivityName { get; }
+
+        /// <inheritdoc/>
         public abstract Type InterfaceType { get; }
 
         /// <inheritdoc/>

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.Serialization.Invocation;

--- a/src/Orleans.Serialization/Invocation/IInvokable.cs
+++ b/src/Orleans.Serialization/Invocation/IInvokable.cs
@@ -61,6 +61,11 @@ namespace Orleans.Serialization.Invocation
         string InterfaceName { get; }
 
         /// <summary>
+        /// Gets the activity name, which refers to both the interface name and method name.
+        /// </summary>
+        string ActivityName { get; }
+
+        /// <summary>
         /// Gets the method info object, which may be <see langword="null"/>.
         /// </summary>
         MethodInfo Method { get; }

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -54,6 +54,7 @@ namespace Orleans.Serialization.Invocation
         public abstract string MethodName { get; }
         public abstract Type[] MethodTypeArguments { get; }
         public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
         public abstract Type[] InterfaceTypeArguments { get; }
         public abstract Type[] ParameterTypes { get; }
@@ -108,6 +109,7 @@ namespace Orleans.Serialization.Invocation
         public abstract string MethodName { get; }
         public abstract Type[] MethodTypeArguments { get; }
         public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
         public abstract Type[] InterfaceTypeArguments { get; }
         public abstract Type[] ParameterTypes { get; }
@@ -163,6 +165,7 @@ namespace Orleans.Serialization.Invocation
         public abstract string MethodName { get; }
         public abstract Type[] MethodTypeArguments { get; }
         public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
         public abstract Type[] InterfaceTypeArguments { get; }
         public abstract Type[] ParameterTypes { get; }
@@ -219,6 +222,7 @@ namespace Orleans.Serialization.Invocation
         public abstract string MethodName { get; }
         public abstract Type[] MethodTypeArguments { get; }
         public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
         public abstract Type[] InterfaceTypeArguments { get; }
         public abstract Type[] ParameterTypes { get; }
@@ -254,6 +258,7 @@ namespace Orleans.Serialization.Invocation
         public abstract string MethodName { get; }
         public abstract Type[] MethodTypeArguments { get; }
         public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
         public abstract Type[] InterfaceTypeArguments { get; }
         public abstract Type[] ParameterTypes { get; }


### PR DESCRIPTION
Fixes #4992
Contributes to #7480

We have support for Open Telemetry already, via `System.Diagnostics.Activity` support (from #6853 and #7443).

This PR enhances that support to include more details and hopefully conform more to the Open Telemetry guidelines surrounding span names and tags for RPC.

One thing which is missing is `net.peer.name`/`.ip`/`.port`. That should be set to the address of the remote endpoint. That information isn't known at the time that the integration executes and the `Activity` isn't in context when the remote peer is resolved or the message is transported to the remote endpoint. I think it's fine to omit this information, despite what the spec says: the remote service will emit a matching trace (with the trace parent set), and if there's a failure, it will be made visible in the trace error.

`IInvokable` now includes an `ActivityName` string property, containing the interface & method names formatted in a way that's hopefully appropriate for Open Telemetry. This replaces the existing constants passed to `StartActivity` (`Orleans.Runtime.GrainCall.In` and `Orleans.Runtime.GrainCall.Out`). Examples of the new `Activity.Name` values:
* `IGrainManagementExtension/DeactivateOnIdle`
* `IBlockingEchoTaskGrain/GetLastEcho`
* `IHungryGrain<T>/EatWith<U>`

The `ActivitySouceName` is now `Microsoft.Orleans` instead of `orleans.runtime.graincall`.

The activity now includes the source & target `GrainId`, so you could use this to create a call graph of which grains call which other grains.

I wonder if we should name the `ISiloBuilder`/`IClientBuilder` extension methods from `AddActivityPropagation` to `AddDistributedTracing` - thoughts?

#### ⚠ Note that this PR relies on #7646, so that must be merged first

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7647)