### PR TITLE
Optimize serializer generated code

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -400,38 +400,6 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        private static IEnumerable<MemberDeclarationSyntax> GetTypeDeclarations(SyntaxNode node)
-        {
-            SyntaxList<MemberDeclarationSyntax> members;
-            switch (node)
-            {
-                case EnumDeclarationSyntax enumDecl:
-                    yield return enumDecl;
-                    members = new SyntaxList<MemberDeclarationSyntax>();
-                    break;
-                case TypeDeclarationSyntax type:
-                    yield return type;
-                    members = type.Members;
-                    break;
-                case NamespaceDeclarationSyntax ns:
-                    members = ns.Members;
-                    break;
-                case CompilationUnitSyntax compilationUnit:
-                    members = compilationUnit.Members;
-                    break;
-                default:
-                    yield break;
-            }
-
-            foreach (var member in members)
-            {
-                foreach (var decl in GetTypeDeclarations(member))
-                {
-                    yield return decl;
-                }
-            }
-        }
-
         // Returns descriptions of all data members (fields and properties) 
         private IEnumerable<IMemberDescription> GetDataMembers(INamedTypeSymbol symbol)
         {

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -51,18 +51,18 @@ namespace Orleans.CodeGenerator
                 .AddModifiers(Token(accessibility), Token(SyntaxKind.SealedKeyword))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())));
 
-            if (type.IsImmutable)
+            if (type.IsShallowCopyable)
             {
                 var copyMethod = GenerateImmutableTypeCopyMethod(type, libraryTypes);
                 classDeclaration = classDeclaration.AddMembers(copyMethod);
             }
             else
             {
-                var fieldDescriptions = GetFieldDescriptions(type, members, libraryTypes);
+                var fieldDescriptions = GetFieldDescriptions(type, members, libraryTypes, out var onlyDeepFields);
                 var fieldDeclarations = GetFieldDeclarations(fieldDescriptions);
                 var ctor = GenerateConstructor(libraryTypes, simpleClassName, fieldDescriptions);
 
-                var copyMethod = GenerateMemberwiseDeepCopyMethod(type, fieldDescriptions, members, libraryTypes);
+                var copyMethod = GenerateMemberwiseDeepCopyMethod(type, fieldDescriptions, members, libraryTypes, onlyDeepFields);
                 classDeclaration = classDeclaration
                     .AddMembers(copyMethod)
                     .AddMembers(fieldDeclarations)
@@ -136,38 +136,40 @@ namespace Orleans.CodeGenerator
             const string CodecProviderParameterName = "codecProvider";
             parameters.Add(Parameter(Identifier(CodecProviderParameterName)).WithType(libraryTypes.ICodecProvider.ToTypeSyntax()));
 
-            IEnumerable<StatementSyntax> GetStatements()
+            List<StatementSyntax> GetStatements()
             {
+                var res = new List<StatementSyntax>();
                 foreach (var field in fieldDescriptions)
                 {
                     switch (field)
                     {
                         case GetterFieldDescription getter:
-                            yield return getter.InitializationSyntax;
+                            res.Add(getter.InitializationSyntax);
                             break;
 
                         case SetterFieldDescription setter:
-                            yield return setter.InitializationSyntax;
+                            res.Add(setter.InitializationSyntax);
                             break;
 
                         case GeneratedFieldDescription _ when field.IsInjected:
-                            yield return ExpressionStatement(
+                            res.Add(ExpressionStatement(
                                 AssignmentExpression(
                                     SyntaxKind.SimpleAssignmentExpression,
                                     ThisExpression().Member(field.FieldName.ToIdentifierName()),
-                                    Unwrapped(field.FieldName.ToIdentifierName())));
+                                    Unwrapped(field.FieldName.ToIdentifierName()))));
                             break;
                         case CopierFieldDescription codec:
                             {
-                                yield return ExpressionStatement(
+                                res.Add(ExpressionStatement(
                                     AssignmentExpression(
                                         SyntaxKind.SimpleAssignmentExpression,
                                         ThisExpression().Member(field.FieldName.ToIdentifierName()),
-                                        GetService(field.FieldType)));
+                                        GetService(field.FieldType))));
                             }
                             break;
                     }
                 }
+                return res;
             }
 
             return ConstructorDeclaration(simpleClassName)
@@ -193,8 +195,12 @@ namespace Orleans.CodeGenerator
         private static List<GeneratedFieldDescription> GetFieldDescriptions(
             ISerializableTypeDescription serializableTypeDescription,
             List<ISerializableMember> members,
-            LibraryTypes libraryTypes)
+            LibraryTypes libraryTypes,
+            out bool onlyDeepFields)
         {
+            var serializationHooks = serializableTypeDescription.SerializationHooks;
+            onlyDeepFields = serializableTypeDescription.IsValueType && serializationHooks.Count == 0;
+
             var fields = new List<GeneratedFieldDescription>();
 
             if (serializableTypeDescription.HasComplexBaseType)
@@ -204,14 +210,17 @@ namespace Orleans.CodeGenerator
 
             if (serializableTypeDescription.UseActivator)
             {
+                onlyDeepFields = false;
                 fields.Add(new ActivatorFieldDescription(libraryTypes.IActivator_1.ToTypeSyntax(serializableTypeDescription.TypeSyntax), ActivatorFieldName));
             }
 
             // Add a codec field for any field in the target which does not have a static codec.
-            fields.AddRange(GetCopierFieldDescriptions(serializableTypeDescription.Members, libraryTypes));
+            GetCopierFieldDescriptions(serializableTypeDescription.Members, libraryTypes, fields);
 
             foreach (var member in members)
             {
+                if (onlyDeepFields && member.IsShallowCopyable) continue;
+
                 if (member.GetGetterFieldDescription() is { } getterFieldDescription)
                 {
                     fields.Add(getterFieldDescription);
@@ -223,31 +232,30 @@ namespace Orleans.CodeGenerator
                 }
             }
 
-            for (var hookIndex = 0; hookIndex < serializableTypeDescription.SerializationHooks.Count; ++hookIndex)
+            for (var hookIndex = 0; hookIndex < serializationHooks.Count; ++hookIndex)
             {
-                var hookType = serializableTypeDescription.SerializationHooks[hookIndex];
+                var hookType = serializationHooks[hookIndex];
                 fields.Add(new SerializationHookFieldDescription(hookType.ToTypeSyntax(), $"_hook{hookIndex}"));
             }
 
             return fields;
         }
 
-        public static IEnumerable<CopierFieldDescription> GetCopierFieldDescriptions(IEnumerable<IMemberDescription> members, LibraryTypes libraryTypes)
+        public static void GetCopierFieldDescriptions(IEnumerable<IMemberDescription> members, LibraryTypes libraryTypes, List<GeneratedFieldDescription> fields)
         {
-            var filteredMembers = members
-                .Distinct(MemberDescriptionTypeComparer.Default)
-                .Where(t => !libraryTypes.StaticCopiers.Any(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, t.Type)));
-
             var fieldIndex = 0;
-            foreach (var member in filteredMembers)
+            foreach (var member in members.Distinct(MemberDescriptionTypeComparer.Default))
             {
-                yield return GetCopierDescription(member, fieldIndex++, libraryTypes);
-            }
-
-            static CopierFieldDescription GetCopierDescription(IMemberDescription member, int fieldIndex, LibraryTypes libraryTypes)
-            {
-                TypeSyntax copierType = null;
                 var t = member.Type;
+
+                if (libraryTypes.IsShallowCopyable(t))
+                    goto skip;
+
+                foreach (var c in libraryTypes.StaticCopiers)
+                    if (SymbolEqualityComparer.Default.Equals(c.UnderlyingType, t))
+                        goto skip;
+
+                TypeSyntax copierType;
                 if (t.HasAttribute(libraryTypes.GenerateSerializerAttribute)
                     && (!SymbolEqualityComparer.Default.Equals(t.ContainingAssembly, libraryTypes.Compilation.Assembly) || t.ContainingAssembly.HasAttribute(libraryTypes.TypeManifestProviderAttribute)))
                 {
@@ -270,7 +278,7 @@ namespace Orleans.CodeGenerator
                     // The codec is not a static copier and is also not a generic copiers.
                     copierType = codec.CopierType.ToTypeSyntax();
                 }
-                else if (t is INamedTypeSymbol named && libraryTypes.WellKnownCopiers.Find(c => t is INamedTypeSymbol named && named.ConstructedFrom is ISymbol unboundFieldType && SymbolEqualityComparer.Default.Equals(c.UnderlyingType, unboundFieldType)) is WellKnownCopierDescription genericCopier)
+                else if (t is INamedTypeSymbol { ConstructedFrom: ISymbol unboundFieldType } named && libraryTypes.WellKnownCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, unboundFieldType)) is { } genericCopier)
                 {
                     // Construct the generic copier type using the field's type arguments.
                     copierType = genericCopier.CopierType.Construct(named.TypeArguments.ToArray()).ToTypeSyntax();
@@ -281,8 +289,9 @@ namespace Orleans.CodeGenerator
                     copierType = libraryTypes.DeepCopier_1.ToTypeSyntax(member.TypeSyntax);
                 }
 
