### PR TITLE
Allow `LocalGrainDirectory` calls while shutting down

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -491,15 +491,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             SiloAddress owner = CalculateGrainDirectoryPartition(grainId);
 
-            if (owner == null)
+            if (owner is null || owner.Equals(MyAddress))
             {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new OrleansGrainDirectoryException("Grain directory is stopping");
-            }
-
-            if (owner.Equals(MyAddress))
-            {
-                // if I am the owner, perform the operation locally
+                // Either we don't know about any other silos and we're stopping, or we are the owner.
+                // Null indicates that the operation should be performed locally.
+                // In the case that this host is terminating, any grain registered to this host must terminate.
                 return null;
             }
 


### PR DESCRIPTION
Currently, users are presented with a `Grain directory is stopping` exception when a shutdown is occurring and there are no directories to forward a request to. In the single silo case, this is benign and in the multiple-silo case, this will not occur (since another silo will have been chosen instead)

I believe it's safe for us to just accept those requests since they can only occur if this is the last silo in the cluster and therefore the world is ending anyway (we're shutting down).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7670)