### PR TITLE
Validate constraints that are themselves generic correctly in GenericMethodInvoker.

### DIFF
--- a/src/Orleans.Core/CodeGeneration/GenericMethodInvoker.cs
+++ b/src/Orleans.Core/CodeGeneration/GenericMethodInvoker.cs
@@ -295,7 +295,8 @@ namespace Orleans.CodeGeneration
                         var constraint = constrain.IsGenericParameter
                             ? typeGenericArgs[constrain.GenericParameterPosition]
                             : constrain;
-                        if (!constraint.IsAssignableFrom(typeParameter))
+                        if (!constraint.IsAssignableFrom(typeParameter)
+                            && !(constraint.IsGenericType && constraint.GetGenericTypeDefinition() == typeParameter.GetGenericTypeDefinition()))
                         {
                             constraintViolated = true;
                             break;


### PR DESCRIPTION
Validate constraints that are themselves generic correctly in GenericMethodInvoker.

Fixes #7875.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7876)