### PR TITLE
Align namespaces for hosting extension methods

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageServiceCollectionExtensions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageServiceCollectionExtensions.cs
@@ -6,43 +6,15 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
+using Orleans;
 
 namespace Orleans.Hosting
 {
-    public static class DynamoDBSiloBuilderExtensions
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class DynamoDBGrainStorageServiceCollectionExtensions
     {
-        /// <summary>
-        /// Configure silo to use AWS DynamoDB storage as the default grain storage.
-        /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<DynamoDBStorageOptions> configureOptions)
-        {
-            return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Configure silo to use AWS DynamoDB storage for grain storage.
-        /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<DynamoDBStorageOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use AWS DynamoDB storage as the default grain storage.
-        /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
-        {
-            return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Configure silo to use AWS DynamoDB storage for grain storage.
-        /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
-        {
-            return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
-        }
-
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageSiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageSiloBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Providers;
+
+namespace Orleans.Hosting
+{
+    public static class DynamoDBGrainStorageSiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure silo to use AWS DynamoDB storage as the default grain storage.
+        /// </summary>
+        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<DynamoDBStorageOptions> configureOptions)
+        {
+            return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+        }
+
+        /// <summary>
+        /// Configure silo to use AWS DynamoDB storage for grain storage.
+        /// </summary>
+        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<DynamoDBStorageOptions> configureOptions)
+        {
+            return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use AWS DynamoDB storage as the default grain storage.
+        /// </summary>
+        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        {
+            return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+        }
+
+        /// <summary>
+        /// Configure silo to use AWS DynamoDB storage for grain storage.
+        /// </summary>
+        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        {
+            return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
+        }
+    }
+}

--- a/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBServiceCollectionReminderExtensions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBServiceCollectionReminderExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Reminders.DynamoDB;
+using System;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class DynamoDBServiceCollectionReminderExtensions
+    {
+        /// <summary>
+        /// Adds reminder storage backed by Amazon DynamoDB.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection.
+        /// </param>
+        /// <param name="configure">
+        /// The delegate used to configure the reminder store.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IServiceCollection"/>, for chaining.
+        /// </returns>
+        public static IServiceCollection UseDynamoDBReminderService(this IServiceCollection services, Action<DynamoDBReminderStorageOptions> configure)
+        {
+            services.AddSingleton<IReminderTable, DynamoDBReminderTable>();
+            services.Configure<DynamoDBReminderStorageOptions>(configure);
+            services.ConfigureFormatter<DynamoDBReminderStorageOptions>();
+            return services;
+        }
+    }
+}

--- a/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBSiloBuilderReminderExtensions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBSiloBuilderReminderExtensions.cs
@@ -8,7 +8,7 @@ namespace Orleans.Hosting
     /// <summary>
     /// Silo host builder extensions.
     /// </summary>
