### PR TITLE
Allow multiple GenerateCodeForDeclaringAssemblyAttributes per assembly

### DIFF
--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -493,7 +493,7 @@ namespace Orleans
     /// Indicates that the source generator should also inspect and generate code for the assembly containing the specified type.
     /// </summary>
     /// <seealso cref="System.Attribute" />
-    [AttributeUsage(AttributeTargets.Assembly)]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public sealed class GenerateCodeForDeclaringAssemblyAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
This helps prevent  CS0579 errors triggering in use cases where code generation is needed across multiple assemblies.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7731)