### PR TITLE
Remove ValidateInitialConnectivity

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -1,4 +1,3 @@
-
 using System;
 
 namespace Orleans.Configuration
@@ -11,13 +10,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets the number of missed "I am alive" updates in the table from a silo that causes warning to be logged.
         /// </summary>
-        /// <remarks>
-        /// This value does not affect the liveness protocol during runtime, but it is used to determine which silos are included
-        /// in the initial connectivity check which is performed at startup.
-        /// </remarks>
-        /// <seealso cref="ValidateInitialConnectivity"/>
         /// <seealso cref="IAmAliveTablePublishTimeout"/>
-        /// <value>The default value is two missed updates before a silo is ignored during the initial connectivity test.</value>
         public int NumMissedTableIAmAliveLimit { get; set; } = 2;
 
         /// <summary>
@@ -63,13 +56,6 @@ namespace Orleans.Configuration
         /// </summary>
         /// <value>Attempt to join for 5 minutes before giving up by default.</value>
         public TimeSpan MaxJoinAttemptTime { get; set; } = TimeSpan.FromMinutes(5);
-                
-        /// <summary>
-        /// Gets or sets a value indicating whether new silo that joins the cluster has to validate the initial connectivity with all other active silos.
-        /// </summary>
-        /// <remarks>Do not disable this for production services.</remarks>
-        /// <value>Connectivity is validated during startup by default.</value>
-        public bool ValidateInitialConnectivity { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether gossip membership updates between hosts.
@@ -115,7 +101,7 @@ namespace Orleans.Configuration
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
-        /// Gets the period after which a silo is ignored for initial connectivity validation if it has not updated its heartbeat in the silo membership table.
+        /// Gets the period after which a silo that didn't updated its status in the table causes a warning to be logged.
         /// </summary>
         internal TimeSpan AllowedIAmAliveMissPeriod => this.IAmAliveTablePublishTimeout.Multiply(this.NumMissedTableIAmAliveLimit);
 

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -101,7 +101,7 @@ namespace Orleans.Configuration
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
-        /// Gets the period after which a silo that didn't updated its status in the table causes a warning to be logged.
+        /// /// Gets the period after which a silo is ignored for initial connectivity validation if it has not updated its heartbeat in the silo membership table.
         /// </summary>
         internal TimeSpan AllowedIAmAliveMissPeriod => this.IAmAliveTablePublishTimeout.Multiply(this.NumMissedTableIAmAliveLimit);
 

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -100,16 +100,7 @@ namespace Orleans.Runtime.MembershipService
                 (int)ErrorCode.MembershipBecomeActive,
                 "-BecomeActive");
 
-            if (this.clusterMembershipOptions.ValidateInitialConnectivity)
-            {
-                await this.ValidateInitialConnectivity();
-            }
-            else
-            {
-                this.log.LogWarning(
-                      (int)ErrorCode.MembershipSendingPreJoinPing,
-                      $"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ValidateInitialConnectivity)} is set to false. This is NOT recommended for a production environment.");
-            }
+            await this.ValidateInitialConnectivity();
 
             try
             {

--- a/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Orleans.Configuration;
 
 namespace Orleans.Runtime.MembershipService


### PR DESCRIPTION
This PR removes `ValidateInitialConnectivity` 

This setting allowed to skip the initial connectivity when a silo tries to join a cluster but introduces a lot of issues just after.

> What may be happening is this: 
> - Old silo A was killed ungracefully, so in the membership table it's still `Active`. 
> - Silo B tries to join the cluster, but with `ValidateInitialConnectivity` set to false, it doesn't try to ping A before joining.
> - Silo B tries to activate some grain. It chooses to place it on silo A, since it's still alive in the membership table
> - These requests fail (timeout) or just wait, until B decide to vote silo A dead (by default it can take few mins)
> - Once this vote occurred, pending request will throw `SiloUnavailableException`

It can cause issues with the distributed directory, streaming infrastructure, etc.

**If you want to redeploy silos while there is stopped silos still marked as active in the membership table, you should use a different `ClusterId` value instead**.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7701)