### PR TITLE
Use preferred exception logging pattern

### DIFF
--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -122,13 +122,13 @@ namespace Orleans
                     this.OnStartStageCompleted(stage);
                 }
             }
-            catch (Exception ex) when (!(ex is OrleansLifecycleCanceledException))
+            catch (Exception ex) when (ex is not OrleansLifecycleCanceledException)
             {
                 this.logger.LogError(
                     (int)ErrorCode.LifecycleStartFailure,
-                    "Lifecycle start canceled due to errors at stage {Stage}: {Exception}",
-                    this.highStage,
-                    ex);
+                    ex,
+                    "Lifecycle start canceled due to errors at stage {Stage}",
+                    this.highStage);
                 throw;
             }
 
@@ -199,7 +199,9 @@ namespace Orleans
                 {
                     this.logger.LogError(
                         (int)ErrorCode.LifecycleStopFailure,
-                        "Stopping lifecycle encountered an error at stage {Stage}. Continuing to stop. Exception: {Exception}", this.highStage, ex);
+                        ex,
+                        "Stopping lifecycle encountered an error at stage {Stage}. Continuing to stop.",
+                        this.highStage);
                 }
 
                 this.OnStopStageCompleted(stage);

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -224,7 +224,7 @@ namespace Orleans.Runtime
                 }
                 catch (Exception exception)
                 {
-                    this.logger.LogError((int)ErrorCode.Runtime_Error_100326, "RunClientMessagePump has thrown an exception: {Exception}. Continuing.", exception);
+                    this.logger.LogError((int)ErrorCode.Runtime_Error_100326, exception, "RunClientMessagePump has thrown an exception. Continuing.");
                 }
             }
         }

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs
@@ -147,10 +147,10 @@ namespace Orleans.Runtime
                 {
                     this.logger.LogError(
                         (int)ErrorCode.LifecycleStartFailure,
-                        "{Name} failed to start due to errors at stage {Stage}: {Exception}",
+                        exception,
+                        "{Name} failed to start due to errors at stage {Stage}",
                         this.Name,
-                        this.StageName,
-                        exception);
+                        this.StageName);
                     throw;
                 }
             }
@@ -176,10 +176,10 @@ namespace Orleans.Runtime
                 {
                     this.logger.LogError(
                         (int)ErrorCode.LifecycleStartFailure,
-                        "{Name} failed to stop due to errors at stage {Stage}: {Exception}",
+                        exception,
+                        "{Name} failed to stop due to errors at stage {Stage}",
                         this.Name,
-                        this.StageName,
-                        exception);
+                        this.StageName);
                     throw;
                 }
             }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
-                this.log.LogError("Error processing membership updates: {Exception}", exception);
+                this.log.LogError(exception, "Error processing membership updates");
                 this.fatalErrorHandler.OnFatalException(this, nameof(ProcessMembershipUpdates), exception);
             }
             finally

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.Extensions.Options;
 using System.Linq;
 using Orleans.Internal;
+using System.Reflection.Metadata;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -75,8 +76,8 @@ namespace Orleans.Runtime.MembershipService
                     {
                         this.log.LogError(
                             (int)ErrorCode.MembershipUpdateIAmAliveFailure,
-                            "Failed to update table entry for this silo, will retry shortly: {Exception}",
-                            exception);
+                            exception,
+                            "Failed to update table entry for this silo, will retry shortly");
 
                         // Retry quickly
                         onceOffDelay = TimeSpan.FromMilliseconds(200);
@@ -85,7 +86,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
-                this.log.LogError("Error updating liveness timestamp: {Exception}", exception);
+                this.log.LogError(exception, "Error updating liveness timestamp");
                 this.fatalErrorHandler.OnFatalException(this, nameof(UpdateIAmAlive), exception);
             }
             finally
@@ -113,8 +114,8 @@ namespace Orleans.Runtime.MembershipService
             {
                 this.log.LogInformation(
                     (int)ErrorCode.MembershipFailedToBecomeActive,
-                    "BecomeActive failed: {Exception}",
-                    exception);
+                    exception,
+                    "BecomeActive failed");
                 throw;
             }
         }
@@ -177,7 +178,7 @@ namespace Orleans.Runtime.MembershipService
                 }
                 catch (Exception exception) when (canContinue)
                 {
-                    this.log.LogError("Failed to validate initial cluster connectivity: {Exception}", exception);
+                    this.log.LogError(exception, "Failed to validate initial cluster connectivity");
                     await Task.Delay(TimeSpan.FromSeconds(1));
                 }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -185,8 +186,8 @@ namespace Orleans.Runtime.MembershipService
             {
                 this.log.LogError(
                     (int)ErrorCode.MembershipGossipProcessingFailure,
-                    "Error refreshing membership table: {Exception}",
-                    exception);
+                    exception,
+                    "Error refreshing membership table");
             }
         }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -80,7 +80,7 @@ namespace Orleans.Runtime.MembershipService
                     }
                     catch (Exception exception)
                     {
-                        this.log.LogError((int)ErrorCode.MembershipCleanDeadEntriesFailure, "Failed to clean up defunct membership table entries: {Exception}", exception);
+                        this.log.LogError((int)ErrorCode.MembershipCleanDeadEntriesFailure, exception, "Failed to clean up defunct membership table entries");
                     }
                 }
             }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -145,8 +145,8 @@ namespace Orleans.Runtime.MembershipService
             {
                 success = false;
                 this.log.LogWarning(
-                    "Exception while trying to clean up my table entries: {Exception}",
-                    exception);
+                    exception,
+                    "Exception while trying to clean up my table entries");
             }
 
             // If cleanup was not required then the cleanup result is ignored.
