### PR TITLE
Rename InternalStreamId to QualifiedStreamId and make it public

### DIFF
--- a/src/Orleans.Streaming/Core/StreamSubscriptionManager.cs
+++ b/src/Orleans.Streaming/Core/StreamSubscriptionManager.cs
@@ -20,7 +20,7 @@ namespace Orleans.Streams.Core
         public async Task<StreamSubscription> AddSubscription(string streamProviderName, StreamId streamId, GrainReference grainRef)
         {
             var consumer = grainRef.AsReference<IStreamConsumerExtension>();
-            var internalStreamId = new InternalStreamId(streamProviderName, streamId);
+            var internalStreamId = new QualifiedStreamId(streamProviderName, streamId);
             var subscriptionId = streamPubSub.CreateSubscriptionId(internalStreamId, consumer);
             await streamPubSub.RegisterConsumer(subscriptionId, internalStreamId, consumer, null);
             var newSub = new StreamSubscription(subscriptionId.Guid, streamProviderName, streamId, grainRef.GrainId);
@@ -29,13 +29,13 @@ namespace Orleans.Streams.Core
 
         public async Task RemoveSubscription(string streamProviderName, StreamId streamId, Guid subscriptionId)
         {
-            var internalStreamId = new InternalStreamId(streamProviderName, streamId);
+            var internalStreamId = new QualifiedStreamId(streamProviderName, streamId);
             await streamPubSub.UnregisterConsumer(GuidId.GetGuidId(subscriptionId), internalStreamId);
         }
 
         public Task<IEnumerable<StreamSubscription>> GetSubscriptions(string streamProviderName, StreamId streamId)
         {
-            var internalStreamId = new InternalStreamId(streamProviderName, streamId);
+            var internalStreamId = new QualifiedStreamId(streamProviderName, streamId);
             return streamPubSub.GetAllSubscriptions(internalStreamId).ContinueWith(subs => subs.Result.AsEnumerable());
         }
     }

--- a/src/Orleans.Streaming/Internal/IStreamGrainExtensions.cs
+++ b/src/Orleans.Streaming/Internal/IStreamGrainExtensions.cs
@@ -8,9 +8,9 @@ namespace Orleans.Streams
     // This is the extension interface for stream consumers
     internal interface IStreamConsumerExtension : IGrainExtension
     {
-        Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, InternalStreamId streamId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken);
-        Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, InternalStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken);
-        Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, InternalStreamId streamId, Immutable<IBatchContainer> item, StreamHandshakeToken handshakeToken);
+        Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken);
+        Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken);
+        Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, Immutable<IBatchContainer> item, StreamHandshakeToken handshakeToken);
         Task CompleteStream(GuidId subscriptionId);
         Task ErrorInStream(GuidId subscriptionId, Exception exc);
         Task<StreamHandshakeToken> GetSequenceToken(GuidId subscriptionId);
@@ -20,9 +20,9 @@ namespace Orleans.Streams
     internal interface IStreamProducerExtension : IGrainExtension
     {
         [AlwaysInterleave]
-        Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
+        Task AddSubscriber(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
         [AlwaysInterleave]
-        Task RemoveSubscriber(GuidId subscriptionId, InternalStreamId streamId);
+        Task RemoveSubscriber(GuidId subscriptionId, QualifiedStreamId streamId);
     }
 }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -84,12 +84,12 @@ namespace Orleans.Streams
             return allStreamObservers.TryRemove(subscriptionId, out _);
         }
 
-        public Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, InternalStreamId streamId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+        public Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
         {
             return DeliverMutable(subscriptionId, streamId, item.Value, currentToken, handshakeToken);
         }
 
-        public async Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, InternalStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+        public async Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
         {
             if (logger.IsEnabled(LogLevel.Trace))
             {
@@ -128,7 +128,7 @@ namespace Orleans.Streams
             return default(StreamHandshakeToken);
         }
 
-        public async Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, InternalStreamId streamId, Immutable<IBatchContainer> batch, StreamHandshakeToken handshakeToken)
+        public async Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, Immutable<IBatchContainer> batch, StreamHandshakeToken handshakeToken)
         {
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("DeliverBatch {Batch} for subscription {Subscription}", batch.Value, subscriptionId);
 
@@ -208,7 +208,7 @@ namespace Orleans.Streams
             return Task.FromResult(allStreamObservers.TryGetValue(subscriptionId, out observer) ? observer.GetSequenceToken() : null);
         }
 
