### PR TITLE
Add ITypeFilter interface for opting-in/out of allowing CLR types

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -113,7 +113,7 @@ namespace Orleans
                 (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionFactory>(sp));
 
             services.AddSerializer();
-            services.AddSingleton<ITypeFilter, AllowOrleansTypes>();
+            services.AddSingleton<ITypeNameFilter, AllowOrleansTypes>();
             services.AddSingleton<ISpecializableCodec, GrainReferenceCodecProvider>();
             services.AddSingleton<ISpecializableCopier, GrainReferenceCopierProvider>();
             services.AddSingleton<OnDeserializedCallbacks>();
@@ -147,9 +147,9 @@ namespace Orleans
         }
 
         /// <summary>
-        /// A <see cref="ITypeFilter"/> which allows any type from an assembly containing "Orleans" in its name to be allowed for the purposes of serialization and deserialization.
+        /// A <see cref="ITypeNameFilter"/> which allows any type from an assembly containing "Orleans" in its name to be allowed for the purposes of serialization and deserialization.
         /// </summary>
-        private class AllowOrleansTypes : ITypeFilter
+        private class AllowOrleansTypes : ITypeNameFilter
         {
             /// <inheritdoc />
             public bool? IsTypeNameAllowed(string typeName, string assemblyName)

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -365,7 +365,7 @@ namespace Orleans.Hosting
                 (sp, key) => ActivatorUtilities.CreateInstance<SocketConnectionListenerFactory>(sp));
 
             services.AddSerializer();
-            services.AddSingleton<ITypeFilter, AllowOrleansTypes>();
+            services.AddSingleton<ITypeNameFilter, AllowOrleansTypes>();
             services.AddSingleton<ISpecializableCodec, GrainReferenceCodecProvider>();
             services.AddSingleton<ISpecializableCopier, GrainReferenceCopierProvider>();
             services.AddSingleton<OnDeserializedCallbacks>();
@@ -387,7 +387,7 @@ namespace Orleans.Hosting
             services.AddSingleton<SharedMemoryPool>();
         }
 
-        private class AllowOrleansTypes : ITypeFilter
+        private class AllowOrleansTypes : ITypeNameFilter
         {
             public bool? IsTypeNameAllowed(string typeName, string assemblyName)
             {

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -69,5 +69,11 @@ namespace Orleans.Serialization.Configuration
         /// Gets the mapping of allowed type names.
         /// </summary>
         public HashSet<string> AllowedTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow all types by default.
+        /// Default: <see langword="false"/>.
+        /// </summary>
+        public bool AllowAllTypes { get; set; }
     }
 }

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ namespace Orleans.Serialization
                 services.TryAddSingleton(typeof(IBaseCopier<>), typeof(BaseCopierHolder<>));
 
                 // Type filtering
-                services.AddSingleton<ITypeFilter, DefaultTypeFilter>();
+                services.AddSingleton<ITypeNameFilter, DefaultTypeFilter>();
 
                 // Session
                 services.TryAddSingleton<SerializerSessionPool>();

--- a/src/Orleans.Serialization/TypeSystem/CachedTypeResolver.cs
+++ b/src/Orleans.Serialization/TypeSystem/CachedTypeResolver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Orleans.Serialization.TypeSystem
@@ -48,7 +47,7 @@ namespace Orleans.Serialization.TypeSystem
 
         private bool TryPerformUncachedTypeResolution(string name, out Type type)
         {
-            IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             if (!TryPerformUncachedTypeResolution(name, out type, assemblies))
             {
                 return false;
@@ -81,7 +80,7 @@ namespace Orleans.Serialization.TypeSystem
             }
         }
 
