### PR TITLE
Require opt-in to call chain reentrancy on a per-call-chain basis

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <typeparam name="TComponent">The type used to lookup this component.</typeparam>
         /// <param name="value">The component instance.</param>
-        void SetComponent<TComponent>(TComponent value);
+        void SetComponent<TComponent>(TComponent value) where TComponent : class;
 
         /// <summary>
         /// Submits an incoming message to this instance.
@@ -238,7 +238,7 @@ namespace Orleans.Runtime
         /// <returns>
         /// The implementation of the extension which is bound to this grain.
         /// </returns>
-        TExtensionInterface GetExtension<TExtensionInterface>() where TExtensionInterface : IGrainExtension;
+        TExtensionInterface GetExtension<TExtensionInterface>() where TExtensionInterface : class, IGrainExtension;
 
         /// <summary>
         /// Binds an extension to an addressable object, if not already done.
@@ -248,7 +248,7 @@ namespace Orleans.Runtime
         /// <param name="newExtensionFunc">A factory function that constructs a new extension object.</param>
         /// <returns>A tuple, containing first the extension and second an addressable reference to the extension's interface.</returns>
         (TExtension, TExtensionInterface) GetOrSetExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension;
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension;
     }
 }

--- a/src/Orleans.Core.Abstractions/Core/Internal/ICallChainReentrantGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/Internal/ICallChainReentrantGrainContext.cs
@@ -1,0 +1,21 @@
+using System;
+using Orleans.Runtime;
+
+namespace Orleans.Core.Internal
+{
+    /// <summary>
+    /// Provides functionality for entering and exiting sections of code within a grain during which requests bearing the same <see cref="RequestContext.ReentrancyId"/> are allowed to re-enter the grain.
+    /// </summary>
+    public interface ICallChainReentrantGrainContext
+    {
+        /// <summary>
+        /// Marks the beginning of a section of code within a grain during which requests bearing the same <see cref="RequestContext.ReentrancyId"/> are allowed to re-enter the grain.
+        /// </summary>
+        void OnEnterReentrantSection(Guid reentrancyId);
+
+        /// <summary>
+        /// Marks the end of a section of code within a grain during which requests bearing the same <see cref="RequestContext.ReentrancyId"/> are allowed to re-enter the grain.
+        /// </summary>
+        void OnExitReentrantSection(Guid reentrancyId);
+    }
+}

--- a/src/Orleans.Core.Abstractions/Core/Internal/IGrainManagementExtension.cs
+++ b/src/Orleans.Core.Abstractions/Core/Internal/IGrainManagementExtension.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
-namespace Orleans.Runtime
+namespace Orleans.Core.Internal
 {
     /// <summary>
     /// Provides functionality for performing management operations on a grain activation.

--- a/src/Orleans.Core.Abstractions/Runtime/GrainContextComponentExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainContextComponentExtensions.cs
@@ -20,7 +20,7 @@ namespace Orleans
         /// The grain extension.
         /// </returns>
         public static TComponent GetGrainExtension<TComponent>(this IGrainContext context)
-            where TComponent : IGrainExtension
+            where TComponent : class, IGrainExtension
         {
             var binder = context.GetComponent<IGrainExtensionBinder>();
             return binder.GetExtension<TComponent>();

--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -20,33 +20,33 @@ namespace Orleans.Runtime
     /// </remarks>
     public static class RequestContext
     {
-        internal const string CALL_CHAIN_ID_HEADER = "#CCID";
+        internal const string CALL_CHAIN_REENTRANCY_HEADER = "#CCR";
         internal const string PING_APPLICATION_HEADER = "Ping";
 
         internal static readonly AsyncLocal<ContextProperties> CallContextData = new AsyncLocal<ContextProperties>();
 
-        public static Guid CallChainId
+        public static Guid ReentrancyId
         {
-            get => Get(CALL_CHAIN_ID_HEADER) is Guid guid ? guid : Guid.Empty;
+            get => Get(CALL_CHAIN_REENTRANCY_HEADER) is Guid guid ? guid : Guid.Empty;
             set
             {
                 if (value == Guid.Empty)
                 {
-                    Remove(CALL_CHAIN_ID_HEADER);
+                    Remove(CALL_CHAIN_REENTRANCY_HEADER);
                 }
                 else
                 {
-                    Set(CALL_CHAIN_ID_HEADER, value);
+                    Set(CALL_CHAIN_REENTRANCY_HEADER, value);
                 }
             }
         }
 
         public static ConfiguredCallChain AllowCallChainReentrancy()
         {
-            var originalCallChainId = CallChainId;
+            var originalCallChainId = ReentrancyId;
             if (originalCallChainId == Guid.Empty)
             {
-                CallChainId = Guid.NewGuid();
+                ReentrancyId = Guid.NewGuid();
             }
 
             return new ConfiguredCallChain(originalCallChainId);
@@ -54,10 +54,10 @@ namespace Orleans.Runtime
 
         public static ConfiguredCallChain SuppressCallChainReentrancy()
         {
-            var originalCallChainId = CallChainId;
+            var originalCallChainId = ReentrancyId;
             if (originalCallChainId != Guid.Empty)
             {
-                CallChainId = Guid.Empty;
+                ReentrancyId = Guid.Empty;
             }
 
             return new ConfiguredCallChain(originalCallChainId);
@@ -181,7 +181,7 @@ namespace Orleans.Runtime
                 _originalCallChainId = originalCallChainId;
             }
 
-            public void Dispose() => CallChainId = _originalCallChainId;
+            public void Dispose() => ReentrancyId = _originalCallChainId;
         }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -37,12 +36,6 @@ namespace Orleans.Configuration
         /// </summary>
         /// <value>Messages are dropped once they expire, by default.</value>
         public bool DropExpiredMessages { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the current activity id should be propagated into grain calls.
-        /// </summary>
-        /// <value>Activity ids are not propagates into grain calls by default.</value>
-        public bool PropagateActivityId { get; set; } = false;
 
         /// <summary>
         /// The maximum number of times a message send attempt will be retried.

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -36,9 +36,6 @@ namespace Orleans
             _logger = loggerFactory.CreateLogger<ClusterClient>();
             _clusterClientLifecycle = new ClusterClientLifecycle(_logger);
 
-            //set PropagateActivityId flag from node config
-            RequestContext.PropagateActivityId |= clientMessagingOptions.Value.PropagateActivityId;
-
             // register all lifecycle participants
             IEnumerable<ILifecycleParticipant<IClusterClientLifecycle>> lifecycleParticipants = ServiceProvider.GetServices<ILifecycleParticipant<IClusterClientLifecycle>>();
             foreach (var participant in lifecycleParticipants)

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -21,7 +21,6 @@ namespace Orleans.Runtime
         public PackedHeaders _headers;
         public CorrelationId _id;
 
-        public Guid _callChainId;
         public Dictionary<string, object> _requestContextData;
 
         public SiloAddress _targetSilo;
@@ -225,16 +224,6 @@ namespace Orleans.Runtime
             }
         }
 
-        public Guid CallChainId
-        {
-            get => _callChainId;
-            set
-            {
-                _callChainId = value;
-                _headers.SetFlag(MessageFlags.HasCallChainId, value != Guid.Empty);
-            }
-        }
-
         public GrainInterfaceType InterfaceType
         {
             get => _interfaceType;
@@ -346,10 +335,9 @@ grow:
 
             HasRequestContextData = 1 << 4,
             HasInterfaceVersion = 1 << 5,
-            HasCallChainId = 1 << 6,
-            HasInterfaceType = 1 << 7,
-            HasCacheInvalidationHeader = 1 << 8,
-            HasTimeToLive = 1 << 9,
+            HasInterfaceType = 1 << 6,
+            HasCacheInvalidationHeader = 1 << 7,
+            HasTimeToLive = 1 << 8,
 
             // The most significant bit is reserved, possibly for use to indicate more data follows.
             Reserved = 1 << 15,

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -208,11 +208,6 @@ namespace Orleans.Runtime.Messaging
                 writer.WriteVarUInt32(value.InterfaceVersion);
             }
 
-            if (headers.HasFlag(MessageFlags.HasCallChainId))
-            {
-                GuidCodec.WriteRaw(ref writer, value.CallChainId);
-            }
-
             if (headers.HasFlag(MessageFlags.HasCacheInvalidationHeader))
             {
                 WriteCacheInvalidationHeaders(ref writer, value.CacheInvalidationHeader);
@@ -256,11 +251,6 @@ namespace Orleans.Runtime.Messaging
             if (headers.HasFlag(MessageFlags.HasInterfaceVersion))
             {
                 result.InterfaceVersion = (ushort)reader.ReadVarUInt32();
-            }
-
-            if (headers.HasFlag(MessageFlags.HasCallChainId))
-            {
-                result.CallChainId = GuidCodec.ReadRaw(ref reader);
             }
 
             if (headers.HasFlag(MessageFlags.HasCacheInvalidationHeader))

--- a/src/Orleans.Core/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans.Core/Providers/ClientProviderRuntime.cs
@@ -36,8 +36,8 @@ namespace Orleans.Providers
 
         /// <inheritdoc/>
         public (TExtension Extension, TExtensionInterface ExtensionReference) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             return this.clientContext.GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }

--- a/src/Orleans.Core/Providers/IProviderRuntime.cs
+++ b/src/Orleans.Core/Providers/IProviderRuntime.cs
@@ -27,7 +27,7 @@ namespace Orleans.Providers
         /// <param name="newExtensionFunc">A factory function that constructs a new extension object.</param>
         /// <returns>A tuple, containing first the extension and second an addressable reference to the extension's interface.</returns>
         (TExtension Extension, TExtensionInterface ExtensionReference) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension;
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension;
     }
 }

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Core.Internal;
 using Orleans.Runtime;
 
 namespace Orleans
