### PR TITLE
Add overloads to hosting extensions which do not include HostBuilderContext

### DIFF
--- a/src/Orleans.Core/Hosting/GenericHostExtensions.cs
+++ b/src/Orleans.Core/Hosting/GenericHostExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans;
 using Orleans.Hosting;
 using Orleans.Runtime;
 
@@ -11,6 +10,21 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public static class OrleansClientGenericHostExtensions
     {
+        /// <summary>
+        /// Configures the host builder to host an Orleans client.
+        /// </summary>
+        /// <param name="hostBuilder">The host builder.</param>
+        /// <param name="configureDelegate">The delegate used to configure the client.</param>
+        /// <returns>The host builder.</returns>
+        /// <remarks>
+        /// Calling this method multiple times on the same <see cref="IClientBuilder"/> instance will result in one client being configured.
+        /// However, the effects of <paramref name="configureDelegate"/> will be applied once for each call.
+        /// Note that this method should not be used in conjunction with IHostBuilder.UseOrleans, since UseOrleans includes a client automatically.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="hostBuilder"/> was null or <paramref name="configureDelegate"/> was null.</exception>
+        public static IHostBuilder UseOrleansClient(this IHostBuilder hostBuilder, Action<IClientBuilder> configureDelegate)
+            => hostBuilder.UseOrleansClient((_, clientBuilder) => configureDelegate(clientBuilder));
+
         /// <summary>
         /// Configures the host builder to host an Orleans client.
         /// </summary>

--- a/src/Orleans.Runtime/Hosting/GenericHostExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/GenericHostExtensions.cs
@@ -24,6 +24,20 @@ namespace Microsoft.Extensions.Hosting
         /// </remarks>
         public static IHostBuilder UseOrleans(
             this IHostBuilder hostBuilder,
+            Action<ISiloBuilder> configureDelegate) => hostBuilder.UseOrleans((_, siloBuilder) => configureDelegate(siloBuilder));
+
+        /// <summary>
+        /// Configures the host builder to host an Orleans silo.
+        /// </summary>
+        /// <param name="hostBuilder">The host builder.</param>
+        /// <param name="configureDelegate">The delegate used to configure the silo.</param>
+        /// <returns>The host builder.</returns>
+        /// <remarks>
+        /// Calling this method multiple times on the same <see cref="IHostBuilder"/> instance will result in one silo being configured.
+        /// However, the effects of <paramref name="configureDelegate"/> will be applied once for each call.
+        /// </remarks>
+        public static IHostBuilder UseOrleans(
+            this IHostBuilder hostBuilder,
             Action<HostBuilderContext, ISiloBuilder> configureDelegate)
         {
             if (hostBuilder is null) throw new ArgumentNullException(nameof(hostBuilder));


### PR DESCRIPTION
As suggested by @IEvangelist, one papercut when migrating from Orleans 3.x to 7.0 is that the signature for the hosting extensions changed. This PR adds the original `UseOrleans` `IHostBuilder` overload back.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8034)