### PR TITLE
Remove obsolete net48 & netcoreapp3.1 code

### DIFF
--- a/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStream.cs
@@ -163,24 +163,6 @@ namespace Orleans.Connections.Security
             return _reader.CopyToAsync(destination, cancellationToken);
         }
 
-#if !NET6_0_OR_GREATER
-        private static void ValidateBufferArguments(byte[] buffer, int offset, int size)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if ((uint)offset > (uint)buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
-            if ((uint)size > (uint)(buffer.Length - offset))
-            {
-                throw new ArgumentOutOfRangeException(nameof(size));
-            }
-        }
-#endif
-
         /// <summary>
         /// Provides support for efficiently using Tasks to implement the APM (Begin/End) pattern.
         /// </summary>

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -315,13 +315,11 @@ namespace Orleans.Runtime.Messaging
             }
 
             string result;
-#if NETCOREAPP3_1_OR_GREATER
             if (reader.TryReadBytes(length, out var span))
             {
                 result = Encoding.UTF8.GetString(span);
             }
             else
-#endif
             {
                 var bytes = reader.ReadBytes((uint)length);
                 result = Encoding.UTF8.GetString(bytes);
@@ -339,7 +337,6 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-#if NETCOREAPP3_1_OR_GREATER
             var numBytes = Encoding.UTF8.GetByteCount(value);
             writer.WriteVarInt32(numBytes);
             if (numBytes < 512)
@@ -362,11 +359,6 @@ namespace Orleans.Runtime.Messaging
                 Span<byte> bytes = Encoding.UTF8.GetBytes(value);
                 writer.Write(bytes);
             }
-#else
-            var bytes = Encoding.UTF8.GetBytes(value);
-            writer.WriteVarInt32(bytes.Length);
-            writer.Write(bytes);
-#endif
         }
 
         public void WriteRequestContext<TBufferWriter>(ref Writer<TBufferWriter> writer, Dictionary<string, object> value) where TBufferWriter : IBufferWriter<byte>

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -1,26 +1,14 @@
-using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Orleans.Runtime
 {
-    internal class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>
+    internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>
     {
         private readonly ConcurrentDictionary<GrainId, IGrainContext> _activations = new();
 
         public int Count => _activations.Count;
-
-        public IEnumerable<SystemTarget> AllSystemTargets()
-        {
-            foreach (var kv in _activations)
-            {
-                if (kv.Value is SystemTarget systemTarget)
-                {
-                    yield return systemTarget;
-                }
-            }
-        }
 
         public IGrainContext FindTarget(GrainId key)
         {
@@ -28,39 +16,9 @@ namespace Orleans.Runtime
             return result;
         }
 
-        public void RecordNewTarget(IGrainContext target)
-        {
-            _activations.TryAdd(target.GrainId, target);
-        }
+        public void RecordNewTarget(IGrainContext target) => _activations.TryAdd(target.GrainId, target);
 
-        public void RemoveTarget(IGrainContext target)
-        {
-            if (!TryRemove(target.GrainId, target))
-            {
-                return;
-            }
-        }
-
-        private bool TryRemove(GrainId grainId, IGrainContext target)
-        {
-            var entry = new KeyValuePair<GrainId, IGrainContext>(grainId, target);
-
-#if NET5_0_OR_GREATER
-            return _activations.TryRemove(entry);
-#else
-            // Cast the dictionary to its interface type to access the explicitly implemented Remove method.
-            var cacheDictionary = (IDictionary<GrainId, IGrainContext>)activations;
-            return cacheDictionary.Remove(entry);
-#endif
-        }
-
-        public void ForEachGrainId<T>(Action<T, GrainId> func, T context)
-        {
-            foreach (var pair in _activations)
-            {
-                func(context, pair.Key);
-            }
-        }
+        public void RemoveTarget(IGrainContext target) => _activations.TryRemove(KeyValuePair.Create(target.GrainId, target));
 
         public IEnumerator<KeyValuePair<GrainId, IGrainContext>> GetEnumerator() => _activations.GetEnumerator();
 

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -204,16 +204,14 @@ namespace Orleans.Runtime
         public Task<List<GrainId>> GetActiveGrains(GrainType grainType)
         {
             var results = new List<GrainId>();
-            activationDirectory.ForEachGrainId(AddIfMatch, (grainType, results));
-            return Task.FromResult(results);
-
-            static void AddIfMatch((GrainType Type, List<GrainId> Result) context, GrainId id)
+            foreach (var pair in activationDirectory)
             {
-                if (id.Type.Equals(context.Type))
+                if (grainType.Equals(pair.Key.Type))
                 {
-                    context.Result.Add(id);
+                    results.Add(pair.Key);
                 }
             }
+            return Task.FromResult(results);
         }
     }
 }


### PR DESCRIPTION
Removed unused old code and cleaned up a few related code paths.

I didn't touch anything under Orleans.Serialization - there are lots of old ifdefs, but there's still some plan to support netstandard2.0 for Orleans.Serialization?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7954)