-        internal int DiagCountStreamObservers<T>(InternalStreamId streamId)
+        internal int DiagCountStreamObservers<T>(QualifiedStreamId streamId)
         {
             return allStreamObservers.Count(o => o.Value is StreamSubscriptionHandleImpl<T> i && i.SameStreamId(streamId));
         }

--- a/src/Orleans.Streaming/Internal/StreamDirectory.cs
+++ b/src/Orleans.Streaming/Internal/StreamDirectory.cs
@@ -12,9 +12,9 @@ namespace Orleans.Streams
     /// </summary>
     internal class StreamDirectory : IAsyncDisposable
     {
-        private readonly ConcurrentDictionary<InternalStreamId, object> allStreams = new ConcurrentDictionary<InternalStreamId, object>();
+        private readonly ConcurrentDictionary<QualifiedStreamId, object> allStreams = new ConcurrentDictionary<QualifiedStreamId, object>();
 
-        internal IAsyncStream<T> GetOrAddStream<T>(InternalStreamId streamId, Func<IAsyncStream<T>> streamCreator)
+        internal IAsyncStream<T> GetOrAddStream<T>(QualifiedStreamId streamId, Func<IAsyncStream<T>> streamCreator)
         {
             var stream = allStreams.GetOrAdd(streamId, (_, streamCreator) => streamCreator(), streamCreator);
             var streamOfT = stream as IAsyncStream<T>;
@@ -34,8 +34,8 @@ namespace Orleans.Streams
             }
 
             var promises = new List<Task>();
-            List<InternalStreamId> streamIds = GetUsedStreamIds();
-            foreach (InternalStreamId s in streamIds)
+            List<QualifiedStreamId> streamIds = GetUsedStreamIds();
+            foreach (QualifiedStreamId s in streamIds)
             {
                 IStreamControl streamControl = GetStreamControl(s);
                 if (streamControl != null)
@@ -51,14 +51,14 @@ namespace Orleans.Streams
             allStreams.Clear();
         }
 
-        private IStreamControl GetStreamControl(InternalStreamId streamId)
+        private IStreamControl GetStreamControl(QualifiedStreamId streamId)
         {
             object streamObj;
             bool ok = allStreams.TryGetValue(streamId, out streamObj);
             return ok ? streamObj as IStreamControl : null;
         }
 
-        private List<InternalStreamId> GetUsedStreamIds()
+        private List<QualifiedStreamId> GetUsedStreamIds()
         {
             return allStreams.Select(kv => kv.Key).ToList();
         }

--- a/src/Orleans.Streaming/Internal/StreamImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamImpl.cs
@@ -15,7 +15,7 @@ namespace Orleans.Streams
     internal sealed class StreamImpl<T> : IAsyncStream<T>, IStreamControl, IOnDeserialized
     {
         [Id(1)]
-        private readonly InternalStreamId                        streamId;
+        private readonly QualifiedStreamId                        streamId;
 
         [Id(2)]
         private readonly bool                                    isRewindable;
@@ -35,7 +35,7 @@ namespace Orleans.Streams
         [NonSerialized]
         private IRuntimeClient?                                  runtimeClient;
 
-        internal InternalStreamId InternalStreamId { get { return streamId; } }
+        internal QualifiedStreamId InternalStreamId { get { return streamId; } }
         public StreamId StreamId => streamId;
 
         public bool IsRewindable => isRewindable;
@@ -46,7 +46,7 @@ namespace Orleans.Streams
         {
         }
 
-        internal StreamImpl(InternalStreamId streamId, IInternalStreamProvider provider, bool isRewindable, IRuntimeClient runtimeClient)
+        internal StreamImpl(QualifiedStreamId streamId, IInternalStreamProvider provider, bool isRewindable, IRuntimeClient runtimeClient)
         {
             this.streamId = streamId;
             this.provider = provider ?? throw new ArgumentNullException(nameof(provider));

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -231,7 +231,7 @@ namespace Orleans.Streams
                 : this.observer.OnErrorAsync(ex);
         }
 
-        internal bool SameStreamId(InternalStreamId streamId)
+        internal bool SameStreamId(QualifiedStreamId streamId)
         {
             return IsValid && streamImpl.InternalStreamId.Equals(streamId);
         }

--- a/src/Orleans.Streaming/InternalStreamId.cs
+++ b/src/Orleans.Streaming/InternalStreamId.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
     [Immutable]
     [Serializable]
     [GenerateSerializer]
-    internal readonly struct InternalStreamId : IEquatable<InternalStreamId>, IComparable<InternalStreamId>, ISerializable, ISpanFormattable
+    public readonly struct QualifiedStreamId : IEquatable<QualifiedStreamId>, IComparable<QualifiedStreamId>, ISerializable, ISpanFormattable
     {
         [Id(0)]
         public readonly StreamId StreamId;
@@ -15,29 +15,29 @@ namespace Orleans.Runtime
         [Id(1)]
         public readonly string ProviderName;
 
-        public InternalStreamId(string providerName, StreamId streamId)
+        public QualifiedStreamId(string providerName, StreamId streamId)
         {
             ProviderName = providerName;
             StreamId = streamId;
         }
 
-        private InternalStreamId(SerializationInfo info, StreamingContext context)
+        private QualifiedStreamId(SerializationInfo info, StreamingContext context)
         {
             ProviderName = info.GetString("pvn")!;
             StreamId = (StreamId)info.GetValue("sid", typeof(StreamId))!;
         }
 
-        public static implicit operator StreamId(InternalStreamId internalStreamId) => internalStreamId.StreamId;
+        public static implicit operator StreamId(QualifiedStreamId internalStreamId) => internalStreamId.StreamId;
 
-        public bool Equals(InternalStreamId other) => StreamId.Equals(other) && ProviderName.Equals(other.ProviderName);
+        public bool Equals(QualifiedStreamId other) => StreamId.Equals(other) && ProviderName.Equals(other.ProviderName);
 
-        public override bool Equals(object? obj) => obj is InternalStreamId other ? this.Equals(other) : false;
+        public override bool Equals(object? obj) => obj is QualifiedStreamId other ? this.Equals(other) : false;
 
-        public static bool operator ==(InternalStreamId s1, InternalStreamId s2) => s1.Equals(s2);
+        public static bool operator ==(QualifiedStreamId s1, QualifiedStreamId s2) => s1.Equals(s2);
 
-        public static bool operator !=(InternalStreamId s1, InternalStreamId s2) => !s2.Equals(s1);
+        public static bool operator !=(QualifiedStreamId s1, QualifiedStreamId s2) => !s2.Equals(s1);
 
-        public int CompareTo(InternalStreamId other) => StreamId.CompareTo(other.StreamId);
+        public int CompareTo(QualifiedStreamId other) => StreamId.CompareTo(other.StreamId);
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -154,7 +154,7 @@ namespace Orleans.Providers.Streams.Common
 
         public IAsyncStream<T> GetStream<T>(StreamId streamId)
         {
-            var id = new InternalStreamId(Name, streamId);
+            var id = new QualifiedStreamId(Name, streamId);
             return this.runtime.GetStreamDirectory().GetOrAddStream<T>(
                 id, () => new StreamImpl<T>(id, this, IsRewindable, this.runtimeClient));
         }

--- a/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
+++ b/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
@@ -19,7 +19,7 @@ namespace Orleans.Streams
         [Id(1)]
         public GuidId SubscriptionId;
         [Id(2)]
-        public InternalStreamId StreamId;
+        public QualifiedStreamId StreamId;
         [Id(3)]
         public IStreamConsumerExtension StreamConsumer;
         [Id(4)]
@@ -31,7 +31,7 @@ namespace Orleans.Streams
         [Id(7)]
         public string FilterData;
 
-        public StreamConsumerData(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+        public StreamConsumerData(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             SubscriptionId = subscriptionId;
             StreamId = streamId;

--- a/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
@@ -24,7 +24,7 @@ namespace Orleans.Streams
             lastActivityTime = now;
         }
 
-        public StreamConsumerData AddConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+        public StreamConsumerData AddConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData);
             queueData.Add(subscriptionId, consumerData);

--- a/src/Orleans.Streaming/PersistentStreams/StreamEventDeliveryFailureException.cs
+++ b/src/Orleans.Streaming/PersistentStreams/StreamEventDeliveryFailureException.cs
@@ -29,7 +29,7 @@ namespace Orleans.Streams
         /// Initializes a new instance of the <see cref="StreamEventDeliveryFailureException"/> class.
         /// </summary>
         /// <param name="streamId">The stream identifier.</param>
-        internal StreamEventDeliveryFailureException(InternalStreamId streamId)
+        internal StreamEventDeliveryFailureException(QualifiedStreamId streamId)
             : base(string.Format(ErrorStringFormat, streamId.GetNamespace(), streamId.StreamId)) { }
 
         /// <summary>

--- a/src/Orleans.Streaming/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/IStreamProviderRuntime.cs
@@ -65,22 +65,22 @@ namespace Orleans.Streams
 
     internal interface IStreamPubSub // Compare with: IPubSubRendezvousGrain
     {
-        Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
+        Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
+        Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
+        Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
-        Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId);
+        Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId);
 
-        Task<int> ProducerCount(InternalStreamId streamId);
+        Task<int> ProducerCount(QualifiedStreamId streamId);
 
-        Task<int> ConsumerCount(InternalStreamId streamId);
+        Task<int> ConsumerCount(QualifiedStreamId streamId);
 
-        Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer = null);
+        Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer = null);
 
