### PR TITLE
Check [KnownBaseType] by Type.FullName rather than reference

### DIFF
--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -372,7 +372,6 @@ namespace Orleans.CodeGenerator
         private static bool TypeHasKnownBase(Type type)
         {
             if (type == null) return false;
-            // if (type.GetCustomAttribute<KnownBaseTypeAttribute>() != null) return true;
             if (type.GetCustomAttributes()?.Any(attr => attr.GetType().FullName == typeof(KnownBaseTypeAttribute).FullName) == true ) return true;
             if (TypeHasKnownBase(type.BaseType)) return true;
             var interfaces = type.GetInterfaces();

--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -372,7 +372,8 @@ namespace Orleans.CodeGenerator
         private static bool TypeHasKnownBase(Type type)
         {
             if (type == null) return false;
-            if (type.GetCustomAttribute<KnownBaseTypeAttribute>() != null) return true;
+            // if (type.GetCustomAttribute<KnownBaseTypeAttribute>() != null) return true;
+            if (type.GetCustomAttributes()?.Any(attr => attr.GetType().FullName == typeof(KnownBaseTypeAttribute).FullName) == true ) return true;
             if (TypeHasKnownBase(type.BaseType)) return true;
             var interfaces = type.GetInterfaces();
             foreach (var iface in interfaces)


### PR DESCRIPTION
Fix this issue : https://github.com/dotnet/orleans/issues/7645

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7656)