### PR TITLE
Add Unix socket support to TestingHost

### DIFF
--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -15,6 +15,7 @@ using Orleans.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting;
 using Orleans.TestingHost.InMemoryTransport;
+using Orleans.TestingHost.UnixSocketTransport;
 
 namespace Orleans.TestingHost
 {
@@ -578,9 +579,14 @@ namespace Orleans.TestingHost
                     hostBuilder.UseOrleansClient((context, clientBuilder) =>
                     {
                         bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseInMemoryTransport)], out var useInMemoryTransport);
+                        bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseUnixSocketTransport)], out var useUnixSocketTransport);
                         if (useInMemoryTransport)
                         {
                             clientBuilder.UseInMemoryConnectionTransport(_transportHub);
+                        }
+                        else if (useUnixSocketTransport)
+                        {
+                            clientBuilder.UseUnixSocketConnection();
                         }
                     });
                 });
@@ -629,9 +635,14 @@ namespace Orleans.TestingHost
                 hostBuilder.UseOrleans((context, siloBuilder) =>
                 {
                     bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseInMemoryTransport)], out var useInMemoryTransport);
+                    bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseUnixSocketTransport)], out var useUnixSocketTransport);
                     if (useInMemoryTransport)
                     {
                         siloBuilder.UseInMemoryConnectionTransport(_transportHub);
+                    }
+                    else if (useUnixSocketTransport)
+                    {
+                        siloBuilder.UseUnixSocketConnection();
                     }
                 });
             });

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -578,15 +578,19 @@ namespace Orleans.TestingHost
                 {
                     hostBuilder.UseOrleansClient((context, clientBuilder) =>
                     {
-                        bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseInMemoryTransport)], out var useInMemoryTransport);
-                        bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseUnixSocketTransport)], out var useUnixSocketTransport);
-                        if (useInMemoryTransport)
+                        Enum.TryParse<ConnectionTransportType>(context.Configuration[nameof(TestClusterOptions.ConnectionTransport)], out var transport);
+                        switch (transport)
                         {
-                            clientBuilder.UseInMemoryConnectionTransport(_transportHub);
-                        }
-                        else if (useUnixSocketTransport)
-                        {
-                            clientBuilder.UseUnixSocketConnection();
+                            case ConnectionTransportType.TcpSocket:
+                                break;
+                            case ConnectionTransportType.InMemory:
+                                clientBuilder.UseInMemoryConnectionTransport(_transportHub);
+                                break;
+                            case ConnectionTransportType.UnixSocket:
+                                clientBuilder.UseUnixSocketConnection();
+                                break;
+                            default:
+                                throw new ArgumentException($"Unsupported {nameof(ConnectionTransportType)}: {transport}");
                         }
                     });
                 });
@@ -634,15 +638,19 @@ namespace Orleans.TestingHost
             {
                 hostBuilder.UseOrleans((context, siloBuilder) =>
                 {
-                    bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseInMemoryTransport)], out var useInMemoryTransport);
-                    bool.TryParse(context.Configuration[nameof(TestClusterOptions.UseUnixSocketTransport)], out var useUnixSocketTransport);
-                    if (useInMemoryTransport)
+                    Enum.TryParse<ConnectionTransportType>(context.Configuration[nameof(TestClusterOptions.ConnectionTransport)], out var transport);
+                    switch (transport)
                     {
-                        siloBuilder.UseInMemoryConnectionTransport(_transportHub);
-                    }
-                    else if (useUnixSocketTransport)
-                    {
-                        siloBuilder.UseUnixSocketConnection();
+                        case ConnectionTransportType.TcpSocket:
+                            break;
+                        case ConnectionTransportType.InMemory:
+                            siloBuilder.UseInMemoryConnectionTransport(_transportHub);
+                            break;
+                        case ConnectionTransportType.UnixSocket:
+                            siloBuilder.UseUnixSocketConnection();
+                            break;
+                        default:
+                            throw new ArgumentException($"Unsupported {nameof(ConnectionTransportType)}: {transport}");
                     }
                 });
             });

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -77,7 +77,7 @@ namespace Orleans.TestingHost
                 _createSiloAsync = value;
 
                 // The custom builder does not have access to the in-memory transport.
