### PR TITLE
Simplify SiloConnection

### DIFF
--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -93,14 +93,7 @@ namespace Orleans.Runtime.Messaging
             // information, so a null target silo is OK.
             if (msg.TargetSilo == null || msg.TargetSilo.Matches(this.LocalSiloAddress))
             {
-                // See if it's a message for a client we're proxying.
-                if (messageCenter.TryDeliverToProxy(msg))
-                {
-                    return;
-                }
-
-                // Nope, it's for us
-                messageCenter.DispatchLocalMessage(msg);
+                messageCenter.ReceiveMessage(msg);
                 return;
             }
 


### PR DESCRIPTION
There is a call to `TryDeliverToProxy` in `SiloConnection` which is superfluous since `messageCenter.ReceiveMessage` makes the same call.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7669)