### PR TITLE
Optimize serializer generated code (p2)

### DIFF
--- a/src/Orleans.CodeGenerator/ActivatorGenerator.cs
+++ b/src/Orleans.CodeGenerator/ActivatorGenerator.cs
@@ -42,13 +42,14 @@ namespace Orleans.CodeGenerator
                         Token(SyntaxKind.ReadOnlyKeyword)));
             }
 
-            members.Add(GenerateConstructor(simpleClassName, orderedFields));
+            if (orderedFields.Count > 0)
+                members.Add(GenerateConstructor(simpleClassName, orderedFields));
+
             members.Add(GenerateCreateMethod(libraryTypes, type, orderedFields));
 
             var classDeclaration = ClassDeclaration(simpleClassName)
                 .AddBaseListTypes(SimpleBaseType(baseInterface))
                 .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.SealedKeyword))
-                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(libraryTypes.RegisterActivatorAttribute.ToNameSyntax()))))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())))
                 .AddMembers(members.ToArray());
 

--- a/src/Orleans.CodeGenerator/ActivatorGenerator.cs
+++ b/src/Orleans.CodeGenerator/ActivatorGenerator.cs
@@ -42,7 +42,7 @@ namespace Orleans.CodeGenerator
                         Token(SyntaxKind.ReadOnlyKeyword)));
             }
 
-            members.Add(GenerateConstructor(libraryTypes, simpleClassName, orderedFields));
+            members.Add(GenerateConstructor(simpleClassName, orderedFields));
             members.Add(GenerateCreateMethod(libraryTypes, type, orderedFields));
 
             var classDeclaration = ClassDeclaration(simpleClassName)
@@ -63,7 +63,6 @@ namespace Orleans.CodeGenerator
         public static string GetSimpleClassName(ISerializableTypeDescription serializableType) => $"Activator_{serializableType.Name}";
 
         private static ConstructorDeclarationSyntax GenerateConstructor(
-            LibraryTypes libraryTypes,
             string simpleClassName,
             List<ConstructorArgument> orderedFields)
         {
@@ -76,7 +75,7 @@ namespace Orleans.CodeGenerator
                 body.Add(ExpressionStatement(
                             AssignmentExpression(
                                 SyntaxKind.SimpleAssignmentExpression,
-                                ThisExpression().Member(field.FieldName.ToIdentifierName()),
+                                field.FieldName.ToIdentifierName(),
                                 Unwrapped(field.ParameterName.ToIdentifierName()))));
             }
 

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -84,11 +84,11 @@ namespace Orleans.CodeGenerator
                 if (CopierGenerator.GenerateCopier(LibraryTypes, type, metadataModel.DefaultCopiers) is { } copier)
                     AddMember(ns, copier);
 
-                if (!type.IsEnumType && (!type.IsValueType && type.IsEmptyConstructable && type is not GeneratedInvokerDescription || type.HasActivatorConstructor))
+                if (!type.IsEnumType && (type.IsEmptyConstructable || type.HasActivatorConstructor))
                 {
                     metadataModel.ActivatableTypes.Add(type);
 
-                    // Generate a partial serializer class for each serializable type.
+                    // Generate an activator class for types with default constructor or activator constructor.
                     var activator = ActivatorGenerator.GenerateActivator(LibraryTypes, type);
                     AddMember(ns, activator);
                 }

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -81,8 +81,8 @@ namespace Orleans.CodeGenerator
                 AddMember(ns, serializer);
 
                 // Generate a copier for each serializable type.
-                var copier = CopierGenerator.GenerateCopier(LibraryTypes, type);
-                AddMember(ns, copier);
+                if (CopierGenerator.GenerateCopier(LibraryTypes, type, metadataModel.DefaultCopiers) is { } copier)
+                    AddMember(ns, copier);
 
                 if (!type.IsEnumType && (!type.IsValueType && type.IsEmptyConstructable && type is not GeneratedInvokerDescription || type.HasActivatorConstructor))
                 {

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -115,26 +115,11 @@ namespace Orleans.CodeGenerator
             {
                 switch (description)
                 {
-                    case SetterFieldDescription setter:
-                        {
-                            var fieldSetterVariable = VariableDeclarator(setter.FieldName);
-
-                            return
-                                FieldDeclaration(VariableDeclaration(setter.FieldType).AddVariables(fieldSetterVariable))
-                                    .AddModifiers(
-                                        Token(SyntaxKind.PrivateKeyword),
-                                        Token(SyntaxKind.ReadOnlyKeyword));
-                        }
-                    case GetterFieldDescription getter:
-                        {
-                            var fieldGetterVariable = VariableDeclarator(getter.FieldName);
-
-                            return
-                                FieldDeclaration(VariableDeclaration(getter.FieldType).AddVariables(fieldGetterVariable))
-                                    .AddModifiers(
-                                        Token(SyntaxKind.PrivateKeyword),
-                                        Token(SyntaxKind.ReadOnlyKeyword));
-                        }
+                    case FieldAccessorDescription accessor:
+                        return
+                            FieldDeclaration(VariableDeclaration(accessor.FieldType,
+                                SingletonSeparatedList(VariableDeclarator(accessor.FieldName).WithInitializer(EqualsValueClause(accessor.InitializationSyntax)))))
+                                .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.ReadOnlyKeyword));
                     default:
                         return FieldDeclaration(VariableDeclaration(description.FieldType, SingletonSeparatedList(VariableDeclarator(description.FieldName))))
                             .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.ReadOnlyKeyword));
