### PR TITLE
Fix cluster configuration in PingBenchmark

### DIFF
--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -57,8 +57,6 @@ namespace Benchmarks.Ping
             {
                 var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
                 {
-                    clientBuilder.Configure<ClusterOptions>(options => options.ClusterId = options.ServiceId = "dev");
-
                     if (numSilos == 1)
                     {
                         clientBuilder.UseLocalhostClustering();


### PR DESCRIPTION
Since we now validate ClusterId on connection, the PingBenchmark is failing as the client sets a different ClusterId from the silos.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7650)