### PR TITLE
Use compound type aliases for generated classes

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -61,17 +61,6 @@ namespace Orleans.CodeGenerator
                     }
 
                     AddMember(ns, invokable);
-
-                    var methodSymbol = method.Method;
-                    if (GetWellKnownTypeId(methodSymbol) is uint wellKnownTypeId)
-                    {
-                        metadataModel.WellKnownTypeIds.Add((generatedInvokerDescription.OpenTypeSyntax, wellKnownTypeId));
-                    }
-
-                    if (GetTypeAlias(methodSymbol) is string typeAlias)
-                    {
-                        metadataModel.TypeAliases.Add((generatedInvokerDescription.OpenTypeSyntax, typeAlias));
-                    }
                 }
 
                 var (proxy, generatedProxyDescription) = ProxyGenerator.Generate(LibraryTypes, type, metadataModel);
@@ -195,7 +184,7 @@ namespace Orleans.CodeGenerator
                         metadataModel.WellKnownTypeIds.Add((symbol.ToOpenTypeSyntax(), wellKnownTypeId));
                     }
 
-                    if (GetTypeAlias(symbol) is string typeAlias)
+                    if (GetAlias(symbol) is string typeAlias)
                     {
                         metadataModel.TypeAliases.Add((symbol.ToOpenTypeSyntax(), typeAlias));
                     }
@@ -284,7 +273,7 @@ namespace Orleans.CodeGenerator
                                 this,
                                 semanticModel,
                                 symbol,
-                                GetTypeAlias(symbol) ?? symbol.Name,
+                                GetAlias(symbol) ?? symbol.Name,
                                 baseClass,
                                 isExtension,
                                 invokableBaseTypes);
@@ -513,7 +502,10 @@ namespace Orleans.CodeGenerator
 
             static string Format(IMethodSymbol methodInfo)
             {
-                var result = new StringBuilder(methodInfo.Name);
+                var result = new StringBuilder();
+                result.Append(methodInfo.ContainingType.ToDisplayName());
+                result.Append('.');
+                result.Append(methodInfo.Name);
 
                 if (methodInfo.IsGenericMethod)
                 {
@@ -572,7 +564,7 @@ namespace Orleans.CodeGenerator
             return id;
         }
 
-        private string GetTypeAlias(ISymbol symbol)
+        public string GetAlias(ISymbol symbol)
         {
             var attr = symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(LibraryTypes.WellKnownAliasAttribute, attr.AttributeClass));
             if (attr is null)

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -552,21 +552,11 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        private uint? GetWellKnownTypeId(ISymbol symbol)
-        {
-            var attr = symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(LibraryTypes.WellKnownIdAttribute, attr.AttributeClass));
-            if (attr is null)
-            {
-                return null;
-            }
-
-            var id = (uint)attr.ConstructorArguments.First().Value;
-            return id;
-        }
+        private uint? GetWellKnownTypeId(ISymbol symbol) => GetId(symbol);
 
         public string GetAlias(ISymbol symbol)
         {
-            var attr = symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(LibraryTypes.WellKnownAliasAttribute, attr.AttributeClass));
+            var attr = symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(LibraryTypes.AliasAttribute, attr.AttributeClass));
             if (attr is null)
             {
                 return null;

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -465,7 +465,7 @@ namespace Orleans.CodeGenerator
         // Returns descriptions of all data members (fields and properties)
         private IEnumerable<IMemberDescription> GetDataMembers(FieldIdAssignmentHelper fieldIdAssignmentHelper)
         {
-            var members = new Dictionary<(ushort, bool), IMemberDescription>();
+            var members = new Dictionary<(uint, bool), IMemberDescription>();
 
             foreach (var member in fieldIdAssignmentHelper.Members)
             {
@@ -491,9 +491,9 @@ namespace Orleans.CodeGenerator
             return members.Values;
         }
 
-        public ushort? GetId(ISymbol memberSymbol) => GetId(LibraryTypes, memberSymbol);
+        public uint? GetId(ISymbol memberSymbol) => GetId(LibraryTypes, memberSymbol);
 
-        internal static ushort? GetId(LibraryTypes libraryTypes, ISymbol memberSymbol)
+        internal static uint? GetId(LibraryTypes libraryTypes, ISymbol memberSymbol)
         {
             var idAttr = memberSymbol.GetAttributes().FirstOrDefault(attr => libraryTypes.IdAttributeTypes.Any(t => SymbolEqualityComparer.Default.Equals(t, attr.AttributeClass)));
             if (idAttr is null)
@@ -501,7 +501,7 @@ namespace Orleans.CodeGenerator
                 return null;
             }
 
-            var id = (ushort)idAttr.ConstructorArguments.First().Value;
+            var id = (uint)idAttr.ConstructorArguments.First().Value;
             return id;
         }
 

--- a/src/Orleans.CodeGenerator/Hashing/HexConverter.cs
+++ b/src/Orleans.CodeGenerator/Hashing/HexConverter.cs
@@ -1,0 +1,40 @@
+#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.CodeGenerator.Hashing
+{
+    internal static class HexConverter
+    {
+        public static unsafe string ToString(ReadOnlySpan<byte> bytes)
+        {
+            // Adapted from: https://github.com/dotnet/runtime/blob/f156fb9dcf121e536b93ae90bcc5e8e6d5336062/src/libraries/Common/src/System/HexConverter.cs#L196
+            
+            Span<char> result = bytes.Length > 16 ?
+                new char[bytes.Length * 2].AsSpan() :
+                stackalloc char[bytes.Length * 2];
+
+            int pos = 0;
+            foreach (byte b in bytes)
+            {
+                ToCharsBuffer(b, result, pos);
+                pos += 2;
+            }
+
+            return result.ToString();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static void ToCharsBuffer(byte value, Span<char> buffer, int startingIndex = 0)
+            {
+                var difference = ((value & 0xF0U) << 4) + (value & 0x0FU) - 0x8989U;
+                var packedResult = (((uint)-(int)difference & 0x7070U) >> 4) + difference + 0xB9B9U;
+
+                buffer[startingIndex + 1] = (char)(packedResult & 0xFF);
+                buffer[startingIndex] = (char)(packedResult >> 8);
+            }
+        }
+    }
+}

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -15,7 +15,7 @@ namespace Orleans.CodeGenerator
     /// </summary>
     internal static class InvokableGenerator
     {
-        public static (ClassDeclarationSyntax, GeneratedInvokerDescription) Generate(
+        public static (ClassDeclarationSyntax Syntax, GeneratedInvokerDescription InvokerDescription) Generate(
             LibraryTypes libraryTypes,
             InvokableInterfaceDescription interfaceDescription,
             MethodDescription method)
@@ -35,11 +35,13 @@ namespace Orleans.CodeGenerator
                 Accessibility.Public => SyntaxKind.PublicKeyword,
                 _ => SyntaxKind.InternalKeyword,
             };
+            var compoundTypeAliasArgs = GetCompoundTypeAliasAttributeArguments(method);
             var classDeclaration = ClassDeclaration(generatedClassName)
                 .AddBaseListTypes(SimpleBaseType(baseClassType.ToTypeSyntax(method.TypeParameterSubstitutions)))
                 .AddModifiers(Token(accessibilityKind), Token(SyntaxKind.SealedKeyword))
                 .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())))
+                    AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())),
+                    AttributeList(SingletonSeparatedList(GetCompoundTypeAliasAttribute(libraryTypes, compoundTypeAliasArgs))))
                 .AddMembers(fields);
 
             if (ctor != null)
@@ -83,7 +85,8 @@ namespace Orleans.CodeGenerator
                 fieldDescriptions.OfType<IMemberDescription>().ToList(),
                 serializationHooks,
                 baseClassType,
-                ctorArgs);
+                ctorArgs,
+                compoundTypeAliasArgs);
             return (classDeclaration, invokerDescription);
 
             static Accessibility GetAccessibility(InvokableInterfaceDescription interfaceDescription)
@@ -106,6 +109,36 @@ namespace Orleans.CodeGenerator
 
         private static ClassDeclarationSyntax AddOptionalMembers(ClassDeclarationSyntax decl, params MemberDeclarationSyntax[] items)
             => decl.WithMembers(decl.Members.AddRange(items.Where(i => i != null)));
+
+        internal static AttributeSyntax GetCompoundTypeAliasAttribute(LibraryTypes libraryTypes, CompoundTypeAliasComponent[] argValues)
+        {
+            var args = new AttributeArgumentSyntax[argValues.Length];
+            for (var i = 0; i < argValues.Length; i++)
+            {
+                ExpressionSyntax value;
+                value = argValues[i].Value switch
+                {
+                    string stringValue => LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(stringValue)),
+                    ITypeSymbol typeValue => TypeOfExpression(typeValue.ToOpenTypeSyntax()),
+                    _ => throw new InvalidOperationException($"Unsupported value")
+                };
+
+                args[i] = AttributeArgument(value);
+            }
+
+            return Attribute(libraryTypes.CompoundTypeAliasAttribute.ToNameSyntax()).AddArgumentListArguments(args);
+        }
+
+        internal static CompoundTypeAliasComponent[] GetCompoundTypeAliasAttributeArguments(MethodDescription methodDescription)
+        {
+            return new CompoundTypeAliasComponent[4]
+            {
+                    new CompoundTypeAliasComponent("inv"),
+                    new CompoundTypeAliasComponent(methodDescription.ContainingInterface.ProxyBaseType),
+                    new CompoundTypeAliasComponent(methodDescription.ContainingInterface.InterfaceType),
+                    new CompoundTypeAliasComponent(methodDescription.MethodId)
+            };
+        }
 
         private static INamedTypeSymbol GetBaseClassType(MethodDescription method)
         {
@@ -455,7 +488,7 @@ namespace Orleans.CodeGenerator
         {
             var genericArity = method.AllTypeParameters.Count;
             var typeArgs = genericArity > 0 ? "_" + genericArity : string.Empty;
-            return $"Invokable_{interfaceDescription.Name}_{interfaceDescription.ProxyBaseType.Name}_{method.Name}{typeArgs}";
+            return $"Invokable_{interfaceDescription.Name}_{interfaceDescription.ProxyBaseType.Name}_{method.MethodId}{typeArgs}";
         }
 
         private static MemberDeclarationSyntax[] GetFieldDeclarations(

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -612,7 +612,7 @@ namespace Orleans.CodeGenerator
         {
             var fields = new List<InvokerFieldDescripton>();
 
-            ushort fieldId = 0;
+            uint fieldId = 0;
             foreach (var parameter in method.Method.Parameters)
             {
                 fields.Add(new MethodParameterFieldDescription(method, parameter, $"arg{fieldId}", fieldId));
@@ -649,7 +649,7 @@ namespace Orleans.CodeGenerator
 
         internal sealed class MethodParameterFieldDescription : InvokerFieldDescripton, IMemberDescription
         {
-            public MethodParameterFieldDescription(MethodDescription method, IParameterSymbol parameter, string fieldName, ushort fieldId)
+            public MethodParameterFieldDescription(MethodDescription method, IParameterSymbol parameter, string fieldName, uint fieldId)
                 : base(parameter.Type, fieldName)
             {
                 Method = method;
@@ -672,7 +672,7 @@ namespace Orleans.CodeGenerator
             public ISymbol Symbol { get; }
             public MethodDescription Method { get; }
             public int ParameterOrdinal => Parameter.Ordinal;
-            public ushort FieldId { get; }
+            public uint FieldId { get; }
             public ISymbol Member => Parameter;
             public ITypeSymbol Type => FieldType;
             public INamedTypeSymbol ContainingType => Parameter.ContainingType;

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -26,6 +26,7 @@ namespace Orleans.CodeGenerator
                 FieldCodec_1 = Type("Orleans.Serialization.Codecs.IFieldCodec`1"),
                 DeepCopier_1 = Type("Orleans.Serialization.Cloning.IDeepCopier`1"),
                 IOptionalDeepCopier = Type("Orleans.Serialization.Cloning.IOptionalDeepCopier"),
+                CompoundTypeAliasAttribute = Type("Orleans.CompoundTypeAliasAttribute"),
                 CopyContext = Type("Orleans.Serialization.Cloning.CopyContext"),
                 CopyContextPool = Type("Orleans.Serialization.Cloning.CopyContextPool"),
                 MethodInfo = Type("System.Reflection.MethodInfo"),
@@ -236,6 +237,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol FieldCodec_1 { get; private set; }
         public INamedTypeSymbol FieldCodec { get; private set; }
         public INamedTypeSymbol Func_2 { get; private set; }
+        public INamedTypeSymbol CompoundTypeAliasAttribute { get; private set; }
         public INamedTypeSymbol GenerateMethodSerializersAttribute { get; private set; }
         public INamedTypeSymbol GenerateSerializerAttribute { get; private set; }
         public INamedTypeSymbol IActivator_1 { get; private set; }

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -38,8 +38,7 @@ namespace Orleans.CodeGenerator
                 IBufferWriter = Type("System.Buffers.IBufferWriter`1"),
                 IdAttributeTypes = options.IdAttributes.Select(Type).ToList(),
                 ConstructorAttributeTypes = options.ConstructorAttributes.Select(Type).ToList(),
-                WellKnownAliasAttribute = Type("Orleans.WellKnownAliasAttribute"),
-                WellKnownIdAttribute = Type("Orleans.WellKnownIdAttribute"),
+                AliasAttribute = Type("Orleans.AliasAttribute"),
                 IInvokable = Type("Orleans.Serialization.Invocation.IInvokable"),
                 DefaultInvokeMethodNameAttribute = Type("Orleans.DefaultInvokeMethodNameAttribute"),
                 InvokeMethodNameAttribute = Type("Orleans.InvokeMethodNameAttribute"),
@@ -273,8 +272,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol Writer { get; private set; }
         public List<INamedTypeSymbol> IdAttributeTypes { get; private set; }
         public List<INamedTypeSymbol> ConstructorAttributeTypes { get; private set; }
-        public INamedTypeSymbol WellKnownAliasAttribute { get; private set; }
-        public INamedTypeSymbol WellKnownIdAttribute { get; private set; }
+        public INamedTypeSymbol AliasAttribute { get; private set; }
         public List<WellKnownCodecDescription> StaticCodecs { get; private set; }
         public List<WellKnownCodecDescription> WellKnownCodecs { get; private set; }
         public List<WellKnownCopierDescription> StaticCopiers { get; private set; }

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Orleans.CodeGenerator.SyntaxGeneration;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System;
 
 namespace Orleans.CodeGenerator
 {
@@ -97,8 +98,10 @@ namespace Orleans.CodeGenerator
             foreach (var type in metadataModel.TypeAliases)
             {
                 body.Add(ExpressionStatement(InvocationExpression(addTypeAliasMethod,
-                    ArgumentList(SeparatedList(new[] { Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Alias))), Argument(TypeOfExpression(type.Type)) })))));
+                    ArgumentList(SeparatedList(new[] { Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(type.Alias))), Argument(TypeOfExpression(type.Type)) })))));
             }
