### PR TITLE
Fix Source Link build for CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,9 +14,10 @@
     <PackageIcon>logo_128.png</PackageIcon>
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/dotnet/orleans</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <PublicRepositoryUrl>https://github.com/dotnet/orleans</PublicRepositoryUrl>
     <PrivateRepositoryUrl>$(RepositoryUrl)</PrivateRepositoryUrl>
+    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
     <LangVersion>latest</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
   <PropertyGroup>
     <SourceLinkCreate>true</SourceLinkCreate>
     <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -9,4 +9,27 @@
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(SourceLinkVersion)" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkVersion)" PrivateAssets="all" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
+    <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
+    <_TranslateUrlPattern>https://.*\.visualstudio\.com/.*/_git/[^/]*</_TranslateUrlPattern>
+    <_TranslateUrlReplacement>$(PublicRepositoryUrl)</_TranslateUrlReplacement>
+  </PropertyGroup>
+
+  <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"
+          Condition="'$(DisableSourceLinkUrlTranslation)' == 'false'"
+          DependsOnTargets="$(SourceControlManagerUrlTranslationTargets)"
+          BeforeTargets="SourceControlManagerPublishTranslatedUrls">
+
+    <PropertyGroup>
+      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
+        <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
I suppose it's not common to mirror a repository into another repository and build official packages from there, so this is the price we pay.

This trickery was nabbed from the dotnet/arcade repo here: https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets#L43-L82
As suggested by @tmat here: https://github.com/dotnet/sourcelink/issues/820

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7673)