-        GuidId CreateSubscriptionId(InternalStreamId streamId, IStreamConsumerExtension streamConsumer);
+        GuidId CreateSubscriptionId(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer);
 
-        Task<bool> FaultSubscription(InternalStreamId streamId, GuidId subscriptionId);
+        Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId);
     }
 }

--- a/src/Orleans.Streaming/PubSub/FaultedSubscriptionException.cs
+++ b/src/Orleans.Streaming/PubSub/FaultedSubscriptionException.cs
@@ -31,7 +31,7 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="subscriptionId">The subscription identifier.</param>
         /// <param name="streamId">The stream identifier.</param>
-        internal FaultedSubscriptionException(GuidId subscriptionId, InternalStreamId streamId)
+        internal FaultedSubscriptionException(GuidId subscriptionId, QualifiedStreamId streamId)
             : base(string.Format(ErrorStringFormat, subscriptionId.Guid, streamId)) { }
 
         /// <summary>

--- a/src/Orleans.Streaming/PubSub/GrainBasedPubSubRuntime.cs
+++ b/src/Orleans.Streaming/PubSub/GrainBasedPubSubRuntime.cs
@@ -15,60 +15,60 @@ namespace Orleans.Streams
             this.grainFactory = grainFactory;
         }
 
-        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.RegisterProducer(streamId, streamProducer);
         }
 
