### PR TITLE
Don't use MethodImplOptions.NoInlining on throw-helpers

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -244,7 +243,6 @@ namespace Orleans.Runtime
             return FindOrCreateGrainId(UniqueKey.NewKey(n0, n1, typeCodeData, keyExt));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static LegacyGrainId ThrowNotLegacyGrainId(GrainId id)
         {
             throw new InvalidOperationException($"Cannot convert non-legacy id {id} into legacy id");

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -173,19 +173,14 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowIfLengthsInvalid(int headerLength, int bodyLength)
         {
-            if (headerLength <= 0 || headerLength > _maxHeaderLength)
-            {
-                throw new OrleansException($"Invalid header size: {headerLength} (max configured value is {_maxHeaderLength}, see {nameof(MessagingOptions.MaxMessageHeaderSize)})");
-            }
-
-            if (bodyLength < 0 || bodyLength > _maxBodyLength)
-            {
-                throw new OrleansException($"Invalid body size: {bodyLength} (max configured value is {_maxBodyLength}, see {nameof(MessagingOptions.MaxMessageBodySize)})");
-            }
+            if (headerLength <= 0 || headerLength > _maxHeaderLength) ThrowInvalidHeaderLength(headerLength);
+            if ((uint)bodyLength > (uint)_maxBodyLength) ThrowInvalidBodyLength(bodyLength);
         }
+
+        private void ThrowInvalidHeaderLength(int headerLength) => throw new OrleansException($"Invalid header size: {headerLength} (max configured value is {_maxHeaderLength}, see {nameof(MessagingOptions.MaxMessageHeaderSize)})");
+        private void ThrowInvalidBodyLength(int bodyLength) => throw new OrleansException($"Invalid body size: {bodyLength} (max configured value is {_maxBodyLength}, see {nameof(MessagingOptions.MaxMessageBodySize)})");
 
         private Message Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Message value) where TBufferWriter : IBufferWriter<byte>
         {

--- a/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Orleans.Networking.Shared
@@ -208,13 +207,11 @@ namespace Orleans.Networking.Shared
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
         {
             throw new ArgumentOutOfRangeException("size", $"Cannot allocate more than {maxSize} bytes in a single buffer");
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowObjectDisposedException() => throw new ObjectDisposedException("MemoryPool");
     }
 }

--- a/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
+++ b/src/Orleans.Core/Scheduler/TaskSchedulerAgent.cs
@@ -215,10 +215,9 @@ namespace Orleans.Runtime
 
         private void ThrowIfDisposed()
         {
-            if (disposed)
-            {
-                throw new ObjectDisposedException("Cannot access disposed AsynchAgent");
-            }
+            if (disposed) ThrowDisposed();
+
+            static void ThrowDisposed() => throw new ObjectDisposedException("Cannot access disposed AsynchAgent");
         }
     }
 }

--- a/src/Orleans.Core/Utils/AsyncEnumerable.cs
+++ b/src/Orleans.Core/Utils/AsyncEnumerable.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Internal;
@@ -85,10 +84,8 @@ namespace Orleans.Runtime.Utilities
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidUpdate() => throw new ArgumentException("The value was not valid");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowDisposed() => throw new ObjectDisposedException("This instance has been disposed");
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -188,11 +185,7 @@ namespace Orleans.Runtime.Utilities
 
             public void SetNext(Element next) => this.next.SetResult(next);
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             private static T ThrowInvalidInstance() => throw new InvalidOperationException("This instance does not have a value set.");
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            private static T ThrowDisposed() => throw new ObjectDisposedException("This instance has been disposed");
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/ClientGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientGrainLocator.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
-using Orleans.Internal;
 
 namespace Orleans.Runtime.GrainDirectory
 {
@@ -61,8 +59,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task Unregister(GrainAddress address, UnregistrationCause cause) => throw new InvalidOperationException($"Cannot unregister client grain explicitly");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static GrainId ThrowNotClientGrainId(GrainId grainId) => throw new InvalidOperationException($"{grainId} is not a client id");
+        private static void ThrowNotClientGrainId(GrainId grainId) => throw new InvalidOperationException($"{grainId} is not a client id");
 
         public void CachePlacementDecision(GrainId grainId, SiloAddress siloAddress) { }
 

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -89,7 +89,6 @@ namespace Orleans.Runtime.Placement
             var worker = _workers[grainId.GetUniformHashCode() % PlacementWorkerCount];
             return worker.AddressMessage(message);
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static void ThrowMissingAddress() => throw new InvalidOperationException("Cannot address a message without a target");
         }
 

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -77,8 +77,9 @@ namespace Orleans.Runtime.Versions
 
         private void ThrowIfNotEnabled()
         {
-            if (!IsEnabled)
-                throw new OrleansException("Version store not enabled, make sure the store is configured");
+            if (!IsEnabled) ThrowDisabled();
+
+            static void ThrowDisabled() => throw new OrleansException("Version store not enabled, make sure the store is configured");
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
@@ -46,7 +45,6 @@ namespace Orleans.Runtime
 
         public ValueTask WaitAsync() => new(this, _waitSource.Version);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowConcurrencyViolation() => throw new InvalidOperationException("Concurrent use is not supported");
     }
 

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Core;
 using Orleans.Serialization.Buffers;