-    public static class SiloBuilderReminderExtensions
+    public static class DynamoDBSiloBuilderReminderExtensions
     {
         /// <summary>
         /// Adds reminder storage backed by Amazon DynamoDB.
@@ -26,26 +26,6 @@ namespace Orleans.Hosting
         {
             builder.ConfigureServices(services => services.UseDynamoDBReminderService(configure));
             return builder;
-        }
-
-        /// <summary>
-        /// Adds reminder storage backed by Amazon DynamoDB.
-        /// </summary>
-        /// <param name="services">
-        /// The service collection.
-        /// </param>
-        /// <param name="configure">
-        /// The delegate used to configure the reminder store.
-        /// </param>
-        /// <returns>
-        /// The provided <see cref="IServiceCollection"/>, for chaining.
-        /// </returns>
-        public static IServiceCollection UseDynamoDBReminderService(this IServiceCollection services, Action<DynamoDBReminderStorageOptions> configure)
-        {
-            services.AddSingleton<IReminderTable, DynamoDBReminderTable>();
-            services.Configure<DynamoDBReminderStorageOptions>(configure);
-            services.ConfigureFormatter<DynamoDBReminderStorageOptions>();
-            return services;
         }
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageServiceCollectionExtensions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
@@ -10,52 +11,11 @@ using Orleans.Storage;
 
 namespace Orleans.Hosting
 {
-    public static class SiloBuilderExtensions
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class AdoNetGrainStorageServiceCollectionExtensions
     {
-        /// <summary>
-        /// Configure silo to use AdoNet grain storage as the default grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </summary>
-        /// <remarks>
-        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </remarks>
-        public static ISiloBuilder AddAdoNetGrainStorageAsDefault(this ISiloBuilder builder, Action<AdoNetGrainStorageOptions> configureOptions)
-        {
-            return builder.AddAdoNetGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Configure silo to use  AdoNet grain storage for grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </summary>
-        /// <remarks>
-        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </remarks>
-        public static ISiloBuilder AddAdoNetGrainStorage(this ISiloBuilder builder, string name, Action<AdoNetGrainStorageOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.AddAdoNetGrainStorage(name, configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use  AdoNet grain storage as the default grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </summary>
-        /// <remarks>
-        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </remarks>
-        public static ISiloBuilder AddAdoNetGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<AdoNetGrainStorageOptions>> configureOptions = null)
-        {
-            return builder.AddAdoNetGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Configure silo to use AdoNet grain storage for grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </summary>
-        /// <remarks>
-        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </remarks>
-        public static ISiloBuilder AddAdoNetGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<AdoNetGrainStorageOptions>> configureOptions = null)
-        {
-            return builder.ConfigureServices(services => services.AddAdoNetGrainStorage(name, configureOptions));
-        }
-
         /// <summary>
         /// Configure silo to use  AdoNet grain storage as the default grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
         /// </summary>
@@ -108,5 +68,5 @@ namespace Orleans.Hosting
             return services.AddSingletonNamedService<IGrainStorage>(name, AdoNetGrainStorageFactory.Create)
                            .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
         }
-    }
+    } 
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageSiloBuilderExtensions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageSiloBuilderExtensions.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers;
+
+namespace Orleans.Hosting
+{
+    public static class AdoNetGrainStorageSiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure silo to use AdoNet grain storage as the default grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </remarks>
+        public static ISiloBuilder AddAdoNetGrainStorageAsDefault(this ISiloBuilder builder, Action<AdoNetGrainStorageOptions> configureOptions)
+        {
+            return builder.AddAdoNetGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+        }
+
+        /// <summary>
+        /// Configure silo to use  AdoNet grain storage for grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </remarks>
+        public static ISiloBuilder AddAdoNetGrainStorage(this ISiloBuilder builder, string name, Action<AdoNetGrainStorageOptions> configureOptions)
+        {
+            return builder.ConfigureServices(services => services.AddAdoNetGrainStorage(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use  AdoNet grain storage as the default grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </remarks>
+        public static ISiloBuilder AddAdoNetGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<AdoNetGrainStorageOptions>> configureOptions = null)
+        {
+            return builder.AddAdoNetGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+        }
+
+        /// <summary>
+        /// Configure silo to use AdoNet grain storage for grain storage. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </remarks>
+        public static ISiloBuilder AddAdoNetGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<AdoNetGrainStorageOptions>> configureOptions = null)
+        {
+            return builder.ConfigureServices(services => services.AddAdoNetGrainStorage(name, configureOptions));
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Reminders.AdoNet/AdoNetRemindersServiceCollectionExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/AdoNetRemindersServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime.ReminderService;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class AdoNetRemindersServiceCollectionExtensions
+    {
+        /// <summary>Adds reminder storage using ADO.NET. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.</summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="configureOptions">Configuration delegate.</param>
+        /// <returns>The provided <see cref="IServiceCollection"/>, for chaining.</returns>
+        /// <remarks>
+        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
+        /// </remarks>
+        public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
+        {
+            services.AddSingleton<IReminderTable, AdoNetReminderTable>();
+            services.ConfigureFormatter<AdoNetReminderTableOptions>();
+            services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();
+            configureOptions(services.AddOptions<AdoNetReminderTableOptions>());
+            return services;
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloBuilderReminderExtensions.cs
@@ -3,7 +3,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
-using Orleans.Runtime.ReminderService;
 
 namespace Orleans.Hosting
 {
@@ -38,22 +37,6 @@ namespace Orleans.Hosting
             Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
             return builder.ConfigureServices(services => services.UseAdoNetReminderService(configureOptions));
-        }
-
-        /// <summary>Adds reminder storage using ADO.NET. Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.</summary>
-        /// <param name="services">The service collection.</param>
-        /// <param name="configureOptions">Configuration delegate.</param>
-        /// <returns>The provided <see cref="IServiceCollection"/>, for chaining.</returns>
-        /// <remarks>
-        /// Instructions on configuring your database are available at <see href="http://aka.ms/orleans-sql-scripts"/>.
-        /// </remarks>
-        public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
-        {
-            services.AddSingleton<IReminderTable, AdoNetReminderTable>();
-            services.ConfigureFormatter<AdoNetReminderTableOptions>();
-            services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();
-            configureOptions(services.AddOptions<AdoNetReminderTableOptions>());
-            return services;
         }
     }
 }

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryExtensions.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryExtensions.cs
@@ -3,12 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
-using Orleans.GrainDirectory.AzureStorage;
-using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
-    public static class AzureTableGrainDirectoryExtensions
+    public static class AzureTableGrainDirectorySiloBuilderExtensions
     {
         public static ISiloBuilder UseAzureTableGrainDirectoryAsDefault(
             this ISiloBuilder builder,
@@ -38,21 +36,6 @@ namespace Orleans.Hosting
             Action<OptionsBuilder<AzureTableGrainDirectoryOptions>> configureOptions)
         {
             return builder.ConfigureServices(services => services.AddAzureTableGrainDirectory(name, configureOptions));
-        }
-
-        private static IServiceCollection AddAzureTableGrainDirectory(
-            this IServiceCollection services,
-            string name,
-            Action<OptionsBuilder<AzureTableGrainDirectoryOptions>> configureOptions)
-        {
-            configureOptions.Invoke(services.AddOptions<AzureTableGrainDirectoryOptions>(name));
-            services
-                .AddTransient<IConfigurationValidator>(sp => new AzureTableGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableGrainDirectoryOptions>>().Get(name)))
-                .ConfigureNamedOptionForLogging<AzureTableGrainDirectoryOptions>(name)
-                .AddSingletonNamedService<IGrainDirectory>(name, (sp, name) => ActivatorUtilities.CreateInstance<AzureTableGrainDirectory>(sp, sp.GetOptionsByName<AzureTableGrainDirectoryOptions>(name)))
-                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainDirectory>(n));
-
-            return services;
         }
     }
 }

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.GrainDirectory;
+using Orleans.GrainDirectory.AzureStorage;
+using Orleans.Runtime;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class AzureTableGrainDirectoryServiceCollectionExtensions
+    {
+        internal static IServiceCollection AddAzureTableGrainDirectory(
+            this IServiceCollection services,
+            string name,
+            Action<OptionsBuilder<AzureTableGrainDirectoryOptions>> configureOptions)
+        {
+            configureOptions.Invoke(services.AddOptions<AzureTableGrainDirectoryOptions>(name));
+            services
+                .AddTransient<IConfigurationValidator>(sp => new AzureTableGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableGrainDirectoryOptions>>().Get(name)))
+                .ConfigureNamedOptionForLogging<AzureTableGrainDirectoryOptions>(name)
+                .AddSingletonNamedService<IGrainDirectory>(name, (sp, name) => ActivatorUtilities.CreateInstance<AzureTableGrainDirectory>(sp, sp.GetOptionsByName<AzureTableGrainDirectoryOptions>(name)))
+                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainDirectory>(n));
+
+            return services;
+        }
+    }
+}

