### PR TITLE
Update packages to .NET 7 RC2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,41 +51,41 @@
   <!-- Shared Package Versions -->
   <PropertyGroup>
     <!-- System packages -->
-    <SystemDiagnosticsPerformanceCounterVersion>7.0.0-rc.1.22426.10</SystemDiagnosticsPerformanceCounterVersion>
-    <SystemIOHashingVersion>7.0.0-rc.1.22426.10</SystemIOHashingVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>7.0.0-rc.2.22472.3</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemIOHashingVersion>7.0.0-rc.2.22472.3</SystemIOHashingVersion>
     <SystemNetNameResolutionVersion>4.3.0</SystemNetNameResolutionVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.6</MicrosoftDotNetPlatformAbstractionsVersion>
-    <SystemIoPipelinesVersion>7.0.0-rc.1.22426.10</SystemIoPipelinesVersion>
-    <SystemMemoryDataVersion>7.0.0-rc.1.22426.10</SystemMemoryDataVersion>
+    <SystemIoPipelinesVersion>7.0.0-rc.2.22472.3</SystemIoPipelinesVersion>
+    <SystemMemoryDataVersion>7.0.0-rc.2.22472.3</SystemMemoryDataVersion>
 
     <!-- Microsoft packages -->
-    <MicrosoftBuildVersion>17.3.1</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>4.4.0-2.final</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4-beta1.22403.2</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
 
-    <MicrosoftAspNetCoreConnectionsAbstractionsVersion>7.0.0-rc.1.22427.2</MicrosoftAspNetCoreConnectionsAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyModelVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsLoggingVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsObjectPoolVersion>7.0.0-rc.1.22427.2</MicrosoftExtensionsObjectPoolVersion>
-    <MicrosoftExtensionsOptionsVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsOptionsVersion>
-    <MicrosoftExtensionsHttpVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsHttpVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsHostingAbstractionsVersion>
-    <MicrosoftExtensionsHostingVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsHostingVersion>
+    <MicrosoftAspNetCoreConnectionsAbstractionsVersion>7.0.0-rc.2.22476.2</MicrosoftAspNetCoreConnectionsAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyModelVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsLoggingVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsObjectPoolVersion>7.0.0-rc.2.22476.2</MicrosoftExtensionsObjectPoolVersion>
+    <MicrosoftExtensionsOptionsVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsHttpVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsHostingVersion>7.0.0-rc.2.22472.3</MicrosoftExtensionsHostingVersion>
 
     <MicrosoftApplicationInsightsVersion>2.20.0</MicrosoftApplicationInsightsVersion>
-    <AzureDataTablesVersion>12.4.0</AzureDataTablesVersion>
+    <AzureDataTablesVersion>12.6.1</AzureDataTablesVersion>
     <AzureCoreVersion>1.25.0</AzureCoreVersion>
-    <AzureMessagingEventHubs>5.7.2</AzureMessagingEventHubs>
-    <AzureStorageBlobsVersion>12.13.1</AzureStorageBlobsVersion>
-    <AzureStorageQueuesVersion>12.11.1</AzureStorageQueuesVersion>
+    <AzureMessagingEventHubs>5.7.3</AzureMessagingEventHubs>
+    <AzureStorageBlobsVersion>12.14.0</AzureStorageBlobsVersion>
+    <AzureStorageQueuesVersion>12.12.0</AzureStorageQueuesVersion>
     <MicrosoftServiceFabricServicesVersion>4.1.456</MicrosoftServiceFabricServicesVersion>
 
     <!-- 3rd party packages -->
-    <AWSSDKDynamoDBv2Version>3.7.5.12</AWSSDKDynamoDBv2Version>
-    <AWSSDKSQSVersion>3.7.2.115</AWSSDKSQSVersion>
+    <AWSSDKDynamoDBv2Version>3.7.5.16</AWSSDKDynamoDBv2Version>
+    <AWSSDKSQSVersion>3.7.2.119</AWSSDKSQSVersion>
     <BondCoreCSharpVersion>5.3.1</BondCoreCSharpVersion>
     <ConsulVersion>1.6.10.7</ConsulVersion>
     <GoogleCloudPubSubV1Version>1.0.0-beta13</GoogleCloudPubSubV1Version>
