### PR TITLE
Generate less code for abstract type codecs

### DIFF
--- a/src/Orleans.Serialization/Codecs/ObjectCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ObjectCodec.cs
@@ -56,8 +56,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
         {
-            var fieldType = value?.GetType();
-            if (fieldType is null || fieldType == ObjectType)
+            if (value is null || value.GetType() == typeof(object))
             {
                 if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
                 {
@@ -69,7 +68,7 @@ namespace Orleans.Serialization.Codecs
                 return;
             }
 
-            var specificSerializer = writer.Session.CodecProvider.GetCodec(fieldType);
+            var specificSerializer = writer.Session.CodecProvider.GetCodec(value.GetType());
             specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
         }
     }

--- a/src/Orleans.Serialization/Exceptions.cs
+++ b/src/Orleans.Serialization/Exceptions.cs
@@ -54,7 +54,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class FieldIdNotPresentException : SerializerException
+    public sealed class FieldIdNotPresentException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldIdNotPresentException"/> class.
@@ -68,7 +68,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected FieldIdNotPresentException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private FieldIdNotPresentException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -78,7 +78,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class SchemaTypeInvalidException : SerializerException
+    public sealed class SchemaTypeInvalidException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SchemaTypeInvalidException"/> class.
@@ -92,7 +92,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected SchemaTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private SchemaTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -102,7 +102,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class FieldTypeInvalidException : SerializerException
+    public sealed class FieldTypeInvalidException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldTypeInvalidException"/> class.
@@ -116,7 +116,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected FieldTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private FieldTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -126,7 +126,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class FieldTypeMissingException : SerializerException
+    public sealed class FieldTypeMissingException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldTypeMissingException"/> class.
@@ -141,7 +141,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected FieldTypeMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private FieldTypeMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -151,7 +151,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class ExtendedWireTypeInvalidException : SerializerException
+    public sealed class ExtendedWireTypeInvalidException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExtendedWireTypeInvalidException"/> class.
@@ -166,7 +166,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected ExtendedWireTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private ExtendedWireTypeInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -176,7 +176,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class UnsupportedWireTypeException : SerializerException
+    public sealed class UnsupportedWireTypeException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnsupportedWireTypeException"/> class.
@@ -198,7 +198,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected UnsupportedWireTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private UnsupportedWireTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -208,7 +208,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class ReferenceNotFoundException : SerializerException
+    public sealed class ReferenceNotFoundException : SerializerException
     {
         /// <summary>
         /// Gets the target reference.
@@ -241,7 +241,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected ReferenceNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private ReferenceNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             TargetReference = info.GetUInt32(nameof(TargetReference));
             TargetReferenceType = (Type)info.GetValue(nameof(TargetReferenceType), typeof(Type));
@@ -261,7 +261,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class UnknownReferencedTypeException : SerializerException
+    public sealed class UnknownReferencedTypeException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnknownReferencedTypeException"/> class.
@@ -277,7 +277,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected UnknownReferencedTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private UnknownReferencedTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             info.AddValue(nameof(Reference), Reference);
         }
@@ -302,7 +302,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class UnknownWellKnownTypeException : SerializerException
+    public sealed class UnknownWellKnownTypeException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnknownWellKnownTypeException"/> class.
@@ -318,7 +318,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected UnknownWellKnownTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private UnknownWellKnownTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             info.AddValue(nameof(Id), Id);
         }
@@ -343,7 +343,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class IllegalTypeException : SerializerException
+    public sealed class IllegalTypeException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalTypeException"/> class.
@@ -359,7 +359,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected IllegalTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private IllegalTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             TypeName = info.GetString(nameof(TypeName));
         }