--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureBlobGrainStorageServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureBlobGrainStorageServiceCollectionExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class AzureBlobGrainStorageServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Configure silo to use azure blob storage as the default grain storage.
+        /// </summary>
+        public static IServiceCollection AddAzureBlobGrainStorageAsDefault(this IServiceCollection services, Action<AzureBlobStorageOptions> configureOptions)
+        {
+            return services.AddAzureBlobGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, ob => ob.Configure(configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use azure blob storage for grain storage.
+        /// </summary>
+        public static IServiceCollection AddAzureBlobGrainStorage(this IServiceCollection services, string name, Action<AzureBlobStorageOptions> configureOptions)
+        {
+            return services.AddAzureBlobGrainStorage(name, ob => ob.Configure(configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use azure blob storage as the default grain storage.
+        /// </summary>
+        public static IServiceCollection AddAzureBlobGrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<AzureBlobStorageOptions>> configureOptions = null)
+        {
+            return services.AddAzureBlobGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
+        }
+
+        /// <summary>
+        /// Configure silo to use azure blob storage for grain storage.
+        /// </summary>
+        public static IServiceCollection AddAzureBlobGrainStorage(this IServiceCollection services, string name,
+            Action<OptionsBuilder<AzureBlobStorageOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<AzureBlobStorageOptions>(name));
+            services.AddTransient<IConfigurationValidator>(sp => new AzureBlobStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureBlobStorageOptions>>().Get(name), name));
+            services.AddTransient<IPostConfigureOptions<AzureBlobStorageOptions>, DefaultStorageProviderSerializerOptionsConfigurator<AzureBlobStorageOptions>>();
+            services.ConfigureNamedOptionForLogging<AzureBlobStorageOptions>(name);
+            if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
+            {
+                services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            }
+            return services.AddSingletonNamedService<IGrainStorage>(name, AzureBlobGrainStorageFactory.Create)
+                           .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+        }
+    }
+}