-        public Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.UnregisterProducer(streamId, streamProducer);
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+        public Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData);
         }
 
-        public Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.UnregisterConsumer(subscriptionId, streamId);
         }
 
-        public Task<int> ProducerCount(InternalStreamId streamId)
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.ProducerCount(streamId);
         }
 
-        public Task<int> ConsumerCount(InternalStreamId streamId)
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.ConsumerCount(streamId);
         }
 
-        public Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer = null)
+        public Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer = null)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             return streamRendezvous.GetAllSubscriptions(streamId, streamConsumer);
         }
 
-        private IPubSubRendezvousGrain GetRendezvousGrain(InternalStreamId streamId)
+        private IPubSubRendezvousGrain GetRendezvousGrain(QualifiedStreamId streamId)
         {
             return grainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
         }
 
-        public GuidId CreateSubscriptionId(InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer)
         {
             Guid subscriptionId = SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid());
             return GuidId.GetGuidId(subscriptionId);
         }
 
-        public async Task<bool> FaultSubscription(InternalStreamId streamId, GuidId subscriptionId)
+        public async Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
         {
             var streamRendezvous = GetRendezvousGrain(streamId);
             await streamRendezvous.FaultSubscription(subscriptionId);

--- a/src/Orleans.Streaming/PubSub/IPubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/IPubSubRendezvousGrain.cs
@@ -7,23 +7,23 @@ namespace Orleans.Streams
 {
     internal interface IPubSubRendezvousGrain : IGrainWithStringKey
     {
-        Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
+        Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer);
+        Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer);
 
-        Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
+        Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData);
 
-        Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId);
+        Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId);
 
-        Task<int> ProducerCount(InternalStreamId streamId);
+        Task<int> ProducerCount(QualifiedStreamId streamId);
 
-        Task<int> ConsumerCount(InternalStreamId streamId);
+        Task<int> ConsumerCount(QualifiedStreamId streamId);
 
-        Task<PubSubSubscriptionState[]> DiagGetConsumers(InternalStreamId streamId);
+        Task<PubSubSubscriptionState[]> DiagGetConsumers(QualifiedStreamId streamId);
 
         Task Validate();
 
-        Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer = null);
+        Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer = null);
 
         Task FaultSubscription(GuidId subscriptionId);
     }

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streams
             this.implicitTable = implicitPubSubTable;
         }
 
-        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             ISet<PubSubSubscriptionState> result = new HashSet<PubSubSubscriptionState>();
             if (!ImplicitStreamSubscriberTable.IsImplicitSubscribeEligibleNameSpace(streamId.GetNamespace())) return Task.FromResult(result);
