### PR TITLE
Fix papercuts issue #7099 - silo spew on shutdown

### DIFF
--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -24,11 +24,12 @@ namespace Orleans
     public abstract class LifecycleSubject : ILifecycleSubject
     {
         private readonly List<OrderedObserver> subscribers;
-        private readonly ILogger logger;
+        protected readonly ILogger logger;
         private int? highStage = null;
 
         protected LifecycleSubject(ILogger logger)
         {
+            if (logger == null) throw new ArgumentNullException(nameof(logger));
             this.logger = logger;
             this.subscribers = new List<OrderedObserver>();
         }
@@ -86,7 +87,7 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStart"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStart(int stage, TimeSpan elapsed)
         {
-            if (this.logger != null && this.logger.IsEnabled(LogLevel.Trace))
+            if (this.logger.IsEnabled(LogLevel.Trace))
             {
                 this.logger.LogTrace(
                     (int)ErrorCode.SiloStartPerfMeasure,
@@ -123,7 +124,7 @@ namespace Orleans
             }
             catch (Exception ex) when (!(ex is OrleansLifecycleCanceledException))
             {
-                this.logger?.LogError(
+                this.logger.LogError(
                     (int)ErrorCode.LifecycleStartFailure,
                     "Lifecycle start canceled due to errors at stage {Stage}: {Exception}",
                     this.highStage,
@@ -157,7 +158,7 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStop"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStop(int stage, TimeSpan elapsed)
         {
-            if (this.logger != null && this.logger.IsEnabled(LogLevel.Trace))
+            if (this.logger.IsEnabled(LogLevel.Trace))
             {
                 this.logger.LogTrace(
                     (int)ErrorCode.SiloStartPerfMeasure,
@@ -181,7 +182,7 @@ namespace Orleans
             {
                 if (cancellationToken.IsCancellationRequested && !loggedCancellation)
                 {
-                    this.logger?.LogWarning("Lifecycle stop operations canceled by request.");
+                    this.logger.LogWarning("Lifecycle stop operations canceled by request.");
                     loggedCancellation = true;
                 }
 
@@ -196,7 +197,7 @@ namespace Orleans
                 }
                 catch (Exception ex)
                 {
-                    this.logger?.LogError(
+                    this.logger.LogError(
                         (int)ErrorCode.LifecycleStopFailure,
                         "Stopping lifecycle encountered an error at stage {Stage}. Continuing to stop. Exception: {Exception}", this.highStage, ex);
                 }

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -235,10 +235,6 @@ namespace Orleans.Messaging
                 // the listProvider.GetGateways() is not under lock.
                 var allGateways = await gatewayListProvider.GetGateways();
                 var refreshedGateways = allGateways.Select(gw => gw.ToGatewayAddress()).ToList();
-                if (logger.IsEnabled(LogLevel.Debug))
-                {
-                    logger.LogDebug("Discovered {GatewayCount} gateways: {Gateways}", refreshedGateways.Count, Utils.EnumerableToString(refreshedGateways));
-                }
 
                 await UpdateLiveGatewaysSnapshot(refreshedGateways, gatewayListProvider.MaxStaleness);
             }
@@ -316,9 +312,9 @@ namespace Orleans.Messaging
 
                 DateTime prevRefresh = lastRefreshTime;
                 lastRefreshTime = now;
-                if (logger.IsEnabled(LogLevel.Information))
+                if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.Info(ErrorCode.GatewayManager_FoundKnownGateways,
+                    logger.Debug(ErrorCode.GatewayManager_FoundKnownGateways,
                             "Refreshed the live gateway list. Found {0} gateways from gateway list provider: {1}. Picked only known live out of them. Now has {2} live gateways: {3}. Previous refresh time was = {4}",
                             knownGateways.Count,
                             Utils.EnumerableToString(knownGateways),

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -30,6 +30,7 @@ namespace Orleans.Runtime.Messaging
             ConnectionFactory connectionFactory,
             NetworkingTrace trace)
         {
+            if (trace == null) throw new ArgumentNullException(nameof(trace));
             this.connectionOptions = connectionOptions.Value;
             this.connectionFactory = connectionFactory;
             this.trace = trace;
@@ -269,9 +270,9 @@ namespace Orleans.Runtime.Messaging
         {
             try
             {
-                if (this.trace.IsEnabled(LogLevel.Information))
+                if (this.trace.IsEnabled(LogLevel.Debug))
                 {
-                    this.trace.LogInformation("Shutting down connections");
+                    this.trace.LogDebug("Shutting down connections");
                 }
 
                 this.shutdownCancellation.Cancel(throwOnFirstException: false);
@@ -305,13 +306,13 @@ namespace Orleans.Runtime.Messaging
                     await Task.Delay(10);
                     if (++cycles > 100 && cycles % 500 == 0 && this.ConnectionCount is var remaining and > 0)
                     {
-                        this.trace?.LogWarning("Waiting for {NumRemaining} connections to terminate", remaining);
+                        this.trace.LogWarning("Waiting for {NumRemaining} connections to terminate", remaining);
                     }
                 }
             }
             catch (Exception exception)
             {
-                this.trace?.LogWarning(exception, "Exception during shutdown");
+                this.trace.LogWarning(exception, "Exception during shutdown");
             }
             finally
             {

--- a/src/Orleans.Core/Networking/NetworkingTrace.cs
+++ b/src/Orleans.Core/Networking/NetworkingTrace.cs
@@ -9,9 +9,9 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly ILogger log;
 
-        public NetworkingTrace(ILoggerFactory loggerFactory) : base("Orleans.Networking")
+        public NetworkingTrace(ILoggerFactory loggerFactory) : base(typeof(NetworkingTrace).FullName)
         {
-            this.log = loggerFactory.CreateLogger("Orleans.Networking");
+            this.log = loggerFactory.CreateLogger(typeof(NetworkingTrace).FullName);
         }
 
         public IDisposable BeginScope<TState>(TState state)

--- a/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
@@ -122,10 +122,17 @@ namespace Orleans.Runtime
             }
             catch (Exception exc)
             {
-                // ignore. Just make sure stop does not throw.
-                Log.Debug("Ignoring error during Stop: {0}", exc);
+                if (Log.IsEnabled(LogLevel.Debug))
+                {
+                    // ignore. Just make sure stop does not throw.
+                    Log.Debug("Ignoring error during Stop: {0}", exc);
+                }
             }
-            Log.Debug("Stopped agent");
+
+            if (Log.IsEnabled(LogLevel.Debug))
+            {
+                Log.Debug("Stopped agent");
+            }
         }
 
         public void Dispose()

--- a/src/Orleans.Core/Statistics/LogStatistics.cs
+++ b/src/Orleans.Core/Statistics/LogStatistics.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime
         {
             this.loggerFactory = loggerFactory;
             reportFrequency = writeInterval;
-            logger = loggerFactory.CreateLogger("Orleans.Runtime." + (isSilo ? "SiloLogStatistics" : "ClientLogStatistics"));
+            logger = loggerFactory.CreateLogger($"Orleans.Runtime.{nameof(LogStatistics)}" + (isSilo ? ".Silo" : ".Client"));
         }
 
         internal void Start()
@@ -87,7 +87,10 @@ namespace Orleans.Runtime
             if (counterData == null)
             {
                 // Flush remaining data
-                logger.Info(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.Debug(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                }
                 logMsgBuilder.Clear();
                 return;
             }
@@ -99,7 +102,10 @@ namespace Orleans.Runtime
             {
                 // Flush pending data and start over
                 logMsgBuilder.AppendLine(STATS_LOG_POSTFIX);
-                logger.Info(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.Debug(ErrorCode.PerfCounterDumpAll, logMsgBuilder.ToString());
+                }
                 logMsgBuilder.Clear();
             }
 

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -364,7 +364,10 @@ namespace Orleans.Runtime
 
         public Task DeactivateAllActivations()
         {
-            logger.Info(ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.Debug(ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
+            }
             var activationsToShutdown = new List<IGrainContext>();
             foreach (var pair in activations)
             {

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -200,7 +200,10 @@ namespace Orleans.Runtime
                     var more = await reader.WaitToReadAsync();
                     if (!more)
                     {
-                        this.logger.LogInformation($"{nameof(HostedClient)} completed processing all messages. Shutting down.");
+                        if (this.logger.IsEnabled(LogLevel.Debug))
+                        {
+                            this.logger.LogDebug($"{nameof(HostedClient)} completed processing all messages. Shutting down.");
+                        }
                         break;
                     }
 

--- a/src/Orleans.Runtime/Counters/CountersStatistics.cs
+++ b/src/Orleans.Runtime/Counters/CountersStatistics.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Counters
         {
             if (writeInterval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(writeInterval), "Creating CounterStatsPublisher with negative or zero writeInterval");
             if (telemetryProducer == null) throw new ArgumentNullException(nameof(telemetryProducer));
-            this.logger = loggerFactory.CreateLogger<CounterStatistic>();
+            this.logger = loggerFactory.CreateLogger<CountersStatistics>();
             this.loggerFactory = loggerFactory;
             PerfCountersWriteInterval = writeInterval;
             this.telemetryProducer = telemetryProducer;
@@ -52,7 +52,10 @@ namespace Orleans.Runtime.Counters
         /// </summary>
         public void Stop()
         {
-            logger.Info(ErrorCode.PerfCounterStopping, "Stopping  Windows perf counter stats collection");
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.Debug(ErrorCode.PerfCounterStopping, "Stopping  Windows perf counter stats collection");
+            }
             if (timer != null)
                 timer.Dispose(); // Stop timer
 

--- a/src/Orleans.Runtime/Hosting/SiloHostedService.cs
+++ b/src/Orleans.Runtime/Hosting/SiloHostedService.cs
@@ -15,7 +15,7 @@ namespace Orleans.Hosting
         public SiloHostedService(
             Silo silo,
             IEnumerable<IConfigurationValidator> configurationValidators,
-            ILogger<Silo> logger)
+            ILogger<SiloHostedService> logger)
         {
             this.ValidateSystemConfiguration(configurationValidators);
             this.silo = silo;

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -281,7 +281,11 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeShuttingDown()
         {
-            this.log.Info(ErrorCode.MembershipShutDown, "-Shutdown");
+            if (this.log.IsEnabled(LogLevel.Debug))
+            {
+                this.log.Debug(ErrorCode.MembershipShutDown, "-Shutdown");
+            }
+            
             try
             {
                 await this.UpdateStatus(SiloStatus.ShuttingDown);
@@ -295,7 +299,11 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeStopping()
         {
-            log.Info(ErrorCode.MembershipStop, "-Stop");
+            if (this.log.IsEnabled(LogLevel.Debug))
+            {
+                log.Debug(ErrorCode.MembershipStop, "-Stop");
+            }
+
             try
             {
                 await this.UpdateStatus(SiloStatus.Stopping);
@@ -309,9 +317,12 @@ namespace Orleans.Runtime.MembershipService
 
         private async Task BecomeDead()
         {
-            this.log.LogInformation(
-                (int)ErrorCode.MembershipKillMyself,
-                "Updating status to Dead");
+            if (this.log.IsEnabled(LogLevel.Debug))
+            {
+                this.log.LogDebug(
+                   (int)ErrorCode.MembershipKillMyself,
+                    "Updating status to Dead");
+            }
 
             try
             {

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -25,11 +25,14 @@ namespace Orleans.Runtime.MembershipService
         {
             if (gossipPartners.Count == 0) return Task.CompletedTask;
 
-            this.log.LogInformation(
-                "Gossiping {Silo} status {Status} to {NumPartners} partners",
-                updatedSilo,
-                updatedStatus,
-                gossipPartners.Count);
+            if (log.IsEnabled(LogLevel.Debug))
+            {
+                this.log.LogDebug(
+                    "Gossiping {Silo} status {Status} to {NumPartners} partners",
+                    updatedSilo,
+                    updatedStatus,
+                    gossipPartners.Count);
+            }
 
             var systemTarget = this.serviceProvider.GetRequiredService<MembershipSystemTarget>();
             return systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -472,11 +472,14 @@ namespace Orleans.Runtime.MembershipService
             {
                 this.LogMissedIAmAlives(table);
 
-                this.log.LogInformation(
-                    (int)ErrorCode.MembershipReadAll_2,
-                    nameof(ProcessTableUpdate) + " (called from {Caller}) membership table: {Table}",
-                    caller,
-                    table.WithoutDuplicateDeads().ToString());
+                if (this.log.IsEnabled(LogLevel.Debug))
+                {
+                    this.log.Debug(
+                        (int)ErrorCode.MembershipReadAll_2,
+                        nameof(ProcessTableUpdate) + " (called from {Caller}) membership table: {Table}",
+                        caller,
+                        table.WithoutDuplicateDeads().ToString());
+                }
             }
         }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -426,7 +426,10 @@ namespace Orleans.Runtime
         /// <returns>A <see cref="Task"/> representing the operation.</returns>
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            logger.LogInformation((int)ErrorCode.SiloShuttingDown, "Silo shutting down");
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug((int)ErrorCode.SiloShuttingDown, "Silo shutdown initiated");
+            }            
 
             bool gracefully = !cancellationToken.IsCancellationRequested;
             bool stopAlreadyInProgress = false;
@@ -441,7 +444,7 @@ namespace Orleans.Runtime
                 }
                 else if (!this.SystemStatus.Equals(SystemStatus.Running))
                 {
-                    throw new InvalidOperationException($"Attempted to stop a silo which is not in the {nameof(SystemStatus.Running)} state. This silo is in the {this.SystemStatus} state.");
+                    throw new InvalidOperationException($"Attempted to shutdown a silo which is not in the {nameof(SystemStatus.Running)} state. This silo is in the {this.SystemStatus} state.");
                 }
                 else
                 {
@@ -454,11 +457,18 @@ namespace Orleans.Runtime
 
             if (stopAlreadyInProgress)
             {
-                logger.Info(ErrorCode.SiloStopInProgress, "Silo termination is in progress - Will wait for it to finish");
-                var pause = TimeSpan.FromSeconds(1);
-                while (!this.SystemStatus.Equals(SystemStatus.Terminated))
+                if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.Info(ErrorCode.WaitingForSiloStop, "Waiting {0} for termination to complete", pause);
+                    logger.Debug(ErrorCode.SiloStopInProgress, "Silo shutdown in progress. Waiting for shutdown to be completed.");
+                }
+                var pause = TimeSpan.FromSeconds(1);                
+
+                while (!this.SystemStatus.Equals(SystemStatus.Terminated))
+                {                    
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.Debug(ErrorCode.WaitingForSiloStop, "Silo shutdown still in progress...", pause);
+                    }
                     await Task.Delay(pause).ConfigureAwait(false);
                 }
 
@@ -473,7 +483,10 @@ namespace Orleans.Runtime
             finally
             {
                 // Signal to all awaiters that the silo has terminated.
-                logger.LogInformation((int)ErrorCode.SiloShutDown, "Silo shutdown completed");
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug((int)ErrorCode.SiloShutDown, "Silo shutdown completed!");
+                }
                 await Task.Run(() => this.siloTerminatedTask.TrySetResult(0)).ConfigureAwait(false);
             }
         }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -477,7 +477,7 @@ namespace Orleans.Runtime
                 {                    
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
-                        logger.Debug(ErrorCode.WaitingForSiloStop, "Silo shutdown still in progress...", pause);
+                        logger.Debug(ErrorCode.WaitingForSiloStop, "Silo shutdown still in progress...");
                     }
                     await Task.Delay(pause).ConfigureAwait(false);
                 }

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans;
 using Xunit;
 
@@ -112,7 +113,7 @@ namespace Tester
 
         private class TestLifecycleSubject : LifecycleSubject
         {
-            public TestLifecycleSubject(ILogger logger) : base(logger)
+            public TestLifecycleSubject() : base(NullLogger.Instance)
             {
             }
         }
@@ -120,7 +121,7 @@ namespace Tester
         [Fact, TestCategory("BVT"), TestCategory("Lifecycle")]
         public async Task MultiStageObserverLifecycleTest()
         {
-            var lifecycle = new TestLifecycleSubject(null);
+            var lifecycle = new TestLifecycleSubject();
             var multiStageObserver = new MultiStageObserver();
             multiStageObserver.Participate(lifecycle);
             await lifecycle.OnStart();
@@ -135,7 +136,7 @@ namespace Tester
         {
             // setup lifecycle observers
             var observersByStage = new Dictionary<TestStages, List<Observer>>();
-            var lifecycle = new TestLifecycleSubject(null);
+            var lifecycle = new TestLifecycleSubject();
             foreach (KeyValuePair<TestStages, int> kvp in observerCountByStage)
             {
                 List<Observer> observers = Enumerable


### PR DESCRIPTION
- Focused on silo shutdown code path and reducing verbosity of LogLevel.Information
- Changed many LogLevels from Information to Debug
- Added IsEnabled conditional around modified code blocks to mitigate string build overhead
- Cleaned up a small number of logging related ctors, fields and logging context/type strings

[Shutdown log before](https://gist.github.com/MarkNickeson/33b1472a923c193fb935ab6a2f462c67)
[Shutdown log after](https://gist.github.com/MarkNickeson/24e9fd759503be7a19fc858d84b732b6)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7733)