### PR TITLE
Fix invalid podLabelSelector for KubernetesClusterAgent

### DIFF
--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -47,7 +47,7 @@ namespace Orleans.Hosting.Kubernetes
             _clusterMembershipService = clusterMembershipService;
             _config = _options.CurrentValue.GetClientConfiguration?.Invoke() ?? throw new ArgumentNullException(nameof(KubernetesHostingOptions) + "." + nameof(KubernetesHostingOptions.GetClientConfiguration));
             _client = new k8s.Kubernetes(_config);
-            _podLabelSelector = $"{KubernetesHostingOptions.ServiceIdLabel}={_clusterOptions.ServiceId},{KubernetesHostingOptions.ClusterIdLabel}={_clusterOptions.ClusterId}";
+            _podLabelSelector = $"{KubernetesHostingOptions.ClusterIdLabel}={_clusterOptions.ClusterId}";
             _podNamespace = _options.CurrentValue.Namespace;
             _podName = _options.CurrentValue.PodName;
         }


### PR DESCRIPTION
Fix for https://github.com/dotnet/orleans/issues/7654

**What changed in this PR:**
I've changed the label selector to select all pods within the cluster.

**Explanation:**
The following code returns entire cluster members
https://github.com/dotnet/orleans/blob/bed9ff19badadafa3bf88cb6b3bcbf2608732ca0/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs#L68

The following line returns pods corresponding to label selector
https://github.com/dotnet/orleans/blob/bed9ff19badadafa3bf88cb6b3bcbf2608732ca0/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs#L71-L74
and label selector is restricting to own service, not cluster.
https://github.com/dotnet/orleans/blob/bed9ff19badadafa3bf88cb6b3bcbf2608732ca0/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs#L50

So when service X pod starts, service X pod found service Y pod is in the cluster, it kills.
https://github.com/dotnet/orleans/blob/bed9ff19badadafa3bf88cb6b3bcbf2608732ca0/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs#L105-L112

Resulting in multiple each silo marking and killing different service pod/silos, when especially k8s restarting pods, it creates a whole new mayhem.

**What could be done better:**
I'm not sure we absolutely necessary to have this start-up interrogation logic. it may cause race conditions when full cluster startup or half of the cluster went dead. and it also takes much more time to start.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7710)