### PR TITLE
Remove GrainAddress and ActivationId from Message to reduce overhead

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
@@ -41,20 +41,39 @@ namespace Orleans.Runtime
         public override bool Equals(object obj)
         {
             return obj is GrainAddress address &&
-                   this.Matches(address) &&
+                   this.ActivationEqual(address) &&
                    this.MembershipVersion == address.MembershipVersion;
         }
 
         /// <summary>
-        /// Two grain addresses match if they are equal ignoring their <see cref="MembershipVersion"/> value.
+        /// Two grain addresses have equal activations if they are equal ignoring their <see cref="MembershipVersion"/> value.
         /// </summary>
-        /// <param name="address"> The other GrainAddress to compare this one with.</param>
-        /// <returns> Returns <c>true</c> if the two GrainAddress are considered to match</returns>
-        public bool Matches(GrainAddress address)
+        /// <param name="address"> The other <see cref="GrainAddress"/> to compare this one with.</param>
+        /// <returns> Returns <c>true</c> if the two <see cref="GrainAddress"/> are considered to match</returns>
+        public bool ActivationEqual(GrainAddress address)
         {
-            return this.SiloAddress == address.SiloAddress &&
+            return this.SiloAddress.Equals(address.SiloAddress) &&
                    this.GrainId == address.GrainId &&
                    this.ActivationId == address.ActivationId;
+        }
+
+        /// <summary>
+        /// Two grain addresses match if they have equal <see cref="SiloAddress"/> and <see cref="GrainId"/> values
+        /// and either one has a default <see cref="ActivationId"/> value or both have equal <see cref="ActivationId"/> values.
+        /// </summary>
+        /// <param name="other"> The other <see cref="GrainAddress"/> to compare this one with.</param>
+        /// <returns> Returns <c>true</c> if the two <see cref="GrainAddress"/> are considered to match.</returns>
+        public bool Matches(GrainAddress other)
+        {
+            if (other is null || GrainId != other.GrainId || !SiloAddress.Equals(other.SiloAddress)) return false;
+
+            // If both activation ids are set, compare them, otherwise, ignore them.
+            if (!ActivationId.IsDefault && !other.ActivationId.IsDefault)
+            {
+                return ActivationId.Equals(other.ActivationId);
+            }
+
+            return true;
         }
 
         public override int GetHashCode() => HashCode.Combine(this.SiloAddress, this.GrainId, this.ActivationId);

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -62,24 +62,12 @@ namespace Orleans.Runtime
             if (!request.SendingGrain.IsDefault)
             {
                 response.TargetGrain = request.SendingGrain;
-                if (!request.SendingActivation.IsDefault)
-                {
-                    response.TargetActivation = request.SendingActivation;
-                }
             }
 
             response.SendingSilo = request.TargetSilo;
             if (!request.TargetGrain.IsDefault)
             {
                 response.SendingGrain = request.TargetGrain;
-                if (!request.TargetActivation.IsDefault)
-                {
-                    response.SendingActivation = request.TargetActivation;
-                }
-                else if (request.TargetGrain.IsSystemTarget())
-                {
-                    response.SendingActivation = ActivationId.GetDeterministic(request.TargetGrain);
-                }
             }
 
             response.CacheInvalidationHeader = request.CacheInvalidationHeader;

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -233,11 +233,6 @@ namespace Orleans.Runtime.Messaging
                 writer.WriteByte((byte)value.Result);
             }
 
-            if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
-            {
-                WriteActivationId(ref writer, value.SendingActivation);
-            }
-
             if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
             {
                 WriteGrainId(ref writer, value.SendingGrain);
@@ -246,11 +241,6 @@ namespace Orleans.Runtime.Messaging
             if ((headers & Headers.SENDING_SILO) != Headers.NONE)
             {
                 WriteSiloAddress(ref writer, value.SendingSilo);
-            }
-
-            if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
-            {
-                WriteActivationId(ref writer, value.TargetActivation);
             }
 
             if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)