@@ -193,8 +192,7 @@ namespace Orleans.Serialization
             return FSharpValueOption<T>.None;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
+        internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
 
@@ -287,7 +285,7 @@ namespace Orleans.Serialization
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -325,10 +323,6 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]
@@ -419,7 +413,7 @@ namespace Orleans.Serialization
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -458,10 +452,6 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]
@@ -566,7 +556,7 @@ namespace Orleans.Serialization
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -606,10 +596,6 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]
@@ -726,7 +712,7 @@ namespace Orleans.Serialization
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -767,10 +753,6 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]
@@ -899,7 +881,7 @@ namespace Orleans.Serialization
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -941,10 +923,6 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]
@@ -1253,7 +1231,7 @@ namespace Orleans.Serialization
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -1290,10 +1268,6 @@ namespace Orleans.Serialization
 
             throw new NotSupportedException("Cannot deserialize instance without value field");
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
     }
     
     [RegisterCopier]

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -1,16 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
+using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
-using Newtonsoft.Json;
-using System;
-using System.Runtime.CompilerServices;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Buffers.Adaptors;
-using System.IO;
-using Microsoft.Extensions.Options;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Orleans.Serialization;
 
@@ -194,11 +193,9 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
         return false;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
         $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for JSON fields. {field}");
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 
     private bool IsSupportedType(Type type) => ((IGeneralizedCodec)this).IsSupportedType(type) || ((IGeneralizedCopier)this).IsSupportedType(type);

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Buffers.Adaptors;
@@ -5,12 +10,6 @@ using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text.Json;
 
 namespace Orleans.Serialization;
 
@@ -224,10 +223,8 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
     /// <inheritdoc/>
     bool? ITypeFilter.IsTypeAllowed(Type type) => (((IGeneralizedCopier)this).IsSupportedType(type) || ((IGeneralizedCodec)this).IsSupportedType(type)) ? true : null;
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
         $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for JSON fields. {field}");
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 }

--- a/src/Orleans.Serialization/Buffers/Adaptors/ArrayStreamBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/ArrayStreamBufferWriter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using System.IO;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Buffers.Adaptors
 {
@@ -94,13 +93,10 @@ namespace Orleans.Serialization.Buffers.Adaptors
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNegativeSizeHint() => throw new ArgumentException("Negative values are not supported", "sizeHint");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNegativeAdvanceCount() => throw new ArgumentException("Negative values are not supported", "count");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowAdvancePastCapacity() => throw new InvalidOperationException("Cannod advance past the end of the current capacity");
     }
 }

