### PR TITLE
Fix DynamoDB provider and tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <MicrosoftServiceFabricServicesVersion>4.1.456</MicrosoftServiceFabricServicesVersion>
 
     <!-- 3rd party packages -->
-    <AWSSDKDynamoDBv2Version>3.7.2.12</AWSSDKDynamoDBv2Version>
+    <AWSSDKDynamoDBv2Version>3.7.3.30</AWSSDKDynamoDBv2Version>
     <AWSSDKSQSVersion>3.7.2.14</AWSSDKSQSVersion>
     <BondCoreCSharpVersion>5.3.1</BondCoreCSharpVersion>
     <ConsulVersion>1.6.10.4</ConsulVersion>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -152,7 +152,7 @@ namespace Orleans.Storage
                         GrainReference = fields[GRAIN_REFERENCE_PROPERTY_NAME].S,
                         ETag = int.Parse(fields[ETAG_PROPERTY_NAME].N),
                         BinaryState = fields.ContainsKey(BINARY_STATE_PROPERTY_NAME) ? fields[BINARY_STATE_PROPERTY_NAME].B?.ToArray() : null,
-                        StringState = fields.ContainsKey(STRING_STATE_PROPERTY_NAME) ? fields[STRING_STATE_PROPERTY_NAME].S : string.Empty
+                        StringState = fields.ContainsKey(STRING_STATE_PROPERTY_NAME) ? fields[STRING_STATE_PROPERTY_NAME].S : null
                     };
                 }).ConfigureAwait(false);
 

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -217,13 +217,17 @@ namespace Orleans.Transactions.DynamoDB
 
             try
             {
-                await ddbClient.CreateTableAsync(request);
+                try
+                {
+                    await ddbClient.CreateTableAsync(request);
+                }
+                catch (ResourceInUseException)
+                {
+                    // The table has already been created.
+                }
+
                 TableDescription tableDescription = await TableWaitOnStatusAsync(tableName, TableStatus.CREATING, TableStatus.ACTIVE);
                 tableDescription = await TableUpdateTtlAsync(tableDescription, ttlAttributeName);
-            }
-            catch (ResourceInUseException)
-            {
-                // The table has already been created.
             }
             catch (Exception exc)
             {

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -221,6 +221,10 @@ namespace Orleans.Transactions.DynamoDB
                 TableDescription tableDescription = await TableWaitOnStatusAsync(tableName, TableStatus.CREATING, TableStatus.ACTIVE);
                 tableDescription = await TableUpdateTtlAsync(tableDescription, ttlAttributeName);
             }
+            catch (ResourceInUseException)
+            {
+                // The table has already been created.
+            }
             catch (Exception exc)
             {
                 Logger.Error(ErrorCode.StorageProviderBase, $"Could not create table {tableName}", exc);

--- a/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/Extensions/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -50,7 +50,7 @@ namespace AWSUtils.Tests.MembershipTests
 
         protected override Task<string> GetConnectionString()
         {
-            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.Service}" : null);
+            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.DynamoDbService}" : null);
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
@@ -40,7 +40,7 @@ namespace AWSUtils.Tests.RemindersTest
 
         protected override Task<string> GetConnectionString()
         {
-            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.Service}" : null);
+            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.DynamoDbService}" : null);
         }
 
         [SkippableFact]

--- a/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
@@ -6,6 +6,7 @@ using Orleans.AWSUtils.Tests;
 using Orleans.Internal;
 using System;
 using System.Collections.Generic;
+using TestExtensions;
 
 namespace AWSUtils.Tests.StorageTests
 {
@@ -13,22 +14,31 @@ namespace AWSUtils.Tests.StorageTests
     {
         private static readonly Lazy<bool> _isDynamoDbAvailable = new Lazy<bool>(() =>
         {
+            if (string.IsNullOrEmpty(DynamoDbService))
+            {
+                return false;
+            }
+
             try
             {
                 DynamoDBStorage storage;
                 try
                 {
-                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), Service);
+                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), DynamoDbService);
                 }
                 catch (AmazonServiceException)
                 {
                     return false;
                 }
-                storage.InitializeTable("TestTable", new List<KeySchemaElement> {
-                    new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH }
-                }, new List<AttributeDefinition> {
-                    new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S }
-                }).WithTimeout(TimeSpan.FromSeconds(2)).Wait();
+                storage.InitializeTable(
+                    "TestTable",
+                    new List<KeySchemaElement> {
+                        new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH }
+                    },
+                    new List<AttributeDefinition> {
+                        new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S }
+                    })
+                .WithTimeout(TimeSpan.FromSeconds(2)).Wait();
                 return true;
             }
             catch (Exception exc)