@@ -151,14 +136,6 @@ namespace Orleans.CodeGenerator
             {
                 switch (field)
                 {
-                    case GetterFieldDescription getter:
-                        statements.Add(getter.InitializationSyntax);
-                        break;
-
-                    case SetterFieldDescription setter:
-                        statements.Add(setter.InitializationSyntax);
-                        break;
-
                     case GeneratedFieldDescription _ when field.IsInjected:
                         parameters.Add(Parameter(field.FieldName.ToIdentifier()).WithType(field.FieldType));
                         statements.Add(ExpressionStatement(

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -54,7 +54,7 @@ namespace Orleans.CodeGenerator
                     GenerateGetMethod(libraryTypes),
                     GenerateSetTargetMethod(libraryTypes, interfaceDescription, targetField),
                     GenerateGetTargetMethod(libraryTypes, targetField),
-                    GenerateDisposeMethod(libraryTypes, method, fieldDescriptions, baseClassType),
+                    GenerateDisposeMethod(libraryTypes, fieldDescriptions, baseClassType),
                     GenerateGetArgumentMethod(libraryTypes, method, fieldDescriptions),
                     GenerateSetArgumentMethod(libraryTypes, method, fieldDescriptions),
                     GenerateInvokeInnerMethod(libraryTypes, method, fieldDescriptions, targetField));
@@ -324,13 +324,13 @@ namespace Orleans.CodeGenerator
             var args = SeparatedList(
                 fields.OfType<MethodParameterFieldDescription>()
                     .OrderBy(p => p.ParameterOrdinal)
-                    .Select(p => Argument(ThisExpression().Member(p.FieldName))));
+                    .Select(p => Argument(IdentifierName(p.FieldName))));
             ExpressionSyntax methodCall;
             if (method.MethodTypeParameters.Count > 0)
             {
                 methodCall = MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    ThisExpression().Member(target.FieldName),
+                    IdentifierName(target.FieldName),
                     GenericName(
                         Identifier(method.Method.Name),
                         TypeArgumentList(
@@ -339,7 +339,7 @@ namespace Orleans.CodeGenerator
             }
             else
             {
-                methodCall = ThisExpression().Member(target.FieldName).Member(method.Method.Name);
+                methodCall = IdentifierName(target.FieldName).Member(method.Method.Name);
             }
 
             return MethodDeclaration(method.Method.ReturnType.ToTypeSyntax(method.TypeParameterSubstitutions), "InvokeInner")
@@ -351,7 +351,6 @@ namespace Orleans.CodeGenerator
 
         private static MemberDeclarationSyntax GenerateDisposeMethod(
             LibraryTypes libraryTypes,
-            MethodDescription methodDescription,
             List<InvokerFieldDescripton> fields,
             INamedTypeSymbol baseClassType)
         {
@@ -364,8 +363,8 @@ namespace Orleans.CodeGenerator
                         ExpressionStatement(
                             AssignmentExpression(
                                 SyntaxKind.SimpleAssignmentExpression,
-                                ThisExpression().Member(field.FieldName),
-                                DefaultExpression(field.FieldType.ToTypeSyntax(methodDescription.TypeParameterSubstitutions)))));
+                                IdentifierName(field.FieldName),
+                                LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
                 }
             }
 
@@ -556,7 +555,7 @@ namespace Orleans.CodeGenerator
             foreach (var (methodName, methodArgument) in method.CustomInitializerMethods)
             {
                 var argumentExpression = methodArgument.ToExpression();
-                body.Add(ExpressionStatement(InvocationExpression(ThisExpression().Member(methodName), ArgumentList(SeparatedList(new[] { Argument(argumentExpression) })))));
+                body.Add(ExpressionStatement(InvocationExpression(IdentifierName(methodName), ArgumentList(SeparatedList(new[] { Argument(argumentExpression) })))));
             }
 
             if (body.Count == 0 && parameters.Count == 0)

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -179,7 +179,7 @@ namespace Orleans.CodeGenerator
                     IPAddress = Type("System.Net.IPAddress"),
                     IPEndPoint = Type("System.Net.IPEndPoint"),
                     CancellationToken = Type("System.Threading.CancellationToken"),
-                TupleTypes = new[]
+                ImmutableContainerTypes = new[]
                 {
                     Type("System.Tuple`1"),
                     Type("System.Tuple`2"),
@@ -294,7 +294,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol IPAddress { get; private set; }
         public INamedTypeSymbol IPEndPoint { get; private set; }
         public INamedTypeSymbol CancellationToken { get; private set; }
-        public INamedTypeSymbol[] TupleTypes { get; private set; }
+        public INamedTypeSymbol[] ImmutableContainerTypes { get; private set; }
         public INamedTypeSymbol ValueTuple { get; private set; }
         public List<INamedTypeSymbol> ImmutableAttributes { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }
@@ -382,7 +382,7 @@ namespace Orleans.CodeGenerator
                     return _shallowCopyableTypes[type] = IsShallowCopyable(namedType.TypeArguments.Single());
                 }
 
-                foreach (var t in TupleTypes)
+                foreach (var t in ImmutableContainerTypes)
                 {
                     if (SymbolEqualityComparer.Default.Equals(t, def))
                         return _shallowCopyableTypes[type] = namedType.TypeArguments.All(IsShallowCopyable);

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -382,9 +382,10 @@ namespace Orleans.CodeGenerator
                     return _shallowCopyableTypes[type] = IsShallowCopyable(namedType.TypeArguments.Single());
                 }
 
-                if (TupleTypes.Any(t => SymbolEqualityComparer.Default.Equals(t, def)))
+                foreach (var t in TupleTypes)
                 {
-                    return _shallowCopyableTypes[type] = namedType.TypeArguments.All(IsShallowCopyable);
+                    if (SymbolEqualityComparer.Default.Equals(t, def))
+                        return _shallowCopyableTypes[type] = namedType.TypeArguments.All(IsShallowCopyable);
                 }
             }
             else

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -1,9 +1,8 @@
-using Orleans.CodeGenerator.SyntaxGeneration;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
-using System.Linq;
+using Orleans.CodeGenerator.SyntaxGeneration;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Orleans.CodeGenerator
@@ -17,140 +16,87 @@ namespace Orleans.CodeGenerator
             var addCopierMethod = configParam.Member("Copiers").Member("Add");
             var addConverterMethod = configParam.Member("Converters").Member("Add");
             var body = new List<StatementSyntax>();
-            body.AddRange(
-                metadataModel.SerializableTypes.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addSerializerMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(GetCodecTypeName(type)))))))
-                ));
-            body.AddRange(
-                metadataModel.SerializableTypes.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addCopierMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(GetCopierTypeName(type)))))))
-                ));
-            body.AddRange(
-                metadataModel.DetectedCopiers.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addCopierMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
-                ));
-            body.AddRange(
-                metadataModel.DetectedSerializers.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addSerializerMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
-                ));
-            body.AddRange(
-                metadataModel.DetectedConverters.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addConverterMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))));
+
+            foreach (var type in metadataModel.SerializableTypes)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addSerializerMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(GetCodecTypeName(type))))))));
+            }
+
+            foreach (var type in metadataModel.SerializableTypes)
+            {
+                if (!metadataModel.DefaultCopiers.TryGetValue(type, out var typeName))
+                    typeName = GetCopierTypeName(type);
+
+                body.Add(ExpressionStatement(InvocationExpression(addCopierMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(typeName)))))));
+            }
+
+            foreach (var type in metadataModel.DetectedCopiers)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addCopierMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.ToOpenTypeSyntax())))))));
+            }
+
+            foreach (var type in metadataModel.DetectedSerializers)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addSerializerMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.ToOpenTypeSyntax())))))));
+            }
+
+            foreach (var type in metadataModel.DetectedConverters)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addConverterMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.ToOpenTypeSyntax())))))));
+            }
+
             var addProxyMethod = configParam.Member("InterfaceProxies").Member("Add");
