### PR TITLE
Add a blob container client factory for customisation

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers.Azure;
 using Orleans.Runtime;
-using Orleans.Serialization;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.Storage
@@ -34,7 +33,6 @@ namespace Orleans.Storage
         public AzureBlobGrainStorage(
             string name,
             AzureBlobStorageOptions options,
-            IGrainStorageSerializer grainStorageSerializer,
             IBlobContainerFactory blobContainerFactory,
             IServiceProvider services,
             ILogger<AzureBlobGrainStorage> logger)

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -52,7 +52,7 @@ namespace Orleans.Storage
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainType, grainId);
+            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
 
             if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading,
                 "Reading: GrainType={GrainType} Grainid={GrainId} ETag={ETag} from BlobName={BlobName} in Container={ContainerName}",
@@ -146,7 +146,7 @@ namespace Orleans.Storage
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainType, grainId);
+            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
 
             try
             {
@@ -192,7 +192,7 @@ namespace Orleans.Storage
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainType, grainId);
+            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
 
             try
             {
@@ -245,7 +245,7 @@ namespace Orleans.Storage
 
         private async Task WriteStateAndCreateContainerIfNotExists<T>(string grainType, GrainId grainId, IGrainState<T> grainState, BinaryData contents, string mimeType, BlobClient blob)
         {
-            var container = this.blobContainerFactory.BuildContainerClient(grainType, grainId);
+            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
 
             try
             {

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -52,7 +52,7 @@ namespace Orleans.Storage
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
+            var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
             if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.LogTrace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading,
                 "Reading: GrainType={GrainType} Grainid={GrainId} ETag={ETag} from BlobName={BlobName} in Container={ContainerName}",
@@ -146,7 +146,7 @@ namespace Orleans.Storage
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
+            var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
             try
             {
@@ -192,7 +192,7 @@ namespace Orleans.Storage
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
+            var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
             try
             {
@@ -245,7 +245,7 @@ namespace Orleans.Storage
 
         private async Task WriteStateAndCreateContainerIfNotExists<T>(string grainType, GrainId grainId, IGrainState<T> grainState, BinaryData contents, string mimeType, BlobClient blob)
         {
-            var container = this.blobContainerFactory.BuildContainerClient(grainId.GrainId);
+            var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
             try
             {
@@ -316,7 +316,7 @@ namespace Orleans.Storage
                 }
 
                 var client = await createClient();
-                await this.blobContainerFactory.Init(client);
+                await this.blobContainerFactory.InitializeAsync(client);
                 stopWatch.Stop();
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider,
                     "Initializing provider {ProviderName} of type {ProviderType} in stage {Stage} took {ElapsedMilliseconds} Milliseconds.",

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
@@ -4,6 +4,8 @@ using Azure;
 using Azure.Core;
 using Azure.Storage;
 using Azure.Storage.Blobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Orleans.Persistence.AzureStorage;
 using Orleans.Runtime;
@@ -36,7 +38,13 @@ namespace Orleans.Configuration
         public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
 
         /// <inheritdoc/>
-        public IGrainStorageSerializer GrainStorageSerializer { get; set;}
+        public IGrainStorageSerializer GrainStorageSerializer { get; set; }
+
+        /// <summary>
+        /// A function for building container factory instances
+        /// </summary>
+        public Func<IServiceProvider, AzureBlobStorageOptions, IBlobContainerFactory> BuildContainerFactory { get; set; }
+            = static (provider, options) => ActivatorUtilities.CreateInstance<DefaultBlobContainerFactory>(provider, options);
 
         /// <summary>
         /// Configures the <see cref="BlobServiceClient"/> using a connection string.

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
@@ -23,7 +23,7 @@ public interface IBlobContainerFactory
     public BlobContainerClient BuildContainerClient(string grainType, GrainReference grainId);
 
     /// <summary>
-    /// Initialize any required dependenceis using the provided client and options
+    /// Initialize any required dependencies using the provided client and options
     /// </summary>
     /// <param name="client">The connected blob client</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Orleans.Configuration;
+using Orleans.Runtime;
+
+namespace Orleans.Storage;
+
+/// <summary>
+/// A factory for building container clients for blob storage using grainType and grainId
+/// </summary>
+public interface IBlobContainerFactory
+{
+    /// <summary>
+    /// Build a container for the specific grain type and grain id
+    /// </summary>
+    /// <param name="grainType">The grain type</param>
+    /// <param name="grainId">The grain id</param>
+    /// <returns>A configured blob client</returns>
+    public BlobContainerClient BuildContainerClient(string grainType, GrainReference grainId);
+
+    /// <summary>
+    /// Initialize any required dependenceis using the provided client and options
+    /// </summary>
+    /// <param name="client">The connected blob client</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public Task Init(BlobServiceClient client);
+}
+
+/// <summary>
+/// A default blob container factory that uses the default container name
+/// </summary>
+internal class DefaultBlobContainerFactory : IBlobContainerFactory
+{
+    private readonly AzureBlobStorageOptions _options;
+    private BlobContainerClient _defaultContainer = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultBlobContainerFactory"/> class.
+    /// </summary>
+    /// <param name="options">The blob storage options</param>
+    public DefaultBlobContainerFactory(AzureBlobStorageOptions options)
+    {
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public BlobContainerClient BuildContainerClient(string grainType, GrainReference grainId)
+        => _defaultContainer;
+
+    /// <inheritdoc/>
+    public async Task Init(BlobServiceClient client)
+    {
+        _defaultContainer = client.GetBlobContainerClient(_options.ContainerName);
+        await _defaultContainer.CreateIfNotExistsAsync();
+    }
+}

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Orleans.Configuration;
@@ -15,22 +11,22 @@ namespace Orleans.Storage;
 public interface IBlobContainerFactory
 {
     /// <summary>
-    /// Build a container for the specific grain type and grain id
+    /// Gets the container which should be used for the specified grain.
     /// </summary>
     /// <param name="grainId">The grain id</param>
     /// <returns>A configured blob client</returns>
-    public BlobContainerClient BuildContainerClient(GrainId grainId);
+    public BlobContainerClient GetBlobContainerClient(GrainId grainId);
 
     /// <summary>
-    /// Initialize any required dependencies using the provided client and options
+    /// Initialize any required dependencies using the provided client and options.
     /// </summary>
     /// <param name="client">The connected blob client</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task Init(BlobServiceClient client);
+    public Task InitializeAsync(BlobServiceClient client);
 }
 
 /// <summary>
-/// A default blob container factory that uses the default container name
+/// A default blob container factory that uses the default container name.
 /// </summary>
 internal class DefaultBlobContainerFactory : IBlobContainerFactory
 {
@@ -47,11 +43,11 @@ internal class DefaultBlobContainerFactory : IBlobContainerFactory
     }
 
     /// <inheritdoc/>
-    public BlobContainerClient BuildContainerClient(GrainId grainId)
+    public BlobContainerClient GetBlobContainerClient(GrainId grainId)
         => _defaultContainer;
 
     /// <inheritdoc/>
-    public async Task Init(BlobServiceClient client)
+    public async Task InitializeAsync(BlobServiceClient client)
     {
         _defaultContainer = client.GetBlobContainerClient(_options.ContainerName);
         await _defaultContainer.CreateIfNotExistsAsync();

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
@@ -17,10 +17,9 @@ public interface IBlobContainerFactory
     /// <summary>
     /// Build a container for the specific grain type and grain id
     /// </summary>
-    /// <param name="grainType">The grain type</param>
     /// <param name="grainId">The grain id</param>
     /// <returns>A configured blob client</returns>
-    public BlobContainerClient BuildContainerClient(string grainType, GrainReference grainId);
+    public BlobContainerClient BuildContainerClient(GrainId grainId);
 
     /// <summary>
     /// Initialize any required dependencies using the provided client and options
@@ -48,7 +47,7 @@ internal class DefaultBlobContainerFactory : IBlobContainerFactory
     }
 
     /// <inheritdoc/>
-    public BlobContainerClient BuildContainerClient(string grainType, GrainReference grainId)
+    public BlobContainerClient BuildContainerClient(GrainId grainId)
         => _defaultContainer;
 
     /// <inheritdoc/>


### PR DESCRIPTION
Allows blob containers to be customised based on grainType and grain id. This is wrapped in an interface to allow injection of dependencies and state to be maintained.

Fixes #7831 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7849)