### PR TITLE
Cache local request handlers in `GrainReference`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "feature",
-    "version": "6.0.101"
+    "rollForward": "latestFeature",
+    "version": "6.0.200"
   }
 }

--- a/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Activation/IGrainContext.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Represents a grain from the perspective of the runtime.
     /// </summary>
-    public interface IGrainContext : ITargetHolder, IEquatable<IGrainContext>
+    public interface IGrainContext : ITargetHolder, IEquatable<IGrainContext>, ICachedMessageReceiver
     {
         /// <summary>
         /// Gets a reference to this grain.

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -282,6 +282,11 @@ namespace Orleans.Runtime
         /// </summary>
         public GrainInterfaceType InterfaceType => _shared.InterfaceType;
 
+        /// <summary>
+        /// Gets or sets a cached recipient which can be used to handle messages sent to the target represented by this instance.
+        /// </summary>
+        internal ICachedMessageReceiver CachedReceiver { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="GrainReference"/> class.</summary>
         /// <param name="shared">
         /// The grain reference functionality which is shared by all grain references of a given type.

--- a/src/Orleans.Core.Abstractions/Runtime/ICachedMessageReceiver.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/ICachedMessageReceiver.cs
@@ -1,0 +1,16 @@
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Functionality to facilitate caching the recipient of a message for performance.
+    /// </summary>
+    public interface ICachedMessageReceiver
+    {
+        /// <summary>
+        /// Sends a message to this instance.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if this handler remains valid; otherwise <see langword="false"/> if this handler has become invalid and should be replaced.
+        /// </returns>
+        bool HandleMessage(object message);
+    }
+}

--- a/src/Orleans.Core/Messaging/IMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/IMessageCenter.cs
@@ -2,7 +2,7 @@ namespace Orleans.Runtime
 {
     internal interface IMessageCenter
     {
-        void SendMessage(Message msg);
+        void SendMessage(Message msg, GrainReference targetReference);
 
         void DispatchLocalMessage(Message message);
     }

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -100,7 +100,7 @@ namespace Orleans.Runtime.Messaging
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
                 msg.TargetActivation = default;
                 msg.TargetSilo = null;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, targetReference: null);
                 return false;
             }
 
@@ -120,7 +120,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 msg.RetryCount = msg.RetryCount + 1;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, targetReference: null);
             }
             else
             {
@@ -163,7 +163,7 @@ namespace Orleans.Runtime.Messaging
         protected override void OnSendMessageFailure(Message message, string error)
         {
             message.TargetSilo = null;
-            this.messageCenter.SendMessage(message);
+            this.messageCenter.SendMessage(message, targetReference: null);
         }
     }
 }

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -153,5 +153,10 @@ namespace Orleans
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;
+        bool ICachedMessageReceiver.HandleMessage(object message)
+        {
+            ReceiveMessage(message);
+            return true;
+        }
     }
 }

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -343,6 +343,11 @@ namespace Orleans
             public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
             public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
             public Task Deactivated => Task.CompletedTask;
+            bool ICachedMessageReceiver.HandleMessage(object message)
+            {
+                ReceiveMessage(message);
+                return LocalObject.IsAlive;
+            }
         }
     }
 }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -247,7 +247,7 @@ namespace Orleans
             OrleansOutsideRuntimeClientEvent.Log.SendResponse(message);
             message.BodyObject = response;
 
-            MessageCenter.SendMessage(message);
+            MessageCenter.SendMessage(message, targetReference: null);
         }
 
         public void SendRequest(GrainReference target, IInvokable request, IResponseCompletionSource context, InvokeMethodOptions options)
@@ -293,7 +293,7 @@ namespace Orleans
             }
 
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Send {0}", message);
-            MessageCenter.SendMessage(message);
+            MessageCenter.SendMessage(message, target);
         }
 
         public void ReceiveResponse(Message response)

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -508,7 +508,7 @@ namespace Orleans.Runtime
                         }
 
                         var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, diagnostics);
-                        messageCenter.SendMessage(response);
+                        messageCenter.SendMessage(response, targetReference: null);
                     }
                 }
 
@@ -530,7 +530,7 @@ namespace Orleans.Runtime
                         };
 
                         var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, messageDiagnostics);
-                        messageCenter.SendMessage(response);
+                        messageCenter.SendMessage(response, targetReference: null);
                     }
                 }
 
@@ -549,7 +549,7 @@ namespace Orleans.Runtime
                         };
 
                         var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: false, isWaiting: true, messageDiagnostics);
-                        messageCenter.SendMessage(response);
+                        messageCenter.SendMessage(response, targetReference: null);
                     }
 
                     queueLength++;
@@ -1028,6 +1028,12 @@ namespace Orleans.Runtime
             {
                 ReceiveRequest(message);
             }