-            body.AddRange(
-                metadataModel.GeneratedProxies.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addProxyMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.TypeSyntax))))))
-                ));
+            foreach (var type in metadataModel.GeneratedProxies)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addProxyMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.TypeSyntax)))))));
+            }
+
             var addInvokableInterfaceMethod = configParam.Member("Interfaces").Member("Add");
-            body.AddRange(
-                metadataModel.InvokableInterfaces.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addInvokableInterfaceMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.InterfaceType.ToOpenTypeSyntax()))))))
-                ));
+            foreach (var type in metadataModel.InvokableInterfaces)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addInvokableInterfaceMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.InterfaceType.ToOpenTypeSyntax())))))));
+            }
+
             var addInvokableInterfaceImplementationMethod = configParam.Member("InterfaceImplementations").Member("Add");
-            body.AddRange(
-                metadataModel.InvokableInterfaceImplementations.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addInvokableInterfaceImplementationMethod ,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
-                ));
+            foreach (var type in metadataModel.InvokableInterfaceImplementations)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addInvokableInterfaceImplementationMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.ToOpenTypeSyntax())))))));
+            }
 
             var addActivatorMethod = configParam.Member("Activators").Member("Add");
-            body.AddRange(
-                metadataModel.ActivatableTypes.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addActivatorMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(GetActivatorTypeName(type)))))))
-                ));
-            body.AddRange(
-                metadataModel.DetectedActivators.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addActivatorMethod,
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
-                ));
+            foreach (var type in metadataModel.ActivatableTypes)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addActivatorMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(GetActivatorTypeName(type))))))));
+            }
+
+            foreach (var type in metadataModel.DetectedActivators)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addActivatorMethod,
+                    ArgumentList(SingletonSeparatedList(Argument(TypeOfExpression(type.ToOpenTypeSyntax())))))));
+            }
 
             var addWellKnownTypeIdMethod = configParam.Member("WellKnownTypeIds").Member("Add");