--- a/src/Orleans.Serialization/Buffers/Adaptors/MemoryBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/MemoryBufferWriter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Buffers.Adaptors
 {
@@ -35,7 +34,6 @@ namespace Orleans.Serialization.Buffers.Adaptors
             {
                 ThrowInvalidCount();
 
-                [MethodImpl(MethodImplOptions.NoInlining)]
                 static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
             }
 
@@ -64,7 +62,6 @@ namespace Orleans.Serialization.Buffers.Adaptors
             return _buffer.Span.Slice(_bytesWritten);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowInsufficientCapacity(int sizeHint) => throw new InvalidOperationException($"Insufficient capacity to perform the requested operation. Buffer size is {_buffer.Length}. Current length is {_bytesWritten} and requested size increase is {sizeHint}");
     }
 }

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -71,7 +71,6 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         _currentPosition += bytes;
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         static void ThrowInvalidOperation() => throw new InvalidOperationException("Attempted to advance past the end of a buffer.");
     }
 

--- a/src/Orleans.Serialization/Buffers/Adaptors/SpanBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/SpanBufferWriter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Buffers.Adaptors
 {
@@ -42,7 +41,6 @@ namespace Orleans.Serialization.Buffers.Adaptors
             ThrowNotSupported();
             return default;
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static void ThrowNotSupported() => throw new NotSupportedException("Method is not supported on this instance");
         }
 
@@ -57,11 +55,9 @@ namespace Orleans.Serialization.Buffers.Adaptors
             ThrowNotSupported();
             return default;
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static void ThrowNotSupported() => throw new NotSupportedException("Method is not supported on this instance");
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowInsufficientCapacity(int sizeHint) => throw new InvalidOperationException($"Insufficient capacity to perform the requested operation. Buffer size is {_maxLength}. Current length is {_bytesWritten} and requested size increase is {sizeHint}");
     }
 }

--- a/src/Orleans.Serialization/Buffers/BufferWriterExtensions.cs
+++ b/src/Orleans.Serialization/Buffers/BufferWriterExtensions.cs
@@ -20,15 +20,8 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Writer<TBufferWriter> CreateWriter<TBufferWriter>(this TBufferWriter buffer, SerializerSession session) where TBufferWriter : IBufferWriter<byte>
         {
-            if (session is null)
-            {
-                ThrowSessionNull();
-            }
-
+            ArgumentNullException.ThrowIfNull(session);
             return Writer.Create(buffer, session);
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            void ThrowSessionNull() => throw new ArgumentNullException(nameof(session));
         }
     }
 }

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -196,7 +196,6 @@ namespace Orleans.Serialization.Buffers
             return false;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
 
         private static byte[] GetScratchBuffer() => Scratch ??= new byte[1024];
@@ -476,7 +475,6 @@ namespace Orleans.Serialization.Buffers
                 throw new NotSupportedException($"Type {typeof(TInput)} is not supported");
             }
             
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static void ThrowInvalidPosition(long expectedPosition, long actualPosition)
             {
                 throw new InvalidOperationException($"Expected to arrive at position {expectedPosition} after ForkFrom, but resulting position is {actualPosition}");
@@ -514,7 +512,6 @@ namespace Orleans.Serialization.Buffers
                 ThrowInvalidPosition(position, Position);
             }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static void ThrowInvalidPosition(long expectedPosition, long actualPosition)
             {
                 throw new InvalidOperationException($"Expected to arrive at position {expectedPosition} after ResumeFrom, but resulting position is {actualPosition}");
@@ -685,7 +682,6 @@ namespace Orleans.Serialization.Buffers
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
 
         /// <summary>
@@ -986,13 +982,10 @@ namespace Orleans.Serialization.Buffers
             return ExceptionHelper.ThrowArgumentOutOfRange<ulong>("value");
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T ThrowNotSupportedInput<T>() => throw new NotSupportedException($"Type {typeof(TInput)} is not supported");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotSupportedInput() => throw new NotSupportedException($"Type {typeof(TInput)} is not supported");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(uint length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(byte[])}, {length}, is greater than total length of input.");
     }

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -1,11 +1,10 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -111,19 +110,15 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T[] ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(T[])}, {length}, is greater than total length of input.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T[] ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
@@ -266,18 +261,14 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T[] ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T[] ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ReadOnlyMemory<T>)}, {length}, is greater than total length of input.");
     }
@@ -430,18 +421,14 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static Memory<T> ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static Memory<T> ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Memory<T>)}, {length}, is greater than total length of input.");
     }
