### PR TITLE
Suppress flow of `ExecutionContext` when interacting with reminders

### DIFF
--- a/src/Orleans.Core/Timers/NonCapturingTimer.cs
+++ b/src/Orleans.Core/Timers/NonCapturingTimer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Orleans.Runtime.Internal;
 
 namespace Orleans.Runtime
 {
@@ -19,25 +20,9 @@ namespace Orleans.Runtime
             }
 
             // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
 
-                return new Timer(callback, state, dueTime, period);
-            }
-            finally
-            {
-                // Restore the current ExecutionContext
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
+            return new Timer(callback, state, dueTime, period);
         }
     }
 }

--- a/src/Orleans.Core/Utils/ExecutionContextSuppressor.cs
+++ b/src/Orleans.Core/Utils/ExecutionContextSuppressor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 
 namespace Orleans.Runtime.Internal;
@@ -6,7 +5,10 @@ namespace Orleans.Runtime.Internal;
 /// <summary>
 /// Suppresses the flow of <see cref="ExecutionContext"/> until it is disposed.
 /// </summary>
-public struct ExecutionContextSuppressor : IDisposable
+/// <remarks>
+/// Note that this is a ref-struct to avoid it being used in an async method.
+/// </remarks>
+public ref struct ExecutionContextSuppressor
 {
     private readonly bool _restoreFlow;
 
@@ -26,7 +28,9 @@ public struct ExecutionContextSuppressor : IDisposable
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
     public void Dispose()
     {
         if (_restoreFlow)

--- a/src/Orleans.Core/Utils/ExecutionContextSuppressor.cs
+++ b/src/Orleans.Core/Utils/ExecutionContextSuppressor.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+
+namespace Orleans.Runtime.Internal;
+
+/// <summary>
+/// Suppresses the flow of <see cref="ExecutionContext"/> until it is disposed.
+/// </summary>
+public struct ExecutionContextSuppressor : IDisposable
+{
+    private readonly bool _restoreFlow;
+
+    /// <summary>
+    /// Initializes a new <see cref="ExecutionContextSuppressor"/> instance.
+    /// </summary>
+    public ExecutionContextSuppressor()
+    {
+        if (!ExecutionContext.IsFlowSuppressed())
+        {
+            ExecutionContext.SuppressFlow();
+            _restoreFlow = true;
+        }
+        else
+        {
+            _restoreFlow = false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_restoreFlow)
+        {
+            ExecutionContext.RestoreFlow();
+        }
+    }
+}

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -96,7 +96,7 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         public void Start()
         {
-            using var _ = new ExecutionContextSuppressor();
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
             lock (_lockObj)
             {
                 if (_stoppingCancellation.IsCancellationRequested)

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
+using Orleans.Runtime.Internal;
 using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
 
 namespace Orleans.Runtime.MembershipService
@@ -95,6 +96,7 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         public void Start()
         {
+            using var _ = new ExecutionContextSuppressor();
             lock (_lockObj)
             {
                 if (_stoppingCancellation.IsCancellationRequested)

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.CodeGeneration;
 using Orleans.Internal;
+using Orleans.Runtime.Internal;
 
 namespace Orleans.Runtime.ReminderService
 {
@@ -525,6 +526,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 if (runTask is null)
                 {
+                    using var _ = new ExecutionContextSuppressor();
                     this.runTask = this.RunAsync();
                 }
                 else

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -526,7 +526,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 if (runTask is null)
                 {
-                    using var _ = new ExecutionContextSuppressor();
+                    using var suppressExecutionContext = new ExecutionContextSuppressor();
                     this.runTask = this.RunAsync();
                 }
                 else

--- a/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Runtime.Internal;
 using Orleans.Runtime.Services;
 using Orleans.Timers;
 
@@ -72,12 +73,14 @@ namespace Orleans.Runtime.ReminderService
             }
 
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
             return GetGrainService(callingGrainId).RegisterOrUpdateReminder(callingGrainReference, reminderName, dueTime, period);
         }
 
         public Task UnregisterReminder(GrainId callingGrainId, IGrainReminder reminder)
         {
             this.EnsureReminderServiceRegistered();
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
             return GetGrainService(callingGrainId).UnregisterReminder(reminder);
         }
 
@@ -89,6 +92,7 @@ namespace Orleans.Runtime.ReminderService
                 throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
             }
 
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
             return GetGrainService(callingGrainId).GetReminder(callingGrainReference, reminderName);
         }
@@ -96,6 +100,8 @@ namespace Orleans.Runtime.ReminderService
         public Task<List<IGrainReminder>> GetReminders(GrainId callingGrainId)
         {
             this.EnsureReminderServiceRegistered();
+
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
             return GetGrainService(callingGrainId).GetReminders(callingGrainReference);
         }

--- a/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderRegistry.cs
@@ -73,14 +73,12 @@ namespace Orleans.Runtime.ReminderService
             }
 
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
-            using var suppressExecutionContext = new ExecutionContextSuppressor();
             return GetGrainService(callingGrainId).RegisterOrUpdateReminder(callingGrainReference, reminderName, dueTime, period);
         }
 
         public Task UnregisterReminder(GrainId callingGrainId, IGrainReminder reminder)
         {
             this.EnsureReminderServiceRegistered();
-            using var suppressExecutionContext = new ExecutionContextSuppressor();
             return GetGrainService(callingGrainId).UnregisterReminder(reminder);
         }
 
@@ -92,7 +90,6 @@ namespace Orleans.Runtime.ReminderService
                 throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
             }
 