-                var fieldName = '_' + ToLowerCamelCase(member.TypeNameIdentifier) + "Copier" + fieldIndex;
-                return new CopierFieldDescription(copierType, fieldName, t);
+                var fieldName = $"_{ToLowerCamelCase(member.TypeNameIdentifier)}Copier{fieldIndex++}";
+                fields.Add(new CopierFieldDescription(copierType, fieldName, t));
+skip:;
             }
 
             static string ToLowerCamelCase(string input) => char.IsLower(input, 0) ? input : char.ToLowerInvariant(input[0]) + input.Substring(1);
@@ -292,7 +301,8 @@ namespace Orleans.CodeGenerator
             ISerializableTypeDescription type,
             List<GeneratedFieldDescription> copierFields,
             List<ISerializableMember> members,
-            LibraryTypes libraryTypes)
+            LibraryTypes libraryTypes,
+            bool onlyDeepFields)
         {
             var returnType = type.TypeSyntax;
 
@@ -361,7 +371,7 @@ namespace Orleans.CodeGenerator
                                 })))));
                 }
             }
-            else
+            else if (!onlyDeepFields)
             {
                 // C#: TField result = _activator.Create();
                 // or C#: TField result = new TField();
@@ -370,12 +380,15 @@ namespace Orleans.CodeGenerator
                         type.TypeSyntax,
                         SingletonSeparatedList(VariableDeclarator(resultVar.Identifier)
                         .WithInitializer(EqualsValueClause(createValueExpression))))));
-
+            }
+            else
+            {
+                originalParam = resultVar;
             }
 
-            body.AddRange(AddSerializationCallbacks(type, originalParam, resultVar, "OnCopying"));
-            body.AddRange(GenerateMemberwiseCopy(copierFields, members, libraryTypes, originalParam, contextParam, resultVar));
-            body.AddRange(AddSerializationCallbacks(type, originalParam, resultVar, "OnCopied"));
+            AddSerializationCallbacks(type, originalParam, resultVar, "OnCopying", body);
+            GenerateMemberwiseCopy(copierFields, members, libraryTypes, originalParam, contextParam, resultVar, body, onlyDeepFields);
+            AddSerializationCallbacks(type, originalParam, resultVar, "OnCopied", body);
 
             body.Add(ReturnStatement(resultVar));
 
@@ -419,9 +432,9 @@ namespace Orleans.CodeGenerator
                             })))));
             }
 
-            body.AddRange(AddSerializationCallbacks(type, inputParam, resultParam, "OnCopying"));
-            body.AddRange(GenerateMemberwiseCopy(copierFields, members, libraryTypes, inputParam, contextParam, resultParam));
-            body.AddRange(AddSerializationCallbacks(type, inputParam, resultParam, "OnCopied"));
+            AddSerializationCallbacks(type, inputParam, resultParam, "OnCopying", body);
+            GenerateMemberwiseCopy(copierFields, members, libraryTypes, inputParam, contextParam, resultParam, body);
+            AddSerializationCallbacks(type, inputParam, resultParam, "OnCopied", body);
 
             var parameters = new[]
             {
@@ -437,13 +450,15 @@ namespace Orleans.CodeGenerator
                 .AddBodyStatements(body.ToArray());
         }
 
-        public static IEnumerable<StatementSyntax> GenerateMemberwiseCopy(
+        private static void GenerateMemberwiseCopy(
             List<GeneratedFieldDescription> copierFields,
             List<ISerializableMember> members,
             LibraryTypes libraryTypes,
             IdentifierNameSyntax sourceVar,
             IdentifierNameSyntax contextVar,
-            IdentifierNameSyntax destinationVar)
+            IdentifierNameSyntax destinationVar,
+            List<StatementSyntax> body,
+            bool onlyDeepFields = false)
         {
             var codecs = copierFields.OfType<ICopierDescription>()
                     .Concat(libraryTypes.StaticCopiers)
@@ -452,15 +467,19 @@ namespace Orleans.CodeGenerator
             var orderedMembers = members.OrderBy(m => m.Member.FieldId);
             foreach (var member in orderedMembers)
             {
+                if (onlyDeepFields && member.IsShallowCopyable) continue;
+
                 var getValueExpression = GenerateMemberCopy(
                     copierFields,
                     libraryTypes,
                     inputValue: member.GetGetter(sourceVar),
                     contextVar,
                     codecs,
-                    member);
-                var memberAssignment = ExpressionStatement(member.GetSetter(destinationVar, getValueExpression));
-                yield return memberAssignment;
+                    member,
+                    onlyDeepFields);
+
+                if (getValueExpression is { })
+                    body.Add(ExpressionStatement(member.GetSetter(destinationVar, getValueExpression)));
             }
         }
 
@@ -470,37 +489,37 @@ namespace Orleans.CodeGenerator
             ExpressionSyntax inputValue,
             ExpressionSyntax copyContextVar,
             List<ICopierDescription> codecs,
-            ISerializableMember member)
+            ISerializableMember member,
+            bool onlyDeepFields = false)
         {
+            if (member.IsShallowCopyable)
+                return inputValue;
+
             var description = member.Member;
 
             // Copiers can either be static classes or injected into the constructor.
             // Either way, the member signatures are the same.
             var memberType = description.Type;
-            var codec = codecs.FirstOrDefault(f => SymbolEqualityComparer.Default.Equals(f.UnderlyingType, memberType));
-            var staticCopier = libraryTypes.StaticCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, memberType));
+            var codec = codecs.Find(f => SymbolEqualityComparer.Default.Equals(f.UnderlyingType, memberType));
             ExpressionSyntax getValueExpression;
 
-            if (member.IsShallowCopyable)
+            if (codec is null)
             {
-                getValueExpression = inputValue;
-            }
-            else if (codec is null)
-            {
-                getValueExpression = InvocationExpression(
+                return onlyDeepFields ? null : InvocationExpression(
                     copyContextVar.Member(DeepCopyMethodName),
                     ArgumentList(SeparatedList(new[] { Argument(inputValue) })));
             }
             else
             {
                 ExpressionSyntax codecExpression;
+                var staticCopier = libraryTypes.StaticCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, memberType));
                 if (staticCopier != null)
                 {
                     codecExpression = staticCopier.CopierType.ToNameSyntax();
                 }
                 else
                 {
-                    var instanceCopier = copierFields.OfType<CopierFieldDescription>().First(f => SymbolEqualityComparer.Default.Equals(f.UnderlyingType, memberType));
+                    var instanceCopier = copierFields.First(f => f is CopierFieldDescription cf && SymbolEqualityComparer.Default.Equals(cf.UnderlyingType, memberType));
                     codecExpression = ThisExpression().Member(instanceCopier.FieldName);
                 }
 
@@ -543,11 +562,12 @@ namespace Orleans.CodeGenerator
                 .AddBodyStatements(body.ToArray());
         }
 
-        private static IEnumerable<StatementSyntax> AddSerializationCallbacks(ISerializableTypeDescription type, IdentifierNameSyntax originalInstance, IdentifierNameSyntax resultInstance, string callbackMethodName)
+        private static void AddSerializationCallbacks(ISerializableTypeDescription type, IdentifierNameSyntax originalInstance, IdentifierNameSyntax resultInstance, string callbackMethodName, List<StatementSyntax> body)
         {
-            for (var hookIndex = 0; hookIndex < type.SerializationHooks.Count; ++hookIndex)
+            var serializationHooks = type.SerializationHooks;
+            for (var hookIndex = 0; hookIndex < serializationHooks.Count; ++hookIndex)
             {
-                var hookType = type.SerializationHooks[hookIndex];
+                var hookType = serializationHooks[hookIndex];
                 var member = hookType.GetAllMembers<IMethodSymbol>(callbackMethodName, Accessibility.Public).FirstOrDefault();
                 if (member is null || member.Parameters.Length != 2)
                 {
@@ -566,9 +586,9 @@ namespace Orleans.CodeGenerator
                     resultArgument = resultArgument.WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword));
                 }
 
-                yield return ExpressionStatement(InvocationExpression(
+                body.Add(ExpressionStatement(InvocationExpression(
                     ThisExpression().Member($"_hook{hookIndex}").Member(callbackMethodName),
-                    ArgumentList(SeparatedList(new[] { originalArgument, resultArgument }))));
+                    ArgumentList(SeparatedList(new[] { originalArgument, resultArgument })))));
             }
         }
 

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -475,11 +475,9 @@ skip:;
                     inputValue: member.GetGetter(sourceVar),
                     contextVar,
                     codecs,