@@ -40,13 +50,12 @@ namespace AWSUtils.Tests.StorageTests
             }
         });
 
-        public static string DefaultSQSConnectionString = "";
-
-        public static string AccessKey { get; set; }
-        public static string SecretKey { get; set; }
-        public static string Service { get; set; } = "http://localhost:8000";
+        public static string DynamoDbAccessKey { get; set; } = TestDefaultConfiguration.DynamoDbAccessKey;
+        public static string DynamoDbSecretKey { get; set; } = TestDefaultConfiguration.DynamoDbSecretKey;
+        public static string DynamoDbService { get; set; } = TestDefaultConfiguration.DynamoDbService;
+        public static string SqsConnectionString { get; set; } = TestDefaultConfiguration.SqsConnectionString;
 
         public static bool IsDynamoDbAvailable => _isDynamoDbAvailable.Value;
-        public static bool IsSqsAvailable => !string.IsNullOrWhiteSpace(DefaultSQSConnectionString);
+        public static bool IsSqsAvailable => !string.IsNullOrWhiteSpace(SqsConnectionString);
     }
 }

--- a/test/Extensions/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
@@ -287,6 +287,9 @@ namespace AWSUtils.Tests.StorageTests
             Assert.Equal(initialServiceId, serviceId);  // "ServiceId same after restart."
             Assert.Equal(initialDeploymentId, this.HostedCluster.Options.ClusterId);  // "ClusterId same after restart."
 
+            // Since the client was destroyed and restarted, the grain reference needs to be recreated.
+            grain = this.fixture.GrainFactory.GetGrain<IAWSStorageTestGrain>(id);
+
             val = await grain.GetValue();
             Assert.Equal(1, val);  // "Value after Write-1"
 
@@ -349,14 +352,13 @@ namespace AWSUtils.Tests.StorageTests
         }
 
 
-        protected async Task Persistence_Silo_StorageProvider_AWS(Type providerType)
+        protected async Task Persistence_Silo_StorageProvider_AWS(string providerName)
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                string provider = providerType.FullName;
                 ICollection<string> providers = await this.HostedCluster.Client.GetTestHooks(silo).GetStorageProviderNames();
-                Assert.True(providers.Contains(provider), $"No storage provider found: {provider}");
+                Assert.True(providers.Contains(providerName), $"No storage provider found: {providerName}");
             }
         }
 

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -30,18 +30,18 @@ namespace AWSUtils.Tests.StorageTests
         {
             this.output = output;
             this.fixture = fixture;
-            providerCfgProps["DataConnectionString"] = $"Service={AWSTestConstants.Service}";
+            providerCfgProps["DataConnectionString"] = $"Service={AWSTestConstants.DynamoDbService}";
             this.providerRuntime = new ClientProviderRuntime(
                 fixture.InternalGrainFactory,
                 fixture.Services,
                 fixture.Services.GetRequiredService<ClientGrainContext>());
         }
 
-        [SkippableTheory, TestCategory("Functional"), TestCategory("DynamoDB")]
+        [SkippableTheory, TestCategory("Functional")]
         [InlineData(null, false)]
         [InlineData(null, true)]