@@ -94,33 +94,33 @@
     <NewRelicAgentApiVersion>9.4.0</NewRelicAgentApiVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <ZooKeeperNetExVersion>3.4.12.4</ZooKeeperNetExVersion>
-    <StackExchangeRedisVersion>2.6.66</StackExchangeRedisVersion>
+    <StackExchangeRedisVersion>2.6.70</StackExchangeRedisVersion>
     <KubernetesClientVersion>7.0.7</KubernetesClientVersion>
 
     <!-- Test related packages -->
-    <FluentAssertionsVersion>6.4.0</FluentAssertionsVersion>
+    <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
     <MoqVersion>4.16.0</MoqVersion>
     <MicrosoftTestSdkVersion>17.3.2</MicrosoftTestSdkVersion>
     <BenchmarkDotNetVersion>0.13.2</BenchmarkDotNetVersion>
     <XunitSkippableFactVersion>1.4.13</XunitSkippableFactVersion>
     <xUnitVersion>2.4.2</xUnitVersion>
     <xUnitRunnerVersion>2.4.5</xUnitRunnerVersion>
-    <NodaTimeVersion>3.1.3</NodaTimeVersion>
+    <NodaTimeVersion>3.1.4</NodaTimeVersion>
     <AutofacExtensionsDependencyInjectionVersion>8.0.0</AutofacExtensionsDependencyInjectionVersion>
     <StructureMapMicrosoftDependencyInjectionVersion>2.0.0</StructureMapMicrosoftDependencyInjectionVersion>
-    <SystemCodeDomVersion>7.0.0-rc.1.22426.10</SystemCodeDomVersion>
+    <SystemCodeDomVersion>7.0.0-rc.2.22472.3</SystemCodeDomVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.3</MicrosoftNETFrameworkReferenceAssembliesVersion>
     <AzureIdentityVersion>1.7.0</AzureIdentityVersion>
     <AzureKeyVaultVersion>4.4.0</AzureKeyVaultVersion>
-    <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
-    <NSubstituteVersion>4.3.0</NSubstituteVersion>
+    <FSharpCoreVersion>6.0.6</FSharpCoreVersion>
+    <NSubstituteVersion>4.4.0</NSubstituteVersion>
     <NSubstituteAnalyzersCSharpVersion>1.0.15</NSubstituteAnalyzersCSharpVersion>
     <CoverletVersion>3.0.3</CoverletVersion>
     <CsCheckVersion>2.10.0</CsCheckVersion>
     <DotnetReportGeneratorCliVersion>4.3.0</DotnetReportGeneratorCliVersion>
-    <SystemDataSqlClientVersion>4.8.3</SystemDataSqlClientVersion>
-    <NpgsqlVersion>6.0.2</NpgsqlVersion>
-    <MySqlDataVersion>8.0.30</MySqlDataVersion>
+    <SystemDataSqlClientVersion>4.8.4</SystemDataSqlClientVersion>
+    <NpgsqlVersion>6.0.7</NpgsqlVersion>
+    <MySqlDataVersion>8.0.31</MySqlDataVersion>
     <MicrosoftExtensionsConfigurationAzureKeyVaultVersion>3.1.24</MicrosoftExtensionsConfigurationAzureKeyVaultVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21308.1</SystemCommandLineVersion>
     <CrankVersion>0.2.0-alpha.21457.1</CrankVersion>
@@ -129,7 +129,7 @@
     <Utf8JsonVersion>1.3.7</Utf8JsonVersion>
     <SpanJsonVersion>3.3.1</SpanJsonVersion>
     <HyperionVersion>0.12.2</HyperionVersion>
-    <GrpcToolsVersion>2.43.0</GrpcToolsVersion>
+    <GrpcToolsVersion>2.50.0</GrpcToolsVersion>
 
     <!-- Tooling related packages -->
     <SourceLinkVersion>1.1.1</SourceLinkVersion>


### PR DESCRIPTION
... and update other packages to latest stable version.
The omissions are KubernetesClient, since the API has changed again and it will require more work to upgrade, and Google.Cloud.PubSub.V1, also since the API is substantially different from the current version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8027)