### PR TITLE
Fix compilation on C# 11 (`scoped` refs) & migrate to .NET 7.0

### DIFF
--- a/.azure/pipelines/pr.yaml
+++ b/.azure/pipelines/pr.yaml
@@ -14,7 +14,7 @@ parameters:
     displayName: Frameworks
     type: object
     default:
-    - net6.0
+    - net7.0
   - name: tests_categories
     displayName: Test categories
     type: object
@@ -24,7 +24,7 @@ parameters:
     - Functional
 
 variables:
-  build_flags: ' /m /v:m' 
+  build_flags: ' /m /v:m'
   solution: 'Orleans.sln'
 
 jobs:
@@ -68,4 +68,3 @@ jobs:
           testRunTitle: ${{category}} on ${{framework}}
           arguments: '--no-build --framework ${{framework}} --configuration "${{parameters.build_configuration}}" --filter Category=${{category}} -- -parallel none -noshadow'
 
-  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Build
       run: dotnet build
   test-redis:
@@ -43,6 +45,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -70,6 +74,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -92,7 +98,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -119,7 +127,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -144,7 +154,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&Category=${{ matrix.suite }}" --framework ${{ matrix.framework }} --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -168,7 +180,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -192,7 +206,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -217,7 +233,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v1
+      with:
+        include-prerelease: true
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Build
       run: dotnet build
   test-redis:
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -92,7 +92,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -119,7 +119,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&Category=${{ matrix.suite }}" --framework ${{ matrix.framework }} --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -168,7 +168,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -192,7 +192,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -217,7 +217,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     strategy:
       matrix:
         suite: ["BVT", "SlowBVT", "Functional"]
-        framework: ["netcoreapp3.1", "net5.0", "net6.0"]
+        framework: ["net7.0"]
         provider: ["AzureStorage"]
     services:
       azurite:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
         dotnet-version: '5.0.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
+      with:
+        include-prerelease: true
     - name: Build
       run: dotnet build src
     - name: Publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,25 +12,25 @@ jobs:
         repository: 'dotnet/orleans-docs'
         ref: ${{ github.event.client_payload.ref }}
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '5.0.x'
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
     - name: Build
       run: dotnet build src
     - name: Publish
       run: |
         cd _site
-        
+
         $remote_repo="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$($env:GITHUB_REPOSITORY).git"
         $remote_branch="gh-pages"
-        
+
         git init
         git checkout -b scratch
         git config user.name "$($env:GITHUB_ACTOR)"
         git config user.email "$($env:GITHUB_ACTOR)@users.noreply.github.com"
         git add .
-        
+
         git commit -m "GitHub Action - Automated build"
         git push --force $remote_repo scratch:$remote_branch

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <PrivateRepositoryUrl>$(RepositoryUrl)</PrivateRepositoryUrl>
     <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <Features>strict</Features>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -59,8 +59,8 @@
     <SystemMemoryDataVersion>1.0.1</SystemMemoryDataVersion>
 
     <!-- Microsoft packages -->
-    <MicrosoftBuildVersion>17.2.0</MicrosoftBuildVersion>
-    <MicrosoftCodeAnalysisVersion>4.2.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftBuildVersion>17.3.1</MicrosoftBuildVersion>
+    <MicrosoftCodeAnalysisVersion>4.3.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,8 +13,8 @@
   <PropertyGroup Condition=" '$(OrleansBuildTimeCodeGen)' == 'msbuild' ">
     <DotNetHost Condition="'$(DotNetHost)' == ''">dotnet</DotNetHost>
     <Asm>Orleans.CodeGenerator.MSBuild.Bootstrap</Asm>
-    <OrleansCodeGenCoreAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net6.0/$(Asm).dll</OrleansCodeGenCoreAssembly>
-    <OrleansCodeGenTasksAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net6.0/Orleans.CodeGenerator.MSBuild.Tasks.dll</OrleansCodeGenTasksAssembly>
+    <OrleansCodeGenCoreAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net7.0/$(Asm).dll</OrleansCodeGenCoreAssembly>
+    <OrleansCodeGenTasksAssembly>$(MSBuildThisFileDirectory)src/BootstrapBuild/$(Asm)/bin/$(Configuration)/publish/net7.0/Orleans.CodeGenerator.MSBuild.Tasks.dll</OrleansCodeGenTasksAssembly>
     <OrleansBootstrapBuildProject>$(MSBuildThisFileDirectory)src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj</OrleansBootstrapBuildProject>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
       <Project>{CB36EF45-6E90-443F-AEE4-394677068147}</Project>
       <Name>Orleans.CodeGenerator.MSBuild.Bootstrap</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <AssetTargetFallback>net6.0</AssetTargetFallback>