-        [InlineData(15 * 64 * 1024 - 256, false)]
-        [InlineData(15 * 32 * 1024 - 256, true)]
+        [InlineData(400_000, false)]
+        [InlineData(400_000, true)]
         public async Task PersistenceProvider_DynamoDB_WriteRead(int? stringLength, bool useJson)
         {
             var testName = string.Format("{0}({1} = {2}, {3} = {4})",
@@ -57,11 +57,11 @@ namespace AWSUtils.Tests.StorageTests
             await Test_PersistenceProvider_WriteRead(testName, store, grainState);
         }
 
-        [SkippableTheory, TestCategory("Functional"), TestCategory("DynamoDB")]
+        [SkippableTheory, TestCategory("Functional")]
         [InlineData(null, false)]
         [InlineData(null, true)]
-        [InlineData(15 * 64 * 1024 - 256, false)]
-        [InlineData(15 * 32 * 1024 - 256, true)]
+        [InlineData(400_000, false)]
+        [InlineData(400_000, true)]
         public async Task PersistenceProvider_DynamoDB_WriteClearRead(int? stringLength, bool useJson)
         {
             var testName = string.Format("{0}({1} = {2}, {3} = {4})",
@@ -77,11 +77,11 @@ namespace AWSUtils.Tests.StorageTests
             await Test_PersistenceProvider_WriteClearRead(testName, store, grainState);
         }
 
-        [SkippableTheory, TestCategory("Functional"), TestCategory("DynamoDB")]
+        [SkippableTheory, TestCategory("Functional")]
         [InlineData(null, true, false)]
         [InlineData(null, false, true)]
-        [InlineData(15 * 32 * 1024 - 256, true, false)]
-        [InlineData(15 * 32 * 1024 - 256, false, true)]
+        [InlineData(400_000, true, false)]
+        [InlineData(400_000, false, true)]
         public async Task PersistenceProvider_DynamoDB_ChangeReadFormat(int? stringLength, bool useJsonForWrite, bool useJsonForRead)
         {
             var testName = string.Format("{0}({1} = {2}, {3} = {4}, {5} = {6})",
@@ -104,11 +104,11 @@ namespace AWSUtils.Tests.StorageTests
             await Test_PersistenceProvider_Read(testName, store, grainState, grainId);
         }
 
-        [SkippableTheory, TestCategory("Functional"), TestCategory("DynamoDB")]
+        [SkippableTheory, TestCategory("Functional")]
         [InlineData(null, true, false)]
         [InlineData(null, false, true)]
-        [InlineData(15 * 32 * 1024 - 256, true, false)]
-        [InlineData(15 * 32 * 1024 - 256, false, true)]
+        [InlineData(100_000, true, false)]
+        [InlineData(100_000, false, true)]
         public async Task PersistenceProvider_DynamoDB_ChangeWriteFormat(int? stringLength, bool useJsonForFirstWrite, bool useJsonForSecondWrite)
         {
             var testName = string.Format("{0}({1}={2},{3}={4},{5}={6})",
@@ -134,11 +134,11 @@ namespace AWSUtils.Tests.StorageTests
             await Test_PersistenceProvider_WriteRead(testName, store, grainState, grainId);
         }
 
-        [SkippableTheory, TestCategory("Functional"), TestCategory("DynamoDB")]
+        [SkippableTheory, TestCategory("Functional")]
         [InlineData(null, false)]
         [InlineData(null, true)]
-        [InlineData(15 * 64 * 1024 - 256, false)]
-        [InlineData(15 * 32 * 1024 - 256, true)]
+        [InlineData(400_000, false)]
+        [InlineData(400_000, true)]
         public async Task DynamoDBStorage_ConvertToFromStorageFormat(int? stringLength, bool useJson)
         {
             var testName = string.Format("{0}({1} = {2}, {3} = {4})",
@@ -176,7 +176,7 @@ namespace AWSUtils.Tests.StorageTests
         {
             var options = new DynamoDBStorageOptions
             {
-                Service = AWSTestConstants.Service,
+                Service = AWSTestConstants.DynamoDbService,
                 UseJson = useJson
             };
             return InitDynamoDBGrainStorage(options);

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -36,6 +36,8 @@ namespace AWSUtils.Tests.StorageTests
                 public void Configure(ISiloBuilder hostBuilder)
                 {
                     hostBuilder.AddMemoryGrainStorage("MemoryStore");
+                    hostBuilder.AddMemoryGrainStorage("test1");
+                    hostBuilder.AddDynamoDBGrainStorage("DDBStore", options => options.Service = AWSTestConstants.DynamoDbService);
                 }
             }
         }
@@ -124,7 +126,7 @@ namespace AWSUtils.Tests.StorageTests
         [SkippableFact, TestCategory("Functional")]
         public Task Persistence_Silo_StorageProvider_AWSDynamoDBStore()
         {
-            return base.Persistence_Silo_StorageProvider_AWS(typeof(DynamoDBGrainStorage));
+            return base.Persistence_Silo_StorageProvider_AWS("DDBStore");
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -181,7 +183,7 @@ namespace AWSUtils.Tests.StorageTests
         private async Task<DynamoDBGrainStorage> InitDynamoDBTableStorageProvider(IProviderRuntime runtime, string storageName)
         {
             var options = new DynamoDBStorageOptions();
-            options.Service = AWSTestConstants.Service;
+            options.Service = AWSTestConstants.DynamoDbService;
 
             DynamoDBGrainStorage store = ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(runtime.ServiceProvider, "PersistenceGrainTests", options);
             ISiloLifecycleSubject lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(runtime.ServiceProvider, NullLogger<SiloLifecycleSubject>.Instance);

--- a/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
@@ -56,7 +56,7 @@ namespace AWSUtils.Tests.StorageTests
 
             if (fields.ContainsKey("BinaryData"))
             {
-                BinaryData = fields["BinaryData"].B.ToArray();
+                BinaryData = fields["BinaryData"].B?.ToArray();
             }
         }
 
@@ -94,7 +94,7 @@ namespace AWSUtils.Tests.StorageTests
         public const string INSTANCE_TABLE_NAME = "UnitTestDDBTableData";
 
         public UnitTestDynamoDBStorage()
-            : base(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), AWSTestConstants.Service)
+            : base(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), AWSTestConstants.DynamoDbService)
         {
             if (AWSTestConstants.IsDynamoDbAvailable)
             {

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -48,12 +48,12 @@ namespace AWSUtils.Tests.Streaming
 
         public async Task DisposeAsync()
         {
-            if (!string.IsNullOrWhiteSpace(AWSTestConstants.DefaultSQSConnectionString))
+            if (!string.IsNullOrWhiteSpace(AWSTestConstants.SqsConnectionString))
             {
                 await SQSStreamProviderUtils.DeleteAllUsedQueues(
                     SQS_STREAM_PROVIDER_NAME,
                     this.clusterId,
-                    AWSTestConstants.DefaultSQSConnectionString,
+                    AWSTestConstants.SqsConnectionString,
                     NullLoggerFactory.Instance);
             }
         }
@@ -63,7 +63,7 @@ namespace AWSUtils.Tests.Streaming
         {
             var options = new SqsOptions
             {
-                ConnectionString = AWSTestConstants.DefaultSQSConnectionString,
+                ConnectionString = AWSTestConstants.SqsConnectionString,
             };
             var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, new HashRingStreamQueueMapperOptions(), new SimpleQueueCacheOptions(), Options.Create(new ClusterOptions()), null, null);
             adapterFactory.Init();

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -20,7 +20,7 @@ namespace AWSUtils.Tests.Streaming
     {
         private const string SQSStreamProviderName = "SQSProvider";
         private const string StreamNamespace = "SQSSubscriptionMultiplicityTestsNamespace";
-        private string StorageConnectionString = AWSTestConstants.DefaultSQSConnectionString;
+        private string StorageConnectionString = AWSTestConstants.SqsConnectionString;
 
         private readonly ITestOutputHelper output;
         private ClientStreamTestRunner runner;
@@ -54,7 +54,7 @@ namespace AWSUtils.Tests.Streaming
                 hostBuilder
                     .AddSqsStreams(SQSStreamProviderName, options => 
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
                     })
                     .AddMemoryGrainStorage("PubSubStore")
                     .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(5));
@@ -66,10 +66,10 @@ namespace AWSUtils.Tests.Streaming
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .AddSqsStreams(SQSStreamProviderName, options =>
+                    .AddSqsStreams(SQSStreamProviderName, (Action<SqsOptions>)(options =>
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
-                    });
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
+                    }));
             }
         }
 

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -38,25 +38,25 @@ namespace AWSUtils.Tests.Streaming
                     .AddSimpleMessageStreamProvider("SMSProvider")
                     .AddSqsStreams("SQSProvider", options =>
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
                     })
                     .AddSqsStreams("SQSProvider2", options =>
                      {
-                         options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
+                         options.ConnectionString = AWSTestConstants.SqsConnectionString;
                      })
                     .AddDynamoDBGrainStorage("DynamoDBStore", options =>
                     {
-                        options.Service = AWSTestConstants.Service;
-                        options.SecretKey = AWSTestConstants.SecretKey;
-                        options.AccessKey = AWSTestConstants.AccessKey;
+                        options.Service = AWSTestConstants.DynamoDbService;
+                        options.SecretKey = AWSTestConstants.DynamoDbSecretKey;
+                        options.AccessKey = AWSTestConstants.DynamoDbAccessKey;
                         options.DeleteStateOnClear = true;
                         options.UseJson = true;
                     })
                     .AddDynamoDBGrainStorage("PubSubStore", options =>
                     {
-                        options.Service = AWSTestConstants.Service;
-                        options.SecretKey = AWSTestConstants.SecretKey;
-                        options.AccessKey = AWSTestConstants.AccessKey;
+                        options.Service = AWSTestConstants.DynamoDbService;
+                        options.SecretKey = AWSTestConstants.DynamoDbSecretKey;
+                        options.AccessKey = AWSTestConstants.DynamoDbAccessKey;
                     })
                     .AddMemoryGrainStorage("MemoryStore", op=>op.NumStorageGrains = 1);
             }
