### PR TITLE
Don't generate activators for simple invokables

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -84,7 +84,7 @@ namespace Orleans.CodeGenerator
                 var copier = CopierGenerator.GenerateCopier(LibraryTypes, type);
                 AddMember(ns, copier);
 
-                if (type.IsEmptyConstructable || type.HasActivatorConstructor)
+                if (!type.IsEnumType && (!type.IsValueType && type.IsEmptyConstructable && type is not GeneratedInvokerDescription || type.HasActivatorConstructor))
                 {
                     metadataModel.ActivatableTypes.Add(type);
 

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -37,7 +37,7 @@ namespace Orleans.CodeGenerator
             };
             var classDeclaration = ClassDeclaration(generatedClassName)
                 .AddBaseListTypes(SimpleBaseType(baseClassType.ToTypeSyntax(method.TypeParameterSubstitutions)))
-                .AddModifiers(Token(accessibilityKind), Token(SyntaxKind.SealedKeyword), Token(SyntaxKind.PartialKeyword))
+                .AddModifiers(Token(accessibilityKind), Token(SyntaxKind.SealedKeyword))
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(CodeGenerator.GetGeneratedCodeAttributeSyntax())))
                 .AddMembers(fields)

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -1,14 +1,13 @@
-using Orleans.CodeGenerator.SyntaxGeneration;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Orleans.CodeGenerator.SyntaxGeneration;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Orleans.CodeGenerator
 {
-    internal class GeneratedInvokerDescription : ISerializableTypeDescription
+    internal sealed class GeneratedInvokerDescription : ISerializableTypeDescription
     {
         private readonly MethodDescription _methodDescription;
         private TypeSyntax _openTypeSyntax;
@@ -54,7 +53,6 @@ namespace Orleans.CodeGenerator
         public InvokableInterfaceDescription InterfaceDescription { get; }
         public SemanticModel SemanticModel => InterfaceDescription.SemanticModel;
         public bool IsEmptyConstructable => ActivatorConstructorParameters is not { Count: > 0 };
-        public bool IsPartial => true;
         public bool UseActivator => ActivatorConstructorParameters is { Count: > 0 };
         public bool TrackReferences => false;
         public bool OmitDefaultMemberValues => false;
@@ -62,7 +60,7 @@ namespace Orleans.CodeGenerator
         public List<INamedTypeSymbol> SerializationHooks { get; }
         public bool IsShallowCopyable => false;
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
-        public bool HasActivatorConstructor => true;
+        public bool HasActivatorConstructor => UseActivator;
 
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => ObjectCreationExpression(TypeSyntax).WithArgumentList(ArgumentList());
 

--- a/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -25,7 +25,6 @@ namespace Orleans.CodeGenerator
         bool UseActivator { get; }
         bool IsEmptyConstructable { get; }
         bool HasActivatorConstructor { get; }
-        bool IsPartial { get; }
         bool TrackReferences { get; }
         bool OmitDefaultMemberValues { get; }
         ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes);

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -170,23 +170,6 @@ namespace Orleans.CodeGenerator
 
         public bool HasActivatorConstructor { get; }
 
-        public bool IsPartial
-        {
-            get
-            {
-                foreach (var reference in Type.DeclaringSyntaxReferences)
-                {
-                    var syntax = reference.GetSyntax();
-                    if (syntax is TypeDeclarationSyntax typeDeclaration && typeDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PartialKeyword))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-        }
-
         public bool UseActivator => Type.HasAttribute(_libraryTypes.UseActivatorAttribute) || !IsEmptyConstructable || HasActivatorConstructor;
 
         public bool TrackReferences => !IsValueType && !Type.HasAttribute(_libraryTypes.SuppressReferenceTrackingAttribute);


### PR DESCRIPTION
Don't generate activators for simple invokables and value types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8001)