-                    member,
-                    onlyDeepFields);
-
-                if (getValueExpression is { })
-                    body.Add(ExpressionStatement(member.GetSetter(destinationVar, getValueExpression)));
+                    member);
+                var memberAssignment = ExpressionStatement(member.GetSetter(destinationVar, getValueExpression));
+                body.Add(memberAssignment);
             }
         }
 
@@ -489,8 +487,7 @@ skip:;
             ExpressionSyntax inputValue,
             ExpressionSyntax copyContextVar,
             List<ICopierDescription> codecs,
-            ISerializableMember member,
-            bool onlyDeepFields = false)
+            ISerializableMember member)
         {
             if (member.IsShallowCopyable)
                 return inputValue;
@@ -505,7 +502,7 @@ skip:;
 
             if (codec is null)
             {
-                return onlyDeepFields ? null : InvocationExpression(
+                getValueExpression = InvocationExpression(
                     copyContextVar.Member(DeepCopyMethodName),
                     ArgumentList(SeparatedList(new[] { Argument(inputValue) })));
             }

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -382,7 +382,7 @@ namespace Orleans.CodeGenerator
 
         private static MemberDeclarationSyntax GenerateGetArgumentCount(LibraryTypes libraryTypes, MethodDescription methodDescription)
             => methodDescription.Method.Parameters.Length is var count and not 0 ?
-            PropertyDeclaration(libraryTypes.Int32.ToTypeSyntax(), "ArgumentCount")
+            MethodDeclaration(libraryTypes.Int32.ToTypeSyntax(), "GetArgumentCount")
                 .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(count))))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)) : null;
@@ -399,7 +399,7 @@ namespace Orleans.CodeGenerator
             var interfaceName = methodDescription.Method.ContainingType.ToDisplayName(methodDescription.TypeParameterSubstitutions, includeGlobalSpecifier: false, includeNamespace: false);
             var methodName = methodDescription.Method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             var activityName = $"{interfaceName}/{methodName}";
-            return PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "ActivityName")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "GetActivityName")
                 .WithExpressionBody(
                     ArrowExpressionClause(
                         LiteralExpression(
@@ -412,7 +412,7 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax GenerateGetMethodName(
             LibraryTypes libraryTypes,
             MethodDescription methodDescription) =>
-            PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "MethodName")
+            MethodDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "GetMethodName")
                 .WithExpressionBody(
                     ArrowExpressionClause(
                         LiteralExpression(
@@ -424,7 +424,7 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax GenerateGetInterfaceName(
             LibraryTypes libraryTypes,
             MethodDescription methodDescription) =>
-            PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "InterfaceName")
+            MethodDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), "GetInterfaceName")
                 .WithExpressionBody(
                     ArrowExpressionClause(
                         LiteralExpression(
@@ -436,7 +436,7 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax GenerateGetInterfaceType(
             LibraryTypes libraryTypes,
             MethodDescription methodDescription) =>
-            PropertyDeclaration(libraryTypes.Type.ToTypeSyntax(), "InterfaceType")
+            MethodDeclaration(libraryTypes.Type.ToTypeSyntax(), "GetInterfaceType")
                 .WithExpressionBody(
                     ArrowExpressionClause(
                         TypeOfExpression(methodDescription.Method.ContainingType.ToTypeSyntax(methodDescription.TypeParameterSubstitutions))))
@@ -445,7 +445,7 @@ namespace Orleans.CodeGenerator
 
         private static MemberDeclarationSyntax GenerateGetMethod(
             LibraryTypes libraryTypes)
-            => PropertyDeclaration(libraryTypes.MethodInfo.ToTypeSyntax(), "Method")
+            => MethodDeclaration(libraryTypes.MethodInfo.ToTypeSyntax(), "GetMethod")
                 .WithExpressionBody(ArrowExpressionClause(IdentifierName("MethodBackingField")))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -76,6 +76,7 @@ namespace Orleans.CodeGenerator
                 ValueSerializer = Type("Orleans.Serialization.Serializers.IValueSerializer`1"),
                 ValueTask = Type("System.Threading.Tasks.ValueTask"),
                 ValueTask_1 = Type("System.Threading.Tasks.ValueTask`1"),
+                ValueTypeGetter_2 = Type("Orleans.Serialization.Utilities.ValueTypeGetter`2"),
                 ValueTypeSetter_2 = Type("Orleans.Serialization.Utilities.ValueTypeSetter`2"),
                 Void = compilation.GetSpecialType(SpecialType.System_Void),
                 Writer = Type("Orleans.Serialization.Buffers.Writer`1"),
@@ -253,6 +254,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol ValueSerializer { get; private set; }
         public INamedTypeSymbol ValueTask { get; private set; }
         public INamedTypeSymbol ValueTask_1 { get; private set; }
+        public INamedTypeSymbol ValueTypeGetter_2 { get; private set; }
         public INamedTypeSymbol ValueTypeSetter_2 { get; private set; }
         public INamedTypeSymbol Void { get; private set; }
         public INamedTypeSymbol Writer { get; private set; }

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -60,7 +60,7 @@ namespace Orleans.CodeGenerator
         public bool OmitDefaultMemberValues => false;
         public List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters => _methodDescription.AllTypeParameters;
         public List<INamedTypeSymbol> SerializationHooks { get; }
-        public bool IsImmutable => false;
+        public bool IsShallowCopyable => false;
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
         public bool HasActivatorConstructor => true;
 

--- a/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -30,7 +30,7 @@ namespace Orleans.CodeGenerator
         bool OmitDefaultMemberValues { get; }
         ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes);
         List<INamedTypeSymbol> SerializationHooks { get; }
-        bool IsImmutable { get; }
+        bool IsShallowCopyable { get; }
         List<TypeSyntax> ActivatorConstructorParameters { get; }
     }
 }

--- a/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
@@ -49,7 +49,7 @@ namespace Orleans.CodeGenerator
             }
 
             InvokableBaseTypes = invokableBaseTypes;
-            Methods = GetMethods(interfaceType).ToList();
+            Methods = GetMethods(interfaceType);
 
             static string GetTypeParameterName(HashSet<string> names, ITypeParameterSymbol tp)
             {
@@ -67,7 +67,7 @@ namespace Orleans.CodeGenerator
 
         public CodeGenerator CodeGenerator { get; }
 
-        private IEnumerable<MethodDescription> GetMethods(INamedTypeSymbol symbol)
+        private List<MethodDescription> GetMethods(INamedTypeSymbol symbol)
         {
 #pragma warning disable RS1024 // Compare symbols correctly
             var methods = new Dictionary<IMethodSymbol, bool>(MethodSignatureComparer.Default);
@@ -87,6 +87,7 @@ namespace Orleans.CodeGenerator
             }
 
             var idCounter = 1;
+            var res = new List<MethodDescription>();
             foreach (var pair in methods.OrderBy(kv => kv.Key, MethodSignatureComparer.Default))
             {
                 var method = pair.Key;
@@ -96,8 +97,9 @@ namespace Orleans.CodeGenerator
                     idCounter = id + 1;
                 }
 
-                yield return new MethodDescription(this, method, id.ToString(CultureInfo.InvariantCulture), hasCollision: pair.Value);
+                res.Add(new(this, method, id.ToString(CultureInfo.InvariantCulture), hasCollision: pair.Value));
             }
+            return res;
 
             IEnumerable<INamedTypeSymbol> GetAllInterfaces(INamedTypeSymbol s)
             {

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -194,7 +194,7 @@ namespace Orleans.CodeGenerator
 
         public List<INamedTypeSymbol> SerializationHooks { get; }
 
-        public bool IsImmutable => IsEnumType || Type.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
+        public bool IsShallowCopyable => IsEnumType || !Type.HasBaseType(_libraryTypes.Exception) && _libraryTypes.IsShallowCopyable(Type);
 
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes)
         {

--- a/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
@@ -73,11 +73,6 @@ namespace Orleans
         MethodInfo InterfaceMethod { get; }
 
         /// <summary>
-        /// Gets the arguments for this method invocation.
-        /// </summary>
-        IMethodArguments Arguments { get; }
-
-        /// <summary>
         /// Gets or sets the result.
         /// </summary>
         object Result { get; set; }
@@ -121,45 +116,5 @@ namespace Orleans
         /// Gets the grain context of the sender.
         /// </summary>
         public IGrainContext SourceContext { get; }
-    }
-
-    /// <summary>
-    /// Represents the arguments to a method invocation.
-    /// </summary>
-    public interface IMethodArguments
-    {
-        /// <summary>
-        /// Gets the number of arguments.
-        /// </summary>
-        int Length { get; }
-
-        /// <summary>
-        /// Gets the argument at the provided index.
-        /// </summary>
-        /// <param name="index">The argument index.</param>
-        /// <returns>The argument at the provided index.</returns>
-        object this[int index] { get; set; }
-
-        /// <summary>
-        /// Gets the argument at the provided index.
-        /// </summary>
-        /// <param name="index">
-        /// The argument index.
-        /// </param>
-        /// <typeparam name="T">
-        /// The type of the argument.
-        /// </typeparam>
-        /// <returns>
-        /// The argument at the provided index.
-        /// </returns>
-        T GetArgument<T>(int index);
-
-        /// <summary>
-        /// Sets the argument at the provided index.
-        /// </summary>
-        /// <typeparam name="T">The type of the argument.</typeparam>
-        /// <param name="index">The argument index.</param>
-        /// <param name="value">The new argument value.</param>
-        void SetArgument<T>(int index, T value);
     }
 }

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -469,17 +469,16 @@ namespace Orleans.Runtime
         public abstract ValueTask<Response> Invoke();
 
         /// <inheritdoc/>