@@ -384,7 +384,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class TypeMissingException : SerializerException
+    public sealed class TypeMissingException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TypeMissingException"/> class.
@@ -398,7 +398,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected TypeMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private TypeMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -408,7 +408,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class RequiredFieldMissingException : SerializerException
+    public sealed class RequiredFieldMissingException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredFieldMissingException"/> class.
@@ -423,7 +423,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected RequiredFieldMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private RequiredFieldMissingException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -433,7 +433,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class CodecNotFoundException : SerializerException
+    public sealed class CodecNotFoundException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CodecNotFoundException"/> class.
@@ -448,7 +448,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected CodecNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private CodecNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }
@@ -458,7 +458,7 @@ namespace Orleans.Serialization
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class UnexpectedLengthPrefixValueException : SerializerException
+    public sealed class UnexpectedLengthPrefixValueException : SerializerException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnexpectedLengthPrefixValueException"/> class.
@@ -484,7 +484,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        protected UnexpectedLengthPrefixValueException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private UnexpectedLengthPrefixValueException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/Orleans.Serialization/Invocation/PooledResponse.cs
+++ b/src/Orleans.Serialization/Invocation/PooledResponse.cs
@@ -9,7 +9,7 @@ namespace Orleans.Serialization.Invocation
     /// <typeparam name="TResult">The underlying result type.</typeparam>
     [GenerateSerializer]
     [SuppressReferenceTracking]
