### PR TITLE
Remove netcoreapp3.1 and net5.0 support in main

### DIFF
--- a/.azure/pipelines/pr.yaml
+++ b/.azure/pipelines/pr.yaml
@@ -56,14 +56,6 @@ jobs:
         inputs:
           useGlobalJson: true
         displayName: 'Use .NET Core sdk'
-      - task: UseDotNet@2
-        inputs:
-          version: 3.1.x
-        displayName: 'Install .NET Core sdk 3.1.x'
-      - task: UseDotNet@2
-        inputs:
-          version: 5.0.x
-        displayName: 'Install .NET Core sdk 5.0.x'
       - task: DotNetCoreCLI@2
         displayName: Build
         inputs:

--- a/.azure/pipelines/pr.yaml
+++ b/.azure/pipelines/pr.yaml
@@ -14,8 +14,6 @@ parameters:
     displayName: Frameworks
     type: object
     default:
-    - netcoreapp3.1
-    - net5.0
     - net6.0
   - name: tests_categories
     displayName: Test categories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.x'
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Build
@@ -49,14 +41,6 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -84,14 +68,6 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -115,14 +91,6 @@ jobs:
           MARIADB_ROOT_PASSWORD: "mariadb"
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -148,14 +116,6 @@ jobs:
           SA_PASSWORD: "yourWeak(!)Password"
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -181,14 +141,6 @@ jobs:
           - 10002:10002
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -211,14 +163,6 @@ jobs:
           - 8600:8600/udp
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -241,14 +185,6 @@ jobs:
           ALLOW_ANONYMOUS_LOGIN: "yes"
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test
@@ -274,14 +210,6 @@ jobs:
           AWS_REGION: us-east-1
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Test

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,8 +6,8 @@
   <Import Project="$(_ParentDirectoryBuildPropsPath)" Condition="Exists('$(_ParentDirectoryBuildPropsPath)')"/>
 
   <PropertyGroup>
-    <StandardTargetFrameworks>netcoreapp3.1;net5.0;net6.0</StandardTargetFrameworks>
-    <MultiTargetFrameworks>netcoreapp3.1;net5.0;net6.0</MultiTargetFrameworks>
+    <StandardTargetFrameworks>net6.0</StandardTargetFrameworks>
+    <MultiTargetFrameworks>net6.0</MultiTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -14,7 +14,8 @@
 
   <!-- For test project we still need to target various desktop .Net versions instead of .Net Standard -->
   <PropertyGroup>
-    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net5.0;net6.0;netcoreapp3.1</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net6.0</TestTargetFrameworks>
+    <MinTestTargetFramework Condition="'$(MinTestTargetFramework)' == ''">net6.0</MinTestTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/TestFSharp/TestFSharp.fsproj
+++ b/test/Grains/TestFSharp/TestFSharp.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>

--- a/test/Grains/TestFSharpGrainInterfaces/TestFSharpGrainInterfaces.csproj
+++ b/test/Grains/TestFSharpGrainInterfaces/TestFSharpGrainInterfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>msbuild</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 

--- a/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -66,10 +66,6 @@ namespace UnitTests.Grains
         public async Task BecomeConsumer(Guid streamId, string providerToUse)
         {
             _logger.Info("Consumer.BecomeConsumer");
-            if (streamId == null)
-            {
-                throw new ArgumentNullException("streamId");
-            }
             if (String.IsNullOrEmpty(providerToUse))
             {
                 throw new ArgumentNullException("providerToUse");

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -37,10 +37,6 @@ namespace UnitTests.Grains
         public Task BecomeProducer(Guid streamId, string providerToUse)
         {
             _logger.Info("Producer.BecomeProducer");
-            if (streamId == null)
-            {
-                throw new ArgumentNullException("streamId");
-            }
             if (String.IsNullOrEmpty(providerToUse))
             {
                 throw new ArgumentNullException("providerToUse");

--- a/test/Grains/TestGrains/TestGrains.csproj
+++ b/test/Grains/TestGrains/TestGrains.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>UnitTests.Grains</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <NoWarn>$(NoWarn);1591;1591;618</NoWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/test/Grains/TestInternalGrainInterfaces/TestInternalGrainInterfaces.csproj
+++ b/test/Grains/TestInternalGrainInterfaces/TestInternalGrainInterfaces.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <AssemblyName>TestInternalGrainInterfaces</AssemblyName>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/TestInternalGrains/TestInternalGrains.csproj
+++ b/test/Grains/TestInternalGrains/TestInternalGrains.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>UnitTests.Grains</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <NoWarn>$(NoWarn);1591;1591;618</NoWarn>
   </PropertyGroup>

--- a/test/Misc/TestInternalDtosRefOrleans/TestInternalDtosRefOrleans.csproj
+++ b/test/Misc/TestInternalDtosRefOrleans/TestInternalDtosRefOrleans.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>TestInternalDtosRefOrleans</RootNamespace>
     <AssemblyName>TestInternalDtosRefOrleans</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -82,11 +82,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var files = Directory.GetFiles(directory, VersionTestBinaryName, SearchOption.AllDirectories)
                 .Where(f => !f.Contains(Path.DirectorySeparatorChar + "ref" + Path.DirectorySeparatorChar))
                 .Where(f => f.Contains("publish"))
-#if NET5_0_OR_GREATER
-                .Where(f => f.Contains("net5"))
-#else
-                .Where(f => f.Contains("netcoreapp"))
-#endif
+                .Where(f => f.Contains($"net{Environment.Version.Major}.{Environment.Version.Minor}"))
                 .ToArray();
 
             if (files.Length != 1)


### PR DESCRIPTION
net5.0 has already reached EOL, and 3.1 should reach EOL shortly after 4.0 release, it doesn't make sense to keep them for our main branch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7794)