### PR TITLE
Add new SerializerTransparentAttribute for abstract classes

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -226,7 +226,7 @@ namespace Orleans.CodeGenerator
                                 }
                                 else
                                 {
-                                    var annotatedConstructors = symbol.Constructors.Where(ctor => LibraryTypes.ConstructorAttributeTypes.Any(ctor.HasAttribute)).ToList();
+                                    var annotatedConstructors = symbol.Constructors.Where(ctor => ctor.HasAnyAttribute(LibraryTypes.ConstructorAttributeTypes)).ToList();
                                     if (annotatedConstructors.Count == 1)
                                     {
                                         constructorParameters = annotatedConstructors[0].Parameters;

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -189,7 +189,7 @@ namespace Orleans.CodeGenerator
                 fields.Add(GetBaseTypeField(serializableTypeDescription, libraryTypes));
             }
 
-            if (!serializableTypeDescription.IsUnsealedImmutable)
+            if (!serializableTypeDescription.IsImmutable)
             {
                 if (serializableTypeDescription.UseActivator && !serializableTypeDescription.IsAbstractType)
                 {

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -353,8 +353,14 @@ skip:;
                     body.Add(IfStatement(exactTypeMatch, ReturnStatement(contextCopy)));
                 }
 
-                // C#: result = _activator.Create();
-                body.Add(ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, resultVar, GetCreateValueExpression(type, copierFields, libraryTypes))));
+                // C#: var result = _activator.Create();
+                body.Add(LocalDeclarationStatement(
+                    VariableDeclaration(
+                        IdentifierName("var"),
+                        SingletonSeparatedList(VariableDeclarator(
+                            resultVar.Identifier,
+                            argumentList: null,
+                            initializer: EqualsValueClause(GetCreateValueExpression(type, copierFields, libraryTypes)))))));
 
                 // C#: context.RecordCopy(original, result);
                 body.Add(ExpressionStatement(InvocationExpression(contextParam.Member("RecordCopy"), ArgumentList(SeparatedList(new[]

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -189,14 +189,17 @@ namespace Orleans.CodeGenerator
                 fields.Add(GetBaseTypeField(serializableTypeDescription, libraryTypes));
             }
 
-            if (serializableTypeDescription.UseActivator && !serializableTypeDescription.IsAbstractType)
+            if (!serializableTypeDescription.IsUnsealedImmutable)
             {
-                onlyDeepFields = false;
-                fields.Add(new ActivatorFieldDescription(libraryTypes.IActivator_1.ToTypeSyntax(serializableTypeDescription.TypeSyntax), ActivatorFieldName));
-            }
+                if (serializableTypeDescription.UseActivator && !serializableTypeDescription.IsAbstractType)
+                {
+                    onlyDeepFields = false;
+                    fields.Add(new ActivatorFieldDescription(libraryTypes.IActivator_1.ToTypeSyntax(serializableTypeDescription.TypeSyntax), ActivatorFieldName));
+                }
 
-            // Add a copier field for any field in the target which does not have a static copier.
-            GetCopierFieldDescriptions(serializableTypeDescription.Members, libraryTypes, fields);
+                // Add a copier field for any field in the target which does not have a static copier.
+                GetCopierFieldDescriptions(serializableTypeDescription.Members, libraryTypes, fields);
+            }
 
             foreach (var member in members)
             {
@@ -275,12 +278,12 @@ namespace Orleans.CodeGenerator
                     }
                     copierType = QualifiedName(ParseName(GetGeneratedNamespaceName(t)), name);
                 }
-                else if (libraryTypes.WellKnownCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, t)) is WellKnownCopierDescription copier)
+                else if (libraryTypes.WellKnownCopiers.FindByUnderlyingType(t) is { } copier)
                 {
                     // The copier is not a static copier and is also not a generic copiers.
                     copierType = copier.CopierType.ToTypeSyntax();
                 }
-                else if (t is INamedTypeSymbol { ConstructedFrom: ISymbol unboundFieldType } named && libraryTypes.WellKnownCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, unboundFieldType)) is { } genericCopier)
+                else if (t is INamedTypeSymbol { ConstructedFrom: ISymbol unboundFieldType } named && libraryTypes.WellKnownCopiers.FindByUnderlyingType(unboundFieldType) is { } genericCopier)
                 {
                     // Construct the generic copier type using the field's type arguments.
                     copierType = genericCopier.CopierType.Construct(named.TypeArguments.ToArray()).ToTypeSyntax();
@@ -315,7 +318,16 @@ skip:;
             if (type.IsAbstractType)
             {
                 // C#: return context.DeepCopy(original)
-                body.Add(ReturnStatement(InvocationExpression(contextParam.Member("DeepCopy")).WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(originalParam))))));
+                body.Add(ReturnStatement(InvocationExpression(contextParam.Member("DeepCopy"), ArgumentList(SingletonSeparatedList(Argument(originalParam))))));
+                membersCopied = true;
+            }
+            else if (type.IsUnsealedImmutable)
+            {
+                // C#: return original is null || original.GetType() == typeof(T) ? original : context.DeepCopy(original);
+                var exactTypeMatch = BinaryExpression(SyntaxKind.EqualsExpression, InvocationExpression(originalParam.Member("GetType")), TypeOfExpression(type.TypeSyntax));
+                var nullOrTypeMatch = BinaryExpression(SyntaxKind.LogicalOrExpression, BinaryExpression(SyntaxKind.IsExpression, originalParam, LiteralExpression(SyntaxKind.NullLiteralExpression)), exactTypeMatch);
+                var contextCopy = InvocationExpression(contextParam.Member("DeepCopy"), ArgumentList(SingletonSeparatedList(Argument(originalParam))));
+                body.Add(ReturnStatement(ConditionalExpression(nullOrTypeMatch, originalParam, contextCopy)));
                 membersCopied = true;
             }
             else if (!type.IsValueType)
