### PR TITLE
[3.x] Fix `NullReferenceException` when too many instances of a `[StatelessWorker]` are created and `Debug` logging is enabled

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -528,10 +528,12 @@ namespace Orleans.Runtime
                             {
                                 logger.LogDebug(
                                     (int)ErrorCode.Catalog_DuplicateActivation,
-                                    "Trying to create too many {GrainType} activations on this silo. Redirecting to activation {RedirectActivation}",
-                                    result.Name,
-                                    redirect.ActivationId);
+                                    "Trying to create too many {GrainType} activations on this silo while requesting grain {GrainId}. Redirecting to activation {RedirectActivation}",
+                                    grainType,
+                                    address.Grain,
+                                    redirect?.ActivationId?.ToString());
                             }
+
                             return redirect;
                         }
                         // The newly created StatelessWorker will be registered in RegisterMessageTarget()


### PR DESCRIPTION
We've seen one or two reports of this biting people. This appears to be the root issue.

Fixes #7918

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7918)