### PR TITLE
Ignore KnownAssembly attribute which points to the containing assembly

### DIFF
--- a/src/Orleans.CodeGenerator/Analysis/CompilationAnalyzer.cs
+++ b/src/Orleans.CodeGenerator/Analysis/CompilationAnalyzer.cs
@@ -285,6 +285,13 @@ namespace Orleans.CodeGenerator.Analysis
 
             void ExpandKnownAssemblies(IAssemblySymbol asm)
             {
+                // This can occur if a developer adds [assembly: KnownAssembly(type(x))] where x is the main assembly being inspected
+                // by the code generator. i.e., the attribute is self-referential.
+                if (asm is null)
+                {
+                    return;
+                }
+
                 if (!this.KnownAssemblies.Add(asm))
                 {
                     return;


### PR DESCRIPTION
Fixes #7642

Ignores `[KnownAssembly]` in the event that the assembly of the `Type` argument is `null`, indicating that it's referring to the containing assembly and is hence self-referential.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7664)