@@ -337,13 +349,12 @@ skip:;
                 {
                     // C#: if (original.GetType() != typeof(T)) { return context.DeepCopy(original); }
                     var exactTypeMatch = BinaryExpression(SyntaxKind.NotEqualsExpression, InvocationExpression(originalParam.Member("GetType")), TypeOfExpression(type.TypeSyntax));
-                    var contextCopy = InvocationExpression(contextParam.Member("DeepCopy")).WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(originalParam))));
+                    var contextCopy = InvocationExpression(contextParam.Member("DeepCopy"), ArgumentList(SingletonSeparatedList(Argument(originalParam))));
                     body.Add(IfStatement(exactTypeMatch, ReturnStatement(contextCopy)));
                 }
 
-                // C#: var result = _activator.Create();
-                body.Add(LocalDeclarationStatement(VariableDeclaration(IdentifierName("var"), SingletonSeparatedList(VariableDeclarator("result")
-                    .WithInitializer(EqualsValueClause(GetCreateValueExpression(type, copierFields, libraryTypes)))))));
+                // C#: result = _activator.Create();
+                body.Add(ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, resultVar, GetCreateValueExpression(type, copierFields, libraryTypes))));
 
                 // C#: context.RecordCopy(original, result);
                 body.Add(ExpressionStatement(InvocationExpression(contextParam.Member("RecordCopy"), ArgumentList(SeparatedList(new[]
@@ -475,7 +486,7 @@ skip:;
         {
             AddSerializationCallbacks(type, sourceVar, destinationVar, "OnCopying", body);
 
-            var copiers = copierFields.OfType<ICopierDescription>()
+            var copiers = type.IsUnsealedImmutable ? null : copierFields.OfType<ICopierDescription>()
                     .Concat(libraryTypes.StaticCopiers)
                     .ToList();
 
@@ -506,7 +517,7 @@ skip:;
             List<ICopierDescription> copiers,
             ISerializableMember member)
         {
-            if (member.IsShallowCopyable)
+            if (copiers is null || member.IsShallowCopyable)
                 return inputValue;
 
             var description = member.Member;
@@ -526,7 +537,7 @@ skip:;
             else
             {
                 ExpressionSyntax copierExpression;
-                var staticCopier = libraryTypes.StaticCopiers.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, memberType));
+                var staticCopier = libraryTypes.StaticCopiers.FindByUnderlyingType(memberType);
                 if (staticCopier != null)
                 {
                     copierExpression = staticCopier.CopierType.ToNameSyntax();

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -37,7 +37,7 @@ internal class FieldIdAssignmentHelper
 
     public bool TryGetSymbolKey(ISymbol symbol, out (uint, bool) key) => _symbols.TryGetValue(symbol, out key);
 
-    private bool HasMemberWithIdAnnotation() => _memberSymbols.Any(member => _libraryTypes.IdAttributeTypes.Any(member.HasAttribute));
+    private bool HasMemberWithIdAnnotation() => _memberSymbols.Any(member => member.HasAnyAttribute(_libraryTypes.IdAttributeTypes));
 
     private IEnumerable<ISymbol> GetMembers(INamedTypeSymbol symbol)
     {

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -77,6 +77,9 @@ namespace Orleans.CodeGenerator
                 }
             }
 
+            while (baseClassType.HasAttribute(libraryTypes.SerializerTransparentAttribute))
+                baseClassType = baseClassType.BaseType;
+
             var invokerDescription = new GeneratedInvokerDescription(
                 interfaceDescription,
                 method,
@@ -403,7 +406,7 @@ namespace Orleans.CodeGenerator
 
             // C# base.Dispose();
             if (baseClassType is { }
-                && baseClassType.AllInterfaces.Contains(libraryTypes.IDisposable)
+                && baseClassType.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_IDisposable)
                 && baseClassType.GetAllMembers<IMethodSymbol>("Dispose").FirstOrDefault(m => !m.IsAbstract && m.DeclaredAccessibility != Accessibility.Private) is { })
             {
                 body.Add(ExpressionStatement(InvocationExpression(BaseExpression().Member("Dispose")).WithArgumentList(ArgumentList())));

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -2,12 +2,12 @@ using Orleans.CodeGenerator.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Orleans.CodeGenerator
 {
-    internal class LibraryTypes
+    internal sealed class LibraryTypes
     {
         private LibraryTypes() { }
 
@@ -36,8 +36,8 @@ namespace Orleans.CodeGenerator
                 SerializationCallbacksAttribute = Type("Orleans.SerializationCallbacksAttribute"),
                 IActivator_1 = Type("Orleans.Serialization.Activators.IActivator`1"),
                 IBufferWriter = Type("System.Buffers.IBufferWriter`1"),
-                IdAttributeTypes = options.IdAttributes.Select(Type).ToList(),
-                ConstructorAttributeTypes = options.ConstructorAttributes.Select(Type).ToList(),
+                IdAttributeTypes = options.IdAttributes.Select(Type).ToArray(),
+                ConstructorAttributeTypes = options.ConstructorAttributes.Select(Type).ToArray(),
                 AliasAttribute = Type("Orleans.AliasAttribute"),
                 IInvokable = Type("Orleans.Serialization.Invocation.IInvokable"),
                 DefaultInvokeMethodNameAttribute = Type("Orleans.DefaultInvokeMethodNameAttribute"),
@@ -49,6 +49,7 @@ namespace Orleans.CodeGenerator
                 InvokableBaseTypeAttribute = Type("Orleans.InvokableBaseTypeAttribute"),
                 RegisterSerializerAttribute = Type("Orleans.RegisterSerializerAttribute"),
                 GeneratedActivatorConstructorAttribute = Type("Orleans.GeneratedActivatorConstructorAttribute"),
+                SerializerTransparentAttribute = Type("Orleans.SerializerTransparentAttribute"),
                 RegisterActivatorAttribute = Type("Orleans.RegisterActivatorAttribute"),
                 RegisterConverterAttribute = Type("Orleans.RegisterConverterAttribute"),
                 RegisterCopierAttribute = Type("Orleans.RegisterCopierAttribute"),
@@ -82,10 +83,9 @@ namespace Orleans.CodeGenerator
                 ValueTypeSetter_2 = Type("Orleans.Serialization.Utilities.ValueTypeSetter`2"),
                 Void = compilation.GetSpecialType(SpecialType.System_Void),
                 Writer = Type("Orleans.Serialization.Buffers.Writer`1"),
-                IDisposable = Type("System.IDisposable"),
                 FSharpSourceConstructFlagsOrDefault = TypeOrDefault("Microsoft.FSharp.Core.SourceConstructFlags"),
                 FSharpCompilationMappingAttributeOrDefault = TypeOrDefault("Microsoft.FSharp.Core.CompilationMappingAttribute"),
-                StaticCodecs = new List<WellKnownCodecDescription>
+                StaticCodecs = new WellKnownCodecDescription[]
                 {
                     new(compilation.GetSpecialType(SpecialType.System_Object), Type("Orleans.Serialization.Codecs.ObjectCodec")),
                     new(compilation.GetSpecialType(SpecialType.System_Boolean), Type("Orleans.Serialization.Codecs.BoolCodec")),
@@ -99,7 +99,6 @@ namespace Orleans.CodeGenerator
                     new(compilation.GetSpecialType(SpecialType.System_UInt32), Type("Orleans.Serialization.Codecs.UInt32Codec")),
                     new(compilation.GetSpecialType(SpecialType.System_UInt64), Type("Orleans.Serialization.Codecs.UInt64Codec")),
                     new(compilation.GetSpecialType(SpecialType.System_String), Type("Orleans.Serialization.Codecs.StringCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Object), Type("Orleans.Serialization.Codecs.ObjectCodec")),
                     new(compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Byte), 1), Type("Orleans.Serialization.Codecs.ByteArrayCodec")),
                     new(compilation.GetSpecialType(SpecialType.System_Single), Type("Orleans.Serialization.Codecs.FloatCodec")),
                     new(compilation.GetSpecialType(SpecialType.System_Double), Type("Orleans.Serialization.Codecs.DoubleCodec")),
@@ -114,12 +113,12 @@ namespace Orleans.CodeGenerator
                     new(Type("System.Net.IPAddress"), Type("Orleans.Serialization.Codecs.IPAddressCodec")),
                     new(Type("System.Net.IPEndPoint"), Type("Orleans.Serialization.Codecs.IPEndPointCodec")),
                 },
-                WellKnownCodecs = new List<WellKnownCodecDescription>
+                WellKnownCodecs = new WellKnownCodecDescription[]
                 {
                     new(Type("System.Collections.Generic.Dictionary`2"), Type("Orleans.Serialization.Codecs.DictionaryCodec`2")),
                     new(Type("System.Collections.Generic.List`1"), Type("Orleans.Serialization.Codecs.ListCodec`1")),
                 },
-                StaticCopiers = new List<WellKnownCopierDescription>
+                StaticCopiers = new WellKnownCopierDescription[]
                 {
                     new(compilation.GetSpecialType(SpecialType.System_Object), Type("Orleans.Serialization.Codecs.ObjectCopier")),
                     new(compilation.GetSpecialType(SpecialType.System_Boolean), Type("Orleans.Serialization.Codecs.BoolCodec")),
@@ -147,38 +146,17 @@ namespace Orleans.CodeGenerator
                     new(Type("System.Net.IPAddress"), Type("Orleans.Serialization.Codecs.IPAddressCopier")),
                     new(Type("System.Net.IPEndPoint"), Type("Orleans.Serialization.Codecs.IPEndPointCopier")),
                 },
-                WellKnownCopiers = new List<WellKnownCopierDescription>
+                WellKnownCopiers = new WellKnownCopierDescription[]
                 {
                     new(Type("System.Collections.Generic.Dictionary`2"), Type("Orleans.Serialization.Codecs.DictionaryCopier`2")),
                     new(Type("System.Collections.Generic.List`1"), Type("Orleans.Serialization.Codecs.ListCopier`1")),
                 },
-                ImmutableTypes = new List<ITypeSymbol>
-                {
-                    compilation.GetSpecialType(SpecialType.System_Boolean),
-                    compilation.GetSpecialType(SpecialType.System_Char),
-                    compilation.GetSpecialType(SpecialType.System_Byte),
-                    compilation.GetSpecialType(SpecialType.System_SByte),
-                    compilation.GetSpecialType(SpecialType.System_Int16),
-                    compilation.GetSpecialType(SpecialType.System_Int32),
-                    compilation.GetSpecialType(SpecialType.System_Int64),
-                    compilation.GetSpecialType(SpecialType.System_UInt16),
-                    compilation.GetSpecialType(SpecialType.System_UInt32),
-                    compilation.GetSpecialType(SpecialType.System_UInt64),
-                    compilation.GetSpecialType(SpecialType.System_String),
-                    compilation.GetSpecialType(SpecialType.System_Single),
-                    compilation.GetSpecialType(SpecialType.System_Double),
-                    compilation.GetSpecialType(SpecialType.System_Decimal),
-                    compilation.GetSpecialType(SpecialType.System_DateTime),
-                },
-                    Exception = Type("System.Exception"),
-                    ImmutableAttributes = options.ImmutableAttributes.Select(Type).ToList(),
-                    ValueTuple = Type("System.ValueTuple"),
-                    TimeSpan = Type("System.TimeSpan"),
-                    DateTimeOffset = Type("System.DateTimeOffset"),
-                    Guid = Type("System.Guid"),
-                    IPAddress = Type("System.Net.IPAddress"),
-                    IPEndPoint = Type("System.Net.IPEndPoint"),
-                    CancellationToken = Type("System.Threading.CancellationToken"),
+                Exception = Type("System.Exception"),
+                ImmutableAttributes = options.ImmutableAttributes.Select(Type).ToArray(),
+                TimeSpan = Type("System.TimeSpan"),
+                IPAddress = Type("System.Net.IPAddress"),
+                IPEndPoint = Type("System.Net.IPEndPoint"),
+                CancellationToken = Type("System.Threading.CancellationToken"),
                 ImmutableContainerTypes = new[]
                 {
                     Type("System.Tuple`1"),
@@ -270,13 +248,13 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol ValueTypeSetter_2 { get; private set; }
         public INamedTypeSymbol Void { get; private set; }
         public INamedTypeSymbol Writer { get; private set; }
-        public List<INamedTypeSymbol> IdAttributeTypes { get; private set; }
-        public List<INamedTypeSymbol> ConstructorAttributeTypes { get; private set; }
+        public INamedTypeSymbol[] IdAttributeTypes { get; private set; }
+        public INamedTypeSymbol[] ConstructorAttributeTypes { get; private set; }
         public INamedTypeSymbol AliasAttribute { get; private set; }
-        public List<WellKnownCodecDescription> StaticCodecs { get; private set; }
-        public List<WellKnownCodecDescription> WellKnownCodecs { get; private set; }
-        public List<WellKnownCopierDescription> StaticCopiers { get; private set; }
-        public List<WellKnownCopierDescription> WellKnownCopiers { get; private set; }
+        public WellKnownCodecDescription[] StaticCodecs { get; private set; }
+        public WellKnownCodecDescription[] WellKnownCodecs { get; private set; }
+        public WellKnownCopierDescription[] StaticCopiers { get; private set; }
+        public WellKnownCopierDescription[] WellKnownCopiers { get; private set; }
         public INamedTypeSymbol RegisterCopierAttribute { get; private set; }
         public INamedTypeSymbol RegisterSerializerAttribute { get; private set; }
         public INamedTypeSymbol RegisterConverterAttribute { get; private set; }
@@ -287,16 +265,12 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol CopyContext { get; private set; }
         public INamedTypeSymbol CopyContextPool { get; private set; }
         public Compilation Compilation { get; private set; }
-        public List<ITypeSymbol> ImmutableTypes { get; private set; }
-        public INamedTypeSymbol TimeSpan { get; private set; }
-        public INamedTypeSymbol DateTimeOffset { get; private set; }
-        public INamedTypeSymbol Guid { get; private set; }
-        public INamedTypeSymbol IPAddress { get; private set; }
-        public INamedTypeSymbol IPEndPoint { get; private set; }
-        public INamedTypeSymbol CancellationToken { get; private set; }
-        public INamedTypeSymbol[] ImmutableContainerTypes { get; private set; }
-        public INamedTypeSymbol ValueTuple { get; private set; }
-        public List<INamedTypeSymbol> ImmutableAttributes { get; private set; }
+        private INamedTypeSymbol TimeSpan;
+        private INamedTypeSymbol IPAddress;
+        private INamedTypeSymbol IPEndPoint;
+        private INamedTypeSymbol CancellationToken;
+        private INamedTypeSymbol[] ImmutableContainerTypes;
+        public INamedTypeSymbol[] ImmutableAttributes { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }
         public INamedTypeSymbol ApplicationPartAttribute { get; private set; }
         public INamedTypeSymbol InvokeMethodNameAttribute { get; private set; }
@@ -307,7 +281,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol SerializationCallbacksAttribute { get; private set; }
         public INamedTypeSymbol DefaultInvokeMethodNameAttribute { get; private set; }
         public INamedTypeSymbol GeneratedActivatorConstructorAttribute { get; private set; }
-        public INamedTypeSymbol IDisposable { get; private set; }
+        public INamedTypeSymbol SerializerTransparentAttribute { get; private set; }
         public INamedTypeSymbol FSharpCompilationMappingAttributeOrDefault { get; private set; }
         public INamedTypeSymbol FSharpSourceConstructFlagsOrDefault { get; private set; }
         public INamedTypeSymbol FormatterServices { get; private set; }
@@ -352,12 +326,9 @@ namespace Orleans.CodeGenerator
                 return result;
             }
 
-            foreach (var attr in ImmutableAttributes)
+            if (type.IsSealed && type.HasAnyAttribute(ImmutableAttributes))
             {
-                if (type.HasAttribute(attr))
-                {
-                    return _shallowCopyableTypes[type] = true;
-                }
+                return _shallowCopyableTypes[type] = true;
             }
 
             if (type.HasBaseType(Exception))
@@ -372,20 +343,20 @@ namespace Orleans.CodeGenerator
 
             if (namedType.IsTupleType)
             {
-                return _shallowCopyableTypes[type] = namedType.TupleElements.All(f => IsShallowCopyable(f.Type));
+                return _shallowCopyableTypes[type] = AreShallowCopyable(namedType.TupleElements);
             }
             else if (namedType.IsGenericType)
             {
                 var def = namedType.ConstructedFrom;
                 if (def.SpecialType == SpecialType.System_Nullable_T)
                 {
-                    return _shallowCopyableTypes[type] = IsShallowCopyable(namedType.TypeArguments.Single());
+                    return _shallowCopyableTypes[type] = AreShallowCopyable(namedType.TypeArguments);
                 }
 
                 foreach (var t in ImmutableContainerTypes)
                 {
                     if (SymbolEqualityComparer.Default.Equals(t, def))
-                        return _shallowCopyableTypes[type] = namedType.TypeArguments.All(IsShallowCopyable);
+                        return _shallowCopyableTypes[type] = AreShallowCopyable(namedType.TypeArguments);
                 }
             }
             else
@@ -425,6 +396,45 @@ namespace Orleans.CodeGenerator
             }
 
             return true;
+        }
+
+        private bool AreShallowCopyable(ImmutableArray<ITypeSymbol> types)
+        {
+            foreach (var t in types)
+                if (!IsShallowCopyable(t))
+                    return false;
+
+            return true;
+        }
+
+        private bool AreShallowCopyable(ImmutableArray<IFieldSymbol> fields)
+        {
+            foreach (var f in fields)
+                if (!IsShallowCopyable(f.Type))
+                    return false;
+
+            return true;
+        }
+    }
+
+    internal static class LibraryExtensions
+    {
+        public static WellKnownCodecDescription FindByUnderlyingType(this WellKnownCodecDescription[] values, ISymbol type)
+        {
+            foreach (var c in values)
+                if (SymbolEqualityComparer.Default.Equals(c.UnderlyingType, type))
+                    return c;
+
+            return null;
+        }
+
+        public static WellKnownCopierDescription FindByUnderlyingType(this WellKnownCopierDescription[] values, ISymbol type)
+        {
+            foreach (var c in values)
+                if (SymbolEqualityComparer.Default.Equals(c.UnderlyingType, type))
+                    return c;
+
+            return null;
         }
     }
 }

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -40,7 +40,7 @@ namespace Orleans.CodeGenerator
         public Accessibility Accessibility { get; }
         public TypeSyntax TypeSyntax => _typeSyntax ??= CreateTypeSyntax();
         public TypeSyntax OpenTypeSyntax => _openTypeSyntax ??= CreateOpenTypeSyntax();
-        public bool HasComplexBaseType => BaseType is not null;
+        public bool HasComplexBaseType => BaseType is { SpecialType: not SpecialType.System_Object };
         public bool SupportsPrimaryConstructorParameters => false;
         public INamedTypeSymbol BaseType { get; }
         public TypeSyntax BaseTypeSyntax => _baseTypeSyntax ??= BaseType.ToTypeSyntax(_methodDescription.TypeParameterSubstitutions);
@@ -62,11 +62,13 @@ namespace Orleans.CodeGenerator
         public List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters => _methodDescription.AllTypeParameters;
         public List<INamedTypeSymbol> SerializationHooks { get; }
         public bool IsShallowCopyable => false;
+        public bool IsUnsealedImmutable => false;
+        public bool IsExceptionType => false;
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
         public bool HasActivatorConstructor => UseActivator;
         public CompoundTypeAliasComponent[] CompoundTypeAliasArguments {get;}
 
-        public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => ObjectCreationExpression(TypeSyntax).WithArgumentList(ArgumentList());
+        public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => ObjectCreationExpression(TypeSyntax, ArgumentList(), null);
 
         private TypeSyntax CreateTypeSyntax()
         {

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -62,7 +62,8 @@ namespace Orleans.CodeGenerator
         public List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters => _methodDescription.AllTypeParameters;
         public List<INamedTypeSymbol> SerializationHooks { get; }
         public bool IsShallowCopyable => false;
-        public bool IsUnsealedImmutable => false;
+        public bool IsUnsealedImmutable => !IsSealedType && IsImmutable;
+        public bool IsImmutable => false;
         public bool IsExceptionType => false;
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
         public bool HasActivatorConstructor => UseActivator;

--- a/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -32,6 +32,7 @@ namespace Orleans.CodeGenerator
         List<INamedTypeSymbol> SerializationHooks { get; }
         bool IsShallowCopyable { get; }
         bool IsUnsealedImmutable { get; }
+        bool IsImmutable { get; }
         bool IsExceptionType { get; }
         List<TypeSyntax> ActivatorConstructorParameters { get; }
     }

--- a/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -31,6 +31,8 @@ namespace Orleans.CodeGenerator
         ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes);
         List<INamedTypeSymbol> SerializationHooks { get; }
         bool IsShallowCopyable { get; }
+        bool IsUnsealedImmutable { get; }
+        bool IsExceptionType { get; }
         List<TypeSyntax> ActivatorConstructorParameters { get; }
     }
 }

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -12,6 +12,7 @@ namespace Orleans.CodeGenerator
     {
         private readonly LibraryTypes _libraryTypes;
         private TypeSyntax _typeSyntax;
+        private INamedTypeSymbol _baseType;
         private TypeSyntax _baseTypeSyntax;
 
         public SerializableTypeDescription(SemanticModel semanticModel, INamedTypeSymbol type, bool supportsPrimaryConstructorParameters, IEnumerable<IMemberDescription> members, LibraryTypes libraryTypes)
@@ -111,13 +112,19 @@ namespace Orleans.CodeGenerator
 
         public TypeSyntax BaseTypeSyntax => _baseTypeSyntax ??= BaseType.ToTypeSyntax();
 
-        public bool HasComplexBaseType => !IsValueType &&
-                                          Type.BaseType != null &&
-                                          Type.BaseType.SpecialType != SpecialType.System_Object;
+        public bool HasComplexBaseType => !IsValueType && BaseType is { SpecialType: not SpecialType.System_Object };
 
         public bool SupportsPrimaryConstructorParameters { get; }
 
-        public INamedTypeSymbol BaseType => Type.EnumUnderlyingType ?? Type.BaseType;
+        public INamedTypeSymbol BaseType => _baseType ??= GetEffectiveBaseType();
+
+        private INamedTypeSymbol GetEffectiveBaseType()
+        {
+            var type = Type.EnumUnderlyingType ?? Type.BaseType;
+            while (type != null && type.HasAttribute(_libraryTypes.SerializerTransparentAttribute))
+                type = type.BaseType;
+            return type;
+        }
 
         public string Namespace => Type.GetNamespaceAndNesting();
 
@@ -180,6 +187,10 @@ namespace Orleans.CodeGenerator
 
         public bool IsShallowCopyable => IsEnumType || !Type.HasBaseType(_libraryTypes.Exception) && _libraryTypes.IsShallowCopyable(Type);
 
+        public bool IsUnsealedImmutable => !Type.IsSealed && Type.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
+
+        public bool IsExceptionType => Type.HasBaseType(_libraryTypes.Exception);
+
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes)
         {
             if (IsValueType)
@@ -207,7 +218,7 @@ namespace Orleans.CodeGenerator
 
             if (isConstructible)
             {
-                return ObjectCreationExpression(TypeSyntax).WithArgumentList(ArgumentList());
+                return ObjectCreationExpression(TypeSyntax, ArgumentList(), null);
             }
             else
             {

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -187,7 +187,9 @@ namespace Orleans.CodeGenerator
 
         public bool IsShallowCopyable => IsEnumType || !Type.HasBaseType(_libraryTypes.Exception) && _libraryTypes.IsShallowCopyable(Type);
 
-        public bool IsUnsealedImmutable => !Type.IsSealed && Type.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
+        public bool IsUnsealedImmutable => !Type.IsSealed && IsImmutable;
+
+        public bool IsImmutable => Type.HasAnyAttribute(_libraryTypes.ImmutableAttributes);
 
         public bool IsExceptionType => Type.HasBaseType(_libraryTypes.Exception);
 

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -214,9 +215,13 @@ namespace Orleans.CodeGenerator
             foreach (var member in serializableTypeDescription.Members.Distinct(MemberDescriptionTypeComparer.Default))
             {
                 fields.Add(new TypeFieldDescription(libraryTypes.Type.ToTypeSyntax(), $"_type{typeIndex}", member.TypeSyntax, member.Type));
+
                 // Add a codec field for any field in the target which does not have a static codec.
-                if (!libraryTypes.StaticCodecs.Exists(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, member.Type)))
+                if (!Array.Exists(libraryTypes.StaticCodecs, c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, member.Type)))
+                {
                     fields.Add(GetCodecDescription(member, typeIndex));
+                }
+
                 typeIndex++;
             }
 

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -262,12 +262,12 @@ namespace Orleans.CodeGenerator
                     }
                     codecType = QualifiedName(ParseName(GetGeneratedNamespaceName(t)), name);
                 }