-            using var suppressExecutionContext = new ExecutionContextSuppressor();
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
             return GetGrainService(callingGrainId).GetReminder(callingGrainReference, reminderName);
         }
@@ -101,7 +98,6 @@ namespace Orleans.Runtime.ReminderService
         {
             this.EnsureReminderServiceRegistered();
 
-            using var suppressExecutionContext = new ExecutionContextSuppressor();
             var callingGrainReference = grainFactory.GetGrain(callingGrainId).AsReference();
             return GetGrainService(callingGrainId).GetReminders(callingGrainReference);
         }

--- a/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
+++ b/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime.Internal;
 
 namespace Orleans.Runtime.Scheduler
 {
@@ -29,94 +30,34 @@ namespace Orleans.Runtime.Scheduler
 
         public static void QueueAction(this TaskScheduler taskScheduler, Action action)
         {
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
+            using var suppressExecutionContext = new ExecutionContextSuppressor(); 
 
-                var task = new Task(action);
-                task.Start(taskScheduler);
-            }
-            finally
-            {
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
+            var task = new Task(action);
+            task.Start(taskScheduler);
         }
 
         public static void QueueAction(this TaskScheduler taskScheduler, Action<object> action, object state)
         {
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
+            using var suppressExecutionContext = new ExecutionContextSuppressor(); 
 
-                var task = new Task(action, state);
-                task.Start(taskScheduler);
-            }
-            finally
-            {
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
+            var task = new Task(action, state);
+            task.Start(taskScheduler);
         }
 
         public static void QueueWorkItem(this TaskScheduler taskScheduler, IWorkItem todo)
         {
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
+            using var suppressExecutionContext = new ExecutionContextSuppressor(); 
 
-                var workItemTask = new Task(TaskFunc, todo);
-                workItemTask.Start(taskScheduler);
-            }
-            finally
-            {
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
+            var workItemTask = new Task(TaskFunc, todo);
+            workItemTask.Start(taskScheduler);
         }
 
         public static void QueueThreadPoolWorkItem(this TaskScheduler taskScheduler, IThreadPoolWorkItem workItem)
         {
-            bool restoreFlow = false;
-            try
-            {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
+            using var suppressExecutionContext = new ExecutionContextSuppressor(); 
 
-                var workItemTask = new Task(ThreadPoolWorkItemTaskFunc , workItem);
-                workItemTask.Start(taskScheduler);
-            }
-            finally
-            {
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
+            var workItemTask = new Task(ThreadPoolWorkItemTaskFunc , workItem);
+            workItemTask.Start(taskScheduler);
         }
     }
 }


### PR DESCRIPTION
It's possible for reminders to temporarily capture the ExecutionContext (RequestContext, etc) of the caller when a reminder is scheduled.

This PR suppresses execution context when interacting with reminders and unifies how ExecutionContext is suppress in other areas in the codebase.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7789)