@@ -188,7 +188,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exception)
             {
-                this.log.LogError((int)ErrorCode.MembershipFailedToStart, "Membership failed to start: {Exception}", exception);
+                this.log.LogError((int)ErrorCode.MembershipFailedToStart, exception, "Membership failed to start");
                 throw;
             }
         }
@@ -266,8 +266,8 @@ namespace Orleans.Runtime.MembershipService
                     {
                         this.log.LogError(
                             (int)ErrorCode.MembershipUpdateIAmAliveFailure,
-                            "Failed to refresh membership table, will retry shortly: {Exception}",
-                            exception);
+                            exception,
+                            "Failed to refresh membership table, will retry shortly");
 
                         // Retry quickly
                         onceOffDelay = TimeSpan.FromMilliseconds(200);
@@ -276,7 +276,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
-                this.log.LogError("Error refreshing membership table: {Exception}", exception);
+                this.log.LogError(exception, "Error refreshing membership table");
                 this.fatalErrorHandler.OnFatalException(this, nameof(PeriodicallyRefreshMembershipTable), exception);
             }
             finally

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -88,7 +88,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
-                this.log.LogError("Error processing membership updates: {Exception}", exception);
+                this.log.LogError(exception, "Error processing membership updates");
                 this.fatalErrorHandler.OnFatalException(this, nameof(ProcessMembershipUpdates), exception);
             }
             finally
@@ -121,9 +121,9 @@ namespace Orleans.Runtime.MembershipService
                     catch (Exception exception)
                     {
                         this.log.LogError(
-                            "Exception while calling " + nameof(ISiloStatusListener.SiloStatusChangeNotification) + " on listener {Listener}: {Exception}",
-                            listener,
-                            exception);
+                            exception,
+                            "Exception while calling " + nameof(ISiloStatusListener.SiloStatusChangeNotification) + " on listener {Listener}",
+                            listener);
                     }
                 }
             }

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -100,7 +100,7 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exception)
             {
-                this.NetworkingTrace.LogCritical("Exception in AcceptAsync: {Exception}", exception);
+                this.NetworkingTrace.LogCritical(exception, "Exception in AcceptAsync");
             }
         }
 
@@ -131,7 +131,7 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exception)
             {
-                this.NetworkingTrace.LogWarning("Exception during shutdown: {Exception}", exception);
+                this.NetworkingTrace.LogWarning(exception, "Exception during shutdown");
             }
         }
 

--- a/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
@@ -57,7 +57,7 @@ namespace Orleans.Runtime.Messaging
             }
             catch (Exception exception)
             {
-                this.log.LogInformation("Exception while closing connections to defunct silo {SiloAddress}: {Exception}", silo, exception);
+                this.log.LogInformation(exception, "Exception while closing connections to defunct silo {SiloAddress}", silo);
             }
         }
     }

--- a/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Runtime/ReminderService/LocalReminderService.cs
@@ -578,10 +578,9 @@ namespace Orleans.Runtime.ReminderService
                     {
                         this.reminderService.logger.LogWarning(
                             exception,
-                            "Exception firing reminder \"{ReminderName}\" for grain {GrainId}: {Exception}",
+                            "Exception firing reminder \"{ReminderName}\" for grain {GrainId}",
                             this.Identity.ReminderName,
-                            this.Identity.GrainRef?.GrainId,
-                            exception);
+                            this.Identity.GrainRef?.GrainId);
                     }
 
                     dueTimeSpan = CalculateDueTime();

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -241,9 +241,8 @@ namespace Orleans.Runtime.Scheduler
                         this.log.LogError(
                             (int)ErrorCode.SchedulerExceptionFromExecute,
                             ex,
-                            "Worker thread caught an exception thrown from Execute by task {Task}. Exception: {Exception}",
-                            OrleansTaskExtentions.ToString(task),
-                            ex);
+                            "Worker thread caught an exception thrown from Execute by task {Task}",
+                            OrleansTaskExtentions.ToString(task));
                         throw;
                     }
                     finally
@@ -274,9 +273,8 @@ namespace Orleans.Runtime.Scheduler
                 this.log.LogError(
                     (int)ErrorCode.Runtime_Error_100032,
                     ex,
-                    "Worker thread {Thread} caught an exception thrown from IWorkItem.Execute: {Exception}",
-                    Thread.CurrentThread.ManagedThreadId,
-                    ex);
+                    "Worker thread {Thread} caught an exception thrown from IWorkItem.Execute",
+                    Thread.CurrentThread.ManagedThreadId);
             }
             finally
             {

--- a/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
@@ -38,7 +38,7 @@ namespace UnitTests.Grains
 
             Task OnError(Exception ex)
             {
-                this.logger.LogError("Error: {Exception}", ex);
+                this.logger.LogError(ex, "Error");
                 this.errorCounter++;
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
We should not log exceptions as regular parameters, but instead always pass them directly to the log call.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7845)