-            body.AddRange(
-                metadataModel.WellKnownTypeIds.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addWellKnownTypeIdMethod,
-                                ArgumentList(SeparatedList(
-                                    new[]
-                                    {
-                                        Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Id))),
-                                        Argument(TypeOfExpression(type.Type))
-                                    }))))
-                ));
-            
+            foreach (var type in metadataModel.WellKnownTypeIds)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addWellKnownTypeIdMethod,
+                    ArgumentList(SeparatedList(new[] { Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Id))), Argument(TypeOfExpression(type.Type)) })))));
+            }
+
             var addTypeAliasMethod = configParam.Member("WellKnownTypeAliases").Member("Add");
-            body.AddRange(
-                metadataModel.TypeAliases.Select(
-                    type =>
-                        (StatementSyntax)ExpressionStatement(
-                            InvocationExpression(
-                                addTypeAliasMethod,
-                                ArgumentList(SeparatedList(
-                                    new[]
-                                    {
-                                        Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Alias))),
-                                        Argument(TypeOfExpression(type.Type))
-                                    }))))
-                ));
+            foreach (var type in metadataModel.TypeAliases)
+            {
+                body.Add(ExpressionStatement(InvocationExpression(addTypeAliasMethod,
+                    ArgumentList(SeparatedList(new[] { Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Alias))), Argument(TypeOfExpression(type.Type)) })))));
+            }
 
             var configType = libraryTypes.TypeManifestOptions;
             var configureMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Configure")
@@ -173,7 +119,7 @@ namespace Orleans.CodeGenerator
             var name = SerializerGenerator.GetSimpleClassName(type);
             if (genericArity > 0)
             {
-                name += $"<{new string(',', genericArity - 1)}>";
+                name = $"{name}<{new string(',', genericArity - 1)}>";
             }
 
             return ParseTypeName(type.GeneratedNamespace + "." + name);
@@ -185,7 +131,7 @@ namespace Orleans.CodeGenerator
             var name = CopierGenerator.GetSimpleClassName(type);
             if (genericArity > 0)
             {
-                name += $"<{new string(',', genericArity - 1)}>";
+                name = $"{name}<{new string(',', genericArity - 1)}>";
             }
 
             return ParseTypeName(type.GeneratedNamespace + "." + name);