@@ -68,10 +68,10 @@ namespace AWSUtils.Tests.Streaming
             {
                 clientBuilder
                     .AddSimpleMessageStreamProvider("SMSProvider")
-                    .AddSqsStreams("SQSProvider", options =>
+                    .AddSqsStreams("SQSProvider", (System.Action<Orleans.Configuration.SqsOptions>)(options =>
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
-                    });
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
+                    }));
             }
         }
         
@@ -85,9 +85,9 @@ namespace AWSUtils.Tests.Streaming
         {
             var clusterId = HostedCluster.Options.ClusterId;
             await base.DisposeAsync();
-            if (!string.IsNullOrWhiteSpace(AWSTestConstants.DefaultSQSConnectionString))
+            if (!string.IsNullOrWhiteSpace(AWSTestConstants.SqsConnectionString))
             {
-                SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+                SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.SqsConnectionString, NullLoggerFactory.Instance).Wait();
             }
         }
 

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -18,7 +18,7 @@ namespace AWSUtils.Tests.Streaming
     {
         private const string SQSStreamProviderName = "SQSProvider";
         private const string StreamNamespace = "SQSSubscriptionMultiplicityTestsNamespace";
-        private string StreamConnectionString = AWSTestConstants.DefaultSQSConnectionString;
+        private string StreamConnectionString = AWSTestConstants.SqsConnectionString;
         private SubscriptionMultiplicityTestRunner runner;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -38,10 +38,10 @@ namespace AWSUtils.Tests.Streaming
             {
                 hostBuilder
                     .AddMemoryGrainStorage("PubSubStore")
-                    .AddSqsStreams(SQSStreamProviderName, options =>
+                    .AddSqsStreams(SQSStreamProviderName, (Action<Orleans.Configuration.SqsOptions>)(options =>
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
-                    });
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
+                    }));
             }
         }
 