@@ -588,18 +575,14 @@ namespace Orleans.Serialization.Codecs
             return new ArraySegment<T>(result);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArraySegment<T> ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArraySegment<T> ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ArraySegment<T>)}, {length}, is greater than total length of input.");
     }

--- a/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
@@ -1,9 +1,8 @@
+using System;
+using System.Buffers;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -69,7 +68,6 @@ namespace Orleans.Serialization.Codecs
             writer.Write(value);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for byte[] fields. {field}");
     }
@@ -165,7 +163,6 @@ namespace Orleans.Serialization.Codecs
             writer.Write(value.Span);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for ReadOnlyMemory<byte> fields. {field}");
     }
@@ -285,7 +282,6 @@ namespace Orleans.Serialization.Codecs
             writer.Write(value.Span);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for ReadOnlyMemory<byte> fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
@@ -1,11 +1,10 @@
+using System;
+using System.Buffers;
+using System.Globalization;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Globalization;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -80,7 +79,6 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for {nameof(CompareInfo)} fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
@@ -1,9 +1,8 @@
+using System;
+using System.Buffers;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -44,7 +43,6 @@ namespace Orleans.Serialization.Codecs
             return DateTime.FromBinary(reader.ReadInt64());
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(DateTime)} fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
@@ -1,9 +1,8 @@
+using System;
+using System.Buffers;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -67,7 +66,6 @@ namespace Orleans.Serialization.Codecs
             return new DateTimeOffset(dateTime, offset);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for {nameof(DateTimeOffset)} fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -1,12 +1,11 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
 using Orleans.Serialization.Activators;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -129,11 +128,9 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
     }

--- a/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
+++ b/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
@@ -58,7 +58,6 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public T DeepCopy(T input, CopyContext context) => input;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {typeof(T).GetType()} fields. {field}");
 

--- a/src/Orleans.Serialization/Codecs/FloatCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FloatCodec.cs
@@ -82,11 +82,9 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ReadFloatRaw<TInput>(ref Reader<TInput> reader) => BitConverter.UInt32BitsToSingle(reader.ReadUInt32());
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new ArgumentOutOfRangeException(
             $"{nameof(wireType)} {wireType} is not supported by this codec.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowValueOutOfRange<T>(T value) => throw new ArgumentOutOfRangeException(
             $"The {typeof(T)} value has a magnitude too high {value} to be converted to {typeof(float)}.");
     }
@@ -166,7 +164,6 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ReadDoubleRaw<TInput>(ref Reader<TInput> reader) => BitConverter.UInt64BitsToDouble(reader.ReadUInt64());
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new ArgumentOutOfRangeException(
             $"{nameof(wireType)} {wireType} is not supported by this codec.");
     }
@@ -278,11 +275,9 @@ namespace Orleans.Serialization.Codecs
             public ulong Lo64;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new ArgumentOutOfRangeException(
             $"{nameof(wireType)} {wireType} is not supported by this codec.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowValueOutOfRange<T>(T value) => throw new ArgumentOutOfRangeException(
             $"The {typeof(T)} value has a magnitude too high {value} to be converted to {typeof(decimal)}.");
     }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -1,12 +1,11 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -120,11 +119,9 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");
     }

--- a/src/Orleans.Serialization/Codecs/ImmutableStackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ImmutableStackCodec.cs
@@ -173,19 +173,15 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(Stack<T>)} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 

--- a/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
+++ b/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
@@ -1,10 +1,9 @@
+using System;
+using System.Collections.Generic;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -85,7 +84,6 @@ namespace Orleans.Serialization.Codecs
             return new KeyValuePair<TKey, TValue>(key, value);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -117,19 +117,15 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(List<T>)} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -1,10 +1,9 @@
+using System;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -156,15 +155,12 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public bool IsSupportedType(Type type) => type.IsArray && type.GetArrayRank() > 1;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static object ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static T ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }
 

--- a/src/Orleans.Serialization/Codecs/NullableCodec.cs
+++ b/src/Orleans.Serialization/Codecs/NullableCodec.cs
@@ -1,9 +1,8 @@
+using System;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -51,17 +50,6 @@ namespace Orleans.Serialization.Codecs
             // Read the non-null value.
             return _fieldCodec.ReadValue(ref reader, field);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