--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureBlobSiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureBlobSiloBuilderExtensions.cs
@@ -1,12 +1,9 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Runtime;
-using Orleans.Storage;
 
 namespace Orleans.Hosting
 {
@@ -42,48 +39,6 @@ namespace Orleans.Hosting
         public static ISiloBuilder AddAzureBlobGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureBlobStorageOptions>> configureOptions = null)
         {
             return builder.ConfigureServices(services => services.AddAzureBlobGrainStorage(name, configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
-        /// </summary>
-        public static IServiceCollection AddAzureBlobGrainStorageAsDefault(this IServiceCollection services, Action<AzureBlobStorageOptions> configureOptions)
-        {
-            return services.AddAzureBlobGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
-        /// </summary>
-        public static IServiceCollection AddAzureBlobGrainStorage(this IServiceCollection services, string name, Action<AzureBlobStorageOptions> configureOptions)
-        {
-            return services.AddAzureBlobGrainStorage(name, ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
-        /// </summary>
-        public static IServiceCollection AddAzureBlobGrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<AzureBlobStorageOptions>> configureOptions = null)
-        {
-            return services.AddAzureBlobGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
-        /// </summary>
-        public static IServiceCollection AddAzureBlobGrainStorage(this IServiceCollection services, string name,
-            Action<OptionsBuilder<AzureBlobStorageOptions>> configureOptions = null)
-        {
-            configureOptions?.Invoke(services.AddOptions<AzureBlobStorageOptions>(name));
-            services.AddTransient<IConfigurationValidator>(sp => new AzureBlobStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureBlobStorageOptions>>().Get(name), name));
-            services.AddTransient<IPostConfigureOptions<AzureBlobStorageOptions>, DefaultStorageProviderSerializerOptionsConfigurator<AzureBlobStorageOptions>>();
-            services.ConfigureNamedOptionForLogging<AzureBlobStorageOptions>(name);
-            if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
-            {
-                services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
-            }
-            return services.AddSingletonNamedService<IGrainStorage>(name, AzureBlobGrainStorageFactory.Create)
-                           .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
         }
     }
 }

--- a/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans;
 using Orleans.Configuration;
 using Orleans.Reminders.AzureStorage;
 using Orleans.Runtime.ReminderService;
@@ -8,64 +9,10 @@ using Orleans.Runtime.ReminderService;
 namespace Orleans.Hosting
 {
     /// <summary>
-    /// Silo host builder extensions.
+    /// <see cref="IServiceCollection"/> extensions.
     /// </summary>
-    public static class SiloBuilderReminderExtensions
+    public static class AzureStorageReminderServiceCollectionExtensions
     {
-        /// <summary>
-        /// Adds reminder storage backed by Azure Table Storage.
-        /// </summary>
-        /// <param name="builder">
-        /// The builder.
-        /// </param>
-        /// <param name="configure">
-        /// The delegate used to configure the reminder store.
-        /// </param>
-        /// <returns>
-        /// The provided <see cref="ISiloBuilder"/>, for chaining.
-        /// </returns>
-        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, Action<AzureTableReminderStorageOptions> configure)
-        {
-            builder.ConfigureServices(services => services.UseAzureTableReminderService(configure));
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds reminder storage backed by Azure Table Storage.
-        /// </summary>
-        /// <param name="builder">
-        /// The builder.
-        /// </param>
-        /// <param name="configureOptions">
-        /// The configuration delegate.
-        /// </param>
-        /// <returns>
-        /// The provided <see cref="ISiloBuilder"/>, for chaining.
-        /// </returns>
-        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, Action<OptionsBuilder<AzureTableReminderStorageOptions>> configureOptions)
-        {
-            builder.ConfigureServices(services => services.UseAzureTableReminderService(configureOptions));
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds reminder storage backed by Azure Table Storage.
-        /// </summary>
-        /// <param name="builder">
-        /// The builder.
-        /// </param>
-        /// <param name="connectionString">
-        /// The storage connection string.
-        /// </param>
-        /// <returns>
-        /// The provided <see cref="ISiloBuilder"/>, for chaining.
-        /// </returns>
-        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, string connectionString)
-        {
-            builder.UseAzureTableReminderService(options => options.ConfigureTableServiceClient(connectionString));
-            return builder;
-        }
-
         /// <summary>
         /// Adds reminder storage backed by Azure Table Storage.
         /// </summary>

--- a/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderSiloBuilderReminderExtensions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderSiloBuilderReminderExtensions.cs
@@ -1,0 +1,67 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Reminders.AzureStorage;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Silo host builder extensions.
+    /// </summary>
+    public static class AzureStorageReminderSiloBuilderExtensions
+    {
+        /// <summary>
+        /// Adds reminder storage backed by Azure Table Storage.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configure">
+        /// The delegate used to configure the reminder store.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloBuilder"/>, for chaining.
+        /// </returns>
+        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, Action<AzureTableReminderStorageOptions> configure)
+        {
+            builder.ConfigureServices(services => services.UseAzureTableReminderService(configure));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds reminder storage backed by Azure Table Storage.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloBuilder"/>, for chaining.
+        /// </returns>
+        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, Action<OptionsBuilder<AzureTableReminderStorageOptions>> configureOptions)
+        {
+            builder.ConfigureServices(services => services.UseAzureTableReminderService(configureOptions));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds reminder storage backed by Azure Table Storage.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="connectionString">
+        /// The storage connection string.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloBuilder"/>, for chaining.
+        /// </returns>
+        public static ISiloBuilder UseAzureTableReminderService(this ISiloBuilder builder, string connectionString)
+        {
+            builder.UseAzureTableReminderService(options => options.ConfigureTableServiceClient(connectionString));
+            return builder;
+        }
+    }
+}

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
@@ -5,7 +5,6 @@ namespace Orleans.Hosting
 {
     public static class ClientBuilderExtensions
     {
-
         /// <summary>
         /// Configure cluster client to use event hub persistent streams.
         /// </summary>

--- a/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionServicecollectionExtensions.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionServicecollectionExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.AzureStorage;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class AzureTableTransactionServicecollectionExtensions
+    {
+        internal static IServiceCollection AddAzureTableTransactionalStateStorage(this IServiceCollection services, string name,
+            Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<AzureTableTransactionalStateOptions>(name));
+
+            services.TryAddSingleton<ITransactionalStateStorageFactory>(sp => sp.GetServiceByName<ITransactionalStateStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            services.AddSingletonNamedService<ITransactionalStateStorageFactory>(name, AzureTableTransactionalStateStorageFactory.Create);
+            services.AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<ITransactionalStateStorageFactory>(n));
+
+            return services;
+        }
+    }
+}

--- a/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionsSiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionsSiloBuilderExtensions.cs
@@ -1,16 +1,12 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
-using Orleans.Runtime;
-using Orleans.Transactions.Abstractions;
-using Orleans.Transactions.AzureStorage;
 
 namespace Orleans.Hosting
 {
-    public static class AzureTableSiloBuilderExtensions
+    public static class AzureTableTransactionSiloBuilderExtensions
     {
         /// <summary>
         /// Configure silo to use azure table storage as the default transactional grain storage.
@@ -42,18 +38,6 @@ namespace Orleans.Hosting
         public static ISiloBuilder AddAzureTableTransactionalStateStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
         {
             return builder.ConfigureServices(services => services.AddAzureTableTransactionalStateStorage(name, configureOptions));
-        }
-
-        private static IServiceCollection AddAzureTableTransactionalStateStorage(this IServiceCollection services, string name,
-            Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
-        {
-            configureOptions?.Invoke(services.AddOptions<AzureTableTransactionalStateOptions>(name));
-
-            services.TryAddSingleton<ITransactionalStateStorageFactory>(sp => sp.GetServiceByName<ITransactionalStateStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
-            services.AddSingletonNamedService<ITransactionalStateStorageFactory>(name, AzureTableTransactionalStateStorageFactory.Create);
-            services.AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<ITransactionalStateStorageFactory>(n));
-
-            return services;
         }
     }
 }

--- a/src/Orleans.CodeGenerator.MSBuild/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\Orleans.CodeGenerator.MSBuild.targets" />
+  <Import Project="..\build\Microsoft.Orleans.CodeGenerator.MSBuild.targets" />
 </Project>

--- a/src/Orleans.CodeGenerator/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.props
+++ b/src/Orleans.CodeGenerator/buildMultiTargeting/Microsoft.Orleans.CodeGenerator.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\Orleans.CodeGenerator.props" />
+  <Import Project="..\build\Microsoft.Orleans.CodeGenerator.props" />
 </Project>

--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.IClientBuilder.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.IClientBuilder.cs
@@ -3,9 +3,9 @@ using System.Security.Cryptography.X509Certificates;
 using Orleans.Configuration;
 using Orleans.Connections.Security;
 
-namespace Orleans
+namespace Orleans.Hosting
 {
-    public static class OrleansConnectionSecurityHostingExtensions
+    public static partial class OrleansConnectionSecurityHostingExtensions
     {
         /// <summary>
         /// Configures TLS.

--- a/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Orleans.Hosting;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Builder for configuring an Orleans client.

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Orleans
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Extension methods for <see cref="IClientBuilder"/>.

--- a/src/Orleans.Core/Core/ClientBuilderGrainCallFilterExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderGrainCallFilterExtensions.cs
@@ -1,6 +1,4 @@
-using Orleans.Hosting;
-
-namespace Orleans
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Extensions for configuring grain call filters.

--- a/src/Orleans.Core/Core/GrainCallFilterServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Core/GrainCallFilterServiceCollectionExtensions.cs
@@ -4,7 +4,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Hosting
 {
-    public static class GrainCallFilterExtensions
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class GrainCallFilterServiceCollectionExtensions
     {
         /// <summary>
         /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.

--- a/src/Orleans.Core/Core/IClientBuilder.cs
+++ b/src/Orleans.Core/Core/IClientBuilder.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Builder for configuring an Orleans client.

--- a/src/Orleans.Core/Hosting/GenericHostExtensions.cs
+++ b/src/Orleans.Core/Hosting/GenericHostExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 
 namespace Microsoft.Extensions.Hosting

--- a/src/Orleans.Runtime/Hosting/GrainCallFilterExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/GrainCallFilterExtensions.cs
@@ -1,9 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Orleans.Hosting
 {
     /// <summary>
     /// Extension methods for configuring <see cref="IIncomingGrainCallFilter"/> and <see cref="IOutgoingGrainCallFilter"/> implementations.
     /// </summary>
-    public static class GrainCallFilterExtensions
+    public static class GrainCallFilterSiloBuilderExtensions
     {
         /// <summary>
         /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.

--- a/src/Orleans.Sdk/build/Microsoft.Orleans.Sdk.targets
+++ b/src/Orleans.Sdk/build/Microsoft.Orleans.Sdk.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable' ">
+    <Using Include="Orleans"/>
+    <Using Include="Orleans.Hosting"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Orleans.Sdk/buildMultiTargeting/Microsoft.Orleans.Sdk.targets
+++ b/src/Orleans.Sdk/buildMultiTargeting/Microsoft.Orleans.Sdk.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.Sdk.targets" />
+</Project>

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -20,6 +20,9 @@ using System.Threading.Tasks;
 namespace Orleans.Serialization
 {
     /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    /// <summary>
     /// Extensions for <see cref="IServiceCollection"/>.
     /// </summary>
     public static class ServiceCollectionExtensions

--- a/src/Orleans.Streaming/Hosting/ClientBuilderStreamingExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/ClientBuilderStreamingExtensions.cs
@@ -8,7 +8,6 @@ using Orleans.Streams;
 using Orleans.Streams.Core;
 using Orleans.Configuration.Internal;
 using System.Linq;
-using Orleans.Providers.Streams.SimpleMessageStream;
 
 namespace Orleans.Hosting
 {
@@ -19,28 +18,7 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The client builder.</returns>
-        public static IClientBuilder AddStreaming(this IClientBuilder builder) => builder.ConfigureServices(AddClientStreaming);
-
-        /// <summary>
-        /// Add support for streaming to this client.
-        /// </summary>
-        /// <param name="services">The services.</param>
-        public static void AddClientStreaming(this IServiceCollection services)
-        {
-            if (services.Any(service => service.ServiceType.Equals(typeof(ClientStreamingProviderRuntime))))
-            {
-                return;
-            }
-
-            services.AddSingleton<ClientStreamingProviderRuntime>();
-            services.AddFromExisting<IStreamProviderRuntime, ClientStreamingProviderRuntime>();
-            services.AddSingleton<IStreamSubscriptionManagerAdmin, StreamSubscriptionManagerAdmin>();
-            services.AddSingleton<ImplicitStreamSubscriberTable>();
-            services.AddSingleton<IStreamNamespacePredicateProvider, DefaultStreamNamespacePredicateProvider>();
-            services.AddSingleton<IStreamNamespacePredicateProvider, ConstructorStreamNamespacePredicateProvider>();
-            services.AddSingletonKeyedService<string, IStreamIdMapper, DefaultStreamIdMapper>(DefaultStreamIdMapper.Name);
-            services.AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, ClientStreamingProviderRuntime>();
-        }
+        public static IClientBuilder AddStreaming(this IClientBuilder builder) => builder.ConfigureServices(services => services.AddClientStreaming());
 
         /// <summary>
         /// Adds a new in-memory stream provider to the client.

--- a/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Configuration.Internal;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Runtime.Providers;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Orleans.Streams.Filtering;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extension methods for configuring streaming on silos.
+    /// </summary>
+    public static class StreamingServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add support for streaming to this silo.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        public static void AddSiloStreaming(this IServiceCollection services)
+        {
+            if (services.Any(service => service.ServiceType.Equals(typeof(SiloStreamProviderRuntime))))
+            {
+                return;
+            }
+
+            services.AddSingleton<PubSubGrainStateStorageFactory>();
+            services.AddSingleton<SiloStreamProviderRuntime>();
+            services.AddFromExisting<IStreamProviderRuntime, SiloStreamProviderRuntime>();
+            services.AddSingleton<ImplicitStreamSubscriberTable>();
+            services.AddSingleton<IConfigureGrainContext, StreamConsumerGrainContextAction>();
+            services.AddSingleton<IStreamNamespacePredicateProvider, DefaultStreamNamespacePredicateProvider>();
+            services.AddSingleton<IStreamNamespacePredicateProvider, ConstructorStreamNamespacePredicateProvider>();
+            services.AddSingletonKeyedService<string, IStreamIdMapper, DefaultStreamIdMapper>(DefaultStreamIdMapper.Name);
+            services.AddTransientKeyedService<Type, IGrainExtension>(typeof(IStreamConsumerExtension), (sp, _) =>
+            {
+                var runtime = sp.GetRequiredService<IStreamProviderRuntime>();
+                var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();
+                return new StreamConsumerExtension(runtime, grainContextAccessor.GrainContext?.GrainInstance as IStreamSubscriptionObserver);
+            });
+            services.AddSingleton<IStreamSubscriptionManagerAdmin>(sp =>
+                new StreamSubscriptionManagerAdmin(sp.GetRequiredService<IStreamProviderRuntime>()));
+            services.AddTransient<IStreamQueueBalancer, ConsistentRingQueueBalancer>();
+
+            // One stream directory per activation
+            services.AddScoped<StreamDirectory>();
+        }
+
+        /// <summary>
+        /// Add support for streaming to this client.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        public static void AddClientStreaming(this IServiceCollection services)
+        {
+            if (services.Any(service => service.ServiceType.Equals(typeof(ClientStreamingProviderRuntime))))
+            {
+                return;
+            }
+
+            services.AddSingleton<ClientStreamingProviderRuntime>();
+            services.AddFromExisting<IStreamProviderRuntime, ClientStreamingProviderRuntime>();
+            services.AddSingleton<IStreamSubscriptionManagerAdmin, StreamSubscriptionManagerAdmin>();
+            services.AddSingleton<ImplicitStreamSubscriberTable>();
+            services.AddSingleton<IStreamNamespacePredicateProvider, DefaultStreamNamespacePredicateProvider>();
+            services.AddSingleton<IStreamNamespacePredicateProvider, ConstructorStreamNamespacePredicateProvider>();
+            services.AddSingletonKeyedService<string, IStreamIdMapper, DefaultStreamIdMapper>(DefaultStreamIdMapper.Name);
+            services.AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, ClientStreamingProviderRuntime>();
+        }
+
+        /// <summary>
+        /// Adds a stream filter. 
+        /// </summary>
+        /// <typeparam name="T">The stream filter type.</typeparam>
+        /// <param name="services">The service collection.</param>
+        /// <param name="name">The stream filter name.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddStreamFilter<T>(this IServiceCollection services, string name) where T : class, IStreamFilter
+        {
+            return services.AddSingletonNamedService<IStreamFilter, T>(name);
+        }
+    }
+}

--- a/src/Orleans.TestingHost/IClientBuilderConfigurator.cs
+++ b/src/Orleans.TestingHost/IClientBuilderConfigurator.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Orleans.Hosting;
 
 namespace Orleans.TestingHost
 {

--- a/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportListenerFactory.cs
+++ b/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportListenerFactory.cs
@@ -2,20 +2,17 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Internal;
 using Orleans.Networking.Shared;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
-using Orleans.Timers.Internal;
 
 namespace Orleans.TestingHost.InMemoryTransport;
 

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageServiceCollectionExtensions.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Storage;
+using Orleans.TestingHost;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extension methods for <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class FaultInjectionStorageServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Configures a silo to use <see cref="FaultInjectionGrainStorage" />.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="name">The storage provider name.</param>
+        /// <param name="configureOptions">The memory storage configuration delegate.</param>
+        /// <param name="configureFaultInjectionOptions">The fault injection provider configuration delegate.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddFaultInjectionMemoryStorage(
+            this IServiceCollection services,
+            string name,
+            Action<MemoryGrainStorageOptions> configureOptions,
+            Action<FaultInjectionGrainStorageOptions> configureFaultInjectionOptions)
+        {
+            return services.AddFaultInjectionMemoryStorage(name,
+                ob => ob.Configure(configureOptions), faultOb => faultOb.Configure(configureFaultInjectionOptions));
+        }
+
+        /// <summary>
+        /// Configures a silo to use <see cref="FaultInjectionGrainStorage" />.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="name">The storage provider name.</param>
+        /// <param name="configureOptions">The memory storage configuration delegate.</param>
+        /// <param name="configureFaultInjectionOptions">The fault injection provider configuration delegate.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddFaultInjectionMemoryStorage(
+            this IServiceCollection services,
+            string name,
+            Action<OptionsBuilder<MemoryGrainStorageOptions>> configureOptions = null,
+            Action<OptionsBuilder<FaultInjectionGrainStorageOptions>> configureFaultInjectionOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<MemoryGrainStorageOptions>(name));
+            configureFaultInjectionOptions?.Invoke(services.AddOptions<FaultInjectionGrainStorageOptions>(name));
+            services.ConfigureNamedOptionForLogging<MemoryGrainStorageOptions>(name);
+            services.ConfigureNamedOptionForLogging<FaultInjectionGrainStorageOptions>(name);
+            services.AddSingletonNamedService<IGrainStorage>(name, (svc, n) => FaultInjectionGrainStorageFactory.Create(svc, n, MemoryGrainStorageFactory.Create))
+                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n)); ;
+            return services;
+        }
+    }
+}

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultyMemoryStorage.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultyMemoryStorage.cs
@@ -1,4 +1,3 @@
-
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -49,47 +48,5 @@ namespace Orleans.TestingHost
             return builder.ConfigureServices(services => services.AddFaultInjectionMemoryStorage(name,
                configureOptions, configureFaultInjectionOptions));
         }
-
-        /// <summary>
-        /// Configures a silo to use <see cref="FaultInjectionGrainStorage" />.
-        /// </summary>
-        /// <param name="services">The services.</param>
-        /// <param name="name">The storage provider name.</param>
-        /// <param name="configureOptions">The memory storage configuration delegate.</param>
-        /// <param name="configureFaultInjectionOptions">The fault injection provider configuration delegate.</param>
-        /// <returns>The service collection.</returns>
-        public static IServiceCollection AddFaultInjectionMemoryStorage(
-            this IServiceCollection services,
-            string name,
-            Action<MemoryGrainStorageOptions> configureOptions,
-            Action<FaultInjectionGrainStorageOptions> configureFaultInjectionOptions)
-        {
-            return services.AddFaultInjectionMemoryStorage(name,
-                ob => ob.Configure(configureOptions), faultOb => faultOb.Configure(configureFaultInjectionOptions));
-        }
-
-        /// <summary>
-        /// Configures a silo to use <see cref="FaultInjectionGrainStorage" />.
-        /// </summary>
-        /// <param name="services">The services.</param>
-        /// <param name="name">The storage provider name.</param>
-        /// <param name="configureOptions">The memory storage configuration delegate.</param>
-        /// <param name="configureFaultInjectionOptions">The fault injection provider configuration delegate.</param>
-        /// <returns>The service collection.</returns>
-        public static IServiceCollection AddFaultInjectionMemoryStorage(
-            this IServiceCollection services,
-            string name,
-            Action<OptionsBuilder<MemoryGrainStorageOptions>> configureOptions = null,
-            Action<OptionsBuilder<FaultInjectionGrainStorageOptions>> configureFaultInjectionOptions = null)
-        {
-            configureOptions?.Invoke(services.AddOptions<MemoryGrainStorageOptions>(name));
-            configureFaultInjectionOptions?.Invoke(services.AddOptions<FaultInjectionGrainStorageOptions>(name));
-            services.ConfigureNamedOptionForLogging<MemoryGrainStorageOptions>(name);
-            services.ConfigureNamedOptionForLogging<FaultInjectionGrainStorageOptions>(name);
-            services.AddSingletonNamedService<IGrainStorage>(name, (svc, n) => FaultInjectionGrainStorageFactory.Create(svc, n, MemoryGrainStorageFactory.Create))
-                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n)); ;
-            return services;
-        }
     }
