### PR TITLE
Remove Directory handoff on silo shutdown

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -13,15 +13,11 @@ namespace Orleans.Runtime.GrainDirectory
     /// </summary>
     internal class GrainDirectoryHandoffManager
     {
-        private const int HANDOFF_CHUNK_SIZE = 500;
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
         private const int MAX_OPERATION_DEQUEUE = 2;
         private readonly LocalGrainDirectory localDirectory;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IInternalGrainFactory grainFactory;
-        private readonly Dictionary<SiloAddress, GrainDirectoryPartition> directoryPartitionsMap;
-        private readonly List<SiloAddress> silosHoldingMyPartition;
-        private readonly Dictionary<SiloAddress, Task> lastPromise;
         private readonly ILogger logger;
         private readonly Factory<GrainDirectoryPartition> createPartion;
         private readonly Queue<(string name, Func<Task> action)> pendingOperations = new Queue<(string name, Func<Task> action)>();
@@ -39,167 +35,14 @@ namespace Orleans.Runtime.GrainDirectory
             this.siloStatusOracle = siloStatusOracle;
             this.grainFactory = grainFactory;
             this.createPartion = createPartion;
-            directoryPartitionsMap = new Dictionary<SiloAddress, GrainDirectoryPartition>();
-            silosHoldingMyPartition = new List<SiloAddress>();
-            lastPromise = new Dictionary<SiloAddress, Task>();
         }
 
-        internal List<ActivationAddress> GetHandedOffInfo(GrainId grain)
-        {
-            lock (this)
-            {
-                foreach (var partition in directoryPartitionsMap.Values)
-                {
-                    var result = partition.LookUpActivations(grain);
-                    if (result.Addresses != null)
-                        return result.Addresses;
-                }
-            }
-            return null;
-        }
-
-        private async Task HandoffMyPartitionUponStop(List<KeyValuePair<GrainId, IGrainInfo>> batchUpdate, List<SiloAddress> silosHoldingMyPartitionCopy, bool isFullCopy)
-        {
-            if (batchUpdate.Count == 0 || silosHoldingMyPartitionCopy.Count == 0)
-            {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug((isFullCopy ? "FULL" : "DELTA") + " handoff finished with empty delta (nothing to send)");
-                return;
-            }
-
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Sending {0} items to my {1}: (ring status is {2})", 
-                batchUpdate.Count, silosHoldingMyPartitionCopy.ToStrings(), localDirectory.RingStatusToString());
-
-            var tasks = new List<Task>();
-
-            var n = 0;
-            var chunk = new Dictionary<GrainId, IGrainInfo>();
-
-            // Note that batchUpdate will not change while this method is executing
-            foreach (var pair in batchUpdate)
-            {
-                chunk[pair.Key] = pair.Value;
-                n++;
-                if ((n % HANDOFF_CHUNK_SIZE != 0) && (n != batchUpdate.Count))
-                {
-                    // If we haven't filled in a chunk yet, keep looping.
-                    continue;
-                }
-
-                foreach (SiloAddress silo in silosHoldingMyPartitionCopy)
-                {
-                    SiloAddress captureSilo = silo;
-                    Dictionary<GrainId, IGrainInfo> captureChunk = chunk;
-                    bool captureIsFullCopy = isFullCopy;
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Sending handed off partition to " + captureSilo);
-
-                    Task pendingRequest;
-                    if (lastPromise.TryGetValue(captureSilo, out pendingRequest))
-                    {
-                        try
-                        {
-                            await pendingRequest;
-                        }
-                        catch (Exception)
-                        {
-                        }
-                    }
-                    Task task = localDirectory.Scheduler.RunOrQueueTask(
-                                () => localDirectory.GetDirectoryReference(captureSilo).AcceptHandoffPartition(
-                                        localDirectory.MyAddress,
-                                        captureChunk,
-                                        captureIsFullCopy),
-                                localDirectory.RemoteGrainDirectory);
-                    lastPromise[captureSilo] = task;
-                    tasks.Add(task);
-                }
-                // We need to use a new Dictionary because the call to AcceptHandoffPartition, which reads the current Dictionary,
-                // happens asynchronously (and typically after some delay).
-                chunk = new Dictionary<GrainId, IGrainInfo>();
-
-                // This is a quick temporary solution. We send a full copy by sending one chunk as a full copy and follow-on chunks as deltas.
-                // Obviously, this will really mess up if there's a failure after the first chunk but before the others are sent, since on a
-                // full copy receive the follower dumps all old data and replaces it with the new full copy. 
-                // On the other hand, over time things should correct themselves, and of course, losing directory data isn't necessarily catastrophic.
-                isFullCopy = false;
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        internal void ProcessSiloRemoveEvent(SiloAddress removedSilo)
-        {
-            lock (this)
-            {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo remove event for " + removedSilo);
-
-                // Reset our follower list to take the changes into account
-                ResetFollowers();
-
-                // check if this is one of our successors (i.e., if I hold this silo's copy)
-                // (if yes, adjust local and/or handoffed directory partitions)
-                if (!directoryPartitionsMap.TryGetValue(removedSilo, out var partition)) return;
-
-                // at least one predcessor should exist, which is me
-                SiloAddress predecessor = localDirectory.FindPredecessors(removedSilo, 1)[0];
-                Dictionary<SiloAddress, List<ActivationAddress>> duplicates;
-                if (localDirectory.MyAddress.Equals(predecessor))
-                {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Merging my partition with the copy of silo " + removedSilo);
-                    // now I am responsible for this directory part
-                    duplicates = localDirectory.DirectoryPartition.Merge(partition);
-                    // no need to send our new partition to all others, as they
-                    // will realize the change and combine their copies without any additional communication (see below)
-                }
-                else
-                {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Merging partition of " + predecessor + " with the copy of silo " + removedSilo);
-                    // adjust copy for the predecessor of the failed silo
-                    duplicates = directoryPartitionsMap[predecessor].Merge(partition);
-                }
-
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removed copied partition of silo " + removedSilo);
-                directoryPartitionsMap.Remove(removedSilo);
-                DestroyDuplicateActivations(duplicates);
-            }
-        }
-
-        internal Task ProcessSiloStoppingEvent()
-        {
-            return ProcessSiloStoppingEvent_Impl();
-        }
-
-        private async Task ProcessSiloStoppingEvent_Impl()
-        {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo stopping event");
-
-            // As we're about to enter an async context further down, this is the latest opportunity to lock, modify and copy
-            // silosHoldingMyPartition for use inside of HandoffMyPartitionUponStop
-            List<SiloAddress> silosHoldingMyPartitionCopy;
-            lock (this)
-            {
-                // Select our nearest predecessor to receive our hand-off, since that's the silo that will wind up owning our partition (assuming
-                // that it doesn't also fail and that no other silo joins during the transition period).
-                if (silosHoldingMyPartition.Count == 0)
-                {
-                    silosHoldingMyPartition.AddRange(localDirectory.FindPredecessors(localDirectory.MyAddress, 1));
-                }
-
-                silosHoldingMyPartitionCopy = silosHoldingMyPartition.ToList();
-            }
-
-            // take a copy of the current directory partition
-            var batchUpdate = localDirectory.DirectoryPartition.GetItems();
-
-            await HandoffMyPartitionUponStop(batchUpdate, silosHoldingMyPartitionCopy, true);
-        }
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)
         {
             lock (this)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Processing silo add event for " + addedSilo);
-
-                // Reset our follower list to take the changes into account
-                ResetFollowers();
 
                 // check if this is one of our successors (i.e., if I should hold this silo's copy)
                 // (if yes, adjust local and/or copied directory partitions by splitting them between old successors and the new one)
@@ -229,35 +72,6 @@ namespace Orleans.Runtime.GrainDirectory
                         $"{nameof(ProcessSiloAddEvent)}({addedSilo})",
                         () => ProcessAddedSiloAsync(addedSilo, splitPartListSingle, splitPartListMulti));
                 }