-                else if (libraryTypes.WellKnownCodecs.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, t)) is WellKnownCodecDescription codec)
+                else if (libraryTypes.WellKnownCodecs.FindByUnderlyingType(t) is { } codec)
                 {
                     // The codec is not a static codec and is also not a generic codec.
                     codecType = codec.CodecType.ToTypeSyntax();
                 }
-                else if (t is INamedTypeSymbol named && libraryTypes.WellKnownCodecs.Find(c => t is INamedTypeSymbol named && named.ConstructedFrom is ISymbol unboundFieldType && SymbolEqualityComparer.Default.Equals(c.UnderlyingType, unboundFieldType)) is WellKnownCodecDescription genericCodec)
+                else if (t is INamedTypeSymbol { ConstructedFrom: { } unboundFieldType } named && libraryTypes.WellKnownCodecs.FindByUnderlyingType(unboundFieldType) is { } genericCodec)
                 {
                     // Construct the generic codec type using the field's type arguments.
                     codecType = genericCodec.CodecType.Construct(named.TypeArguments.ToArray()).ToTypeSyntax();
@@ -392,7 +392,7 @@ namespace Orleans.CodeGenerator
                 // Codecs can either be static classes or injected into the constructor.
                 // Either way, the member signatures are the same.
                 var memberType = description.Type;
-                var staticCodec = libraryTypes.StaticCodecs.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, memberType));
+                var staticCodec = libraryTypes.StaticCodecs.FindByUnderlyingType(memberType);
                 ExpressionSyntax codecExpression;
                 if (staticCodec != null && libraryTypes.Compilation.IsSymbolAccessibleWithin(staticCodec.CodecType, libraryTypes.Compilation.Assembly))
                 {
@@ -588,7 +588,7 @@ namespace Orleans.CodeGenerator
                     // Either way, the member signatures are the same.
                     var codec = codecs.First(f => SymbolEqualityComparer.Default.Equals(f.UnderlyingType, description.Type));
                     var memberType = description.Type;
-                    var staticCodec = libraryTypes.StaticCodecs.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, memberType));
+                    var staticCodec = libraryTypes.StaticCodecs.FindByUnderlyingType(memberType);
                     ExpressionSyntax codecExpression;
                     if (staticCodec != null)
                     {
@@ -942,7 +942,7 @@ namespace Orleans.CodeGenerator
 
             // Codecs can either be static classes or injected into the constructor.
             // Either way, the member signatures are the same.
-            var staticCodec = libraryTypes.StaticCodecs.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, type.BaseType));
+            var staticCodec = libraryTypes.StaticCodecs.FindByUnderlyingType(type.BaseType);
             var codecExpression = staticCodec.CodecType.ToNameSyntax();
 
             body.Add(
@@ -984,7 +984,7 @@ namespace Orleans.CodeGenerator
             var readerParam = "reader".ToIdentifierName();
             var fieldParam = "field".ToIdentifierName();
 
-            var staticCodec = libraryTypes.StaticCodecs.Find(c => SymbolEqualityComparer.Default.Equals(c.UnderlyingType, type.BaseType));
+            var staticCodec = libraryTypes.StaticCodecs.FindByUnderlyingType(type.BaseType);
             ExpressionSyntax codecExpression = staticCodec.CodecType.ToNameSyntax();
             ExpressionSyntax readValueExpression = InvocationExpression(
                 codecExpression.Member("ReadValue"),

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -281,31 +281,36 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             return false;
         }
 
-        public static bool HasAnyAttribute(this ISymbol symbol, List<INamedTypeSymbol> attributeType)
+        public static bool HasAnyAttribute(this ISymbol symbol, INamedTypeSymbol[] attributeTypes) => GetAnyAttribute(symbol, attributeTypes) != null;
+
+        public static AttributeData GetAnyAttribute(this ISymbol symbol, INamedTypeSymbol[] attributeTypes)
         {
-            foreach (var t in attributeType)
+            foreach (var attr in symbol.GetAttributes())
             {
-                if (symbol.HasAttribute(t))
+                foreach (var t in attributeTypes)
                 {
-                    return true;
+                    if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, t))
+                    {
+                        return attr;
+                    }
                 }
             }