-
 }

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionExtensions.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionExtensions.cs
@@ -1,18 +1,13 @@
 using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Orleans.Hosting;
-using Orleans.Networking.Shared;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
 
 namespace Orleans.TestingHost.UnixSocketTransport;
 
-public  static class UnixSocketConnectionExtensions
+public static class UnixSocketConnectionExtensions
 {
     public static ISiloBuilder UseUnixSocketConnection(this ISiloBuilder siloBuilder)
     {

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/HostingExtensions.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/HostingExtensions.cs
@@ -1,12 +1,11 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Runtime;
-using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.TestKit;
 
 namespace Orleans.Transactions.TestKit
 {
@@ -20,17 +19,6 @@ namespace Orleans.Transactions.TestKit
             return builder.ConfigureServices(services => services.UseControlledFaultInjectionTransactionState());
         }
 
-        /// <summary>
-        /// Configure cluster to use the distributed TM algorithm
-        /// </summary>
-        public static IServiceCollection UseControlledFaultInjectionTransactionState(this IServiceCollection services)
-        {
-            services.AddSingleton<IAttributeToFactoryMapper<FaultInjectionTransactionalStateAttribute>, FaultInjectionTransactionalStateAttributeMapper>();
-            services.TryAddTransient<IFaultInjectionTransactionalStateFactory, FaultInjectionTransactionalStateFactory>();
-            services.AddTransient(typeof(IFaultInjectionTransactionalState<>), typeof(FaultInjectionTransactionalState<>));
-            return services;
-        }
-
         public static ISiloBuilder AddFaultInjectionAzureTableTransactionalStateStorage(this ISiloBuilder builder, Action<AzureTableTransactionalStateOptions> configureOptions)
         {
             return builder.AddFaultInjectionAzureTableTransactionalStateStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
@@ -39,18 +27,6 @@ namespace Orleans.Transactions.TestKit
         public static ISiloBuilder AddFaultInjectionAzureTableTransactionalStateStorage(this ISiloBuilder builder, string name, Action<AzureTableTransactionalStateOptions> configureOptions)
         {
             return builder.ConfigureServices(services => services.AddFaultInjectionAzureTableTransactionalStateStorage(name, ob => ob.Configure(configureOptions)));
-        }
-
-        private static IServiceCollection AddFaultInjectionAzureTableTransactionalStateStorage(this IServiceCollection services, string name,
-            Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
-        {
-            configureOptions?.Invoke(services.AddOptions<AzureTableTransactionalStateOptions>(name));
-
-            services.TryAddSingleton<ITransactionalStateStorageFactory>(sp => sp.GetServiceByName<ITransactionalStateStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
-            services.AddSingletonNamedService<ITransactionalStateStorageFactory>(name, FaultInjectionAzureTableTransactionStateStorageFactory.Create);
-            services.AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<ITransactionalStateStorageFactory>(n));
-
-            return services;
         }
     }
 }

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/TransactionFaultInjectionServiceCollectionExtensions.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/TransactionFaultInjectionServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.TestKit;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class TransactionFaultInjectionServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Configure cluster to use the distributed TM algorithm
+        /// </summary>
+        public static IServiceCollection UseControlledFaultInjectionTransactionState(this IServiceCollection services)
+        {
+            services.AddSingleton<IAttributeToFactoryMapper<FaultInjectionTransactionalStateAttribute>, FaultInjectionTransactionalStateAttributeMapper>();
+            services.TryAddTransient<IFaultInjectionTransactionalStateFactory, FaultInjectionTransactionalStateFactory>();
+            services.AddTransient(typeof(IFaultInjectionTransactionalState<>), typeof(FaultInjectionTransactionalState<>));
+            return services;
+        }
+
+        internal static IServiceCollection AddFaultInjectionAzureTableTransactionalStateStorage(this IServiceCollection services, string name,
+            Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<AzureTableTransactionalStateOptions>(name));
+
+            services.TryAddSingleton<ITransactionalStateStorageFactory>(sp => sp.GetServiceByName<ITransactionalStateStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            services.AddSingletonNamedService<ITransactionalStateStorageFactory>(name, FaultInjectionAzureTableTransactionStateStorageFactory.Create);
+            services.AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<ITransactionalStateStorageFactory>(n));
+
+            return services;
+        }
+    }
+}