-                Options.UseInMemoryTransport = false;
+                Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
             }
         }
         

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -90,21 +90,12 @@ namespace Orleans.TestingHost
         public List<string> ClientBuilderConfiguratorTypes { get; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use an in-memory transport for connecting silos and clients, instead of TCP.
+        /// Gets or sets a value indicating what transport to use for connecting silos and clients.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see langword="true"/>
+        /// Defaults to InMemory.
         /// </remarks>
-        public bool UseInMemoryTransport { get; set; } = true;
-
-        /// <summary>
-        ///  Gets or sets a value indicating whether to use Unix socket as transport  for connecting silos and clients, instead of TCP.
-        ///  Ignored if <see cref="UseInMemoryTransport"/> is enabled.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see langword="false"/>
-        /// </remarks>
-        public bool UseUnixSocketTransport { get; set; } = false;
+        public ConnectionTransportType ConnectionTransport { get; set; } = ConnectionTransportType.InMemory;
 
         /// <summary>
         /// Converts these options into a dictionary.
@@ -125,7 +116,7 @@ namespace Orleans.TestingHost
                 [nameof(ConfigureFileLogging)] = this.ConfigureFileLogging.ToString(),
                 [nameof(AssumeHomogenousSilosForTesting)] = this.AssumeHomogenousSilosForTesting.ToString(),
                 [nameof(GatewayPerSilo)] = this.GatewayPerSilo.ToString(),
-                [nameof(UseInMemoryTransport)] = this.UseInMemoryTransport.ToString(),
+                [nameof(ConnectionTransport)] = this.ConnectionTransport.ToString(),
             };
             
             if (this.SiloBuilderConfiguratorTypes != null)
@@ -226,5 +217,24 @@ namespace Orleans.TestingHost
             [nameof(SiloName)] = this.SiloName,
             [nameof(PrimarySiloPort)] = this.PrimarySiloPort.ToString()
         };
+    }
+
+    /// <summary>
+    /// Describe a transport method
+    /// </summary>
+    public enum ConnectionTransportType
+    {
+        /// <summary>
+        /// Uses real TCP socket.
+        /// </summary>
+        TcpSocket = 0,
+        /// <summary>
+        /// Uses in memory socket.
+        /// </summary>
+        InMemory = 1,
+        /// <summary>
+        /// Uses in Unix socket.
+        /// </summary>
+        UnixSocket = 2,
     }
 }

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -98,6 +98,15 @@ namespace Orleans.TestingHost
         public bool UseInMemoryTransport { get; set; } = true;
 
         /// <summary>
