### PR TITLE
Fix bug in PrefixingBufferWriter when hintSize is 0 and buffer is full

### DIFF
--- a/src/Orleans.Core/Messaging/PrefixingBufferWriter.cs
+++ b/src/Orleans.Core/Messaging/PrefixingBufferWriter.cs
@@ -119,7 +119,7 @@ namespace Orleans.Runtime.Messaging
         {
             this.EnsureInitialized(sizeHint);
 
-            if (this.privateWriter != null || sizeHint > this.realMemory.Length - this.advanced)
+            if (this.privateWriter != null || sizeHint >= this.realMemory.Length - this.advanced)
             {
                 if (this.privateWriter == null)
                 {


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7777)