-        public abstract TTarget GetTarget<TTarget>();
+        public abstract object GetTarget();
 
         /// <inheritdoc/>
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder)
-            where TTargetHolder : ITargetHolder;
+        public abstract void SetTarget(ITargetHolder holder);
 
         /// <inheritdoc/>
-        public virtual TArgument GetArgument<TArgument>(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public virtual object GetArgument(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
 
         /// <inheritdoc/>
-        public virtual void SetArgument<TArgument>(int index, in TArgument value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public virtual void SetArgument(int index, object value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
 
         /// <inheritdoc/>
         public abstract void Dispose();
@@ -513,7 +512,7 @@ namespace Orleans.Runtime
         {
             var result = new StringBuilder();
             result.Append(InterfaceName);
-            if (GetTarget<object>() is { } target)
+            if (GetTarget() is { } target)
             {
                 result.Append("[(");
                 result.Append(InterfaceName);
@@ -529,14 +528,15 @@ namespace Orleans.Runtime
             result.Append('.');
             result.Append(MethodName);
             result.Append('(');
-            for (var n = 0; n < ArgumentCount; n++)
+            var argumentCount = ArgumentCount;
+            for (var n = 0; n < argumentCount; n++)
             {
                 if (n > 0)
                 {
                     result.Append(", ");
                 }
 
-                result.Append(GetArgument<object>(n));
+                result.Append(GetArgument(n));
             }
 
             result.Append(')');

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -451,7 +451,7 @@ namespace Orleans.Runtime
         public InvokeMethodOptions Options { get; private set; }
 
         /// <inheritdoc/>
-        public virtual int ArgumentCount => 0;
+        public virtual int GetArgumentCount() => 0;
 
         /// <summary>
         /// Incorporates the provided invocation options.
@@ -484,42 +484,42 @@ namespace Orleans.Runtime
         public abstract void Dispose();
 
         /// <inheritdoc/>
-        public abstract string MethodName { get; }
+        public abstract string GetMethodName();
 
         /// <inheritdoc/>
-        public abstract string InterfaceName { get; }
+        public abstract string GetInterfaceName();
 
         /// <inheritdoc/>
-        public abstract string ActivityName { get; }
+        public abstract string GetActivityName();
 
         /// <inheritdoc/>
-        public abstract Type InterfaceType { get; }
+        public abstract Type GetInterfaceType();
 
         /// <inheritdoc/>
-        public abstract MethodInfo Method { get; }
+        public abstract MethodInfo GetMethod();
 
         /// <inheritdoc/>
         public override string ToString()
         {
             var result = new StringBuilder();
-            result.Append(InterfaceName);
+            result.Append(GetInterfaceName());
             if (GetTarget() is { } target)
             {
                 result.Append("[(");
-                result.Append(InterfaceName);
+                result.Append(GetInterfaceName());
                 result.Append(')');
                 result.Append(target.ToString());
                 result.Append(']');
             }
             else
             {
-                result.Append(InterfaceName);
+                result.Append(GetInterfaceName());
             }
 
             result.Append('.');
-            result.Append(MethodName);
+            result.Append(GetMethodName());
             result.Append('(');
-            var argumentCount = ArgumentCount;
+            var argumentCount = GetArgumentCount();
             for (var n = 0; n < argumentCount; n++)
             {
                 if (n > 0)

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -487,9 +487,6 @@ namespace Orleans.Runtime
         public abstract string MethodName { get; }
 
         /// <inheritdoc/>
-        public virtual Type[] MethodTypeArguments => Type.EmptyTypes;
-
-        /// <inheritdoc/>
         public abstract string InterfaceName { get; }
 
         /// <inheritdoc/>
@@ -497,12 +494,6 @@ namespace Orleans.Runtime
 
         /// <inheritdoc/>
         public abstract Type InterfaceType { get; }
-
-        /// <inheritdoc/>
-        public virtual Type[] InterfaceTypeArguments => Type.EmptyTypes;
-
-        /// <inheritdoc/>
-        public virtual Type[] ParameterTypes => Type.EmptyTypes;
 
         /// <inheritdoc/>
         public abstract MethodInfo Method { get; }

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -451,7 +451,7 @@ namespace Orleans.Runtime
         public InvokeMethodOptions Options { get; private set; }
 
         /// <inheritdoc/>
-        public abstract int ArgumentCount { get; }
+        public virtual int ArgumentCount => 0;
 
         /// <summary>
         /// Incorporates the provided invocation options.
@@ -476,10 +476,10 @@ namespace Orleans.Runtime
             where TTargetHolder : ITargetHolder;
 
         /// <inheritdoc/>
-        public abstract TArgument GetArgument<TArgument>(int index);
+        public virtual TArgument GetArgument<TArgument>(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
 
         /// <inheritdoc/>
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
+        public virtual void SetArgument<TArgument>(int index, in TArgument value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
 
         /// <inheritdoc/>
         public abstract void Dispose();
@@ -488,7 +488,7 @@ namespace Orleans.Runtime
         public abstract string MethodName { get; }
 
         /// <inheritdoc/>
-        public abstract Type[] MethodTypeArguments { get; }
+        public virtual Type[] MethodTypeArguments => Type.EmptyTypes;
 
         /// <inheritdoc/>
         public abstract string InterfaceName { get; }
@@ -500,10 +500,10 @@ namespace Orleans.Runtime
         public abstract Type InterfaceType { get; }
 
         /// <inheritdoc/>
-        public abstract Type[] InterfaceTypeArguments { get; }
+        public virtual Type[] InterfaceTypeArguments => Type.EmptyTypes;
 
         /// <inheritdoc/>
-        public abstract Type[] ParameterTypes { get; }
+        public virtual Type[] ParameterTypes => Type.EmptyTypes;
 
         /// <inheritdoc/>
         public abstract MethodInfo Method { get; }
@@ -551,7 +551,7 @@ namespace Orleans.Runtime
     public abstract class Request : RequestBase 
     {
         [DebuggerHidden]
-        public override ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -600,7 +600,7 @@ namespace Orleans.Runtime
     {
         /// <inheritdoc/>
         [DebuggerHidden]
-        public override ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -651,7 +651,7 @@ namespace Orleans.Runtime
     {
         /// <inheritdoc/>
         [DebuggerHidden]
-        public override ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -700,7 +700,7 @@ namespace Orleans.Runtime
     {
         /// <inheritdoc/>
         [DebuggerHidden]
-        public override ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -750,7 +750,7 @@ namespace Orleans.Runtime
     {
         /// <inheritdoc/>
         [DebuggerHidden]
-        public override ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -86,7 +86,7 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public Task Invoke(IOutgoingGrainCallContext context)
         {
-            var activity = Source.StartActivity(context.Request.ActivityName, ActivityKind.Client);
+            var activity = Source.StartActivity(context.Request.GetActivityName(), ActivityKind.Client);
 
             if (activity is not null)
             {
@@ -131,7 +131,7 @@ namespace Orleans.Runtime
 
             if (!string.IsNullOrEmpty(traceParent))
             {
-                activity = Source.CreateActivity(context.Request.ActivityName, ActivityKind.Server, traceParent);
+                activity = Source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, traceParent);
 
                 if (activity is not null)
                 {
@@ -157,7 +157,7 @@ namespace Orleans.Runtime
             }
             else
             {
-                activity = Source.CreateActivity(context.Request.ActivityName, ActivityKind.Server);
+                activity = Source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server);
             }
 
             activity?.Start();

--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -99,9 +99,10 @@ namespace Orleans.Runtime
         /// </summary>
         private void SetGrainCancellationTokensTarget(GrainReference target, IInvokable request)
         {
-            for (var i = 0; i < request.ArgumentCount; i++)
+            var argumentCount = request.ArgumentCount;
+            for (var i = 0; i < argumentCount; i++)
             {
-                var arg = request.GetArgument<object>(i);
+                var arg = request.GetArgument(i);
                 if (arg is not GrainCancellationToken grainToken)
                 {
                     continue;

--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -99,7 +99,7 @@ namespace Orleans.Runtime
         /// </summary>
         private void SetGrainCancellationTokensTarget(GrainReference target, IInvokable request)
         {
-            var argumentCount = request.ArgumentCount;
+            var argumentCount = request.GetArgumentCount();
             for (var i = 0; i < argumentCount; i++)
             {
                 var arg = request.GetArgument(i);

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -77,7 +77,7 @@ namespace Orleans
             Utils.SafeExecute(() => tokenSource?.Dispose());
         }
 
-        public class LocalObjectData : IGrainContext
+        public sealed class LocalObjectData : IGrainContext
         {
             private static readonly Func<object, Task> HandleFunc = self => ((LocalObjectData)self).LocalObjectMessagePumpAsync();
             private readonly InvokableObjectManager _manager;

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Invokes a request on a grain reference.
     /// </summary>
-    internal class OutgoingCallInvoker<TResult> : IOutgoingGrainCallContext, IMethodArguments
+    internal sealed class OutgoingCallInvoker<TResult> : IOutgoingGrainCallContext
     {
         private readonly IInvokable request;
         private readonly InvokeMethodOptions options;
@@ -56,29 +56,15 @@ namespace Orleans.Runtime
 
         public MethodInfo InterfaceMethod => request.Method;
 
-        public IMethodArguments Arguments => this;
-
         public object Result { get => TypedResult; set => TypedResult = (TResult)value; }
 
         public Response Response { get; set; }
 
         public TResult TypedResult { get => Response.GetResult<TResult>(); set => Response = Response.FromResult(value); }
 
-        object IMethodArguments.this[int index]
-        {
-            get => request.GetArgument<object>(index);
-            set => request.SetArgument(index, value);
-        }
-
-        T IMethodArguments.GetArgument<T>(int index) => request.GetArgument<T>(index);
-
-        void IMethodArguments.SetArgument<T>(int index, T value) => request.SetArgument(index, value);
-
-        int IMethodArguments.Length => request.ArgumentCount;
-
         public IGrainContext SourceContext { get; }
 
-        public GrainId? SourceId => SourceContext is { } source ? source.GrainId : null;
+        public GrainId? SourceId => SourceContext?.GrainId;
 
         public GrainId TargetId => grainReference.GrainId;
 

--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -54,7 +54,7 @@ namespace Orleans.Runtime
 
         public object Grain => this.grainReference;
 
-        public MethodInfo InterfaceMethod => request.Method;
+        public MethodInfo InterfaceMethod => request.GetMethod();
 
         public object Result { get => TypedResult; set => TypedResult = (TResult)value; }
 
@@ -70,9 +70,9 @@ namespace Orleans.Runtime
 
         public GrainInterfaceType InterfaceType => grainReference.InterfaceType;
 
-        public string InterfaceName => request.InterfaceName;
+        public string InterfaceName => request.GetInterfaceName();
 
-        public string MethodName => request.MethodName;
+        public string MethodName => request.GetMethodName();
 
         public async Task Invoke()
         {

--- a/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
             IGrainContext target,
             IInvokable request)
         {
-            var argumentCount = request.ArgumentCount;
+            var argumentCount = request.GetArgumentCount();
             for (var i = 0; i < argumentCount; i++)
             {
                 var arg = request.GetArgument(i);

--- a/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
@@ -61,9 +61,10 @@ namespace Orleans.Runtime
             IGrainContext target,
             IInvokable request)
         {
-            for (var i = 0; i < request.ArgumentCount; i++)
+            var argumentCount = request.ArgumentCount;
+            for (var i = 0; i < argumentCount; i++)
             {
-                var arg = request.GetArgument<object>(i);
+                var arg = request.GetArgument(i);
                 if (arg is not GrainCancellationToken grainToken)
                 {
                     continue;

--- a/src/Orleans.Runtime/Core/GrainMethodInvoker.cs
+++ b/src/Orleans.Runtime/Core/GrainMethodInvoker.cs
@@ -51,7 +51,7 @@ namespace Orleans.Runtime
 
         public object Grain => grainContext.GrainInstance;
 
-        public MethodInfo InterfaceMethod => request.Method;
+        public MethodInfo InterfaceMethod => request.GetMethod();
 
         public MethodInfo ImplementationMethod => GetMethodEntry().ImplementationMethod;
 
@@ -75,9 +75,9 @@ namespace Orleans.Runtime
 
         public GrainInterfaceType InterfaceType => message.InterfaceType;
 
-        public string InterfaceName => request.InterfaceName;
+        public string InterfaceName => request.GetInterfaceName();
 
-        public string MethodName => request.MethodName;
+        public string MethodName => request.GetMethodName();
 
         public async Task Invoke()
         {
@@ -160,7 +160,7 @@ namespace Orleans.Runtime
 
         private (MethodInfo ImplementationMethod, MethodInfo InterfaceMethod) GetMethodEntry()
         {
-            var interfaceType = this.request.InterfaceType;
+            var interfaceType = this.request.GetInterfaceType();
             var implementationType = this.request.GetTarget().GetType();
 
             // Get or create the implementation map for this object.
@@ -169,7 +169,7 @@ namespace Orleans.Runtime
                 interfaceType);
 
             // Get the method info for the method being invoked.
-            var method = request.Method;
+            var method = request.GetMethod();
             if (method.IsConstructedGenericMethod)
             {
                 if (implementationMap.TryGetValue(method.GetGenericMethodDefinition(), out var entry))

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -353,8 +353,7 @@ namespace Orleans.Runtime
         {
             try
             {
-                var copiedException = _deepCopier.Copy(ex);
-                SendResponse(message, Response.FromException(copiedException));
+                SendResponse(message, Response.FromException(ex));
             }
             catch (Exception exc1)
             {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -1,31 +1,28 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.CodeGeneration;
-using Orleans.Runtime.GrainDirectory;
-using Orleans.Runtime.Scheduler;
-using Orleans.Serialization;
-using Orleans.Storage;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Threading;
+using Orleans.CodeGeneration;
 using Orleans.Configuration;
 using Orleans.GrainReferences;
 using Orleans.Metadata;
-using Orleans.Serialization.Invocation;
+using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Messaging;
+using Orleans.Serialization;
+using Orleans.Serialization.Invocation;
+using Orleans.Storage;
 
 namespace Orleans.Runtime
 {
     /// <summary>
     /// Internal class for system grains to get access to runtime object
     /// </summary>
-    internal class InsideRuntimeClient : IRuntimeClient, ILifecycleParticipant<ISiloLifecycle>
+    internal sealed class InsideRuntimeClient : IRuntimeClient, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly ILogger logger;
         private readonly ILogger invokeExceptionLogger;
@@ -352,49 +349,11 @@ namespace Orleans.Runtime
             }
         }
 
-        private static readonly Lazy<Func<Exception, Exception>> prepForRemotingLazy =
-            new Lazy<Func<Exception, Exception>>(CreateExceptionPrepForRemotingMethod);
-
-        private static Func<Exception, Exception> CreateExceptionPrepForRemotingMethod()
-        {
-            var methodInfo = typeof(Exception).GetMethod(
-                "PrepForRemoting",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-
-            //This was added to avoid failure on .Net Core since Remoting APIs aren't available there.
-            if (methodInfo == null)
-                return exc => exc;
-
-            var method = new DynamicMethod(
-                "PrepForRemoting",
-                typeof(Exception),
-                new[] { typeof(Exception) },
-                typeof(InsideRuntimeClient).Module,
-                true);
-            var il = method.GetILGenerator();
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, methodInfo);
-            il.Emit(OpCodes.Ret);
-            return (Func<Exception, Exception>)method.CreateDelegate(typeof(Func<Exception, Exception>));
-        }
-
-        private static Exception PrepareForRemoting(Exception exception)
-        {
-            // Call the Exception.PrepForRemoting internal method, which preserves the original stack when the exception
-            // is rethrown at the remote site (and appends the call site stacktrace). If this is not done, then when the
-            // exception is rethrown the original stacktrace is entire replaced.
-            // Note: another commonly used approach since .NET 4.5 is to use ExceptionDispatchInfo.Capture(ex).Throw()
-            // but that involves rethrowing the exception in-place, which is not what we want here, but could in theory
-            // be done at the receiving end with some rework (could be tackled when we reopen #875 Avoid unnecessary use of TCS).
-            prepForRemotingLazy.Value.Invoke(exception);
-            return exception;
-        }
-
         private void SafeSendExceptionResponse(Message message, Exception ex)
         {
             try
             {
-                var copiedException = PrepareForRemoting((Exception)this._deepCopier.Copy(ex));
+                var copiedException = _deepCopier.Copy(ex);
                 SendResponse(message, Response.FromException(copiedException));
             }
             catch (Exception exc1)

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -144,7 +144,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <summary>        
         /// Generated code helper method which throws an <see cref="ArgumentOutOfRangeException"/>.
         /// </summary>                
-        public static TArgument InvokableThrowArgumentOutOfRange<TArgument>(int index, int maxArgs)
+        public static object InvokableThrowArgumentOutOfRange(int index, int maxArgs)
             => throw new ArgumentOutOfRangeException(message: $"The argument index value {index} must be between 0 and {maxArgs}", null);
 
         /// <summary>

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -140,11 +140,12 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
 
             return null;
         }
-        
+
         /// <summary>        
         /// Generated code helper method which throws an <see cref="ArgumentOutOfRangeException"/>.
         /// </summary>                
-        public static TArgument InvokableThrowArgumentOutOfRange<TArgument>(int index, int maxArgs) => throw new ArgumentOutOfRangeException($"The argument index value {index} must be between 0 and {maxArgs}");
+        public static TArgument InvokableThrowArgumentOutOfRange<TArgument>(int index, int maxArgs)
+            => throw new ArgumentOutOfRangeException(message: $"The argument index value {index} must be between 0 and {maxArgs}", null);
 
         /// <summary>
         /// Reads a field header.
@@ -241,12 +242,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
                     continue;
                 }
 
-                if (!current.ContainsGenericParameters && methodTypeParameters is { Length: > 0 })
-                {
-                    continue;
-                }
-
-                if (current.ContainsGenericParameters && methodTypeParameters is null or { Length: 0 })
+                if (current.ContainsGenericParameters != methodTypeParameters is { Length: > 0 })
                 {
                     continue;
                 }
@@ -262,7 +258,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
                 }
 
                 var parameters = current.GetParameters();
-                if (parameters.Length != parameterTypes.Length)
+                if (parameters.Length != (parameterTypes?.Length ?? 0))
                 {
                     continue;
                 }

--- a/src/Orleans.Serialization/Invocation/IInvokable.cs
+++ b/src/Orleans.Serialization/Invocation/IInvokable.cs
@@ -30,7 +30,7 @@ namespace Orleans.Serialization.Invocation
         /// <summary>
         /// Gets the number of arguments.
         /// </summary>
-        int ArgumentCount { get; }
+        int GetArgumentCount();
 
         /// <summary>
         /// Gets the argument at the specified index.
@@ -49,26 +49,26 @@ namespace Orleans.Serialization.Invocation
         /// <summary>
         /// Gets the method name.
         /// </summary>
-        string MethodName { get; }
+        string GetMethodName();
 
         /// <summary>
         /// Gets the full interface name.
         /// </summary>
-        string InterfaceName { get; }
+        string GetInterfaceName();
 
         /// <summary>
         /// Gets the activity name, which refers to both the interface name and method name.
         /// </summary>
-        string ActivityName { get; }
+        string GetActivityName();
 
         /// <summary>
         /// Gets the method info object, which may be <see langword="null"/>.
         /// </summary>
-        MethodInfo Method { get; }
+        MethodInfo GetMethod();
 
         /// <summary>
         /// Gets the interface type.
         /// </summary>
-        Type InterfaceType { get; }
+        Type GetInterfaceType();
     }
 }

--- a/src/Orleans.Serialization/Invocation/IInvokable.cs
+++ b/src/Orleans.Serialization/Invocation/IInvokable.cs
@@ -70,20 +70,5 @@ namespace Orleans.Serialization.Invocation
         /// Gets the interface type.
         /// </summary>
         Type InterfaceType { get; }
-
-        /// <summary>
-        /// Gets the type arguments for the method if the method is generic, otherwise an empty array.
-        /// </summary>
-        Type[] MethodTypeArguments { get; }
-
-        /// <summary>
-        /// Gets the type arguments for the interface if the interface is generic, otherwise an empty array.
-        /// </summary>
-        Type[] InterfaceTypeArguments { get; }
-
-        /// <summary>
-        /// Gets the parameter types for the method.
-        /// </summary>
-        Type[] ParameterTypes { get; }
     }
 }

--- a/src/Orleans.Serialization/Invocation/IInvokable.cs
+++ b/src/Orleans.Serialization/Invocation/IInvokable.cs
@@ -13,16 +13,14 @@ namespace Orleans.Serialization.Invocation
         /// <summary>
         /// Gets the invocation target.
         /// </summary>
-        /// <typeparam name="TTarget">The target type.</typeparam>
         /// <returns>The invocation target.</returns>
-        TTarget? GetTarget<TTarget>();
+        object? GetTarget();
 
         /// <summary>
         /// Sets the invocation target from an instance of <see cref="ITargetHolder"/>.
         /// </summary>
-        /// <typeparam name="TTargetHolder">The target holder type.</typeparam>
         /// <param name="holder">The invocation target.</param>
-        void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
+        void SetTarget(ITargetHolder holder);
 
         /// <summary>
         /// Invoke the object.
@@ -37,18 +35,16 @@ namespace Orleans.Serialization.Invocation
         /// <summary>
         /// Gets the argument at the specified index.
         /// </summary>
-        /// <typeparam name="TArgument">The argument type.</typeparam>
         /// <param name="index">The argument index.</param>
         /// <returns>The argument at the specified index.</returns>
-        TArgument? GetArgument<TArgument>(int index);
+        object? GetArgument(int index);
 
         /// <summary>
         /// Sets the argument at the specified index.
         /// </summary>
-        /// <typeparam name="TArgument">The argument type.</typeparam>
         /// <param name="index">The argument index.</param>
         /// <param name="value">The argument value</param>
-        void SetArgument<TArgument>(int index, in TArgument value);
+        void SetArgument(int index, object value);
 
         /// <summary>
         /// Gets the method name.

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -135,7 +135,7 @@ namespace Orleans.Serialization.TypeSystem
                 });
             }
 
-            void AddFromMetadata(IEnumerable<Type> metadataCollection, Type genericType)
+            void AddFromMetadata(HashSet<Type> metadataCollection, Type genericType)
             {
                 Debug.Assert(genericType.GetGenericArguments().Length >= 1);
 

--- a/src/Orleans.Serialization/Utilities/FieldAccessor.cs
+++ b/src/Orleans.Serialization/Utilities/FieldAccessor.cs
@@ -57,7 +57,7 @@ namespace Orleans.Serialization.Utilities
             emitter.Emit(OpCodes.Ldfld, field);
             emitter.Emit(OpCodes.Ret);
 
-            return method.CreateDelegate(typeof(Func<,>).MakeGenericType(declaringType, field.FieldType));
+            return method.CreateDelegate((byref ? typeof(ValueTypeGetter<,>) : typeof(Func<,>)).MakeGenericType(declaringType, field.FieldType));
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/Utilities/FieldAccessor.cs
+++ b/src/Orleans.Serialization/Utilities/FieldAccessor.cs
@@ -10,8 +10,16 @@ namespace Orleans.Serialization.Utilities
     /// <typeparam name="TDeclaring">The declaring type of the field.</typeparam>
     /// <typeparam name="TField">The field type.</typeparam>
     /// <param name="instance">The instance having its field set.</param>
+    public delegate TField ValueTypeGetter<TDeclaring, out TField>(ref TDeclaring instance) where TDeclaring : struct;
+
+    /// <summary>
+    /// The delegate used to set fields in value types.
+    /// </summary>
+    /// <typeparam name="TDeclaring">The declaring type of the field.</typeparam>
+    /// <typeparam name="TField">The field type.</typeparam>
+    /// <param name="instance">The instance having its field set.</param>
     /// <param name="value">The value being set.</param>
-    public delegate void ValueTypeSetter<TDeclaring, in TField>(ref TDeclaring instance, TField value);
+    public delegate void ValueTypeSetter<TDeclaring, in TField>(ref TDeclaring instance, TField value) where TDeclaring : struct;
 
     /// <summary>
     /// Functionality for accessing fields.
@@ -25,10 +33,7 @@ namespace Orleans.Serialization.Utilities
         /// The field.
         /// </param>
         /// <returns>A delegate to get the value of a specified field.</returns>
-        public static Delegate GetGetter(FieldInfo field) => GetGetDelegate(
-                field,
-                typeof(Func<,>).MakeGenericType(field.DeclaringType, field.FieldType),
-                new[] { field.DeclaringType });
+        public static Delegate GetGetter(FieldInfo field) => GetGetter(field, false);
 
         /// <summary>
         /// Returns a delegate to get the value of a specified field.
@@ -36,91 +41,52 @@ namespace Orleans.Serialization.Utilities
         /// <param name="field">
         /// The field.
         /// </param>
-        /// <param name="delegateType">The delegate type.</param>
-        /// <param name="parameterTypes">The parameter types.</param>
         /// <returns>A delegate to get the value of a specified field.</returns>
-        private static Delegate GetGetDelegate(FieldInfo field, Type delegateType, Type[] parameterTypes)
+        public static Delegate GetValueGetter(FieldInfo field) => GetGetter(field, true);
+
+        private static Delegate GetGetter(FieldInfo field, bool byref)
         {
-            var declaringType = field.DeclaringType;
-            if (declaringType is null)
-            {
-                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
-            }
+            var declaringType = field.DeclaringType ?? throw new InvalidOperationException($"Field {field.Name} does not have a declaring type.");
+            var parameterTypes = new[] { typeof(object), byref ? declaringType.MakeByRefType() : declaringType };
 
-            // Create a method to hold the generated IL.
-            var method = new DynamicMethod(
-                field.Name + "Get",
-                field.FieldType,
-                parameterTypes,
-                typeof(FieldAccessor).Module,
-                true);
+            var method = new DynamicMethod(field.Name + "Get", field.FieldType, parameterTypes, typeof(FieldAccessor).Module, true);
 
-            // Emit IL to return the value of the Transaction property.
             var emitter = method.GetILGenerator();
-            emitter.Emit(OpCodes.Ldarg_0);
+            // arg0 is unused for better delegate performance (avoids argument shuffling thunk)
+            emitter.Emit(OpCodes.Ldarg_1);
             emitter.Emit(OpCodes.Ldfld, field);
             emitter.Emit(OpCodes.Ret);
 
-            return method.CreateDelegate(delegateType);
+            return method.CreateDelegate(typeof(Func<,>).MakeGenericType(declaringType, field.FieldType));
         }
 
         /// <summary>
         /// Returns a delegate to set the value of this field for an instance.
         /// </summary>
         /// <returns>A delegate to set the value of this field for an instance.</returns>
-        public static Delegate GetReferenceSetter(FieldInfo field)
-        {
-            var delegateType = typeof(Action<,>).MakeGenericType(field.DeclaringType, field.FieldType);
-            return GetSetDelegate(field, delegateType, new[] { field.DeclaringType, field.FieldType });
-        }
+        public static Delegate GetReferenceSetter(FieldInfo field) => GetSetter(field, false);
 
         /// <summary>
         /// Returns a delegate to set the value of this field for an instance.
         /// </summary>
         /// <returns>A delegate to set the value of this field for an instance.</returns>
-        public static Delegate GetValueSetter(FieldInfo field)
+        public static Delegate GetValueSetter(FieldInfo field) => GetSetter(field, true);
+
+        private static Delegate GetSetter(FieldInfo field, bool byref)
         {
-            var declaringType = field.DeclaringType;
-            if (declaringType is null)
-            {
-                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
-            }
+            var declaringType = field.DeclaringType ?? throw new InvalidOperationException($"Field {field.Name} does not have a declaring type.");
+            var parameterTypes = new[] { typeof(object), byref ? declaringType.MakeByRefType() : declaringType, field.FieldType };
 
-            // Value types need to be passed by-ref.
-            var parameterTypes = new[] { declaringType.MakeByRefType(), field.FieldType };
-            var delegateType = typeof(ValueTypeSetter<,>).MakeGenericType(field.DeclaringType, field.FieldType);
-
-            return GetSetDelegate(field, delegateType, parameterTypes);
-        }
-
-        /// <summary>
-        /// Returns a delegate to set the value of a specified field.
-        /// </summary>
-        /// <param name="field">
-        /// The field.
-        /// </param>
-        /// <param name="delegateType">The delegate type.</param>
-        /// <param name="parameterTypes">The parameter types.</param>
-        /// <returns>A delegate to set the value of a specified field.</returns>
-        private static Delegate GetSetDelegate(FieldInfo field, Type delegateType, Type[] parameterTypes)
-        {
-            var declaringType = field.DeclaringType;
-            if (declaringType is null)
-            {
-                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
-            }
-
-            // Create a method to hold the generated IL.
             var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, typeof(FieldAccessor).Module, true);
 
-            // Emit IL to return the value of the Transaction property.
             var emitter = method.GetILGenerator();
-            emitter.Emit(OpCodes.Ldarg_0);
+            // arg0 is unused for better delegate performance (avoids argument shuffling thunk)
             emitter.Emit(OpCodes.Ldarg_1);
+            emitter.Emit(OpCodes.Ldarg_2);
             emitter.Emit(OpCodes.Stfld, field);
             emitter.Emit(OpCodes.Ret);
 
-            return method.CreateDelegate(delegateType);
+            return method.CreateDelegate((byref ? typeof(ValueTypeSetter<,>) : typeof(Action<,>)).MakeGenericType(declaringType, field.FieldType));
         }
     }
 }

--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -319,7 +319,7 @@ namespace Orleans
         {
         }
 
-        protected override ValueTask<Response> BaseInvoke()
+        protected sealed override ValueTask<Response> BaseInvoke()
         {
             try
             {
@@ -363,7 +363,7 @@ namespace Orleans
         {
         }
 
-        protected override ValueTask<Response> BaseInvoke()
+        protected sealed override ValueTask<Response> BaseInvoke()
         {
             try
             {
@@ -406,7 +406,7 @@ namespace Orleans
         {
         }
 
-        protected override ValueTask<Response> BaseInvoke()
+        protected sealed override ValueTask<Response> BaseInvoke()
         {
             try
             {
@@ -450,7 +450,7 @@ namespace Orleans
         {
         }
 
-        protected override ValueTask<Response> BaseInvoke()
+        protected sealed override ValueTask<Response> BaseInvoke()
         {
             try
             {

--- a/test/Grains/TestGrains/MethodInterceptionGrain.cs
+++ b/test/Grains/TestGrains/MethodInterceptionGrain.cs
@@ -134,7 +134,7 @@ namespace UnitTests.Grains
         {
             if (context.ImplementationMethod.Name == nameof(GetInputAsString))
             {
-                context.Result = $"Hah! You wanted {context.Arguments[0]}, but you got me!";
+                context.Result = $"Hah! You wanted {context.Request.GetArgument(0)}, but you got me!";
                 return;
             }
 
@@ -155,7 +155,7 @@ namespace UnitTests.Grains
         {
             if (context.ImplementationMethod.Name == nameof(GetInputAsString))
             {
-                context.Result = $"Hah! You wanted {context.Arguments[0]}, but you got me!";
+                context.Result = $"Hah! You wanted {context.Request.GetArgument(0)}, but you got me!";
                 return;
             }
 
@@ -206,9 +206,9 @@ namespace UnitTests.Grains
                 }
                 catch (ArgumentOutOfRangeException) when (attemptsRemaining > 1)
                 {
-                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero)) && ctx.Arguments[0] is int value)
+                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero)) && ctx.Request.GetArgument(0) is int value)
                     {
-                        ctx.Arguments[0] = (object)(value - 1);
+                        ctx.Request.SetArgument(0, value - 1);
                     }
 
                     --attemptsRemaining;

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -97,11 +97,11 @@ namespace UnitTests.Grains
 
             // assume single argument message
             if (req.ArgumentCount == 1)
-                arg = (string)UnwrapImmutable(req.GetArgument<object>(0));
+                arg = (string)UnwrapImmutable(req.GetArgument(0));
 
             // assume stream message
             if (req.ArgumentCount == 2)
-                arg = (string)UnwrapImmutable(req.GetArgument<object>(1));
+                arg = (string)UnwrapImmutable(req.GetArgument(1));
 
             if (arg == "err")
                 throw new ApplicationException("boom");

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -90,17 +90,17 @@ namespace UnitTests.Grains
         public static bool MayInterleave(IInvokable req)
         {
             // not interested
-            if (req.ArgumentCount == 0)
+            if (req.GetArgumentCount() == 0)
                 return false;
 
             string arg = null;
 
             // assume single argument message
-            if (req.ArgumentCount == 1)
+            if (req.GetArgumentCount() == 1)
                 arg = (string)UnwrapImmutable(req.GetArgument(0));
 
             // assume stream message
-            if (req.ArgumentCount == 2)
+            if (req.GetArgumentCount() == 2)
                 arg = (string)UnwrapImmutable(req.GetArgument(1));
 
             if (arg == "err")

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -7,18 +7,20 @@ namespace Orleans.Serialization.Invocation
 {
     public abstract class UnitTestRequestBase : IInvokable
     {
-        public virtual int ArgumentCount => 0;
+        public virtual int GetArgumentCount() => 0;
         public abstract ValueTask<Response> Invoke();
         public abstract object GetTarget();
         public abstract void SetTarget(ITargetHolder holder);
         public virtual object GetArgument(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
         public virtual void SetArgument(int index, object value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
         public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract MethodInfo Method { get; }
+        public abstract string GetMethodName();
+        public abstract string GetInterfaceName();
+
+        public abstract string GetActivityName();
+        public abstract Type GetInterfaceType();
+
+        public abstract MethodInfo GetMethod();
     }
 
     public abstract class UnitTestRequest : UnitTestRequestBase

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -9,10 +9,10 @@ namespace Orleans.Serialization.Invocation
     {
         public virtual int ArgumentCount => 0;
         public abstract ValueTask<Response> Invoke();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public virtual TArgument GetArgument<TArgument>(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
-        public virtual void SetArgument<TArgument>(int index, in TArgument value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public abstract object GetTarget();
+        public abstract void SetTarget(ITargetHolder holder);
+        public virtual object GetArgument(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public virtual void SetArgument(int index, object value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
         public abstract void Dispose();
         public abstract string MethodName { get; }
         public virtual Type[] MethodTypeArguments => Type.EmptyTypes;

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -15,12 +15,9 @@ namespace Orleans.Serialization.Invocation
         public virtual void SetArgument(int index, object value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
         public abstract void Dispose();
         public abstract string MethodName { get; }
-        public virtual Type[] MethodTypeArguments => Type.EmptyTypes;
         public abstract string InterfaceName { get; }
         public abstract string ActivityName { get; }
         public abstract Type InterfaceType { get; }
-        public virtual Type[] InterfaceTypeArguments => Type.EmptyTypes;
-        public virtual Type[] ParameterTypes => Type.EmptyTypes;
         public abstract MethodInfo Method { get; }
     }
 

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -5,12 +5,29 @@ using System.Threading.Tasks;
 
 namespace Orleans.Serialization.Invocation
 {
-    public abstract class UnitTestRequest : IInvokable
+    public abstract class UnitTestRequestBase : IInvokable
     {
-        public abstract int ArgumentCount { get; }
+        public virtual int ArgumentCount => 0;
+        public abstract ValueTask<Response> Invoke();
+        public abstract TTarget GetTarget<TTarget>();
+        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
+        public virtual TArgument GetArgument<TArgument>(int index) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public virtual void SetArgument<TArgument>(int index, in TArgument value) => throw new ArgumentOutOfRangeException(message: "The request has zero arguments", null);
+        public abstract void Dispose();
+        public abstract string MethodName { get; }
+        public virtual Type[] MethodTypeArguments => Type.EmptyTypes;
+        public abstract string InterfaceName { get; }
+        public abstract string ActivityName { get; }
+        public abstract Type InterfaceType { get; }
+        public virtual Type[] InterfaceTypeArguments => Type.EmptyTypes;
+        public virtual Type[] ParameterTypes => Type.EmptyTypes;
+        public abstract MethodInfo Method { get; }
+    }
 
+    public abstract class UnitTestRequest : UnitTestRequestBase
+    {
         [DebuggerHidden]
-        public ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -46,27 +63,12 @@ namespace Orleans.Serialization.Invocation
         // Generated
         [DebuggerHidden]
         protected abstract ValueTask InvokeInner();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public abstract TArgument GetArgument<TArgument>(int index);
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
-        public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract Type[] MethodTypeArguments { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract Type[] InterfaceTypeArguments { get; }
-        public abstract Type[] ParameterTypes { get; }
-        public abstract MethodInfo Method { get; }
     }
 
-    public abstract class UnitTestRequest<TResult> : IInvokable
+    public abstract class UnitTestRequest<TResult> : UnitTestRequestBase
     {
-        public abstract int ArgumentCount { get; }
-
         [DebuggerHidden]
-        public ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -101,27 +103,12 @@ namespace Orleans.Serialization.Invocation
         // Generated
         [DebuggerHidden]
         protected abstract ValueTask<TResult> InvokeInner();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public abstract TArgument GetArgument<TArgument>(int index);
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
-        public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract Type[] MethodTypeArguments { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract Type[] InterfaceTypeArguments { get; }
-        public abstract Type[] ParameterTypes { get; }
-        public abstract MethodInfo Method { get; }
     }
 
-    public abstract class UnitTestTaskRequest<TResult> : IInvokable
+    public abstract class UnitTestTaskRequest<TResult> : UnitTestRequestBase
     {
-        public abstract int ArgumentCount { get; }
-
         [DebuggerHidden]
-        public ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -157,27 +144,12 @@ namespace Orleans.Serialization.Invocation
         // Generated
         [DebuggerHidden]
         protected abstract Task<TResult> InvokeInner();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public abstract TArgument GetArgument<TArgument>(int index);
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
-        public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract Type[] MethodTypeArguments { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract Type[] InterfaceTypeArguments { get; }
-        public abstract Type[] ParameterTypes { get; }
-        public abstract MethodInfo Method { get; }
     }
 
-    public abstract class UnitTestTaskRequest : IInvokable
+    public abstract class UnitTestTaskRequest : UnitTestRequestBase
     {
-        public abstract int ArgumentCount { get; }
-
         [DebuggerHidden]
-        public ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -214,27 +186,12 @@ namespace Orleans.Serialization.Invocation
         // Generated
         [DebuggerHidden]
         protected abstract Task InvokeInner();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public abstract TArgument GetArgument<TArgument>(int index);
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
-        public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract Type[] MethodTypeArguments { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract Type[] InterfaceTypeArguments { get; }
-        public abstract Type[] ParameterTypes { get; }
-        public abstract MethodInfo Method { get; }
     }
 
-    public abstract class UnitTestVoidRequest : IInvokable
+    public abstract class UnitTestVoidRequest : UnitTestRequestBase
     {
-        public abstract int ArgumentCount { get; }
-
         [DebuggerHidden]
-        public ValueTask<Response> Invoke()
+        public sealed override ValueTask<Response> Invoke()
         {
             try
             {
@@ -250,18 +207,5 @@ namespace Orleans.Serialization.Invocation
         // Generated
         [DebuggerHidden]
         protected abstract void InvokeInner();
-        public abstract TTarget GetTarget<TTarget>();
-        public abstract void SetTarget<TTargetHolder>(TTargetHolder holder) where TTargetHolder : ITargetHolder;
-        public abstract TArgument GetArgument<TArgument>(int index);
-        public abstract void SetArgument<TArgument>(int index, in TArgument value);
-        public abstract void Dispose();
-        public abstract string MethodName { get; }
-        public abstract Type[] MethodTypeArguments { get; }
-        public abstract string InterfaceName { get; }
-        public abstract string ActivityName { get; }
-        public abstract Type InterfaceType { get; }
-        public abstract Type[] InterfaceTypeArguments { get; }
-        public abstract Type[] ParameterTypes { get; }
-        public abstract MethodInfo Method { get; }
     }
 }

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -58,8 +58,8 @@ namespace UnitTests.General
                             if (ctx.InterfaceMethod?.Name == "Echo")
                             {
                                 // Concatenate the input to itself.
-                                var orig = (string)ctx.Arguments[0];
-                                ctx.Arguments[0] = orig + orig;
+                                var orig = (string)ctx.Request.GetArgument(0);
+                                ctx.Request.SetArgument(0, orig + orig);
                             }
 
                             if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IMethodInterceptionGrain.SystemWideCallFilterMarker)))
@@ -87,7 +87,7 @@ namespace UnitTests.General
                             if (ctx.InterfaceMethod?.DeclaringType == typeof(IOutgoingMethodInterceptionGrain)
                                 && ctx.InterfaceMethod?.Name == nameof(IOutgoingMethodInterceptionGrain.EchoViaOtherGrain))
                             {
-                                ctx.Arguments[1] = ((string)ctx.Arguments[1]).ToUpperInvariant();
+                                ctx.Request.SetArgument(1, ((string)ctx.Request.GetArgument(1)).ToUpperInvariant());
                             }
 
                             await ctx.Invoke();
@@ -115,9 +115,9 @@ namespace UnitTests.General
                             }
                             catch (ArgumentOutOfRangeException) when (attemptsRemaining > 1 && ctx.Grain is IOutgoingMethodInterceptionGrain)
                             {
-                                if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IOutgoingMethodInterceptionGrain.ThrowIfGreaterThanZero)) && ctx.Arguments[0] is int value)
+                                if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IOutgoingMethodInterceptionGrain.ThrowIfGreaterThanZero)) && ctx.Request.GetArgument(0) is int value)
                                 {
-                                    ctx.Arguments[0] = value - 1;
+                                    ctx.Request.SetArgument(0, value - 1);
                                 }
 
                                 --attemptsRemaining;


### PR DESCRIPTION
* Use specialized field getters for struct fields that pass instances by reference.
* Change generated dynamic method signatures to avoid argument shuffling delegate thunks.
* Don't generate unused property setters for settable properties.
* Don't generate copier fields for shallow-copyable types.
* In struct copiers set only fields that need deep-copying and use the input parameter directly for everything else.
* Replace generic methods on `IInvokable` with untyped methods.
* Remove unused properties from `IInvokable`.
* Replace generated properties with methods to reduce metadata size.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7960)