--- a/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions;
 
@@ -19,24 +17,6 @@ namespace Orleans.Hosting
             return builder.ConfigureServices(services => services.UseTransactions(withStatisticsReporter))
                           .AddGrainExtension<ITransactionManagerExtension, TransactionManagerExtension>()
                           .AddGrainExtension<ITransactionalResourceExtension, TransactionalResourceExtension>();
-        }
-
-        internal static IServiceCollection UseTransactions(this IServiceCollection services, bool withReporter)
-        {
-            services.TryAddSingleton<IClock,Clock>();
-            services.TryAddSingleton<ITransactionAgentStatistics, TransactionAgentStatistics>();
-            services.TryAddSingleton<ITransactionOverloadDetector,TransactionOverloadDetector>();
-            services.AddSingleton<ITransactionAgent, TransactionAgent>();
-            services.TryAddSingleton(typeof(ITransactionDataCopier<>), typeof(DefaultTransactionDataCopier<>));
-            services.AddSingleton<IAttributeToFactoryMapper<TransactionalStateAttribute>, TransactionalStateAttributeMapper>();
-            services.TryAddTransient<ITransactionalStateFactory, TransactionalStateFactory>();
-            services.AddSingleton<IAttributeToFactoryMapper<TransactionCommitterAttribute>, TransactionCommitterAttributeMapper>();
-            services.TryAddTransient<ITransactionCommitterFactory, TransactionCommitterFactory>();
-            services.TryAddTransient<INamedTransactionalStateStorageFactory, NamedTransactionalStateStorageFactory>();
-            services.AddTransient(typeof(ITransactionalState<>), typeof(TransactionalState<>));
-            if (withReporter)
-                services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, TransactionAgentStatisticsReporter>();
-            return services;
         }
     }
 }