@@ -43,26 +44,26 @@ namespace Orleans
 
         public bool Equals(IGrainContext other) => ReferenceEquals(this, other);
 
-        public TComponent GetComponent<TComponent>()
+        public TComponent GetComponent<TComponent>() where TComponent : class
         {
             if (this is TComponent component) return component;
             return default;
         }
 
-        public TTarget GetTarget<TTarget>()
+        public TTarget GetTarget<TTarget>() where TTarget : class
         {
             if (this is TTarget target) return target;
             return default;
         }
 
-        public void SetComponent<TComponent>(TComponent instance)
+        public void SetComponent<TComponent>(TComponent instance) where TComponent : class
         {
             throw new NotSupportedException($"Cannot set components on shared client instance. Extension contract: {typeof(TComponent)}. Component: {instance} (Type: {instance?.GetType()})");
         }
 
         public (TExtension, TExtensionInterface) GetOrSetExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             (TExtension, TExtensionInterface) result;
             if (this.TryGetExtension(out result))
@@ -86,8 +87,8 @@ namespace Orleans
         }
 
         private bool TryGetExtension<TExtension, TExtensionInterface>(out (TExtension, TExtensionInterface) result)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             if (_extensions.TryGetValue(typeof(TExtensionInterface), out var existing))
             {
@@ -118,7 +119,7 @@ namespace Orleans
         }
 
         public TExtensionInterface GetExtension<TExtensionInterface>()
-            where TExtensionInterface : IGrainExtension
+            where TExtensionInterface : class, IGrainExtension
         {
             if (this.TryGetExtension<TExtensionInterface>(out var result))
             {

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -220,9 +220,9 @@ namespace Orleans
                             continue;
                         }
 
-                        if (message.RequestContextData is { Count: > 0 } || message.CallChainId != Guid.Empty)
+                        if (message.RequestContextData is { Count: > 0 })
                         {
-                            RequestContextExtensions.Import(message.RequestContextData, message);
+                            RequestContextExtensions.Import(message.RequestContextData);
                         }
 
                         IInvokable request = null;

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -220,7 +220,11 @@ namespace Orleans
                             continue;
                         }
 
-                        RequestContextExtensions.Import(message.RequestContextData, message);
+                        if (message.RequestContextData is { Count: > 0 } || message.CallChainId != Guid.Empty)
+                        {
+                            RequestContextExtensions.Import(message.RequestContextData, message);
+                        }
+
                         IInvokable request = null;
                         try
                         {
@@ -260,10 +264,6 @@ namespace Orleans
                         _manager.logger.LogWarning(
                             outerException,
                             "Exception in " + nameof(LocalObjectMessagePumpAsync));
-                    }
-                    finally
-                    {
-                        RequestContext.Clear();
                     }
                 }
             }

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -113,7 +113,7 @@ namespace Orleans
 
             public IWorkItemScheduler Scheduler => throw new NotImplementedException();
 
