### PR TITLE
Fix build.ps1 not suffixing local package builds with date

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,7 @@ $Platform = $null
  $DOTNET_MULTILEVEL_LOOKUP = 0
 
  # Set DateTime suffix for debug builds
- if ($BuildConfiguration -eq "Debug")
+ if ($env:BuildConfiguration -eq "Debug")
  {
     $dateSuffix = Get-Date -Format "yyyyMMddHHmm"
     $AdditionalConfigurationProperties=";VersionDateSuffix=$dateSuffix"


### PR DESCRIPTION
Currently, locally built packages are not having their versions suffixed with the date, which is frustrating for local dev.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7732)