--- a/src/Orleans.Transactions/Hosting/TransactionsServiceCollectionExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/TransactionsServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class TransactionsServiceCollectionExtensions
+    {
+        internal static IServiceCollection UseTransactions(this IServiceCollection services, bool withReporter)
+        {
+            services.TryAddSingleton<IClock,Clock>();
+            services.TryAddSingleton<ITransactionAgentStatistics, TransactionAgentStatistics>();
+            services.TryAddSingleton<ITransactionOverloadDetector,TransactionOverloadDetector>();
+            services.AddSingleton<ITransactionAgent, TransactionAgent>();
+            services.TryAddSingleton(typeof(ITransactionDataCopier<>), typeof(DefaultTransactionDataCopier<>));
+            services.AddSingleton<IAttributeToFactoryMapper<TransactionalStateAttribute>, TransactionalStateAttributeMapper>();
+            services.TryAddTransient<ITransactionalStateFactory, TransactionalStateFactory>();
+            services.AddSingleton<IAttributeToFactoryMapper<TransactionCommitterAttribute>, TransactionCommitterAttributeMapper>();
+            services.TryAddTransient<ITransactionCommitterFactory, TransactionCommitterFactory>();
+            services.TryAddTransient<INamedTransactionalStateStorageFactory, NamedTransactionalStateStorageFactory>();
+            services.AddTransient(typeof(ITransactionalState<>), typeof(TransactionalState<>));
+            if (withReporter)
+                services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, TransactionAgentStatisticsReporter>();
+            return services;
+        }
+    }
+}

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/HostBuilderExtensions.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/HostBuilderExtensions.cs
@@ -1,68 +1,8 @@
-#define LOG_MEMORY_PERF_COUNTERS
-
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Orleans.Configuration.Internal;
-using Orleans.Hosting;
 using Orleans.Runtime;