+      <AssetTargetFallback>net7.0</AssetTargetFallback>
       <Visible>false</Visible>
       <!-- Workaround. See: https://github.com/dotnet/sdk/issues/939#issuecomment-284641613 -->
       <!-- This causes the 'Dependency' node in VS to show a warning icon. See https://github.com/dotnet/project-system/issues/2928 -->

--- a/distributed-tests.yml
+++ b/distributed-tests.yml
@@ -2,7 +2,7 @@ variables:
   clusterId: '{{ "now" | date: "%s" }}'
   serviceId: '{{ "now" | date: "%s" }}'
   secretSource: KeyVault
-  framework: net5.0
+  framework: net7.0
 
 jobs:
   server:
@@ -10,23 +10,23 @@ jobs:
       localFolder: Artifacts/DistributedTests/DistributedTests.Server/{{framework}}
     executable: DistributedTests.Server.exe
     readyStateText: Orleans Silo started.
-    framework: net5.0
+    framework: net7.0
     arguments: "{{configurator}} --clusterId {{clusterId}} --serviceId {{serviceId}} --secretSource {{secretSource}} {{configuratorOptions}}"
-    onConfigure: 
-      - if (job.endpoints.Count > 0) { 
-          job.endpoints.RemoveRange(job.variables.instances, job.endpoints.Count - job.variables.instances); 
+    onConfigure:
+      - if (job.endpoints.Count > 0) {
+          job.endpoints.RemoveRange(job.variables.instances, job.endpoints.Count - job.variables.instances);
         }
   client:
     source:
       localFolder: Artifacts/DistributedTests/DistributedTests.Client/{{framework}}
     executable: DistributedTests.Client.exe
     waitForExit: true
-    framework: net5.0
+    framework: net7.0
     arguments: "{{command}} --clusterId {{clusterId}} --serviceId {{serviceId}} --secretSource {{secretSource}} {{commandOptions}}"
-    onConfigure: 
-      - if (job.endpoints.Count > 0) { 
+    onConfigure:
+      - if (job.endpoints.Count > 0) {
           job.endpoints.Reverse();
-          job.endpoints.RemoveRange(job.variables.instances, job.endpoints.Count - job.variables.instances); 
+          job.endpoints.RemoveRange(job.variables.instances, job.endpoints.Count - job.variables.instances);
         }
 
 scenarios:
@@ -61,7 +61,7 @@ scenarios:
     client:
       job: client
       variables:
-        command: counter 
+        command: counter
         instances: 1
         commandOptions: "requests errors"
   reliability:
@@ -129,15 +129,15 @@ profiles:
   local:
     variables:
       secretSource: File
-    jobs: 
+    jobs:
       server:
-        endpoints: 
+        endpoints:
           - http://localhost:5010
         variables:
           instances: 1
       client:
-        endpoints: 
+        endpoints:
           - http://localhost:5010
       chaosagent:
-        endpoints: 
+        endpoints:
           - http://localhost:5010

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.400"
+    "version": "7.0.100-rc.1.22431.12"
   }
 }

--- a/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.CodeGenerator.MSBuild.Bootstrap/Orleans.CodeGenerator.MSBuild.Bootstrap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build;PostBuildPublish">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <CompatibilityTargetFrameworks>netstandard2.0</CompatibilityTargetFrameworks>
-    <DefaultTargetFrameworks>net6.0</DefaultTargetFrameworks>
+    <DefaultTargetFrameworks>net7.0</DefaultTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.CodeGenerator.MSBuild</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <PackageDescription>Code generator for projects using Orleans.Serialization with MSBuild</PackageDescription>
     <OutputType>Exe</OutputType>

--- a/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -18,7 +18,7 @@
 
     <!-- Specify the assembly containing the code generator. -->
     <Orleans_GeneratorAssembly Condition="'$(OrleansCodeGenCoreAssembly)' != ''">$(OrleansCodeGenCoreAssembly)</Orleans_GeneratorAssembly>