-                else
-                {
-                    // adjust partitions by splitting them accordingly between new and old silos
-                    SiloAddress predecessorOfNewSilo = localDirectory.FindPredecessors(addedSilo, 1)[0];
-                    if (!directoryPartitionsMap.TryGetValue(predecessorOfNewSilo, out var predecessorPartition))
-                    {
-                        // we should have the partition of the predcessor of our new successor
-                        logger.Warn(ErrorCode.DirectoryPartitionPredecessorExpected, "This silo is expected to hold directory partition of " + predecessorOfNewSilo);
-                    }
-                    else
-                    {
-                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Splitting partition of " + predecessorOfNewSilo + " and creating a copy for " + addedSilo);
-                        GrainDirectoryPartition splitPart = predecessorPartition.Split(
-                            grain =>
-                            {
-                                // Need to review the 2nd line condition.
-                                var s = localDirectory.CalculateGrainDirectoryPartition(grain);
-                                return (s != null) && !predecessorOfNewSilo.Equals(s);
-                            }, true);
-                        directoryPartitionsMap[addedSilo] = splitPart;
-                    }
-                }
-
-                // remove partition of one of the old successors that we do not need to now
-                SiloAddress oldSuccessor = directoryPartitionsMap.FirstOrDefault(pair => !successors.Contains(pair.Key)).Key;
-                if (oldSuccessor == null) return;
-
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removing copy of the directory partition of silo " + oldSuccessor + " (holding copy of " + addedSilo + " instead)");
-                directoryPartitionsMap.Remove(oldSuccessor);
             }
         }
 
@@ -391,64 +205,6 @@ namespace Orleans.Runtime.GrainDirectory
                     }
                 }
             }