+using Orleans.Statistics;
 
-namespace Orleans.Statistics
+namespace Orleans.Hosting
 {
-    /// <summary>
-    /// Validates <see cref="LinuxEnvironmentStatistics"/> requirements for.
-    /// </summary>
-    internal class LinuxEnvironmentStatisticsValidator : IConfigurationValidator
-    {
-        internal static readonly string InvalidOS = $"Tried to add '{nameof(LinuxEnvironmentStatistics)}' on non-linux OS";
-
-        /// <inheritdoc />
-        public void ValidateConfiguration()
-        {
-            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            if (!isLinux)
-            {
-                throw new OrleansConfigurationException(InvalidOS);
-            }
-
-            var missingFiles = LinuxEnvironmentStatistics.RequiredFiles
-                .Select(f => new { FilePath = f, FileExists = File.Exists(f) })
-                .Where(f => !f.FileExists)
-                .ToList();
-
-            if (missingFiles.Any())
-            {
-                var paths = string.Join(", ", missingFiles.Select(f => f.FilePath));
-                throw new OrleansConfigurationException($"Missing files for {nameof(LinuxEnvironmentStatistics)}: {paths}");
-            }
-        }
-    }
-
-    internal static class LinuxEnvironmentStatisticsServices
-    {
-        /// <summary>
-        /// Registers <see cref="LinuxEnvironmentStatistics"/> services.
-        /// </summary>
-        internal static void RegisterServices<TLifecycleObservable>(IServiceCollection services) where TLifecycleObservable : ILifecycleObservable
-        {
-            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            if (!isLinux)
-            {
-                var logger = services.BuildServiceProvider().GetService<ILogger<LinuxEnvironmentStatistics>>();
-                logger?.LogWarning((int)ErrorCode.OS_InvalidOS, LinuxEnvironmentStatisticsValidator.InvalidOS);
-
-                return;
-            }
-
-            services.AddTransient<IConfigurationValidator, LinuxEnvironmentStatisticsValidator>();
-            services.AddSingleton<LinuxEnvironmentStatistics>();
-            services.AddFromExisting<IHostEnvironmentStatistics, LinuxEnvironmentStatistics>();
-            services.AddFromExisting(typeof(ILifecycleParticipant<TLifecycleObservable>), typeof(LinuxEnvironmentStatistics));
-        }
-    }
-
     public static class SiloBuilderExtensions
     {
         /// <summary>

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatisticsServices.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatisticsServices.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration.Internal;
+
+namespace Orleans.Statistics
+{
+    internal static class LinuxEnvironmentStatisticsServices
+    {
+        /// <summary>
+        /// Registers <see cref="LinuxEnvironmentStatistics"/> services.
+        /// </summary>
+        internal static void RegisterServices<TLifecycleObservable>(IServiceCollection services) where TLifecycleObservable : ILifecycleObservable
+        {
+            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            if (!isLinux)
+            {
+                var logger = services.BuildServiceProvider().GetService<ILogger<LinuxEnvironmentStatistics>>();
+                logger?.LogWarning((int)ErrorCode.OS_InvalidOS, LinuxEnvironmentStatisticsValidator.InvalidOS);
+
+                return;
+            }
+
+            services.AddTransient<IConfigurationValidator, LinuxEnvironmentStatisticsValidator>();
+            services.AddSingleton<LinuxEnvironmentStatistics>();
+            services.AddFromExisting<IHostEnvironmentStatistics, LinuxEnvironmentStatistics>();
+            services.AddFromExisting(typeof(ILifecycleParticipant<TLifecycleObservable>), typeof(LinuxEnvironmentStatistics));
+        }
+    }
+}

--- a/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatisticsValidator.cs
+++ b/src/TelemetryConsumers/Orleans.TelemetryConsumers.Linux/LinuxEnvironmentStatisticsValidator.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Orleans.Runtime;
+
+namespace Orleans.Statistics
+{
+    /// <summary>
+    /// Validates <see cref="LinuxEnvironmentStatistics"/> requirements for.
+    /// </summary>
+    internal class LinuxEnvironmentStatisticsValidator : IConfigurationValidator
+    {
+        internal static readonly string InvalidOS = $"Tried to add '{nameof(LinuxEnvironmentStatistics)}' on non-linux OS";
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            if (!isLinux)
+            {
+                throw new OrleansConfigurationException(InvalidOS);
+            }
+
+            var missingFiles = LinuxEnvironmentStatistics.RequiredFiles
+                .Select(f => new { FilePath = f, FileExists = File.Exists(f) })
+                .Where(f => !f.FileExists)
+                .ToList();
+
+            if (missingFiles.Any())
+            {
+                var paths = string.Join(", ", missingFiles.Select(f => f.FilePath));
+                throw new OrleansConfigurationException($"Missing files for {nameof(LinuxEnvironmentStatistics)}: {paths}");
+            }
+        }
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -21,4 +21,5 @@
   <ItemGroup>
     <None Include="*.xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
 </Project>

--- a/test/Extensions/AWSUtils.Tests/LivenessTests.cs
+++ b/test/Extensions/AWSUtils.Tests/LivenessTests.cs
@@ -1,15 +1,7 @@
-using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.Model;
-using Amazon.Runtime;
 using AWSUtils.Tests.StorageTests;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
-using Orleans;
 using Orleans.Hosting;
-using Orleans.Internal;
 using Orleans.TestingHost;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnitTests.MembershipTests;
 using Xunit;

--- a/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -82,7 +82,7 @@ namespace UnitTests.StreamingTests
                     .AddMemoryGrainStorage("MemoryStore", options => options.NumStorageGrains = 1);
             }
 
-            public void Configure(IConfiguration configuration, Orleans.IClientBuilder clientBuilder) => clientBuilder.AddStreaming();
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder.AddStreaming();
         }
 
         public StreamLimitTests(ITestOutputHelper output)

--- a/test/Tester/ClientConnectionTests/ClientConnectionEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientConnectionEventTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;

--- a/test/Tester/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;

--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Orleans;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.TestingHost;

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Orleans;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;


### PR DESCRIPTION
Fixes #7707

All hosting methods are now under the `Orleans.Hosting` namespace, which is added as an implicit/global using by the Orleans.Sdk package

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7801)