### PR TITLE
Copy request arguments efficiently, in-place.

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -26,6 +26,7 @@ namespace Orleans.CodeGenerator
                 FieldCodec_1 = Type("Orleans.Serialization.Codecs.IFieldCodec`1"),
                 DeepCopier_1 = Type("Orleans.Serialization.Cloning.IDeepCopier`1"),
                 CopyContext = Type("Orleans.Serialization.Cloning.CopyContext"),
+                CopyContextPool = Type("Orleans.Serialization.Cloning.CopyContextPool"),
                 MethodInfo = Type("System.Reflection.MethodInfo"),
                 Func_2 = Type("System.Func`2"),
                 GenerateMethodSerializersAttribute = Type("Orleans.GenerateMethodSerializersAttribute"),
@@ -268,6 +269,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol SuppressReferenceTrackingAttribute { get; private set; }
         public INamedTypeSymbol OmitDefaultMemberValuesAttribute { get; private set; }
         public INamedTypeSymbol CopyContext { get; private set; }
+        public INamedTypeSymbol CopyContextPool { get; private set; }
         public Compilation Compilation { get; private set; }
         public List<ITypeSymbol> ImmutableTypes { get; private set; }
         public INamedTypeSymbol TimeSpan { get; private set; }

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -1127,7 +1127,8 @@ namespace Orleans.CodeGenerator
                 _member = member;
             }
 
-            public IMemberDescription Member => _member;
+            IMemberDescription ISerializableMember.Member => _member;
+            public MethodParameterFieldDescription Member => _member;
 
             private LibraryTypes LibraryTypes => _member.Method.ContainingInterface.CodeGenerator.LibraryTypes;
 

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -210,7 +210,7 @@ namespace Orleans.Serialization.Cloning
         /// <typeparam name="T">The value type.</typeparam>
         /// <param name="value">The value.</param>
         /// <returns>A copy of the provided value.</returns>
-        public T Copy<T>(T value)
+        public T DeepCopy<T>(T value)
         {
             if (!typeof(T).IsValueType)
             {

--- a/src/Orleans.Serialization/Codecs/ArrayListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayListCodec.cs
@@ -90,7 +90,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(ArrayList))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new ArrayList(input.Count);

--- a/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
@@ -101,7 +101,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(ConcurrentDictionary<TKey, TValue>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             // Note that this cannot propagate the input's key comparer, since it is not exposed from ConcurrentDictionary.

--- a/src/Orleans.Serialization/Codecs/ConcurrentQueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ConcurrentQueueCodec.cs
@@ -94,7 +94,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(ConcurrentQueue<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             // Note that this cannot propagate the input's key comparer, since it is not exposed from ConcurrentDictionary.

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -170,7 +170,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Dictionary<TKey, TValue>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new Dictionary<TKey, TValue>(input.Count, input.Comparer);

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -157,7 +157,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(HashSet<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new HashSet<T>(input.Comparer);

--- a/src/Orleans.Serialization/Codecs/ImmutableStackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ImmutableStackCodec.cs
@@ -217,7 +217,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Stack<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new Stack<T>(input.Count);

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -161,7 +161,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(List<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new List<T>(input.Count);

--- a/src/Orleans.Serialization/Codecs/NameValueCollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/NameValueCollectionCodec.cs
@@ -92,7 +92,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(NameValueCollection))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new NameValueCollection(input.Count);

--- a/src/Orleans.Serialization/Codecs/ObjectCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ObjectCodec.cs
@@ -91,7 +91,7 @@ namespace Orleans.Serialization.Codecs
             var type = input.GetType();
             if (type != typeof(object))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new object();

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -147,7 +147,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Queue<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new Queue<T>(input.Count);

--- a/src/Orleans.Serialization/Codecs/ReadOnlyCollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReadOnlyCollectionCodec.cs
@@ -88,7 +88,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(ReadOnlyCollection<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             var tempResult = new T[input.Count];

--- a/src/Orleans.Serialization/Codecs/ReadOnlyDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReadOnlyDictionaryCodec.cs
@@ -69,7 +69,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(ReadOnlyDictionary<TKey, TValue>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             var temp = new Dictionary<TKey, TValue>(input.Count);

--- a/src/Orleans.Serialization/Codecs/SortedDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedDictionaryCodec.cs
@@ -126,7 +126,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(SortedDictionary<TKey, TValue>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new SortedDictionary<TKey, TValue>(input.Comparer);

--- a/src/Orleans.Serialization/Codecs/SortedListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedListCodec.cs
@@ -126,7 +126,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(SortedList<TKey, TValue>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new SortedList<TKey, TValue>(input.Comparer);

--- a/src/Orleans.Serialization/Codecs/SortedSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedSetCodec.cs
@@ -112,7 +112,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(SortedSet<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new SortedSet<T>(input.Comparer);

--- a/src/Orleans.Serialization/Codecs/TupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TupleCodec.cs
@@ -116,7 +116,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new Tuple<T>(_copier.DeepCopy(input.Item1, context));
@@ -247,7 +247,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -401,7 +401,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -572,7 +572,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3, T4>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -763,7 +763,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -971,7 +971,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -1197,7 +1197,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = Tuple.Create(
@@ -1439,7 +1439,7 @@ namespace Orleans.Serialization.Codecs
 
             if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6, T7, T8>))
             {
-                return context.Copy(input);
+                return context.DeepCopy(input);
             }
 
             result = new Tuple<T1, T2, T3, T4, T5, T6, T7, T8>(

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -1735,7 +1735,7 @@ namespace Orleans.Serialization
         public T Copy<T>(T value)
         {
             using var context = _contextPool.GetContext();
-            return context.Copy(value);
+            return context.DeepCopy(value);
         }
     }
 

--- a/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
+++ b/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
@@ -1,4 +1,6 @@
+using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Invocation;
+using Orleans.Serialization.Serializers;
 using Orleans.Serialization.UnitTests;
 using System;
 using System.Collections.Generic;
@@ -27,6 +29,10 @@ namespace Orleans.Serialization.UnitTests
         protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
 
         protected ValueTask InvokeAsync(IInvokable body) => default;
+
+        protected CopyContextPool CopyContextPool { get; }
+
+        protected CodecProvider CodecProvider { get; }
     }
 
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(UnitTestRequest<>))]
@@ -45,6 +51,10 @@ namespace Orleans.Serialization.UnitTests
         protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
 
         protected ValueTask InvokeAsync(IInvokable body) => default;
+
+        protected CopyContextPool CopyContextPool { get; }
+
+        protected CodecProvider CodecProvider { get; }
     }
 
     [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]


### PR DESCRIPTION
Avoid unconditionally copying the request object, only copying individual parameters if they are not shallow-copyable (eg, primitive types and parameters marked as `[Immutable]`).

This allows for methods to be declared with `[Immutable]` parameters instead of requiring `[Immutable]` to be declared on the parameter type or wrapping the parameter in `Immutable<>`. Eg, you can write the following grain interface:

``` csharp
interface IMyFastGrain : IGrain
{
  ValueTask<int> GoFast([Immutable] Dictionary<int, int> dictVal, string stringVal, int intVal);
}
```

None of the arguments will be copied, since:
* `dictVal` is marked as `[Immutable]`
* `stringVal` is known by Orleans to be immutable
* `intVal` is a primitive

In tests where the caller and grain are in the same silo, this can provide a 20% performance increase.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7741)