+        ///  Gets or sets a value indicating whether to use Unix socket as transport  for connecting silos and clients, instead of TCP.
+        ///  Ignored if <see cref="UseInMemoryTransport"/> is enabled.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see langword="false"/>
+        /// </remarks>
+        public bool UseUnixSocketTransport { get; set; } = false;
+
+        /// <summary>
         /// Converts these options into a dictionary.
         /// </summary>
         /// <returns>The options dictionary.</returns>

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionExtensions.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Hosting;
+using Orleans.Networking.Shared;
+using Orleans.Runtime;
+using Orleans.Runtime.Messaging;
+
+namespace Orleans.TestingHost.UnixSocketTransport;
+
+public  static class UnixSocketConnectionExtensions
+{
+    public static ISiloBuilder UseUnixSocketConnection(this ISiloBuilder siloBuilder)
+    {
+        siloBuilder.ConfigureServices(services =>
+        {
+            services.AddSingletonKeyedService<object, IConnectionFactory>(SiloConnectionFactory.ServicesKey, CreateUnixSocketConnectionFactory());
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(SiloConnectionListener.ServicesKey, CreateUnixSocketConnectionListenerFactory());
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(GatewayConnectionListener.ServicesKey, CreateUnixSocketConnectionListenerFactory());
+        });
+
+        return siloBuilder;
+    }
+
+    public static IClientBuilder UseUnixSocketConnection(this IClientBuilder clientBuilder)
+    {
+        clientBuilder.ConfigureServices(services =>
+        {
+            services.AddSingletonKeyedService<object, IConnectionFactory>(ClientOutboundConnectionFactory.ServicesKey, CreateUnixSocketConnectionFactory());
+        });
+
+        return clientBuilder;
+    }
+
+    private static Func<IServiceProvider, object, IConnectionFactory> CreateUnixSocketConnectionFactory()
+    {
+        return (IServiceProvider sp, object key) => ActivatorUtilities.CreateInstance<UnixSocketConnectionFactory>(sp);
+    }
+
+    private static Func<IServiceProvider, object, IConnectionListenerFactory> CreateUnixSocketConnectionListenerFactory()
+    {
+        return (IServiceProvider sp, object key) => ActivatorUtilities.CreateInstance<UnixSocketConnectionListenerFactory>(sp);
+    }
+}

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionFactory.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionFactory.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Networking.Shared;
+
+namespace Orleans.TestingHost.UnixSocketTransport;
+
+internal class UnixSocketConnectionFactory : IConnectionFactory
+{
+    private readonly SocketsTrace trace;
+    private readonly UnixSocketConnectionOptions socketConnectionOptions;
+    private readonly SocketSchedulers schedulers;
+    private readonly MemoryPool<byte> memoryPool;
+
+    public UnixSocketConnectionFactory(
+        ILoggerFactory loggerFactory,
+        IOptions<UnixSocketConnectionOptions> options,
+        SocketSchedulers schedulers,
+        SharedMemoryPool memoryPool)
+    {
+        var logger = loggerFactory.CreateLogger("Orleans.UnixSocket");
+        this.trace = new SocketsTrace(logger);
+        this.socketConnectionOptions = options.Value;
+        this.schedulers = schedulers;
+        this.memoryPool = memoryPool.Pool;
+    }
+
+    public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+    {
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        var unixEndpoint = new UnixDomainSocketEndPoint(socketConnectionOptions.ConvertEndpointToPath(endpoint));
+        await socket.ConnectAsync(unixEndpoint);
+        var scheduler = this.schedulers.GetScheduler();
+        var connection = new SocketConnection(socket, memoryPool, scheduler, trace);
+        connection.Start();
+        return connection;
+    }
+}

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Buffers;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Orleans.Networking.Shared;
+
+namespace Orleans.TestingHost.UnixSocketTransport;
+
+internal class UnixSocketConnectionListener : IConnectionListener
+{
+    private UnixDomainSocketEndPoint _unixEndpoint;
+    private EndPoint _endpoint;
+    private UnixSocketConnectionOptions _socketConnectionOptions;
+    private SocketsTrace _trace;
+    private SocketSchedulers _schedulers;
+    private MemoryPool<byte> _memoryPool;
+    private Socket _listenSocket;
+
+    public UnixSocketConnectionListener(UnixDomainSocketEndPoint unixEndpoint, EndPoint endpoint, UnixSocketConnectionOptions socketConnectionOptions, SocketsTrace trace, SocketSchedulers schedulers)
+    {
+        _unixEndpoint = unixEndpoint;
+        _endpoint = endpoint;
+        _socketConnectionOptions = socketConnectionOptions;
+        _trace = trace;
+        _schedulers = schedulers;
+        _memoryPool = socketConnectionOptions.MemoryPoolFactory();
+    }
+
+    public EndPoint EndPoint => _endpoint;
+
+    public void Bind()
+    {
+        _listenSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        _listenSocket.Bind(_unixEndpoint);
+        _listenSocket.Listen(512);
+    }
+
+    public async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            try
+            {
+                var acceptSocket = await _listenSocket.AcceptAsync();
+
+                var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
+
+                connection.Start();
+
+                return connection;
+            }
+            catch (ObjectDisposedException)
+            {
+                // A call was made to UnbindAsync/DisposeAsync just return null which signals we're done
+                return null;
+            }
+            catch (SocketException e) when (e.SocketErrorCode == SocketError.OperationAborted)
+            {
+                // A call was made to UnbindAsync/DisposeAsync just return null which signals we're done
+                return null;
+            }
+            catch (SocketException)
+            {
+                // The connection got reset while it was in the backlog, so we try again.
+                _trace.ConnectionReset(connectionId: "(null)");
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _listenSocket?.Dispose();
+        return default;
+    }
+
+    public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
+    {
+        _listenSocket?.Dispose();
+        _memoryPool?.Dispose();
+        return default;
+    }
+}

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListenerFactory.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListenerFactory.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Networking.Shared;
+
+namespace Orleans.TestingHost.UnixSocketTransport;
+
+internal class UnixSocketConnectionListenerFactory : IConnectionListenerFactory
+{
+    private readonly UnixSocketConnectionOptions socketConnectionOptions;
+    private readonly SocketsTrace trace;
+    private readonly SocketSchedulers schedulers;
+
+    public UnixSocketConnectionListenerFactory(
+        ILoggerFactory loggerFactory,
+        IOptions<UnixSocketConnectionOptions> socketConnectionOptions,
+        SocketSchedulers schedulers)
+    {
+        this.socketConnectionOptions = socketConnectionOptions.Value;
+        var logger = loggerFactory.CreateLogger("Orleans.UnixSockets");
+        this.trace = new SocketsTrace(logger);
+        this.schedulers = schedulers;
+    }
+
+    public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+    {
+        var unixEndpoint = new UnixDomainSocketEndPoint(socketConnectionOptions.ConvertEndpointToPath(endpoint));
+
+        var listener = new UnixSocketConnectionListener(unixEndpoint, endpoint, this.socketConnectionOptions, this.trace, this.schedulers);
+        listener.Bind();
+        return new ValueTask<IConnectionListener>(listener);
+    }
+}

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionOptions.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Text.RegularExpressions;
+using Orleans.Networking.Shared;
+
+namespace Orleans.TestingHost.UnixSocketTransport;
+
+public class UnixSocketConnectionOptions
+{
+    /// <summary>
+    /// Get or sets to function used to get a filename given an endpoint
+    /// </summary>
+    public Func<EndPoint, string> ConvertEndpointToPath { get; set; } = DefaultConvertEndpointToPath;
+
+    /// <summary>
+    /// Gets or sets the memory pool factory.
+    /// </summary>
+    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => KestrelMemoryPool.Create();
+
+    private static string DefaultConvertEndpointToPath(EndPoint endPoint) => Path.Combine(Path.GetTempPath(), Regex.Replace(endPoint.ToString(), "[^a-zA-Z0-9]", "_"));
+}