-            void IGrainContext.SetComponent<TComponent>(TComponent value)
+            void IGrainContext.SetComponent<TComponent>(TComponent value) where TComponent : class
             {
                 if (this.LocalObject.Target is TComponent)
                 {
@@ -123,7 +123,7 @@ namespace Orleans
                 _manager.rootGrainContext.SetComponent(value);
             }
 
-            public TComponent GetComponent<TComponent>()
+            public TComponent GetComponent<TComponent>() where TComponent : class
             {
                 if (this.LocalObject.Target is TComponent component)
                 {
@@ -133,7 +133,7 @@ namespace Orleans
                 return _manager.rootGrainContext.GetComponent<TComponent>();
             }
 
-            public TTarget GetTarget<TTarget>() => (TTarget)(object)this.LocalObject.Target;
+            public TTarget GetTarget<TTarget>() where TTarget : class => (TTarget)this.LocalObject.Target;
 
             bool IEquatable<IGrainContext>.Equals(IGrainContext other) => ReferenceEquals(this, other);
 

--- a/src/Orleans.Core/Runtime/RequestContextExtensions.cs
+++ b/src/Orleans.Core/Runtime/RequestContextExtensions.cs
@@ -1,6 +1,6 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Orleans.Serialization;
 
@@ -15,28 +15,8 @@ namespace Orleans.Runtime
         /// Imports the specified context data into the current <see cref="RequestContext"/>, clearing all existing values.
         /// </summary>
         /// <param name="contextData">The context data.</param>
-        public static void Import(Dictionary<string, object> contextData) => Import(contextData, null); 
-
-        /// <summary>
-        /// Imports the specified context data into the current <see cref="RequestContext"/>, clearing all existing values.
-        /// </summary>
-        /// <param name="contextData">The context data.</param>
-        /// <param name="requestMessage">The request message, or <see langword="null"/> if no request is present.</param>
-        internal static void Import(Dictionary<string, object> contextData, object requestMessage)
+        public static void Import(Dictionary<string, object>? contextData)
         {
-            if (RequestContext.PropagateActivityId)
-            {
-                object activityIdObj = Guid.Empty;
-                if (contextData?.TryGetValue(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER, out activityIdObj) == true)
-                {
-                    Trace.CorrelationManager.ActivityId = (Guid)activityIdObj;
-                }
-                else
-                {
-                    Trace.CorrelationManager.ActivityId = Guid.Empty;
-                }
-            }
-
             var values = contextData switch
             {
                 { Count: > 0 } => contextData.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
@@ -45,9 +25,7 @@ namespace Orleans.Runtime
 
             RequestContext.CallContextData.Value = new RequestContext.ContextProperties
             {
-                RequestObject = requestMessage,
                 Values = values,
-
             };
         }
 
@@ -56,77 +34,24 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="copier">The copier.</param>
         /// <returns>A copy of the current request context.</returns>
-        public static Dictionary<string, object> Export(DeepCopier copier)
-        {
-            var (values, _) = ExportInternal(copier);
-            return values;
-        }
-
-        /// <summary>
-        /// Exports a copy of the current <see cref="RequestContext"/>.
-        /// </summary>
-        /// <param name="copier">The copier.</param>
-        /// <returns>A copy of the current request context.</returns>
-        internal static (Dictionary<string, object> Values, object RequestObject) ExportInternal(DeepCopier copier)
+        public static Dictionary<string, object>? Export(DeepCopier copier)
         {
             var properties = RequestContext.CallContextData.Value;
             var values = properties.Values;
 
-            if (RequestContext.PropagateActivityId)
-            {
-                var activityIdOverride = Trace.CorrelationManager.ActivityId;
-                if (activityIdOverride != Guid.Empty)
-                {
-                    object existingActivityId;
-                    if (values == null
-                        || !values.TryGetValue(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER, out existingActivityId)
-                        || activityIdOverride != (Guid)existingActivityId)
-                    {
-                        // Create new copy before mutating data
-                        values = values == null ? new Dictionary<string, object>() : new Dictionary<string, object>(values);
-                        values[RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER] = activityIdOverride;
-                    }
-                }
-            }
-
             var resultValues = (values != null && values.Count > 0)
                 ? copier.Copy(values)
                 : null;
-            return (resultValues, properties.RequestObject);
+            return resultValues;
         }
 
-        /// <summary>
-        /// Suppresses the flow of the currently executing call chain.
-        /// </summary>
-        internal static object SuppressCurrentCallChainFlow()
-        {
-            var properties = RequestContext.CallContextData.Value;
-            var result = properties.RequestObject;
-            if (result is not null)
-            {
-                RequestContext.CallContextData.Value = new RequestContext.ContextProperties
-                {
-                    Values = properties.Values,
-                };
-            }
+        internal static Guid GetCallChainId(this Message message) => GetCallChainId(message?.RequestContextData);
 
-            return result;
-        }
-
-        /// <summary>
-        /// Restores the flow of a previously suppressed call chain.
-        /// </summary>
-        internal static void RestoreCurrentCallChainFlow(object requestMessage)
+        internal static Guid GetCallChainId(Dictionary<string, object>? contextData)
         {
-            if (requestMessage is not null)
-            {
-                var properties = RequestContext.CallContextData.Value;
-                RequestContext.CallContextData.Value = new RequestContext.ContextProperties
-                {
-                    Values = properties.Values,
-                    RequestObject = requestMessage,
-                };
-            }
+            if (contextData is not { Count: > 0 }) return Guid.Empty;
+            _ = contextData.TryGetValue(RequestContext.CALL_CHAIN_ID_HEADER, out var callChainId);
+            return callChainId is Guid guid ? guid : Guid.Empty;
         }
     }
 }

--- a/src/Orleans.Core/Runtime/RequestContextExtensions.cs
+++ b/src/Orleans.Core/Runtime/RequestContextExtensions.cs
@@ -47,6 +47,7 @@ namespace Orleans.Runtime
             {
                 RequestObject = requestMessage,
                 Values = values,
+
             };
         }
 

--- a/src/Orleans.Core/Runtime/RequestContextExtensions.cs
+++ b/src/Orleans.Core/Runtime/RequestContextExtensions.cs
@@ -45,13 +45,13 @@ namespace Orleans.Runtime
             return resultValues;
         }
 
-        internal static Guid GetCallChainId(this Message message) => GetCallChainId(message?.RequestContextData);
+        internal static Guid GetReentrancyId(this Message message) => GetReentrancyId(message?.RequestContextData);
 
-        internal static Guid GetCallChainId(Dictionary<string, object>? contextData)
+        internal static Guid GetReentrancyId(Dictionary<string, object>? contextData)
         {
             if (contextData is not { Count: > 0 }) return Guid.Empty;
-            _ = contextData.TryGetValue(RequestContext.CALL_CHAIN_ID_HEADER, out var callChainId);
-            return callChainId is Guid guid ? guid : Guid.Empty;
+            _ = contextData.TryGetValue(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, out var reentrancyId);
+            return reentrancyId is Guid guid ? guid : Guid.Empty;
         }
     }
 }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Core.Internal;
 using Orleans.GrainReferences;
 using Orleans.Metadata;
 using Orleans.Runtime.Scheduler;

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1250,10 +1250,6 @@ namespace Orleans.Runtime
 
                     return false;
                 }
-                finally
-                {
-                    RequestContext.Clear();
-                }
             }
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -879,10 +879,9 @@ namespace Orleans.Runtime
                 }
 
                 // Handle call-chain reentrancy
-                if (_shared.SchedulingOptions.AllowCallChainReentrancy
-                    && incoming.GetCallChainId() is Guid callChainId
-                    && callChainId == _blockingRequest.GetCallChainId()
-                    && callChainId != Guid.Empty)
+                if (incoming.GetReentrancyId() is Guid id
+                    && id != Guid.Empty
+                    && id == _blockingRequest.GetReentrancyId())
                 {
                     return true;
                 }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -880,8 +880,9 @@ namespace Orleans.Runtime
 
                 // Handle call-chain reentrancy
                 if (_shared.SchedulingOptions.AllowCallChainReentrancy
-                    && incoming.CallChainId == _blockingRequest.CallChainId
-                    && incoming.CallChainId != Guid.Empty)
+                    && incoming.GetCallChainId() is Guid callChainId
+                    && callChainId == _blockingRequest.GetCallChainId()
+                    && callChainId != Guid.Empty)
                 {
                     return true;
                 }

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -105,15 +105,15 @@ namespace Orleans.Runtime
 
         public bool Equals([AllowNull] IGrainContext other) => other is not null && ActivationId.Equals(other.ActivationId);
 