-            $"Encountered too many elements in array of type {typeof(T?)} with declared length {length}.");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -1,10 +1,9 @@
+using System;
+using System.Collections.Generic;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -107,15 +106,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(Queue<T>)} with declared length {length}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 

--- a/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
@@ -165,7 +165,6 @@ namespace Orleans.Serialization.Codecs
             return ++referencedObject.CurrentReferenceId;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowReferenceNotFound(Type expectedType, uint reference) => throw new ReferenceNotFoundException(expectedType, reference);
     }
 }

--- a/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
@@ -109,7 +109,6 @@ namespace Orleans.Serialization.Codecs
         /// <param name="surrogate">The surrogate.</param>
         public abstract void ConvertToSurrogate(TField value, ref TSurrogate surrogate); 
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
         private static void ThrowSerializerNotFoundException(Type type) => throw new KeyNotFoundException($"Could not find a serializer of type {type}.");
     }

--- a/src/Orleans.Serialization/Codecs/SkipFieldExtension.cs
+++ b/src/Orleans.Serialization/Codecs/SkipFieldExtension.cs
@@ -1,8 +1,7 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -74,11 +73,9 @@ namespace Orleans.Serialization.Codecs
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ThrowUnexpectedExtendedWireType(Field field) => throw new ArgumentOutOfRangeException(
                 $"Unexpected {nameof(ExtendedWireType)} value [{field.ExtendedWireType}] in field {field} while skipping field.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ThrowUnexpectedWireType(Field field) => throw new ArgumentOutOfRangeException(
                 $"Unexpected {nameof(WireType)} value [{field.WireType}] in field {field} while skipping field.");
 

--- a/src/Orleans.Serialization/Codecs/StringCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StringCodec.cs
@@ -112,7 +112,6 @@ namespace Orleans.Serialization.Codecs
 
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for string fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
@@ -1,9 +1,8 @@
+using System;
+using System.Buffers;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -57,7 +56,6 @@ namespace Orleans.Serialization.Codecs
             return TimeSpan.FromTicks(reader.ReadInt64());
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(TimeSpan)} fields. {field}");
     }

--- a/src/Orleans.Serialization/Codecs/TupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TupleCodec.cs
@@ -1,9 +1,8 @@
+using System;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -52,7 +51,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -82,10 +81,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -176,7 +171,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -210,10 +205,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -318,7 +309,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -356,10 +347,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -480,7 +467,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -522,10 +509,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
     
     /// <summary>
@@ -662,7 +645,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -708,10 +691,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -861,7 +840,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -911,10 +890,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
     
     /// <summary>
@@ -1078,7 +1053,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -1132,10 +1107,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
     
     /// <summary>
@@ -1311,7 +1282,7 @@ namespace Orleans.Serialization.Codecs
 
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
@@ -1369,10 +1340,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
     
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
@@ -1,9 +1,8 @@
+using System;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -35,8 +34,7 @@ namespace Orleans.Serialization.Codecs
             return default;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
+        internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
@@ -89,7 +87,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -117,10 +115,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T>(item1);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -191,7 +185,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -223,10 +217,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2>(item1, item2);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -312,7 +302,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -348,10 +338,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3>(item1, item2, item3);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -452,7 +438,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -492,10 +478,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -608,7 +590,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -652,10 +634,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -782,7 +760,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -830,10 +808,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
     
     /// <summary>
@@ -975,7 +949,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -1027,10 +1001,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -1184,7 +1154,7 @@ namespace Orleans.Serialization.Codecs
         {
             if (field.WireType != WireType.TagDelimited)
             {
-                ThrowUnsupportedWireTypeException();
+                ValueTupleCodec.ThrowUnsupportedWireTypeException();
             }
 
             ReferenceCodec.MarkValueField(reader.Session);
@@ -1240,10 +1210,6 @@ namespace Orleans.Serialization.Codecs
 
             return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(item1, item2, item3, item4, item5, item6, item7, item8);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/VoidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/VoidCodec.cs
@@ -1,8 +1,7 @@
+using System;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -31,10 +30,8 @@ namespace Orleans.Serialization.Codecs
             return ReferenceCodec.ReadReference<object, TInput>(ref reader, field);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidWireType(Field field) => throw new UnsupportedWireTypeException($"Expected a reference, but encountered wire type of '{field.WireType}'.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotNullException(object value) => throw new InvalidOperationException(
             $"Expected a value of null, but encountered a value of '{value}'.");
     }
