### PR TITLE
Fix Null Reference exception in call filters

### DIFF
--- a/test/Grains/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -20,6 +20,8 @@ namespace UnitTests.GrainInterfaces
         Task<string> Throw();
         Task<string> IncorrectResultType();
         Task FilterThrows();
+
+        Task SystemWideCallFilterMarker();
     }
 
     [GrainInterfaceType("custom-outgoing-interception-grain")]
@@ -55,6 +57,9 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetRequestContext();
 
         Task<int> SumSet(HashSet<int> numbers);
+
+        Task SystemWideCallFilterMarker();
+        Task GrainSpecificCallFilterMarker();
     }
 
     public interface IHungryGrain<T> : IGrainWithIntegerKey

--- a/test/Grains/TestGrains/MethodInterceptionGrain.cs
+++ b/test/Grains/TestGrains/MethodInterceptionGrain.cs
@@ -53,6 +53,8 @@ namespace UnitTests.Grains
 
         public Task FilterThrows() => Task.CompletedTask;
 
+        public Task SystemWideCallFilterMarker() => Task.CompletedTask;
+
         public Task<string> IncorrectResultType() => Task.FromResult("hop scotch");
 
         async Task IIncomingGrainCallFilter.Invoke(IIncomingGrainCallContext context)
@@ -192,6 +194,12 @@ namespace UnitTests.Grains
                         throw new ArgumentException("InterfaceMethod.Name != ImplementationMethod.Name");
                     }
 
+                    if (string.Equals(implementationMethod.Name, nameof(GrainSpecificCallFilterMarker)))
+                    {
+                        // explicitely do not continue calling Invoke
+                        return;
+                    }
+
                     if (RequestContext.Get(Key) is string value) RequestContext.Set(Key, value + '3');
                     await ctx.Invoke();
                     return;
@@ -211,6 +219,16 @@ namespace UnitTests.Grains
         public Task<int> SumSet(HashSet<int> numbers)
         {
             return Task.FromResult(numbers.Sum());
+        }
+
+        public Task SystemWideCallFilterMarker()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task GrainSpecificCallFilterMarker()
+        {
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
When a call fitler does not properly call the `Invoke` method on the
provided context object, a `NullReferenceException` is thrown. While
correct, this behavior is not the most intuitive and doesn't point users
to the underlying issue well.

This PR changes the behavior to throw an `InvalidOperationException` with
a helpful error message including the name of the call filter which is
buggy. Added some unit tests to verify the functionality works.

Should address #7610 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7763)