### PR TITLE
Fix support for grains with no namespace (in global namespace)

### DIFF
--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -324,7 +324,7 @@ namespace Orleans.Runtime
                        + new string(',', t.GetArrayRank() - 1)
                        + "]";
             }
-            return t.FullName ?? (t.IsGenericParameter ? t.Name : t.Namespace + "." + t.Name);
+            return t.FullName ?? ((t.IsGenericParameter || string.IsNullOrWhiteSpace(t.Namespace)) ? t.Name : t.Namespace + "." + t.Name);
         }
 
         /// <summary>

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -33,12 +33,27 @@ namespace DefaultCluster.Tests.General
             return  this.GrainFactory.GetGrain<TGrainInterface>(GetRandomGrainId());
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        public async Task GenericGrainTests_GlobalNamespace()
+        {
+            var genericGrain = GrainFactory.GetGrain<IMyGenericGrainWithNoNamespace<int>>(Guid.NewGuid().ToString());
+
+            await genericGrain.SetValue(4);
+            var genericValue = await genericGrain.GetValue();
+            Assert.Equal(4, genericValue);
+
+            var grain = GrainFactory.GetGrain<IMyGrainWithNoNamespace>(Guid.NewGuid().ToString());
+
+            await grain.SetValue("hi");
+            var value = await grain.GetValue();
+            Assert.Equal("hi", value);
+        }
+
         /// Can instantiate multiple concrete grain types that implement
         /// different specializations of the same generic interface
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
         {
-
             var grainOfIntFloat1 = GetGrain<IGenericGrain<int, float>>();
             var grainOfIntFloat2 = GetGrain<IGenericGrain<int, float>>();
             var grainOfFloatString = GetGrain<IGenericGrain<float, string>>();

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -3,6 +3,18 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
 
+public interface IMyGenericGrainWithNoNamespace<T> : IGrainWithStringKey
+{
+    Task SetValue(T value);
+    Task<T> GetValue();
+}
+
+public interface IMyGrainWithNoNamespace : IGrainWithStringKey
+{
+    Task SetValue(object value);
+    Task<object> GetValue();
+}
+
 namespace UnitTests.GrainInterfaces
 {
     public interface IGenericGrainWithGenericState<TFirstTypeParam, TStateType, TLastTypeParam> : IGrainWithGuidKey

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -11,6 +11,28 @@ using Orleans.Providers;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
+public class MyGenericGrainWithNoNamespace<T> : Grain, IMyGenericGrainWithNoNamespace<T>
+{
+    T _value;
+    public Task<T> GetValue() => Task.FromResult(_value);
+    public Task SetValue(T value)
+    {
+        _value = value;
+        return Task.CompletedTask;
+    }
+}
+
+public class MyGrainWithNoNamespace : Grain, IMyGrainWithNoNamespace
+{
+    object _value;
+    public Task<object> GetValue() => Task.FromResult(_value);
+    public Task SetValue(object value)
+    {
+        _value = value;
+        return Task.CompletedTask;
+    }
+}
+
 namespace UnitTests.Grains
 {
     [Serializable]


### PR DESCRIPTION
Currently, grain interfaces defined in the global namespace (i.e, outside of any other namespace) cannot be accessed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7758)