+        }
+
+        bool ICachedMessageReceiver.HandleMessage(object message)
+        {
+            ReceiveMessage(message);
+            return State is not ActivationState.Invalid or ActivationState.FailedToActivate;
         }
 
         private void ReceiveResponse(Message message)

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -5,8 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Orleans.Configuration;
 
 namespace Orleans.Runtime
 {
@@ -85,6 +83,12 @@ namespace Orleans.Runtime
         {
             _workItems.Enqueue(new(WorkItemType.Message, message));
             _workSignal.Signal();
+        }
+
+        bool ICachedMessageReceiver.HandleMessage(object message)
+        {
+            ReceiveMessage(message);
+            return true;
         }
 
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null)

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -344,5 +344,10 @@ namespace Orleans.Runtime
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;
+        bool ICachedMessageReceiver.HandleMessage(object message)
+        {
+            ReceiveMessage(message);
+            return true;
+        }
     }
 }

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -308,5 +308,11 @@ namespace Orleans.Runtime
 
         /// <inheritdoc/>
         public Task Deactivated => Task.CompletedTask;
+
+        bool ICachedMessageReceiver.HandleMessage(object message)
+        {
+            ReceiveMessage(message);
+            return true;
+        }
     }
 }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -12,7 +12,7 @@ using Orleans.Configuration;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal class Gateway : IConnectedClientCollection
+    internal sealed class Gateway : IConnectedClientCollection
     {
         private readonly GatewayClientCleanupAgent clientCleanupAgent;
 
@@ -216,7 +216,6 @@ namespace Orleans.Runtime.Messaging
         /// <summary>
         /// See if this message is intended for a grain we're proxying, and queue it for delivery if so.
         /// </summary>
-        /// <param name="msg"></param>
         /// <returns>true if the message should be delivered to a proxied grain, false if not.</returns>
         internal bool TryDeliverToProxy(Message msg)
         {
@@ -393,7 +392,7 @@ namespace Orleans.Runtime.Messaging
                             msg,
                             Message.RejectionTypes.Unrecoverable,
                             "Unknown client " + msg.TargetGrain);
-                        messageCenter.SendMessage(error);
+                        messageCenter.SendMessage(error, targetReference: null);
                     }
                     else
                     {

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime.Messaging
             {
                 MessagingStatisticsGroup.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
-                this.messageCenter.TryDeliverToProxy(rejection);
+                this.messageCenter.TryDeliverToProxy(rejection, targetReference: null);
                 if (this.Log.IsEnabled(LogLevel.Debug)) this.Log.Debug("Rejecting a request due to overloading: {0}", msg.ToString());
                 loadSheddingCounter.Increment();
                 return;
@@ -97,7 +97,7 @@ namespace Orleans.Runtime.Messaging
                     msg.TargetActivation = ActivationId.GetDeterministic(msg.TargetGrain);
                 }
 
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, targetReference: null);
             }
         }
 
@@ -175,7 +175,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 msg.RetryCount++;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, targetReference: null);
             }
             else
             {

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -93,14 +93,7 @@ namespace Orleans.Runtime.Messaging
             // information, so a null target silo is OK.
             if (msg.TargetSilo == null || msg.TargetSilo.Matches(this.LocalSiloAddress))
             {
-                // See if it's a message for a client we're proxying.
-                if (messageCenter.TryDeliverToProxy(msg))
-                {
-                    return;
-                }
-
-                // Nope, it's for us
-                messageCenter.DispatchLocalMessage(msg);
+                messageCenter.ReceiveMessage(msg, targetReference: null);
                 return;
             }
 
@@ -108,7 +101,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // If the message is for some other silo altogether, then we need to forward it.
                 if (this.Log.IsEnabled(LogLevel.Trace)) this.Log.Trace("Forwarding message {0} from {1} to silo {2}", msg.Id, msg.SendingSilo, msg.TargetSilo);
-                messageCenter.SendMessage(msg);
+                messageCenter.SendMessage(msg, targetReference: null);
                 return;
             }
 
@@ -304,7 +297,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 msg.RetryCount = msg.RetryCount + 1;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, targetReference: null);
             }
             else
             {

--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -57,8 +57,6 @@ namespace Benchmarks.Ping
             {
                 var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
                 {
-                    clientBuilder.Configure<ClusterOptions>(options => options.ClusterId = options.ServiceId = "dev");
-
                     if (numSilos == 1)
                     {
                         clientBuilder.UseLocalhostClustering();

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -53,6 +53,7 @@ namespace UnitTests.SchedulerTests
         public void SetComponent<TComponent>(TComponent value) => throw new NotImplementedException();
 
         bool IEquatable<IGrainContext>.Equals(IGrainContext other) => ReferenceEquals(this, other);
+        bool ICachedMessageReceiver.HandleMessage(object message) => throw new NotImplementedException();
     }
     
     [TestCategory("BVT"), TestCategory("Scheduler")]


### PR DESCRIPTION
For local calls, this can improve performance by around 25%

We could also cache which `Connection` is appropriate for a given grain (i.,e which host it resolved to), but that would need extra care to ensure that caches are invalidated appropriately.

Caching for response handlers would likely involve first moving the response dictionary into the `IGrainContext` implementation before it can have a positive effect, eg, by reducing contention on a central `ConcurrentDictionary<(GrainId, CorrelationId), CallbackData>`. That would need more experimentation, but this optimization is a more obvious win.