### PR TITLE
GrainDirectory simplification

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
@@ -78,15 +78,9 @@ namespace Orleans.Runtime
 
         public override int GetHashCode() => HashCode.Combine(this.SiloAddress, this.GrainId, this.ActivationId);
 
-        public string ToFullString()
-        {
-            return
-                String.Format(
-                    "[GrainAddress: {0}, Full GrainId: {1}, Full ActivationId: {2}]",
-                    this.ToString(),                        // 0
-                    this.GrainId.ToString(),                  // 1
-                    this.ActivationId.ToParsableString());        // 2
-        }
+        public override string ToString() => $"[{nameof(GrainAddress)} GrainId {GrainId.ToString()}, ActivationId: {ActivationId.ToParsableString()}, SiloAddress: {SiloAddress.ToParsableString()}]";
+
+        public string ToFullString() => $"[{nameof(GrainAddress)} GrainId {GrainId.ToString()}, ActivationId: {ActivationId.ToParsableString()}, SiloAddress: {SiloAddress.ToParsableString()}, MembershipVersion: {MembershipVersion}]";
 
         internal static GrainAddress NewActivationAddress(SiloAddress silo, GrainId grain)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Scheduler;
 
+#nullable enable
 namespace Orleans.Runtime.GrainDirectory
 {
     /// <summary>
@@ -58,9 +59,9 @@ namespace Orleans.Runtime.GrainDirectory
                 if (!directoryPartitionsMap.TryGetValue(removedSilo, out var partition)) return;
 
                 // at least one predcessor should exist, which is me
-                SiloAddress predecessor = localDirectory.FindPredecessor(removedSilo);
+                var predecessor = localDirectory.FindPredecessor(removedSilo);
                 Debug.Assert(predecessor is not null);
-                Dictionary<SiloAddress, List<GrainAddress>> duplicates;
+                Dictionary<SiloAddress, List<GrainAddress>>? duplicates;
                 if (localDirectory.MyAddress.Equals(predecessor))
                 {
                     if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Merging my partition with the copy of silo {RemovedSilo}", removedSilo);
@@ -91,10 +92,11 @@ namespace Orleans.Runtime.GrainDirectory
                 // Reset our follower list to take the changes into account
                 ResetFollowers();
 
-                // check if this is the immediate successors (i.e., if I should hold this silo's copy)
+                // check if this is our immediate successor (i.e., if I should hold this silo's copy)
                 // (if yes, adjust local and/or copied directory partitions by splitting them between old successors and the new one)
                 // NOTE: We need to move part of our local directory to the new silo if it is an immediate successor.
                 var successor = localDirectory.FindSuccessor(localDirectory.MyAddress);
+                Debug.Assert(successor is not null);
                 if (!successor.Equals(addedSilo))
                 {
                     if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("{AddedSilo} is not my immediate successor.", addedSilo);
@@ -286,7 +288,7 @@ namespace Orleans.Runtime.GrainDirectory
                 .Ignore();
         }
 
-        private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<GrainAddress>> duplicates)
+        private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<GrainAddress>>? duplicates)
         {
             if (duplicates == null || duplicates.Count == 0) return;
             this.EnqueueOperation(

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -96,8 +96,7 @@ namespace Orleans.Runtime.GrainDirectory
                 // (if yes, adjust local and/or copied directory partitions by splitting them between old successors and the new one)
                 // NOTE: We need to move part of our local directory to the new silo if it is an immediate successor.
                 var successor = localDirectory.FindSuccessor(localDirectory.MyAddress);
-                Debug.Assert(successor is not null);
-                if (!successor.Equals(addedSilo))
+                if (successor is null || !successor.Equals(addedSilo))
                 {
                     if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("{AddedSilo} is not my immediate successor.", addedSilo);
                     return;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
 
+#nullable enable
 namespace Orleans.Runtime.GrainDirectory
 {
     [Serializable]
@@ -14,7 +15,7 @@ namespace Orleans.Runtime.GrainDirectory
     {
         public const int NO_ETAG = -1;
 
-        public GrainAddress Activation { get; private set; }
+        public GrainAddress? Activation { get; private set; }
 
         public DateTime TimeCreated { get; private set; }
 
@@ -69,7 +70,7 @@ namespace Orleans.Runtime.GrainDirectory
             return wasRemoved;
         }
 
-        public GrainAddress Merge(GrainInfo other)
+        public GrainAddress? Merge(GrainInfo other)
         {
             var otherActivation = other.Activation;
             if (otherActivation is not null && Activation is null)
@@ -256,9 +257,9 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         /// <param name="other"></param>
         /// <returns>Activations which must be deactivated.</returns>
-        internal Dictionary<SiloAddress, List<GrainAddress>> Merge(GrainDirectoryPartition other)
+        internal Dictionary<SiloAddress, List<GrainAddress>>? Merge(GrainDirectoryPartition other)
         {
-            Dictionary<SiloAddress, List<GrainAddress>> activationsToRemove = null;
+            Dictionary<SiloAddress, List<GrainAddress>>? activationsToRemove = null;
             lock (lockable)
             {
                 foreach (var pair in other.partitionData)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -6,37 +6,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
-using Orleans.Internal;
 
 namespace Orleans.Runtime.GrainDirectory
 {
     [Serializable]
-    internal class ActivationInfo
-    {
-        public SiloAddress SiloAddress { get; private set; }
-
-        public DateTime TimeCreated { get; private set; }
-
-        public ActivationInfo(SiloAddress siloAddress)
-        {
-            SiloAddress = siloAddress;
-            TimeCreated = DateTime.UtcNow;
-        }
-
-        public ActivationInfo(ActivationInfo iActivationInfo)
-        {
-            SiloAddress = iActivationInfo.SiloAddress;
-            TimeCreated = iActivationInfo.TimeCreated;
-        }
-
-        public override string ToString()
-        {
-            return String.Format("{0}, {1}", SiloAddress, TimeCreated);
-        }
-    }
-
-    [Serializable]
-    internal class GrainInfo
+    internal sealed class GrainInfo
     {
         public const int NO_ETAG = -1;
 
@@ -77,7 +51,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 Activation = address;
                 TimeCreated = DateTime.UtcNow;
-                VersionTag = ThreadSafeRandom.Next();
+                VersionTag = Random.Shared.Next();
                 return address;
             }
         }
@@ -85,11 +59,11 @@ namespace Orleans.Runtime.GrainDirectory
         public bool RemoveActivation(ActivationId act, UnregistrationCause cause, TimeSpan lazyDeregistrationDelay, out bool wasRemoved)
         {
             wasRemoved = false;
-            if (Activation is { } existing  && existing.ActivationId.Equals(act) && OkToRemove(cause, lazyDeregistrationDelay))
+            if (Activation is { } existing && existing.ActivationId.Equals(act) && OkToRemove(cause, lazyDeregistrationDelay))
             {
                 wasRemoved = true;
                 Activation = null;
-                VersionTag = ThreadSafeRandom.Next();
+                VersionTag = Random.Shared.Next();
             }
 
             return wasRemoved;
@@ -102,9 +76,9 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 Activation = other.Activation;
                 TimeCreated = other.TimeCreated;
-                VersionTag = ThreadSafeRandom.Next();
+                VersionTag = Random.Shared.Next();
             }
-            else if (Activation is not null && otherActivation is not null) 
+            else if (Activation is not null && otherActivation is not null)
             {
                 // Grain is supposed to be in single activation mode, but we have two activations!!
                 // Eventually we should somehow delegate handling this to the silo, but for now, we'll arbitrarily pick one value.
@@ -113,7 +87,7 @@ namespace Orleans.Runtime.GrainDirectory
                     var activationToDrop = Activation;
                     Activation = otherActivation;
                     TimeCreated = other.TimeCreated;
-                    VersionTag = ThreadSafeRandom.Next();
+                    VersionTag = Random.Shared.Next();
                     return activationToDrop;
                 }
 
@@ -125,7 +99,7 @@ namespace Orleans.Runtime.GrainDirectory
         }
     }
 
-    internal class GrainDirectoryPartition
+    internal sealed class GrainDirectoryPartition
     {
         // Should we change this to SortedList<> or SortedDictionary so we can extract chunks better for shipping the full
         // parition to a follower, or should we leave it as a Dictionary to get O(1) lookups instead of O(log n), figuring we do
@@ -136,22 +110,18 @@ namespace Orleans.Runtime.GrainDirectory
         private Dictionary<GrainId, GrainInfo> partitionData;
         private readonly object lockable;
         private readonly ILogger log;
-        private readonly ILoggerFactory loggerFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
-        private readonly IInternalGrainFactory grainFactory;
         private readonly IOptions<GrainDirectoryOptions> grainDirectoryOptions;
 
         internal int Count { get { return partitionData.Count; } }
 
-        public GrainDirectoryPartition(ISiloStatusOracle siloStatusOracle, IOptions<GrainDirectoryOptions> grainDirectoryOptions, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory)
+        public GrainDirectoryPartition(ISiloStatusOracle siloStatusOracle, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
         {
             partitionData = new Dictionary<GrainId, GrainInfo>();
             lockable = new object();
             log = loggerFactory.CreateLogger<GrainDirectoryPartition>();
             this.siloStatusOracle = siloStatusOracle;
             this.grainDirectoryOptions = grainDirectoryOptions;
-            this.grainFactory = grainFactory;
-            this.loggerFactory = loggerFactory;
         }
 
         private bool IsValidSilo(SiloAddress silo)
@@ -183,11 +153,9 @@ namespace Orleans.Runtime.GrainDirectory
         /// Adds a new activation to the directory partition
         /// </summary>
         /// <returns>The registered ActivationAddress and version associated with this directory mapping</returns>
-        internal virtual AddressAndTag AddSingleActivation(GrainAddress address)
+        internal AddressAndTag AddSingleActivation(GrainAddress address)
         {
             if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Adding single activation for grain {SiloAddress} {GrainId} {ActivationId}", address.SiloAddress, address.GrainId, address.ActivationId);
-
-            AddressAndTag result = new AddressAndTag();
 
             if (!IsValidSilo(address.SiloAddress))
             {
@@ -195,10 +163,10 @@ namespace Orleans.Runtime.GrainDirectory
                 throw new OrleansException($"Trying to register {address.GrainId} on invalid silo: {address.SiloAddress}. Known status: {siloStatus}");
             }
 
-            GrainInfo grainInfo;
+            AddressAndTag result;
             lock (lockable)
             {
-                if (!partitionData.TryGetValue(address.GrainId, out grainInfo))
+                if (!partitionData.TryGetValue(address.GrainId, out var grainInfo))
                 {
                     partitionData[address.GrainId] = grainInfo = new GrainInfo();
                 }
@@ -232,7 +200,7 @@ namespace Orleans.Runtime.GrainDirectory
             if (log.IsEnabled(LogLevel.Trace)) log.LogTrace("Removing activation for grain {GrainId} cause={Cause} was_removed={WasRemoved}", grain.ToString(), cause, wasRemoved);
         }
 
-   
+
         /// <summary>
         /// Removes the grain (and, effectively, all its activations) from the directory
         /// </summary>
@@ -276,15 +244,9 @@ namespace Orleans.Runtime.GrainDirectory
         /// <returns></returns>
         internal int GetGrainETag(GrainId grain)
         {
-            GrainInfo grainInfo;
             lock (lockable)
             {
-                if (!partitionData.TryGetValue(grain, out grainInfo))
-                {
-                    return GrainInfo.NO_ETAG;
-                }
-
-                return grainInfo.VersionTag;
+                return partitionData.TryGetValue(grain, out var info) ? info.VersionTag : GrainInfo.NO_ETAG;
             }
         }
 
@@ -337,42 +299,27 @@ namespace Orleans.Runtime.GrainDirectory
         /// This method is supposed to be used by handoff manager to update the partitions when the system view (set of live silos) changes.
         /// </summary>
         /// <param name="predicate">filter predicate (usually if the given grain is owned by particular silo)</param>
-        /// <param name="modifyOrigin">flag controlling whether the source partition should be modified (i.e., the entries should be moved or just copied) </param>
-        /// <returns>new grain directory partition containing entries satisfying the given predicate</returns>
-        internal GrainDirectoryPartition Split(Predicate<GrainId> predicate, bool modifyOrigin)
+        /// <returns>Entries satisfying the given predicate</returns>
+        internal List<GrainAddress> Split(Predicate<GrainId> predicate)
         {
-            var newDirectory = new GrainDirectoryPartition(this.siloStatusOracle, this.grainDirectoryOptions, this.grainFactory, this.loggerFactory);
+            var result = new List<GrainAddress>();
 
             lock (lockable)
             {
                 foreach (var pair in partitionData)
                 {
-                    if (predicate(pair.Key))
+                    if (pair.Value.Activation is { } address && predicate(pair.Key))
                     {
-                        newDirectory.partitionData.Add(pair.Key, pair.Value);
-
-                        if (modifyOrigin)
-                        {
-                            partitionData.Remove(pair.Key);
-                        }
+                        result.Add(address);
                     }
                 }
             }
 
-            return newDirectory;
-        }
-
-        internal List<GrainAddress> ToListOfActivations()
-        {
-            var result = new List<GrainAddress>();
-            lock (lockable)
+            for (var i = result.Count - 1; i >= 0; i--)
             {
-                foreach (var pair in partitionData)
+                if (!IsValidSilo(result[i].SiloAddress))
                 {
-                    if (pair.Value.Activation is { } address && IsValidSilo(address.SiloAddress))
-                    {
-                        result.Add(address);
-                    }
+                    result.RemoveAt(i);
                 }
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 
+#nullable enable
 namespace Orleans.Runtime.GrainDirectory
 {
     internal interface ILocalGrainDirectory : IDhtGrainDirectory
@@ -71,7 +73,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         /// <param name="grain"></param>
         /// <returns></returns>
-        SiloAddress GetPrimaryForGrain(GrainId grain);
+        SiloAddress? GetPrimaryForGrain(GrainId grain);
 
         /// <summary>
         /// Returns the directory information held in a local directory partition for the provided grain ID.
@@ -88,12 +90,12 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         /// <param name="grain"></param>
         /// <returns></returns>
-        GrainAddress GetLocalCacheData(GrainId grain);
+        GrainAddress? GetLocalCacheData(GrainId grain);
 
         /// <summary>
         /// Attempts to find the specified grain in the directory cache.
         /// </summary>
-        bool TryCachedLookup(GrainId grainId, out GrainAddress address);
+        bool TryCachedLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address);
 
         /// <summary>
         /// For determining message forwarding logic, we sometimes check if a silo is part of this cluster or not

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.Serialization;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,7 +9,7 @@ using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal class LocalGrainDirectory : ILocalGrainDirectory, ISiloStatusListener
+    internal sealed class LocalGrainDirectory : ILocalGrainDirectory, ISiloStatusListener
     {
         private readonly AdaptiveDirectoryCacheMaintainer maintainer;
         private readonly ILogger log;
@@ -26,23 +24,17 @@ namespace Orleans.Runtime.GrainDirectory
         internal const int HOP_LIMIT = 6; // forward a remote request no more than 5 times
         public static readonly TimeSpan RETRY_DELAY = TimeSpan.FromMilliseconds(200); // Pause 200ms between forwards to let the membership directory settle down
 
-        protected SiloAddress Seed { get { return seed; } }
-
-        internal ILogger Logger { get { return log; } } // logger is shared with classes that manage grain directory
-
         internal bool Running;
 
-        internal SiloAddress MyAddress { get; private set; }
+        internal SiloAddress MyAddress { get; }
 
-        internal IGrainDirectoryCache DirectoryCache { get; private set; }
-        internal GrainDirectoryPartition DirectoryPartition { get; private set; }
+        internal IGrainDirectoryCache DirectoryCache { get; }
+        internal GrainDirectoryPartition DirectoryPartition { get; }
 
-        public RemoteGrainDirectory RemoteGrainDirectory { get; private set; }
-        public RemoteGrainDirectory CacheValidator { get; private set; }
+        public RemoteGrainDirectory RemoteGrainDirectory { get; }
+        public RemoteGrainDirectory CacheValidator { get; }
 
-        internal GrainDirectoryHandoffManager HandoffManager { get; private set; }
-
-        public string ClusterId { get; }
+        internal GrainDirectoryHandoffManager HandoffManager { get; }
 
         public LocalGrainDirectory(
             IServiceProvider serviceProvider,
@@ -56,12 +48,10 @@ namespace Orleans.Runtime.GrainDirectory
         {
             this.log = loggerFactory.CreateLogger<LocalGrainDirectory>();
 
-            var clusterId = siloDetails.ClusterId;
             MyAddress = siloDetails.SiloAddress;
 
             this.siloStatusOracle = siloStatusOracle;
             this.grainFactory = grainFactory;
-            ClusterId = clusterId;
 
             DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value);
             maintainer =
@@ -96,15 +86,10 @@ namespace Orleans.Runtime.GrainDirectory
             });
             DirectoryInstruments.RegisterRingSizeObserve(() => this.directoryMembership.MembershipRingList.Count);
 
-            Func<SiloAddress, string> siloAddressPrint = (SiloAddress addr) =>
-                String.Format("{0}/{1:X}", addr.ToLongString(), addr.GetConsistentHashCode());
-            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING, () =>
-            {
-                var ring = this.directoryMembership.MembershipRingList;
-                return Utils.EnumerableToString(ring, siloAddressPrint);
-            });
-            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_PREDECESSORS, () => Utils.EnumerableToString(this.FindPredecessors(this.MyAddress, 1), siloAddressPrint));
-            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_SUCCESSORS, () => Utils.EnumerableToString(this.FindSuccessors(this.MyAddress, 1), siloAddressPrint));
+            Func<SiloAddress, string> siloAddressPrint = addr => $"{addr}/{addr.GetConsistentHashCode():X}";
+            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING, () => Utils.EnumerableToString(directoryMembership.MembershipRingList, siloAddressPrint));
+            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_PREDECESSORS, () => FindPredecessor(MyAddress) is { } s ? siloAddressPrint(s) : null);
+            StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_RING_SUCCESSORS, () => FindSuccessor(MyAddress) is { } s ? siloAddressPrint(s) : null);
         }
 
         public void Start()
@@ -133,10 +118,7 @@ namespace Orleans.Runtime.GrainDirectory
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
 
-            if (maintainer != null)
-            {
-                maintainer.Stop();
-            }
+            maintainer?.Stop();
 
             DirectoryPartition.Clear();
             DirectoryCache.Clear();
@@ -152,7 +134,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        protected void AddServer(SiloAddress silo)
+        private void AddServer(SiloAddress silo)
         {
             lock (this.writeLock)
             {
@@ -184,7 +166,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        protected void RemoveServer(SiloAddress silo, SiloStatus status)
+        private void RemoveServer(SiloAddress silo, SiloStatus status)
         {
             lock (this.writeLock)
             {
@@ -226,21 +208,19 @@ namespace Orleans.Runtime.GrainDirectory
         /// <summary>
         /// Adjust local directory following the addition/removal of a silo
         /// </summary>
-        protected void AdjustLocalDirectory(SiloAddress silo, bool dead)
+        private void AdjustLocalDirectory(SiloAddress silo, bool dead)
         {
             // Determine which activations to remove.
             var activationsToRemove = new List<(GrainId, ActivationId)>();
             foreach (var entry in this.DirectoryPartition.GetItems())
             {
-                var (grain, grainInfo) = (entry.Key, entry.Value);
-                if (grainInfo.Activation is { } address)
+                if (entry.Value.Activation is { } address)
                 {
                     // Include any activations from dead silos and from predecessors.
                     var siloIsDead = dead && address.SiloAddress.Equals(silo);
-                    var siloIsPredecessor = address.SiloAddress.IsPredecessorOf(silo);
-                    if (siloIsDead || siloIsPredecessor)
+                    if (siloIsDead || address.SiloAddress.IsPredecessorOf(silo))
                     {
-                        activationsToRemove.Add((grain, address.ActivationId));
+                        activationsToRemove.Add((entry.Key, address.ActivationId));
                     }
                 }
             }
@@ -260,7 +240,7 @@ namespace Orleans.Runtime.GrainDirectory
         ///     We don't do that since first cache refresh handles that.
         ///     Second, since Membership events are not guaranteed to be ordered, we may remove a cache entry that does not really point to a failed silo.
         ///     To do that properly, we need to store for each cache entry who was the directory owner that registered this activation (the original partition owner).
-        protected void AdjustLocalCache(SiloAddress silo, bool dead)
+        private void AdjustLocalCache(SiloAddress silo, bool dead)
         {
             // remove all records of activations located on the removed silo
             foreach (var tuple in DirectoryCache.KeyValues)
@@ -271,6 +251,7 @@ namespace Orleans.Runtime.GrainDirectory
                 if (MyAddress.Equals(CalculateGrainDirectoryPartition(activationAddress.GrainId)))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
+                    continue;
                 }
 
                 // 1) remove entries that point to activations located on the removed silo
@@ -283,10 +264,10 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        internal List<SiloAddress> FindPredecessors(SiloAddress silo, int count)
+        internal SiloAddress FindPredecessor(SiloAddress silo)
         {
-            var existing = this.directoryMembership;
-            int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
+            var existing = directoryMembership.MembershipRingList;
+            int index = existing.IndexOf(silo);
             if (index == -1)
             {
                 log.LogWarning(
@@ -296,20 +277,13 @@ namespace Orleans.Runtime.GrainDirectory
                 return null;
             }
 
-            var result = new List<SiloAddress>();
-            int numMembers = existing.MembershipRingList.Count;
-            for (int i = index - 1; ((i + numMembers) % numMembers) != index && result.Count < count; i--)
-            {
-                result.Add(existing.MembershipRingList[(i + numMembers) % numMembers]);
-            }
-
-            return result;
+            return existing.Count > 1 ? existing[(index == 0 ? existing.Count : index) - 1] : null;
         }
 
-        internal List<SiloAddress> FindSuccessors(SiloAddress silo, int count)
+        internal SiloAddress FindSuccessor(SiloAddress silo)
         {
-            var existing = this.directoryMembership;
-            int index = existing.MembershipRingList.FindIndex(elem => elem.Equals(silo));
+            var existing = directoryMembership.MembershipRingList;
+            int index = existing.IndexOf(silo);
             if (index == -1)
             {
                 log.LogWarning(
@@ -319,14 +293,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return null;
             }
 
-            var result = new List<SiloAddress>();
-            int numMembers = existing.MembershipRingList.Count;
-            for (int i = index + 1; i % numMembers != index && result.Count < count; i++)
-            {
-                result.Add(existing.MembershipRingList[i % numMembers]);
-            }
-
-            return result;
+            return existing.Count > 1 ? existing[(index + 1) % existing.Count] : null;
         }
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
@@ -365,7 +332,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 if (Constants.SystemMembershipTableType.Equals(grainId.Type))
                 {
-                    if (Seed == null)
+                    if (seed == null)
                     {
                         var errorMsg =
                             $"Development clustering cannot run without a primary silo. " +
@@ -532,7 +499,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public async Task UnregisterAsync(GrainAddress address, UnregistrationCause cause, int hopCount)
         {
-            if(hopCount > 0)
+            if (hopCount > 0)
             {
                 DirectoryInstruments.UnregistrationsRemoteReceived.Add(1);
             }
@@ -573,20 +540,9 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AddToDictionary<K, V>(ref Dictionary<K, List<V>> dictionary, K key, V value)
-        {
-            if (dictionary == null)
-                dictionary = new Dictionary<K, List<V>>();
-            List<V> list;
-            if (!dictionary.TryGetValue(key, out list))
-                dictionary[key] = list = new List<V>();
-            list.Add(value);
-        }
-
-
         // helper method to avoid code duplication inside UnregisterManyAsync
-        private void UnregisterOrPutInForwardList(IEnumerable<GrainAddress> addresses, UnregistrationCause cause, int hopCount,
-            ref Dictionary<SiloAddress, List<GrainAddress>> forward, List<Task> tasks, string context)
+        private void UnregisterOrPutInForwardList(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount,
+            ref Dictionary<SiloAddress, List<GrainAddress>> forward, string context)
         {
             foreach (var address in addresses)
             {
@@ -595,7 +551,10 @@ namespace Orleans.Runtime.GrainDirectory
 
                 if (forwardAddress != null)
                 {
-                    AddToDictionary(ref forward, forwardAddress, address);
+                    forward ??= new();
+                    if (!forward.TryGetValue(forwardAddress, out var list))
+                        forward[forwardAddress] = list = new();
+                    list.Add(address);
                 }
                 else
                 {
@@ -610,7 +569,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
         {
-            if(hopCount > 0)
+            if (hopCount > 0)
             {
                 DirectoryInstruments.UnregistrationsManyRemoteReceived.Add(1);
             }
@@ -620,16 +579,15 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             Dictionary<SiloAddress, List<GrainAddress>> forwardlist = null;
-            var tasks = new List<Task>();
 
-            UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, tasks, "UnregisterManyAsync");
+            UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, "UnregisterManyAsync");
 
             // before forwarding to other silos, we insert a retry delay and re-check destination
             if (hopCount > 0 && forwardlist != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 Dictionary<SiloAddress, List<GrainAddress>> forwardlist2 = null;
-                UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist2, tasks, "UnregisterManyAsync");
+                UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist2, "UnregisterManyAsync");
                 forwardlist = forwardlist2;
                 if (forwardlist != null)
                 {
@@ -643,15 +601,16 @@ namespace Orleans.Runtime.GrainDirectory
             // forward the requests
             if (forwardlist != null)
             {
+                var tasks = new List<Task>();
                 foreach (var kvp in forwardlist)
                 {
                     DirectoryInstruments.UnregistrationsManyRemoteSent.Add(1);
                     tasks.Add(GetDirectoryReference(kvp.Key).UnregisterManyAsync(kvp.Value, cause, hopCount + 1));
                 }
-            }
 
-            // wait for all the requests to finish
-            await Task.WhenAll(tasks);
+                // wait for all the requests to finish
+                await Task.WhenAll(tasks);
+            }
         }
 
 
@@ -858,21 +817,7 @@ namespace Orleans.Runtime.GrainDirectory
             return CalculateGrainDirectoryPartition(grain);
         }
 
-        private long RingDistanceToSuccessor()
-        {
-            long distance;
-            List<SiloAddress> successorList = FindSuccessors(MyAddress, 1);
-            if (successorList == null || successorList.Count == 0)
-            {
-                distance = 0;
-            }
-            else
-            {
-                SiloAddress successor = successorList[0];
-                distance = successor == null ? 0 : CalcRingDistance(MyAddress, successor);
-            }
-            return distance;
-        }
+        private long RingDistanceToSuccessor() => FindSuccessor(MyAddress) is { } successor ? CalcRingDistance(MyAddress, successor) : 0;
 
         private static long CalcRingDistance(SiloAddress silo1, SiloAddress silo2)
         {
@@ -884,22 +829,6 @@ namespace Orleans.Runtime.GrainDirectory
             if (hash2 < hash1) return ringSize - (hash1 - hash2);
 
             return 0;
-        }
-
-        public string RingStatusToString()
-        {
-            var sb = new StringBuilder();
-
-            sb.AppendFormat("Silo address is {0}, silo consistent hash is {1:X}.", MyAddress, MyAddress.GetConsistentHashCode()).AppendLine();
-            sb.AppendLine("Ring is:");
-
-            var membershipRingList = this.directoryMembership.MembershipRingList;
-            foreach (var silo in membershipRingList)
-                sb.AppendFormat("    Silo {0}, consistent hash is {1:X}", silo, silo.GetConsistentHashCode()).AppendLine();
-
-            sb.AppendFormat("My predecessors: {0}", FindPredecessors(MyAddress, 1).ToStrings(addr => String.Format("{0}/{1:X}---", addr, addr.GetConsistentHashCode()), " -- ")).AppendLine();
-            sb.AppendFormat("My successors: {0}", FindSuccessors(MyAddress, 1).ToStrings(addr => String.Format("{0}/{1:X}---", addr, addr.GetConsistentHashCode()), " -- "));
-            return sb.ToString();
         }
 
         internal IRemoteGrainDirectory GetDirectoryReference(SiloAddress silo)
@@ -933,27 +862,6 @@ namespace Orleans.Runtime.GrainDirectory
 
             public ImmutableList<SiloAddress> MembershipRingList { get; }
             public ImmutableHashSet<SiloAddress> MembershipCache { get; }
-        }
-    }
-
-    [Serializable]
-    [GenerateSerializer]
-    public class OrleansGrainDirectoryException : OrleansException
-    {
-        public OrleansGrainDirectoryException()
-        {
-        }
-
-        public OrleansGrainDirectoryException(string message) : base(message)
-        {
-        }
-
-        public OrleansGrainDirectoryException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected OrleansGrainDirectoryException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
     }
 }


### PR DESCRIPTION
The existing code in `ProcessSiloAddEvent` implies that it tries to check all successors, while in fact it only checks the immediate successor. I cleaned up the grain directory code around this to match the actual logic.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7842)