@@ -55,7 +52,6 @@ namespace Orleans.Serialization.Codecs
             return null;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotNullException(object value) => throw new InvalidOperationException($"Expected a value of null, but encountered a value of type '{value.GetType()}'.");
     }
 }

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -1,15 +1,12 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Serializers;
-using Orleans.Serialization.Utilities;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -239,16 +236,13 @@ namespace Orleans.Serialization.Codecs
 #endif
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for OrdinalComparer fields. {field}");
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotSupported(Field field, uint value) => throw new NotSupportedException($"Values of type {field.FieldType} are not supported. Value: {value}");
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowNotSupported(Type type) => throw new NotSupportedException($"Values of type {type} are not supported");
     }
 

--- a/src/Orleans.Serialization/Exceptions.cs
+++ b/src/Orleans.Serialization/Exceptions.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace Orleans.Serialization
 {
     internal static class ExceptionHelper
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T ThrowArgumentOutOfRange<T>(string argument) => throw new ArgumentOutOfRangeException(argument);
     }
 

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -144,7 +144,6 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <summary>        
         /// Generated code helper method which throws an <see cref="ArgumentOutOfRangeException"/>.
         /// </summary>                
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static TArgument InvokableThrowArgumentOutOfRange<TArgument>(int index, int maxArgs) => throw new ArgumentOutOfRangeException($"The argument index value {index} must be between 0 and {maxArgs}");
 
         /// <summary>

--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -1,18 +1,17 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans.Serialization.Activators;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Configuration;
 using Orleans.Serialization.GeneratedCodeHelpers;