-        public TComponent GetComponent<TComponent>() => this switch
+        public TComponent GetComponent<TComponent>() where TComponent : class => this switch
         {
             TComponent contextResult => contextResult,
             _ => _shared.GetComponent<TComponent>()
         };
 
-        public void SetComponent<TComponent>(TComponent instance) => throw new ArgumentException($"Cannot set a component on a {nameof(StatelessWorkerGrainContext)}");
+        public void SetComponent<TComponent>(TComponent instance) where TComponent : class => throw new ArgumentException($"Cannot set a component on a {nameof(StatelessWorkerGrainContext)}");
 
-        public TTarget GetTarget<TTarget>() => throw new NotImplementedException();
+        public TTarget GetTarget<TTarget>() where TTarget : class => throw new NotImplementedException();
 
         private async Task RunMessageLoop()
         {

--- a/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
@@ -54,11 +54,5 @@ namespace Orleans.Configuration
         /// Gets or sets the period of time after which to log errors for tasks scheduled to stopped activations.
         /// </summary>
         public TimeSpan StoppedActivationWarningInterval { get; set; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
-        /// Whether or not to allow reentrancy for calls within the same call chain.
-        /// </summary>
-        public bool AllowCallChainReentrancy { get; set; } = DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY;
-        public const bool DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY = false;
     }
 }

--- a/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
@@ -59,6 +59,6 @@ namespace Orleans.Configuration
         /// Whether or not to allow reentrancy for calls within the same call chain.
         /// </summary>
         public bool AllowCallChainReentrancy { get; set; } = DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY;
-        public const bool DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY = true;
+        public const bool DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY = false;
     }
 }

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -130,13 +130,13 @@ namespace Orleans.Runtime
             }
         }
 
-        public TComponent GetComponent<TComponent>()
+        public TComponent GetComponent<TComponent>() where TComponent : class
         {
             if (this is TComponent component) return component;
             return default;
         }
 
-        public void SetComponent<TComponent>(TComponent instance)
+        public void SetComponent<TComponent>(TComponent instance) where TComponent : class
         {
             throw new NotSupportedException($"Cannot set components on shared client instance. Extension contract: {typeof(TComponent)}. Component: {instance} (Type: {instance?.GetType()})");
         }
@@ -259,8 +259,8 @@ namespace Orleans.Runtime
         public bool Equals(IGrainContext other) => ReferenceEquals(this, other);
 
         public (TExtension, TExtensionInterface) GetOrSetExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             (TExtension, TExtensionInterface) result;
             if (this.TryGetExtension(out result))
@@ -284,8 +284,8 @@ namespace Orleans.Runtime
         }
 
         private bool TryGetExtension<TExtension, TExtensionInterface>(out (TExtension, TExtensionInterface) result)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             if (_extensions.TryGetValue(typeof(TExtensionInterface), out var existing))
             {
@@ -316,7 +316,7 @@ namespace Orleans.Runtime
         }
 
         public TExtensionInterface GetExtension<TExtensionInterface>()
-            where TExtensionInterface : IGrainExtension
+            where TExtensionInterface : class, IGrainExtension
         {
             if (this.TryGetExtension<TExtensionInterface>(out var result))
             {
@@ -343,7 +343,7 @@ namespace Orleans.Runtime
             }
         }
 
-        public TTarget GetTarget<TTarget>() => throw new NotImplementedException();
+        public TTarget GetTarget<TTarget>() where TTarget : class => throw new NotImplementedException();
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) { }
         public Task Deactivated => Task.CompletedTask;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -252,7 +252,10 @@ namespace Orleans.Runtime
                     return;
                 }
 
-                RequestContextExtensions.Import(message.RequestContextData, message);
+                if (message.RequestContextData is { Count: > 0 } || message.CallChainId != Guid.Empty)
+                {
+                    RequestContextExtensions.Import(message.RequestContextData, message);
+                }
 
                 Response response;
                 try
@@ -326,10 +329,6 @@ namespace Orleans.Runtime
                 {
                     SafeSendExceptionResponse(message, exc2);
                 }
-            }
-            finally
-            {
-                RequestContext.Clear();
             }
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -252,9 +252,9 @@ namespace Orleans.Runtime
                     return;
                 }
 
-                if (message.RequestContextData is { Count: > 0 } || message.CallChainId != Guid.Empty)
+                if (message.RequestContextData is { Count: > 0 })
                 {
-                    RequestContextExtensions.Import(message.RequestContextData, message);
+                    RequestContextExtensions.Import(message.RequestContextData);
                 }
 
                 Response response;

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -126,7 +126,7 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        public void SetComponent<TComponent>(TComponent instance)
+        public void SetComponent<TComponent>(TComponent instance) where TComponent : class
         {
             if (this is TComponent)
             {
@@ -206,8 +206,8 @@ namespace Orleans.Runtime
 
         /// <inheritdoc/>
         public (TExtension, TExtensionInterface) GetOrSetExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             TExtension implementation;
             if (this.GetComponent<TExtensionInterface>() is object existing)
@@ -252,7 +252,7 @@ namespace Orleans.Runtime
 
         /// <inheritdoc/>
         public TExtensionInterface GetExtension<TExtensionInterface>()
-            where TExtensionInterface : IGrainExtension
+            where TExtensionInterface : class, IGrainExtension
         {
             if (this.GetComponent<TExtensionInterface>() is TExtensionInterface result)
             {
@@ -290,7 +290,7 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc/>
-        public TTarget GetTarget<TTarget>() => (TTarget)(object)this;
+        public TTarget GetTarget<TTarget>() where TTarget : class => (TTarget)(object)this;
 
         /// <inheritdoc/>
         public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) { }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -100,7 +100,6 @@ namespace Orleans.Runtime
 
             //set PropagateActivityId flag from node config
             IOptions<SiloMessagingOptions> messagingOptions = services.GetRequiredService<IOptions<SiloMessagingOptions>>();
-            RequestContext.PropagateActivityId = messagingOptions.Value.PropagateActivityId;
             this.waitForMessageToBeQueuedForOutbound = messagingOptions.Value.WaitForMessageToBeQueuedForOutboundTime;
 
             this.loggerFactory = this.Services.GetRequiredService<ILoggerFactory>();

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -22,8 +22,8 @@ namespace Orleans.Runtime.Providers
         public IServiceProvider ServiceProvider { get; }
 
         public (TExtension, TExtensionInterface) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             return _grainContextAccessor.GrainContext.GetComponent<IGrainExtensionBinder>().GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }

--- a/src/Orleans.Serialization/Invocation/ITargetHolder.cs
+++ b/src/Orleans.Serialization/Invocation/ITargetHolder.cs
@@ -10,13 +10,13 @@ namespace Orleans.Serialization.Invocation
         /// </summary>
         /// <typeparam name="TTarget">The target type.</typeparam>
         /// <returns>The target.</returns>
-        TTarget GetTarget<TTarget>();
+        TTarget GetTarget<TTarget>() where TTarget : class;
 
         /// <summary>
         /// Gets the component with the specified type.
         /// </summary>
         /// <typeparam name="TComponent">The component type.</typeparam>
         /// <returns>The component with the specified type.</returns>
-        TComponent GetComponent<TComponent>();
+        TComponent GetComponent<TComponent>() where TComponent : class;
     }
 }

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -85,7 +85,7 @@ namespace Orleans.Streams
             if (batchObserver is GrainReference)
                 throw new ArgumentException("On-behalf subscription via grain references is not supported. Only passing of object references is allowed.", nameof(batchObserver));
 