-        private bool TryPerformUncachedTypeResolution(string fullName, out Type type, IEnumerable<Assembly> assemblies)
+        private bool TryPerformUncachedTypeResolution(string fullName, out Type type, Assembly[] assemblies)
         {
             if (null == assemblies)
             {

--- a/src/Orleans.Serialization/TypeSystem/DefaultTypeFilter.cs
+++ b/src/Orleans.Serialization/TypeSystem/DefaultTypeFilter.cs
@@ -5,7 +5,7 @@ namespace Orleans.Serialization.TypeSystem
     /// <summary>
     /// Type which allows any exception type to be resolved.
     /// </summary>
-    public sealed class DefaultTypeFilter : ITypeFilter
+    public sealed class DefaultTypeFilter : ITypeNameFilter
     {
         /// <inheritdoc/>
         public bool? IsTypeNameAllowed(string typeName, string assemblyName)

--- a/src/Orleans.Serialization/TypeSystem/ITypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/ITypeConverter.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Orleans.Serialization.TypeSystem
+namespace Orleans.Serialization
 {
     /// <summary>
     /// Converts between <see cref="Type"/> and <see cref="string"/> representations.
@@ -21,7 +21,7 @@ namespace Orleans.Serialization.TypeSystem
     /// <summary>
     /// Functionality for allowing types to be loaded and to participate in serialization, deserialization, etcetera.
     /// </summary>
-    public interface ITypeFilter
+    public interface ITypeNameFilter
     {
         /// <summary>
         /// Determines whether the specified type name corresponds to a type which is allowed to be loaded, serialized, deserialized, etcetera.
@@ -30,5 +30,18 @@ namespace Orleans.Serialization.TypeSystem
         /// <param name="assemblyName">Name of the assembly.</param>
         /// <returns><see langword="true" /> if the specified type is allowed; otherwise, <see langword="false" />.</returns>
         bool? IsTypeNameAllowed(string typeName, string assemblyName);
+    }
+
+    /// <summary>
+    /// Functionality for allowing types to be loaded and to participate in serialization, deserialization, etcetera.
+    /// </summary>
+    public interface ITypeFilter
+    {
+        /// <summary>
+        /// Determines whether the specified type is allowed to be serialized, deserialized, etcetera.
+        /// </summary>
+        /// <param name="type">The type</param>
+        /// <returns><see langword="true" /> if the specified type is allowed; otherwise, <see langword="false" />.</returns>
+        bool? IsTypeAllowed(Type type);
     }
 }

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
@@ -11,16 +11,17 @@ namespace Orleans.Serialization.TypeSystem
         /// Signature for a delegate which rewrites a <see cref="QualifiedType"/>.
         /// </summary>
         /// <param name="input">The input.</param>
+        /// <param name="state">The state provided to the rewriter method.</param>
         /// <returns>The rewritten qualified type.</returns>
-        public delegate QualifiedType Rewriter(in QualifiedType input);
+        public delegate QualifiedType Rewriter<TState>(in QualifiedType input, ref TState state);
 
         /// <summary>
         /// Rewrites a <see cref="TypeSpec"/> using the provided rewriter delegate.
         /// </summary>
-        public static TypeSpec Rewrite(TypeSpec input, Rewriter rewriter)
+        public static TypeSpec Rewrite<TState>(TypeSpec input, Rewriter<TState> rewriter, ref TState state)
         {
-            var result = ApplyInner(input, null, rewriter);
-            if (result.Assembly is object)
+            var result = ApplyInner(input, null, rewriter, ref state);
+            if (result.Assembly is not null)
             {
                 // If the rewriter bubbled up an assembly, add it here. 
                 return new AssemblyQualifiedTypeSpec(result.Type, result.Assembly);
@@ -29,32 +30,32 @@ namespace Orleans.Serialization.TypeSystem
             return result.Type;
         }
 
-        private static (TypeSpec Type, string Assembly) ApplyInner(TypeSpec input, string assemblyName, Rewriter replaceFunc) =>
+        private static (TypeSpec Type, string Assembly) ApplyInner<TState>(TypeSpec input, string assemblyName, Rewriter<TState> replaceFunc, ref TState state) =>
             // A type's assembly is passed downwards through the graph, and modifications to the assembly (from the user-provided delegate) flow upwards.
             input switch
             {
-                ConstructedGenericTypeSpec type => HandleGeneric(type, assemblyName, replaceFunc),
-                NamedTypeSpec type => HandleNamedType(type, assemblyName, replaceFunc),
-                AssemblyQualifiedTypeSpec type => HandleAssembly(type, assemblyName, replaceFunc),
-                ArrayTypeSpec type => HandleArray(type, assemblyName, replaceFunc),
-                PointerTypeSpec type => HandlePointer(type, assemblyName, replaceFunc),
-                ReferenceTypeSpec type => HandleReference(type, assemblyName, replaceFunc),
+                ConstructedGenericTypeSpec type => HandleGeneric(type, assemblyName, replaceFunc, ref state),
+                NamedTypeSpec type => HandleNamedType(type, assemblyName, replaceFunc, ref state),
+                AssemblyQualifiedTypeSpec type => HandleAssembly(type, assemblyName, replaceFunc, ref state),
+                ArrayTypeSpec type => HandleArray(type, assemblyName, replaceFunc, ref state),
+                PointerTypeSpec type => HandlePointer(type, assemblyName, replaceFunc, ref state),
+                ReferenceTypeSpec type => HandleReference(type, assemblyName, replaceFunc, ref state),
                 null => throw new ArgumentNullException(nameof(input)),
                 _ => throw new NotSupportedException($"Argument of type {input.GetType()} is nut supported"),
             };
 
-        private static (TypeSpec Type, string Assembly) HandleGeneric(ConstructedGenericTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandleGeneric<TState>(ConstructedGenericTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
-            var (unconstructed, replacementAssembly) = ApplyInner(type.UnconstructedType, assemblyName, replaceTypeName);
+            var (unconstructed, replacementAssembly) = ApplyInner(type.UnconstructedType, assemblyName, replaceTypeName, ref state);
 
             var newArguments = new TypeSpec[type.Arguments.Length];
             var didChange = false;
             for (var i = 0; i < type.Arguments.Length; i++)
             {
                 // Generic type parameters do not inherit the assembly of the generic type.
-                var args = ApplyInner(type.Arguments[i], null, replaceTypeName);
+                var args = ApplyInner(type.Arguments[i], null, replaceTypeName, ref state);
 
-                if (args.Assembly is object)
+                if (args.Assembly is not null)
                 {
                     newArguments[i] = new AssemblyQualifiedTypeSpec(args.Type, args.Assembly);
                 }
@@ -74,10 +75,10 @@ namespace Orleans.Serialization.TypeSystem
             return (new ConstructedGenericTypeSpec((NamedTypeSpec)unconstructed, newArguments), replacementAssembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleNamedType(NamedTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandleNamedType<TState>(NamedTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
             var nsQualified = type.GetNamespaceQualifiedName();
-            var names = replaceTypeName(new QualifiedType(assembly: assemblyName, type: nsQualified));
+            var names = replaceTypeName(new QualifiedType(assembly: assemblyName, type: nsQualified), ref state);
 
             if (!string.Equals(nsQualified, names.Type, StringComparison.Ordinal))
             {
@@ -95,10 +96,10 @@ namespace Orleans.Serialization.TypeSystem
                 // Only change the assembly;
                 return (type, names.Assembly);
             }
-            else if (type.ContainingType is object)
+            else if (type.ContainingType is not null)
             {
                 // Give the user an opportunity to change the parent, including the assembly.
-                var replacementParent = ApplyInner(type.ContainingType, assemblyName, replaceTypeName);
+                var replacementParent = ApplyInner(type.ContainingType, assemblyName, replaceTypeName, ref state);
                 if (ReferenceEquals(replacementParent.Type, type.ContainingType))
                 {
                     // No change to the type.
@@ -115,9 +116,9 @@ namespace Orleans.Serialization.TypeSystem
             }
         }
 
-        private static (TypeSpec Type, string Assembly) HandleAssembly(AssemblyQualifiedTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandleAssembly<TState>(AssemblyQualifiedTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
-            var replacement = ApplyInner(type.Type, type.Assembly, replaceTypeName);
+            var replacement = ApplyInner(type.Type, type.Assembly, replaceTypeName, ref state);
 
             // Assembly name changes never bubble up past the assembly qualifier node.
             if (string.IsNullOrWhiteSpace(replacement.Assembly))
@@ -135,9 +136,9 @@ namespace Orleans.Serialization.TypeSystem
             return (type, assemblyName);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleArray(ArrayTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandleArray<TState>(ArrayTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);
@@ -146,9 +147,9 @@ namespace Orleans.Serialization.TypeSystem
             return (new ArrayTypeSpec(element.Type, type.Dimensions), element.Assembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleReference(ReferenceTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandleReference<TState>(ReferenceTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);
@@ -157,9 +158,9 @@ namespace Orleans.Serialization.TypeSystem
             return (new ReferenceTypeSpec(element.Type), element.Assembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandlePointer(PointerTypeSpec type, string assemblyName, Rewriter replaceTypeName)
+        private static (TypeSpec Type, string Assembly) HandlePointer<TState>(PointerTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName);
+            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);

--- a/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
@@ -1,8 +1,11 @@
 using Orleans.Serialization.Buffers;
 using System;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -108,7 +111,7 @@ namespace Orleans.Serialization.TypeSystem
             }
 
             _ = _typeConverter.TryParse(typeNameString, out type);
-            if (type is object)
+            if (type is not null)
             {
                 var key = new TypeKey(hashCode, typeName.ToArray());
                 while (!_typeKeyCache.TryAdd(candidateHashCode++, (key, type)))
@@ -177,14 +180,12 @@ namespace Orleans.Serialization.TypeSystem
             _ = _typeConverter.TryParse(typeNameString, out type);
             var key = new TypeKey(hashCode, typeName.ToArray());
             typeString = key.ToString();
-            return type is object; 
+            return type is not null; 
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedVersion(byte version)
-        {
-            throw new NotSupportedException($"Type encoding version {version} is not supported");
-        }
+        [DoesNotReturn]
+        private static void ThrowUnsupportedVersion(byte version) => throw new NotSupportedException($"Type encoding version {version} is not supported");
 
         /// <summary>
         /// Represents a named type for the purposes of serialization.

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -11,6 +11,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Orleans.Serialization.TypeSystem
 {
@@ -20,27 +22,60 @@ namespace Orleans.Serialization.TypeSystem
     public class TypeConverter
     {
         private readonly ITypeConverter[] _converters;
-        private readonly ITypeFilter[] _filters;
+        private readonly ITypeNameFilter[] _typeNameFilters;
+        private readonly ITypeFilter[] _typeFilters;
+        private readonly bool _allowAllTypes;
         private readonly TypeResolver _resolver;
-        private readonly RuntimeTypeNameRewriter.Rewriter _convertToDisplayName;
-        private readonly RuntimeTypeNameRewriter.Rewriter _convertFromDisplayName;
+        private readonly RuntimeTypeNameRewriter.Rewriter<ValidationResult> _convertToDisplayName;
+        private readonly RuntimeTypeNameRewriter.Rewriter<ValidationResult> _convertFromDisplayName;
         private readonly Dictionary<QualifiedType, QualifiedType> _wellKnownAliasToType;
         private readonly Dictionary<QualifiedType, QualifiedType> _wellKnownTypeToAlias;
         private readonly ConcurrentDictionary<QualifiedType, bool> _allowedTypes;
         private readonly HashSet<string> _allowedTypesConfiguration;
+        private static readonly List<(string DisplayName, string RuntimeName)> WellKnownTypeAliases = new()
+        {
+            ("object", "System.Object"),
+            ("string", "System.String"),
+            ("char", "System.Char"),
+            ("sbyte", "System.SByte"),
+            ("byte", "System.Byte"),
+            ("bool", "System.Boolean"),
+            ("short", "System.Int16"),
+            ("ushort", "System.UInt16"),
+            ("int", "System.Int32"),
+            ("uint", "System.UInt32"),
+            ("long", "System.Int64"),
+            ("ulong", "System.UInt64"),
+            ("float", "System.Single"),
+            ("double", "System.Double"),
+            ("decimal", "System.Decimal"),
+            ("Guid", "System.Guid"),
+            ("TimeSpan", "System.TimeSpan"),
+            ("DateTime", "System.DateTime"),
+            ("DateTimeOffset", "System.DateTimeOffset"),
+            ("Type", "System.Type"),
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TypeConverter"/> class.
         /// </summary>
         /// <param name="formatters">The type name formatters.</param>
-        /// <param name="filters">The type filters.</param>
+        /// <param name="typeNameFilters">The type name filters.</param>
+        /// <param name="typeFilters">The type filters.</param>
         /// <param name="options">The options.</param>
         /// <param name="typeResolver">The type resolver.</param>
-        public TypeConverter(IEnumerable<ITypeConverter> formatters, IEnumerable<ITypeFilter> filters, IOptions<TypeManifestOptions> options, TypeResolver typeResolver)
+        public TypeConverter(
+            IEnumerable<ITypeConverter> formatters,
+            IEnumerable<ITypeNameFilter> typeNameFilters,
+            IEnumerable<ITypeFilter> typeFilters,
+            IOptions<TypeManifestOptions> options,
+            TypeResolver typeResolver)
         {
             _resolver = typeResolver;
             _converters = formatters.ToArray();
-            _filters = filters.ToArray();
+            _typeNameFilters = typeNameFilters.ToArray();
+            _typeFilters = typeFilters.ToArray();
+            _allowAllTypes = options.Value.AllowAllTypes;
             _convertToDisplayName = ConvertToDisplayName;
             _convertFromDisplayName = ConvertFromDisplayName;
 
@@ -49,12 +84,16 @@ namespace Orleans.Serialization.TypeSystem
 
             _allowedTypes = new ConcurrentDictionary<QualifiedType, bool>(QualifiedType.EqualityComparer);
             _allowedTypesConfiguration = new(StringComparer.Ordinal);
-            foreach (var t in options.Value.AllowedTypes)
-            {
-                _allowedTypesConfiguration.Add(t);
-            }
 
-            ConsumeMetadata(options.Value);
+            if (!_allowAllTypes)
+            {
+                foreach (var t in options.Value.AllowedTypes)
+                {
+                    _allowedTypesConfiguration.Add(t);
+                }
+
+                ConsumeMetadata(options.Value);
+            }
 
             var aliases = options.Value.WellKnownTypeAliases;
             foreach (var item in aliases)
@@ -90,8 +129,9 @@ namespace Orleans.Serialization.TypeSystem
             AddFromMetadata(metadata.Copiers, typeof(IBaseCopier<>));
             foreach (var type in metadata.InterfaceProxies)
             {
-                AddAllowedType(type switch {
-                    { IsGenericType: true} => type.GetGenericTypeDefinition(),
+                AddAllowedType(type switch
+                {
+                    { IsGenericType: true } => type.GetGenericTypeDefinition(),
                     _ => type
                 });
             }
@@ -157,10 +197,11 @@ namespace Orleans.Serialization.TypeSystem
                 var parsed = RuntimeTypeNameParser.Parse(formatted);
 
                 // Use the type name rewriter to visit every component of the type.
-                _ = RuntimeTypeNameRewriter.Rewrite(parsed, AddQualifiedType);
-                QualifiedType AddQualifiedType(in QualifiedType type)
+                var converter = this;
+                _ = RuntimeTypeNameRewriter.Rewrite(parsed, AddQualifiedType, ref converter);
+                static QualifiedType AddQualifiedType(in QualifiedType type, ref TypeConverter self)
                 {
-                    _allowedTypes[type] = true;
+                    self._allowedTypes[type] = true;
                     return type;
                 }
             }
@@ -170,16 +211,18 @@ namespace Orleans.Serialization.TypeSystem
         /// Formats the provided type.
         /// </summary>
         /// <param name="type">The type.</param>
+        /// <param name="allowAllTypes">Whether all types are allowed or not.</param>
         /// <returns>The formatted type name.</returns>
-        public string Format(Type type) => FormatInternal(type);
+        public string Format(Type type, bool allowAllTypes = false) => FormatInternal(type);
 
         /// <summary>
         /// Formats the provided type, rewriting elements using the provided delegate.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="rewriter">A delegate used to rewrite the type.</param>
+        /// <param name="allowAllTypes">Whether all types are allowed or not.</param>
         /// <returns>The formatted type name.</returns>
-        public string Format(Type type, Func<TypeSpec, TypeSpec> rewriter) => FormatInternal(type, rewriter);
+        public string Format(Type type, Func<TypeSpec, TypeSpec> rewriter, bool allowAllTypes = false) => FormatInternal(type, rewriter);
 
         /// <summary>
         /// Parses the provided type string.
@@ -231,13 +274,27 @@ namespace Orleans.Serialization.TypeSystem
             }
 
             var runtimeTypeSpec = RuntimeTypeNameParser.Parse(runtimeType);
-            var displayTypeSpec = RuntimeTypeNameRewriter.Rewrite(runtimeTypeSpec, _convertToDisplayName);
-            if (rewriter is object)
+            ValidationResult validationState = default;
+            var displayTypeSpec = RuntimeTypeNameRewriter.Rewrite(runtimeTypeSpec, _convertToDisplayName, ref validationState);
+            if (rewriter is not null)
             {
                 displayTypeSpec = rewriter(displayTypeSpec);
             }
 
             var formatted = displayTypeSpec.Format();
+
+            if (validationState.IsTypeNameAllowed == false)
+            {
+                ThrowTypeNotAllowed(formatted, validationState.ErrorTypes);
+            }
+
+            if (!_allowAllTypes && validationState.IsTypeNameAllowed != true)
+            {
+                if (InspectType(_typeFilters, type) == false)
+                {
+                    ThrowTypeNotAllowed(type);
+                }
+            }
 
             return formatted;
         }
@@ -245,8 +302,14 @@ namespace Orleans.Serialization.TypeSystem
         private bool ParseInternal(string formatted, out Type type)
         {
             var parsed = RuntimeTypeNameParser.Parse(formatted);
-            var runtimeTypeSpec = RuntimeTypeNameRewriter.Rewrite(parsed, _convertFromDisplayName);
+            ValidationResult validationState = default;
+            var runtimeTypeSpec = RuntimeTypeNameRewriter.Rewrite(parsed, _convertFromDisplayName, ref validationState);
             var runtimeType = runtimeTypeSpec.Format();
+
+            if (validationState.IsTypeNameAllowed == false)
+            {
+                ThrowTypeNotAllowed(formatted, validationState.ErrorTypes);
+            }
 
             foreach (var converter in _converters)
             {
@@ -256,14 +319,40 @@ namespace Orleans.Serialization.TypeSystem
                 }
             }
 
-            return _resolver.TryResolveType(runtimeType, out type);
+            if (_resolver.TryResolveType(runtimeType, out type))
+            {
+                if (!_allowAllTypes && validationState.IsTypeNameAllowed != true)
+                {
+                    if (InspectType(_typeFilters, type) == false)
+                    {
+                        ThrowTypeNotAllowed(type);
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
-        private bool IsTypeAllowed(in QualifiedType type)
+        private bool? IsNameTypeAllowed(in QualifiedType type)
         {
+            if (_allowAllTypes)
+            {
+                return true;
+            }
+
             if (_allowedTypes.TryGetValue(type, out var allowed))
             {
                 return allowed;
+            }
+
+            foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
+            {
+                if (displayName.Equals(type.Type) || runtimeName.Equals(type.Type))
+                {
+                    return true;
+                }
             }
 
             if (_allowedTypesConfiguration.Contains(type.Type))
@@ -271,7 +360,7 @@ namespace Orleans.Serialization.TypeSystem
                 return true;
             }
 
-            foreach (var filter in _filters)
+            foreach (var filter in _typeNameFilters)
             {
                 var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly);
                 if (isAllowed.HasValue)
@@ -281,79 +370,166 @@ namespace Orleans.Serialization.TypeSystem
                 }
             }
 
-            return false;
+            return null;
         }
 
-        private QualifiedType ConvertToDisplayName(in QualifiedType input) => input switch
+        private QualifiedType ConvertToDisplayName(in QualifiedType input, ref ValidationResult state)
         {
-            (_, "System.Object") => new QualifiedType(null, "object"),
-            (_, "System.String") => new QualifiedType(null, "string"),
-            (_, "System.Char") => new QualifiedType(null, "char"),
-            (_, "System.SByte") => new QualifiedType(null, "sbyte"),
-            (_, "System.Byte") => new QualifiedType(null, "byte"),
-            (_, "System.Boolean") => new QualifiedType(null, "bool"),
-            (_, "System.Int16") => new QualifiedType(null, "short"),
-            (_, "System.UInt16") => new QualifiedType(null, "ushort"),
-            (_, "System.Int32") => new QualifiedType(null, "int"),
-            (_, "System.UInt32") => new QualifiedType(null, "uint"),
-            (_, "System.Int64") => new QualifiedType(null, "long"),
-            (_, "System.UInt64") => new QualifiedType(null, "ulong"),
-            (_, "System.Single") => new QualifiedType(null, "float"),
-            (_, "System.Double") => new QualifiedType(null, "double"),
-            (_, "System.Decimal") => new QualifiedType(null, "decimal"),
-            (_, "System.Guid") => new QualifiedType(null, "Guid"),
-            (_, "System.TimeSpan") => new QualifiedType(null, "TimeSpan"),
-            (_, "System.DateTime") => new QualifiedType(null, "DateTime"),
-            (_, "System.DateTimeOffset") => new QualifiedType(null, "DateTimeOffset"),
-            (_, "System.Type") => new QualifiedType(null, "Type"),
-            (_, "System.RuntimeType") => new QualifiedType(null, "Type"),
-            _ when _wellKnownTypeToAlias.TryGetValue(input, out var alias) => alias,
-            var value when IsTypeAllowed(in value) => input,
-            var value => ThrowTypeNotAllowed(in value)
-        };
+            state = UpdateValidationResult(input, state);
 
-        private QualifiedType ConvertFromDisplayName(in QualifiedType input) => input switch
-        {
-            (_, "object") => new QualifiedType(null, "System.Object"),
-            (_, "string") => new QualifiedType(null, "System.String"),
-            (_, "char") => new QualifiedType(null, "System.Char"),
-            (_, "sbyte") => new QualifiedType(null, "System.SByte"),
-            (_, "byte") => new QualifiedType(null, "System.Byte"),
-            (_, "bool") => new QualifiedType(null, "System.Boolean"),
-            (_, "short") => new QualifiedType(null, "System.Int16"),
-            (_, "ushort") => new QualifiedType(null, "System.UInt16"),
-            (_, "int") => new QualifiedType(null, "System.Int32"),
-            (_, "uint") => new QualifiedType(null, "System.UInt32"),
-            (_, "long") => new QualifiedType(null, "System.Int64"),
-            (_, "ulong") => new QualifiedType(null, "System.UInt64"),
-            (_, "float") => new QualifiedType(null, "System.Single"),
-            (_, "double") => new QualifiedType(null, "System.Double"),
-            (_, "decimal") => new QualifiedType(null, "System.Decimal"),
-            (_, "Guid") => new QualifiedType(null, "System.Guid"),
-            (_, "TimeSpan") => new QualifiedType(null, "System.TimeSpan"),
-            (_, "DateTime") => new QualifiedType(null, "System.DateTime"),
-            (_, "DateTimeOffset") => new QualifiedType(null, "System.DateTimeOffset"),
-            (_, "Type") => new QualifiedType(null, "System.Type"),
-            _ when _wellKnownAliasToType.TryGetValue(input, out var type) => type,
-            var value when IsTypeAllowed(in value) => input,
-            var value => ThrowTypeNotAllowed(in value)
-        };
-
-        private static QualifiedType ThrowTypeNotAllowed(in QualifiedType value)
-
-        {
-            string message;
-
-            if (!string.IsNullOrWhiteSpace(value.Assembly))
+            foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
             {
-                message = $"Type \"{value.Type}\" from assembly \"{value.Assembly}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeFilter)} instance which allows it.";
-            }
-            else
-            {
-                message = $"Type \"{value.Type}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeFilter)} instance which allows it.";
+                if (string.Equals(input.Type, runtimeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new QualifiedType(null, displayName);
+                }
             }
 
+            if (_wellKnownTypeToAlias.TryGetValue(input, out var alias))
+            {
+                return alias;
+            }
+
+            return input;
+        }
+
+        private QualifiedType ConvertFromDisplayName(in QualifiedType input, ref ValidationResult state)
+        {
+            state = UpdateValidationResult(input, state);
+
+            foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
+            {
+                if (string.Equals(input.Type, displayName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new QualifiedType(null, runtimeName);
+                }
+            }
+
+            if (_wellKnownAliasToType.TryGetValue(input, out var type))
+            {
+                return type;
+            }
+
+            return input;
+        }
+
+        private ValidationResult UpdateValidationResult(QualifiedType input, ValidationResult state)
+        {
+            // If there has not been an error yet, inspect this type to ensure it is allowed.
+            if (IsNameTypeAllowed(input) is bool allowed)
+            {
+                var newAllowed = allowed && (state.IsTypeNameAllowed ?? true);
+                var newErrorList = state.ErrorTypes ?? new List<QualifiedType>();
+                if (!allowed)
+                {
+                    newErrorList.Add(input);
+                }
+
+                return new(newAllowed, newErrorList);
+            }
+
+            return state;
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static QualifiedType ThrowTypeNotAllowed(string fullTypeName, List<QualifiedType> errors)
+        {
+            if (errors is { Count: 1 })
+            {
+                var value = errors[0];
+
+                if (!string.IsNullOrWhiteSpace(value.Assembly))
+                {
+                    throw new InvalidOperationException($"Type \"{value.Type}\" from assembly \"{value.Assembly}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows it.");
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Type \"{value.Type}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows it.");
+                }
+            }
+
+            StringBuilder message = new($"Some types in the type string \"{fullTypeName}\" are not allowed by configuration. To allow them, add them to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows them.");
+            foreach (var value in errors)
+            {
+                if (!string.IsNullOrWhiteSpace(value.Assembly))
+                {
+                    message.AppendLine($"Type \"{value.Type}\" from assembly \"{value.Assembly}\"");
+                }
+                else
+                {
+                    message.AppendLine($"Type \"{value.Type}\"");
+                }
+            }
+
+            throw new InvalidOperationException(message.ToString());
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowTypeNotAllowed(Type value)
+        {
+            var message = $"Type \"{value.FullName}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it.";
             throw new InvalidOperationException(message);
+        }
+
+        private readonly struct ValidationResult
+        {
+            public ValidationResult(bool? isTypeNameAllowed, List<QualifiedType> errorTypes)
+            {
+                IsTypeNameAllowed = isTypeNameAllowed;
+                ErrorTypes = errorTypes;
+            }
+
+            public bool? IsTypeNameAllowed { get; }
+            public List<QualifiedType> ErrorTypes { get; }
+        }
+
+        private static bool? InspectType(ITypeFilter[] filters, Type type)
+        {
+            bool? result = null;
+            if (type.HasElementType)
+            {
+                result = Combine(result, InspectType(filters, type.GetElementType()));
+                return result;
+            }
+
+            foreach (var filter in filters)
+            {
+                result = Combine(result, filter.IsTypeAllowed(type));
+                if (result == false)
+                {
+                    return false;
+                }
+            }
+
+            if (type.IsConstructedGenericType)
+            {
+                foreach (var parameter in type.GenericTypeArguments)
+                {
+                    result = Combine(result, InspectType(filters, parameter));
+                    if (result == false)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return result;
+
+            static bool? Combine(bool? left, bool? right)
+            {
+                if (left == false || right == false)
+                {
+                    return false;
+                }
+                else if (left == true || right == true)
+                {
+                    return true;
+                }
+
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds functionality to inspect types using `Type` instead of only `string` names for assembly/type.
This is useful because it allows general-purpose serializers (JSON, etc) to opt-in to allowing types based on what they support.

Also adds an `AllowAllTypes` option, defaulting (for now) to `false`.
I'm not against defaulting that to `true`, since it can make people's lives easier.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7781)