-using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Options;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Orleans.Serialization.Serializers
 {
@@ -447,7 +446,7 @@ namespace Orleans.Serialization.Serializers
 
             if (result is null)
             {
-                ThrowBaseCodecNotFound<TField>(type);
+                ThrowBaseCodecNotFound(type);
             }
 
             return result;
@@ -900,31 +899,22 @@ namespace Orleans.Serialization.Serializers
             return copierType != null ? (IDeepCopier)GetServiceOrCreateInstance(copierType, constructorArguments) : null;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowPointerType(Type fieldType) => throw new NotSupportedException($"Type {fieldType} is a pointer type and is therefore not supported.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowByRefType(Type fieldType) => throw new NotSupportedException($"Type {fieldType} is a by-ref type and is therefore not supported.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowGenericTypeDefinition(Type fieldType) => throw new InvalidOperationException($"Type {fieldType} is a non-constructed generic type and is therefore unsupported.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IFieldCodec<TField> ThrowCodecNotFound<TField>(Type fieldType) => throw new CodecNotFoundException($"Could not find a codec for type {fieldType}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IDeepCopier<T> ThrowCopierNotFound<T>(Type type) => throw new CodecNotFoundException($"Could not find a copier for type {type}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static IBaseCodec<TField> ThrowBaseCodecNotFound<TField>(Type fieldType) where TField : class => throw new KeyNotFoundException($"Could not find a base type serializer for type {fieldType}.");
+        private static void ThrowBaseCodecNotFound(Type fieldType) => throw new KeyNotFoundException($"Could not find a base type serializer for type {fieldType}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IValueSerializer<TField> ThrowValueSerializerNotFound<TField>(Type fieldType) where TField : struct => throw new KeyNotFoundException($"Could not find a value serializer for type {fieldType}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IActivator<T> ThrowActivatorNotFound<T>(Type type) => throw new KeyNotFoundException($"Could not find an activator for type {type}.");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IBaseCopier<T> ThrowBaseCopierNotFound<T>(Type type) where T : class => throw new KeyNotFoundException($"Could not find a base type copier for type {type}.");
 
         private sealed class TypeTypeValueTupleComparer : IEqualityComparer<(Type, Type)>

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -83,13 +83,10 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
 
         // The type is a descendant, not an exact match, so get the specific serializer for it.
         var specificSerializer = reader.Session.CodecProvider.GetCodec(fieldType);
-        if (specificSerializer != null)
-        {
-            return (TField)specificSerializer.ReadValue(ref reader, field);
-        }
+        if (specificSerializer == null)
+            ThrowSerializerNotFoundException(fieldType);
 
-        ThrowSerializerNotFoundException(fieldType);
-        return default;
+        return (TField)specificSerializer.ReadValue(ref reader, field);
     }
 
     /// <inheritdoc/>
@@ -162,11 +159,9 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
         _populator.Populate(copy, output);
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     [DoesNotReturn]
     private static void ThrowSerializerNotFoundException(Type type) => throw new KeyNotFoundException($"Could not find a serializer of type {type}.");
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
     [DoesNotReturn]
     private static void ThrowNoPopulatorException() => throw new NotSupportedException($"Surrogate type {typeof(TConverter)} does not implement {typeof(IPopulator<TField, TSurrogate>)} and therefore cannot be used in an inheritance hierarchy.");
 }

--- a/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
@@ -190,7 +190,6 @@ namespace Orleans.Serialization.Session
             {
                 // Unknown field markers can be replaced once the type is known.
                 ThrowReferenceExistsException(reference);
-                return;
             }
 
             if (_referenceToObjectOverflow is { } overflow)
@@ -223,7 +222,6 @@ namespace Orleans.Serialization.Session
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowReferenceExistsException(uint reference) => throw new InvalidOperationException($"Reference {reference} already exists");
 
         /// <summary>

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -212,7 +212,6 @@ namespace Orleans.Serialization.TypeSystem
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowGenericArityTooLarge(int arity) => throw new NotSupportedException($"An arity of {arity} is not supported");
 
         private ref struct BufferReader
@@ -254,7 +253,6 @@ namespace Orleans.Serialization.TypeSystem
                     if (assertChar != c)
                     {
                         ThrowUnexpectedCharacter(assertChar, c);
-                        return;
                     }
 
                     ++Index;
@@ -272,10 +270,8 @@ namespace Orleans.Serialization.TypeSystem
                 }
             }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
         }
     }