@@ -197,7 +143,7 @@ namespace Orleans.CodeGenerator
             var name = ActivatorGenerator.GetSimpleClassName(type);
             if (genericArity > 0)
             {
-                name += $"<{new string(',', genericArity - 1)}>";
+                name = $"{name}<{new string(',', genericArity - 1)}>";
             }
 
             return ParseTypeName(type.GeneratedNamespace + "." + name);

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -25,6 +25,8 @@ namespace Orleans.CodeGenerator
 
             foreach (var type in metadataModel.SerializableTypes)
             {
+                if (type.IsEnumType) continue;
+
                 if (!metadataModel.DefaultCopiers.TryGetValue(type, out var typeName))
                     typeName = GetCopierTypeName(type);
 

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -47,6 +47,7 @@ namespace Orleans.CodeGenerator
         public string Name { get; }
         public bool IsValueType => false;
         public bool IsSealedType => true;
+        public bool IsAbstractType => false;
         public bool IsEnumType => false;
         public bool IsGenericType => TypeParameters.Count > 0;
         public List<IMemberDescription> Members { get; }

--- a/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -17,6 +17,7 @@ namespace Orleans.CodeGenerator
         string Name { get; }
         bool IsValueType { get; }
         bool IsSealedType { get; }
+        bool IsAbstractType { get; }
         bool IsEnumType { get; }
         bool IsGenericType { get; }
         List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters { get; }

--- a/src/Orleans.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MetadataModel.cs
@@ -14,6 +14,7 @@ namespace Orleans.CodeGenerator
         public List<ISerializableTypeDescription> ActivatableTypes { get; } = new(1024);
         public List<INamedTypeSymbol> DetectedSerializers { get; } = new();
         public List<INamedTypeSymbol> DetectedActivators { get; } = new();
+        public Dictionary<ISerializableTypeDescription, TypeSyntax> DefaultCopiers { get; } = new();
         public List<INamedTypeSymbol> DetectedCopiers { get; } = new();
         public List<INamedTypeSymbol> DetectedConverters { get; } = new();
         public List<(TypeSyntax Type, string Alias)> TypeAliases { get; } = new(1024);

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -131,6 +131,7 @@ namespace Orleans.CodeGenerator
 
         public bool IsValueType => Type.IsValueType;
         public bool IsSealedType => Type.IsSealed;
+        public bool IsAbstractType => Type.IsAbstract;
         public bool IsEnumType => Type.EnumUnderlyingType != null;
 
         public bool IsGenericType => Type.IsGenericType;

--- a/src/Orleans.CodeGenerator/ProxyGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxyGenerator.cs
@@ -1,15 +1,15 @@
-using Orleans.CodeGenerator.SyntaxGeneration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
-using System.Linq;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using System;
 using Orleans.CodeGenerator.Diagnostics;
-using static Orleans.CodeGenerator.SerializerGenerator;
-using static Orleans.CodeGenerator.InvokableGenerator;
+using Orleans.CodeGenerator.SyntaxGeneration;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Orleans.CodeGenerator.CopierGenerator;
+using static Orleans.CodeGenerator.InvokableGenerator;
+using static Orleans.CodeGenerator.SerializerGenerator;
 
 namespace Orleans.CodeGenerator
 {
@@ -190,7 +190,7 @@ namespace Orleans.CodeGenerator
                 var valueExpression = GenerateMemberCopy(
                     fieldDescriptions,
                     libraryTypes,
-                    IdentifierName(SyntaxFactoryUtility.GetSanitizedName(parameter.Member.Parameter, parameterIndex)),
+                    IdentifierName($"arg{parameterIndex}"),
                     copyContextVariable,
                     codecs,
                     parameter);
@@ -332,7 +332,7 @@ namespace Orleans.CodeGenerator
 
             static ArgumentSyntax GetBaseInitializerArgument(IParameterSymbol parameter, int index)
             {
-                var name = SyntaxFactoryUtility.GetSanitizedName(parameter, index);
+                var name = $"arg{index}";
                 var result = Argument(IdentifierName(name));
                 switch (parameter.RefKind)
                 {
@@ -370,7 +370,7 @@ namespace Orleans.CodeGenerator
                                 res.Add(ExpressionStatement(
                                     AssignmentExpression(
                                         SyntaxKind.SimpleAssignmentExpression,
-                                        ThisExpression().Member(field.FieldName.ToIdentifierName()),
+                                        field.FieldName.ToIdentifierName(),
                                         GetService(field.FieldType))));
                             }
                             break;
@@ -396,7 +396,7 @@ namespace Orleans.CodeGenerator
 
         private static ParameterSyntax GetParameterSyntax(int index, IParameterSymbol parameter, Dictionary<ITypeParameterSymbol, string> typeParameterSubstitutions)
         {
-            var result = Parameter(Identifier(SyntaxFactoryUtility.GetSanitizedName(parameter, index))).WithType(parameter.Type.ToTypeSyntax(typeParameterSubstitutions));
+            var result = Parameter(Identifier($"arg{index}")).WithType(parameter.Type.ToTypeSyntax(typeParameterSubstitutions));
             switch (parameter.RefKind)
             {
                 case RefKind.None:

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -227,35 +227,10 @@ namespace Orleans.CodeGenerator
                             .AddArgumentListArguments(instanceArg, Argument(value));
                 }
 
-                public GetterFieldDescription GetGetterFieldDescription() => null;
+                public FieldAccessorDescription GetGetterFieldDescription() => null;
 
-                public SetterFieldDescription GetSetterFieldDescription()
-                {
-                    TypeSyntax fieldType;
-                    if (ContainingType != null && ContainingType.IsValueType)
-                    {
-                        fieldType = _libraryTypes.ValueTypeSetter_2.ToTypeSyntax(GetTypeSyntax(ContainingType), TypeSyntax);
-                    }
-                    else
-                    {
-                        fieldType = _libraryTypes.Action_2.ToTypeSyntax(GetTypeSyntax(ContainingType), TypeSyntax);
-                    }
-
-                    // Generate syntax to initialize the field in the constructor
-                    var fieldAccessorUtility = AliasQualifiedName("global", IdentifierName("Orleans.Serialization")).Member("Utilities").Member("FieldAccessor");
-                    var fieldInfo = SerializableMember.GetGetFieldInfoExpression(ContainingType, FieldName);
-                    var isContainedByValueType = ContainingType != null && ContainingType.IsValueType;
-                    var accessorMethod = isContainedByValueType ? "GetValueSetter" : "GetReferenceSetter";
-                    var accessorInvoke = CastExpression(
-                        fieldType,
-                        InvocationExpression(fieldAccessorUtility.Member(accessorMethod))
-                            .AddArgumentListArguments(Argument(fieldInfo)));
-
-                    var initializationSyntax = ExpressionStatement(
-                        AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName(SetterFieldName), accessorInvoke));
-
-                    return new SetterFieldDescription(fieldType, SetterFieldName, initializationSyntax);
-                }
+                public FieldAccessorDescription GetSetterFieldDescription()
+                    => SerializableMember.GetFieldAccessor(ContainingType, TypeSyntax, FieldName, SetterFieldName, _libraryTypes, true);
             }
         }
 
@@ -365,35 +340,10 @@ namespace Orleans.CodeGenerator
                             .AddArgumentListArguments(instanceArg, Argument(value));
                 }
 
