### PR TITLE
Add support for serialization converters/surrogates

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -258,6 +258,11 @@ namespace Orleans.CodeGenerator
                             metadataModel.DetectedCopiers.Add(symbol);
                         }
 
+                        if (symbol.HasAttribute(LibraryTypes.RegisterConverterAttribute))
+                        {
+                            metadataModel.DetectedConverters.Add(symbol);
+                        }
+
                         // Find all implementations of invokable interfaces
                         foreach (var iface in symbol.AllInterfaces)
                         {

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -48,6 +48,7 @@ namespace Orleans.CodeGenerator
                 RegisterSerializerAttribute = Type("Orleans.RegisterSerializerAttribute"),
                 GeneratedActivatorConstructorAttribute = Type("Orleans.GeneratedActivatorConstructorAttribute"),
                 RegisterActivatorAttribute = Type("Orleans.RegisterActivatorAttribute"),
+                RegisterConverterAttribute = Type("Orleans.RegisterConverterAttribute"),
                 RegisterCopierAttribute = Type("Orleans.RegisterCopierAttribute"),
                 UseActivatorAttribute = Type("Orleans.UseActivatorAttribute"),
                 SuppressReferenceTrackingAttribute = Type("Orleans.SuppressReferenceTrackingAttribute"),
@@ -264,6 +265,7 @@ namespace Orleans.CodeGenerator
         public List<WellKnownCopierDescription> WellKnownCopiers { get; private set; }
         public INamedTypeSymbol RegisterCopierAttribute { get; private set; }
         public INamedTypeSymbol RegisterSerializerAttribute { get; private set; }
+        public INamedTypeSymbol RegisterConverterAttribute { get; private set; }
         public INamedTypeSymbol RegisterActivatorAttribute { get; private set; }
         public INamedTypeSymbol UseActivatorAttribute { get; private set; }
         public INamedTypeSymbol SuppressReferenceTrackingAttribute { get; private set; }

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -15,6 +15,7 @@ namespace Orleans.CodeGenerator
             var configParam = "config".ToIdentifierName();
             var addSerializerMethod = configParam.Member("Serializers").Member("Add");
             var addCopierMethod = configParam.Member("Copiers").Member("Add");
+            var addConverterMethod = configParam.Member("Converters").Member("Add");
             var body = new List<StatementSyntax>();
             body.AddRange(
                 metadataModel.SerializableTypes.Select(
@@ -56,6 +57,15 @@ namespace Orleans.CodeGenerator
                                     SingletonSeparatedList(
                                         Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
                 ));
+            body.AddRange(
+                metadataModel.DetectedConverters.Select(
+                    type =>
+                        (StatementSyntax)ExpressionStatement(
+                            InvocationExpression(
+                                addConverterMethod,
+                                ArgumentList(
+                                    SingletonSeparatedList(
+                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))));
             var addProxyMethod = configParam.Member("InterfaceProxies").Member("Add");
             body.AddRange(
                 metadataModel.GeneratedProxies.Select(

--- a/src/Orleans.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MetadataModel.cs
@@ -15,6 +15,7 @@ namespace Orleans.CodeGenerator
         public List<INamedTypeSymbol> DetectedSerializers { get; } = new();
         public List<INamedTypeSymbol> DetectedActivators { get; } = new();
         public List<INamedTypeSymbol> DetectedCopiers { get; } = new();
+        public List<INamedTypeSymbol> DetectedConverters { get; } = new();
         public List<(TypeSyntax Type, string Alias)> TypeAliases { get; } = new(1024);
         public List<(TypeSyntax Type, uint Id)> WellKnownTypeIds { get; } = new(1024);
         public HashSet<string> ApplicationParts { get; } = new();

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -391,6 +391,14 @@ namespace Orleans
     }
 
     /// <summary>
+    /// When applied to a type, indicates that the type is a converter and that it should be automatically registered.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class RegisterConverterAttribute : Attribute
+    {
+    }
+
+    /// <summary>
     /// When applied to a type, indicates that the type should be activated using a registered activator rather than via its constructor or another mechanism.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
@@ -510,5 +518,38 @@ namespace Orleans
         /// </summary>
         /// <value>The type.</value>
         public Type Type { get; }
+    }
+
+    /// <summary>
+    /// Functionality for converting between two types.
+    /// </summary>
+    public interface IConverter<TValue, TSurrogate> where TSurrogate : struct
+    {
+        /// <summary>
+        /// Converts a surrogate value to the value type.
+        /// </summary>
+        /// <param name="surrogate">The surrogate.</param>
+        /// <returns>The value.</returns>
+        TValue ConvertFromSurrogate(in TSurrogate surrogate);
+
+        /// <summary>
+        /// Converts a value to the valuetype.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The surrogate.</returns>
+        TSurrogate ConvertToSurrogate(in TValue value); 
+    }
+
+    /// <summary>
+    /// Functionality for populating one type from another.
+    /// </summary>
+    public interface IPopulator<TValue, TSurrogate> where TSurrogate : struct where TValue : class
+    {
+        /// <summary>
+        /// Populates <paramref name="value"/> with values from <paramref name="surrogate"/>.
+        /// </summary>
+        /// <param name="surrogate">The surrogate.</param>
+        /// <param name="value">The value.</param>
+        void Populate(in TSurrogate surrogate, TValue value);
     }
 }

--- a/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
@@ -1,0 +1,66 @@
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Codecs;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO.Pipelines;
+using Xunit;
+using Orleans.Serialization.Serializers;
+
+namespace Orleans.Serialization.TestKit
+{
+    public abstract class ValueTypeFieldCodecTester<TField, TCodec> : FieldCodecTester<TField, TCodec> where TField : struct where TCodec : class, IFieldCodec<TField>
+    {
+        [Fact]
+        public void ValueSerializerRoundTrip()
+        {
+            var serializer = ServiceProvider.GetRequiredService<ValueSerializer<TField>>();
+            foreach (var value in TestValues)
+            {
+                var valueCopy = value;
+                var serialized = serializer.SerializeToArray(ref valueCopy);
+                var deserializedValue = default(TField);
+                serializer.Deserialize(serialized, ref deserializedValue);
+                Assert.Equal(value, deserializedValue);
+            }
+        }
+
+        [Fact]
+        public void DirectAccessValueSerializerRoundTrip()
+        {
+            foreach (var value in TestValues)
+            {
+                var valueLocal = value;
+                TestRoundTrippedValueViaValueSerializer(ref valueLocal);
+            }
+        }
+
+        private void TestRoundTrippedValueViaValueSerializer(ref TField original)
+        {
+            var codecProvider = ServiceProvider.GetRequiredService<IValueSerializerProvider>();
+            var serializer = codecProvider.GetValueSerializer<TField>();
+
+            var pipe = new Pipe();
+            using var writerSession = SessionPool.GetSession();
+            var writer = Writer.Create(pipe.Writer, writerSession);
+            var writerCodec = serializer;
+            writerCodec.Serialize(ref writer, ref original);
+            writer.WriteEndObject();
+            writer.Commit();
+            _ = pipe.Writer.FlushAsync().AsTask().GetAwaiter().GetResult();
+            pipe.Writer.Complete();
+
+            _ = pipe.Reader.TryRead(out var readResult);
+            using var readerSession = SessionPool.GetSession();
+            var reader = Reader.Create(readResult.Buffer, readerSession);
+            var readerCodec = serializer;
+            TField deserialized = default;
+            readerCodec.Deserialize(ref reader, ref deserialized);
+            pipe.Reader.AdvanceTo(readResult.Buffer.End);
+            pipe.Reader.Complete();
+            var isEqual = Equals(original, deserialized);
+            Assert.True(
+                isEqual,
+                isEqual ? string.Empty : $"Deserialized value \"{deserialized}\" must equal original value \"{original}\"");
+            Assert.Equal(writerSession.ReferencedObjects.CurrentReferenceId, readerSession.ReferencedObjects.CurrentReferenceId);
+        }
+    }
+}

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -106,7 +106,7 @@ namespace Orleans.Serialization.Cloning
     /// <summary>
     /// Indicates that an <see cref="IDeepCopier"/> implementation generalizes over all sub-types.
     /// </summary>
-    public interface IDerivedTypeCopier
+    public interface IDerivedTypeCopier : IDeepCopier
     {
     }
 

--- a/src/Orleans.Serialization/Codecs/IFieldCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IFieldCodec.cs
@@ -43,7 +43,7 @@ namespace Orleans.Serialization.Codecs
     /// <summary>
     /// Marker interface for codecs which directly support serializing all derived types of their specified type.
     /// </summary>
-    public interface IDerivedTypeCodec
+    public interface IDerivedTypeCodec : IFieldCodec
     {
     }
 

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -56,7 +56,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         /// <inheritdoc/>
-        public bool DeepCopy(bool input, CopyContext _) => input; 
+        public bool DeepCopy(bool input, CopyContext _) => input;
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
@@ -4,6 +4,7 @@ using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
@@ -13,7 +14,7 @@ namespace Orleans.Serialization.Codecs
     /// </summary>
     /// <typeparam name="TField">The type which the implementation of this class supports.</typeparam>
     /// <typeparam name="TSurrogate">The surrogate type serialized in place of <typeparamref name="TField"/>.</typeparam>
-    public abstract class ReferenceTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField> where TField : class where TSurrogate : struct
+    public abstract class ReferenceTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField> where TSurrogate : struct
     {
         private static readonly Type CodecFieldType = typeof(TField);
         private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
@@ -54,7 +55,7 @@ namespace Orleans.Serialization.Codecs
             }
 
             ThrowSerializerNotFoundException(fieldType);
-            return null;
+            return default;
         }
 
         /// <inheritdoc/>
@@ -109,6 +110,7 @@ namespace Orleans.Serialization.Codecs
         public abstract void ConvertToSurrogate(TField value, ref TSurrogate surrogate); 
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
         private static void ThrowSerializerNotFoundException(Type type) => throw new KeyNotFoundException($"Could not find a serializer of type {type}.");
     }
 }

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -38,6 +38,11 @@ namespace Orleans.Serialization.Configuration
         public HashSet<Type> Copiers { get; } = new HashSet<Type>();
 
         /// <summary>