--- a/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
@@ -184,7 +184,6 @@ namespace Orleans.Serialization.TypeSystem
             return type is not null; 
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
         private static void ThrowUnsupportedVersion(byte version) => throw new NotSupportedException($"Type encoding version {version} is not supported");
 

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -1,9 +1,3 @@
-using Microsoft.Extensions.Options;
-using Orleans.Serialization.Activators;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Codecs;
-using Orleans.Serialization.Configuration;
-using Orleans.Serialization.Serializers;
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
@@ -11,8 +5,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Configuration;
+using Orleans.Serialization.Serializers;
 
 namespace Orleans.Serialization.TypeSystem
 {
@@ -439,8 +438,7 @@ namespace Orleans.Serialization.TypeSystem
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static QualifiedType ThrowTypeNotAllowed(string fullTypeName, List<QualifiedType> errors)
+        private static void ThrowTypeNotAllowed(string fullTypeName, List<QualifiedType> errors)
         {
             if (errors is { Count: 1 })
             {
@@ -473,7 +471,6 @@ namespace Orleans.Serialization.TypeSystem
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowTypeNotAllowed(Type value)
         {
             var message = $"Type \"{value.FullName}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it.";

--- a/src/Orleans.Serialization/WireProtocol/Field.cs
+++ b/src/Orleans.Serialization/WireProtocol/Field.cs
@@ -65,7 +65,7 @@ namespace Orleans.Serialization.WireProtocol
 #if DEBUG
                 if (!HasFieldId)
                 {
-                    ThrowFieldIdInvalid();
+                    throw new FieldIdNotPresentException();
                 }
 #endif
                 return FieldIdDeltaRaw;
@@ -100,7 +100,7 @@ namespace Orleans.Serialization.WireProtocol
 #if DEBUG
                 if (!IsSchemaTypeValid)
                 {
-                    ThrowFieldTypeInvalid();
+                    throw new FieldTypeInvalidException();
                 }
 #endif
                 return FieldTypeRaw;
@@ -112,7 +112,7 @@ namespace Orleans.Serialization.WireProtocol
 #if DEBUG
                 if (!IsSchemaTypeValid)
                 {
-                    ThrowFieldTypeInvalid();
+                    throw new FieldTypeInvalidException();
                 }
 #endif
                 FieldTypeRaw = value;
@@ -160,7 +160,7 @@ namespace Orleans.Serialization.WireProtocol
 #if DEBUG
                 if (!IsSchemaTypeValid)
                 {
-                    ThrowSchemaTypeInvalid();
+                    throw new SchemaTypeInvalidException();
                 }
 #endif
 
@@ -181,7 +181,7 @@ namespace Orleans.Serialization.WireProtocol
 #if DEBUG
                 if (WireType != WireType.Extended)
                 {
-                    ThrowExtendedWireTypeInvalid();
+                    throw new ExtendedWireTypeInvalidException();
                 }
 #endif
                 return Tag.ExtendedWireType;
@@ -257,17 +257,5 @@ namespace Orleans.Serialization.WireProtocol
             builder.AppendLiteral("]");
             return builder.ToStringAndClear();
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowFieldIdInvalid() => throw new FieldIdNotPresentException();
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowSchemaTypeInvalid() => throw new SchemaTypeInvalidException();
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowFieldTypeInvalid() => throw new FieldTypeInvalidException();
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowExtendedWireTypeInvalid() => throw new ExtendedWireTypeInvalidException();
     }
 }


### PR DESCRIPTION
If an inline candidate method never returns (by always throwing an exception), then RyuJIT will move the call-site to cold code region and will not inline it. Marking throw-helpers with `NoInlining` prevents RyuJIT from analyzing such methods, so it's actually counterproductive.

[Codegen sample](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4aNYgGYmpBrMnZgAWRj5oATwAKECJIYBvGg1cMxUXguwYYDSFy4GAy8PAwA+sCSEGAA1rK8AF5+ALwMKHQAnEga1G7unt6+/hCBwaHBAIJclgnJDGlw5LkubjoMEMAAVjBgwWwwPAAUFQy4SakM1bUTAJStrs55+W68AGYMQ+P1AHwRUTHxcwsr+QAqABZQEADulVAA5hwCPADyHBiva2zYXA8wAFEECoxHxSuEAEIcNZrGQDACOHFUGDOdgAMthHjAhpFonE6jBZi1lqdvFAGAc4g0GGiYHhsUSTvliAB2Cl42K5fIAX00JKYuk6PT6DAGPHCADkIABJLiSUKhB4jMLbSbTAnzflLU6udabVUMPa4w4apk6y7XO6PZ6DT4fL4/P6A4EwUG8cFQmFwmCI5GoiAYrGSmVyhV/HGUo7JRnUM2uMnsw7U2n0oYxnVMNmRrluXn8k4AbTMGAuEAAJtLxJIhsXSxWq683aVcCwpbL5VxFbMALonDxeHx+IW9YIp3AMhp7EuWhhcDiSSTEvuFQdMchIJgoBgW273J4vO2fb6/f5AkFgriQ6GwqAIpFBf2B/7K4L4bAIU1auMMae3WcwG4pmtA93iPR1TxdJsuCGAAiVUYLQBgABIYKEX4uAgYJsAXGJVwsWAfwuX4nDfD8Jm5ClLF8XAQi4BhsDGRVpApa8ZBg9Ncz5fIixgEty0rMRq1rfiGygls21DTs/h7ZcB2KZgN2ILcdytfdbVAh0T2dc93UvT0bzvP10Uxf5g3bMMlVGUjP3ybUdV/QCuAAoC1Lee1jydM9XQvWD4MQlC0K4DCsJwsA8OgPwS2IxxrPIyjqNo+jGL+ZjgFYqB2JzVw825IA=)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7951)