### PR TITLE
Fix ZooKeeper tests

### DIFF
--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -40,20 +40,22 @@ namespace Orleans.Runtime.Membership
 
         private const int ZOOKEEPER_CONNECTION_TIMEOUT = 2000;
 
-        private ZooKeeperWatcher watcher;
+        private readonly ZooKeeperWatcher watcher;
 
         /// <summary>
         /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/ClusterId"
         /// </summary>
-        private string deploymentConnectionString;
+        private readonly string deploymentConnectionString;
+
         /// <summary>
         /// the node name for this deployment. for eg. /ClusterId
         /// </summary>
-        private string clusterPath;
+        private readonly string clusterPath;
+
         /// <summary>
         /// The root connection string. for eg. "192.168.1.1,192.168.1.2"
         /// </summary>
-        private string rootConnectionString;
+        private readonly string rootConnectionString;
         
         public ZooKeeperBasedMembershipTable(
             ILogger<ZooKeeperBasedMembershipTable> logger, 
@@ -63,7 +65,9 @@ namespace Orleans.Runtime.Membership
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
-            InitConfig(options.ConnectionString, clusterOptions.Value.ClusterId);
+            this.clusterPath = "/" + clusterOptions.Value.ClusterId;
+            rootConnectionString = options.ConnectionString;
+            deploymentConnectionString = options.ConnectionString + this.clusterPath;
         }
 
         /// <summary>
@@ -91,13 +95,6 @@ namespace Orleans.Runtime.Membership
                     this.logger.Debug("Deployment path already exists: " + this.clusterPath);
                 }
             });
-        }
-
-        private void InitConfig(string dataConnectionString, string clusterId)
-        {
-            this.clusterPath = "/" + clusterId;
-            deploymentConnectionString = dataConnectionString + this.clusterPath;
-            rootConnectionString = dataConnectionString;
         }
 
         /// <summary>

--- a/test/Extensions/TesterZooKeeperUtils/LivenessTests.cs
+++ b/test/Extensions/TesterZooKeeperUtils/LivenessTests.cs
@@ -26,7 +26,7 @@ namespace Tester.ZooKeeperUtils
         {
             public void Configure(ISiloBuilder hostBuilder)
             {
-                hostBuilder.UseZooKeeperClustering(options => { options.ConnectionString = TestDefaultConfiguration.DataConnectionString; });
+                hostBuilder.UseZooKeeperClustering(options => { options.ConnectionString = TestDefaultConfiguration.ZooKeeperConnectionString; });
             }
         }
 

--- a/test/Extensions/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/Extensions/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -43,7 +43,7 @@ namespace UnitTests.MembershipTests
             var options = new ZooKeeperGatewayListProviderOptions();
             options.ConnectionString = this.connectionString;
 
-            return ActivatorUtilities.CreateInstance<ZooKeeperGatewayListProvider>(this.Services, Options.Create(options));
+            return ActivatorUtilities.CreateInstance<ZooKeeperGatewayListProvider>(this.Services, Options.Create(options), this.clusterOptions);
         }
 
         protected override async Task<string> GetConnectionString()

--- a/test/Extensions/TesterZooKeeperUtils/ZookeeperTestUtils.cs
+++ b/test/Extensions/TesterZooKeeperUtils/ZookeeperTestUtils.cs
@@ -1,4 +1,4 @@
-﻿using org.apache.zookeeper;
+using org.apache.zookeeper;
 using System;
 using System.Threading.Tasks;
 using TestExtensions;
@@ -23,7 +23,8 @@ namespace Tester.ZooKeeperUtils
             {
                 return false;
             }
-            return await ZooKeeper.Using(connectionString, 2000, null, async zk =>
+
+            return await ZooKeeper.Using(connectionString, 2000, new ZooKeeperWatcher(), async zk =>
             {
                 try
                 {
@@ -35,6 +36,11 @@ namespace Tester.ZooKeeperUtils
                     return false;
                 }
             });
+        }
+
+        private class ZooKeeperWatcher : Watcher
+        {
+            public override Task process(WatchedEvent @event) => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
ZooKeeper tests were broken due to the cluster options not being passed to `ZooKeeperGatewayListProvider`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7715)