### PR TITLE
Avoid accessing Assembly file path when publishing as a single file

### DIFF
--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -14,6 +14,10 @@ namespace Orleans.Runtime
             get
             {
                 Assembly thisProg = typeof(RuntimeVersion).Assembly;
+                if(string.IsNullOrWhiteSpace(thisProg.Location))
+                {
+                    return ApiVersion;
+                }
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
                 bool isDebug = IsAssemblyDebugBuild(thisProg);
                 string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
@@ -41,6 +45,10 @@ namespace Orleans.Runtime
             get
             {
                 Assembly thisProg = typeof(RuntimeVersion).Assembly;
+                if (string.IsNullOrWhiteSpace(thisProg.Location))
+                {
+                    return ApiVersion;
+                }
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
                 string fileVersion = progVersionInfo.FileVersion;
                 return string.IsNullOrEmpty(fileVersion) ? ApiVersion : fileVersion;

--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
             get
             {
                 Assembly thisProg = typeof(RuntimeVersion).Assembly;
-                if(string.IsNullOrWhiteSpace(thisProg.Location))
+                if (string.IsNullOrWhiteSpace(thisProg.Location))
                 {
                     return ApiVersion;
                 }


### PR DESCRIPTION
Exception encountered when running a client in Kubernetes
` System.ArgumentException: The path is empty. (Parameter 'path') 
 at System.IO.Path.GetFullPath(String path) 
 at System.Diagnostics.FileVersionInfo.GetVersionInfo(String fileName) 
 at Orleans.Runtime.RuntimeVersion.get_Current() in /_/src/Orleans.Core/Runtime/RuntimeVersion.cs:line 17 
 at Orleans.OutsideRuntimeClient.ConsumeServices(IServiceProvider services) in /_/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs:line 156 
 at Orleans.ClientBuilder.Build() in /_/src/Orleans.Core/Core/ClientBuilder.cs:line 63`

The application is built as follows:

`dotnet publish my.csproj -c Release  --runtime linux-musl-x64 -p:PublishSingleFile=true --self-contained -p:PublishReadyToRun=true   -o /app/publish`

Error seems related to https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000

Suggesting that application can still run if `Assembly.Location` is an empty string

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7841)