-            _ = RequestContext.SuppressCallChainReentrancy();
+            using var _ = RequestContext.SuppressCallChainReentrancy();
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Subscribe Token={Token}", token);
             await BindExtensionLazy();
@@ -143,7 +143,7 @@ namespace Orleans.Streams
             IAsyncBatchObserver<T> batchObserver,
             StreamSequenceToken token = null)
         {
-            _ = RequestContext.SuppressCallChainReentrancy();
+            using var _ = RequestContext.SuppressCallChainReentrancy();
 
             StreamSubscriptionHandleImpl<T> oldHandleImpl = CheckHandleValidity(handle);
 
@@ -166,7 +166,7 @@ namespace Orleans.Streams
 
         public async Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle)
         {
-            _ = RequestContext.SuppressCallChainReentrancy();
+            using var _ = RequestContext.SuppressCallChainReentrancy();
 
             await BindExtensionLazy();
 
@@ -187,7 +187,7 @@ namespace Orleans.Streams
 
         public async Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
         {
-            _ = RequestContext.SuppressCallChainReentrancy();
+            using var _ = RequestContext.SuppressCallChainReentrancy();
 
             await BindExtensionLazy();
 
@@ -198,7 +198,7 @@ namespace Orleans.Streams
 
         public async Task Cleanup()
         {
-            _ = RequestContext.SuppressCallChainReentrancy();
+            using var _ = RequestContext.SuppressCallChainReentrancy();
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Cleanup() called");
             if (myExtension == null)

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -85,7 +85,7 @@ namespace Orleans.Streams
             if (batchObserver is GrainReference)
                 throw new ArgumentException("On-behalf subscription via grain references is not supported. Only passing of object references is allowed.", nameof(batchObserver));
 
-            _ = RequestContextExtensions.SuppressCurrentCallChainFlow();
+            _ = RequestContext.SuppressCallChainReentrancy();
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Subscribe Token={Token}", token);
             await BindExtensionLazy();
@@ -143,7 +143,7 @@ namespace Orleans.Streams
             IAsyncBatchObserver<T> batchObserver,
             StreamSequenceToken token = null)
         {
-            _ = RequestContextExtensions.SuppressCurrentCallChainFlow();
+            _ = RequestContext.SuppressCallChainReentrancy();
 
             StreamSubscriptionHandleImpl<T> oldHandleImpl = CheckHandleValidity(handle);
 
@@ -166,7 +166,7 @@ namespace Orleans.Streams
 
         public async Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle)
         {
-            _ = RequestContextExtensions.SuppressCurrentCallChainFlow();
+            _ = RequestContext.SuppressCallChainReentrancy();
 
             await BindExtensionLazy();
 
@@ -187,7 +187,7 @@ namespace Orleans.Streams
 
         public async Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
         {
-            _ = RequestContextExtensions.SuppressCurrentCallChainFlow();
+            _ = RequestContext.SuppressCallChainReentrancy();
 
             await BindExtensionLazy();
 
@@ -198,7 +198,7 @@ namespace Orleans.Streams
 
         public async Task Cleanup()
         {
-            _ = RequestContextExtensions.SuppressCurrentCallChainFlow();
+            _ = RequestContext.SuppressCallChainReentrancy();
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Cleanup() called");
             if (myExtension == null)

--- a/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
@@ -67,8 +67,8 @@ namespace Orleans.Providers
         }
 
         public (TExtension, TExtensionInterface) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             return this.clientContext.GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -135,8 +135,8 @@ namespace Orleans.Runtime.Providers
         }
 
         public (TExtension, TExtensionInterface) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : TExtensionInterface
-            where TExtensionInterface : IGrainExtension
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
         {
             if (this.grainContextAccessor.GrainContext is ActivationData activationData && activationData.IsStatelessWorker)
             {

--- a/test/Benchmarks/Ping/ConcurrentLoadGenerator.cs
+++ b/test/Benchmarks/Ping/ConcurrentLoadGenerator.cs
@@ -162,7 +162,7 @@ namespace Benchmarks.Ping
                 }
 
                 workBlock.EndTimestamp = Stopwatch.GetTimestamp();
-                await completedBlockWriter.WriteAsync(workBlock);
+                await completedBlockWriter.WriteAsync(workBlock).ConfigureAwait(false);
                 --numBlocks;
             }
         }

--- a/test/Benchmarks/run_test.cmd
+++ b/test/Benchmarks/run_test.cmd
@@ -1,3 +1,5 @@
+pushd %~dp0
 git log -n 1
 git --no-pager diff
 dotnet run -c Release -- ConcurrentPing
+popd

--- a/test/Grains/BenchmarkGrainInterfaces/Ping/IPingGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/Ping/IPingGrain.cs
@@ -12,11 +12,4 @@ namespace BenchmarkGrainInterfaces.Ping
         [AlwaysInterleave]
         ValueTask PingPongInterleave(IPingGrain other, int count);
     }
-
-
-
-
-
-
-
 }

--- a/test/Grains/TestGrainInterfaces/IDeadlockGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IDeadlockGrain.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
+using Orleans.Runtime;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -16,4 +18,27 @@ namespace UnitTests.GrainInterfaces
         Task CallNext_1(List<(long GrainId, bool Blocking)> callChain, int currCallIndex);
         Task CallNext_2(List<(long GrainId, bool Blocking)> callChain, int currCallIndex);
     }
+
+    public interface ICallChainObserver : IGrainObserver
+    {
+        Task OnEnter(string grain, int callIndex);
+        Task OnExit(string grain, int callIndex);
+    }
+
+    public interface ICallChainReentrancyGrain : IGrainWithStringKey
+    {
+        Task CallChain(ICallChainObserver observer, List<(string TargetGrain, ReentrancyCallType CallType)> callChain, int callIndex);
+
+        [AlwaysInterleave]
+        Task UnblockWaiters();
+    }
+
+    [GenerateSerializer]
+    public enum ReentrancyCallType
+    {
+        Regular,
+        AllowCallChainReentrancy,
+        SuppressCallChainReentrancy,
+    }
 }
+

--- a/test/Grains/TestGrainInterfaces/IRequestContextTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IRequestContextTestGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans;
 
@@ -15,8 +15,6 @@ namespace UnitTests.GrainInterfaces
         Task<string> TraceIdDelayedEcho2();
 
         Task<Guid> E2EActivityId();
-
-        Task<Guid> E2ELegacyActivityId();
     }
 
     public interface IRequestContextTaskGrain : IGrainWithIntegerKey

