### PR TITLE
Messaging: cache encoded `GrainType` and `GrainInterfaceType`

### DIFF
--- a/src/Orleans.Core/Messaging/CachingIdSpanCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingIdSpanCodec.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
+using System.Runtime.InteropServices;
+
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// A serializer for <see cref="IdSpan"/> which caches values and avoids re-encoding and unnecessary allocations.
+    /// </summary>
+    internal sealed class CachingIdSpanCodec
+    {
+        internal static LRU<IdSpan, (IdSpan Value, byte[] Encoded)> SharedCache { get; } = new(maxSize: 128_000, maxAge: TimeSpan.FromHours(1));
+
+        // Purge entries which have not been accessed in over 2 minutes. 
+        private const long PurgeAfterMilliseconds = 2 * 60 * 1000;
+
+        // Scan for entries which are expired every minute
+        private const long GarbageCollectionIntervalMilliseconds = 60 * 1000;
+
+        private readonly Dictionary<int, CacheEntry> _cache = new();
+        private long _lastGarbageCollectionTimestamp;
+
+        public CachingIdSpanCodec()
+        {
+            _lastGarbageCollectionTimestamp = Environment.TickCount64;
+        }
+
+        public IdSpan ReadRaw<TInput>(ref Reader<TInput> reader)
+        {
+            var currentTimestamp = Environment.TickCount64;
+
+            IdSpan result = default;
+            byte[] payloadArray = default;
+            var length = reader.ReadVarInt32();
+            if (length == -1)
+            {
+                return default;
+            }
+
+            if (!reader.TryReadBytes(length, out var payloadSpan))
+            {
+                payloadSpan = payloadArray = reader.ReadBytes((uint)length);
+            }
+
+            var innerReader = Reader.Create(payloadSpan, null);
+            var hashCode = innerReader.ReadInt32();
+
+            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
+            if (exists && new ReadOnlySpan<byte>(cacheEntry.Encoded).SequenceEqual(payloadSpan))
+            {
+                result = cacheEntry.Value;
+                cacheEntry.LastSeen = currentTimestamp;
+            }
+
+            if (!exists || result.IsDefault)
+            {
+                if (payloadArray is null)
+                {
+                    payloadArray = new byte[length];
+                    payloadSpan.CopyTo(payloadArray);
+                }
+
+                result = ReadRawInner(ref innerReader, hashCode);
+
+                // Before adding this value to the private cache and returning it, intern it via the shared cache to hopefully reduce duplicates.
+                (result, _) = SharedCache.GetOrAdd(result, static (encoded, key) => (key, encoded), payloadArray);
+
+                // Update the cache. If there is a hash collision, the last entry wins.
+                cacheEntry = new CacheEntry { Encoded = payloadArray, Value = result, LastSeen = currentTimestamp };
+            }
+
+            // Perform periodic maintenance to prevent unbounded memory leaks.
+            if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
+            {
+                PurgeStaleEntries();
+                _lastGarbageCollectionTimestamp = currentTimestamp;
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void PurgeStaleEntries()
+        {
+            var currentTimestamp = Environment.TickCount64;
+            List<int> purgeKeys = default;
+            foreach (var entry in _cache)
+            {
+                if (currentTimestamp - entry.Value.LastSeen > PurgeAfterMilliseconds)
+                {
+                    purgeKeys ??= new();
+                    purgeKeys.Add(entry.Key);
+                }
+            }
+
+            if (purgeKeys is not null)
+            {
+                foreach (var key in purgeKeys)
+                {
+                    _cache.Remove(key);
+                }
+            }
+        }
+
+        public void WriteRaw<TBufferWriter>(ref Writer<TBufferWriter> writer, IdSpan value) where TBufferWriter : IBufferWriter<byte>
+        {
+            var currentTimestamp = Environment.TickCount64;
+            if (value.IsDefault)
+            {
+                writer.WriteVarInt32(-1);
+                return;
+            }
+
+            var hashCode = value.GetHashCode();
+            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
+            if (exists && value.Equals(cacheEntry.Value))
+            {
+                writer.WriteVarInt32(cacheEntry.Encoded.Length);
+                writer.Write(cacheEntry.Encoded);
+
+                cacheEntry.LastSeen = currentTimestamp;
+
+                // Perform periodic maintenance to prevent unbounded memory leaks.
+                if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
+                {
+                    PurgeStaleEntries();
+                    _lastGarbageCollectionTimestamp = currentTimestamp;
+                }
+
+                return;
+            }
+
+            var innerWriter = Writer.Create(new PooledArrayBufferWriter(), null);
+            innerWriter.WriteInt32(value.GetHashCode());
+            WriteRawInner(ref innerWriter, value);
+            innerWriter.Commit();
+
+            writer.WriteVarInt32((int)innerWriter.Output.Length);
+            innerWriter.Output.CopyTo(ref writer);
+            var payloadArray = innerWriter.Output.ToArray();
+            innerWriter.Dispose();
+
+            // Before adding this value to the private cache, intern it via the shared cache to hopefully reduce duplicates.
+            (_, payloadArray) = SharedCache.GetOrAdd(value, static (encoded, key) => (key, encoded), payloadArray);
+
+            // If there is a hash collision, then the last seen entry will always win.
+            cacheEntry = new CacheEntry { Encoded = payloadArray, Value = value, LastSeen = currentTimestamp };
+        }
+
+        /// <summary>
+        /// Writes an <see cref="IdSpan"/> value to the provided writer without field framing.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="value">The value to write.</param>
+        /// <typeparam name="TBufferWriter">The underlying buffer writer type.</typeparam>
+        private static void WriteRawInner<TBufferWriter>(
+            ref Writer<TBufferWriter> writer,
+            IdSpan value)
+            where TBufferWriter : IBufferWriter<byte>
+        {
+            var bytes = IdSpan.UnsafeGetArray(value);
+            var bytesLength = value.IsDefault ? 0 : bytes.Length;
+            writer.WriteVarUInt32((uint)bytesLength);
+            writer.Write(bytes);
+        }
+
+        /// <summary>
+        /// Reads an <see cref="IdSpan"/> value from a reader without any field framing.
+        /// </summary>
+        /// <typeparam name="TInput">The underlying reader input type.</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <param name="hashCode">The hash code for the span.</param>
+        /// <returns>An <see cref="IdSpan"/>.</returns>
+        private static IdSpan ReadRawInner<TInput>(ref Reader<TInput> reader, int hashCode)
+        {
+            var length = reader.ReadVarUInt32();
+            var payloadArray = reader.ReadBytes(length);
+            var value = IdSpan.UnsafeCreate(payloadArray, hashCode);
+            return value;
+        }
+
+        private struct CacheEntry
+        {
+            public byte[] Encoded { get; set; }
+            public IdSpan Value { get; set; }
+            public long LastSeen { get; set; }
+        }
+    }
+}

--- a/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.CompilerServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
+using System.Runtime.InteropServices;
+
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// A serializer for <see cref="SiloAddress"/> which caches values and avoids re-encoding and unnecessary allocations.
+    /// </summary>
+    internal sealed class CachingSiloAddressCodec
+    {
+        internal static LRU<SiloAddress, (SiloAddress Value, byte[] Encoded)> SharedCache { get; } = new(maxSize: 128_000, maxAge: TimeSpan.FromHours(1));
+
+        // Purge entries which have not been accessed in over 2 minutes.
+        private const long PurgeAfterMilliseconds = 2 * 60 * 1000;
+
+        // Scan for entries which are expired every minute
+        private const long GarbageCollectionIntervalMilliseconds = 60 * 1000;
+
+        private readonly Dictionary<int, CacheEntry> _cache = new();
+        private long _lastGarbageCollectionTimestamp;
+
+        public CachingSiloAddressCodec()
+        {
+            _lastGarbageCollectionTimestamp = Environment.TickCount64;
+        }
+
+        public SiloAddress ReadRaw<TInput>(ref Reader<TInput> reader)
+        {
+            var currentTimestamp = Environment.TickCount64;
+
+            SiloAddress result = null;
+            byte[] payloadArray = default;
+            var length = reader.ReadVarInt32();
+            if (length == -1)
+            {
+                return null;
+            }
+
+            if (!reader.TryReadBytes(length, out var payloadSpan))
+            {
+                payloadSpan = payloadArray = reader.ReadBytes((uint)length);
+            }
+
+            var innerReader = Reader.Create(payloadSpan, null);
+            var hashCode = innerReader.ReadInt32();
+
+            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
+            if (exists && new ReadOnlySpan<byte>(cacheEntry.Encoded).SequenceEqual(payloadSpan))
+            {
+                result = cacheEntry.Value;
+                cacheEntry.LastSeen = currentTimestamp;
+            }
+
+            if (result is null)
+            {
+                if (payloadArray is null)
+                {
+                    payloadArray = new byte[length];
+                    payloadSpan.CopyTo(payloadArray);
+                }
+
+                result = ReadSiloAddressInner(ref innerReader);
+                result.InternalSetConsistentHashCode(hashCode);
+
+                // Before adding this value to the private cache and returning it, intern it via the shared cache to hopefully reduce duplicates.
+                (result, _) = SharedCache.GetOrAdd(result, static (encoded, key) => (key, encoded), payloadArray);
+
+                // If there is a hash collision, then the last seen entry will always win.
+                cacheEntry = new CacheEntry { Encoded = payloadArray, Value = result, LastSeen = currentTimestamp };
+            }
+
+            // Perform periodic maintenance to prevent unbounded memory leaks.
+            if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
+            {
+                PurgeStaleEntries();
+                _lastGarbageCollectionTimestamp = currentTimestamp;
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void PurgeStaleEntries()
+        {
+            var currentTimestamp = Environment.TickCount64;
+            List<int> purgeKeys = default;
+            foreach (var entry in _cache)
+            {
+                if (currentTimestamp - entry.Value.LastSeen > PurgeAfterMilliseconds)
+                {
+                    purgeKeys ??= new();
+                    purgeKeys.Add(entry.Key);
+                }
+            }
+
+            if (purgeKeys is not null)
+            {
+                foreach (var key in purgeKeys)
+                {
+                    _cache.Remove(key);
+                }
+            }
+        }
+
+        private static SiloAddress ReadSiloAddressInner<TInput>(ref Reader<TInput> reader)
+        {
+            IPAddress ip;
+            var length = reader.ReadVarInt32();
+#if NET5_0_OR_GREATER
+            if (reader.TryReadBytes(length, out var bytes))
+            {
+                ip = new IPAddress(bytes);
+            }
+            else
+            {
+#endif
+                var addressBytes = reader.ReadBytes((uint)length);
+                ip = new IPAddress(addressBytes);
+#if NET5_0_OR_GREATER
+            }
+#endif
+            var port = (int)reader.ReadVarUInt32();
+            var generation = reader.ReadInt32();
+
+            return SiloAddress.New(new IPEndPoint(ip, port), generation);
+        }
+
+        public void WriteRaw<TBufferWriter>(ref Writer<TBufferWriter> writer, SiloAddress value) where TBufferWriter : IBufferWriter<byte>
+        {
+            var currentTimestamp = Environment.TickCount64;
+            if (value is null)
+            {
+                writer.WriteVarInt32(-1);
+                return;
+            }
+
+            var hashCode = value.GetConsistentHashCode();
+            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
+            if (exists && value.Equals(cacheEntry.Value))
+            {
+                writer.WriteVarInt32(cacheEntry.Encoded.Length);
+                writer.Write(cacheEntry.Encoded);
+
+                cacheEntry.LastSeen = currentTimestamp;
+
+                // Perform periodic maintenance to prevent unbounded memory leaks.
+                if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
+                {
+                    PurgeStaleEntries();
+                    _lastGarbageCollectionTimestamp = currentTimestamp;
+                }
+
+                return;
+            }
+
+            var innerWriter = Writer.Create(new PooledArrayBufferWriter(), null);
+            innerWriter.WriteInt32(value.GetConsistentHashCode());
+            WriteSiloAddressInner(ref innerWriter, value);
+            innerWriter.Commit();
+
+            writer.WriteVarInt32((int)innerWriter.Output.Length);
+            innerWriter.Output.CopyTo(ref writer);
+            var payloadArray = innerWriter.Output.ToArray();
+            innerWriter.Dispose();
+
+            // Before adding this value to the private cache, intern it via the shared cache to hopefully reduce duplicates.
+            (_, payloadArray) = SharedCache.GetOrAdd(value, static (encoded, key) => (key, encoded), payloadArray);
+
+            // If there is a hash collision, then the last seen entry will always win.
+            cacheEntry = new CacheEntry { Encoded = payloadArray, Value = value, LastSeen = currentTimestamp };
+        }
+
+        private static void WriteSiloAddressInner<TBufferWriter>(ref Writer<TBufferWriter> writer, SiloAddress value) where TBufferWriter : IBufferWriter<byte>
+        {
+#if NET5_0_OR_GREATER
+            var ep = value.Endpoint;
+            Span<byte> buffer = stackalloc byte[64];
+            if (ep.Address.TryWriteBytes(buffer, out var length))
+            {
+                var writable = writer.WritableSpan;
+                if (writable.Length > length)
+                {
+                    // IP
+                    writer.WriteVarInt32(length);
+                    buffer.Slice(0, length).CopyTo(writable[1..]);
+                    writer.AdvanceSpan(length);
+
+                    // Port
+                    writer.WriteVarUInt32((uint)ep.Port);
+
+                    // Generation
+                    writer.WriteInt32(value.Generation);
+
+                    return;
+                }
+            }
+#endif
+
+            // IP
+            var bytes = ep.Address.GetAddressBytes();
+            writer.WriteVarInt32(bytes.Length);
+            writer.Write(bytes);
+
+            // Port
+            writer.WriteVarUInt32((uint)ep.Port);
+
+            // Generation
+            writer.WriteInt32(value.Generation);
+        }
+
+        private struct CacheEntry
+        {
+            public byte[] Encoded { get; set; }
+            public SiloAddress Value { get; set; }
+            public long LastSeen { get; set; }
+        }
+    }
+}

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,12 +14,6 @@ using Orleans.Serialization.Codecs;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Utilities;
-using Orleans.Serialization.WireProtocol;
-using Orleans.Runtime.Serialization;
-using Orleans.Utilities;
-using Orleans.Serialization.Buffers.Adaptors;
-using System.Runtime.InteropServices;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -30,8 +23,10 @@ namespace Orleans.Runtime.Messaging
         private const int MessageSizeHint = 4096;
         private readonly Serializer<object> _bodySerializer;
         private readonly Serializer<GrainAddress> _activationAddressCodec;
-        private readonly CachingSiloAddressCodec _readerSiloAddressCachingCodec;
-        private readonly CachingSiloAddressCodec _writerSiloAddressCachingCodec;
+        private readonly CachingSiloAddressCodec _readerSiloAddressCodec;
+        private readonly CachingSiloAddressCodec _writerSiloAddressCodec;
+        private readonly CachingIdSpanCodec _readerIdSpanCodec;
+        private readonly CachingIdSpanCodec _writerIdSpanCodec;
         private readonly Serializer _serializer;
         private readonly SerializerSession _serializationSession;
         private readonly SerializerSession _deserializationSession;
@@ -52,8 +47,10 @@ namespace Orleans.Runtime.Messaging
             int maxHeaderSize,
             int maxBodySize)
         {
-            _readerSiloAddressCachingCodec = new CachingSiloAddressCodec();
-            _writerSiloAddressCachingCodec = new CachingSiloAddressCodec();
+            _readerSiloAddressCodec = new CachingSiloAddressCodec();
+            _writerSiloAddressCodec = new CachingSiloAddressCodec();
+            _readerIdSpanCodec = new CachingIdSpanCodec();
+            _writerIdSpanCodec = new CachingIdSpanCodec();
             _serializer = ActivatorUtilities.CreateInstance<Serializer>(services);
             _activationAddressCodec = activationAddressSerializer;
             _serializationSession = sessionPool.GetSession();
@@ -254,7 +251,7 @@ namespace Orleans.Runtime.Messaging
 
             if ((headers & Headers.SENDING_SILO) != Headers.NONE)
             {
-                _writerSiloAddressCachingCodec.WriteRaw(ref writer, value.SendingSilo);
+                _writerSiloAddressCodec.WriteRaw(ref writer, value.SendingSilo);
             }
 
             if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
@@ -274,12 +271,12 @@ namespace Orleans.Runtime.Messaging
 
             if ((headers & Headers.TARGET_SILO) != Headers.NONE)
             {
-                _writerSiloAddressCachingCodec.WriteRaw(ref writer, value.TargetSilo);
+                _writerSiloAddressCodec.WriteRaw(ref writer, value.TargetSilo);
             }
 
             if ((headers & Headers.INTERFACE_TYPE) != Headers.NONE)
             {
-                IdSpanCodec.WriteRaw(ref writer, value.InterfaceType.Value);
+                _writerIdSpanCodec.WriteRaw(ref writer, value.InterfaceType.Value);
             }
 
             // Always write RequestContext last
@@ -348,7 +345,7 @@ namespace Orleans.Runtime.Messaging
 
             if ((headers & Headers.SENDING_SILO) != Headers.NONE)
             {
-                result.SendingSilo = _readerSiloAddressCachingCodec.ReadRaw(ref reader);
+                result.SendingSilo = _readerSiloAddressCodec.ReadRaw(ref reader);
             }
 
             if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
@@ -368,12 +365,12 @@ namespace Orleans.Runtime.Messaging
 
             if ((headers & Headers.TARGET_SILO) != Headers.NONE)
             {
-                result.TargetSilo = _readerSiloAddressCachingCodec.ReadRaw(ref reader);
+                result.TargetSilo = _readerSiloAddressCodec.ReadRaw(ref reader);
             }
 
             if ((headers & Headers.INTERFACE_TYPE) != Headers.NONE)
             {
-                var interfaceTypeSpan = IdSpanCodec.ReadRaw(ref reader);
+                var interfaceTypeSpan = _readerIdSpanCodec.ReadRaw(ref reader);
                 result.InterfaceType = new GrainInterfaceType(interfaceTypeSpan);
             }
 
@@ -502,16 +499,16 @@ namespace Orleans.Runtime.Messaging
             return result;
         }
 
-        private static GrainId ReadGrainId<TInput>(ref Reader<TInput> reader)
+        private GrainId ReadGrainId<TInput>(ref Reader<TInput> reader)
         {
-            var grainType = IdSpanCodec.ReadRaw(ref reader);
+            var grainType = _readerIdSpanCodec.ReadRaw(ref reader);
             var grainKey = IdSpanCodec.ReadRaw(ref reader);
             return new GrainId(new GrainType(grainType), grainKey);
         }
 
-        private static void WriteGrainId<TBufferWriter>(ref Writer<TBufferWriter> writer, GrainId value) where TBufferWriter : IBufferWriter<byte>
+        private void WriteGrainId<TBufferWriter>(ref Writer<TBufferWriter> writer, GrainId value) where TBufferWriter : IBufferWriter<byte>
         {
-            IdSpanCodec.WriteRaw(ref writer, value.Type.Value);
+            _writerIdSpanCodec.WriteRaw(ref writer, value.Type.Value);
             IdSpanCodec.WriteRaw(ref writer, value.Key);
         }
 
@@ -553,219 +550,6 @@ namespace Orleans.Runtime.Messaging
             }
 
             writer.Write(value.Key.ToByteArray());
