### PR TITLE
Fix reminder providers, `LocalReminderService`, and tests

### DIFF
--- a/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBServiceCollectionReminderExtensions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/DynamoDBServiceCollectionReminderExtensions.cs
@@ -25,6 +25,7 @@ namespace Orleans.Hosting
         /// </returns>
         public static IServiceCollection UseDynamoDBReminderService(this IServiceCollection services, Action<DynamoDBReminderStorageOptions> configure)
         {
+            services.AddReminders();
             services.AddSingleton<IReminderTable, DynamoDBReminderTable>();
             services.Configure<DynamoDBReminderStorageOptions>(configure);
             services.ConfigureFormatter<DynamoDBReminderStorageOptions>();

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloBuilderReminderExtensions.cs
@@ -38,7 +38,6 @@ namespace Orleans.Hosting
             this ISiloBuilder builder,
             Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
-            builder.AddReminders();
             return builder.ConfigureServices(services => services.UseAdoNetReminderService(configureOptions));
         }
 
@@ -51,6 +50,7 @@ namespace Orleans.Hosting
         /// </remarks>
         public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
+            services.AddReminders();
             services.AddSingleton<IReminderTable, AdoNetReminderTable>();
             services.ConfigureFormatter<AdoNetReminderTableOptions>();
             services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();

--- a/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ namespace Orleans.Hosting
         /// </returns>
         public static IServiceCollection UseAzureTableReminderService(this IServiceCollection services, Action<AzureTableReminderStorageOptions> configure)
         {
+            services.AddReminders();
             services.AddSingleton<IReminderTable, AzureBasedReminderTable>();
             services.Configure<AzureTableReminderStorageOptions>(configure);
             services.ConfigureFormatter<AzureTableReminderStorageOptions>();
@@ -46,6 +47,7 @@ namespace Orleans.Hosting
         /// </returns>
         public static IServiceCollection UseAzureTableReminderService(this IServiceCollection services, Action<OptionsBuilder<AzureTableReminderStorageOptions>> configureOptions)
         {
+            services.AddReminders();
             services.AddSingleton<IReminderTable, AzureBasedReminderTable>();
             configureOptions?.Invoke(services.AddOptions<AzureTableReminderStorageOptions>());
             services.ConfigureFormatter<AzureTableReminderStorageOptions>();

--- a/src/Orleans.Reminders/Hosting/SiloBuilderReminderExtensions.cs
+++ b/src/Orleans.Reminders/Hosting/SiloBuilderReminderExtensions.cs
@@ -20,7 +20,7 @@ public static class SiloBuilderReminderExtensions
     /// Add support for reminders to this client.
     /// </summary>
     /// <param name="services">The services.</param>
-    private static void AddReminders(this IServiceCollection services)
+    public static void AddReminders(this IServiceCollection services)
     {
         if (services.Any(service => service.ServiceType.Equals(typeof(LocalReminderService))))
         {

--- a/test/Grains/TestGrainInterfaces/IReminderTestGrain2.cs
+++ b/test/Grains/TestGrainInterfaces/IReminderTestGrain2.cs
@@ -23,6 +23,7 @@ namespace UnitTests.GrainInterfaces
         Task StopReminder(IGrainReminder reminder);
 
         Task<TimeSpan> GetReminderPeriod(string reminderName);
+        Task<(TimeSpan DueTime, TimeSpan Period)> GetReminderDueTimeAndPeriod(string reminderName);
         Task<long> GetCounter(string name);
         Task<IGrainReminder> GetReminderObject(string reminderName);
         Task<List<IGrainReminder>> GetRemindersList();

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -190,6 +190,11 @@ namespace UnitTests.Grains
             return Task.FromResult(this.period);
         }
 
+        public Task<(TimeSpan DueTime, TimeSpan Period)> GetReminderDueTimeAndPeriod(string reminderName)
+        {
+            return Task.FromResult((this.period - TimeSpan.FromSeconds(2), this.period));
+        }
+
         public Task<long> GetCounter(string name)
         {
             string fileName = GetFileName(name);
@@ -274,7 +279,7 @@ namespace UnitTests.Grains
             this.logger.LogInformation("Starting reminder {ReminderName} for {GrainId}", reminderName, this.GrainId);
             IGrainReminder r;
             if (validate)
-                r = await this.RegisterOrUpdateReminder(reminderName, /*TimeSpan.FromSeconds(3)*/usePeriod - TimeSpan.FromSeconds(2), usePeriod);
+                r = await this.RegisterOrUpdateReminder(reminderName, usePeriod - TimeSpan.FromSeconds(2), usePeriod);
             else
                 r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(
                     this.GrainId,


### PR DESCRIPTION
* Reminders providers should be calling `AddReminders`
* `LocalReminderService` should compensate for clock resolution issues to prevent double-firing reminders
* Compute expected min/max reminder calls programmatically in tests

cc @ElanHasson

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7855)