-    public class PooledResponse<TResult> : Response<TResult>
+    public sealed class PooledResponse<TResult> : Response<TResult>
     {
         [Id(0)]
         private TResult _result;

--- a/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
@@ -33,15 +33,14 @@ namespace Orleans.Serialization.Serializers
         /// <inheritdoc/>
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
         {
-            var fieldType = value?.GetType();
-            if (fieldType is null || fieldType == CodecFieldType)
+            if (value is null || value.GetType() == typeof(TField))
             {
                 if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
                 {
                     return;
                 }
 
-                writer.WriteStartObject(fieldIdDelta, expectedType, fieldType);
+                writer.WriteStartObject(fieldIdDelta, expectedType, CodecFieldType);
                 _serializer.Serialize(ref writer, value);
                 writer.WriteEndObject();
             }

--- a/src/Orleans.Streaming/Internal/StreamHandshakeToken.cs
+++ b/src/Orleans.Streaming/Internal/StreamHandshakeToken.cs
@@ -4,7 +4,7 @@ namespace Orleans.Streams
 {
     [Serializable]
     [GenerateSerializer]
-    internal class StreamHandshakeToken : IEquatable<StreamHandshakeToken>
+    internal abstract class StreamHandshakeToken : IEquatable<StreamHandshakeToken>
     {
         [Id(1)]
         public StreamSequenceToken Token { get; private set; }

--- a/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
@@ -29,10 +29,8 @@ namespace Orleans.Transactions.Abstractions
         );
     }
 
-    [GenerateSerializer]
-    [Serializable]
-    [Immutable]
-    public class PendingTransactionState<TState>
+    [Serializable, GenerateSerializer, Immutable]
+    public sealed class PendingTransactionState<TState>
         where TState : class, new()
     {
         /// <summary>
@@ -71,10 +69,8 @@ namespace Orleans.Transactions.Abstractions
         public TState State { get; set; }
     }
 
-    [GenerateSerializer]
-    [Serializable]
-    [Immutable]
-    public class TransactionalStorageLoadResponse<TState>
+    [Serializable, GenerateSerializer, Immutable]
+    public sealed class TransactionalStorageLoadResponse<TState>
         where TState : class, new()
     {
         public TransactionalStorageLoadResponse() : this(null, new TState(), 0, new TransactionalStateMetaData(), Array.Empty<PendingTransactionState<TState>>()) { }
@@ -118,7 +114,7 @@ namespace Orleans.Transactions.Abstractions
     /// </summary>
     [GenerateSerializer]
     [Serializable]
-    public class TransactionalStateMetaData
+    public sealed class TransactionalStateMetaData
     {
         [Id(0)]
         public DateTime TimeStamp { get; set; } = default;
@@ -127,10 +123,8 @@ namespace Orleans.Transactions.Abstractions
         public Dictionary<Guid, CommitRecord> CommitRecords { get; set; } = new Dictionary<Guid, CommitRecord>();
     }
 
-    [GenerateSerializer]
-    [Serializable]
-    [Immutable]
-    public class CommitRecord
+    [Serializable, GenerateSerializer, Immutable]
+    public sealed class CommitRecord
     {
         [Id(0)]
         public DateTime Timestamp { get; set; }

--- a/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
+++ b/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
@@ -6,9 +6,7 @@ using Orleans.Transactions.Abstractions;
 
 namespace Orleans.Transactions
 {
-    [GenerateSerializer]
-    [Serializable]
-    [Immutable]
+    [Serializable, GenerateSerializer, Immutable]
     public readonly struct ParticipantId
     {
         public static readonly IEqualityComparer<ParticipantId> Comparer = new IdComparer();

--- a/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
@@ -8,7 +8,7 @@ using Orleans.Transactions.Abstractions;
 namespace Orleans.Transactions
 {
     [GenerateSerializer]
-    public class TransactionInfo
+    public sealed class TransactionInfo
     {
         public TransactionInfo()
         {

--- a/src/Orleans.Transactions/OrleansTransactionException.cs
+++ b/src/Orleans.Transactions/OrleansTransactionException.cs
@@ -28,14 +28,14 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionsDisabledException : OrleansTransactionException
+    public sealed class OrleansTransactionsDisabledException : OrleansTransactionException
     {
         public OrleansTransactionsDisabledException()
             : base("Orleans transactions have not been enabled. Transactions are disabled by default and must be configured to be used.")
         {
         }
 
-        public OrleansTransactionsDisabledException(SerializationInfo info, StreamingContext context)
+        private OrleansTransactionsDisabledException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -46,14 +46,14 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansStartTransactionFailedException : OrleansTransactionException
+    public sealed class OrleansStartTransactionFailedException : OrleansTransactionException
     {
         public OrleansStartTransactionFailedException(Exception innerException)
             : base("Failed to start transaction. Check InnerException for details", innerException)
         {
         }
 
-        public OrleansStartTransactionFailedException(SerializationInfo info, StreamingContext context)
+        private OrleansStartTransactionFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -64,7 +64,7 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionOverloadException : OrleansTransactionException
+    public sealed class OrleansTransactionOverloadException : OrleansTransactionException
     {
         public OrleansTransactionOverloadException()
             : base("Transaction is overloaded on current silo, please try again later.")
@@ -78,7 +78,7 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionInDoubtException : OrleansTransactionException
+    public sealed class OrleansTransactionInDoubtException : OrleansTransactionException
     {
         [Id(0)]
         public string TransactionId { get; private set; }
@@ -98,7 +98,7 @@ namespace Orleans.Transactions
             this.TransactionId = transactionId;
         }
 
-        public OrleansTransactionInDoubtException(SerializationInfo info, StreamingContext context)
+        private OrleansTransactionInDoubtException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.TransactionId = info.GetString(nameof(this.TransactionId));
@@ -140,7 +140,7 @@ namespace Orleans.Transactions
             TransactionId = transactionId;
         }
 
-        public OrleansTransactionAbortedException(SerializationInfo info, StreamingContext context)
+        protected OrleansTransactionAbortedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.TransactionId = info.GetString(nameof(this.TransactionId));
@@ -158,7 +158,7 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansCascadingAbortException : OrleansTransactionTransientFailureException
+    public sealed class OrleansCascadingAbortException : OrleansTransactionTransientFailureException
     {
         [Id(0)]
         public string DependentTransactionId { get; private set; }
@@ -179,7 +179,7 @@ namespace Orleans.Transactions
         {
         }
 
-        public OrleansCascadingAbortException(SerializationInfo info, StreamingContext context)
+        private OrleansCascadingAbortException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.DependentTransactionId = info.GetString(nameof(this.DependentTransactionId));
@@ -197,7 +197,7 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansOrphanCallException : OrleansTransactionAbortedException
+    public sealed class OrleansOrphanCallException : OrleansTransactionAbortedException
     {
         public OrleansOrphanCallException(string transactionId, int pendingCalls)
             : base(
@@ -206,7 +206,7 @@ namespace Orleans.Transactions
         {
         }
 
-        public OrleansOrphanCallException(SerializationInfo info, StreamingContext context)
+        private OrleansOrphanCallException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -217,14 +217,14 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansReadOnlyViolatedException : OrleansTransactionAbortedException
+    public sealed class OrleansReadOnlyViolatedException : OrleansTransactionAbortedException
     {
         public OrleansReadOnlyViolatedException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because it attempted to write a grain", transactionId))
         {
         }
 
-        public OrleansReadOnlyViolatedException(SerializationInfo info, StreamingContext context)
+        private OrleansReadOnlyViolatedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -232,13 +232,13 @@ namespace Orleans.Transactions
 
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionServiceNotAvailableException : OrleansTransactionException
+    public sealed class OrleansTransactionServiceNotAvailableException : OrleansTransactionException
     {
         public OrleansTransactionServiceNotAvailableException() : base("Transaction service not available")
         {
         }
 
-        public OrleansTransactionServiceNotAvailableException(SerializationInfo info, StreamingContext context)
+        private OrleansTransactionServiceNotAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -249,7 +249,7 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansBrokenTransactionLockException : OrleansTransactionTransientFailureException
+    public sealed class OrleansBrokenTransactionLockException : OrleansTransactionTransientFailureException
     {
         public OrleansBrokenTransactionLockException(string transactionId, string situation)
             : base(transactionId, $"Transaction {transactionId} aborted because a broken lock was detected, {situation}")
@@ -261,7 +261,7 @@ namespace Orleans.Transactions
         {
         }
 
-        public OrleansBrokenTransactionLockException(SerializationInfo info, StreamingContext context)
+        private OrleansBrokenTransactionLockException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -272,14 +272,14 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionLockUpgradeException : OrleansTransactionTransientFailureException
+    public sealed class OrleansTransactionLockUpgradeException : OrleansTransactionTransientFailureException
     {
         public OrleansTransactionLockUpgradeException(string transactionId) :
             base(transactionId, $"Transaction {transactionId} Aborted because it could not upgrade a lock, because of a higher-priority conflicting transaction")
         {
         }
 
-        public OrleansTransactionLockUpgradeException(SerializationInfo info, StreamingContext context)
+        private OrleansTransactionLockUpgradeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -290,14 +290,14 @@ namespace Orleans.Transactions
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public class OrleansTransactionPrepareTimeoutException : OrleansTransactionTransientFailureException
+    public sealed class OrleansTransactionPrepareTimeoutException : OrleansTransactionTransientFailureException
     {
         public OrleansTransactionPrepareTimeoutException(string transactionId, Exception innerException)
             : base(transactionId, $"Transaction {transactionId} Aborted because the prepare phase did not complete within the timeout limit", innerException)
         {
         }
 
-        public OrleansTransactionPrepareTimeoutException(SerializationInfo info, StreamingContext context)
+        private OrleansTransactionPrepareTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
@@ -321,7 +321,7 @@ namespace Orleans.Transactions
         {
         }
 
-        public OrleansTransactionTransientFailureException(SerializationInfo info, StreamingContext context)
+        protected OrleansTransactionTransientFailureException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -155,7 +155,7 @@ namespace Orleans.Transactions
 
         [Serializable]
         [GenerateSerializer]
-        public class OperationState
+        public sealed class OperationState
         {
             [Id(0)]
             public ITransactionCommitOperation<TService> Operation { get; set; }


### PR DESCRIPTION
Abstract type codecs are identical for `IFieldCodec`, and for types with no serializable fields also for `IBaseCodec`.
Removed the type specific (de)serialization code path from `WriteField/ReadValue` for abstract types since they can never be created anyway.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8014)