-
-            return false;
+            return null;
         }
 
-        public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
+        public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType) => GetAttribute(symbol, attributeType) != null;
+
+        public static AttributeData GetAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
         {
-            var attributes = symbol.GetAttributes();
-            foreach (var attr in attributes)
+            foreach (var attr in symbol.GetAttributes())
             {
                 if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType))
                 {
-                    return true;
+                    return attr;
                 }
             }
 
-            return false;
+            return null;
         }
 
         /// <summary>

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -283,7 +283,7 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
 
         public static bool HasAnyAttribute(this ISymbol symbol, INamedTypeSymbol[] attributeTypes) => GetAnyAttribute(symbol, attributeTypes) != null;
 
-        public static AttributeData GetAnyAttribute(this ISymbol symbol, INamedTypeSymbol[] attributeTypes)
+        public static AttributeData? GetAnyAttribute(this ISymbol symbol, INamedTypeSymbol[] attributeTypes)
         {
             foreach (var attr in symbol.GetAttributes())
             {
@@ -300,7 +300,7 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
 
         public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType) => GetAttribute(symbol, attributeType) != null;
 
-        public static AttributeData GetAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
+        public static AttributeData? GetAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
         {
             foreach (var attr in symbol.GetAttributes())
             {

--- a/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
+++ b/src/Orleans.Core.Abstractions/Placement/PlacementStrategy.cs
@@ -13,17 +13,9 @@ namespace Orleans.Runtime
     /// Placement directors are associated with grains using a placement strategy.
     /// Grains indicate their preferred placement strategy using an attribute on the grain class.
     /// </remarks>
-    [Serializable]
-    [GenerateSerializer]
+    [Serializable, SerializerTransparent]
     public abstract class PlacementStrategy
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PlacementStrategy"/> class.
-        /// </summary>
-        protected PlacementStrategy()
-        {
-        }
-
         /// <summary>
         /// Gets a value indicating whether or not this placement strategy requires activations to be registered in
         /// the grain directory.

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -436,7 +436,7 @@ namespace Orleans.Runtime
     /// Base type used for method requests.
     /// </summary>
     [SuppressReferenceTracking]
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class RequestBase : IInvokable
     {
         /// <summary>
@@ -533,7 +533,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Base class for requests for methods which return <see cref="ValueTask"/>.
     /// </summary>
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class Request : RequestBase 
     {
         [DebuggerHidden]
@@ -581,7 +581,7 @@ namespace Orleans.Runtime
     /// <typeparam name="TResult">
     /// The underlying result type.
     /// </typeparam>
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class Request<TResult> : RequestBase
     {
         /// <inheritdoc/>
@@ -632,7 +632,7 @@ namespace Orleans.Runtime
     /// <typeparam name="TResult">
     /// The underlying result type.
     /// </typeparam>
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class TaskRequest<TResult> : RequestBase
     {
         /// <inheritdoc/>
@@ -681,7 +681,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Base class for requests for methods which return <see cref="ValueTask"/>.
     /// </summary>
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class TaskRequest : RequestBase
     {
         /// <inheritdoc/>
@@ -731,7 +731,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Base class for requests for void-returning methods.
     /// </summary>
-    [GenerateSerializer]
+    [SerializerTransparent]
     public abstract class VoidRequest : RequestBase
     {
         /// <inheritdoc/>

--- a/src/Orleans.Core.Abstractions/Versions/Compatibility/ICompatibilityDirector.cs
+++ b/src/Orleans.Core.Abstractions/Versions/Compatibility/ICompatibilityDirector.cs
@@ -19,8 +19,7 @@ namespace Orleans.Versions.Compatibility
     /// <summary>
     /// Base class for all grain interface version compatibility strategies.
     /// </summary>
-    [Serializable]
-    [GenerateSerializer]
+    [Serializable, SerializerTransparent]
     public abstract class CompatibilityStrategy
     {
     }

--- a/src/Orleans.Core.Abstractions/Versions/Selector/IVersionSelector.cs
+++ b/src/Orleans.Core.Abstractions/Versions/Selector/IVersionSelector.cs
@@ -21,8 +21,7 @@ namespace Orleans.Versions.Selector
     /// <summary>
     /// Base class for all grain interface version selector strategies.
     /// </summary>
-    [Serializable]
-    [GenerateSerializer]
+    [Serializable, SerializerTransparent]
     public abstract class VersionSelectorStrategy
     {
     }

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -422,12 +422,21 @@ namespace Orleans
 
     /// <summary>
     /// Indicates that the type, type member, parameter, or return value which it is applied to should be treated as immutable and therefore that defensive copies are never required.
+    /// When applied to non-sealed classes, derived types are not guaranteed to be immutable.
     /// </summary>
     /// <seealso cref="System.Attribute" />
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited = false)]
     public sealed class ImmutableAttribute : Attribute
     {
     }
+
+    /// <summary>
+    /// Indicates that the specific type is invisible for serialization purposes.
+    /// Usable only on abstract types with no serialized fields and effectively removes it from the inheritance hierarchy.
+    /// Adding/removing this attribute from a type will cause serialization protocol level incompatibility (like type hierarchy changes).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class SerializerTransparentAttribute : Attribute { }
 
     /// <summary>
     /// Specifies an assembly to be added as an application part.

--- a/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
+++ b/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
@@ -41,8 +41,8 @@ namespace Orleans.Transactions
             return $"ParticipantId.{Name}.{Reference}";
         }
 
-        [GenerateSerializer]
-        public class IdComparer : IEqualityComparer<ParticipantId>
+        [GenerateSerializer, Immutable]
+        public sealed class IdComparer : IEqualityComparer<ParticipantId>
         {
             public bool Equals(ParticipantId x, ParticipantId y)
             {

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -3,8 +3,10 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FSharp.Core;
 using Newtonsoft.Json;
 using Orleans;
+using Orleans.Serialization.UnitTests;
 
 [GenerateSerializer]
 public record Person([property: Id(0)] int Age, [property: Id(1)] string Name)
@@ -42,6 +44,93 @@ public record Person4(int Age, string Name);
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
 public sealed class MyJsonSerializableAttribute : Attribute
 {
+}
+
+interface IMyBase
+{
+    MyValue BaseValue { get; set; }
+}
+
+interface IMySub : IMyBase
+{
+    MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+public class MyValue : IEquatable<MyValue>
+{
+    [Id(0)]
+    public int Value { get; set; }
+
+    public MyValue(int value) => Value = value;
+
+    public static implicit operator int(MyValue value) => value.Value;
+    public static implicit operator MyValue(int value) => new(value);
+
+    public bool Equals(MyValue other)
+    {
+        return other is not null && Value == other.Value;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as MyValue);
+    }
+
+    public override int GetHashCode() => Value;
+} 
+
+[GenerateSerializer]
+[Immutable]
+public class MyImmutableBase : IMyBase
+{
+    [Id(0)]
+    public MyValue BaseValue { get; set; }
+}
+
+[GenerateSerializer]
+public sealed class MyMutableSub : MyImmutableBase, IMySub
+{
+    [Id(0)]
+    public MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+[Immutable]
+public sealed class MyImmutableSub : MyImmutableBase, IMySub
+{
+    [Id(0)]
+    public MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+public class MyMutableBase : IMyBase
+{
+    [Id(0)]
+    public MyValue BaseValue { get; set; }
+}
+
+[GenerateSerializer]
+public sealed class MySealedSub : MyMutableBase, IMySub
+{
+    [Id(0)]
+    public MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+[Immutable]
+public sealed class MySealedImmutableSub : MyMutableBase, IMySub
+{
+    [Id(0)]
+    public MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+[Immutable]
+public class MyUnsealedImmutableSub : MyMutableBase, IMySub
+{
+    [Id(0)]
+    public MyValue SubValue { get; set; }
 }
 
 [GenerateSerializer]


### PR DESCRIPTION
* Make `ImmutableAttribute` non-inheritable.
* Add new `SerializerTransparentAttribute` for abstract classes.

This is very effective on all invokable types where it effectively removes two empty abstract classes from the type hierarchy for each invokable.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8015)