### PR TITLE
Add build-time analyzer for unsupported grain interface method return types

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -24,11 +24,13 @@ $Platform = $null
 # Disable multilevel lookup https://github.com/dotnet/core-setup/blob/main/Documentation/design-docs/multilevel-sharedfx-lookup.md
  $DOTNET_MULTILEVEL_LOOKUP = 0
 
+$BuildProperties = "/p:Configuration=$env:BuildConfiguration";
+
  # Set DateTime suffix for debug builds
  if ($env:BuildConfiguration -eq "Debug")
  {
     $dateSuffix = Get-Date -Format "yyyyMMddHHmm"
-    $AdditionalConfigurationProperties=";VersionDateSuffix=$dateSuffix"
+    $BuildProperties = $BuildProperties + " /p:VersionDateSuffix=$dateSuffix"
  }
 
 Write-Output "===== Building $solution ====="
@@ -38,11 +40,11 @@ Install-Dotnet
 if ($args[0] -ne "Pack")
 {
     Write-Output "Build $env:BuildConfiguration =============================="
-    Invoke-Dotnet -Command "restore" -Arguments "$env:BUILD_FLAGS /bl:${env:BuildConfiguration}-Restore.binlog /p:Configuration=${env:BuildConfiguration}${AdditionalConfigurationProperties} `"$solution`""
-    Invoke-Dotnet -Command "build" -Arguments "$env:BUILD_FLAGS /bl:${env:BuildConfiguration}-Build.binlog /p:Configuration=${env:BuildConfiguration}${AdditionalConfigurationProperties} `"$solution`""
+    Invoke-Dotnet -Command "restore" -Arguments "$env:BUILD_FLAGS /bl:${env:BuildConfiguration}-Restore.binlog ${BuildProperties} `"$solution`""
+    Invoke-Dotnet -Command "build" -Arguments "$env:BUILD_FLAGS /bl:${env:BuildConfiguration}-Build.binlog ${BuildProperties} `"$solution`""
 }
 
 Write-Output "Package $env:BuildConfiguration ============================"
-Invoke-Dotnet -Command "pack" -Arguments "--no-build --no-restore $BUILD_FLAGS /bl:${env:BuildConfiguration}-Pack.binlog /p:Configuration=${env:BuildConfiguration}${AdditionalConfigurationProperties} `"$solution`""
+Invoke-Dotnet -Command "pack" -Arguments "--no-build --no-restore $BUILD_FLAGS /bl:${env:BuildConfiguration}-Pack.binlog ${BuildProperties} `"$solution`""
 
 Write-Output "===== Build succeeded for $solution ====="

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.200"
+    "version": "6.0.400"
   }
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/InvalidGrainMethodReturnTypeDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InvalidGrainMethodReturnTypeDiagnostic.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public class InvalidGrainMethodReturnTypeDiagnostic
+{
+    public const string RuleId = "ORLEANS0102"; 
+    private const string Category = "Usage";
+    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeMessageFormat), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeDescription), Resources.ResourceManager, typeof(Resources));
+
+    internal static DiagnosticDescriptor Rule { get; } = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+    public static Diagnostic CreateDiagnostic(Location location, string returnType, string methodIdentifier, string supportedReturnTypeList) => Diagnostic.Create(Rule, location, returnType, methodIdentifier, supportedReturnTypeList);
+
+    internal static Diagnostic CreateDiagnostic(MethodDescription methodDescription)
+    {
+        var methodReturnType = methodDescription.Method.ReturnType;
+        var diagnostic = CreateDiagnostic(
+            methodDescription.Method.OriginalDefinition.Locations.FirstOrDefault(),
+            methodReturnType.ToDisplayString(),
+            methodDescription.Method.ToDisplayString(),
+            string.Join(", ", methodDescription.InvokableBaseTypes.Keys.Select(v => v.ToDisplayString())));
+        return diagnostic;
+    }
+}

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Orleans.CodeGenerator.Diagnostics;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Orleans.CodeGenerator
@@ -105,18 +106,23 @@ namespace Orleans.CodeGenerator
 
         private static INamedTypeSymbol GetBaseClassType(MethodDescription method)
         {
-            var methodReturnType = (INamedTypeSymbol)method.Method.ReturnType;
-            if (method.InvokableBaseTypes.TryGetValue(methodReturnType, out var baseClassType))
+            var methodReturnType = method.Method.ReturnType;
+            if (methodReturnType is not INamedTypeSymbol namedMethodReturnType)
+            {
+                var diagnostic = InvalidGrainMethodReturnTypeDiagnostic.CreateDiagnostic(method);
+                throw new OrleansGeneratorDiagnosticAnalysisException(diagnostic);
+            }
+            if (method.InvokableBaseTypes.TryGetValue(namedMethodReturnType, out var baseClassType))
             {
                 return baseClassType;
             }
 
-            if (methodReturnType.ConstructedFrom is { } constructedFrom)
+            if (namedMethodReturnType.ConstructedFrom is { } constructedFrom)
             {
                 var unbound = constructedFrom.ConstructUnboundGenericType();
                 if (method.InvokableBaseTypes.TryGetValue(unbound, out baseClassType))
                 {
-                    return baseClassType.ConstructedFrom.Construct(methodReturnType.TypeArguments.ToArray());
+                    return baseClassType.ConstructedFrom.Construct(namedMethodReturnType.TypeArguments.ToArray());
                 }
             }
             

--- a/src/Orleans.CodeGenerator/Resources.Designer.cs
+++ b/src/Orleans.CodeGenerator/Resources.Designer.cs
@@ -86,5 +86,32 @@ namespace Orleans.CodeGenerator {
                 return ResourceManager.GetString("InaccessibleSetterTitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The return type of a grain method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;..
+        /// </summary>
+        internal static string InvalidGrainMethodReturnTypeDescription {
+            get {
+                return ResourceManager.GetString("InvalidGrainMethodReturnTypeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type {0} for the grain interface method {1} cannot be used as a grain method return type. Grain methods must return one of the following types: {2}..
+        /// </summary>
+        internal static string InvalidGrainMethodReturnTypeMessageFormat {
+            get {
+                return ResourceManager.GetString("InvalidGrainMethodReturnTypeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid return type for grain interface method..
+        /// </summary>
+        internal static string InvalidGrainMethodReturnTypeTitle {
+            get {
+                return ResourceManager.GetString("InvalidGrainMethodReturnTypeTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Orleans.CodeGenerator/Resources.resx
+++ b/src/Orleans.CodeGenerator/Resources.resx
@@ -126,4 +126,13 @@
   <data name="InaccessibleSetterTitle" xml:space="preserve">
     <value>Serializable properties with bodies must be settable.</value>
   </data>
+  <data name="InvalidGrainMethodReturnTypeDescription" xml:space="preserve">
+    <value>The return type of a grain method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;.</value>
+  </data>
+  <data name="InvalidGrainMethodReturnTypeMessageFormat" xml:space="preserve">
+    <value>The type {0} for the grain interface method {1} cannot be used as a grain method return type. Grain methods must return one of the following types: {2}.</value>
+  </data>
+  <data name="InvalidGrainMethodReturnTypeTitle" xml:space="preserve">
+    <value>Invalid return type for grain interface method.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #7907 by adding an analyzer to fail the build on unsupported grain interface method types.
Note that this is based on #7926, which therefore comes first.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7930)