### PR TITLE
Unify configuration for Consul tests

### DIFF
--- a/test/Extensions/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Extensions/Consul.Tests/ConsulMembershipTableTest.cs
@@ -55,7 +55,7 @@ namespace Consul.Tests
 
         protected override async Task<string> GetConnectionString()
         {
-            return await ConsulTestUtils.EnsureConsulAsync() ? ConsulTestUtils.CONSUL_ENDPOINT : null;
+            return await ConsulTestUtils.EnsureConsulAsync() ? ConsulTestUtils.ConsulConnectionString : null;
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/Consul.Tests/ConsulTestUtils.cs
+++ b/test/Extensions/Consul.Tests/ConsulTestUtils.cs
@@ -1,14 +1,16 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using TestExtensions;
 using Xunit;
 
 namespace Consul.Tests
 {
     public static class ConsulTestUtils
     {
-        public const string CONSUL_ENDPOINT = "http://localhost:8500";
+        public static string ConsulConnectionString = TestDefaultConfiguration.ConsulConnectionString;
+
         private static readonly Lazy<bool> EnsureConsulLazy = new Lazy<bool>(() => EnsureConsulAsync().Result);
 
         public static void EnsureConsul()
@@ -23,7 +25,7 @@ namespace Consul.Tests
             {
                 var client = new HttpClient();
                 client.Timeout = TimeSpan.FromSeconds(15);
-                var response = await client.GetAsync($"{CONSUL_ENDPOINT}/v1/health/service/consul?pretty");
+                var response = await client.GetAsync($"{ConsulConnectionString}/v1/health/service/consul?pretty");
                 return response.StatusCode == HttpStatusCode.OK;
             }
             catch (HttpRequestException)

--- a/test/Extensions/Consul.Tests/LivenessTests.cs
+++ b/test/Extensions/Consul.Tests/LivenessTests.cs
@@ -30,7 +30,7 @@ namespace Consul.Tests
             {
                 hostBuilder.UseConsulSiloClustering(options =>
                 {
-                    var address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT);
+                    var address = new Uri(ConsulTestUtils.ConsulConnectionString);
                     options.ConfigureConsulClient(address);
                 });
             }
@@ -43,7 +43,7 @@ namespace Consul.Tests
                 clientBuilder
                     .UseConsulClientClustering(gatewayOptions =>
                     {
-                        var address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT);
+                        var address = new Uri(ConsulTestUtils.ConsulConnectionString);
                         gatewayOptions.ConfigureConsulClient(address);
                     });
             }


### PR DESCRIPTION
Use `TestDefaultConfiguration` for Consul tests so that the connection string can be configured via command line or environment variables

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7716)