+
+            AddCompoundTypeAliases(metadataModel, configParam, body);
 
             var configType = libraryTypes.TypeManifestOptions;
             var configureMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Configure")
@@ -113,6 +116,81 @@ namespace Orleans.CodeGenerator
                 .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.SealedKeyword))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())))
                 .AddMembers(configureMethod);
+        }
+
+        private static void AddCompoundTypeAliases(MetadataModel metadataModel, IdentifierNameSyntax configParam, List<StatementSyntax> body)
+        {
+            // The goal is to emit a tree describing all of the generated invokers in the form:
+            // ("inv", typeof(ProxyBaseType), typeof(ContainingInterface), "<MethodId>")
+            // The first step is to collate the invokers into tree to ease the process of generating a tree in code.
+            var nodeId = 0;
+            AddCompoundTypeAliases(body, configParam.Member("CompoundTypeAliases"), metadataModel.CompoundTypeAliases);
+            void AddCompoundTypeAliases(List<StatementSyntax> body, ExpressionSyntax tree, CompoundTypeAliasTree aliases)
+            {
+                ExpressionSyntax node;
+
+                if (aliases.Key.IsDefault)
+                {
+                    // At the root node, do not create a new node, just enumerate over the child nodes.
+                    node = tree;
+                }
+                else
+                {
+                    var nodeName = IdentifierName($"n{++nodeId}");
+                    node = nodeName;
+                    var valueExpression = aliases.Value switch
+                    {
+                        { } type => Argument(TypeOfExpression(type)),
+                        _ => null
+                    };
+
+                    // Get the arguments for the Add call
+                    var addArguments = aliases.Key switch
+                    {
+                        { IsType: true } typeKey => valueExpression switch
+                        {
+                            // Call the two-argument Add overload to add a key and value.
+                            { } argument => new[] { Argument(TypeOfExpression(typeKey.TypeValue.ToOpenTypeSyntax())), argument },
+
+                            // Call the one-argument Add overload to add only a key.
+                            _ => new[] { Argument(TypeOfExpression(typeKey.TypeValue.ToOpenTypeSyntax())) },
+                        },
+                        { IsString: true } stringKey => valueExpression switch
+                        {
+                            // Call the two-argument Add overload to add a key and value.
+                            { } argument => new[] { Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(stringKey.StringValue))), argument },
+
+                            // Call the one-argument Add overload to add only a key.
+                            _ => new[] { Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(stringKey.StringValue))) },
+                        },
+                        _ => throw new InvalidOperationException("Unexpected alias key")
+                    };
+
+                    if (aliases.Children is { Count: > 0 })
+                    {
+                        // C#: var {newTree.Identifier} = {tree}.Add({addArguments});
+                        body.Add(LocalDeclarationStatement(VariableDeclaration(
+                            ParseTypeName("var"),
+                            SingletonSeparatedList(VariableDeclarator(nodeName.Identifier).WithInitializer(EqualsValueClause(InvocationExpression(
+                                tree.Member("Add"),
+                                ArgumentList(SeparatedList(addArguments)))))))));
+                    }
+                    else
+                    {
+                        // Do not emit a variable.
+                        // C#: {tree}.Add({addArguments});
+                        body.Add(ExpressionStatement(InvocationExpression(tree.Member("Add"), ArgumentList(SeparatedList(addArguments)))));
+                    }
+                }
+
+                if (aliases.Children is { Count: > 0 })
+                {
+                    foreach (var child in aliases.Children.Values)
+                    {
+                        AddCompoundTypeAliases(body, node, child);
+                    }
+                }
+            }
         }
 
         public static TypeSyntax GetCodecTypeName(this ISerializableTypeDescription type)
@@ -150,5 +228,6 @@ namespace Orleans.CodeGenerator
 
             return ParseTypeName(type.GeneratedNamespace + "." + name);
         }
+
     }
 }

