### PR TITLE
Optimize SiloAddress creation

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -79,9 +79,8 @@ namespace Orleans.Clustering.DynamoDB
                 expression, gateway =>
                 {
                     return SiloAddress.New(
-                        new IPEndPoint(
                             IPAddress.Parse(gateway[SiloInstanceRecord.ADDRESS_PROPERTY_NAME].S),
-                            int.Parse(gateway[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N)),
+                            int.Parse(gateway[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N),
                             int.Parse(gateway[SiloInstanceRecord.GENERATION_PROPERTY_NAME].N)).ToGatewayUri();
                 });
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -491,7 +491,7 @@ namespace Orleans.Clustering.DynamoDB
 
             parse.ProxyPort = tableEntry.ProxyPort;
 
-            parse.SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), tableEntry.Port), tableEntry.Generation);
+            parse.SiloAddress = SiloAddress.New(IPAddress.Parse(tableEntry.Address), tableEntry.Port, tableEntry.Generation);
 
             if (!string.IsNullOrEmpty(tableEntry.SiloName))
             {

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -117,7 +117,7 @@ namespace Orleans.Runtime.MembershipService
                 IPAddress address = IPAddress.Parse(addressStr);
                 int port = Int32.Parse(portStr);
                 int generation = Int32.Parse(genStr);
-                return SiloAddress.New(new IPEndPoint(address, port), generation);
+                return SiloAddress.New(address, port, generation);
             }
             catch (Exception exc)
             {

--- a/src/AdoNet/Shared/Storage/DbStoredQueries.cs
+++ b/src/AdoNet/Shared/Storage/DbStoredQueries.cs
@@ -211,7 +211,7 @@ namespace Orleans.Tests.SqlUtils
                 int port = record.GetInt32(portName);
                 int generation = record.GetInt32(nameof(Columns.Generation));
                 string address = record.GetValue<string>(nameof(Columns.Address));
-                var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(address), port), generation);
+                var siloAddress = SiloAddress.New(IPAddress.Parse(address), port, generation);
                 return siloAddress;
             }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -230,7 +230,7 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrEmpty(tableEntry.Generation))
                 int.TryParse(tableEntry.Generation, out gen);
 
-            parse.SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), port), gen);
+            parse.SiloAddress = SiloAddress.New(IPAddress.Parse(tableEntry.Address), port, gen);
 
             parse.RoleName = tableEntry.RoleName;
             if (!string.IsNullOrEmpty(tableEntry.SiloName))

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -106,7 +106,7 @@ namespace Orleans.AzureUtils
             if (!string.IsNullOrEmpty(gateway.Generation))
                 int.TryParse(gateway.Generation, out gen);
 
-            SiloAddress address = SiloAddress.New(new IPEndPoint(IPAddress.Parse(gateway.Address), proxyPort), gen);
+            SiloAddress address = SiloAddress.New(IPAddress.Parse(gateway.Address), proxyPort, gen);
             return address.ToGatewayUri();
         }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
@@ -68,7 +68,7 @@ namespace Orleans.AzureUtils
                 IPAddress address = IPAddress.Parse(addressStr);
                 int port = Int32.Parse(portStr);
                 int generation = Int32.Parse(genStr);
-                return SiloAddress.New(new IPEndPoint(address, port), generation);
+                return SiloAddress.New(address, port, generation);
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -57,8 +57,7 @@ namespace Orleans.Runtime.Membership
                 Where(m => m.Status == SiloStatus.Active && m.ProxyPort != 0).
                 Select(m =>
                 {
-                    var endpoint = new IPEndPoint(m.SiloAddress.Endpoint.Address, m.ProxyPort);
-                    var gatewayAddress = SiloAddress.New(endpoint, m.SiloAddress.Generation);
+                    var gatewayAddress = SiloAddress.New(m.SiloAddress.Endpoint.Address, m.ProxyPort, m.SiloAddress.Generation);
                     return gatewayAddress.ToGatewayUri();
                 }).ToList();
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -53,8 +53,7 @@ namespace Orleans.Runtime.Membership
                 Where(m => m.Status == SiloStatus.Active && m.ProxyPort != 0).
                 Select(m =>
                 {
-                    var endpoint = new IPEndPoint(m.SiloAddress.Endpoint.Address, m.ProxyPort);
-                    var gatewayAddress = SiloAddress.New(endpoint, m.SiloAddress.Generation);
+                    var gatewayAddress = SiloAddress.New(m.SiloAddress.Endpoint.Address, m.ProxyPort, m.SiloAddress.Generation);
                     return gatewayAddress.ToGatewayUri();
                 }).ToList();
         }

--- a/src/Orleans.Core.Abstractions/Utils/Utils.cs
+++ b/src/Orleans.Core.Abstractions/Utils/Utils.cs
@@ -139,7 +139,7 @@ namespace Orleans.Runtime
         /// <param name="uri">The input Uri</param>
         public static SiloAddress? ToGatewayAddress(this Uri uri) => uri.Scheme switch
         {
-            "gwy.tcp" => SiloAddress.New(uri.ToIPEndPoint()!, 0),
+            "gwy.tcp" => SiloAddress.New(System.Net.IPAddress.Parse(uri.Host), uri.Port, 0),
             _ => null,
         };
 

--- a/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime.Messaging
             var port = (int)reader.ReadVarUInt32();
             var generation = reader.ReadInt32();
 
