### PR TITLE
DynamoDB optional table create / update and update corner cases

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -35,13 +35,9 @@ namespace Orleans.Clustering.DynamoDB
 
         public Task InitializeGatewayListProvider()
         {
-            this.storage = new DynamoDBStorage(
-                this.logger,
-                this.options.Service,
-                this.options.AccessKey,
-                this.options.SecretKey,
-                this.options.ReadCapacityUnits,
-                this.options.WriteCapacityUnits);
+            this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
+                this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput,
+                this.options.CreateIfNotExists, this.options.UpdateIfExists);
 
             return this.storage.InitializeTable(this.options.TableName,
                 new List<KeySchemaElement>

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -40,7 +40,8 @@ namespace Orleans.Clustering.DynamoDB
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                  this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput,
+                  this.options.CreateIfNotExists, this.options.UpdateIfExists);
 
             logger.Info(ErrorCode.MembershipBase, "Initializing AWS DynamoDB Membership Table");
             await storage.InitializeTable(this.options.TableName,

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringOptions.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Clustering.DynamoDB;
+using Orleans.Clustering.DynamoDB;
 
 namespace Orleans.Configuration
 {
@@ -30,6 +30,21 @@ namespace Orleans.Configuration
         /// Write capacity unit for DynamoDB storage
         /// </summary>
         public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
+
+        /// <summary>
+        /// Use Provisioned Throughput for tables
+        /// </summary>
+        public bool UseProvisionedThroughput { get; set; } = true;
+
+        /// <summary>
+        /// Create the table if it doesn't exist
+        /// </summary>
+        public bool CreateIfNotExists { get; set; } = true;
+
+        /// <summary>
+        /// Update the table if it exists
+        /// </summary>
+        public bool UpdateIfExists { get; set; } = true;
 
         /// <summary>
         /// DynamoDB table name.

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBGatewayOptions.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Clustering.DynamoDB;
+using Orleans.Clustering.DynamoDB;
 
 namespace Orleans.Configuration
 {
@@ -28,6 +28,21 @@ namespace Orleans.Configuration
         /// Write capacity unit for DynamoDB storage
         /// </summary>
         public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
+
+        /// <summary>
+        /// Use Provisioned Throughput for tables
+        /// </summary>
+        public bool UseProvisionedThroughput { get; set; } = true;
+
+        /// <summary>
+        /// Create the table if it doesn't exist
+        /// </summary>
+        public bool CreateIfNotExists { get; set; } = true;
+
+        /// <summary>
+        /// Update the table if it exists
+        /// </summary>
+        public bool UpdateIfExists { get; set; } = true;
 
         /// <summary>
         /// DynamoDB table name.

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -35,6 +35,16 @@ namespace Orleans.Configuration
         public bool UseProvisionedThroughput { get; set; } = true;
 
         /// <summary>
+        /// Create the table if it doesn't exist
+        /// </summary>
+        public bool CreateIfNotExists { get; set; } = true;
+
+        /// <summary>
+        /// Update the table if it exists
+        /// </summary>
+        public bool UpdateIfExists { get; set; } = true;
+
+        /// <summary>
         /// Read capacity unit for DynamoDB storage
         /// </summary>
         public int ReadCapacityUnits { get; set; } = DynamoDBStorage.DefaultReadCapacityUnits;

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -85,7 +85,8 @@ namespace Orleans.Storage
                 this.logger.LogInformation((int)ErrorCode.StorageProviderBase, $"AWS DynamoDB Grain Storage {this.name} is initializing: {initMsg}");
 
                 this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput);
+                    this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput,
+                    this.options.CreateIfNotExists, this.options.UpdateIfExists);
 
                 await storage.InitializeTable(this.options.TableName,
                     new List<KeySchemaElement>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -57,7 +57,8 @@ namespace Orleans.Reminders.DynamoDB
         public Task Init()
         {
             this.storage = new DynamoDBStorage(this.logger, this.options.Service, this.options.AccessKey, this.options.SecretKey,
-                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits);
+                 this.options.ReadCapacityUnits, this.options.WriteCapacityUnits, this.options.UseProvisionedThroughput,
+                 this.options.CreateIfNotExists, this.options.UpdateIfExists);
 
             this.logger.Info(ErrorCode.ReminderServiceBase, "Initializing AWS DynamoDB Reminders Table");
 

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
@@ -35,6 +35,21 @@ namespace Orleans.Configuration
         public int WriteCapacityUnits { get; set; } = DynamoDBStorage.DefaultWriteCapacityUnits;
 
         /// <summary>
+        /// Use Provisioned Throughput for tables
+        /// </summary>
+        public bool UseProvisionedThroughput { get; set; } = true;
+
+        /// <summary>
+        /// Create the table if it doesn't exist
+        /// </summary>
+        public bool CreateIfNotExists { get; set; } = true;
+
+        /// <summary>
+        /// Update the table if it exists
+        /// </summary>
+        public bool UpdateIfExists { get; set; } = true;
+
+        /// <summary>
         /// DynamoDB table name.
         /// Defaults to 'OrleansReminders'.
         /// </summary>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptionsExtensions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptionsExtensions.cs
@@ -13,6 +13,9 @@ namespace Orleans.Configuration
         private const string ServicePropertyName = "Service";
         private const string ReadCapacityUnitsPropertyName = "ReadCapacityUnits";
         private const string WriteCapacityUnitsPropertyName = "WriteCapacityUnits";
+        private const string UseProvisionedThroughputPropertyName = "UseProvisionedThroughput";
+        private const string CreateIfNotExistsPropertyName = "CreateIfNotExists";
+        private const string UpdateIfExistsPropertyName = "UpdateIfExists";
 
         /// <summary>
         /// Configures this instance using the provided connection string.
@@ -59,6 +62,30 @@ namespace Orleans.Configuration
                 var value = writeCapacityUnitsConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                 if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
                     options.WriteCapacityUnits = int.Parse(value[1]);
+            }
+
+            var useProvisionedThroughputConfig = parameters.Where(p => p.Contains(UseProvisionedThroughputPropertyName)).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(useProvisionedThroughputConfig))
+            {
+                var value = useProvisionedThroughputConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
+                    options.UseProvisionedThroughput = bool.Parse(value[1]);
+            }
+
+            var createIfNotExistsPropertyNameConfig = parameters.Where(p => p.Contains(CreateIfNotExistsPropertyName)).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(createIfNotExistsPropertyNameConfig))
+            {
+                var value = createIfNotExistsPropertyNameConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
+                    options.CreateIfNotExists = bool.Parse(value[1]);
+            }
+
+            var updateIfExistsPropertyNameConfig = parameters.Where(p => p.Contains(UpdateIfExistsPropertyName)).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(updateIfExistsPropertyNameConfig))
+            {
+                var value = updateIfExistsPropertyNameConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
+                    options.UpdateIfExists = bool.Parse(value[1]);
             }
         }
     }


### PR DESCRIPTION
Issues:

- #7682
- #7683
- #7684

Fixes / Improvements in this PR:

- Ability to disable automatic table create or update via the configuration properties `CreateIfNotExists` and `UpdateIfExists` respectively. This is important as in a production environment the infrastructure is provisioned and maintained via other solutions (e.g.: CloudFormation, Terraform etc). Not having this ability means that when a grain starts, it will observe that the DynamoDB capacity has changed and update it back to what the Orleans configuration dictates. This change is **essential** for a production environment (required after the Orleans library also gained the ability to update existing tables via the `UpdateTableAsync` method).
- Added a missing configuration parameter `UseProvisionedThroughput` to the reminders implementation
- Fixed several corner cases in the `UpdateTableAsync` method


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7681)