+        /// Gets the set of converters, which are responsible for converting from one type to another.
+        /// </summary>
+        public HashSet<Type> Converters { get; } = new HashSet<Type>();
+
+        /// <summary>
         /// Gets the set of known interfaces, which are interfaces that have corresponding proxies in the <see cref="InterfaceProxies"/> collection.
         /// </summary>
         public HashSet<Type> Interfaces { get; } = new HashSet<Type>();

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -864,7 +864,6 @@ namespace Orleans.Serialization
     {
         private readonly IValueSerializer<T> _codec;
         private readonly SerializerSessionPool _sessionPool;
-        private readonly Type _expectedType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueSerializer{T}"/> class.
@@ -874,7 +873,6 @@ namespace Orleans.Serialization
         public ValueSerializer(IValueSerializerProvider codecProvider, SerializerSessionPool sessionPool)
         {
             _sessionPool = sessionPool;
-            _expectedType = typeof(T);
             _codec = OrleansGeneratedCodeHelper.UnwrapService(null, codecProvider.GetValueSerializer<T>());
         }
 
@@ -886,7 +884,6 @@ namespace Orleans.Serialization
         /// <param name="destination">The destination where serialized data will be written.</param>
         public void Serialize<TBufferWriter>(ref T value, ref Writer<TBufferWriter> destination) where TBufferWriter : IBufferWriter<byte>
         {
-            destination.WriteStartObject(0, _expectedType, _expectedType);
             _codec.Serialize(ref destination, ref value);
             destination.WriteEndObject();
             destination.Commit();
@@ -903,6 +900,7 @@ namespace Orleans.Serialization
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
 
             // Do not dispose, since the buffer writer is not owned by the method.
@@ -919,6 +917,7 @@ namespace Orleans.Serialization
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
 
             // Do not dispose, since the buffer writer is not owned by the method.
@@ -937,6 +936,7 @@ namespace Orleans.Serialization
             try
             {
                 _codec.Serialize(ref writer, ref value);
+                writer.WriteEndObject();
                 writer.Commit();
                 return writer.Output.ToArray();
             }
@@ -969,6 +969,7 @@ namespace Orleans.Serialization
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -984,6 +985,7 @@ namespace Orleans.Serialization
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -999,6 +1001,7 @@ namespace Orleans.Serialization
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -1014,6 +1017,7 @@ namespace Orleans.Serialization
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -1029,6 +1033,7 @@ namespace Orleans.Serialization
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             return writer.Position;
         }
@@ -1044,6 +1049,7 @@ namespace Orleans.Serialization
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
+            writer.WriteEndObject();
             writer.Commit();
             return writer.Position;
         }