-        }
-    }
-
-    /// <summary>
-    /// A serializer for <see cref="SiloAddress"/> which caches values and avoids re-encoding and unnecessary allocations.
-    /// </summary>
-    internal sealed class CachingSiloAddressCodec
-    {
-        internal static LRU<SiloAddress, (SiloAddress Value, byte[] Encoded)> SharedCache { get; } = new(maxSize: 128_000, maxAge: TimeSpan.FromHours(1));
-
-        // Purge entries which have not been accessed in over 2 minutes.
-        private const long PurgeAfterMilliseconds = 2 * 60 * 1000;
-
-        // Scan for entries which are expired every minute
-        private const long GarbageCollectionIntervalMilliseconds = 60 * 1000;
-
-        private readonly Dictionary<int, CacheEntry> _cache = new();
-        private long _lastGarbageCollectionTimestamp;
-
-        public CachingSiloAddressCodec()
-        {
-            _lastGarbageCollectionTimestamp = Environment.TickCount64;
-        }
-
-        public SiloAddress ReadRaw<TInput>(ref Reader<TInput> reader)
-        {
-            var currentTimestamp = Environment.TickCount64;
-
-            SiloAddress result = null;
-            byte[] payloadArray = default;
-            var length = reader.ReadVarInt32();
-            if (length == -1)
-            {
-                return null;
-            }
-
-            if (!reader.TryReadBytes(length, out var payloadSpan))
-            {
-                payloadSpan = payloadArray = reader.ReadBytes((uint)length);
-            }
-
-            var innerReader = Reader.Create(payloadSpan, null);
-            var hashCode = innerReader.ReadInt32();
-
-            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
-            if (exists && new ReadOnlySpan<byte>(cacheEntry.Encoded).SequenceEqual(payloadSpan))
-            {
-                result = cacheEntry.Value;
-                cacheEntry.LastSeen = currentTimestamp;
-            }
-
-            if (result is null)
-            {
-                if (payloadArray is null)
-                {
-                    payloadArray = new byte[length];
-                    payloadSpan.CopyTo(payloadArray);
-                }
-
-                result = ReadSiloAddressInner(ref innerReader);
-                result.InternalSetConsistentHashCode(hashCode);
-
-                // Before adding this value to the private cache and returning it, intern it via the shared cache to hopefully reduce duplicates.
-                (result, _) = SharedCache.GetOrAdd(result, static (encoded, key) => (key, encoded), payloadArray);
-
-                // If there is a hash collision, then the last seen entry will always win.
-                cacheEntry = new CacheEntry { Encoded = payloadArray, Value = result, LastSeen = currentTimestamp };
-            }
-
-            // Perform periodic maintenance to prevent unbounded memory leaks.
-            if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
-            {
-                PurgeStaleEntries();
-                _lastGarbageCollectionTimestamp = currentTimestamp;
-            }
-
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void PurgeStaleEntries()
-        {
-            var currentTimestamp = Environment.TickCount64;
-            List<int> purgeKeys = default;
-            foreach (var entry in _cache)
-            {
-                if (currentTimestamp - entry.Value.LastSeen > PurgeAfterMilliseconds)
-                {
-                    purgeKeys ??= new();
-                    purgeKeys.Add(entry.Key);
-                }
-            }
-
-            if (purgeKeys is not null)
-            {
-                foreach (var key in purgeKeys)
-                {
-                    _cache.Remove(key);
-                }
-            }
-        }
-
-        private static SiloAddress ReadSiloAddressInner<TInput>(ref Reader<TInput> reader)
-        {
-            IPAddress ip;
-            var length = reader.ReadVarInt32();
-#if NET5_0_OR_GREATER
-            if (reader.TryReadBytes(length, out var bytes))
-            {
-                ip = new IPAddress(bytes);
-            }
-            else
-            {
-#endif
-                var addressBytes = reader.ReadBytes((uint)length);
-                ip = new IPAddress(addressBytes);
-#if NET5_0_OR_GREATER
-            }
-#endif
-            var port = (int)reader.ReadVarUInt32();
-            var generation = reader.ReadInt32();
-
-            return SiloAddress.New(new IPEndPoint(ip, port), generation);
-        }
-
-        public void WriteRaw<TBufferWriter>(ref Writer<TBufferWriter> writer, SiloAddress value) where TBufferWriter : IBufferWriter<byte>
-        {
-            var currentTimestamp = Environment.TickCount64;
-            if (value is null)
-            {
-                writer.WriteVarInt32(-1);
-                return;
-            }
-
-            var hashCode = value.GetConsistentHashCode();
-            ref var cacheEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, hashCode, out var exists);
-            if (exists && value.Equals(cacheEntry.Value))
-            {
-                writer.WriteVarInt32(cacheEntry.Encoded.Length);
-                writer.Write(cacheEntry.Encoded);
-
-                cacheEntry.LastSeen = currentTimestamp;
-
-                // Perform periodic maintenance to prevent unbounded memory leaks.
-                if (currentTimestamp - _lastGarbageCollectionTimestamp > GarbageCollectionIntervalMilliseconds)
-                {
-                    PurgeStaleEntries();
-                    _lastGarbageCollectionTimestamp = currentTimestamp;
-                }
-
-                return;
-            }
-
-            var innerWriter = Writer.Create(new PooledArrayBufferWriter(), null);
-            innerWriter.WriteInt32(value.GetConsistentHashCode());
-            WriteSiloAddressInner(ref innerWriter, value);
-            innerWriter.Commit();
-
-            writer.WriteVarInt32((int)innerWriter.Output.Length);
-            innerWriter.Output.CopyTo(ref writer);
-            var payloadArray = innerWriter.Output.ToArray();
-            innerWriter.Dispose();
-
-            // Before adding this value to the private cache, intern it via the shared cache to hopefully reduce duplicates.
-            (_, payloadArray) = SharedCache.GetOrAdd(value, static (encoded, key) => (key, encoded), payloadArray);
-
-            // If there is a hash collision, then the last seen entry will always win.
-            cacheEntry = new CacheEntry { Encoded = payloadArray, Value = value, LastSeen = currentTimestamp };
-        }
-
-        private static void WriteSiloAddressInner<TBufferWriter>(ref Writer<TBufferWriter> writer, SiloAddress value) where TBufferWriter : IBufferWriter<byte>
-        {
-#if NET5_0_OR_GREATER
-            var ep = value.Endpoint;
-            Span<byte> buffer = stackalloc byte[64];
-            if (ep.Address.TryWriteBytes(buffer, out var length))
-            {
-                var writable = writer.WritableSpan;
-                if (writable.Length > length)
-                {
-                    // IP
-                    writer.WriteVarInt32(length);
-                    buffer.Slice(0, length).CopyTo(writable[1..]);
-                    writer.AdvanceSpan(length);
-
-                    // Port
-                    writer.WriteVarUInt32((uint)ep.Port);
-
-                    // Generation
-                    writer.WriteInt32(value.Generation);
-
-                    return;
-                }
-            }
-#endif
-
-            // IP
-            var bytes = ep.Address.GetAddressBytes();
-            writer.WriteVarInt32(bytes.Length);
-            writer.Write(bytes);
-
-            // Port
-            writer.WriteVarUInt32((uint)ep.Port);
-
-            // Generation
-            writer.WriteInt32(value.Generation);
-        }
-
-        private struct CacheEntry
-        {
-            public byte[] Encoded { get; set; }
-            public SiloAddress Value { get; set; }
-            public long LastSeen { get; set; }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #7816, extending the same optimization to `IdSpan` for the two abovementioned types which are backed by `IdSpan`

I verified that there are no changes to `CachingSiloAddressCodec`, it's just a move into a separate file for organization.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7821)