--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -22,7 +22,7 @@ namespace Tester.ClientConnectionTests
     {
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            builder.Options.UseInMemoryTransport = false;
+            builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
         }
 
         /// <summary>

--- a/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
@@ -54,7 +54,7 @@ namespace Tester
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             builder.Options.UseTestClusterMembership = false;
-            builder.Options.UseInMemoryTransport = false;
+            builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
             builder.Options.InitialSilosCount = 1;
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             builder.AddClientBuilderConfigurator<ClientBuilderConfigurator>();

--- a/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
@@ -15,7 +15,7 @@ namespace Tester.ClientConnectionTests
     {
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            builder.Options.UseInMemoryTransport = false;
+            builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
         }
 
         [Fact, TestCategory("Functional")]

--- a/test/Tester/ClientConnectionTests/StallConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/StallConnectionTests.cs
@@ -21,7 +21,7 @@ namespace Tester.ClientConnectionTests
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            builder.Options.UseInMemoryTransport = false;
+            builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
             builder.Options.InitialSilosCount = 1;
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             builder.AddClientBuilderConfigurator<ClientConfigurator>();

--- a/test/Tester/TransportTests/TransportTestsBase.cs
+++ b/test/Tester/TransportTests/TransportTestsBase.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace Tester.TransportTests;
+
+public abstract class TransportTestsBase
+{
+    private readonly BaseTestClusterFixture _fixture;
+
+    protected TransportTestsBase(BaseTestClusterFixture fixture)
+    {
+        _fixture = fixture;
+        Assert.True(fixture.HostedCluster.Silos.Count >= 2);
+    }
+
+    [SkippableFact, TestCategory("BVT"), TestCategory("Transport")]
+    public async Task SimplePing()
+    {
+        var grain = _fixture.Client.GetGrain<IGenericPingSelf<int>>(Guid.NewGuid());
+        var value = await grain.Ping(10);
+        Assert.Equal(10, value);
+    }
+
+    [SkippableFact, TestCategory("BVT"), TestCategory("Transport")]
+    public async Task ProxyPing()
+    {
+        var grain1 = _fixture.Client.GetGrain<IGenericPingSelf<int>>(Guid.NewGuid());
+        for (var i = 0; i < 10; i++)
+        {
+            var grain2 = _fixture.Client.GetGrain<IGenericPingSelf<int>>(Guid.NewGuid());
+            var value = await grain1.PingOther(grain2, i);
+            Assert.Equal(i, value);
+        }
+    }
+}

--- a/test/Tester/TransportTests/UnixSocketTransportTests.cs
+++ b/test/Tester/TransportTests/UnixSocketTransportTests.cs
@@ -28,8 +28,7 @@ public class UnixSocketTransportTests : TransportTestsBase, IClassFixture<UnixSo
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            builder.Options.UseInMemoryTransport = false;
-            builder.Options.UseUnixSocketTransport = true;
+            builder.Options.ConnectionTransport = ConnectionTransportType.UnixSocket;
         }
     }
 }

--- a/test/Tester/TransportTests/UnixSocketTransportTests.cs
+++ b/test/Tester/TransportTests/UnixSocketTransportTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Sockets;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.TransportTests;
+
+public class UnixSocketTransportTests : TransportTestsBase, IClassFixture<UnixSocketTransportTests.Fixture>
+{
+    public UnixSocketTransportTests(Fixture fixture) : base(fixture)
+    {
+    }
+
+    public class Fixture : BaseTestClusterFixture
+    {
+        protected override void CheckPreconditionsOrThrow()
+        {
+            try
+            {
+                var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressFamilyNotSupported)
+            {
+                throw new SkipException("Unix socket not supported", ex);
+            }
+        }
+
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.UseInMemoryTransport = false;
+            builder.Options.UseUnixSocketTransport = true;
+        }
+    }
+}

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -23,7 +23,7 @@ namespace Tests.GeoClusterTests
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                builder.Options.UseInMemoryTransport = false;
+                builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
                 builder.Options.InitialSilosCount = 1;
                 builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             }


### PR DESCRIPTION
Can be useful to test with multiple out of process silos.

I was able to reuse `SocketConnection` but not `SocketConnectionListener` since it has some logic relying on the endpoint beeing an `IPEndPoint`. Since this Unix socket support is limited to the testing host, I didn't want to modify `SocketConnectionListener`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7748)