### PR TITLE
Orleans.Reminders.DynamoDB use the Query operation for ReadRows

### DIFF
--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -258,14 +258,16 @@ namespace Orleans.Transactions.DynamoDB
 
         private async Task<TableDescription> TableWaitOnStatusAsync(string tableName, TableStatus whileStatus, TableStatus desiredStatus, int delay = 2000)
         {
-            TableDescription ret;
+            TableDescription ret = null;
 
             do
             {
+                if (ret != null)
+                {
+                    await Task.Delay(delay);
+                }
+                
                 ret = await GetTableDescription(tableName);
-
-                await Task.Delay(delay);
-
             } while (ret.TableStatus == whileStatus);
 
             if (ret.TableStatus != desiredStatus)
@@ -279,17 +281,18 @@ namespace Orleans.Transactions.DynamoDB
         private async Task<TableDescription> TableIndexWaitOnStatusAsync(string tableName, string indexName, IndexStatus whileStatus, IndexStatus desiredStatus = null, int delay = 2000)
         {
             TableDescription ret;
-            GlobalSecondaryIndexDescription index;
+            GlobalSecondaryIndexDescription index = null;
 
             do
             {
+                if (index != null)
+                {
+                    await Task.Delay(delay);
+                }
+
                 ret = await GetTableDescription(tableName);
-
-                await Task.Delay(delay);
-
                 index = ret.GlobalSecondaryIndexes.FirstOrDefault(index => index.IndexName == indexName);
-
-            } while (ret.GlobalSecondaryIndexes.FirstOrDefault(index => index.IndexName == indexName).IndexStatus == whileStatus);
+            } while (index.IndexStatus == whileStatus);
 
             if (desiredStatus != null && index.IndexStatus != desiredStatus)
             {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/orleans/issues/7657

The `scan` operation is inefficient especially as the table size increases. This is because the `scan` operation reads the entire table (therefore consumes RCUs for all the data in the table) and filters out rows based on the expression.

On the other hand, the `query` operation is very efficient as it pulls out only the specific records that match the HashKey and the SortKey without wasting any RCUs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7658)