### PR TITLE
Reduce transcoding and allocations for JSON serializer

### DIFF
--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -516,12 +516,12 @@ namespace Orleans.Runtime.Messaging
         {
             if (reader.ReadByte() == 0)
             {
-                return ActivationId.Zero;
+                return default;
             }
 
             if (reader.TryReadBytes(16, out var readOnly))
             {
-                return ActivationId.GetActivationId(new Guid(readOnly));
+                return new(new Guid(readOnly));
             }
 
             Span<byte> bytes = stackalloc byte[16];
@@ -530,7 +530,7 @@ namespace Orleans.Runtime.Messaging
                 bytes[i] = reader.ReadByte();
             }
 
-            return ActivationId.GetActivationId(new Guid(bytes));
+            return new(new Guid(bytes));
         }
 
         private static void WriteActivationId<TBufferWriter>(ref Writer<TBufferWriter> writer, ActivationId value) where TBufferWriter : IBufferWriter<byte>

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime.GrainDirectory
     internal class GrainDirectoryResolver
     {
         private readonly Dictionary<string, IGrainDirectory> directoryPerName = new Dictionary<string, IGrainDirectory>();
-        private readonly ConcurrentDictionary<GrainType, IGrainDirectory> directoryPerType = new ConcurrentDictionary<GrainType, IGrainDirectory>(GrainType.Comparer.Instance);
+        private readonly ConcurrentDictionary<GrainType, IGrainDirectory> directoryPerType = new();
         private readonly GrainPropertiesResolver grainPropertiesResolver;
         private readonly IGrainDirectoryResolver[] resolvers;
         private readonly Func<GrainType, IGrainDirectory> getGrainDirectoryInternal;

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime.GrainDirectory
 {
     internal class GrainLocatorResolver
     {
-        private readonly ConcurrentDictionary<GrainType, IGrainLocator> resolvedLocators = new(GrainType.Comparer.Instance);
+        private readonly ConcurrentDictionary<GrainType, IGrainLocator> resolvedLocators = new();
         private readonly Func<GrainType, IGrainLocator> getLocatorInternal;
         private readonly IServiceProvider _servicesProvider;
         private readonly GrainDirectoryResolver grainDirectoryResolver;

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.Messaging
             // so every GW needs to behave as a different "activation" with a different ActivationId (its not enough that they have different SiloAddress)
             string stringToHash = clientId.ToString() + siloAddress.Endpoint + siloAddress.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);
             Guid hash = Utils.CalculateGuidHash(stringToHash);
-            var activationId = ActivationId.GetActivationId(hash);
+            var activationId = new ActivationId(hash);
             return GrainAddress.GetAddress(siloAddress, clientId, activationId);
         }
 

--- a/src/Orleans.Runtime/Placement/PlacementStrategyResolver.cs
+++ b/src/Orleans.Runtime/Placement/PlacementStrategyResolver.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime.Placement
     /// </summary>
     public sealed class PlacementStrategyResolver
     {
-        private readonly ConcurrentDictionary<GrainType, PlacementStrategy> _resolvedStrategies = new ConcurrentDictionary<GrainType, PlacementStrategy>(GrainType.Comparer.Instance);
+        private readonly ConcurrentDictionary<GrainType, PlacementStrategy> _resolvedStrategies = new();
         private readonly Func<GrainType, PlacementStrategy> _getStrategyInternal;
         private readonly IPlacementStrategyResolver[] _resolvers;
         private readonly IServiceProvider _services;


### PR DESCRIPTION
* Reduce transcoding of UTF16 to UTF8 by writing UTF8 directly using `WriteStringValue`.
* Reduce allocations when preparing and parsing serialized values.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7835)