@@ -37,12 +37,12 @@ namespace Orleans.Streams
             return Task.FromResult(result);
         }
 
-        public Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             return Task.CompletedTask;
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+        public Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             // TODO BPETIT filter data?
             if (!IsImplicitSubscriber(streamConsumer, streamId))
@@ -52,7 +52,7 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             if (!IsImplicitSubscriber(subscriptionId, streamId))
             {
@@ -61,17 +61,17 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public Task<int> ProducerCount(InternalStreamId streamId)
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
         {
             return Task.FromResult(0);
         }
 
-        public Task<int> ConsumerCount(InternalStreamId streamId)
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
         {
             return Task.FromResult(0);
         }
 
-        public Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer = null)
+        public Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer = null)
         {
             if (!ImplicitStreamSubscriberTable.IsImplicitSubscribeEligibleNameSpace(streamId.GetNamespace()))
                 return Task.FromResult(new List<StreamSubscription>());
@@ -96,17 +96,17 @@ namespace Orleans.Streams
             }   
         }
 
-        internal bool IsImplicitSubscriber(IAddressable addressable, InternalStreamId streamId)
+        internal bool IsImplicitSubscriber(IAddressable addressable, QualifiedStreamId streamId)
         {
             return implicitTable.IsImplicitSubscriber(addressable.GetGrainId(), streamId);
         }
 
-        internal bool IsImplicitSubscriber(GuidId subscriptionId, InternalStreamId streamId)
+        internal bool IsImplicitSubscriber(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             return SubscriptionMarker.IsImplicitSubscription(subscriptionId.Guid);
         }
 
-        public GuidId CreateSubscriptionId(InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer)
         {
             GrainId grainId = streamConsumer.GetGrainId();
             Guid subscriptionGuid;
@@ -117,7 +117,7 @@ namespace Orleans.Streams
             return GuidId.GetGuidId(subscriptionGuid);
         }
 
-        public Task<bool> FaultSubscription(InternalStreamId streamId, GuidId subscriptionId)
+        public Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
         {
             return Task.FromResult(false);
         }

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
@@ -107,7 +107,7 @@ namespace Orleans.Streams
         /// <returns>A set of references to implicitly subscribed grains. They are expected to support the streaming consumer extension.</returns>
         /// <exception cref="System.ArgumentException">The stream ID doesn't have an associated namespace.</exception>
         /// <exception cref="System.InvalidOperationException">Internal invariant violation.</exception>
