### PR TITLE
Change the activation strategy for StatelessWorkers from round-robin to on-demand

### DIFF
--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime
         private readonly int _maxWorkers;
         private readonly List<ActivationData> _workers = new();
         private readonly ConcurrentQueue<(WorkItemType Type, object State)> _workItems = new();
-        private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = false };        
+        private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = false };
 
         /// <summary>
         /// The <see cref="Task"/> representing the <see cref="RunMessageLoop"/> invocation.

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -291,10 +291,6 @@ namespace Orleans.Runtime
                         {
                             tasks.Add(disposable.DisposeAsync().AsTask());
                         }
-                        //else if (worker is IDisposable syncDisposable)
-                        //{
-                        //    syncDisposable.Dispose();
-                        //}
                     }
                     catch (Exception exception)
                     {

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -115,7 +115,7 @@ namespace DefaultCluster.Tests.General
             IStatelessWorkerScalingGrain firstGrain = this.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(0);
             IStatelessWorkerScalingGrain secondGrain = this.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(0);
 
-            foreach (var taskNo in Enumerable.Range(0, 10))
+            foreach (var _ in Enumerable.Range(0, 10))
             {
                 IStatelessWorkerScalingGrain transientGrain = this.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(0);
                 var activation1 = await firstGrain.GetActivation();
@@ -140,7 +140,7 @@ namespace DefaultCluster.Tests.General
             var secondActivation = await secondGrain.GetActivation();   // Now that the semaphore is blocking the first call,
                                                                         // get the activation number
             await Task.WhenAll(firstGrain.Release(),
-                               secondGrain.Release());                  // And then release the semaphore
+                               secondGrain.Release());                  // And then release the semaphores
             
             Assert.Equal(1, firstActivation);
             Assert.Equal(2, secondActivation);

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerScalingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerScalingGrain.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
@@ -10,12 +6,14 @@ namespace UnitTests.GrainInterfaces;
 
 public interface IStatelessWorkerScalingGrain : IGrainWithIntegerKey
 {
-    [AlwaysInterleave]
     Task Wait();
 
     [AlwaysInterleave]
     Task Release();
 
     [AlwaysInterleave]
-    Task<int> GetActivation();
+    Task<int> GetActivationCount();
+
+    [AlwaysInterleave]
+    Task<int> GetWaitingCount();
 }

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerScalingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerScalingGrain.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Concurrency;
+
+namespace UnitTests.GrainInterfaces;
+
+public interface IStatelessWorkerScalingGrain : IGrainWithIntegerKey
+{
+    [AlwaysInterleave]
+    Task Wait();
+
+    [AlwaysInterleave]
+    Task Release();
+
+    [AlwaysInterleave]
+    Task<int> GetActivation();
+}

--- a/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
@@ -11,12 +11,12 @@ namespace UnitTests.Grains;
 public class StatelessWorkerScalingGrain : Grain, IStatelessWorkerScalingGrain
 {
     private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
-    private static ConcurrentDictionary<long, int> activationCounter = new();
-    private int activation;
+    private static ConcurrentDictionary<long, int> _activationCounter = new();
+    private int _activation;
 
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        activation = activationCounter.AddOrUpdate(this.GetPrimaryKeyLong(), 1, (k, v) => v + 1);
+        _activation = _activationCounter.AddOrUpdate(this.GetPrimaryKeyLong(), 1, (k, v) => v + 1);
         return base.OnActivateAsync(cancellationToken);
     }
 
@@ -38,5 +38,5 @@ public class StatelessWorkerScalingGrain : Grain, IStatelessWorkerScalingGrain
         return Task.CompletedTask;
     }
 
-    public Task<int> GetActivation() => Task.FromResult(activation);
+    public Task<int> GetActivation() => Task.FromResult(_activation);
 }

--- a/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
@@ -3,40 +3,43 @@ using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
+using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains;
 
-[StatelessWorker]
+public class StatelessWorkerScalingGrainSharedState
+{
+    public SemaphoreSlim Semaphore { get; } = new(0);
+    public ConcurrentDictionary<GrainId, int> ActivationCounts { get; } = new();
+    public ConcurrentDictionary<GrainId, int> WaitingActivations { get; } = new();
+}
+
+[StatelessWorker(maxLocalWorkers: 4)]
 public class StatelessWorkerScalingGrain : Grain, IStatelessWorkerScalingGrain
 {
-    private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
-    private static ConcurrentDictionary<long, int> _activationCounter = new();
-    private int _activation;
+    private readonly StatelessWorkerScalingGrainSharedState _shared;
 
-    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    public StatelessWorkerScalingGrain(StatelessWorkerScalingGrainSharedState shared)
     {
-        _activation = _activationCounter.AddOrUpdate(this.GetPrimaryKeyLong(), 1, (k, v) => v + 1);
-        return base.OnActivateAsync(cancellationToken);
+        _shared = shared;
+        _shared.ActivationCounts.AddOrUpdate(this.GetGrainId(), 1, (k, v) => v + 1);
+        _shared.WaitingActivations.TryAdd(this.GetGrainId(), 0);
     }
 
-    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    public async Task Wait()
     {
-        _semaphore.Dispose();
-        return base.OnDeactivateAsync(reason, cancellationToken);
-    }
-
-    public Task Wait()
-    {        
-        _semaphore.Wait();
-        return Task.CompletedTask;
+        _shared.WaitingActivations.AddOrUpdate(this.GetGrainId(), 1, (k, v) => v + 1);
+        await _shared.Semaphore.WaitAsync();
+        _shared.WaitingActivations.AddOrUpdate(this.GetGrainId(), 0, (k, v) => v - 1);
     }
 
     public Task Release()
     {
-        _semaphore.Release();
+        _shared.Semaphore.Release();
         return Task.CompletedTask;
     }
 
-    public Task<int> GetActivation() => Task.FromResult(_activation);
+    public Task<int> GetActivationCount() => Task.FromResult(_shared.ActivationCounts[this.GetGrainId()]);
+    public Task<int> GetWaitingCount() => Task.FromResult(_shared.WaitingActivations[this.GetGrainId()]);
 }

