### PR TITLE
3.x - Ensure timestamp is updated on codegen output for incremental builds

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -121,6 +121,8 @@
 
     <!-- Use dotnet to execute the process. -->
     <Exec Command="&quot;$(Orleans_DotNetHost)&quot; &quot;$(Orleans_GeneratorAssembly)&quot; SourceToSource &quot;$(Orleans_ArgsFile)&quot;" Outputs="$(Orleans_OutputFileName)" />
+	
+	<Touch Files="$(Orleans_OutputFileName)" />
 
     <ItemGroup>
       <Compile Include="$(Orleans_OutputFileName)" Condition="Exists('$(Orleans_OutputFileName)')" />


### PR DESCRIPTION
We noticed an issue with our local dev incremental builds where after a file was changed in a project using the msbuild code generator targets it would always run the code generator, even when no files have changed build-to-build. I investigated and tracked this down to the code generator not updating the timestamp of the output file when it runs. I propose the following solution: when the code generator is executed we touch the output file afterward to ensure its timestamp is updated, and thus the output timestamp will always end up being newer than the input args file.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7687)