--- a/test/Grains/TestGrains/RequestContextTestGrain.cs
+++ b/test/Grains/TestGrains/RequestContextTestGrain.cs
@@ -34,13 +34,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.ActivityId);
-        }
-
-        public Task<Guid> E2ELegacyActivityId()
-        {
-            if (!RequestContext.PropagateActivityId) throw new InvalidOperationException("ActivityId propagation is not enabled on silo.");
-            return Task.FromResult(Trace.CorrelationManager.ActivityId);
+            return Task.FromResult(RequestContext.CallChainId);
         }
     }
 
@@ -130,7 +124,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.ActivityId);
+            return Task.FromResult(RequestContext.CallChainId);
         }
 
         public async Task<Tuple<string, string>> TestRequestContext()

--- a/test/Grains/TestGrains/RequestContextTestGrain.cs
+++ b/test/Grains/TestGrains/RequestContextTestGrain.cs
@@ -34,7 +34,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.CallChainId);
+            return Task.FromResult(RequestContext.ReentrancyId);
         }
     }
 
@@ -124,7 +124,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.CallChainId);
+            return Task.FromResult(RequestContext.ReentrancyId);
         }
 
         public async Task<Tuple<string, string>> TestRequestContext()

--- a/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
@@ -17,16 +17,12 @@ namespace UnitTests.General
     {
         private readonly Dictionary<string, object> headers = new Dictionary<string, object>();
 
-        private static bool oldPropagateActivityId;
 
         private readonly TestEnvironmentFixture fixture;
 
         public RequestContextTests_Local(TestEnvironmentFixture fixture)
         {
             this.fixture = fixture;
-            oldPropagateActivityId = RequestContext.PropagateActivityId;
-            RequestContext.PropagateActivityId = true;
-            RequestContextTestUtils.SetActivityId(Guid.Empty);
             RequestContext.Clear();
             headers.Clear();
         }
@@ -81,18 +77,18 @@ namespace UnitTests.General
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.False(headers.ContainsKey(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER), "ActivityId should not be be present " + headers.ToStrings(separator: ","));
+            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId should not be be present " + headers.ToStrings(separator: ","));
             TestCleanup();
 
-            RequestContextTestUtils.SetActivityId(activityId);
+            RequestContext.CallChainId = activityId;
             msg = new Message();
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.True(headers.ContainsKey(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER), "ActivityId #1 should be present " + headers.ToStrings(separator: ","));
-            object result = headers[RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER];
+            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId #1 should be present " + headers.ToStrings(separator: ","));
+            object result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
             Assert.NotNull(result);// ActivityId #1 should not be null
             Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly"
             Assert.Equal(activityId, RequestContextTestUtils.GetActivityId());  // "Original E2E ActivityId #1 should not have changed"
@@ -105,7 +101,7 @@ namespace UnitTests.General
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.False(headers.ContainsKey(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER), "Null ActivityId should not be present " + headers.ToStrings(separator: ","));
+            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "Null ActivityId should not be present " + headers.ToStrings(separator: ","));
             TestCleanup();
 
             RequestContextTestUtils.SetActivityId(activityId2);
@@ -115,8 +111,8 @@ namespace UnitTests.General
             {
                 headers.Add(kvp.Key, kvp.Value);
             };
-            Assert.True(headers.ContainsKey(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER), "ActivityId #2 should be present " + headers.ToStrings(separator: ","));
-            result = headers[RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER];
+            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId #2 should be present " + headers.ToStrings(separator: ","));
+            result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
             Assert.NotNull(result); // ActivityId #2 should not be null
             Assert.Equal(activityId2, result);  // "E2E ActivityId #2 not propagated correctly"
 
@@ -135,7 +131,7 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            var actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
+            var actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
             Assert.Null(actId);
             TestCleanup();
 
@@ -144,13 +140,13 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
             Assert.NotNull(actId); // "ActivityId #1 should be present " + headers.ToStrings(separator: ",")
-            object result = headers[RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER];
+            object result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
             Assert.NotNull(result);// "ActivityId #1 should not be null"
             Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly"
             Assert.Equal(activityId, RequestContextTestUtils.GetActivityId());  // "Original E2E ActivityId #1 should not have changed"
@@ -161,7 +157,7 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
             Assert.Null(actId);
             TestCleanup();
 
@@ -170,13 +166,13 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
             Assert.NotNull(actId); // "ActivityId #2 should be present " + headers.ToStrings(separator: ",")
-            result = headers[RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER];
+            result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
             Assert.NotNull(result); // "ActivityId #2 should not be null"
             Assert.Equal(activityId2, result);// "E2E ActivityId #2 not propagated correctly
 

--- a/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
@@ -77,18 +77,18 @@ namespace UnitTests.General
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId should not be be present " + headers.ToStrings(separator: ","));
+            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_REENTRANCY_HEADER), "ActivityId should not be be present " + headers.ToStrings(separator: ","));
             TestCleanup();
 
-            RequestContext.CallChainId = activityId;
+            RequestContext.ReentrancyId = activityId;
             msg = new Message();
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId #1 should be present " + headers.ToStrings(separator: ","));
-            object result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
+            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_REENTRANCY_HEADER), "ActivityId #1 should be present " + headers.ToStrings(separator: ","));
+            object result = headers[RequestContext.CALL_CHAIN_REENTRANCY_HEADER];
             Assert.NotNull(result);// ActivityId #1 should not be null
             Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly"
             Assert.Equal(activityId, RequestContextTestUtils.GetActivityId());  // "Original E2E ActivityId #1 should not have changed"
@@ -101,7 +101,7 @@ namespace UnitTests.General
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
-            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "Null ActivityId should not be present " + headers.ToStrings(separator: ","));
+            Assert.False(headers.ContainsKey(RequestContext.CALL_CHAIN_REENTRANCY_HEADER), "Null ActivityId should not be present " + headers.ToStrings(separator: ","));
             TestCleanup();
 
             RequestContextTestUtils.SetActivityId(activityId2);
@@ -111,8 +111,8 @@ namespace UnitTests.General
             {
                 headers.Add(kvp.Key, kvp.Value);
             };
-            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_ID_HEADER), "ActivityId #2 should be present " + headers.ToStrings(separator: ","));
-            result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
+            Assert.True(headers.ContainsKey(RequestContext.CALL_CHAIN_REENTRANCY_HEADER), "ActivityId #2 should be present " + headers.ToStrings(separator: ","));
+            result = headers[RequestContext.CALL_CHAIN_REENTRANCY_HEADER];
             Assert.NotNull(result); // ActivityId #2 should not be null
             Assert.Equal(activityId2, result);  // "E2E ActivityId #2 not propagated correctly"
 
@@ -131,7 +131,7 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            var actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
+            var actId = RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER);
             Assert.Null(actId);
             TestCleanup();
 
@@ -140,13 +140,13 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
             Assert.NotNull(actId); // "ActivityId #1 should be present " + headers.ToStrings(separator: ",")
