### PR TITLE
Fix AzureQueueAdapterFactory.Create constructor arguments

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -88,8 +88,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             var cacheOptions = services.GetOptionsByName<SimpleQueueCacheOptions>(name);
             var dataAdapter = services.GetServiceByName<IQueueDataAdapter<string, IBatchContainer>>(name)
                 ?? services.GetService<IQueueDataAdapter<string, IBatchContainer>>();
-            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(name);
-            var factory = ActivatorUtilities.CreateInstance<AzureQueueAdapterFactory>(services, name, azureQueueOptions, cacheOptions, dataAdapter, clusterOptions);
+            var factory = ActivatorUtilities.CreateInstance<AzureQueueAdapterFactory>(services, name, azureQueueOptions, cacheOptions, dataAdapter);
             factory.Init();
             return factory;
         }


### PR DESCRIPTION
There is an extra argument being passed, resulting in test failures.
Caused by #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7942)