@@ -50,10 +50,10 @@ namespace AWSUtils.Tests.Streaming
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .AddSqsStreams(SQSStreamProviderName, options =>
+                    .AddSqsStreams(SQSStreamProviderName, (Action<Orleans.Configuration.SqsOptions>)(options =>
                     {
-                        options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
-                    });
+                        options.ConnectionString = AWSTestConstants.SqsConnectionString;
+                    }));
             }
         }
 

--- a/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
+++ b/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
@@ -47,6 +47,10 @@ namespace TestExtensions
         public static string PostgresConnectionString => defaultConfiguration[nameof(PostgresConnectionString)];
         public static string MySqlConnectionString => defaultConfiguration[nameof(MySqlConnectionString)];
         public static string MsSqlConnectionString => defaultConfiguration[nameof(MsSqlConnectionString)];
+        public static string DynamoDbService => defaultConfiguration[nameof(DynamoDbService)];
+        public static string DynamoDbAccessKey => defaultConfiguration[nameof(DynamoDbAccessKey)];
+        public static string DynamoDbSecretKey => defaultConfiguration[nameof(DynamoDbSecretKey)];
+        public static string SqsConnectionString => defaultConfiguration[nameof(SqsConnectionString)];
 
         public static bool GetValue(string key, out string value)
         {


### PR DESCRIPTION
* Upgrade to latest DynamoDB library
* Do not include DynamoDB exception as the `InnerExeption` in `InconsistentStateException`
* When switching storage formats, clear now-unused columns
* Align ETag passed to storage during ClearStateAsync with ETag used for other operations
* Swallow 409 during `CreateTableAsync`
* Use `TestDefaultConfiguration` for all configuration values so that they can be set via environment variables / JSON
* Fix configuration used in perf tests
* Decrease data size used in some tests (DynamoDB Local was complaining)
* Fix connection string passed to gateway provider in liveness tests (remove `Service=` portion)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7721)