### PR TITLE
Trim the correct queue on Chirper account state

### DIFF
--- a/samples/Chirper/Chirper.Grains/ChirperAccount.cs
+++ b/samples/Chirper/Chirper.Grains/ChirperAccount.cs
@@ -198,9 +198,9 @@ public class ChirperAccount : Grain, IChirperAccount
         _state.State.RecentReceivedMessages.Enqueue(chirp);
 
         // only relevant when not using fixed queue
-        while (_state.State.MyPublishedMessages.Count > PublishedMessagesCacheSize) // to keep not more than the max number of messages
+        while (_state.State.RecentReceivedMessages.Count > ReceivedMessagesCacheSize) // to keep not more than the max number of messages
         {
-            _state.State.MyPublishedMessages.Dequeue();
+            _state.State.RecentReceivedMessages.Dequeue();
         }
 
         await WriteStateAsync();


### PR DESCRIPTION
Noticed a copy/paste error in the Chirper sample when I was reviewing the code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7890)