@@ -1063,6 +1069,7 @@ namespace Orleans.Serialization
                 using var session = _sessionPool.GetSession();
                 var writer = Writer.Create(buffer, session);
                 _codec.Serialize(ref writer, ref value);
+                writer.WriteEndObject();
                 writer.Commit();
             }
             else
@@ -1072,6 +1079,7 @@ namespace Orleans.Serialization
                 try
                 {
                     _codec.Serialize(ref writer, ref value);
+                    writer.WriteEndObject();
                     writer.Commit();
                 }
                 finally
@@ -1096,6 +1104,7 @@ namespace Orleans.Serialization
                 var buffer = new MemoryStreamBufferWriter(memoryStream);
                 var writer = Writer.Create(buffer, session);
                 _codec.Serialize(ref writer, ref value);
+                writer.WriteEndObject();
                 writer.Commit();
             }
             else
@@ -1104,6 +1113,7 @@ namespace Orleans.Serialization
                 try
                 {
                     _codec.Serialize(ref writer, ref value);
+                    writer.WriteEndObject();
                     writer.Commit();
                 }
                 finally
@@ -1122,8 +1132,6 @@ namespace Orleans.Serialization
         /// <returns>The deserialized value.</returns>
         public void Deserialize<TInput>(ref Reader<TInput> source, ref T result)
         {
-            Field ignored = default;
-            source.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref source, ref result);
         }
 