@@ -327,11 +317,6 @@ namespace Orleans.Runtime.Messaging
             if ((headers & Headers.RESULT) != Headers.NONE)
                 result.Result = (ResponseTypes)reader.ReadByte();
 
-            if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
-            {
-                result.SendingActivation = ReadActivationId(ref reader);
-            }
-
             if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
             {
                 result.SendingGrain = ReadGrainId(ref reader);
@@ -340,11 +325,6 @@ namespace Orleans.Runtime.Messaging
             if ((headers & Headers.SENDING_SILO) != Headers.NONE)
             {
                 result.SendingSilo = ReadSiloAddress(ref reader);
-            }
-
-            if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
-            {
-                result.TargetActivation = ReadActivationId(ref reader);
             }
 
             if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -98,7 +98,6 @@ namespace Orleans.Runtime.Messaging
             if (!this.IsValid)
             {
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
-                msg.TargetActivation = default;
                 msg.TargetSilo = null;
                 this.messageCenter.SendMessage(msg);
                 return false;
@@ -107,8 +106,6 @@ namespace Orleans.Runtime.Messaging
             if (msg.TargetSilo != null) return true;
 
             msg.TargetSilo = this.RemoteSiloAddress;
-            if (msg.TargetGrain.IsSystemTarget())
-                msg.TargetActivation = ActivationId.GetDeterministic(msg.TargetGrain);
 
             return true;
         }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -265,14 +265,12 @@ namespace Orleans
             var targetGrainId = target.GrainId;
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             message.SendingGrain = CurrentActivationAddress.GrainId;
-            message.SendingActivation = CurrentActivationAddress.ActivationId;
             message.TargetGrain = targetGrainId;
 
             if (SystemTargetGrainId.TryParse(targetGrainId, out var systemTargetGrainId))
             {
                 // If the silo isn't be supplied, it will be filled in by the sender to be the gateway silo
                 message.TargetSilo = systemTargetGrainId.GetSiloAddress();
-                message.TargetActivation = ActivationId.GetDeterministic(targetGrainId);
             }
 
             if (message.IsExpirableMessage(this.clientMessagingOptions.DropExpiredMessages))

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
     internal class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>
     {
         private readonly ConcurrentDictionary<GrainId, IGrainContext> activations = new();                // Activation data (app grains) only.
-        private readonly ConcurrentDictionary<ActivationId, SystemTarget> systemTargets = new();                // SystemTarget only.
+        private readonly ConcurrentDictionary<GrainId, SystemTarget> systemTargets = new();                // SystemTarget only.
         private readonly ConcurrentDictionary<string, CounterStatistic> systemTargetCounts = new();             // simple statistics systemTargetTypeName->count
 
         public int Count => activations.Count;
@@ -22,7 +22,7 @@ namespace Orleans.Runtime
             return result;
         }
 
-        public SystemTarget FindSystemTarget(ActivationId key)
+        public SystemTarget FindSystemTarget(GrainId key)
         {
             systemTargets.TryGetValue(key, out var result);
             return result;
@@ -44,7 +44,7 @@ namespace Orleans.Runtime
         public void RecordNewSystemTarget(SystemTarget target)
         {
             var systemTarget = (ISystemTargetBase) target;
-            systemTargets.TryAdd(target.ActivationId, target);
+            systemTargets.TryAdd(target.GrainId, target);
             if (!Constants.IsSingletonSystemTarget(systemTarget.GrainId.Type))
             {
                 FindSystemTargetCounter(Constants.SystemTargetName(systemTarget.GrainId.Type)).Increment();
@@ -54,7 +54,7 @@ namespace Orleans.Runtime
         public void RemoveSystemTarget(SystemTarget target)
         {
             var systemTarget = (ISystemTargetBase) target;
-            systemTargets.TryRemove(target.ActivationId, out _);
+            systemTargets.TryRemove(target.GrainId, out _);
             if (!Constants.IsSingletonSystemTarget(systemTarget.GrainId.Type))
             {
                 FindSystemTargetCounter(Constants.SystemTargetName(systemTarget.GrainId.Type)).DecrementBy(1);

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -136,11 +136,9 @@ namespace Orleans.Runtime
             {
                 var clientAddress = this.HostedClient.Address;
                 message.SendingGrain = clientAddress.GrainId;
-                message.SendingActivation = clientAddress.ActivationId;
             }
             else
             {
-                message.SendingActivation = sendingActivation.ActivationId;
                 message.SendingGrain = sendingActivation.GrainId;
             }
 
@@ -151,7 +149,6 @@ namespace Orleans.Runtime
             if (SystemTargetGrainId.TryParse(targetGrainId, out var systemTargetGrainId))
             {
                 message.TargetSilo = systemTargetGrainId.GetSiloAddress();
-                message.TargetActivation = ActivationId.GetDeterministic(targetGrainId);
                 message.Category = targetGrainId.Type.Equals(Constants.MembershipServiceType) ?
                     Message.Categories.Ping : Message.Categories.System;
                 sharedData = this.systemSharedCallbackData;
@@ -456,7 +453,7 @@ namespace Orleans.Runtime
                             // Remove from local directory cache. Note that SendingGrain is the original target, since message is the rejection response.
                             // If CacheInvalidationHeader is present, we already did this. Otherwise, we left this code for backward compatability. 
                             // It should be retired as we move to use CacheMgmtHeader in all relevant places.
-                            this.GrainLocator.InvalidateCache(message.SendingAddress);
+                            this.GrainLocator.InvalidateCache(message.SendingGrain);
                         }
                         break;
 

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -48,7 +48,7 @@ namespace Orleans.Runtime
         public GrainReference GrainReference => selfReference ??= this.RuntimeClient.ServiceProvider.GetRequiredService<GrainReferenceActivator>().CreateReference(this.id.GrainId, default);
 
         /// <inheritdoc/>
-        GrainId IGrainContext.GrainId => this.id.GrainId;
+        public GrainId GrainId => this.id.GrainId;
 
         /// <inheritdoc/>
         object IGrainContext.GrainInstance => this;

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveGrainDirectoryCache.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private static readonly Func<GrainAddress, GrainDirectoryCacheEntry, bool> ActivationAddressEqual = (addr, entry) => addr.Equals(entry.Address);
+        private static readonly Func<GrainAddress, GrainDirectoryCacheEntry, bool> ActivationAddressesMatches = (addr, entry) => addr.Matches(entry.Address);
 
         private readonly LRU<GrainId, GrainDirectoryCacheEntry> cache;
         /// controls the time the new entry is considered "fresh" (unit: ms)
@@ -78,7 +78,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool Remove(GrainId key) => cache.RemoveKey(key);
 
-        public bool Remove(GrainAddress key) => cache.TryRemove(key.GrainId, ActivationAddressEqual, key);
+        public bool Remove(GrainAddress key) => cache.TryRemove(key.GrainId, ActivationAddressesMatches, key);
 
         public void Clear() => cache.Clear();
 

--- a/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
@@ -6,7 +6,7 @@ namespace Orleans.Runtime.GrainDirectory
 {
     internal class LRUBasedGrainDirectoryCache : IGrainDirectoryCache
     {
-        private static readonly Func<GrainAddress, (GrainAddress Address, int Version), bool> ActivationAddressEqual = (a, b) => a.Equals(b.Address);
+        private static readonly Func<GrainAddress, (GrainAddress Address, int Version), bool> ActivationAddressesMatch = (a, b) => a.Matches(b.Address);
         private readonly LRU<GrainId, (GrainAddress ActivationAddress, int Version)> cache;
 
         public LRUBasedGrainDirectoryCache(int maxCacheSize, TimeSpan maxEntryAge) => cache = new(maxCacheSize, maxEntryAge);
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool Remove(GrainId key) => cache.RemoveKey(key);
 
-        public bool Remove(GrainAddress grainAddress) => cache.TryRemove(grainAddress.GrainId, ActivationAddressEqual, grainAddress);
+        public bool Remove(GrainAddress grainAddress) => cache.TryRemove(grainAddress.GrainId, ActivationAddressesMatch, grainAddress);
 
         public void Clear() => cache.Clear();
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -532,7 +532,8 @@ namespace Orleans.Runtime.Messaging
                     else
                     {
                         var targetActivation = catalog.GetOrCreateActivation(
-                            msg.TargetAddress,
+                            msg.TargetGrain,
+                            msg.TargetActivation,
                             msg.RequestContextData);
 
                         if (targetActivation is null)

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -73,14 +73,11 @@ namespace Orleans.Runtime.Messaging
             {
                 // reroute via Dispatcher
                 msg.TargetSilo = null;
-                msg.TargetActivation = default;
-                msg.ClearTargetAddress();
 
                 if (SystemTargetGrainId.TryParse(msg.TargetGrain, out var systemTargetId))
                 {
                     msg.TargetSilo = this.myAddress;
                     msg.TargetGrain = systemTargetId.WithSiloAddress(this.myAddress).GrainId;
-                    msg.TargetActivation = ActivationId.GetDeterministic(msg.TargetGrain);
                 }
 
                 MessagingStatisticsGroup.OnMessageReRoute(msg);
@@ -94,7 +91,6 @@ namespace Orleans.Runtime.Messaging
                 if (SystemTargetGrainId.TryParse(msg.TargetGrain, out var systemTargetId))
                 {
                     msg.TargetGrain = systemTargetId.WithSiloAddress(targetAddress).GrainId;
-                    msg.TargetActivation = ActivationId.GetDeterministic(msg.TargetGrain);
                 }
 
                 this.messageCenter.SendMessage(msg);

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -116,9 +116,9 @@ namespace Orleans.Runtime.Messaging
                     $"The target silo is no longer active: target was {msg.TargetSilo.ToLongString()}, but this silo is {this.LocalSiloAddress.ToLongString()}. The rejected message is {msg}.");
 
                 // Invalidate the remote caller's activation cache entry.
-                if (msg.TargetAddress != null)
+                if (msg.TargetSilo != null)
                 {
-                    rejection.AddToCacheInvalidationHeader(msg.TargetAddress);
+                    rejection.AddToCacheInvalidationHeader(new GrainAddress { GrainId = msg.TargetGrain, SiloAddress = msg.TargetSilo });
                 }
 
                 this.Send(rejection);

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -73,7 +73,7 @@ namespace Orleans.Runtime.Placement
             var grainId = message.TargetGrain;
             if (_grainLocator.TryLookupInCache(grainId, out var result))
             {
-                SetMessageTargetPlacement(message, result.ActivationId, result.SiloAddress);
+                SetMessageTargetPlacement(message, result.SiloAddress);
                 return Task.CompletedTask;
             }
 
@@ -84,9 +84,8 @@ namespace Orleans.Runtime.Placement
             static void ThrowMissingAddress() => throw new InvalidOperationException("Cannot address a message without a target");
         }
 
-        private void SetMessageTargetPlacement(Message message, ActivationId activationId, SiloAddress targetSilo)
+        private void SetMessageTargetPlacement(Message message, SiloAddress targetSilo)
         {
-            message.TargetActivation = activationId;
             message.TargetSilo = targetSilo;
 #if DEBUG
             if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace((int)ErrorCode.Dispatcher_AddressMsg_SelectTarget, "AddressMessage Placement SelectTarget {Message}", message);
@@ -269,7 +268,7 @@ namespace Orleans.Runtime.Placement
                     foreach (var message in messages)
                     {
                         var result = resultTask.Result;
-                        _placementService.SetMessageTargetPlacement(message.Message, result.ActivationId, result.SiloAddress);
+                        _placementService.SetMessageTargetPlacement(message.Message, result.SiloAddress);
                         message.Completion.TrySetResult(true);
                     }
 


### PR DESCRIPTION
Fixes #6880

This performance improvement PR removes 48 bytes per message object in memory (2x ActivationId + 2x cached GrainAddress refs), and ~32 bytes on the wire (2x ActivationId).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7813)