### PR TITLE
Stop publishing Microsoft.Orleans.CodeGenerator.MSBuild package

### DIFF
--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <PackageDescription>Code generator for projects using Orleans.Serialization with MSBuild</PackageDescription>
+    <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>


### PR DESCRIPTION
We want to reduce the amount of confusion, so we are going to experiment with not publishing the `.MSBuild` codegenerator package. You should continue to use the `Microsoft.Orleans.CodeGenerator` Source Generator, which is included in the `Microsoft.Orleans.Sdk` package.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8017)