### PR TITLE
Remove TLS 1.1 from defaults, since it's deprecated

### DIFF
--- a/src/Orleans.Connections.Security/Security/TlsOptions.cs
+++ b/src/Orleans.Connections.Security/Security/TlsOptions.cs
@@ -67,9 +67,9 @@ namespace Orleans.Connections.Security
         public RemoteCertificateValidator RemoteCertificateValidation { get; set; }
 
         /// <summary>
-        /// Specifies allowable SSL protocols. Defaults to <see cref="System.Security.Authentication.SslProtocols.Tls12" /> and <see cref="System.Security.Authentication.SslProtocols.Tls11"/>.
+        /// Specifies allowable SSL protocols. Defaults to <see cref="System.Security.Authentication.SslProtocols.Tls13" /> and <see cref="System.Security.Authentication.SslProtocols.Tls12"/>.
         /// </summary>
-        public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls12 | SslProtocols.Tls11;
+        public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls13 | SslProtocols.Tls12;
 
         /// <summary>
         /// Specifies whether the certificate revocation list is checked during authentication.


### PR DESCRIPTION
Default to TLS 1.3 and 1.2 only

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7988)