--- a/src/Orleans.CodeGenerator/Model/FieldDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/FieldDescription.cs
@@ -8,7 +8,7 @@ namespace Orleans.CodeGenerator
 {
     internal class FieldDescription : IFieldDescription
     {
-        public FieldDescription(ushort fieldId, bool isPrimaryConstructorParameter, IFieldSymbol member)
+        public FieldDescription(uint fieldId, bool isPrimaryConstructorParameter, IFieldSymbol member)
         {
             FieldId = fieldId;
             IsPrimaryConstructorParameter = isPrimaryConstructorParameter;
@@ -28,7 +28,7 @@ namespace Orleans.CodeGenerator
 
         public ISymbol Symbol => Field;
         public IFieldSymbol Field { get; }
-        public ushort FieldId { get; }
+        public uint FieldId { get; }
         public ITypeSymbol Type { get; }
         public INamedTypeSymbol ContainingType { get; }
         public TypeSyntax TypeSyntax { get; }

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -22,7 +22,8 @@ namespace Orleans.CodeGenerator
             List<IMemberDescription> members,
             List<INamedTypeSymbol> serializationHooks,
             INamedTypeSymbol baseType,
-            List<TypeSyntax> constructorArguments)
+            List<TypeSyntax> constructorArguments,
+            CompoundTypeAliasComponent[] compoundTypeAliasArguments)
         {
             InterfaceDescription = interfaceDescription;
             _methodDescription = methodDescription;
@@ -33,6 +34,7 @@ namespace Orleans.CodeGenerator
             Accessibility = accessibility;
             SerializationHooks = serializationHooks;
             ActivatorConstructorParameters = constructorArguments;
+            CompoundTypeAliasArguments = compoundTypeAliasArguments;
         }
 
         public Accessibility Accessibility { get; }
@@ -62,6 +64,7 @@ namespace Orleans.CodeGenerator
         public bool IsShallowCopyable => false;
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
         public bool HasActivatorConstructor => UseActivator;
+        public CompoundTypeAliasComponent[] CompoundTypeAliasArguments {get;}
 
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => ObjectCreationExpression(TypeSyntax).WithArgumentList(ArgumentList());
 

--- a/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
@@ -7,7 +7,7 @@ namespace Orleans.CodeGenerator
 {
     internal interface IMemberDescription
     {
-        ushort FieldId { get; }
+        uint FieldId { get; }
         ISymbol Symbol { get; }
         ITypeSymbol Type { get; }
         INamedTypeSymbol ContainingType { get; }

--- a/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
@@ -86,19 +86,14 @@ namespace Orleans.CodeGenerator
                 }
             }
 
-            var idCounter = 1;
             var res = new List<MethodDescription>();
             foreach (var pair in methods.OrderBy(kv => kv.Key, MethodSignatureComparer.Default))
             {
                 var method = pair.Key;
-                var id = CodeGenerator.GetId(method) ?? idCounter;
-                if (id >= idCounter)
-                {
-                    idCounter = id + 1;
-                }
-
-                res.Add(new(this, method, id.ToString(CultureInfo.InvariantCulture), hasCollision: pair.Value));
+                var methodId = CodeGenerator.GetId(method)?.ToString(CultureInfo.InvariantCulture) ?? CodeGenerator.CreateHashedMethodId(method);
+                res.Add(new(this, method, methodId, hasCollision: pair.Value));
             }
+
             return res;
 
             IEnumerable<INamedTypeSymbol> GetAllInterfaces(INamedTypeSymbol s)

--- a/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
@@ -3,8 +3,6 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.CodeGenerator
 {
@@ -76,7 +74,7 @@ namespace Orleans.CodeGenerator
             {
                 foreach (var method in iface.GetDeclaredInstanceMembers<IMethodSymbol>())
                 {
-                    if (methods.TryGetValue(method, out var description))
+                    if (methods.TryGetValue(method, out _))
                     {
                         methods[method] = true;
                         continue;
@@ -87,10 +85,12 @@ namespace Orleans.CodeGenerator
             }
 
             var res = new List<MethodDescription>();
-            foreach (var pair in methods.OrderBy(kv => kv.Key, MethodSignatureComparer.Default))
+            foreach (var pair in methods)
             {
                 var method = pair.Key;
-                var methodId = CodeGenerator.GetId(method)?.ToString(CultureInfo.InvariantCulture) ?? CodeGenerator.CreateHashedMethodId(method);
+                var methodId = CodeGenerator.GetId(method)?.ToString(CultureInfo.InvariantCulture)
+                    ?? CodeGenerator.GetAlias(method)
+                    ?? CodeGenerator.CreateHashedMethodId(method);
                 res.Add(new(this, method, methodId, hasCollision: pair.Value));
             }
 

--- a/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
@@ -109,6 +109,7 @@ namespace Orleans.CodeGenerator
                 }
 
                 foreach (var i in s.AllInterfaces)
+
                 {
                     yield return i;
                 }

--- a/src/Orleans.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MetadataModel.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using System.Collections.Generic;
 
 namespace Orleans.CodeGenerator
@@ -18,7 +19,189 @@ namespace Orleans.CodeGenerator
         public List<INamedTypeSymbol> DetectedCopiers { get; } = new();
         public List<INamedTypeSymbol> DetectedConverters { get; } = new();
         public List<(TypeSyntax Type, string Alias)> TypeAliases { get; } = new(1024);
+        public CompoundTypeAliasTree CompoundTypeAliases { get; } = CompoundTypeAliasTree.Create();
         public List<(TypeSyntax Type, uint Id)> WellKnownTypeIds { get; } = new(1024);
         public HashSet<string> ApplicationParts { get; } = new();
+    }
+
+    /// <summary>
+    /// Represents a compound type aliases as a prefix tree.
+    /// </summary>
+    internal sealed class CompoundTypeAliasTree
+    {
+        private Dictionary<object, CompoundTypeAliasTree> _children;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundTypeAliasTree"/> class.
+        /// </summary>
+        private CompoundTypeAliasTree(CompoundTypeAliasComponent key, TypeSyntax value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets the key for this node.
+        /// </summary>
+        public CompoundTypeAliasComponent Key { get; }
+
+        /// <summary>
+        /// Gets the value for this node.
+        /// </summary>
+        public TypeSyntax Value { get; private set; }
+
+        /// <summary>
+        /// Creates a new tree with a root node which has no key or value.
+        /// </summary>
+        public static CompoundTypeAliasTree Create() => new(default, default);
+
+        public Dictionary<object, CompoundTypeAliasTree> Children => _children;
+
+        internal CompoundTypeAliasTree GetChildOrDefault(object key)
+        {
+            TryGetChild(key, out var result);
+            return result;
+        }
+
+        internal bool TryGetChild(object key, out CompoundTypeAliasTree result)
+        {
+            if (_children is { } children)
+            {
+                return children.TryGetValue(key, out result);
+            }
+
+            result = default;
+            return false;
+        }
+
+        public void Add(CompoundTypeAliasComponent[] key, TypeSyntax value)
+        {
+            Add(key.AsSpan(), value);
+        }
+
+        public void Add(ReadOnlySpan<CompoundTypeAliasComponent> keys, TypeSyntax value)
+        {
+            if (keys.Length == 0)
+            {
+                throw new InvalidOperationException("No valid key specified.");
+            }
+
+            var key = keys[0];
+            if (keys.Length == 1)
+            {
+                AddInternal(key, value);
+            }
+            else
+            {
+                var childNode = GetChildOrDefault(key) ?? AddInternal(key);
+                childNode.Add(keys.Slice(1), value);
+            }
+        }
+
+        /// <summary>
+        /// Adds a node to the tree.
+        /// </summary>
+        /// <param name="key">The key for the new node.</param>
+        public CompoundTypeAliasTree Add(ITypeSymbol key) => AddInternal(new CompoundTypeAliasComponent(key));
+
+        /// <summary>
+        /// Adds a node to the tree.
+        /// </summary>
+        /// <param name="key">The key for the new node.</param>
+        public CompoundTypeAliasTree Add(string key) => AddInternal(new CompoundTypeAliasComponent(key));
+
+        /// <summary>
+        /// Adds a node to the tree.
+        /// </summary>
+        /// <param name="key">The key for the new node.</param>
+        /// <param name="value">The value for the new node.</param>
+        public CompoundTypeAliasTree Add(string key, TypeSyntax value) => AddInternal(new CompoundTypeAliasComponent(key), value);
+
+        /// <summary>
+        /// Adds a node to the tree.
+        /// </summary>
+        /// <param name="key">The key for the new node.</param>
+        /// <param name="value">The value for the new node.</param>
+        public CompoundTypeAliasTree Add(ITypeSymbol key, TypeSyntax value) => AddInternal(new CompoundTypeAliasComponent(key), value);
+
+        private CompoundTypeAliasTree AddInternal(CompoundTypeAliasComponent key) => AddInternal(key, default);
+        private CompoundTypeAliasTree AddInternal(CompoundTypeAliasComponent key, TypeSyntax value)
+        {
+            _children ??= new();
+
+            if (_children.TryGetValue(key, out var existing))
+            {
+                if (value is not null && existing.Value is not null)
+                {
+                    throw new ArgumentException("A key with this value already exists");
+                }
+
+                existing.Value = value;
+                return existing;
+            }
+            else
+            {
+                return _children[key] = new CompoundTypeAliasTree(key, value); ;
+            }
+        }
+    }
+
+    internal readonly struct CompoundTypeAliasComponent : IEquatable<CompoundTypeAliasComponent>
+    {
+        private readonly Either<string, ITypeSymbol> _value;
+        public CompoundTypeAliasComponent(string value) => _value = new Either<string, ITypeSymbol>(value);
+        public CompoundTypeAliasComponent(ITypeSymbol value) => _value = new Either<string, ITypeSymbol>(value);
+        public static CompoundTypeAliasComponent Default => new();
+        public bool IsDefault => _value.RawValue is null;
+        public bool IsString => _value.IsLeft;
+        public string StringValue => _value.LeftValue;
+        public bool IsType => _value.IsRight;
+        public ITypeSymbol TypeValue => _value.RightValue;
+        public object Value => _value.RawValue;
+
+        public bool Equals(CompoundTypeAliasComponent other) => (Value, other.Value) switch
+        {
+            (null, null) => true,
+            (string stringValue, string otherStringValue) => string.Equals(stringValue, otherStringValue),
+            (ITypeSymbol typeValue, ITypeSymbol otherTypeValue) => SymbolEqualityComparer.Default.Equals(typeValue, otherTypeValue),
+            _ => false,
+        };
+        public override bool Equals(object obj) => obj is CompoundTypeAliasComponent other && Equals(other);
+        public override int GetHashCode() => _value.RawValue switch
+        {
+            string stringValue => stringValue.GetHashCode(),
+            ITypeSymbol type => SymbolEqualityComparer.Default.GetHashCode(type),
+            _ => throw new InvalidOperationException($"Unsupported type {_value.RawValue}")
+        };
+
+        internal readonly struct EqualityComparer : IEqualityComparer<CompoundTypeAliasComponent>
+        {
+            public static EqualityComparer Default => default;
+            public bool Equals(CompoundTypeAliasComponent x, CompoundTypeAliasComponent y) => x.Equals(y);
+            public int GetHashCode(CompoundTypeAliasComponent obj) => obj.GetHashCode();
+        }
+    }
+
+    internal readonly struct Either<T, U> where T : class where U : class
+    {
+        private readonly bool _isLeft;
+        private readonly object _value;
+        public Either(T value)
+        {
+            _value = value;
+            _isLeft = true;
+        }
+
+        public Either(U value)
+        {
+            _value = value;
+            _isLeft = false;
+        }
+
+        public bool IsLeft => _isLeft;
+        public bool IsRight => !IsLeft;
+        public T LeftValue => (T)_value;
+        public U RightValue => (U)_value;
+        public object RawValue => _value;
     }
 }

--- a/src/Orleans.CodeGenerator/Model/MethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/MethodDescription.cs
@@ -10,11 +10,11 @@ namespace Orleans.CodeGenerator
     {
         private readonly InvokableInterfaceDescription _iface;
 
-        public MethodDescription(InvokableInterfaceDescription containingType, IMethodSymbol method, string name, bool hasCollision)
+        public MethodDescription(InvokableInterfaceDescription containingType, IMethodSymbol method, string methodId, bool hasCollision)
         {
             _iface = containingType;
             Method = method;
-            Name = name;
+            MethodId = methodId;
             HasCollision = hasCollision;
 
             var names = new HashSet<string>(StringComparer.Ordinal);
@@ -145,7 +145,7 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        public string Name { get; }
+        public string MethodId { get; }
 
         public IMethodSymbol Method { get; }
 

--- a/src/Orleans.CodeGenerator/Model/PropertyDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/PropertyDescription.cs
@@ -12,7 +12,7 @@ namespace Orleans.CodeGenerator
 
     internal class PropertyDescription : IPropertyDescription
     {
-        public PropertyDescription(ushort fieldId, bool isPrimaryConstructorParameter, IPropertySymbol property)
+        public PropertyDescription(uint fieldId, bool isPrimaryConstructorParameter, IPropertySymbol property)
         {
             FieldId = fieldId;
             IsPrimaryConstructorParameter = isPrimaryConstructorParameter;
@@ -28,7 +28,7 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        public ushort FieldId { get; }
+        public uint FieldId { get; }
         public ISymbol Symbol => Property;
         public ITypeSymbol Type => Property.Type;
         public INamedTypeSymbol ContainingType => Property.ContainingType;

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -71,6 +71,8 @@ namespace Orleans.CodeGenerator
 
             static bool HandleException(GeneratorExecutionContext context, Exception exception)
             {
+                Console.WriteLine(exception);
+
                 if (exception is OrleansGeneratorDiagnosticAnalysisException analysisException)
                 {
                     context.ReportDiagnostic(analysisException.Diagnostic);

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -117,7 +117,7 @@ namespace Orleans.CodeGenerator
 
                 dataMembers.Sort(FSharpUnionCasePropertyNameComparer.Default);
 
-                ushort id = 0;
+                uint id = 0;
                 foreach (var field in dataMembers)
                 {
                     yield return new FSharpUnionCaseFieldDescription(libraryTypes, field, id);
@@ -152,14 +152,14 @@ namespace Orleans.CodeGenerator
                 private readonly LibraryTypes _libraryTypes;
                 private readonly IPropertySymbol _property;
 
-                public FSharpUnionCaseFieldDescription(LibraryTypes libraryTypes, IPropertySymbol property, ushort ordinal)
+                public FSharpUnionCaseFieldDescription(LibraryTypes libraryTypes, IPropertySymbol property, uint ordinal)
                 {
                     _libraryTypes = libraryTypes;
                     FieldId = ordinal;
                     _property = property;
                 }
 
-                public ushort FieldId { get; }
+                public uint FieldId { get; }
 
                 public bool IsShallowCopyable => _libraryTypes.IsShallowCopyable(Type) || _property.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
 
@@ -242,7 +242,7 @@ namespace Orleans.CodeGenerator
 
             private static IEnumerable<IMemberDescription> GetRecordDataMembers(LibraryTypes libraryTypes, INamedTypeSymbol symbol)
             {
-                List<(IPropertySymbol, ushort)> dataMembers = new();
+                List<(IPropertySymbol, uint)> dataMembers = new();
                 foreach (var property in symbol.GetDeclaredInstanceMembers<IPropertySymbol>())
                 {
                     var id = CodeGenerator.GetId(libraryTypes, property);
@@ -265,14 +265,14 @@ namespace Orleans.CodeGenerator
                 private readonly LibraryTypes _libraryTypes;
                 private readonly IPropertySymbol _property;
 
-                public FSharpRecordPropertyDescription(LibraryTypes libraryTypes, IPropertySymbol property, ushort ordinal)
+                public FSharpRecordPropertyDescription(LibraryTypes libraryTypes, IPropertySymbol property, uint ordinal)
                 {
                     _libraryTypes = libraryTypes;
                     FieldId = ordinal;
                     _property = property;
                 }
 
-                public ushort FieldId { get; }
+                public uint FieldId { get; }
 
                 public bool IsShallowCopyable => _libraryTypes.IsShallowCopyable(Type) || _property.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
 

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -216,7 +216,7 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             }
         }
 
-        public static TypeSyntax ToOpenTypeSyntax(this INamedTypeSymbol typeSymbol)
+        public static TypeSyntax ToOpenTypeSyntax(this ITypeSymbol typeSymbol)
         {
             var displayString = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             var nameSyntax = ParseName(displayString);

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -251,7 +251,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// This is the base class for all grain references.
     /// </summary>
-    [WellKnownAlias("GrainRef")]
+    [Alias("GrainRef")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -251,6 +251,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// This is the base class for all grain references.
     /// </summary>
+    [WellKnownAlias("GrainRef")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(Request<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(Request))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(TaskRequest<>))]

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Orleans.Serialization.Invocation;
 
 namespace Orleans.Runtime
 {
-    [WellKnownId(101)]
+    [Id(101)]
     internal sealed class Message : ISpanFormattable
     {
         public const int LENGTH_HEADER_SIZE = 8;

--- a/src/Orleans.Core/Utils/TypeConverterExtensions.cs
+++ b/src/Orleans.Core/Utils/TypeConverterExtensions.cs
@@ -58,7 +58,7 @@ namespace Orleans.Utilities
                 typeSpecs[i] = RuntimeTypeNameParser.Parse(formatter.Format(typeArguments[i]));
             }
 
-            var constructed = new ConstructedGenericTypeSpec(new NamedTypeSpec(null, unconstructed.ToString(), typeArguments.Length), typeSpecs).Format();
+            var constructed = new ConstructedGenericTypeSpec(new NamedTypeSpec(null, unconstructed.ToString(), typeArguments.Length), typeArguments.Length, typeSpecs).Format();
             return IdSpan.Create(constructed);
         }
 

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -267,7 +267,7 @@ namespace Orleans
         /// Initializes a new instance of the <see cref="IdAttribute"/> class.
         /// </summary>
         /// <param name="id">The identifier.</param>
-        public IdAttribute(ushort id)
+        public IdAttribute(uint id)
         {
             Id = id;
         }
@@ -276,7 +276,7 @@ namespace Orleans
         /// Gets the identifier.
         /// </summary>
         /// <value>The identifier.</value>
-        public ushort Id { get; }
+        public uint Id { get; }
     }
 
     /// <summary>

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -298,42 +298,6 @@ namespace Orleans
     }
 
     /// <summary>
-    /// When applied to a type or method, indicates that a well-known numeric identifier can be used to uniquely identify that type or method.
-    /// </summary>
-    /// <remarks>
-    /// In the case of a type, the numeric id must be globally unique. In the case of a method, the numeric id must be unique to the declaring type.
-    /// </remarks>
-    /// <seealso cref="System.Attribute" />
-    [AttributeUsage(
-        AttributeTargets.Class
-        | AttributeTargets.Interface
-        | AttributeTargets.Struct
-        | AttributeTargets.Enum
-        | AttributeTargets.Method)]
-    public sealed class WellKnownIdAttribute : Attribute
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WellKnownIdAttribute"/> class.
-        /// </summary>
-        /// <param name="id">The identifier.</param>
-        /// <remarks>
-        /// In the case of a type, the numeric id must be globally unique. In the case of a method, the numeric id must be unique to the declaring type.
-        /// </remarks>
-        public WellKnownIdAttribute(uint id)
-        {
-            Id = id;
-        }
-
-        /// <summary>
-        /// Gets the identifier.
-        /// </summary>
-        /// <remarks>
-        /// In the case of a type, the numeric id must be globally unique. In the case of a method, the numeric id must be unique to the declaring type.
-        /// </remarks>
-        public uint Id { get; }
-    }
-
-    /// <summary>
     /// When applied to a type or method, specifies a well-known name which can be used to identify that type or method.
     /// </summary>
     /// <remarks>
@@ -346,16 +310,16 @@ namespace Orleans
         | AttributeTargets.Struct
         | AttributeTargets.Enum
         | AttributeTargets.Method)]
-    public sealed class WellKnownAliasAttribute : Attribute
+    public sealed class AliasAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="WellKnownAliasAttribute"/> class.
+        /// Initializes a new instance of the <see cref="AliasAttribute"/> class.
         /// </summary>
         /// <param name="alias">The alias.</param>
         /// <remarks>
         /// In the case of a type, the alias must be globally unique. In the case of a method, the alias must be unique to the declaring type.
         /// </remarks>
-        public WellKnownAliasAttribute(string alias)
+        public AliasAttribute(string alias)
         {
             Alias = alias;
         }

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -370,6 +370,32 @@ namespace Orleans
     }
 
     /// <summary>
+    /// When applied to a type, indicates that the type should be encoded as a relation from a specified type.
+    /// </summary>
+    /// <seealso cref="Attribute" />
+    [AttributeUsage(
+        AttributeTargets.Class
+        | AttributeTargets.Interface
+        | AttributeTargets.Struct
+        | AttributeTargets.Enum)]
+    public sealed class CompoundTypeAliasAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundTypeAliasAttribute"/> class.
+        /// </summary>
+        /// <param name="components">The alias components, each of which must be a <see cref="Components"/> or a <see cref="string"/>.</param>
+        public CompoundTypeAliasAttribute(params object[] components)
+        {
+            Components = components;
+        }
+
+        /// <summary>
+        /// Gets the alias components.
+        /// </summary>
+        public object[] Components { get; }
+    }
+
+    /// <summary>
     /// When applied to a type, indicates that the type is a serializer and that it should be automatically registered.
     /// </summary>
     /// <seealso cref="System.Attribute" />

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -13,7 +13,7 @@ using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization;
 
-[WellKnownAlias(WellKnownAlias)]
+[Alias(WellKnownAlias)]
 public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
 {
     private static readonly Type SelfType = typeof(NewtonsoftJsonCodec);

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -16,7 +16,7 @@ namespace Orleans.Serialization;
 /// <summary>
 /// A serialization codec which uses <see cref="JsonSerializer"/>.
 /// </summary>
-[WellKnownAlias(WellKnownAlias)]
+[Alias(WellKnownAlias)]
 public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
 {
     private static readonly Type SelfType = typeof(JsonCodec);

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -13,7 +13,7 @@ namespace Orleans.Serialization.Codecs
     /// <summary>
     /// Serializer for well-known <see cref="StringComparer"/> types.
     /// </summary>
-    [WellKnownAlias("StringComparer")]
+    [Alias("StringComparer")]
     public sealed class WellKnownStringComparerCodec : IGeneralizedCodec
     {
         private static readonly Type CodecType = typeof(WellKnownStringComparerCodec);

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Orleans.Serialization.TypeSystem;
 
 namespace Orleans.Serialization.Configuration
 {
@@ -74,6 +75,11 @@ namespace Orleans.Serialization.Configuration
         /// Gets the mapping of allowed type names.
         /// </summary>
         public HashSet<string> AllowedTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the mapping from compound type aliases to types.
+        /// </summary>
+        public CompoundTypeAliasTree CompoundTypeAliases { get; } = CompoundTypeAliasTree.Create();
 
         /// <summary>
         /// Gets or sets a value indicating whether to allow all types by default.

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -14,7 +14,7 @@ namespace Orleans.Serialization
     /// <summary>
     /// Serializer for types which implement the <see cref="ISerializable"/> pattern.
     /// </summary>
-    [WellKnownAlias("ISerializable")]
+    [Alias("ISerializable")]
     public class DotNetSerializableCodec : IGeneralizedCodec
     {
         public static readonly Type CodecType = typeof(DotNetSerializableCodec);

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -22,7 +22,7 @@ namespace Orleans.Serialization
     /// </summary>
     [RegisterSerializer]
     [RegisterCopier]
-    [WellKnownAlias("Exception")]
+    [Alias("Exception")]
     internal class ExceptionCodec : IFieldCodec<Exception>, IBaseCodec<Exception>, IGeneralizedCodec, IGeneralizedBaseCodec, IBaseCopier<Exception>
     {
         private readonly StreamingContext _streamingContext;

--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Serialization.TypeSystem;
+
+/// <summary>
+/// Represents a compound type aliases as a prefix tree.
+/// </summary>
+public class CompoundTypeAliasTree
+{
+    private Dictionary<object, CompoundTypeAliasTree>? _children;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompoundTypeAliasTree"/> class.
+    /// </summary>
+    private CompoundTypeAliasTree(object? key, Type? value)
+    {
+        Key = key;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the key for this node.
+    /// </summary>
+    public object? Key { get; }
+
+    /// <summary>
+    /// Gets the value for this node.
+    /// </summary>
+    public Type? Value { get; private set; }
+
+    /// <summary>
+    /// Creates a new tree with a root node which has no key or value.
+    /// </summary>
+    public static CompoundTypeAliasTree Create() => new(default, default);
+
+    internal CompoundTypeAliasTree? GetChildOrDefault(object key)
+    {
+        TryGetChild(key, out var result);
+        return result;
+    }
+
+    internal bool TryGetChild(object key, out CompoundTypeAliasTree? result)
+    {
+        if (_children is { } children)
+        {
+            return children.TryGetValue(key, out result);
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Adds a node to the tree.
+    /// </summary>
+    /// <param name="key">The key for the new node.</param>
+    public CompoundTypeAliasTree Add(Type key) => AddInternal(key);
+
+    /// <summary>
+    /// Adds a node to the tree.
+    /// </summary>
+    /// <param name="key">The key for the new node.</param>
+    public CompoundTypeAliasTree Add(string key) => AddInternal(key);
+
+    /// <summary>
+    /// Adds a node to the tree.
+    /// </summary>
+    /// <param name="key">The key for the new node.</param>
+    /// <param name="value">The value for the new node.</param>
+    public CompoundTypeAliasTree Add(string key, Type value) => AddInternal(key, value);
+
+    /// <summary>
+    /// Adds a node to the tree.
+    /// </summary>
+    /// <param name="key">The key for the new node.</param>
+    /// <param name="value">The value for the new node.</param>
+    public CompoundTypeAliasTree Add(Type key, Type value) => AddInternal(key, value);
+
+    private CompoundTypeAliasTree AddInternal(object key) => AddInternal(key, default);
+    private CompoundTypeAliasTree AddInternal(object key, Type? value)
+    {
+        ArgumentNullException.ThrowIfNull(key, nameof(key));
+        _children ??= new();
+
+        if (_children.TryGetValue(key, out var existing))
+        {
+            if (value is not null && existing.Value is not null)
+            {
+                throw new ArgumentException("A key with this value already exists");
+            }
+
+            existing.Value = value;
+            return existing;
+        }
+        else
+        {
+            return _children[key] = new CompoundTypeAliasTree(key, value);;
+        }
+    }
+}

--- a/src/Orleans.Serialization/TypeSystem/QualifiedType.cs
+++ b/src/Orleans.Serialization/TypeSystem/QualifiedType.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -19,7 +21,7 @@ namespace Orleans.Serialization.TypeSystem
         /// </summary>
         /// <param name="assembly">The assembly.</param>
         /// <param name="type">The type.</param>
-        public QualifiedType(string assembly, string type)
+        public QualifiedType(string? assembly, string type)
         {
             Assembly = assembly;
             Type = type;
@@ -29,7 +31,7 @@ namespace Orleans.Serialization.TypeSystem
         /// Gets the assembly.
         /// </summary>
         /// <value>The assembly.</value>
-        public string Assembly { get; }
+        public string? Assembly { get; }
 
         /// <summary>
         /// Gets the type.
@@ -42,14 +44,14 @@ namespace Orleans.Serialization.TypeSystem
         /// </summary>
         /// <param name="assembly">The assembly.</param>
         /// <param name="type">The type.</param>
-        public void Deconstruct(out string assembly, out string type)
+        public void Deconstruct(out string? assembly, out string type)
         {
             assembly = Assembly;
             type = Type;
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is QualifiedType type && string.Equals(Assembly, type.Assembly, StringComparison.Ordinal) && string.Equals(Type, type.Type, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is QualifiedType type && string.Equals(Assembly, type.Assembly, StringComparison.Ordinal) && string.Equals(Type, type.Type, StringComparison.Ordinal);
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Combine(Assembly, Type);

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameFormatter.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameFormatter.cs
@@ -3,179 +3,239 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 
-namespace Orleans.Serialization.TypeSystem
+namespace Orleans.Serialization.TypeSystem;
+
+/// <summary>
+/// Utility methods for formatting <see cref="Type"/> and <see cref="TypeInfo"/> instances in a way which can be parsed by
+/// <see cref="Type.GetType(string)"/>.
+/// </summary>
+public static class RuntimeTypeNameFormatter
 {
+    private static readonly Assembly SystemAssembly = typeof(int).Assembly;
+
+    private static readonly ConcurrentDictionary<Type, string> Cache = new ConcurrentDictionary<Type, string>();
+
     /// <summary>
-    /// Utility methods for formatting <see cref="Type"/> and <see cref="TypeInfo"/> instances in a way which can be parsed by
-    /// <see cref="Type.GetType(string)"/>.
+    /// Returns a <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
     /// </summary>
-    public static class RuntimeTypeNameFormatter
+    /// <param name="type">The type to format.</param>
+    /// <returns>
+    /// A <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
+    /// </returns>
+    public static string Format(Type type) => Cache.GetOrAdd(type, t =>
     {
-        private static readonly Assembly SystemAssembly = typeof(int).Assembly;
+        var builder = new StringBuilder();
+        Format(builder, t, isElementType: false);
+        return builder.ToString();
+    });
 
-        private static readonly ConcurrentDictionary<Type, string> Cache = new ConcurrentDictionary<Type, string>();
+    internal static string FormatInternalNoCache(Type type, bool allowAliases)
+    {
+        var builder = new StringBuilder();
+        Format(builder, type, isElementType: false, allowAliases: allowAliases);
+        return builder.ToString();
+    }
 
-        /// <summary>
-        /// Returns a <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
-        /// </summary>
-        /// <param name="type">The type to format.</param>
-        /// <returns>
-        /// A <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
-        /// </returns>
-        public static string Format(Type type) => Cache.GetOrAdd(type, t =>
+    private static void Format(StringBuilder builder, Type type, bool isElementType, bool allowAliases = true)
+    {
+        if (allowAliases && type.GetCustomAttribute<CompoundTypeAliasAttribute>() is { } compoundAlias)
         {
-            var builder = new StringBuilder();
-            Format(builder, t, isElementType: false);
-            return builder.ToString();
-        });
+            AddCompoundTypeAlias(builder, type, compoundAlias.Components);
+            AddGenericParameters(builder, type);
+            return;
+        }
 
-        private static void Format(StringBuilder builder, Type type, bool isElementType)
+        // Arrays, pointers, and by-ref types are all element types and need to be formatted with their own adornments.
+        if (type.HasElementType)
         {
-            // Arrays, pointers, and by-ref types are all element types and need to be formatted with their own adornments.
-            if (type.HasElementType)
+            // Format the element type.
+            Format(builder, type.GetElementType(), isElementType: true);
+
+            // Format this type's adornments to the element type.
+            AddArrayRank(builder, type);
+            AddPointerSymbol(builder, type);
+            AddByRefSymbol(builder, type);
+        }
+        else
+        {
+            AddNamespace(builder, type);
+            AddClassName(builder, type);
+            AddGenericParameters(builder, type);
+        }
+
+        // Types which are used as elements are not formatted with their assembly name, since that is added after the
+        // element type's adornments.
+        if (!isElementType)
+        {
+            AddAssembly(builder, type);
+        }
+    }
+
+    private static void AddCompoundTypeAlias(StringBuilder builder, Type type, object[] components)
+    {
+        // Start
+        builder.Append('(');
+        for (var i = 0; i < components.Length; ++i)
+        {
+            var component = components[i];
+            if (i > 0)
             {
-                // Format the element type.
-                Format(builder, type.GetElementType(), isElementType: true);
+                builder.Append(',');
+            }
 
-                // Format this type's adornments to the element type.
-                AddArrayRank(builder, type);
-                AddPointerSymbol(builder, type);
-                AddByRefSymbol(builder, type);
+            // Append the component
+            if (component is string s)
+            {
+                builder.Append($"\"{s}\"");
+            }
+            else if (component is Type t)
+            {
+                if (t == type)
+                {
+                    throw new ArgumentException($"Element {i} of argument array, {component}, is equal to the attached type {type}, which is not supported");
+                }
+
+                builder.Append('[');
+                Format(builder, t, isElementType: false);
+                builder.Append(']');
             }
             else
             {
-                AddNamespace(builder, type);
-                AddClassName(builder, type);
-                AddGenericParameters(builder, type);
-            }
-
-            // Types which are used as elements are not formatted with their assembly name, since that is added after the
-            // element type's adornments.
-            if (!isElementType)
-            {
-                AddAssembly(builder, type);
+                throw new ArgumentException($"Element {i} of argument array, {component}, must be a Type or string but is an {component?.GetType().ToString() ?? "null"}");
             }
         }
 
-        private static void AddNamespace(StringBuilder builder, Type type)
+        // End
+        builder.Append(')');
+        if (type.IsGenericType)
         {
-            if (string.IsNullOrWhiteSpace(type.Namespace))
+            int parameterCount = type.IsConstructedGenericType switch
             {
-                return;
-            }
+                true => type.GenericTypeArguments.Length,
+                false => type.GetTypeInfo().GenericTypeParameters.Length
+            };
+            builder.Append($"`{parameterCount}");
+        }
+    }
 
-            _ = builder.Append(type.Namespace);
-            _ = builder.Append('.');
+    private static void AddNamespace(StringBuilder builder, Type type)
+    {
+        if (string.IsNullOrWhiteSpace(type.Namespace))
+        {
+            return;
         }
 
-        private static void AddClassName(StringBuilder builder, Type type)
+        _ = builder.Append(type.Namespace);
+        _ = builder.Append('.');
+    }
+
+    private static void AddClassName(StringBuilder builder, Type type)
+    {
+        // Format the declaring type.
+        if (type.IsNested)
         {
-            // Format the declaring type.
-            if (type.IsNested)
-            {
-                AddClassName(builder, type.DeclaringType);
-                _ = builder.Append('+');
-            }
-
-            // Format the simple type name.
-            var name = type.Name.AsSpan();
-            var index = name.IndexOfAny("`*[&");
-            _ = builder.Append(index > 0 ? name[..index] : name);
-
-            // Format this type's generic arity.
-            AddGenericArity(builder, type);
+            AddClassName(builder, type.DeclaringType);
+            _ = builder.Append('+');
         }
 
-        private static void AddGenericParameters(StringBuilder builder, Type type)
-        {
-            // Generic type definitions (eg, List<> without parameters) and non-generic types do not include any
-            // parameters in their formatting.
-            if (!type.IsConstructedGenericType)
-            {
-                return;
-            }
+        // Format the simple type name.
+        var name = type.Name.AsSpan();
+        var index = name.IndexOfAny("`*[&");
+        _ = builder.Append(index > 0 ? name[..index] : name);
 
-            var args = type.GetGenericArguments();
+        // Format this type's generic arity.
+        AddGenericArity(builder, type);
+    }
+
+    private static void AddGenericParameters(StringBuilder builder, Type type)
+    {
+        // Generic type definitions (eg, List<> without parameters) and non-generic types do not include any
+        // parameters in their formatting.
+        if (!type.IsConstructedGenericType)
+        {
+            return;
+        }
+
+        var args = type.GetGenericArguments();
+        _ = builder.Append('[');
+        for (var i = 0; i < args.Length; i++)
+        {
             _ = builder.Append('[');
-            for (var i = 0; i < args.Length; i++)
-            {
-                _ = builder.Append('[');
-                Format(builder, args[i], isElementType: false);
-                _ = builder.Append(']');
-                if (i + 1 < args.Length)
-                {
-                    _ = builder.Append(',');
-                }
-            }
-
+            Format(builder, args[i], isElementType: false);
             _ = builder.Append(']');
+            if (i + 1 < args.Length)
+            {
+                _ = builder.Append(',');
+            }
         }
 
-        private static void AddGenericArity(StringBuilder builder, Type type)
+        _ = builder.Append(']');
+    }
+
+    private static void AddGenericArity(StringBuilder builder, Type type)
+    {
+        if (!type.IsGenericType)
         {
-            if (!type.IsGenericType)
-            {
-                return;
-            }
-
-            // The arity is the number of generic parameters minus the number of generic parameters in the declaring types.
-            var baseTypeParameterCount =
-                type.IsNested ? type.DeclaringType.GetGenericArguments().Length : 0;
-            var arity = type.GetGenericArguments().Length - baseTypeParameterCount;
-
-            // If all of the generic parameters are in the declaring types then this type has no parameters of its own.
-            if (arity == 0)
-            {
-                return;
-            }
-
-            _ = builder.Append('`');
-            _ = builder.Append(arity);
+            return;
         }
 
-        private static void AddPointerSymbol(StringBuilder builder, Type type)
+        // The arity is the number of generic parameters minus the number of generic parameters in the declaring types.
+        var baseTypeParameterCount =
+            type.IsNested ? type.DeclaringType.GetGenericArguments().Length : 0;
+        var arity = type.GetGenericArguments().Length - baseTypeParameterCount;
+
+        // If all of the generic parameters are in the declaring types then this type has no parameters of its own.
+        if (arity == 0)
         {
-            if (!type.IsPointer)
-            {
-                return;
-            }
-
-            _ = builder.Append('*');
+            return;
         }
 
-        private static void AddByRefSymbol(StringBuilder builder, Type type)
+        _ = builder.Append('`');
+        _ = builder.Append(arity);
+    }
+
+    private static void AddPointerSymbol(StringBuilder builder, Type type)
+    {
+        if (!type.IsPointer)
         {
-            if (!type.IsByRef)
-            {
-                return;
-            }
-
-            _ = builder.Append('&');
+            return;
         }
 
-        private static void AddArrayRank(StringBuilder builder, Type type)
+        _ = builder.Append('*');
+    }
+
+    private static void AddByRefSymbol(StringBuilder builder, Type type)
+    {
+        if (!type.IsByRef)
         {
-            if (!type.IsArray)
-            {
-                return;
-            }
-
-            _ = builder.Append('[');
-            _ = builder.Append(',', type.GetArrayRank() - 1);
-            _ = builder.Append(']');
+            return;
         }
 
-        private static void AddAssembly(StringBuilder builder, Type type)
+        _ = builder.Append('&');
+    }
+
+    private static void AddArrayRank(StringBuilder builder, Type type)
+    {
+        if (!type.IsArray)
         {
-            // Do not include the assembly name for the system assembly.
-            var assembly = type.Assembly;
-            if (SystemAssembly.Equals(assembly))
-            {
-                return;
-            }
-
-            _ = builder.Append(',');
-            _ = builder.Append(assembly.GetName().Name);
+            return;
         }
+
+        _ = builder.Append('[');
+        _ = builder.Append(',', type.GetArrayRank() - 1);
+        _ = builder.Append(']');
+    }
+
+    private static void AddAssembly(StringBuilder builder, Type type)
+    {
+        // Do not include the assembly name for the system assembly.
+        var assembly = type.Assembly;
+        if (SystemAssembly.Equals(assembly))
+        {
+            return;
+        }
+
+        _ = builder.Append(',');
+        _ = builder.Append(assembly.GetName().Name);
     }
 }

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -1,278 +1,384 @@
 using System;
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 
-namespace Orleans.Serialization.TypeSystem
+namespace Orleans.Serialization.TypeSystem;
+
+/// <summary>
+/// Utility class for parsing type names, as formatted by <see cref="RuntimeTypeNameFormatter"/>.
+/// </summary>
+public static class RuntimeTypeNameParser
 {
+    internal const int MaxAllowedGenericArity = 64;
+    internal const char CompoundAliasStartIndicator = '(';
+    internal const char CompoundAliasEndIndicator = ')';
+    internal const char CompoundAliasElementSeparator = ',';
+    internal const char LiteralDelimiter = '"';
+    internal const char PointerIndicator = '*';
+    internal const char ReferenceIndicator = '&';
+    internal const char ArrayStartIndicator = '[';
+    internal const char ArrayDimensionIndicator = ',';
+    internal const char ArrayEndIndicator = ']';
+    internal const char ParameterSeparator = ',';
+    internal const char GenericTypeIndicator = '`';
+    internal const char NestedTypeIndicator = '+';
+    internal const char AssemblyIndicator = ',';
+    internal static ReadOnlySpan<char> LiteralDelimiters => new[] { LiteralDelimiter };
+    internal static ReadOnlySpan<char> TupleDelimiters => new[] { CompoundAliasElementSeparator, CompoundAliasEndIndicator };
+    internal static ReadOnlySpan<char> AssemblyDelimiters => new[] { ArrayEndIndicator, CompoundAliasElementSeparator, CompoundAliasEndIndicator };
+    internal static ReadOnlySpan<char> TypeNameDelimiters => new[] { ArrayStartIndicator, ArrayEndIndicator, PointerIndicator, ReferenceIndicator, AssemblyIndicator, GenericTypeIndicator, NestedTypeIndicator };
+
     /// <summary>
-    /// Utility class for parsing CLR type names, as formatted by <see cref="RuntimeTypeNameFormatter"/>.
+    /// Parse the provided value as a type name.
     /// </summary>
-    public static class RuntimeTypeNameParser
+    /// <param name="input">The input.</param>
+    /// <returns>A parsed type specification.</returns>
+    public static TypeSpec Parse(string input) => Parse(input.AsSpan());
+
+    /// <summary>
+    /// Parse the provided value as a type name.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <returns>A parsed type specification.</returns>
+    public static TypeSpec Parse(ReadOnlySpan<char> input) => ParseInternal(ref input);
+
+    private static TypeSpec ParseInternal(ref ReadOnlySpan<char> input)
     {
-        private const int MaxAllowedGenericArity = 64;
-        private const char PointerIndicator = '*';
-        private const char ReferenceIndicator = '&';
-        private const char ArrayStartIndicator = '[';
-        private const char ArrayDimensionIndicator = ',';
-        private const char ArrayEndIndicator = ']';
-        private const char ParameterSeparator = ',';
-        private const char GenericTypeIndicator = '`';
-        private const char NestedTypeIndicator = '+';
-        private const char AssemblyIndicator = ',';
-        private static ReadOnlySpan<char> AssemblyDelimiters => new[] { ArrayEndIndicator };
-        private static ReadOnlySpan<char> TypeNameDelimiters => new[] { ArrayStartIndicator, ArrayEndIndicator, PointerIndicator, ReferenceIndicator, AssemblyIndicator, GenericTypeIndicator, NestedTypeIndicator };
+        BufferReader s = default;
+        s.Input = input;
+        var result = ParseInternal(ref s);
+        input = s.Remaining;
+        return result;
+    }
 
-        /// <summary>
-        /// Parse the provided value as a type name.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <returns>A parsed type specification.</returns>
-        public static TypeSpec Parse(string input) => Parse(input.AsSpan());
+    private static TypeSpec ParseInternal(ref BufferReader input)
+    {
+        TypeSpec result;
+        char c;
+        var arity = 0;
 
-        /// <summary>
-        /// Parse the provided value as a type name.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <returns>A parsed type specification.</returns>
-        public static TypeSpec Parse(ReadOnlySpan<char> input) => ParseInternal(ref input);
+        TypeSpec coreType = null;
 
-        private static TypeSpec ParseInternal(ref ReadOnlySpan<char> input)
+        // Read tuple
+        if (input.TryPeek(out c) && c == CompoundAliasStartIndicator)
         {
-            TypeSpec result;
-            char c;
-            BufferReader s = default;
-            s.Input = input;
-
-            // Read namespace and class name, including generic arity, which is a part of the class name.
-            NamedTypeSpec named = null;
-            while (true)
+            input.ConsumeCharacter(CompoundAliasStartIndicator);
+            var elements = new List<TypeSpec>();
+            while (input.TryPeek(out c) && c != CompoundAliasEndIndicator)
             {
-                var typeName = ParseTypeName(ref s);
-                named = new NamedTypeSpec(named, typeName.ToString(), s.TotalGenericArity);
-
-                if (s.TryPeek(out c) && c == NestedTypeIndicator)
+                if (c == CompoundAliasElementSeparator)
                 {
-                    // Consume the nested type indicator, then loop to parse the nested type.
-                    s.ConsumeCharacter(NestedTypeIndicator);
-                    continue;
+                    input.ConsumeCharacter(CompoundAliasElementSeparator);
                 }
 
-                break;
+                input.ConsumeWhitespace();
+
+                var element = ParseCompoundTypeAliasElement(ref input);
+                elements.Add(element);
             }
 
-            // Parse generic type parameters
-            if (s.TotalGenericArity > 0 && s.TryPeek(out c) && c == ArrayStartIndicator)
-            {
-                s.ConsumeCharacter(ArrayStartIndicator);
+            input.ConsumeCharacter(CompoundAliasEndIndicator);
 
-                var arguments = new TypeSpec[s.TotalGenericArity];
-                for (var i = 0; i < s.TotalGenericArity; i++)
-                {
-                    if (i > 0)
-                    {
-                        s.ConsumeCharacter(ParameterSeparator);
-                    }
-
-                    // Parse the argument type
-                    s.ConsumeCharacter(ArrayStartIndicator);
-                    var remaining = s.Remaining;
-                    arguments[i] = ParseInternal(ref remaining);
-                    var consumed = s.Remaining.Length - remaining.Length;
-                    s.Consume(consumed);
-                    s.ConsumeCharacter(ArrayEndIndicator);
-                }
-
-                s.ConsumeCharacter(ArrayEndIndicator);
-                result = new ConstructedGenericTypeSpec(named, arguments);
-            }
-            else
-            {
-                // This is not a constructed generic type
-                result = named;
-            }
-
-            // Parse modifiers
-            bool hadModifier;
-            do
-            {
-                hadModifier = false;
-
-                if (!s.TryPeek(out c))
-                {
-                    break;
-                }
-
-                switch (c)
-                {
-                    case ArrayStartIndicator:
-                        var dimensions = ParseArraySpecifier(ref s);
-                        result = new ArrayTypeSpec(result, dimensions);
-                        hadModifier = true;
-                        break;
-                    case PointerIndicator:
-                        result = new PointerTypeSpec(result);
-                        s.ConsumeCharacter(PointerIndicator);
-                        hadModifier = true;
-                        break;
-                    case ReferenceIndicator:
-                        result = new ReferenceTypeSpec(result);
-                        s.ConsumeCharacter(ReferenceIndicator);
-                        hadModifier = true;
-                        break;
-                }
-            } while (hadModifier);
-
-            // Extract the assembly, if specified.
-            if (s.TryPeek(out c) && c == AssemblyIndicator)
-            {
-                s.ConsumeCharacter(AssemblyIndicator);
-                var assembly = ExtractAssemblySpec(ref s);
-                result = new AssemblyQualifiedTypeSpec(result, assembly.ToString());
-            }
-
-            input = s.Remaining;
-            return result;
-        }
-
-        private static ReadOnlySpan<char> ParseTypeName(ref BufferReader s)
-        {
-            var start = s.Index;
-            var typeName = ParseSpan(ref s, TypeNameDelimiters);
             var genericArityStart = -1;
-            while (s.TryPeek(out char c))
+            while (input.TryPeek(out c))
             {
                 if (genericArityStart < 0 && c == GenericTypeIndicator)
                 {
-                    genericArityStart = s.Index + 1;
+                    genericArityStart = input.Index + 1;
                 }
                 else if (genericArityStart < 0 || !char.IsDigit(c))
                 {
                     break;
                 }
 
-                s.ConsumeCharacter(c);
+                input.ConsumeCharacter(c);
             }
 
             if (genericArityStart >= 0)
             {
-                // The generic arity is additive, so that a generic class nested in a generic class has an arity
-                // equal to the sum of specified arity values. For example, "C`1+N`2" has an arity of 3.
-                var aritySlice = s.Input.Slice(genericArityStart, s.Index - genericArityStart);
+                var aritySlice = input.Input[genericArityStart..input.Index];
 #if NETCOREAPP3_1_OR_GREATER
-                var arity = int.Parse(aritySlice);
+                arity = int.Parse(aritySlice);
 #else
-                var arity = int.Parse(aritySlice.ToString());
+                arity = int.Parse(aritySlice.ToString());
 #endif
-                s.TotalGenericArity += arity;
-                if (s.TotalGenericArity > MaxAllowedGenericArity)
+                input.TotalGenericArity += arity;
+                if (input.TotalGenericArity > MaxAllowedGenericArity)
                 {
-                    ThrowGenericArityTooLarge(s.TotalGenericArity);
+                    ThrowGenericArityTooLarge(input.TotalGenericArity);
                 }
-
-                // Include the generic arity in the type name.
-                typeName = s.Input.Slice(start, s.Index - start);
             }
 
-            return typeName;
+            coreType = new TupleTypeSpec(elements.ToArray(), input.TotalGenericArity);
         }
-
-        private static int ParseArraySpecifier(ref BufferReader s)
+        else
         {
-            s.ConsumeCharacter(ArrayStartIndicator);
-            var dimensions = 1;
-
-            while (s.TryPeek(out var c) && c != ArrayEndIndicator)
+            // Read namespace and class name, including generic arity, which is a part of the class name.
+            NamedTypeSpec named = null;
+            while (true)
             {
-                s.ConsumeCharacter(ArrayDimensionIndicator);
-                ++dimensions;
+                var typeName = ParseTypeName(ref input);
+                named = new NamedTypeSpec(named, typeName.ToString(), input.TotalGenericArity);
+                arity = named.Arity;
+
+                if (input.TryPeek(out c) && c == NestedTypeIndicator)
+                {
+                    // Consume the nested type indicator, then loop to parse the nested type.
+                    input.ConsumeCharacter(NestedTypeIndicator);
+                    continue;
+                }
+
+                break;
             }
 
-            s.ConsumeCharacter(ArrayEndIndicator);
-            return dimensions;
+            coreType = named;
         }
 
-        private static ReadOnlySpan<char> ExtractAssemblySpec(ref BufferReader s)
+        // Parse generic type parameters
+        if (input.TotalGenericArity > 0 && input.TryPeek(out c) && c == ArrayStartIndicator)
         {
-            s.ConsumeWhitespace();
-            return ParseSpan(ref s, AssemblyDelimiters);
-        }
+            input.ConsumeCharacter(ArrayStartIndicator);
 
-        private static ReadOnlySpan<char> ParseSpan(ref BufferReader s, ReadOnlySpan<char> delimiters)
+            var arguments = new TypeSpec[input.TotalGenericArity];
+            for (var i = 0; i < input.TotalGenericArity; i++)
+            {
+                if (i > 0)
+                {
+                    input.ConsumeCharacter(ParameterSeparator);
+                }
+
+                // Parse the argument type
+                input.ConsumeCharacter(ArrayStartIndicator);
+                var remaining = input.Remaining;
+                arguments[i] = ParseInternal(ref remaining);
+                var consumed = input.Remaining.Length - remaining.Length;
+                input.Consume(consumed);
+                input.ConsumeCharacter(ArrayEndIndicator);
+            }
+
+            input.ConsumeCharacter(ArrayEndIndicator);
+            result = new ConstructedGenericTypeSpec(coreType, arity, arguments);
+        }
+        else
         {
-            ReadOnlySpan<char> result;
-            if (s.Remaining.IndexOfAny(delimiters) is int index && index > 0)
-            {
-                result = s.Remaining.Slice(0, index);
-            }
-            else
-            {
-                result = s.Remaining;
-            }
-
-            s.Consume(result.Length);
-            return result;
+            // This is not a constructed generic type
+            result = coreType;
         }
 
-        private static void ThrowGenericArityTooLarge(int arity) => throw new NotSupportedException($"An arity of {arity} is not supported");
-
-        private ref struct BufferReader
+        // Parse modifiers
+        bool hadModifier;
+        do
         {
-            public ReadOnlySpan<char> Input;
-            public int Index;
-            public int TotalGenericArity;
+            hadModifier = false;
 
-            public readonly ReadOnlySpan<char> Remaining => Input.Slice(Index);
-
-            public bool TryPeek(out char c)
+            if (!input.TryPeek(out c))
             {
-                if (Index < Input.Length)
-                {
-                    c = Input[Index];
-                    return true;
-                }
-
-                c = default;
-                return false;
+                break;
             }
 
-            public void Consume(int chars)
+            switch (c)
             {
-                if (Index < Input.Length)
-                {
-                    Index += chars;
-                    return;
-                }
-
-                ThrowEndOfInput();
+                case ArrayStartIndicator:
+                    var dimensions = ParseArraySpecifier(ref input);
+                    result = new ArrayTypeSpec(result, dimensions);
+                    hadModifier = true;
+                    break;
+                case PointerIndicator:
+                    result = new PointerTypeSpec(result);
+                    input.ConsumeCharacter(PointerIndicator);
+                    hadModifier = true;
+                    break;
+                case ReferenceIndicator:
+                    result = new ReferenceTypeSpec(result);
+                    input.ConsumeCharacter(ReferenceIndicator);
+                    hadModifier = true;
+                    break;
             }
+        } while (hadModifier);
 
-            public void ConsumeCharacter(char assertChar)
-            {
-                if (Index < Input.Length)
-                {
-                    var c = Input[Index];
-                    if (assertChar != c)
-                    {
-                        ThrowUnexpectedCharacter(assertChar, c);
-                    }
-
-                    ++Index;
-                    return;
-                }
-
-                ThrowEndOfInput();
-            }
-
-            public void ConsumeWhitespace()
-            {
-                while (char.IsWhiteSpace(Input[Index]))
-                {
-                    ++Index;
-                }
-            }
-
-            private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
-
-            private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
+        // Extract the assembly, if specified.
+        if (input.TryPeek(out c) && c == AssemblyIndicator)
+        {
+            input.ConsumeCharacter(AssemblyIndicator);
+            var assembly = ExtractAssemblySpec(ref input);
+            result = new AssemblyQualifiedTypeSpec(result, assembly.ToString());
         }
+
+        return result;
+    }
+
+    private static ReadOnlySpan<char> ParseTypeName(ref BufferReader s)
+    {
+        var start = s.Index;
+        var typeName = ParseSpan(ref s, TypeNameDelimiters);
+        var genericArityStart = -1;
+        while (s.TryPeek(out char c))
+        {
+            if (genericArityStart < 0 && c == GenericTypeIndicator)
+            {
+                genericArityStart = s.Index + 1;
+            }
+            else if (genericArityStart < 0 || !char.IsDigit(c))
+            {
+                break;
+            }
+
+            s.ConsumeCharacter(c);
+        }
+
+        if (genericArityStart >= 0)
+        {
+            // The generic arity is additive, so that a generic class nested in a generic class has an arity
+            // equal to the sum of specified arity values. For example, "C`1+N`2" has an arity of 3.
+            var aritySlice = s.Input[genericArityStart..s.Index];
+#if NETCOREAPP3_1_OR_GREATER
+            var arity = int.Parse(aritySlice);
+#else
+            var arity = int.Parse(aritySlice.ToString());
+#endif
+            s.TotalGenericArity += arity;
+            if (s.TotalGenericArity > MaxAllowedGenericArity)
+            {
+                ThrowGenericArityTooLarge(s.TotalGenericArity);
+            }
+
+            // Include the generic arity in the type name.
+            typeName = s.Input[start..s.Index];
+        }
+
+        return typeName;
+    }
+
+    private static int ParseArraySpecifier(ref BufferReader s)
+    {
+        s.ConsumeCharacter(ArrayStartIndicator);
+        var dimensions = 1;
+
+        while (s.TryPeek(out var c) && c != ArrayEndIndicator)
+        {
+            s.ConsumeCharacter(ArrayDimensionIndicator);
+            ++dimensions;
+        }
+
+        s.ConsumeCharacter(ArrayEndIndicator);
+        return dimensions;
+    }
+
+    private static ReadOnlySpan<char> ExtractAssemblySpec(ref BufferReader s)
+    {
+        s.ConsumeWhitespace();
+        return ParseSpan(ref s, AssemblyDelimiters);
+    }
+
+    private static ReadOnlySpan<char> ParseSpan(ref BufferReader s, ReadOnlySpan<char> delimiters)
+    {
+        ReadOnlySpan<char> result;
+        if (s.Remaining.IndexOfAny(delimiters) is int index && index > 0)
+        {
+            result = s.Remaining[..index];
+        }
+        else
+        {
+            result = s.Remaining;
+        }
+
+        s.Consume(result.Length);
+        return result;
+    }
+
+    private static TypeSpec ParseCompoundTypeAliasElement(ref BufferReader input)
+    {
+        char c;
+
+        // Read literal value
+        if (input.TryPeek(out c))
+        {
+            if (c == LiteralDelimiter)
+            {
+                input.ConsumeCharacter(LiteralDelimiter);
+                var literalSpan = ParseSpan(ref input, LiteralDelimiters);
+                input.ConsumeCharacter(LiteralDelimiter);
+                return new LiteralTypeSpec(new string(literalSpan));
+            }
+            else if (c == ArrayStartIndicator)
+            {
+                // Parse the argument type
+                input.ConsumeCharacter(ArrayStartIndicator);
+                var remaining = input.Remaining;
+                var result = ParseInternal(ref remaining);
+                var consumed = input.Remaining.Length - remaining.Length;
+                input.Consume(consumed);
+                input.ConsumeCharacter(ArrayEndIndicator);
+                return result;
+            }
+
+            throw new ArgumentException($"Unexpected token '{c}' when reading compound type alias element.", nameof(input));
+        }
+        else
+        {
+            throw new IndexOutOfRangeException("Attempted to read past the end of the input buffer.");
+        }
+    }
+
+    private static void ThrowGenericArityTooLarge(int arity) => throw new NotSupportedException($"An arity of {arity} is not supported.");
+
+    private ref struct BufferReader
+    {
+        public ReadOnlySpan<char> Input;
+        public int Index;
+        public int TotalGenericArity;
+
+        public readonly ReadOnlySpan<char> Remaining => Input[Index..];
+
+        public bool TryPeek(out char c)
+        {
+            if (Index < Input.Length)
+            {
+                c = Input[Index];
+                return true;
+            }
+
+            c = default;
+            return false;
+        }
+
+        public void Consume(int chars)
+        {
+            if (Index < Input.Length)
+            {
+                Index += chars;
+                return;
+            }
+
+            ThrowEndOfInput();
+        }
+
+        public void ConsumeCharacter(char assertChar)
+        {
+            if (Index < Input.Length)
+            {
+                var c = Input[Index];
+                if (assertChar != c)
+                {
+                    ThrowUnexpectedCharacter(assertChar, c);
+                }
+
+                ++Index;
+                return;
+            }
+
+            ThrowEndOfInput();
+        }
+
+        public void ConsumeWhitespace()
+        {
+            while (char.IsWhiteSpace(Input[Index]))
+            {
+                ++Index;
+            }
+        }
+
+        private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
+
+        private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
     }
 }

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
@@ -1,26 +1,68 @@
+#nullable enable
+
 using System;
 
-namespace Orleans.Serialization.TypeSystem
+namespace Orleans.Serialization.TypeSystem;
+
+/// <summary>
+/// Rewrites <see cref="TypeSpec"/> graphs.
+/// </summary>
+internal static class RuntimeTypeNameRewriter
 {
     /// <summary>
-    /// Rewrites <see cref="TypeSpec"/> graphs.
+    /// Signature for a delegate which rewrites a <see cref="QualifiedType"/>.
     /// </summary>
-    internal static class RuntimeTypeNameRewriter
-    {
-        /// <summary>
-        /// Signature for a delegate which rewrites a <see cref="QualifiedType"/>.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="state">The state provided to the rewriter method.</param>
-        /// <returns>The rewritten qualified type.</returns>
-        public delegate QualifiedType Rewriter<TState>(in QualifiedType input, ref TState state);
+    /// <param name="input">The input.</param>
+    /// <param name="state">The state provided to the rewriter method.</param>
+    /// <returns>The rewritten qualified type.</returns>
+    public delegate QualifiedType Rewriter<TState>(in QualifiedType input, ref TState state);
 
-        /// <summary>
-        /// Rewrites a <see cref="TypeSpec"/> using the provided rewriter delegate.
-        /// </summary>
-        public static TypeSpec Rewrite<TState>(TypeSpec input, Rewriter<TState> rewriter, ref TState state)
+    /// <summary>
+    /// Signature for a delegate which resolves a compound type alias.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="state">The state provided to the resolve method.</param>
+    /// <returns>The resolved type type.</returns>
+    public delegate TypeSpec CompoundAliasResolver<TState>(TupleTypeSpec input, ref TState state);
+
+    /// <summary>
+    /// Rewrites a <see cref="TypeSpec"/> using the provided rewriter delegate.
+    /// </summary>
+    public static TypeSpec Rewrite<TState>(TypeSpec input, Rewriter<TState> rewriter, ref TState state)
+    {
+        var instance = new TypeRewriter<TState>(rewriter, null, ref state);
+        var result = instance.Rewrite(input);
+        state = instance._userState;
+        return result;
+    }
+
+    /// <summary>
+    /// Rewrites a <see cref="TypeSpec"/> using the provided rewriter delegate.
+    /// </summary>
+    public static TypeSpec Rewrite<TState>(TypeSpec input, Rewriter<TState> rewriter, CompoundAliasResolver<TState>? compoundAliasRewriter, ref TState state)
+    {
+        var instance = new TypeRewriter<TState>(rewriter, compoundAliasRewriter, ref state);
+        var result = instance.Rewrite(input);
+        state = instance._userState;
+        return result;
+    }
+
+    private struct TypeRewriter<TState>
+    {
+        private readonly Rewriter<TState> _nameRewriter { get; }
+        private readonly CompoundAliasResolver<TState>? _compoundTypeRewriter { get; }
+        public TState _userState;
+
+        public TypeRewriter(Rewriter<TState> nameRewriter, CompoundAliasResolver<TState>? compoundTypeRewriter, ref TState initialUserState)
         {
-            var result = ApplyInner(input, null, rewriter, ref state);
+            _nameRewriter = nameRewriter;
+            _compoundTypeRewriter = compoundTypeRewriter;
+            _userState = initialUserState;
+        }
+
+        public TypeSpec Rewrite(TypeSpec input)
+        {
+            var result = ApplyInner(input, null);
             if (result.Assembly is not null)
             {
                 // If the rewriter bubbled up an assembly, add it here. 
@@ -30,30 +72,37 @@ namespace Orleans.Serialization.TypeSystem
             return result.Type;
         }
 
-        private static (TypeSpec Type, string Assembly) ApplyInner<TState>(TypeSpec input, string assemblyName, Rewriter<TState> replaceFunc, ref TState state) =>
-            // A type's assembly is passed downwards through the graph, and modifications to the assembly (from the user-provided delegate) flow upwards.
-            input switch
-            {
-                ConstructedGenericTypeSpec type => HandleGeneric(type, assemblyName, replaceFunc, ref state),
-                NamedTypeSpec type => HandleNamedType(type, assemblyName, replaceFunc, ref state),
-                AssemblyQualifiedTypeSpec type => HandleAssembly(type, assemblyName, replaceFunc, ref state),
-                ArrayTypeSpec type => HandleArray(type, assemblyName, replaceFunc, ref state),
-                PointerTypeSpec type => HandlePointer(type, assemblyName, replaceFunc, ref state),
-                ReferenceTypeSpec type => HandleReference(type, assemblyName, replaceFunc, ref state),
-                null => throw new ArgumentNullException(nameof(input)),
-                _ => throw new NotSupportedException($"Argument of type {input.GetType()} is nut supported"),
-            };
-
-        private static (TypeSpec Type, string Assembly) HandleGeneric<TState>(ConstructedGenericTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) ApplyInner(TypeSpec input, string? assemblyName) =>
+        // A type's assembly is passed downwards through the graph, and modifications to the assembly (from the user-provided delegate) flow upwards.
+        input switch
         {
-            var (unconstructed, replacementAssembly) = ApplyInner(type.UnconstructedType, assemblyName, replaceTypeName, ref state);
+            ConstructedGenericTypeSpec type => HandleGeneric(type, assemblyName),
+            NamedTypeSpec type => HandleNamedType(type, assemblyName),
+            AssemblyQualifiedTypeSpec type => HandleAssembly(type, assemblyName),
+            ArrayTypeSpec type => HandleArray(type, assemblyName),
+            PointerTypeSpec type => HandlePointer(type, assemblyName),
+            ReferenceTypeSpec type => HandleReference(type, assemblyName),
+            TupleTypeSpec type => HandleCompoundType(type, assemblyName),
+            LiteralTypeSpec type => (type, assemblyName),
+            null => throw new ArgumentNullException(nameof(input)),
+            _ => throw new NotSupportedException($"Argument of type {input.GetType()} is nut supported"),
+        };
+
+        private (TypeSpec Type, string? Assembly) HandleGeneric(ConstructedGenericTypeSpec type, string? assemblyName)
+        {
+            var (unconstructed, replacementAssembly) = ApplyInner(type.UnconstructedType, assemblyName);
+            if (unconstructed is AssemblyQualifiedTypeSpec assemblyQualified)
+            {
+                unconstructed = assemblyQualified.Type;
+                replacementAssembly = assemblyQualified.Assembly;
+            }
 
             var newArguments = new TypeSpec[type.Arguments.Length];
             var didChange = false;
             for (var i = 0; i < type.Arguments.Length; i++)
             {
                 // Generic type parameters do not inherit the assembly of the generic type.
-                var args = ApplyInner(type.Arguments[i], null, replaceTypeName, ref state);
+                var args = ApplyInner(type.Arguments[i], null);
 
                 if (args.Assembly is not null)
                 {
@@ -72,34 +121,34 @@ namespace Orleans.Serialization.TypeSystem
                 return (type, replacementAssembly);
             }
 
-            return (new ConstructedGenericTypeSpec((NamedTypeSpec)unconstructed, newArguments), replacementAssembly);
+            return (new ConstructedGenericTypeSpec(unconstructed, newArguments.Length, newArguments), replacementAssembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleNamedType<TState>(NamedTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) HandleNamedType(NamedTypeSpec type, string? assemblyName)
         {
             var nsQualified = type.GetNamespaceQualifiedName();
-            var names = replaceTypeName(new QualifiedType(assembly: assemblyName, type: nsQualified), ref state);
+            var replacementName = _nameRewriter(new QualifiedType(assembly: assemblyName, type: nsQualified), ref _userState);
 
-            if (!string.Equals(nsQualified, names.Type, StringComparison.Ordinal))
+            if (!string.Equals(nsQualified, replacementName.Type, StringComparison.Ordinal))
             {
                 // Change the type name and potentially the assembly.
-                var resultType = RuntimeTypeNameParser.Parse(names.Type);
+                var resultType = RuntimeTypeNameParser.Parse(replacementName.Type);
                 if (!(resultType is NamedTypeSpec))
                 {
-                    throw new InvalidOperationException($"Replacement type name, \"{names.Type}\", can not deviate from the original type structure of the input, \"{nsQualified}\"");
+                    throw new InvalidOperationException($"Replacement type name, \"{replacementName.Type}\", can not deviate from the original type structure of the input, \"{nsQualified}\"");
                 }
 
-                return (resultType, names.Assembly);
+                return (resultType, replacementName.Assembly);
             }
-            else if (!string.Equals(assemblyName, names.Assembly, StringComparison.Ordinal))
+            else if (!string.Equals(assemblyName, replacementName.Assembly, StringComparison.Ordinal))
             {
                 // Only change the assembly;
-                return (type, names.Assembly);
+                return (type, replacementName.Assembly);
             }
             else if (type.ContainingType is not null)
             {
                 // Give the user an opportunity to change the parent, including the assembly.
-                var replacementParent = ApplyInner(type.ContainingType, assemblyName, replaceTypeName, ref state);
+                var replacementParent = ApplyInner(type.ContainingType, assemblyName);
                 if (ReferenceEquals(replacementParent.Type, type.ContainingType))
                 {
                     // No change to the type.
@@ -112,13 +161,13 @@ namespace Orleans.Serialization.TypeSystem
             }
             else
             {
-                return (type, names.Assembly);
+                return (type, replacementName.Assembly);
             }
         }
 
-        private static (TypeSpec Type, string Assembly) HandleAssembly<TState>(AssemblyQualifiedTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) HandleAssembly(AssemblyQualifiedTypeSpec type, string? assemblyName)
         {
-            var replacement = ApplyInner(type.Type, type.Assembly, replaceTypeName, ref state);
+            var replacement = ApplyInner(type.Type, type.Assembly);
 
             // Assembly name changes never bubble up past the assembly qualifier node.
             if (string.IsNullOrWhiteSpace(replacement.Assembly))
@@ -136,9 +185,9 @@ namespace Orleans.Serialization.TypeSystem
             return (type, assemblyName);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleArray<TState>(ArrayTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) HandleArray(ArrayTypeSpec type, string? assemblyName)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
+            var element = ApplyInner(type.ElementType, assemblyName);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);
@@ -147,9 +196,9 @@ namespace Orleans.Serialization.TypeSystem
             return (new ArrayTypeSpec(element.Type, type.Dimensions), element.Assembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandleReference<TState>(ReferenceTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) HandleReference(ReferenceTypeSpec type, string? assemblyName)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
+            var element = ApplyInner(type.ElementType, assemblyName);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);
@@ -158,15 +207,40 @@ namespace Orleans.Serialization.TypeSystem
             return (new ReferenceTypeSpec(element.Type), element.Assembly);
         }
 
-        private static (TypeSpec Type, string Assembly) HandlePointer<TState>(PointerTypeSpec type, string assemblyName, Rewriter<TState> replaceTypeName, ref TState state)
+        private (TypeSpec Type, string? Assembly) HandlePointer(PointerTypeSpec type, string? assemblyName)
         {
-            var element = ApplyInner(type.ElementType, assemblyName, replaceTypeName, ref state);
+            var element = ApplyInner(type.ElementType, assemblyName);
             if (ReferenceEquals(element.Type, type.ElementType))
             {
                 return (type, element.Assembly);
             }
 
             return (new PointerTypeSpec(element.Type), element.Assembly);
+        }
+
+        private (TypeSpec Type, string? Assembly) HandleCompoundType(TupleTypeSpec type, string? assemblyName)
+        {
+            var elements = new TypeSpec[type.Elements.Length];
+            for (var i = 0; i < type.Elements.Length; i++)
+            {
+                (elements[i], _) = ApplyInner(type.Elements[i], assemblyName);
+            }
+
+            // Resolve the compound type alias after first trying to resolve each of the individual elements.
+            var replacementTypeSpec = new TupleTypeSpec(elements, type.Arity);
+            if (_compoundTypeRewriter is { } rewriter)
+            {
+                var resolved = rewriter(replacementTypeSpec, ref _userState);
+                if (resolved is TupleTypeSpec)
+                {
+                    throw new InvalidOperationException($"Compound type alias resolver resolved {type} into {resolved} which is also an alias type.");
+                }
+
+                // Give the rewriter a chance to rewrite the resolved name.
+                return ApplyInner(resolved, assemblyName); 
+            }
+
+            return (replacementTypeSpec, assemblyName);
         }
     }
 }

--- a/test/Grains/TestFSharp/Types.fs
+++ b/test/Grains/TestFSharp/Types.fs
@@ -9,21 +9,21 @@ type SingleCaseDU =
     static member ofInt i = SingleCaseDU i
 
 [<Immutable; GenerateSerializer>]
-type Record = {  [<Id(1us)>] A: SingleCaseDU } with
+type Record = {  [<Id(1u)>] A: SingleCaseDU } with
     static member ofInt x = { A = SingleCaseDU.ofInt x }
 
 [<Immutable; GenerateSerializer>]
-type RecordOfIntOption = {  [<Id(1us)>] A: int option } with
+type RecordOfIntOption = {  [<Id(1u)>] A: int option } with
     static member Empty = { A = None }
     static member ofInt x = { A = Some x}
 
 [<Immutable; GenerateSerializer>]
-type RecordOfIntOptionWithNoAttributes = {  [<Id(1us)>] A: int option } with
+type RecordOfIntOptionWithNoAttributes = {  [<Id(1u)>] A: int option } with
     static member Empty = { A = None }
     static member ofInt x = { A = Some x}
 
 [<Immutable; GenerateSerializer>]
-type GenericRecord<'T> = { [<Id(1us)>] Value: 'T } with
+type GenericRecord<'T> = { [<Id(1u)>] Value: 'T } with
     static member ofT x = { Value = x }
 
 [<Immutable; GenerateSerializer>]

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -210,11 +210,11 @@ namespace UnitTests.GrainInterfaces
         Task<T> GetLastValue();
     }
 
-    [WellKnownAlias("IGenericGrainWithConstraints`3")]
+    [Alias("IGenericGrainWithConstraints`3")]
     public interface IGenericGrainWithConstraints<A, B, C> : IGrainWithStringKey
         where A : ICollection<B>, new() where B : struct where C : class
     {
-        [WellKnownAlias("GetCount")]
+        [Alias("GetCount")]
         Task<int> GetCount();
 
         Task Add(B item);

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -214,7 +214,7 @@ namespace UnitTests.GrainInterfaces
     public interface IGenericGrainWithConstraints<A, B, C> : IGrainWithStringKey
         where A : ICollection<B>, new() where B : struct where C : class
     {
-        [WellKnownAlias("IGenericGrainWithConstraints_GetCount`3")]
+        [WellKnownAlias("GetCount")]
         Task<int> GetCount();
 
         Task Add(B item);

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -733,7 +733,7 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        [WellKnownAlias("GenericGrainWithConstraints.GetCount")]
+        [Alias("GenericGrainWithConstraints.GetCount")]
         public Task<int> GetCount() { return Task.FromResult(collection.Count); }
 
         public Task Add(B item)

--- a/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
+++ b/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
@@ -13,6 +13,7 @@ public interface IHasNoNamespace : IMyInvokableBaseType
 
 namespace Orleans.Serialization.UnitTests
 {
+    [WellKnownAlias("_my_proxy_base_")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(UnitTestRequest<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(UnitTestRequest))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(UnitTestTaskRequest<>))]
@@ -20,21 +21,34 @@ namespace Orleans.Serialization.UnitTests
     [DefaultInvokableBaseType(typeof(void), typeof(UnitTestVoidRequest))]
     public abstract class MyInvokableProxyBase
     {
-        protected void SendRequest(IResponseCompletionSource callback, IInvokable body)
+        public Action<IInvokable> OnInvoke { get; set; }
+
+        protected MyInvokableProxyBase(CopyContextPool copyContextPool, CodecProvider codecProvider)
         {
+            CopyContextPool = copyContextPool;
+            CodecProvider = codecProvider;
         }
         
         protected TInvokable GetInvokable<TInvokable>() where TInvokable : class, IInvokable, new() => InvokablePool.Get<TInvokable>();
 
-        protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
+        protected ValueTask<T> InvokeAsync<T>(IInvokable body)
+        {
+            OnInvoke?.Invoke(body);
+            return default;
+        }
 
-        protected ValueTask InvokeAsync(IInvokable body) => default;
+        protected ValueTask InvokeAsync(IInvokable body)
+        {
+            OnInvoke?.Invoke(body);
+            return default;
+        }
 
         protected CopyContextPool CopyContextPool { get; }
 
         protected CodecProvider CodecProvider { get; }
     }
 
+    [WellKnownAlias("groan")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(UnitTestRequest<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(UnitTestRequest))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(UnitTestTaskRequest<>))]
@@ -42,10 +56,6 @@ namespace Orleans.Serialization.UnitTests
     [DefaultInvokableBaseType(typeof(void), typeof(UnitTestVoidRequest))]
     public abstract class AltInvokableProxyBase
     {
-        protected void InvokeVoid(IInvokable body)
-        {
-        }
-
         protected TInvokable GetInvokable<TInvokable>() where TInvokable : class, IInvokable, new() => InvokablePool.Get<TInvokable>();
 
         protected ValueTask<T> InvokeAsync<T>(IInvokable body) => default;
@@ -57,8 +67,29 @@ namespace Orleans.Serialization.UnitTests
         protected CodecProvider CodecProvider { get; }
     }
 
+    [WellKnownAlias("my_interface")]
     [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]
-    public interface IMyInvokableBaseType { }
+    public interface IMyInvokableBaseType
+    {
+    }
+
+    [WellKnownAlias("_proxy_alias_test_")]
+    [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]
+    public interface IProxyAliasTestGrain
+    {
+        [Id(125)]
+        ValueTask Method();
+        ValueTask Method(int a);
+        ValueTask Method(string a);
+        ValueTask OtherMethod();
+    }
+
+    [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]
+    public interface IGenericProxyAliasTestGrain<T, U, V>
+    {
+        [Id(777)]
+        ValueTask Method<W, X, Y>();
+    }
 
     public interface IG2<T1, T2> : IMyInvokableBaseType 
     { }

--- a/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
+++ b/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
@@ -13,7 +13,7 @@ public interface IHasNoNamespace : IMyInvokableBaseType
 
 namespace Orleans.Serialization.UnitTests
 {
-    [WellKnownAlias("_my_proxy_base_")]
+    [Alias("_my_proxy_base_")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(UnitTestRequest<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(UnitTestRequest))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(UnitTestTaskRequest<>))]
@@ -48,7 +48,7 @@ namespace Orleans.Serialization.UnitTests
         protected CodecProvider CodecProvider { get; }
     }
 
-    [WellKnownAlias("groan")]
+    [Alias("groan")]
     [DefaultInvokableBaseType(typeof(ValueTask<>), typeof(UnitTestRequest<>))]
     [DefaultInvokableBaseType(typeof(ValueTask), typeof(UnitTestRequest))]
     [DefaultInvokableBaseType(typeof(Task<>), typeof(UnitTestTaskRequest<>))]
@@ -67,20 +67,26 @@ namespace Orleans.Serialization.UnitTests
         protected CodecProvider CodecProvider { get; }
     }
 
-    [WellKnownAlias("my_interface")]
+    [Alias("my_interface")]
     [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]
     public interface IMyInvokableBaseType
     {
     }
 
-    [WellKnownAlias("_proxy_alias_test_")]
+    [Alias("_proxy_alias_test_")]
     [GenerateMethodSerializers(typeof(MyInvokableProxyBase))]
     public interface IProxyAliasTestGrain
     {
         [Id(125)]
         ValueTask Method();
+
+        [Alias("Method")]
         ValueTask Method(int a);
+
+        [Alias("StringMethod")]
         ValueTask Method(string a);
+
+        [Alias("MyOtherMethod")]
         ValueTask OtherMethod();
     }
 

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -252,7 +252,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [GenerateSerializer]
-    [WellKnownId(3201)]
+    [Id(3201)]
     public class SomeClassWithSerializers
     {
         [Id(0)]
@@ -273,7 +273,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [GenerateSerializer]
-    [WellKnownAlias("sercla1")]
+    [Alias("sercla1")]
     public class SerializableClassWithCompiledBase : List<int>
     {
         [Id(0)]
@@ -281,7 +281,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [GenerateSerializer]
-    [WellKnownAlias("gpoco`1")]
+    [Alias("gpoco`1")]
     public class GenericPoco<T>
     {
         [Id(0)]

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 namespace Orleans.Serialization.Invocation
 {
+    [GenerateSerializer]
     public abstract class UnitTestRequestBase : IInvokable
     {
         public virtual int GetArgumentCount() => 0;
@@ -23,6 +24,7 @@ namespace Orleans.Serialization.Invocation
         public abstract MethodInfo GetMethod();
     }
 
+    [GenerateSerializer]
     public abstract class UnitTestRequest : UnitTestRequestBase
     {
         [DebuggerHidden]
@@ -64,6 +66,7 @@ namespace Orleans.Serialization.Invocation
         protected abstract ValueTask InvokeInner();
     }
 
+    [GenerateSerializer]
     public abstract class UnitTestRequest<TResult> : UnitTestRequestBase
     {
         [DebuggerHidden]
@@ -104,6 +107,7 @@ namespace Orleans.Serialization.Invocation
         protected abstract ValueTask<TResult> InvokeInner();
     }
 
+    [GenerateSerializer]
     public abstract class UnitTestTaskRequest<TResult> : UnitTestRequestBase
     {
         [DebuggerHidden]
@@ -145,6 +149,7 @@ namespace Orleans.Serialization.Invocation
         protected abstract Task<TResult> InvokeInner();
     }
 
+    [GenerateSerializer]
     public abstract class UnitTestTaskRequest : UnitTestRequestBase
     {
         [DebuggerHidden]
@@ -187,6 +192,7 @@ namespace Orleans.Serialization.Invocation
         protected abstract Task InvokeInner();
     }
 
+    [GenerateSerializer]
     public abstract class UnitTestVoidRequest : UnitTestRequestBase
     {
         [DebuggerHidden]

--- a/test/Orleans.Serialization.UnitTests/TypeEncodingTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeEncodingTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization.Configuration;
+using Orleans.Serialization.Invocation;
+using Orleans.Serialization.Session;
+using Orleans.Serialization.TypeSystem;
+using Orleans.Serialization.Utilities;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests
+{
+    public class TypeEncodingTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly SerializerSessionPool _sessionPool;
+        private readonly Serializer _serializer;
+
+        public TypeEncodingTests()
+        {
+            var services = new ServiceCollection();
+            _ = services.AddSerializer();
+            _serviceProvider = services.BuildServiceProvider();
+            _sessionPool = _serviceProvider.GetRequiredService<SerializerSessionPool>();
+            _serializer = _serviceProvider.GetRequiredService<Serializer>();
+        }
+
+        [Fact]
+        public void CompoundTypeAliasesAreEncodedAsExpected()
+        {
+            var original = new MyCompoundTypeAliasClass
+            {
+                Name = "TwinkleToes",
+                Value = 112
+            };
+            var expectedString = "(\"xx_test_xx\",[_custom_type_alias_],[int],\"1\")";
+            var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
+            var (payload, bitStream) = SerializePayload(original);
+            Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+        }
+
+        [Fact]
+        public void GeneratedProxyClassesHaveExpectedCompoundTypeNames()
+        {
+            var configuration = _serviceProvider.GetRequiredService<IOptions<TypeManifestOptions>>().Value;
+            var generatedProxy = configuration.InterfaceProxies.Single(proxy => typeof(IProxyAliasTestGrain).IsAssignableFrom(proxy));
+            var instance = ActivatorUtilities.CreateInstance(_serviceProvider, generatedProxy);
+            var instanceAsBase = Assert.IsAssignableFrom<MyInvokableProxyBase>(instance);
+            var instanceAsInterface = Assert.IsAssignableFrom<IProxyAliasTestGrain>(instance);
+
+            var calls = new Queue<IInvokable>();
+            instanceAsBase.OnInvoke = body => calls.Enqueue(body);
+
+            var res = instanceAsInterface.Method();
+            Assert.True(res.IsCompletedSuccessfully);
+            var method = calls.Dequeue();
+            var (payload, bitStream) = SerializePayload(method);
+            var expectedString = "(\"inv\",[_my_proxy_base_],[_proxy_alias_test_],\"125\")";
+            var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
+            Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+        }
+
+        [Fact]
+        public void GeneratedProxyClassesHaveExpectedCompoundTypeNames_Generic()
+        {
+            var configuration = _serviceProvider.GetRequiredService<IOptions<TypeManifestOptions>>().Value;
+            var generatedProxy = configuration.InterfaceProxies.Single(proxy => proxy.GetInterfaces().Any(iface => iface.IsGenericType && typeof(IGenericProxyAliasTestGrain<,,>).IsAssignableFrom(iface.GetGenericTypeDefinition())));
+            var instance = ActivatorUtilities.CreateInstance(_serviceProvider, generatedProxy.MakeGenericType(typeof(int), typeof(string), typeof(double)));
+            var instanceAsBase = Assert.IsAssignableFrom<MyInvokableProxyBase>(instance);
+            var instanceAsInterface = Assert.IsAssignableFrom<IGenericProxyAliasTestGrain<int, string, double>>(instance);
+
+            var calls = new Queue<IInvokable>();
+            instanceAsBase.OnInvoke = body => calls.Enqueue(body);
+
+            var res = instanceAsInterface.Method<int, MyTypeAliasClass, int>();
+            Assert.True(res.IsCompletedSuccessfully);
+            var method = calls.Dequeue();
+            var (payload, bitStream) = SerializePayload(method);
+            var expectedString = "(\"inv\",[_my_proxy_base_],[Orleans.Serialization.UnitTests.IGenericProxyAliasTestGrain`3,Orleans.Serialization.UnitTests],\"777\")`6[[int],[string],[double],[int],[_custom_type_alias_],[int]]";
+            var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
+            Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+        }
+
+        private (byte[] Serialized, string FormattedBitStream) SerializePayload(object original)
+        {
+            var payload = _serializer.SerializeToArray<object>(original);
+            using var session = _sessionPool.GetSession();
+            var bitStream = BitStreamFormatter.Format(payload, session);
+            return (payload, bitStream);
+        }
+    }
+
+    [WellKnownAlias("_custom_type_alias_")]
+    public class MyTypeAliasClass
+    {
+    }
+
+    [GenerateSerializer]
+    public class MyCompoundTypeAliasBaseClass
+    {
+        [Id(0)]
+        public int BaseValue { get; set; }
+    }
+
+    [GenerateSerializer]
+    [CompoundTypeAlias("xx_test_xx", typeof(MyTypeAliasClass), typeof(int), "1")]
+    public class MyCompoundTypeAliasClass : MyCompoundTypeAliasBaseClass
+    {
+        [Id(0)]
+        public string? Name { get; set; }
+
+        [Id(1)]
+        public int Value { get; set; }
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/TypeEncodingTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeEncodingTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Options;
 using Orleans.Serialization.Configuration;
 using Orleans.Serialization.Invocation;
 using Orleans.Serialization.Session;
-using Orleans.Serialization.TypeSystem;
 using Orleans.Serialization.Utilities;
 using Xunit;
 
@@ -55,13 +54,25 @@ namespace Orleans.Serialization.UnitTests
             var calls = new Queue<IInvokable>();
             instanceAsBase.OnInvoke = body => calls.Enqueue(body);
 
-            var res = instanceAsInterface.Method();
-            Assert.True(res.IsCompletedSuccessfully);
-            var method = calls.Dequeue();
-            var (payload, bitStream) = SerializePayload(method);
-            var expectedString = "(\"inv\",[_my_proxy_base_],[_proxy_alias_test_],\"125\")";
-            var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
-            Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+            {
+                var res = instanceAsInterface.Method();
+                Assert.True(res.IsCompletedSuccessfully);
+                var method = calls.Dequeue();
+                var (payload, bitStream) = SerializePayload(method);
+                var expectedString = "(\"inv\",[_my_proxy_base_],[_proxy_alias_test_],\"125\")";
+                var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
+                Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+            }
+
+            {
+                var res = instanceAsInterface.OtherMethod();
+                Assert.True(res.IsCompletedSuccessfully);
+                var method = calls.Dequeue();
+                var (payload, bitStream) = SerializePayload(method);
+                var expectedString = "(\"inv\",[_my_proxy_base_],[_proxy_alias_test_],\"MyOtherMethod\")";
+                var expectedEncoding = Encoding.UTF8.GetBytes(expectedString).AsSpan();
+                Assert.True(payload.AsSpan().IndexOf(expectedEncoding) >= 0, $"Expected to find string \"{expectedString}\" in bitstream (formatted: {bitStream})");
+            }
         }
 
         [Fact]
@@ -94,7 +105,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    [WellKnownAlias("_custom_type_alias_")]
+    [Alias("_custom_type_alias_")]
     public class MyTypeAliasClass
     {
     }


### PR DESCRIPTION
Currently, generated classes are identified by name directly. This works for most cases, but it is not version-tolerant.
For example, given the following interface definition:
``` C#
public interface IGrainWithGenericMethods : IMyInvokableBaseType 
{
    Task<T> RoundTrip<T>(T val);
}
```

The serializer will generate an *invokable* named `OrleansCodeGen.Orleans.Serialization.UnitTests.Invokable_IGrainWithGenericMethods_GrainReference_1_1<>`

If the `IGrainWithGenericMethods` interface was to change name, then this class would change name, but there is no way to associate an alias on the former with the latter today. Similarly, if another method was added to the class, or the method name was changed, that could result in the method no longer having the same identifier, breaking version tolerance.

This PR introduces the concept of compound type aliases into the serializer type system in order to handle these cases.
An attribute is placed on the generated class, such as:
`[CompoundTypeAliasAttribute("inv", typeof(GrainReference), typeof(IGrainWithGenericMethods), "1")]`. This can be interpreted as "The invoker for the proxy base type `GrainReference` for the interface `IGrainWtihGenericMethod` and method id 1".

These compound type aliases are added to the assembly metadata in the form of a tree which can be queried at runtime to resolve aliases back to the original type.

When the type is serialized, the attribute is found and the name is encoded as a tuple, `("inv", GrainReference, IGrainWithGenericMethods, "1")`, with generic type parameters appended as per usual. During encoding, the types in that expression are replaced with their aliases (eg, `WellKnownAlias`, if one is set). During decoding, the aliases for the individual component types are replaced with their original types and the expression is compared to metadata to resolve the original type.

This allows individual components to have type aliases and allows the type to survive refactoring.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7943)