@@ -1137,8 +1145,6 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 
@@ -1152,8 +1158,6 @@ namespace Orleans.Serialization
         public void Deserialize(Stream source, ref T result, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 
@@ -1167,8 +1171,6 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 
@@ -1182,8 +1184,6 @@ namespace Orleans.Serialization
         public void Deserialize(ReadOnlySequence<byte> source, ref T result, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 
@@ -1206,8 +1206,6 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 
@@ -1221,8 +1219,6 @@ namespace Orleans.Serialization
         public void Deserialize(ReadOnlySpan<byte> source, ref T result, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
-            Field ignored = default;
-            reader.ReadFieldHeader(ref ignored);
             _codec.Deserialize(ref reader, ref result);
         }
 

--- a/src/Orleans.Serialization/Serializers/IGeneralizedCodec.cs
+++ b/src/Orleans.Serialization/Serializers/IGeneralizedCodec.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Codecs;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Orleans.Serialization.Serializers
 {

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -1,0 +1,172 @@
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.WireProtocol;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Serialization.Serializers;
+
+/// <summary>
+/// Surrogate serializer for <typeparamref name="TField"/>.
+/// </summary>
+/// <typeparam name="TField">The type which the implementation of this class supports.</typeparam>
+/// <typeparam name="TSurrogate">The surrogate type serialized in place of <typeparamref name="TField"/>.</typeparam>
+/// <typeparam name="TConverter">The converter type which converts between <typeparamref name="TField"/> and <typeparamref name="TSurrogate"/>.</typeparam>
+public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
+    : IFieldCodec<TField>, IDeepCopier<TField>, IBaseCodec<TField>, IBaseCopier<TField>
+    where TField : class
+    where TSurrogate : struct
+    where TConverter : IConverter<TField, TSurrogate>
+{
+    private readonly Type _fieldType;
+    private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
+    private readonly IDeepCopier<TSurrogate> _surrogateCopier;
+    private readonly IPopulator<TField, TSurrogate> _populator;
+    private readonly TConverter _converter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SurrogateCodec{TField, TSurrogate, TConverter}"/> class.
+    /// </summary>
+    /// <param name="surrogateSerializer">The surrogate serializer.</param>
+    /// <param name="surrogateCopier">The surrogate copier.</param>
+    /// <param name="converter">The surrogate converter.</param>
+    public SurrogateCodec(
+        IValueSerializer<TSurrogate> surrogateSerializer,
+        IDeepCopier<TSurrogate> surrogateCopier,
+        TConverter converter)
+    {
+        _surrogateSerializer = surrogateSerializer;
+        _surrogateCopier = surrogateCopier;
+        _converter = converter;
+        _populator = converter as IPopulator<TField, TSurrogate>;
+        _fieldType = typeof(TField);
+    }
+
+    /// <inheritdoc/>
+    public TField DeepCopy(TField input, CopyContext context)
+    {
+        if (context.TryGetCopy<TField>(input, out var result))
+        {
+            return result;
+        }
+
+        var surrogate = _converter.ConvertToSurrogate(in input);
+        var copy = _surrogateCopier.DeepCopy(surrogate, context);
+        result = _converter.ConvertFromSurrogate(in copy);
+
+        context.RecordCopy(input, result);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (field.WireType == WireType.Reference)
+        {
+            return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
+        }
+
+        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+        var fieldType = field.FieldType;
+        if (fieldType is null || fieldType == _fieldType)
+        {
+            TSurrogate surrogate = default;
+            _surrogateSerializer.Deserialize(ref reader, ref surrogate);
+            var result = _converter.ConvertFromSurrogate(in surrogate);
+            ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+            return result;
+        }
+
+        // The type is a descendant, not an exact match, so get the specific serializer for it.
+        var specificSerializer = reader.Session.CodecProvider.GetCodec(fieldType);
+        if (specificSerializer != null)
+        {
+            return (TField)specificSerializer.ReadValue(ref reader, field);
+        }
+
+        ThrowSerializerNotFoundException(fieldType);
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+        {
+            return;
+        }
+
+        var fieldType = value.GetType();
+        if (fieldType == _fieldType)
+        {
+            writer.WriteStartObject(fieldIdDelta, expectedType, fieldType);
+            var surrogate = _converter.ConvertToSurrogate(in value);
+            _surrogateSerializer.Serialize(ref writer, ref surrogate);
+            writer.WriteEndObject();
+        }
+        else
+        {
+            SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value, fieldType);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SerializeUnexpectedType<TBufferWriter>(
+        ref Writer<TBufferWriter> writer,
+        uint fieldIdDelta,
+        Type expectedType,
+        TField value,
+        Type fieldType) where TBufferWriter : IBufferWriter<byte>
+    {
+        var specificSerializer = writer.Session.CodecProvider.GetCodec(fieldType);
+        if (specificSerializer != null)
+        {
+            specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
+        }
+        else
+        {
+            ThrowSerializerNotFoundException(fieldType);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, TField value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (_populator is null) ThrowNoPopulatorException();
+
+        var surrogate = _converter.ConvertToSurrogate(in value);
+        _surrogateSerializer.Serialize(ref writer, ref surrogate);
+    }
+
+    /// <inheritdoc/>
+    public void Deserialize<TInput>(ref Reader<TInput> reader, TField value)
+    {
+        if (_populator is null) ThrowNoPopulatorException();
+
+        TSurrogate surrogate = default;
+        _surrogateSerializer.Deserialize(ref reader, ref surrogate);
+        _populator.Populate(surrogate, value);
+    }
+
+    /// <inheritdoc/>
+    public void DeepCopy(TField input, TField output, CopyContext context)
+    {
+        if (_populator is null) ThrowNoPopulatorException();
+
+        var surrogate = _converter.ConvertToSurrogate(in input);
+        var copy = _surrogateCopier.DeepCopy(surrogate, context);
+        _populator.Populate(copy, output);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DoesNotReturn]
+    private static void ThrowSerializerNotFoundException(Type type) => throw new KeyNotFoundException($"Could not find a serializer of type {type}.");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DoesNotReturn]
+    private static void ThrowNoPopulatorException() => throw new NotSupportedException($"Surrogate type {typeof(TConverter)} does not implement {typeof(IPopulator<TField, TSurrogate>)} and therefore cannot be used in an inheritance hierarchy.");
+}

--- a/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
@@ -1,0 +1,87 @@
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.WireProtocol;
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Serialization.Serializers;
+
+/// <summary>
+/// Surrogate serializer for <typeparamref name="TField"/>.
+/// </summary>
+/// <typeparam name="TField">The type which the implementation of this class supports.</typeparam>
+/// <typeparam name="TSurrogate">The surrogate type serialized in place of <typeparamref name="TField"/>.</typeparam>
+/// <typeparam name="TConverter">The converter type which converts between <typeparamref name="TField"/> and <typeparamref name="TSurrogate"/>.</typeparam>
+public sealed class ValueTypeSurrogateCodec<TField, TSurrogate, TConverter>
+    : IFieldCodec<TField>, IDeepCopier<TField>, IValueSerializer<TField>
+    where TField : struct
+    where TSurrogate : struct
+    where TConverter : IConverter<TField, TSurrogate>
+{
+    private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
+    private readonly IDeepCopier<TSurrogate> _surrogateCopier;
+    private readonly TConverter _converter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueTypeSurrogateCodec{TField, TSurrogate, TConverter}"/> class.
+    /// </summary>
+    /// <param name="surrogateSerializer">The surrogate serializer.</param>
+    /// <param name="surrogateCopier">The surrogate copier.</param>
+    /// <param name="converter">The surrogate converter.</param>
+    public ValueTypeSurrogateCodec(
+        IValueSerializer<TSurrogate> surrogateSerializer,
+        IDeepCopier<TSurrogate> surrogateCopier,
+        TConverter converter)
+    {
+        _surrogateSerializer = surrogateSerializer;
+        _surrogateCopier = surrogateCopier;
+        _converter = converter;
+    }
+
+    /// <inheritdoc/>
+    public TField DeepCopy(TField input, CopyContext context)
+    {
+        var surrogate = _converter.ConvertToSurrogate(in input);
+        var copy = _surrogateCopier.DeepCopy(surrogate, context);
+        var result = _converter.ConvertFromSurrogate(in copy);
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deserialize<TInput>(ref Reader<TInput> reader, ref TField value)
+    {
+        TSurrogate surrogate = default;
+        _surrogateSerializer.Deserialize(ref reader, ref surrogate);
+        value = _converter.ConvertFromSurrogate(in surrogate);
+    }
+
+    /// <inheritdoc/>
+    public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        ReferenceCodec.MarkValueField(reader.Session);
+        TField result = default;
+        Deserialize(ref reader, ref result);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ref TField value) where TBufferWriter : IBufferWriter<byte>
+    {
+        var surrogate = _converter.ConvertToSurrogate(in value);
+        _surrogateSerializer.Serialize(ref writer, ref surrogate);
+    }
+
+    /// <inheritdoc/>
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteStartObject(fieldIdDelta, expectedType, typeof(TField));
+        Serialize(ref writer, ref value);
+        writer.WriteEndObject();
+    }
+}

--- a/test/Benchmarks/Serialization/Comparison/ClassSerializeBenchmark.cs
+++ b/test/Benchmarks/Serialization/Comparison/ClassSerializeBenchmark.cs
@@ -47,7 +47,6 @@ namespace Benchmarks.Comparison
 
         static ClassSerializeBenchmark()
         {
-            // 
             var services = new ServiceCollection()
                 .AddSerializer()
                 .BuildServiceProvider();

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.TestKit;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IFieldCodec<MyForeignLibraryType>>
+{
+    protected override MyForeignLibraryType CreateValue() => new(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryType left, MyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
+}
+
+public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopier<MyForeignLibraryType>>
+{
+    protected override MyForeignLibraryType CreateValue() => new(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryType left, MyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
+}
+
+public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibraryType, IFieldCodec<WrapsMyForeignLibraryType>>
+{
+    protected override WrapsMyForeignLibraryType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
+    protected override bool Equals(WrapsMyForeignLibraryType left, WrapsMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
+}
+
+public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryType, IDeepCopier<WrapsMyForeignLibraryType>>
+{
+    protected override WrapsMyForeignLibraryType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
+    protected override bool Equals(WrapsMyForeignLibraryType left, WrapsMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
+}
+
+public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibraryValueType, IFieldCodec<MyForeignLibraryValueType>>
+{
+    protected override MyForeignLibraryValueType CreateValue() => new(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryValueType left, MyForeignLibraryValueType right) => left.Equals(right);
+    protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
+}
+
+public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType, IDeepCopier<MyForeignLibraryValueType>>
+{
+    protected override MyForeignLibraryValueType CreateValue() => new(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryValueType left, MyForeignLibraryValueType right) => left.Equals(right);
+    protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
+}
+
+public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsMyForeignLibraryValueType, IFieldCodec<WrapsMyForeignLibraryValueType>>
+{
+    protected override WrapsMyForeignLibraryValueType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryValueType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
+    protected override bool Equals(WrapsMyForeignLibraryValueType left, WrapsMyForeignLibraryValueType right) => left.Equals(right);
+    protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
+}
+
+public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibraryValueType, IDeepCopier<WrapsMyForeignLibraryValueType>>
+{
+    protected override WrapsMyForeignLibraryValueType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryValueType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
+    protected override bool Equals(WrapsMyForeignLibraryValueType left, WrapsMyForeignLibraryValueType right) => left.Equals(right);
+    protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
+}
+
+public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignLibraryType, IFieldCodec<DerivedFromMyForeignLibraryType>>
+{
+    protected override DerivedFromMyForeignLibraryType CreateValue() => new(658, 12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
+}
+
+public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibraryType, IDeepCopier<DerivedFromMyForeignLibraryType>>
+{
+    protected override DerivedFromMyForeignLibraryType CreateValue() => new(658, 12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
+}

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -30,6 +30,152 @@ public class SomeClassWithSerializers
 
 namespace Orleans.Serialization.UnitTests
 {
+    public class MyForeignLibraryType
+    {
+        public MyForeignLibraryType() { }
+
+        public MyForeignLibraryType(int num, string str, DateTimeOffset dto)
+        {
+            Num = num;
+            String = str;
+            DateTimeOffset = dto;
+        }
+
+        public int Num { get; set; }
+        public string String { get; set; }
+        public DateTimeOffset DateTimeOffset { get; set; }
+
+        public override bool Equals(object obj) =>
+            obj is MyForeignLibraryType type
+            && Num == type.Num
+            && string.Equals(String, type.String, StringComparison.Ordinal)
+            && DateTimeOffset.Equals(type.DateTimeOffset);
+
+        public override int GetHashCode() => HashCode.Combine(Num, String, DateTimeOffset);
+    }
+
+    [GenerateSerializer]
+    public struct MyForeignLibraryTypeSurrogate
+    {
+        [Id(0)]
+        public int Num { get; set; }
+
+        [Id(1)]
+        public string String { get; set; }
+
+        [Id(2)]
+        public DateTimeOffset DateTimeOffset { get; set; }
+    }
+
+    [RegisterConverter]
+    public sealed class MyForeignLibraryTypeSurrogateConverter : IConverter<MyForeignLibraryType, MyForeignLibraryTypeSurrogate>, IPopulator<MyForeignLibraryType, MyForeignLibraryTypeSurrogate>
+    {
+        public MyForeignLibraryType ConvertFromSurrogate(in MyForeignLibraryTypeSurrogate surrogate)
+            => new(surrogate.Num, surrogate.String, surrogate.DateTimeOffset);
+
+        public MyForeignLibraryTypeSurrogate ConvertToSurrogate(in MyForeignLibraryType value)
+            => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };
+        public void Populate(in MyForeignLibraryTypeSurrogate surrogate, MyForeignLibraryType value)
+        {
+            value.Num = surrogate.Num;
+            value.String = surrogate.String;
+            value.DateTimeOffset = surrogate.DateTimeOffset;
+        }
+    }
+
+    [GenerateSerializer]
+    public class WrapsMyForeignLibraryType
+    {
+        [Id(0)]
+        public int IntValue { get; set; }
+
+        [Id(1)]
+        public MyForeignLibraryType ForeignValue { get; set; }
+
+        [Id(2)]
+        public int OtherIntValue { get; set; }
+
+        public override bool Equals(object obj) => obj is WrapsMyForeignLibraryType type && IntValue == type.IntValue && EqualityComparer<MyForeignLibraryType>.Default.Equals(ForeignValue, type.ForeignValue) && OtherIntValue == type.OtherIntValue;
+        public override int GetHashCode() => HashCode.Combine(IntValue, ForeignValue, OtherIntValue);
+    }
+
+    [GenerateSerializer]
+    public class DerivedFromMyForeignLibraryType : MyForeignLibraryType
+    {
+        public DerivedFromMyForeignLibraryType() { }
+        public DerivedFromMyForeignLibraryType(int intValue, int num, string str, DateTimeOffset dto) : base(num, str, dto)
+        {
+            IntValue = intValue;
+        }
+
+        [Id(0)]
+        public int IntValue { get; set; }
+        
+        public override bool Equals(object obj) => obj is DerivedFromMyForeignLibraryType type && base.Equals(obj) && Num == type.Num && String == type.String && DateTimeOffset.Equals(type.DateTimeOffset) && IntValue == type.IntValue;
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Num, String, DateTimeOffset, IntValue);
+    }
+
+    public struct MyForeignLibraryValueType
+    {
+        public MyForeignLibraryValueType(int num, string str, DateTimeOffset dto)
+        {
+            Num = num;
+            String = str;
+            DateTimeOffset = dto;
+        }
+
+        public int Num { get; }
+        public string String { get; }
+        public DateTimeOffset DateTimeOffset { get; }
+
+        public override bool Equals(object obj) =>
+            obj is MyForeignLibraryValueType type
+            && Num == type.Num
+            && string.Equals(String, type.String, StringComparison.Ordinal)
+            && DateTimeOffset.Equals(type.DateTimeOffset);
+
+        public override int GetHashCode() => HashCode.Combine(Num, String, DateTimeOffset);
+    }
+
+    [GenerateSerializer]
+    public struct MyForeignLibraryValueTypeSurrogate
+    {
+        [Id(0)]
+        public int Num { get; set; }
+
+        [Id(1)]
+        public string String { get; set; }
+
+        [Id(2)]
+        public DateTimeOffset DateTimeOffset { get; set; }
+    }
+
+    [RegisterConverter]
+    public sealed class MyForeignLibraryValueTypeSurrogateConverter : IConverter<MyForeignLibraryValueType, MyForeignLibraryValueTypeSurrogate>
+    {
+        public MyForeignLibraryValueType ConvertFromSurrogate(in MyForeignLibraryValueTypeSurrogate surrogate)
+            => new(surrogate.Num, surrogate.String, surrogate.DateTimeOffset);
+
+        public MyForeignLibraryValueTypeSurrogate ConvertToSurrogate(in MyForeignLibraryValueType value)
+            => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };
+    }
+
+    [GenerateSerializer]
+    public struct WrapsMyForeignLibraryValueType
+    {
+        [Id(0)]
+        public int IntValue { get; set; }
+
+        [Id(1)]
+        public MyForeignLibraryValueType ForeignValue { get; set; }
+
+        [Id(2)]
+        public int OtherIntValue { get; set; }
+
+        public override bool Equals(object obj) => obj is WrapsMyForeignLibraryValueType type && IntValue == type.IntValue && EqualityComparer<MyForeignLibraryValueType>.Default.Equals(ForeignValue, type.ForeignValue) && OtherIntValue == type.OtherIntValue;
+        public override int GetHashCode() => HashCode.Combine(IntValue, ForeignValue, OtherIntValue);
+    }
+
     [GenerateSerializer]
     [WellKnownId(3201)]
     public class SomeClassWithSerializers


### PR DESCRIPTION
Fixes #7635
Fixes #7593

Adds support for serialization surrogates and converters.

There are two interfaces introduced and one attribute:

``` C#
/// <summary>
/// When applied to a type, indicates that the type is a converter and that it should be automatically registered.
/// </summary>
[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
public sealed class RegisterConverterAttribute : Attribute
{
}

/// <summary>
/// Functionality for converting between two types.
/// </summary>
public interface IConverter<TValue, TSurrogate> where TSurrogate : struct
{
    /// <summary>
    /// Converts a surrogate value to the value type.
    /// </summary>
    /// <param name="surrogate">The surrogate.</param>
    /// <returns>The value.</returns>
    TValue ConvertFromSurrogate(in TSurrogate surrogate);

    /// <summary>
    /// Converts a value to the valuetype.
    /// </summary>
    /// <param name="value">The value.</param>
    /// <returns>The surrogate.</returns>
    TSurrogate ConvertToSurrogate(in TValue value); 
}

/// <summary>
/// Functionality for populating one type from another.
/// </summary>
public interface IPopulator<TValue, TSurrogate> where TSurrogate : struct where TValue : class
{
    /// <summary>
    /// Populates <paramref name="value"/> with values from <paramref name="surrogate"/>.
    /// </summary>
    /// <param name="surrogate">The surrogate.</param>
    /// <param name="value">The value.</param>
    void Populate(in TSurrogate surrogate, TValue value);
}
```

As a developer, you must create two types: a converter and a surrogate. The converter can optionally implement `IPopulator<TValue, TSurrogate>`, which allows the `TValue` type to appear in a type hierarchy. This allows you to support cases where you need to inherit from foreign types in your own types.

Example surrogate for `DateTimeOffset`:

``` C#
[RegisterConverter]
public class DateTimeOffsetConverter : IConverter<DateTimeOffset, DateTimeOffsetSurrogate>
{
    public DateTimeOffset ConvertFromSurrogate(in DateTimeOffsetSurrogate surrogate) => new(surrogate.Ticks, surrogate.Offset);
    public DateTimeOffsetSurrogate ConvertToSurrogate(in DateTimeOffset value) => new() { Ticks = value.Ticks, Offset = value.Offset };
}

[Immutable]
[GenerateSerializer]
public struct DateTimeOffsetSurrogate
{
    [Id(0)]
    public long Ticks { get; set; }
    [Id(1)]
    public TimeSpan Offset { get; set; }
}
```

Here's a more complex example, this time for a non-sealed class. The second interface `IPopulator<TValue, TSurrogate>` is used for these cases, since the type might appear in a hierarchy.

``` C#
public class MyForeignLibraryType
{
    public int Num { get; set; }
    public string String { get; set; }
    public DateTimeOffset DateTimeOffset { get; set; }
}

[GenerateSerializer]
public struct MyForeignLibraryTypeSurrogate
{
    [Id(0)]
    public int Num { get; set; }
    [Id(1)]
    public string String { get; set; }
    [Id(2)]
    public DateTimeOffset DateTimeOffset { get; set; }
}

[RegisterConverter]
public sealed class MyForeignLibraryTypeSurrogateConverter :
    IConverter<MyForeignLibraryType, MyForeignLibraryTypeSurrogate>,
    IPopulator<MyForeignLibraryType, MyForeignLibraryTypeSurrogate>
{
    public MyForeignLibraryType ConvertFromSurrogate(in MyForeignLibraryTypeSurrogate surrogate)
        => new() { Num = surrogate.Num, String = surrogate.String, DateTimeOffset = surrogate.DateTimeOffset };

    public MyForeignLibraryTypeSurrogate ConvertToSurrogate(in MyForeignLibraryType value)
        => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };

    public void Populate(in MyForeignLibraryTypeSurrogate surrogate, MyForeignLibraryType value)
    {
        value.Num = surrogate.Num;
        value.String = surrogate.String;
        value.DateTimeOffset = surrogate.DateTimeOffset;
    }
}
```

cc @SebastianStehle @VincentH-Net