-                public GetterFieldDescription GetGetterFieldDescription() => null;
+                public FieldAccessorDescription GetGetterFieldDescription() => null;
 
-                public SetterFieldDescription GetSetterFieldDescription()
-                {
-                    TypeSyntax fieldType;
-                    if (ContainingType != null && ContainingType.IsValueType)
-                    {
-                        fieldType = _libraryTypes.ValueTypeSetter_2.ToTypeSyntax(GetTypeSyntax(ContainingType), TypeSyntax);
-                    }
-                    else
-                    {
-                        fieldType = _libraryTypes.Action_2.ToTypeSyntax(GetTypeSyntax(ContainingType), TypeSyntax);
-                    }
-
-                    // Generate syntax to initialize the field in the constructor
-                    var fieldAccessorUtility = AliasQualifiedName("global", IdentifierName("Orleans.Serialization")).Member("Utilities").Member("FieldAccessor");
-                    var fieldInfo = SerializableMember.GetGetFieldInfoExpression(ContainingType, FieldName);
-                    var isContainedByValueType = ContainingType != null && ContainingType.IsValueType;
-                    var accessorMethod = isContainedByValueType ? "GetValueSetter" : "GetReferenceSetter";
-                    var accessorInvoke = CastExpression(
-                        fieldType,
-                        InvocationExpression(fieldAccessorUtility.Member(accessorMethod))
-                            .AddArgumentListArguments(Argument(fieldInfo)));
-
-                    var initializationSyntax = ExpressionStatement(
-                        AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName(SetterFieldName), accessorInvoke));
-
-                    return new SetterFieldDescription(fieldType, SetterFieldName, initializationSyntax);
-                }
+                public FieldAccessorDescription GetSetterFieldDescription()
+                    => SerializableMember.GetFieldAccessor(ContainingType, TypeSyntax, FieldName, SetterFieldName, _libraryTypes, true);
             }
         }
     }

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SyntaxFactoryUtility.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SyntaxFactoryUtility.cs
@@ -111,11 +111,5 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
 
             return allConstraints;
         }
-
-        public static string GetSanitizedName(IParameterSymbol parameter, int index)
-        {
-            var parameterName = string.IsNullOrWhiteSpace(parameter.Name) ? "arg" : parameter.Name;
-            return string.Format(CultureInfo.InvariantCulture, "{0}{1:G}", parameterName, index);
-        }
     }
 }

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -68,21 +68,17 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
                     }
                 }
 
-                return Unwrap(ActivatorUtilities.GetServiceOrCreateInstance<TService>(codecProvider.Services));
-            }
-            finally
-            {
-                state.Exit();
-            }
-
-            static TService Unwrap(TService val)
-            {
+                var val = ActivatorUtilities.GetServiceOrCreateInstance<TService>(codecProvider.Services);
                 while (val is IServiceHolder<TService> wrapping)
                 {
                     val = wrapping.Value;
                 }
 
                 return val;
+            }
+            finally
+            {
+                state.Exit();
             }
         }
 
@@ -295,6 +291,14 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Default copier for shallow-copyable types
+        /// </summary>
+        public sealed class DefaultShallowCopier<T> : IDeepCopier<T>
+        {
+            public T DeepCopy(T input, CopyContext _) => input;
         }
     }
 }