-            object result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
+            object result = headers[RequestContext.CALL_CHAIN_REENTRANCY_HEADER];
             Assert.NotNull(result);// "ActivityId #1 should not be null"
             Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly"
             Assert.Equal(activityId, RequestContextTestUtils.GetActivityId());  // "Original E2E ActivityId #1 should not have changed"
@@ -157,7 +157,7 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER);
             Assert.Null(actId);
             TestCleanup();
 
@@ -166,13 +166,13 @@ namespace UnitTests.General
             msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
             RequestContext.Clear();
             RequestContextExtensions.Import(msg.RequestContextData);
-            actId = RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER);
+            actId = RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER);
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
                 };
             Assert.NotNull(actId); // "ActivityId #2 should be present " + headers.ToStrings(separator: ",")
-            result = headers[RequestContext.CALL_CHAIN_ID_HEADER];
+            result = headers[RequestContext.CALL_CHAIN_REENTRANCY_HEADER];
             Assert.NotNull(result); // "ActivityId #2 should not be null"
             Assert.Equal(activityId2, result);// "E2E ActivityId #2 not propagated correctly
 

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -11,6 +11,7 @@ using Orleans.TestingHost.Utils;
 using Orleans.Internal;
 using System.Collections.Generic;
 using Orleans;
+using Orleans.Core;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -46,11 +47,11 @@ namespace UnitTests.SchedulerTests
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = default) { }
         public Task Deactivated => Task.CompletedTask;
         public void Dispose() => (Scheduler as IDisposable)?.Dispose();
-        public TComponent GetComponent<TComponent>() => throw new NotImplementedException();
-        public TTarget GetTarget<TTarget>() => throw new NotImplementedException();
+        public TComponent GetComponent<TComponent>() where TComponent : class => throw new NotImplementedException();
+        public TTarget GetTarget<TTarget>() where TTarget : class => throw new NotImplementedException();
         public void ReceiveMessage(object message) => throw new NotImplementedException();
 
-        public void SetComponent<TComponent>(TComponent value) => throw new NotImplementedException();
+        public void SetComponent<TComponent>(TComponent value) where TComponent : class => throw new NotImplementedException();
 
         bool IEquatable<IGrainContext>.Equals(IGrainContext other) => ReferenceEquals(this, other);
     }

--- a/test/TestInfrastructure/TestExtensions/TestUtils.cs
+++ b/test/TestInfrastructure/TestExtensions/TestUtils.cs
@@ -124,18 +124,17 @@ namespace Tester
     {
         public static void SetActivityId(Guid id)
         {
-            RequestContext.ActivityId = id;
+            RequestContext.CallChainId = id;
         }
 
         public static Guid GetActivityId()
         {
-            return RequestContext.ActivityId;
+            return RequestContext.CallChainId is Guid value ? value : Guid.Empty;
         }
 
         public static void ClearActivityId()
         {
-            Trace.CorrelationManager.ActivityId = Guid.Empty;
-            RequestContext.ActivityId = Guid.Empty;
+            RequestContext.CallChainId = Guid.Empty;
         }
     }
 }

--- a/test/TestInfrastructure/TestExtensions/TestUtils.cs
+++ b/test/TestInfrastructure/TestExtensions/TestUtils.cs
@@ -124,17 +124,17 @@ namespace Tester
     {
         public static void SetActivityId(Guid id)
         {
-            RequestContext.CallChainId = id;
+            RequestContext.ReentrancyId = id;
         }
 
         public static Guid GetActivityId()
         {
-            return RequestContext.CallChainId is Guid value ? value : Guid.Empty;
+            return RequestContext.ReentrancyId is Guid value ? value : Guid.Empty;
         }
 
         public static void ClearActivityId()
         {
-            RequestContext.CallChainId = Guid.Empty;
+            RequestContext.ReentrancyId = Guid.Empty;
         }
     }
 }

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -6,6 +6,7 @@ using Orleans.Internal;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Orleans.Runtime;
+using Orleans.Core.Internal;
 
 namespace UnitTests.StreamingTests
 {

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -30,24 +30,6 @@ namespace UnitTests.General
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 builder.Options.InitialSilosCount = 1;
-                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
-                builder.AddClientBuilderConfigurator<ClientConfigurator>();
-            }
-        }
-
-        public class SiloConfigurator : ISiloConfigurator
-        {
-            public void Configure(ISiloBuilder hostBuilder)
-            {
-                hostBuilder.Configure<SiloMessagingOptions>(options => options.PropagateActivityId = true);
-            }
-        }
-
-        public class ClientConfigurator : IClientBuilderConfigurator
-        {
-            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
-            {
-                clientBuilder.Configure<SiloMessagingOptions>(options => options.PropagateActivityId = true);
             }
         }
 
@@ -56,7 +38,6 @@ namespace UnitTests.General
             this.output = output;
             this.fixture = fixture;
             this.runtimeClient = this.fixture.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
-            RequestContext.PropagateActivityId = true; // Client-side setting
 
             RequestContextTestUtils.ClearActivityId();
             RequestContext.Clear();
@@ -77,18 +58,6 @@ namespace UnitTests.General
             RequestContextTestUtils.SetActivityId(activityId);
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("RequestContext")]
-        public async Task RequestContext_LegacyActivityId_Simple()
-        {
-            Guid activityId = Guid.NewGuid();
-            IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
-
-            Trace.CorrelationManager.ActivityId = activityId;
-            Assert.True(RequestContext.PropagateActivityId); // "Verify activityId propagation is enabled."
-            Guid result = await grain.E2ELegacyActivityId();
-            Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
         }
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
@@ -173,17 +142,17 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            RequestContext.Set(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER, activityId);
+            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, activityId);
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContext.Set(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER, nullActivityId);
+            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, nullActivityId);
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
-            RequestContext.Set(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER, activityId2);
+            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, activityId2);
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -198,14 +167,14 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            Trace.CorrelationManager.ActivityId = activityId;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.CallChainId = activityId;
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
+            Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            Trace.CorrelationManager.ActivityId = nullActivityId;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            RequestContext.CallChainId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -213,8 +182,8 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            Trace.CorrelationManager.ActivityId = activityId2;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.CallChainId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -229,14 +198,14 @@ namespace UnitTests.General
 
             IRequestContextProxyGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextProxyGrain>(GetRandomGrainId());
 
-            Trace.CorrelationManager.ActivityId = activityId;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.CallChainId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            Trace.CorrelationManager.ActivityId = nullActivityId;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            RequestContext.CallChainId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -244,8 +213,8 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            Trace.CorrelationManager.ActivityId = activityId2;
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.CallChainId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -269,11 +238,11 @@ namespace UnitTests.General
 
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "E2E ActivityId 2 should not exist"
-            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));  // "No ActivityId context should be set"
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));  // "No ActivityId context should be set"
 
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
-                Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));  // "No ActivityId context should be set"
+                Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));  // "No ActivityId context should be set"
 
                 result = await grain.E2EActivityId();
 