-            return SiloAddress.New(new IPEndPoint(ip, port), generation);
+            return SiloAddress.New(ip, port, generation);
         }
 
         public void WriteRaw<TBufferWriter>(ref Writer<TBufferWriter> writer, SiloAddress value) where TBufferWriter : IBufferWriter<byte>

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -80,7 +80,7 @@ namespace Orleans.Messaging
             GatewayManager gatewayManager)
         {
             this.connectionManager = connectionManager;
-            MyAddress = SiloAddress.New(new IPEndPoint(localAddress, 0), gen);
+            MyAddress = SiloAddress.New(localAddress, 0, gen);
             ClientId = clientId;
             this.RuntimeClient = runtimeClient;
             this.messageFactory = messageFactory;

--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -1,8 +1,6 @@
 using System.Net;
-using System.Net.Sockets;
 
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.Configuration
 {
@@ -87,5 +85,18 @@ namespace Orleans.Configuration
         /// If not set will default to <see cref="AdvertisedIPAddress"/> + <see cref="GatewayPort"/>
         /// </summary>
         public IPEndPoint GatewayListeningEndpoint { get; set; }
+
+
+        internal IPEndPoint GetPublicSiloEndpoint() => new(AdvertisedIPAddress, SiloPort);
+
+        internal IPEndPoint GetPublicProxyEndpoint()
+        {
+            var gatewayPort = GatewayPort != 0 ? GatewayPort : GatewayListeningEndpoint?.Port ?? 0;
+            return gatewayPort != 0 ? new(AdvertisedIPAddress, gatewayPort) : null;
+        }
+
+        internal IPEndPoint GetListeningSiloEndpoint() => SiloListeningEndpoint ?? GetPublicSiloEndpoint();
+
+        internal IPEndPoint GetListeningProxyEndpoint() => GatewayListeningEndpoint ?? GetPublicProxyEndpoint();
     }
 }

--- a/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
@@ -88,31 +88,5 @@ namespace Orleans.Hosting
         {
             return builder.ConfigureEndpoints(null, siloPort, gatewayPort, addressFamily, listenOnAnyHostAddress);
         }
-
-        internal static IPEndPoint GetPublicSiloEndpoint(this EndpointOptions options)
-        {
-            return new IPEndPoint(options.AdvertisedIPAddress, options.SiloPort);
-        }
-
-        internal static IPEndPoint GetPublicProxyEndpoint(this EndpointOptions options)
-        {
-            var gatewayPort = options.GatewayPort != 0
-                ? options.GatewayPort
-                : options.GatewayListeningEndpoint?.Port ?? 0;
-
-            return gatewayPort != 0
-                ? new IPEndPoint(options.AdvertisedIPAddress, gatewayPort)
-                : null;
-        }
-
-        internal static IPEndPoint GetListeningSiloEndpoint(this EndpointOptions options)
-        {
-            return options.SiloListeningEndpoint ?? options.GetPublicSiloEndpoint();
-        }
-
-        internal static IPEndPoint GetListeningProxyEndpoint(this EndpointOptions options)
-        {
-            return options.GatewayListeningEndpoint ?? options.GetPublicProxyEndpoint();
-        }
     }
 }

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
             this.DnsHostName = Dns.GetHostName();
 
             var endpointOptions = siloEndpointOptions.Value;
-            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.GetPublicSiloEndpoint(), SiloAddress.AllocateNewGeneration()));
+            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.AdvertisedIPAddress, endpointOptions.SiloPort, SiloAddress.AllocateNewGeneration()));
             this.gatewayAddressLazy = new Lazy<SiloAddress>(() =>
             {
                 var publicProxyEndpoint = endpointOptions.GetPublicProxyEndpoint();

--- a/src/Orleans.Serialization/WireProtocol/Field.cs
+++ b/src/Orleans.Serialization/WireProtocol/Field.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Orleans.Serialization.WireProtocol
 {
@@ -221,38 +220,42 @@ namespace Orleans.Serialization.WireProtocol
         public bool IsEndBaseOrEndObject
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Tag.HasExtendedWireType &&
-                   (Tag.ExtendedWireType == ExtendedWireType.EndTagDelimited ||
-                    Tag.ExtendedWireType == ExtendedWireType.EndBaseFields);
+            get => Tag.HasExtendedWireType && Tag.ExtendedWireType <= ExtendedWireType.EndBaseFields;
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            var builder = new StringBuilder();
-            _ = builder.Append('[').Append((string)WireType.ToString());
+            var builder = new DefaultInterpolatedStringHandler(0, 0);
+            builder.AppendLiteral("[");
+            builder.AppendFormatted(WireType);
+
             if (HasFieldId)
             {
-                _ = builder.Append($", IdDelta:{FieldIdDelta}");
+                builder.AppendLiteral(", IdDelta:");
+                builder.AppendFormatted(FieldIdDelta);
             }
 
             if (IsSchemaTypeValid)
             {
-                _ = builder.Append($", SchemaType:{SchemaType}");
+                builder.AppendLiteral(", SchemaType:");
+                builder.AppendFormatted(SchemaType);
             }
 
             if (HasExtendedSchemaType)
             {
-                _ = builder.Append($", RuntimeType:{FieldType}");
+                builder.AppendLiteral(", RuntimeType:");
+                builder.AppendFormatted(FieldType);
             }
 
             if (WireType == WireType.Extended)
             {
-                _ = builder.Append($": {ExtendedWireType}");
+                builder.AppendLiteral(": ");
+                builder.AppendFormatted(ExtendedWireType);
             }
 
-            _ = builder.Append(']');
-            return builder.ToString();
+            builder.AppendLiteral("]");
+            return builder.ToStringAndClear();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
This removes unnecessary `IPEndPoint` allocations when creating `SiloAddress` instances.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7886)