--- a/src/Orleans.Serialization/Utilities/FieldAccessor.cs
+++ b/src/Orleans.Serialization/Utilities/FieldAccessor.cs
@@ -29,27 +29,21 @@ namespace Orleans.Serialization.Utilities
         /// <summary>
         /// Returns a delegate to get the value of a specified field.
         /// </summary>
-        /// <param name="field">
-        /// The field.
-        /// </param>
         /// <returns>A delegate to get the value of a specified field.</returns>
-        public static Delegate GetGetter(FieldInfo field) => GetGetter(field, false);
+        public static Delegate GetGetter(Type declaringType, string fieldName) => GetGetter(declaringType, fieldName, false);
 
         /// <summary>
         /// Returns a delegate to get the value of a specified field.
         /// </summary>
-        /// <param name="field">
-        /// The field.
-        /// </param>
         /// <returns>A delegate to get the value of a specified field.</returns>
-        public static Delegate GetValueGetter(FieldInfo field) => GetGetter(field, true);
+        public static Delegate GetValueGetter(Type declaringType, string fieldName) => GetGetter(declaringType, fieldName, true);
 
-        private static Delegate GetGetter(FieldInfo field, bool byref)
+        private static Delegate GetGetter(Type declaringType, string fieldName, bool byref)
         {
-            var declaringType = field.DeclaringType ?? throw new InvalidOperationException($"Field {field.Name} does not have a declaring type.");
+            var field = declaringType.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             var parameterTypes = new[] { typeof(object), byref ? declaringType.MakeByRefType() : declaringType };
 
-            var method = new DynamicMethod(field.Name + "Get", field.FieldType, parameterTypes, typeof(FieldAccessor).Module, true);
+            var method = new DynamicMethod(fieldName + "Get", field.FieldType, parameterTypes, typeof(FieldAccessor).Module, true);
 
             var emitter = method.GetILGenerator();
             // arg0 is unused for better delegate performance (avoids argument shuffling thunk)
@@ -64,20 +58,20 @@ namespace Orleans.Serialization.Utilities
         /// Returns a delegate to set the value of this field for an instance.
         /// </summary>
         /// <returns>A delegate to set the value of this field for an instance.</returns>
-        public static Delegate GetReferenceSetter(FieldInfo field) => GetSetter(field, false);
+        public static Delegate GetReferenceSetter(Type declaringType, string fieldName) => GetSetter(declaringType, fieldName, false);
 
         /// <summary>
         /// Returns a delegate to set the value of this field for an instance.
         /// </summary>
         /// <returns>A delegate to set the value of this field for an instance.</returns>
-        public static Delegate GetValueSetter(FieldInfo field) => GetSetter(field, true);
+        public static Delegate GetValueSetter(Type declaringType, string fieldName) => GetSetter(declaringType, fieldName, true);
 
-        private static Delegate GetSetter(FieldInfo field, bool byref)
+        private static Delegate GetSetter(Type declaringType, string fieldName, bool byref)
         {
-            var declaringType = field.DeclaringType ?? throw new InvalidOperationException($"Field {field.Name} does not have a declaring type.");
+            var field = declaringType.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             var parameterTypes = new[] { typeof(object), byref ? declaringType.MakeByRefType() : declaringType, field.FieldType };
 
-            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, typeof(FieldAccessor).Module, true);
+            var method = new DynamicMethod(fieldName + "Set", null, parameterTypes, typeof(FieldAccessor).Module, true);
 
             var emitter = method.GetILGenerator();
             // arg0 is unused for better delegate performance (avoids argument shuffling thunk)

--- a/test/Benchmarks/Serialization/Comparison/CopierBenchmark.cs
+++ b/test/Benchmarks/Serialization/Comparison/CopierBenchmark.cs
@@ -1,0 +1,61 @@
+using System.Buffers;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Benchmarks.Models;
+using Benchmarks.Serialization.Models;
+using Benchmarks.Utilities;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Session;
+using Xunit;
+
+namespace Benchmarks.Serialization.Comparison;
+
+[Config(typeof(BenchmarkConfig))]
+public class CopierBenchmark
+{
+    private static readonly MyVector3[] _vectorArray;
+    private static readonly DeepCopier<MyVector3[]> _arrayCopier;
+    private static readonly DeepCopier<IntStruct> _structCopier;
+    private static readonly IntStruct _intStruct;
+    private static readonly DeepCopier<IntClass> _classCopier;
+    private static readonly ImmutableVector3[] _arrayOfImmutableVectors;
+    private static readonly IntClass _intClass;
+    private static readonly DeepCopier<ImmutableVector3[]> _arrayOfImmutableVectorsCopier;
+    private static readonly SerializerSession _session;
+
+    static CopierBenchmark()
+    {
+        _vectorArray = Enumerable.Repeat(new MyVector3 { X = 10.3f, Y = 40.5f, Z = 13411.3f }, 1000).ToArray();
+        _arrayOfImmutableVectors = Enumerable.Repeat(new ImmutableVector3 { X = 10.3f, Y = 40.5f, Z = 13411.3f }, 1000).ToArray();
+        var serviceProvider = new ServiceCollection()
+            .AddSerializer(builder => builder.AddAssembly(typeof(ArraySerializeBenchmark).Assembly))
+            .BuildServiceProvider();
+        _arrayCopier = serviceProvider.GetRequiredService<DeepCopier<MyVector3[]>>();
+        _structCopier = serviceProvider.GetRequiredService<DeepCopier<IntStruct>>();
+        _intStruct = IntStruct.Create();
+        _classCopier = serviceProvider.GetRequiredService<DeepCopier<IntClass>>();
+        _intClass = IntClass.Create();
+        _arrayOfImmutableVectorsCopier = serviceProvider.GetRequiredService<DeepCopier<ImmutableVector3[]>>();
+        _session = serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession();
+    }
+
+    [Benchmark]
+    public void VectorArray() => _arrayCopier.Copy(_vectorArray);
+
+    [Benchmark]
+    public void ImmutableVectorArray() => _arrayOfImmutableVectorsCopier.Copy(_arrayOfImmutableVectors);
+
+    [Benchmark]
+    public void Struct() => _structCopier.Copy(_intStruct);
+
+    [Benchmark]
+    public void Class() => _classCopier.Copy(_intClass);
+}

--- a/test/Benchmarks/Serialization/ComplexTypeBenchmarks.cs
+++ b/test/Benchmarks/Serialization/ComplexTypeBenchmarks.cs
@@ -18,7 +18,9 @@ namespace Benchmarks
     {
         private static SingleSegmentBuffer Buffer = new(new byte[1000]);
         private readonly Serializer<SimpleStruct> _structSerializer;
+        private readonly DeepCopier<SimpleStruct> _structCopier;
         private readonly Serializer<ComplexClass> _serializer;
+        private readonly DeepCopier<ComplexClass> _copier;
         private readonly SerializerSessionPool _sessionPool;
         private readonly ComplexClass _value;
         private readonly SerializerSession _session;
@@ -33,7 +35,9 @@ namespace Benchmarks
                 .AddSerializer();
             var serviceProvider = services.BuildServiceProvider();
             _serializer = serviceProvider.GetRequiredService<Serializer<ComplexClass>>();
+            _copier = serviceProvider.GetRequiredService<DeepCopier<ComplexClass>>();
             _structSerializer = serviceProvider.GetRequiredService<Serializer<SimpleStruct>>();
+            _structCopier = serviceProvider.GetRequiredService<DeepCopier<SimpleStruct>>();
             _sessionPool = serviceProvider.GetRequiredService<SerializerSessionPool>();
             _value = new ComplexClass
             {
@@ -73,6 +77,18 @@ namespace Benchmarks
             var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
             _ = _serializer.Deserialize(ref reader);
             Buffer.Reset();
+        }
+
+        [Fact]
+        public void CopyComplex()
+        {
+            _copier.Copy(_value); 
+        }
+
+        [Fact]
+        public void CopyComplexStruct()
+        {
+            _structCopier.Copy(_structValue); 
         }
 
         [Fact]

--- a/test/Benchmarks/Serialization/Models/Vector3.cs
+++ b/test/Benchmarks/Serialization/Models/Vector3.cs
@@ -24,3 +24,17 @@ public struct MyVector3
     [Id(2)]
     public float Z;
 }
+
+[Immutable]
+[GenerateSerializer]
+public struct ImmutableVector3
+{
+    [Id(0)]
+    public float X;
+
+    [Id(1)]
+    public float Y;
+
+    [Id(2)]
+    public float Z;
+}

--- a/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
@@ -78,7 +78,6 @@ namespace UnitTests.GrainInterfaces
         public int Number { get; }
     }
 
-    [GenerateSerializer]
     public class UnserializableType
     {
     }


### PR DESCRIPTION
* Make field accessors static.
* Use concrete codec/copier types for base types.
* Use concrete codec/copier types in more places (by fixing the assembly comparison condition).
* Don't generate activators for enum types.
* Don't generate a copier for shallow-copyable types (only register a dummy copier).
* Don't generate unreachable copier code paths for abstract types.
* Reduce metadata size by using more generic names for codec fields and parameters.

Using concrete codec/copier has the side-effect of creating multiple instances of the codec/copier classes because only the generic interface variant is cached in ServiceProvider. Making field accessors static here helps somewhat with that overhead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/7995)