@@ -294,13 +263,13 @@ namespace UnitTests.General
             Assert.Equal(nullActivityId,  result);  // "E2E ActivityId should not exist"
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -308,7 +277,7 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
@@ -322,28 +291,24 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            Trace.CorrelationManager.ActivityId = activityId;
+            RequestContext.CallChainId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly"
             RequestContext.Clear();
 
-            RequestContext.PropagateActivityId = false;
-            output.WriteLine("Set RequestContext.PropagateActivityId={0}", RequestContext.PropagateActivityId);
+            using (RequestContext.SuppressCallChainReentrancy())
+            {
+                result = await grain.E2EActivityId();
+                Assert.Equal(Guid.Empty, result);  // "E2E ActivityId #2 not not have been propagated"
+                RequestContext.Clear();
+            }
 
-            Trace.CorrelationManager.ActivityId = activityId2;
-            result = await grain.E2EActivityId();
-            Assert.Equal(Guid.Empty,  result);  // "E2E ActivityId #2 not not have been propagated"
-            RequestContext.Clear();
-
-            RequestContext.PropagateActivityId = true;
-            output.WriteLine("Set RequestContext.PropagateActivityId={0}", RequestContext.PropagateActivityId);
-
-            Trace.CorrelationManager.ActivityId = activityId2;
+            RequestContext.CallChainId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId #2 should have been propagated"
             RequestContext.Clear();
 
-            Trace.CorrelationManager.ActivityId = activityId;
+            RequestContext.CallChainId = activityId;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly after #2"
             RequestContext.Clear();

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -142,17 +142,17 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, activityId);
+            RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, activityId);
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, nullActivityId);
+            RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, nullActivityId);
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
-            RequestContext.Set(RequestContext.CALL_CHAIN_ID_HEADER, activityId2);
+            RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, activityId2);
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -167,14 +167,14 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
-            RequestContext.CallChainId = activityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            RequestContext.ReentrancyId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContext.CallChainId = nullActivityId;
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.ReentrancyId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -182,8 +182,8 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
-            RequestContext.CallChainId = activityId2;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -198,14 +198,14 @@ namespace UnitTests.General
 
             IRequestContextProxyGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextProxyGrain>(GetRandomGrainId());
 
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
-            RequestContext.CallChainId = activityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            RequestContext.ReentrancyId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContext.CallChainId = nullActivityId;
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+            RequestContext.ReentrancyId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -213,8 +213,8 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
-            RequestContext.CallChainId = activityId2;
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -238,11 +238,11 @@ namespace UnitTests.General
 
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "E2E ActivityId 2 should not exist"
-            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));  // "No ActivityId context should be set"
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));  // "No ActivityId context should be set"
 
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
-                Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));  // "No ActivityId context should be set"
+                Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));  // "No ActivityId context should be set"
 
                 result = await grain.E2EActivityId();
 
@@ -263,13 +263,13 @@ namespace UnitTests.General
             Assert.Equal(nullActivityId,  result);  // "E2E ActivityId should not exist"
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -277,7 +277,7 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_ID_HEADER));
+           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
@@ -291,7 +291,7 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            RequestContext.CallChainId = activityId;
+            RequestContext.ReentrancyId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly"
             RequestContext.Clear();
@@ -303,12 +303,12 @@ namespace UnitTests.General
                 RequestContext.Clear();
             }
 
-            RequestContext.CallChainId = activityId2;
+            RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId #2 should have been propagated"
             RequestContext.Clear();
 
-            RequestContext.CallChainId = activityId;
+            RequestContext.ReentrancyId = activityId;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly after #2"
             RequestContext.Clear();

--- a/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Orleans.Configuration;
 using Orleans.Hosting;
+using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
@@ -48,6 +49,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task DeadlockDetection_1()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_1();
         }
 
@@ -55,6 +57,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_2()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_2();
         }
 
@@ -62,6 +65,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_3()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_3();
         }
 
@@ -69,6 +73,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_4()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_4();
         }
 
@@ -76,6 +81,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_5()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_5();
         }
 
@@ -83,6 +89,7 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_6()
         {
+            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_6();
         }
     }

--- a/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
-using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,21 +14,6 @@ namespace UnitTests.General
 
         public class Fixture : BaseTestClusterFixture
         {
-            protected override void ConfigureTestCluster(TestClusterBuilder builder)
-            {
-                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
-            }
-
-            private class SiloConfigurator : ISiloConfigurator
-            {
-                public void Configure(ISiloBuilder hostBuilder)
-                {
-                    hostBuilder.Configure<SchedulingOptions>(options =>
-                    {
-                        options.AllowCallChainReentrancy = true;
-                    });
-                }
-            }
         }
 
         public AllowCallChainReentrancyTests(ITestOutputHelper output, Fixture fixture)

--- a/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/AllowCallChainReentrancyTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Orleans.Runtime;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,7 +30,6 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task DeadlockDetection_1()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_1();
         }
 
@@ -39,7 +37,6 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_2()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_2();
         }
 
@@ -47,7 +44,6 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_3()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_3();
         }
 
@@ -55,7 +51,6 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_4()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_4();
         }
 
@@ -63,7 +58,6 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_5()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_5();
         }
 
@@ -71,8 +65,13 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
         public async Task CallChainReentrancy_6()
         {
-            using var _ = RequestContext.AllowCallChainReentrancy();
             await _testHelper.CallChainReentrancy_6();
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Deadlock")]
+        public async Task CallChainReentrancy_WithSuppression()
+        {
+            await _testHelper.CallChainReentrancy_WithSuppression();
         }
     }
 } 

--- a/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
+++ b/test/TesterInternal/MessageScheduling/ReentrancyTests.cs
@@ -22,11 +22,7 @@ namespace UnitTests
             hostBuilder
                 .AddMemoryGrainStorage("MemoryStore")
                 .AddMemoryGrainStorage("PubSubStore")
-                .AddMemoryGrainStorageAsDefault()
-                .Configure<SchedulingOptions>(options =>
-                {
-                    options.AllowCallChainReentrancy = false;
-                });
+                .AddMemoryGrainStorageAsDefault();
         }
     }
 


### PR DESCRIPTION
The Call Chain Reentrancy feature uses an AsyncLocal (via RequestContext) which can hurt performance by around 20% in some scenarios. In an effort to uphold the "pay for what you use" philosophy, this PR makes call chain reentrancy opt-in on a per-call-chain basis.

Fixes #8008

After this PR, call chain reetrancy must be explicitly enabled on a per-call-chain basis using the `RequestContext.AllowCallChainReentrancy()` method:
``` C#
using var _ = RequestContext.AllowCallChainReentrancy();
await var myGrain.SomeMethod();
```
Sections of a call chain (for example, a library implemented using grains) can suppress reentrance:

``` C#
using var _ = RequestContext.SuppressCallChainReentrancy();
await var myGrain.SomeMethod();
```

In very advanced use cases, the `ReentrancyId` can be set directly on the `RequestContext`. All calls with the same `ReentrancyId` (a `Guid`) to interleave with each other. `Guid.Empty` indicates that calls cannot interleave with each other.

``` C#
RequestContext.ReentrancyId = MyReentrancyId;
await var myGrain.SomeMethod();
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8023)