--- a/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerScalingGrain.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
@@ -21,7 +17,6 @@ public class StatelessWorkerScalingGrain : Grain, IStatelessWorkerScalingGrain
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
         activation = activationCounter.AddOrUpdate(this.GetPrimaryKeyLong(), 1, (k, v) => v + 1);
-
         return base.OnActivateAsync(cancellationToken);
     }
 

--- a/test/Tester/StatelessWorkerActivationTests.cs
+++ b/test/Tester/StatelessWorkerActivationTests.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace UnitTests.General;
 
@@ -35,12 +31,10 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
     }
 
     private readonly Fixture _fixture;
-    private readonly ITestOutputHelper _output;
 
-    public StatelessWorkerActivationTests(Fixture fixture, ITestOutputHelper output)
+    public StatelessWorkerActivationTests(Fixture fixture)
     {
         _fixture = fixture;
-        _output = output;
     }
 
     [Fact, TestCategory("BVT"), TestCategory("StatelessWorker")]

--- a/test/Tester/StatelessWorkerActivationTests.cs
+++ b/test/Tester/StatelessWorkerActivationTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests.General;
+
+public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActivationTests.Fixture>
+{
+    public class Fixture : BaseTestClusterFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 1;
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        }
+
+        private class SiloConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder.Services.AddSingleton<StatelessWorkerScalingGrainSharedState>();
+            }
+        }
+    }
+
+    private readonly Fixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public StatelessWorkerActivationTests(Fixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("StatelessWorker")]
+    public async Task SingleWorkerInvocationUnderLoad()
+    {
+        var workerGrain = _fixture.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(0);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var activationCount = await workerGrain.GetActivationCount();
+            Assert.Equal(1, activationCount);
+        }
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("StatelessWorker")]
+    public async Task MultipleWorkerInvocationUnderLoad()
+    {
+        const int MaxLocalWorkers = 4;
+        var waiters = new List<Task>();
+        var worker = _fixture.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(1);
+
+        var activationCount = await worker.GetActivationCount();
+        Assert.Equal(1, activationCount);
+
+        waiters.Add(worker.Wait());
+        await Until(async () => 2 == await worker.GetActivationCount());
+        activationCount = await worker.GetActivationCount();
+        Assert.Equal(2, activationCount);
+
+        waiters.Add(worker.Wait());
+        await Until(async () => 3 == await worker.GetActivationCount());
+        activationCount = await worker.GetActivationCount();
+        Assert.Equal(3, activationCount);
+
+        waiters.Add(worker.Wait());
+        await Until(async () => 4 == await worker.GetActivationCount());
+        activationCount = await worker.GetActivationCount();
+        Assert.Equal(4, activationCount);
+
+        var waitingCount = await worker.GetWaitingCount();
+        Assert.Equal(3, waitingCount);
+
+        for (var i = 0; i < MaxLocalWorkers; i++)
+        {
+            waiters.Add(worker.Wait());
+        }
+
+        await Until(async () => MaxLocalWorkers == await worker.GetActivationCount());
+        await Until(async () => MaxLocalWorkers == await worker.GetWaitingCount());
+        activationCount = await worker.GetActivationCount();
+        Assert.Equal(MaxLocalWorkers, activationCount);
+        waitingCount = await worker.GetWaitingCount();
+        Assert.Equal(MaxLocalWorkers, waitingCount);
+
+        // Release all the waiting workers.
+        for (var i = 0; i < waiters.Count; i++)
+        {
+            await worker.Release();
+        }
+
+        // Wait for the waiting tasks to complete.
+        await Task.WhenAll(waiters);
+    }
+
+    private static async Task Until(Func<Task<bool>> condition)
+    {
+        var maxTimeout = 40_000;
+        while (!await condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
+        Assert.True(maxTimeout > 0);
+    }
+}


### PR DESCRIPTION
This implements changing the activation strategy for StatelessWorker in accordance with: https://github.com/dotnet/orleans/issues/7966

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7969)