### PR TITLE
[3.x] Make IKeyedSerializer public for more advanced serialization cases

### DIFF
--- a/src/Orleans.Core/Serialization/IKeyedSerializer.cs
+++ b/src/Orleans.Core/Serialization/IKeyedSerializer.cs
@@ -5,7 +5,7 @@ namespace Orleans.Serialization
     /// <summary>
     /// Interface for serializers which are responsible for serializing type information in addition to object data and can be identified by a numeric id.
     /// </summary>
-    internal interface IKeyedSerializer : IExternalSerializer
+    public interface IKeyedSerializer : IExternalSerializer
     {
         /// <summary>
         /// Gets the identifier for this serializer.

--- a/src/Orleans.Core/Serialization/KeyedSerializerId.cs
+++ b/src/Orleans.Core/Serialization/KeyedSerializerId.cs
@@ -1,9 +1,9 @@
-﻿namespace Orleans.Serialization
+namespace Orleans.Serialization
 {
     /// <summary>
     /// Values for identifying <see cref="IKeyedSerializer"/> serializers.
     /// </summary>
-    internal enum KeyedSerializerId : byte
+    public enum KeyedSerializerId : byte
     {
         /// <summary>
         /// <see cref="Orleans.Serialization.ILBasedSerializer"/>

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -36,8 +36,8 @@ namespace Orleans.Serialization
         private readonly Dictionary<Type, DeepCopier> copiers;
         private readonly Dictionary<Type, Serializer> serializers;
 
-        private readonly CachedReadConcurrentDictionary<Type, IKeyedSerializer> typeToKeyedSerializer =
-            new CachedReadConcurrentDictionary<Type, IKeyedSerializer>();
+        private readonly CachedReadConcurrentDictionary<(Type Type, bool IsFallback), IKeyedSerializer> typeToKeyedSerializer =
+            new CachedReadConcurrentDictionary<(Type Type, bool IsFallback), IKeyedSerializer>();
         private readonly Dictionary<Type, Deserializer> deserializers;
         private readonly ConcurrentDictionary<Type, Func<GrainReference, GrainReference>> grainRefConstructorDictionary;
 
@@ -1641,13 +1641,13 @@ namespace Orleans.Serialization
                 return false;
             }
 
-            if (this.typeToKeyedSerializer.TryGetValue(type, out serializer)) return true;
+            if (this.typeToKeyedSerializer.TryGetValue((type, fallback), out serializer)) return true;
 
             foreach (var keyedSerializer in this.orderedKeyedSerializers)
             {
                 if (keyedSerializer.IsSupportedType(type, isFallback: fallback))
                 {
-                    this.typeToKeyedSerializer[type] = keyedSerializer;
+                    this.typeToKeyedSerializer[(type, fallback)] = keyedSerializer;
                     serializer = keyedSerializer;
                     return true;
                 }


### PR DESCRIPTION
This PR can help teams to support migration from one serialization format to another by using the "keyed serializer" feature which was previously internal-only.
The general strategy to migrate is to implement `IKeyedSerializer` (picking a value between `101` & `255` for the `SerializerId` property), register it with the `IServiceCollection` (`services.AddSingleton<IKeyedSerializer, MyKeyedSerializer>()`), and have it return `false` from the `IsSupportedType` methods. Later, a second deployment changes the `IsSupportedType` method to return `true` for the supported types.

When Orleans serializes a value using an `IKeyedSerializer`, it first writes the `SerializerId` byte before deferring to the `IKeyedSerializer` to write the rest. The `IKeyedSerializer` is responsible for serializing the precise type name so that it can recover it later.

When Orleans encounters a value serialized with a keyed serializer, it reads the `SerializerId` and defers to the corresponding serializer to read the remaining data.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7766)