### PR TITLE
Account for non-determinism in ClusterHealthMonitor_NoIndirectProbes

### DIFF
--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -215,7 +215,7 @@ namespace NonSilo.Tests.Membership
             lastVersion = testAccessor.ObservedVersion;
 
             // Now that this silo is active, it should be monitoring some fraction of the other active silos
-            Assert.NotEmpty(testAccessor.MonitoredSilos);
+            await Until(() => testAccessor.MonitoredSilos.Count > 0);
             Assert.NotEmpty(this.timers);
             Assert.DoesNotContain(testAccessor.MonitoredSilos, s => s.Key.Equals(this.localSilo));
             Assert.Equal(clusterMembershipOptions.NumProbedSilos, testAccessor.MonitoredSilos.Count);


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7754)