### PR TITLE
Code Generator: sanitize assembly name when generating target namespace

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -94,7 +94,7 @@ namespace Orleans.CodeGenerator
             }
 
             // Generate metadata.
-            var metadataClassNamespace = CodeGeneratorName + "." + _compilation.AssemblyName;
+            var metadataClassNamespace = CodeGeneratorName + "." + SyntaxGeneration.Identifier.SanitizeIdentifierName(_compilation.AssemblyName);
             var metadataClass = MetadataGenerator.GenerateMetadata(_compilation, metadataModel, LibraryTypes);
             AddMember(ns: metadataClassNamespace, member: metadataClass);
             var metadataAttribute = AttributeList()

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -150,7 +150,7 @@ namespace Orleans.CodeGenerator
                 .AddBodyStatements(body.ToArray());
 
             var interfaceType = libraryTypes.ITypeManifestProvider;
-            return ClassDeclaration("Metadata_" + compilation.AssemblyName.Replace('.', '_'))
+            return ClassDeclaration("Metadata_" + SyntaxGeneration.Identifier.SanitizeIdentifierName(compilation.AssemblyName))
                 .AddBaseListTypes(SimpleBaseType(interfaceType.ToTypeSyntax()))
                 .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.SealedKeyword))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())))

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Orleans.CodeGenerator.SyntaxGeneration
 {
     internal static class Identifier
@@ -113,5 +115,7 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
                     return false;
             }
         }
+
+        public static string SanitizeIdentifierName(string input) => Regex.Replace(input, "[-\\.]", "_");
     }
 }


### PR DESCRIPTION
Fixes #7751

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7753)