### PR TITLE
Remove exception from IsPrimaryKeyBasedOnLong when key is not integer

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
@@ -157,7 +157,7 @@ namespace Orleans
                 return legacyId.IsLongKey;
             }
 
-            throw new InvalidOperationException($"Unable to extract integer key from grain id {grainId}");
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for #7702
It is possible that someone made behavior based on this exception.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7704)