-    <Orleans_GeneratorAssembly Condition="'$(Orleans_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net6.0\Orleans.CodeGenerator.MSBuild.dll</Orleans_GeneratorAssembly>
+    <Orleans_GeneratorAssembly Condition="'$(Orleans_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net7.0\Orleans.CodeGenerator.MSBuild.dll</Orleans_GeneratorAssembly>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -358,7 +358,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
             }
 
             return MethodDeclaration(returnType, SerializeMethodName)
@@ -512,7 +512,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
             }
 
             return MethodDeclaration(returnType, DeserializeMethodName)

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -687,7 +687,7 @@ namespace Orleans.Serialization.Buffers
         /// <summary>
         /// Reads the specified number of bytes into the provided writer.
         /// </summary>
-        public void ReadBytes<TBufferWriter>(ref TBufferWriter writer, int count) where TBufferWriter : IBufferWriter<byte>
+        public void ReadBytes<TBufferWriter>(scoped ref TBufferWriter writer, int count) where TBufferWriter : IBufferWriter<byte>
         {
             int chunkSize;
             for (var remaining = count; remaining > 0; remaining -= chunkSize)

--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -305,7 +305,7 @@ namespace Orleans.Serialization.Buffers
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(ReadOnlySpan<byte> value)
+        public void Write(scoped ReadOnlySpan<byte> value)
         {
             // Fast path, try copying to the current buffer.
             if (value.Length <= _currentSpan.Length - _bufferPos)
@@ -315,12 +315,12 @@ namespace Orleans.Serialization.Buffers
             }
             else
             {
-                WriteMultiSegment(in value);
+                WriteMultiSegment(value);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void WriteMultiSegment(in ReadOnlySpan<byte> source)
+        private void WriteMultiSegment(scoped ReadOnlySpan<byte> source)
         {
             var input = source;
             while (true)

--- a/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
@@ -127,7 +127,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="reader">The reader.</param>
         /// <param name="field">The field header.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ReadFieldHeader<TInput>(ref this Reader<TInput> reader, ref Field field)
+        public static void ReadFieldHeader<TInput>(ref this Reader<TInput> reader, scoped ref Field field)
         {
             var tag = reader.ReadByte();
 
@@ -177,7 +177,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="reader">The reader.</param>
         /// <param name="field">The field.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static void ReadExtendedFieldHeader<TInput>(ref this Reader<TInput> reader, ref Field field)
+        internal static void ReadExtendedFieldHeader<TInput>(ref this Reader<TInput> reader, scoped ref Field field)
         {
             // If all of the field id delta bits are set and the field isn't an extended wiretype field, read the extended field id delta
             var notExtended = (field.Tag & (byte)WireType.Extended) != (byte)WireType.Extended;
@@ -287,7 +287,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ReadFieldHeaderForAnalysisSlow<TInput>(ref this Reader<TInput> reader, ref Field field, ref string type)
+        private static void ReadFieldHeaderForAnalysisSlow<TInput>(ref this Reader<TInput> reader, scoped ref Field field, scoped ref string type)
         {
             var notExtended = (field.Tag & (byte)WireType.Extended) != (byte)WireType.Extended;
             if ((field.Tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask && notExtended)

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -156,7 +156,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <param name="id">The identifier.</param>
         /// <returns>The field id, if a new field header was written, otherwise <c>-1</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadHeader<TInput>(ref Reader<TInput> reader, ref Field header, int id)
+        public static int ReadHeader<TInput>(ref Reader<TInput> reader, scoped ref Field header, int id)
         {
             reader.ReadFieldHeader(ref header);
             if (header.IsEndBaseOrEndObject)
@@ -176,7 +176,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <param name="id">The identifier.</param>
         /// <returns>The field id, if a new field header was written, otherwise <c>-1</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadHeaderExpectingEndBaseOrEndObject<TInput>(ref Reader<TInput> reader, ref Field header, int id)
+        public static int ReadHeaderExpectingEndBaseOrEndObject<TInput>(ref Reader<TInput> reader, scoped ref Field header, int id)
         {
             reader.ReadFieldHeader(ref header);
             if (header.IsEndBaseOrEndObject)

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -186,9 +186,9 @@ namespace Orleans.Serialization
                 _provider = provider;
             }
 
-            public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ref TField value) where TBufferWriter : IBufferWriter<byte> => Value.Serialize(ref writer, ref value);
+            public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, scoped ref TField value) where TBufferWriter : IBufferWriter<byte> => Value.Serialize(ref writer, ref value);
 
-            public void Deserialize<TInput>(ref Reader<TInput> reader, ref TField value) => Value.Deserialize(ref reader, ref value);
+            public void Deserialize<TInput>(ref Reader<TInput> reader, scoped ref TField value) => Value.Deserialize(ref reader, ref value);
 
             public IValueSerializer<TField> Value => _serializer ??= _provider.GetValueSerializer<TField>();
         }

--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -17,10 +17,6 @@
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingVersion)" NoWarn="NU5104" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0' and '$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.Abstractions\Orleans.Serialization.Abstractions.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Analyzers\Orleans.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -880,7 +880,7 @@ namespace Orleans.Serialization
         /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
-        public void Serialize<TBufferWriter>(ref T value, ref Writer<TBufferWriter> destination) where TBufferWriter : IBufferWriter<byte>
+        public void Serialize<TBufferWriter>(scoped ref T value, ref Writer<TBufferWriter> destination) where TBufferWriter : IBufferWriter<byte>
         {
             _codec.Serialize(ref destination, ref value);
             destination.WriteEndObject();
@@ -893,7 +893,7 @@ namespace Orleans.Serialization
         /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
-        public void Serialize<TBufferWriter>(ref T value, TBufferWriter destination) where TBufferWriter : IBufferWriter<byte>
+        public void Serialize<TBufferWriter>(scoped ref T value, TBufferWriter destination) where TBufferWriter : IBufferWriter<byte>
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
@@ -911,7 +911,7 @@ namespace Orleans.Serialization
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <param name="session">The serializer session.</param>
-        public void Serialize<TBufferWriter>(T value, TBufferWriter destination, SerializerSession session) where TBufferWriter : IBufferWriter<byte>
+        public void Serialize<TBufferWriter>(scoped ref T value, TBufferWriter destination, SerializerSession session) where TBufferWriter : IBufferWriter<byte>
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
@@ -926,7 +926,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="value">The value to serialize.</param>
         /// <returns>A byte array containing the serialized value.</returns>
-        public byte[] SerializeToArray(ref T value)
+        public byte[] SerializeToArray(scoped ref T value)
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.CreatePooled(session);
@@ -949,7 +949,7 @@ namespace Orleans.Serialization
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
-        public void Serialize(ref T value, ArraySegment<byte> destination)
+        public void Serialize(scoped ref T value, ArraySegment<byte> destination)
         {
             var destinationSpan = destination.AsSpan();
             Serialize(ref value, ref destinationSpan);
@@ -961,7 +961,7 @@ namespace Orleans.Serialization
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
-        public void Serialize(ref T value, ref Memory<byte> destination)
+        public void Serialize(scoped ref T value, ref Memory<byte> destination)
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
@@ -978,7 +978,7 @@ namespace Orleans.Serialization
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <param name="session">The serializer session.</param>
         /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
-        public void Serialize(ref T value, ref Memory<byte> destination, SerializerSession session)
+        public void Serialize(scoped ref T value, ref Memory<byte> destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
@@ -993,7 +993,7 @@ namespace Orleans.Serialization
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
-        public void Serialize(ref T value, ref Span<byte> destination)
+        public void Serialize(scoped ref T value, ref Span<byte> destination)
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
@@ -1010,7 +1010,7 @@ namespace Orleans.Serialization
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <param name="session">The serializer session.</param>
         /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
-        public void Serialize(ref T value, ref Span<byte> destination, SerializerSession session)
+        public void Serialize(scoped ref T value, ref Span<byte> destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
@@ -1025,7 +1025,7 @@ namespace Orleans.Serialization
         /// <param name="value">The value to serialize.</param>
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <returns>The length of the serialized data.</returns>
-        public int Serialize(ref T value, byte[] destination)
+        public int Serialize(scoped ref T value, byte[] destination)
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
@@ -1042,7 +1042,7 @@ namespace Orleans.Serialization
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <param name="session">The serializer session.</param>
         /// <returns>The length of the serialized data.</returns>
-        public int Serialize(ref T value, byte[] destination, SerializerSession session)
+        public int Serialize(scoped ref T value, byte[] destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
             _codec.Serialize(ref writer, ref value);
@@ -1058,7 +1058,7 @@ namespace Orleans.Serialization
         /// <param name="destination">The destination where serialized data will be written.</param>
         /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
         /// <remarks>The destination stream will not be flushed by this method.</remarks>
-        public void Serialize(ref T value, Stream destination, int sizeHint = 0)
+        public void Serialize(scoped ref T value, Stream destination, int sizeHint = 0)
         {
             if (destination is MemoryStream memoryStream)
             {
@@ -1094,7 +1094,7 @@ namespace Orleans.Serialization
         /// <param name="session">The serializer session.</param>
         /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
         /// <remarks>The destination stream will not be flushed by this method.</remarks>
-        public void Serialize(ref T value, Stream destination, SerializerSession session, int sizeHint = 0)
+        public void Serialize(scoped ref T value, Stream destination, SerializerSession session, int sizeHint = 0)
         {
             if (destination is MemoryStream memoryStream)
             {
@@ -1127,7 +1127,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize<TInput>(ref Reader<TInput> source, ref T result)
+        public void Deserialize<TInput>(ref Reader<TInput> source, scoped ref T result)
         {
             _codec.Deserialize(ref source, ref result);
         }
@@ -1138,7 +1138,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(Stream source, ref T result)
+        public void Deserialize(Stream source, scoped ref T result)
         {
             using var session = _sessionPool.GetSession();
             var reader = Reader.Create(source, session);
@@ -1152,7 +1152,7 @@ namespace Orleans.Serialization
         /// <param name="result">The deserialized value.</param>
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(Stream source, ref T result, SerializerSession session)
+        public void Deserialize(Stream source, scoped ref T result, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
             _codec.Deserialize(ref reader, ref result);
@@ -1164,42 +1164,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlySequence<byte> source, ref T result)
-        {
-            using var session = _sessionPool.GetSession();
-            var reader = Reader.Create(source, session);
-            _codec.Deserialize(ref reader, ref result);
-        }
-
-        /// <summary>
-        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
-        /// </summary>
-        /// <param name="source">The source buffer.</param>
-        /// <param name="result">The deserialized value.</param>
-        /// <param name="session">The serializer session.</param>
-        /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlySequence<byte> source, ref T result, SerializerSession session)
-        {
-            var reader = Reader.Create(source, session);
-            _codec.Deserialize(ref reader, ref result);
-        }
-
-        /// <summary>
-        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
-        /// </summary>
-        /// <param name="source">The source buffer.</param>
-        /// <param name="result">The deserialized value.</param>
-        /// <param name="session">The serializer session.</param>
-        /// <returns>The deserialized value.</returns>
-        public void Deserialize(ArraySegment<byte> source, ref T result, SerializerSession session) => Deserialize(source.AsSpan(), ref result, session);
-
-        /// <summary>
-        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
-        /// </summary>
-        /// <param name="source">The source buffer.</param>
-        /// <param name="result">The deserialized value.</param>
-        /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlySpan<byte> source, ref T result)
+        public void Deserialize(ReadOnlySequence<byte> source, scoped ref T result)
         {
             using var session = _sessionPool.GetSession();
             var reader = Reader.Create(source, session);
@@ -1213,7 +1178,42 @@ namespace Orleans.Serialization
         /// <param name="result">The deserialized value.</param>
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlySpan<byte> source, ref T result, SerializerSession session)
+        public void Deserialize(ReadOnlySequence<byte> source, scoped ref T result, SerializerSession session)
+        {
+            var reader = Reader.Create(source, session);
+            _codec.Deserialize(ref reader, ref result);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="result">The deserialized value.</param>
+        /// <param name="session">The serializer session.</param>
+        /// <returns>The deserialized value.</returns>
+        public void Deserialize(ArraySegment<byte> source, scoped ref T result, SerializerSession session) => Deserialize(source.AsSpan(), ref result, session);
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="result">The deserialized value.</param>
+        /// <returns>The deserialized value.</returns>
+        public void Deserialize(ReadOnlySpan<byte> source, scoped ref T result)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            _codec.Deserialize(ref reader, ref result);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="result">The deserialized value.</param>
+        /// <param name="session">The serializer session.</param>
+        /// <returns>The deserialized value.</returns>
+        public void Deserialize(ReadOnlySpan<byte> source, scoped ref T result, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
             _codec.Deserialize(ref reader, ref result);
@@ -1225,7 +1225,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(byte[] source, ref T result) => Deserialize(source.AsSpan(), ref result);
+        public void Deserialize(byte[] source, scoped ref T result) => Deserialize(source.AsSpan(), ref result);
 
         /// <summary>
         /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
@@ -1234,7 +1234,7 @@ namespace Orleans.Serialization
         /// <param name="result">The deserialized value.</param>
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(byte[] source, ref T result, SerializerSession session) => Deserialize(source.AsSpan(), ref result, session);
+        public void Deserialize(byte[] source, scoped ref T result, SerializerSession session) => Deserialize(source.AsSpan(), ref result, session);
 
         /// <summary>
         /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
@@ -1242,7 +1242,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlyMemory<byte> source, ref T result) => Deserialize(source.Span, ref result);
+        public void Deserialize(ReadOnlyMemory<byte> source, scoped ref T result) => Deserialize(source.Span, ref result);
 
         /// <summary>
         /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
@@ -1251,7 +1251,7 @@ namespace Orleans.Serialization
         /// <param name="result">The deserialized value.</param>
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(ReadOnlyMemory<byte> source, ref T result, SerializerSession session) => Deserialize(source.Span, ref result, session);
+        public void Deserialize(ReadOnlyMemory<byte> source, scoped ref T result, SerializerSession session) => Deserialize(source.Span, ref result, session);
 
         /// <summary>
         /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
@@ -1259,7 +1259,7 @@ namespace Orleans.Serialization
         /// <param name="source">The source buffer.</param>
         /// <param name="result">The deserialized value.</param>
         /// <returns>The deserialized value.</returns>
-        public void Deserialize(ArraySegment<byte> source, ref T result) => Deserialize(source.AsSpan(), ref result);
+        public void Deserialize(ArraySegment<byte> source, scoped ref T result) => Deserialize(source.AsSpan(), ref result);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Serializers/IValueSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/IValueSerializer.cs
@@ -15,7 +15,7 @@ namespace Orleans.Serialization.Serializers
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="value">The value.</param>
-        void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ref T value) where TBufferWriter : IBufferWriter<byte>;
+        void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, scoped ref T value) where TBufferWriter : IBufferWriter<byte>;
 
         /// <summary>
         /// Deserializes the specified type.
@@ -23,7 +23,7 @@ namespace Orleans.Serialization.Serializers
         /// <typeparam name="TInput">The reader input type.</typeparam>
         /// <param name="reader">The reader.</param>
         /// <param name="value">The value.</param>
-        void Deserialize<TInput>(ref Reader<TInput> reader, ref T value);
+        void Deserialize<TInput>(ref Reader<TInput> reader, scoped ref T value);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
@@ -52,7 +52,7 @@ public sealed class ValueTypeSurrogateCodec<TField, TSurrogate, TConverter>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Deserialize<TInput>(ref Reader<TInput> reader, ref TField value)
+    public void Deserialize<TInput>(ref Reader<TInput> reader, scoped ref TField value)
     {
         TSurrogate surrogate = default;
         _surrogateSerializer.Deserialize(ref reader, ref surrogate);
@@ -70,7 +70,7 @@ public sealed class ValueTypeSurrogateCodec<TField, TSurrogate, TConverter>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ref TField value) where TBufferWriter : IBufferWriter<byte>
+    public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, scoped ref TField value) where TBufferWriter : IBufferWriter<byte>
     {
         var surrogate = _converter.ConvertToSurrogate(in value);
         _surrogateSerializer.Serialize(ref writer, ref surrogate);

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Benchmarks</RootNamespace>
     <AssemblyName>Benchmarks</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <DebugSymbols>true</DebugSymbols>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -9,6 +9,8 @@
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <!-- Do not warn on errors caused by Protocol Buffers codegen, eg: "error CS8981: The type name 'pb' only contains lower-cased ascii characters. Such names may become reserved for the language." -->
+    <NoWarn>$(NoWarn);8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -14,8 +14,8 @@
 
   <!-- For test project we still need to target various desktop .Net versions instead of .Net Standard -->
   <PropertyGroup>
-    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net6.0</TestTargetFrameworks>
-    <MinTestTargetFramework Condition="'$(MinTestTargetFramework)' == ''">net6.0</MinTestTargetFramework>
+    <TestTargetFrameworks Condition="'$(TestTargetFrameworks)' == ''">net7.0</TestTargetFrameworks>
+    <MinTestTargetFramework Condition="'$(MinTestTargetFramework)' == ''">net7.0</MinTestTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
+++ b/test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
+++ b/test/Grains/BenchmarkGrains/BenchmarkGrains.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
C# 11 introduces the `scoped` keyword which can be used in conjunction with `ref` in a method signature to specify that a reference does not escape the method.

I updated the GitHub Actions yamls to allow us to use prerelease versions of the .NET SDK and updated global.json to include the latest .NET 7.0 RC. We would likely want to revert the CI change after release.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7987)