-        internal Dictionary<Guid, IStreamConsumerExtension> GetImplicitSubscribers(InternalStreamId streamId, IInternalGrainFactory grainFactory)
+        internal Dictionary<Guid, IStreamConsumerExtension> GetImplicitSubscribers(QualifiedStreamId streamId, IInternalGrainFactory grainFactory)
         {
             var streamNamespace = streamId.GetNamespace();
             if (!IsImplicitSubscribeEligibleNameSpace(streamNamespace))
@@ -149,7 +149,7 @@ namespace Orleans.Streams
         /// <param name="grainId">The grain identifier.</param>
         /// <param name="streamId">The stream identifier.</param>
         /// <returns>true if the grain id describes an implicit subscriber of the stream described by the stream id.</returns>
-        internal bool IsImplicitSubscriber(GrainId grainId, InternalStreamId streamId)
+        internal bool IsImplicitSubscriber(GrainId grainId, QualifiedStreamId streamId)
         {
             var streamNamespace = streamId.GetNamespace();
             if (!IsImplicitSubscribeEligibleNameSpace(streamNamespace))
@@ -173,7 +173,7 @@ namespace Orleans.Streams
         /// <param name="streamId"></param>
         /// <param name="subscriptionId"></param>
         /// <returns></returns>
-        internal bool TryGetImplicitSubscriptionGuid(GrainId grainId, InternalStreamId streamId, out Guid subscriptionId)
+        internal bool TryGetImplicitSubscriptionGuid(GrainId grainId, QualifiedStreamId streamId, out Guid subscriptionId)
         {
             if (!IsImplicitSubscriber(grainId, streamId))
             {
@@ -188,7 +188,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Create a subscriptionId that is unique per grainId, grainType, namespace combination.
         /// </summary>
-        private Guid MakeSubscriptionGuid(GrainType grainType, InternalStreamId streamId)
+        private Guid MakeSubscriptionGuid(GrainType grainType, QualifiedStreamId streamId)
         {
             Span<byte> bytes = stackalloc byte[16];
             BinaryPrimitives.WriteUInt32LittleEndian(bytes, grainType.GetUniformHashCode());
@@ -229,7 +229,7 @@ namespace Orleans.Streams
         /// <returns></returns>
         private IStreamConsumerExtension MakeConsumerReference(
             IInternalGrainFactory grainFactory,
-            InternalStreamId streamId,
+            QualifiedStreamId streamId,
             StreamSubscriber streamSubscriber)
         {
             var grainId = streamSubscriber.GetGrainId(streamId);
@@ -268,7 +268,7 @@ namespace Orleans.Streams
 
             public override int GetHashCode() => GrainType.GetHashCode();
 
-            internal GrainId GetGrainId(InternalStreamId streamId)
+            internal GrainId GetGrainId(QualifiedStreamId streamId)
             {
                 var grainKeyId = this.streamIdMapper.GetGrainKeyId(this.GrainBindings, streamId);
                 return GrainId.Create(this.GrainType, grainKeyId);

--- a/src/Orleans.Streaming/PubSub/PubSubPublisherState.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubPublisherState.cs
@@ -14,7 +14,7 @@ namespace Orleans.Streams
         // Implement ISerializable if changing any of them to readonly
         [JsonProperty]
         [Id(1)]
-        public InternalStreamId Stream;
+        public QualifiedStreamId Stream;
         [JsonProperty]
         [Id(2)]
         public GrainReference producerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
@@ -24,7 +24,7 @@ namespace Orleans.Streams
 
         // This constructor has to be public for JSonSerialization to work!
         // Implement ISerializable if changing it to non-public
-        public PubSubPublisherState(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public PubSubPublisherState(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             Stream = streamId;
             producerReference = streamProducer as GrainReference;
@@ -41,7 +41,7 @@ namespace Orleans.Streams
             // Note: PubSubPublisherState is a struct, so 'other' can never be null.
             return Equals(other.Stream, other.Producer);
         }
-        public bool Equals(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public bool Equals(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             if (Stream == default) return false;
             if (ReferenceEquals(null, Producer)) return false;

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -92,7 +92,7 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             StreamInstruments.PubSubProducersAdded.Add(1);
 
@@ -120,7 +120,7 @@ namespace Orleans.Streams
             return State.Consumers.Where(c => !c.IsFaulted).ToSet();
         }
 
-        public async Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public async Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             StreamInstruments.PubSubProducersRemoved.Add(1);
             try
@@ -158,7 +158,7 @@ namespace Orleans.Streams
 
         public async Task RegisterConsumer(
             GuidId subscriptionId,
-            InternalStreamId streamId,
+            QualifiedStreamId streamId,
             IStreamConsumerExtension streamConsumer,
             string filterData)
         {
@@ -263,7 +263,7 @@ namespace Orleans.Streams
             State.Producers.Remove(producer);
         }
 
-        public async Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)
+        public async Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             StreamInstruments.PubSubConsumersRemoved.Add(1);
 
@@ -303,22 +303,22 @@ namespace Orleans.Streams
             }
         }
 
-        public Task<int> ProducerCount(InternalStreamId streamId)
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
         {
             return Task.FromResult(State.Producers.Count);
         }
 
-        public Task<int> ConsumerCount(InternalStreamId streamId)
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
         {
             return Task.FromResult(GetConsumersForStream(streamId).Length);
         }
 
-        public Task<PubSubSubscriptionState[]> DiagGetConsumers(InternalStreamId streamId)
+        public Task<PubSubSubscriptionState[]> DiagGetConsumers(QualifiedStreamId streamId)
         {
             return Task.FromResult(GetConsumersForStream(streamId));
         }
 
-        private PubSubSubscriptionState[] GetConsumersForStream(InternalStreamId streamId)
+        private PubSubSubscriptionState[] GetConsumersForStream(QualifiedStreamId streamId)
         {
             return State.Consumers.Where(c => !c.IsFaulted && c.Stream.Equals(streamId)).ToArray();
         }
@@ -374,7 +374,7 @@ namespace Orleans.Streams
             }
         }
 
-        public Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer)
         {
             var grainRef = streamConsumer as GrainReference;
             if (grainRef != null)
@@ -429,7 +429,7 @@ namespace Orleans.Streams
             }
         }
 
-        private async Task NotifyProducersOfRemovedSubscription(GuidId subscriptionId, InternalStreamId streamId)
+        private async Task NotifyProducersOfRemovedSubscription(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             int numProducersBeforeNotify = State.Producers.Count;
             if (numProducersBeforeNotify > 0)

--- a/src/Orleans.Streaming/PubSub/PubSubSubscriptionState.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubSubscriptionState.cs
@@ -24,7 +24,7 @@ namespace Orleans.Streams
 
         [JsonProperty]
         [Id(2)]
-        public InternalStreamId Stream;
+        public QualifiedStreamId Stream;
 
         [JsonProperty]
         [Id(3)]
@@ -48,7 +48,7 @@ namespace Orleans.Streams
         // Implement ISerializable if changing it to non-public
         public PubSubSubscriptionState(
             GuidId subscriptionId,
-            InternalStreamId streamId,
+            QualifiedStreamId streamId,
             IStreamConsumerExtension streamConsumer)
         {
             SubscriptionId = subscriptionId;

--- a/src/Orleans.Streaming/PubSub/StreamPubSubImpl.cs
+++ b/src/Orleans.Streaming/PubSub/StreamPubSubImpl.cs
@@ -28,7 +28,7 @@ namespace Orleans.Streams
             this.implicitPubSub = implicitPubSub;
         }
 
-        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             ISet<PubSubSubscriptionState> explicitRes = await explicitPubSub.RegisterProducer(streamId, streamProducer);
             ISet<PubSubSubscriptionState> implicitRes = await implicitPubSub.RegisterProducer(streamId, streamProducer);
@@ -36,36 +36,36 @@ namespace Orleans.Streams
             return explicitRes;
         }
 
-        public Task UnregisterProducer(InternalStreamId streamId, IStreamProducerExtension streamProducer)
+        public Task UnregisterProducer(QualifiedStreamId streamId, IStreamProducerExtension streamProducer)
         {
             return explicitPubSub.UnregisterProducer(streamId, streamProducer);
         }
 
-        public Task RegisterConsumer(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+        public Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             return implicitPubSub.IsImplicitSubscriber(streamConsumer, streamId)
                 ? implicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData)
                 : explicitPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData);
         }
 
