### PR TITLE
Fix serializer classes not being generated for types in methods external to grain implementations.

### DIFF
--- a/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/Utilities/SymbolExtensions.cs
@@ -225,6 +225,12 @@ namespace Orleans.CodeGenerator.Utilities
             {
                 foreach (var t in baseType.GetInstanceMembers<TSymbol>()) yield return t;
             }
+
+            var interfaces = type.AllInterfaces;
+            foreach (var iface in interfaces)
+            {
+                foreach (var t in iface.GetInstanceMembers<TSymbol>()) yield return t;
+            }
         }
 
         public static TSymbol Member<TSymbol>(this ITypeSymbol type, string name, Func<TSymbol, bool> predicate = null) where TSymbol : class

--- a/test/CodeGeneration/CodeGenerator.Tests/CodeGenerator.Tests.csproj
+++ b/test/CodeGeneration/CodeGenerator.Tests/CodeGenerator.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
@@ -21,13 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="RoslynTypeNameFormatterTests.cs" />
+    <EmbeddedResource Include="CodeGenerationTests.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" />
     <ProjectReference Include="..\..\..\src\Orleans.Core\Orleans.Core.csproj" />
+    <ProjectReference Include="..\..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #7962.

I also did some minor refactoring in `CodeGenerator.Tests` to add some coverage on `CodeGenerator.GenerateCode`. Looks like this wasn't covered previously, unless I missed a better location to add this test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7963)