-        }
-
-        internal void AcceptHandoffPartition(SiloAddress source, Dictionary<GrainId, IGrainInfo> partition, bool isFullCopy)
-        {
-            lock (this)
-            {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Got request to register " + (isFullCopy ? "FULL" : "DELTA") + " directory partition with " + partition.Count + " elements from " + source);
-
-                if (!directoryPartitionsMap.TryGetValue(source, out var sourcePartition))
-                {
-                    if (!isFullCopy)
-                    {
-                        logger.Warn(ErrorCode.DirectoryUnexpectedDelta,
-                            String.Format("Got delta of the directory partition from silo {0} (Membership status {1}) while not holding a full copy. Membership active cluster size is {2}",
-                                source, this.siloStatusOracle.GetApproximateSiloStatus(source),
-                                this.siloStatusOracle.GetApproximateSiloStatuses(true).Count));
-                    }
-
-                    directoryPartitionsMap[source] = sourcePartition = this.createPartion();
-                }
-
-                if (isFullCopy)
-                {
-                    sourcePartition.Set(partition);
-                }
-                else
-                {
-                    sourcePartition.Update(partition);
-                }
-            }
-        }
-
-        internal void RemoveHandoffPartition(SiloAddress source)
-        {
-            lock (this)
-            {
-                if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Got request to unregister directory partition copy from " + source);
-                directoryPartitionsMap.Remove(source);
-            }
-        }
-
-        private void ResetFollowers()
-        {
-            var copyList = silosHoldingMyPartition.ToList();
-            foreach (var follower in copyList)
-            {
-                RemoveOldFollower(follower);
-            }
-        }
-
-        private void RemoveOldFollower(SiloAddress silo)
-        {
-            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Removing my copy from silo " + silo);
-            // release this old copy, as we have got a new one
-            silosHoldingMyPartition.Remove(silo);
-            localDirectory.Scheduler.QueueTask(() =>
-                localDirectory.GetDirectoryReference(silo).RemoveHandoffPartition(localDirectory.MyAddress),
-                localDirectory.RemoteGrainDirectory).Ignore();
         }
 
         private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<ActivationAddress>> duplicates)

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -15,8 +15,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <summary>
         /// Stops the local portion of the directory service.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Stop")]
-        Task Stop(bool doOnStopHandoff);
+        Task Stop();
 
         RemoteGrainDirectory RemoteGrainDirectory { get; }
         RemoteGrainDirectory CacheValidator { get; }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -292,8 +292,6 @@ namespace Orleans.Runtime.GrainDirectory
                 }
 
                 // the call order is important
-                HandoffManager.ProcessSiloRemoveEvent(silo);
-
                 this.directoryMembership = new DirectoryMembership(
                     existing.MembershipRingList.Remove(silo),
                     existing.MembershipCache.Remove(silo));
@@ -931,17 +929,14 @@ namespace Orleans.Runtime.GrainDirectory
         public List<ActivationAddress> GetLocalDataForGrain(GrainId grain, out bool isPrimary)
         {
             var primary = CalculateGrainDirectoryPartition(grain);
-            List<ActivationAddress> backupData = HandoffManager.GetHandedOffInfo(grain);
             if (MyAddress.Equals(primary))
             {
-                log.Assert(ErrorCode.DirectoryBothPrimaryAndBackupForGrain, backupData == null,
-                    "Silo contains both primary and backup directory data for grain " + grain);
                 isPrimary = true;
                 return GetLocalDirectoryData(grain).Addresses;
             }
 
             isPrimary = false;
-            return backupData;
+            return null;
         }
 
         public override string ToString()

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -97,13 +97,13 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task AcceptHandoffPartition(SiloAddress source, Dictionary<GrainId, IGrainInfo> partition, bool isFullCopy)
         {
-            router.HandoffManager.AcceptHandoffPartition(source, partition, isFullCopy);
+            // Keep for backward compatibility
             return Task.CompletedTask;
         }
 
         public Task RemoveHandoffPartition(SiloAddress source)
         {
-            router.HandoffManager.RemoveHandoffPartition(source);
+            // Keep for backward compatibility
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -673,7 +673,7 @@ namespace Orleans.Runtime
                     logger.Info(ErrorCode.SiloShuttingDown, "Silo starting to Shutdown()");
 
                     //Stop LocalGrainDirectory
-                    await scheduler.QueueTask(()=>localGrainDirectory.Stop(true), localGrainDirectory.CacheValidator)
+                    await scheduler.QueueTask(()=>localGrainDirectory.Stop(), localGrainDirectory.CacheValidator)
                         .WithCancellation(ct, "localGrainDirectory Stop failed because the task was cancelled");
                     SafeExecute(() => catalog.DeactivateAllActivations().Wait(ct));
 

--- a/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
+++ b/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
@@ -105,7 +105,7 @@ namespace UnitTests.Directory
             throw new NotImplementedException();
         }
 
-        public Task Stop(bool doOnStopHandoff)
+        public Task Stop()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
The grain directory handoff on silo shutdown was useless since Orleans will deactivate all the grains that were in the directory partition of the stopped silo.

The handoff manager also tried to keep a copy of the partition of its successor, but the logic wasn't really useful and might introduce more invalid directory entries, so I removed it too.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7909)