-        public Task UnregisterConsumer(GuidId subscriptionId, InternalStreamId streamId)
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
             return implicitPubSub.IsImplicitSubscriber(subscriptionId, streamId)
                 ? implicitPubSub.UnregisterConsumer(subscriptionId, streamId)
                 : explicitPubSub.UnregisterConsumer(subscriptionId, streamId);
         }
 
-        public Task<int> ProducerCount(InternalStreamId streamId)
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
         {
             return explicitPubSub.ProducerCount(streamId); 
         }
 
-        public Task<int> ConsumerCount(InternalStreamId streamId)
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
         {
             return explicitPubSub.ConsumerCount(streamId); 
         }
 
-        public async Task<List<StreamSubscription>> GetAllSubscriptions(InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public async Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer)
         {
             if (streamConsumer != null)
             {
@@ -81,14 +81,14 @@ namespace Orleans.Streams
             }
         }
 
-        public GuidId CreateSubscriptionId(InternalStreamId streamId, IStreamConsumerExtension streamConsumer)
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer)
         {
             return implicitPubSub.IsImplicitSubscriber(streamConsumer, streamId)
                ? implicitPubSub.CreateSubscriptionId(streamId, streamConsumer)
                : explicitPubSub.CreateSubscriptionId(streamId, streamConsumer);
         }
 
-        public Task<bool> FaultSubscription(InternalStreamId streamId, GuidId subscriptionId)
+        public Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
         {
             return implicitPubSub.IsImplicitSubscriber(subscriptionId, streamId)
                 ? implicitPubSub.FaultSubscription(streamId, subscriptionId)

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -246,7 +246,7 @@ namespace UnitTests.Grains
             var (myExtension, myExtensionReference) = this.streamProviderRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
                 () => new StreamConsumerExtension(streamProviderRuntime));
             string extKey = providerName + "_" + Encoding.UTF8.GetString(State.Stream.StreamId.Namespace.ToArray());
-            var id = new InternalStreamId(providerName, streamId);
+            var id = new QualifiedStreamId(providerName, streamId);
             IPubSubRendezvousGrain pubsub = GrainFactory.GetGrain<IPubSubRendezvousGrain>(id.ToString());
             GuidId subscriptionId = GuidId.GetNewGuidId();
             await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference, null);

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
             var (myExtension, myExtensionReference) = this.streamProviderRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
                 () => new StreamConsumerExtension(streamProviderRuntime));
 
