### PR TITLE
Use CoarseStopwatch in CallbackData

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime
         private readonly IResponseCompletionSource context;
         private int completed;
         private StatusResponse lastKnownStatus;
-        private ValueStopwatch stopwatch;
+        private CoarseStopwatch stopwatch;
 
         public CallbackData(
             SharedCallbackData shared,
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
             this.shared = shared;
             this.context = ctx;
             this.Message = msg;
-            this.stopwatch = ValueStopwatch.StartNew();
+            this.stopwatch = CoarseStopwatch.StartNew();
         }
 
         public Message Message { get; } // might hold metadata used by response pipeline
@@ -73,7 +73,6 @@ namespace Orleans.Runtime
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage} Target History is: {messageHistory}.");
             var error = Message.CreatePromptExceptionResponse(msg, exception);
             ResponseCallback(error, this.context);
-            //(this.Message.BodyObject as IDisposable)?.Dispose();
         }
 
         public void OnTargetSiloFail()
@@ -105,7 +104,6 @@ namespace Orleans.Runtime
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}Target History is: {messageHistory}. See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
             var error = Message.CreatePromptExceptionResponse(msg, exception);
             ResponseCallback(error, this.context);
-            //(this.Message.BodyObject as IDisposable)?.Dispose();
         }
 
         public void DoCallback(Message response)

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -511,7 +511,7 @@ namespace Orleans
 
         private void OnCallbackExpiryTick(object state)
         {
-            var currentStopwatchTicks = Stopwatch.GetTimestamp();
+            var currentStopwatchTicks = CoarseStopwatch.GetTimestamp();
             foreach (var pair in callbacks)
             {
                 var callback = pair.Value;

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -35,7 +35,7 @@ namespace Orleans.Runtime
             set
             {
                 this.responseTimeout = value;
-                this.ResponseTimeoutStopwatchTicks = (long)(value.TotalSeconds * Stopwatch.Frequency);
+                this.ResponseTimeoutStopwatchTicks = (long)value.TotalMilliseconds;
             }
         }
     }

--- a/src/Orleans.Core/Timers/CoarseStopwatch.cs
+++ b/src/Orleans.Core/Timers/CoarseStopwatch.cs
@@ -21,6 +21,11 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// The number of ticks per second for this stopwatch.
+        /// </summary>
+        public const long Frequency = 1000;
+
+        /// <summary>
         /// Returns true if this instance is running or false otherwise.
         /// </summary>
         public bool IsRunning => _value > 0;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -594,7 +594,7 @@ namespace Orleans.Runtime
 
         private void OnCallbackExpiryTick(object state)
         {
-            var currentStopwatchTicks = Stopwatch.GetTimestamp();
+            var currentStopwatchTicks = CoarseStopwatch.GetTimestamp();
             var responseTimeout = this.messagingOptions.ResponseTimeout;
             foreach (var pair in callbacks)
             {


### PR DESCRIPTION
`ValueStopwatch` is a struct-based `Stopwatch` alternative, using the same underlying APIs (high-precision timer).
`CoarseStopwatch` is also a struct-based Stopwatch alternative, but it uses `Environment.TickCount64` instead of high-precision APIs.

`Environment.TickCount64` is much cheaper than the method `Stopwatch`/`ValueStopwatch` use:

```
|                 Method |      Mean |     Error |    StdDev |
|----------------------- |----------:|----------:|----------:|
|  StopwatchGetTimestamp | 19.814 ns | 0.0535 ns | 0.0474 ns |
|    DateTimeUtcNowTicks | 28.477 ns | 0.1351 ns | 0.1197 ns |
| EnvironmentTickCount64 |  1.669 ns | 0.0106 ns | 0.0094 ns |

```

Where the imprecision is tolerable (typically anything measuring times over about a second), `CoarseStopwatch` can be substantially cheaper than `ValueStopwatch`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7809)