### PR TITLE
Remove PlatformAbstractions on .NET 6

### DIFF
--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0' and '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
The new Microsoft.Orleans.Serialization NuGet package pulls in the Microsoft.DotNet.PlatformAbstractions NuGet package when targeting .NET 6. However, it looks to be unused. The only reference I can find is on [line 142 of `ReferencedAssemblyHelper.cs`](https://github.com/dotnet/orleans/blob/339bf24cd6d7946e99b946567d0655916a62b6d5/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs#L133-L153), but this is conditionally compiled based on a .NET 5 or greater check.

The proposed change removes the Microsoft.DotNet.PlatformAbstractions dependency when targeting .NET 6.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7889)