-            var id = new InternalStreamId(providerName, streamId);
+            var id = new QualifiedStreamId(providerName, streamId);
             IPubSubRendezvousGrain pubsub = GrainFactory.GetGrain<IPubSubRendezvousGrain>(id.ToString());
             GuidId subscriptionId = GuidId.GetNewGuidId();
             await pubsub.RegisterConsumer(subscriptionId, ((StreamImpl<int>)State.Stream).InternalStreamId, myExtensionReference, null);

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -43,7 +43,7 @@ namespace UnitTests.StreamingTests
         public async Task RegisterConsumerFaultTest()
         {
             this.fixture.Logger.LogInformation("************************ RegisterConsumerFaultTest *********************************");
-            var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
+            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(nameof(PubSubRendezvousGrain));
 
@@ -69,7 +69,7 @@ namespace UnitTests.StreamingTests
         public async Task UnregisterConsumerFaultTest()
         {
             this.fixture.Logger.LogInformation("************************ UnregisterConsumerFaultTest *********************************");
-            var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
+            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(nameof(PubSubRendezvousGrain));
 
@@ -115,7 +115,7 @@ namespace UnitTests.StreamingTests
         public async Task RegisterProducerFaultTest()
         {
             this.fixture.Logger.LogInformation("************************ RegisterProducerFaultTest *********************************");
-            var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
+            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(nameof(PubSubRendezvousGrain));
 
@@ -145,7 +145,7 @@ namespace UnitTests.StreamingTests
         public async Task UnregisterProducerFaultTest()
         {
             this.fixture.Logger.LogInformation("************************ UnregisterProducerFaultTest *********************************");
-            var streamId = new InternalStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
+            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("StreamNamespace", Guid.NewGuid()));
             var pubSubGrain = this.fixture.GrainFactory.GetGrain<IPubSubRendezvousGrain>(streamId.ToString());
             var faultGrain = this.fixture.GrainFactory.GetGrain<IStorageFaultGrain>(nameof(PubSubRendezvousGrain));
 
@@ -194,12 +194,12 @@ namespace UnitTests.StreamingTests
                 id = Guid.NewGuid();
             }
 
-            public Task AddSubscriber(GuidId subscriptionId, InternalStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
+            public Task AddSubscriber(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
             {
                 return Task.CompletedTask;
             }
 
-            public Task RemoveSubscriber(GuidId subscriptionId, InternalStreamId streamId)
+            public Task RemoveSubscriber(GuidId subscriptionId, QualifiedStreamId streamId)
             {
                 return Task.CompletedTask;
             }

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -491,7 +491,7 @@ namespace UnitTests.StreamingTests
             if (providerName == SMS_STREAM_PROVIDER_NAME)
             {
                 var streamId = StreamId.Create(StreamTestsConstants.DefaultStreamNamespace, streamIdGuid);
-                var actualCount = await StreamTestUtils.GetStreamPubSub(this.client).ProducerCount(new InternalStreamId(providerName, streamId));
+                var actualCount = await StreamTestUtils.GetStreamPubSub(this.client).ProducerCount(new QualifiedStreamId(providerName, streamId));
                 logger.LogInformation(
                     "StreamingTestRunner.AssertProducerCount: expected={ExpectedCount} actual (SMSStreamRendezvousGrain.ProducerCount)={ActualCount} streamId={StreamId}",
                     expectedCount,
@@ -503,7 +503,7 @@ namespace UnitTests.StreamingTests
 
         private Task ValidatePubSub(StreamId streamId, string providerName)
         {
-            var intStreamId = new InternalStreamId(providerName, streamId);
+            var intStreamId = new QualifiedStreamId(providerName, streamId);
             var rendez = this.client.GetGrain<IPubSubRendezvousGrain>(intStreamId.ToString());
             return rendez.Validate();
         }

--- a/test/TesterInternal/StreamingTests/StreamTestUtils.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestUtils.cs
@@ -44,7 +44,7 @@ namespace UnitTests.StreamingTests
         internal static async Task CheckPubSubCounts(IInternalClusterClient client, ITestOutputHelper output, string when, int expectedPublisherCount, int expectedConsumerCount, Guid streamIdGuid, string streamProviderName, string streamNamespace)
         {
             var pubSub = GetStreamPubSub(client);
-            var streamId = new InternalStreamId(streamProviderName, StreamId.Create(streamNamespace, streamIdGuid));
+            var streamId = new QualifiedStreamId(streamProviderName, StreamId.Create(streamNamespace, streamIdGuid));
             var totalWait = TimeSpan.Zero;
 
             int consumerCount;


### PR DESCRIPTION
Right now, `InternalStreamId` is internal only. Making it public will help pluggability.

`QualifiedStreamId` is also a better name for this struct.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7971)