### PR TITLE
Update Microsoft.Orleans.Sdk.targets

### DIFF
--- a/src/Orleans.Sdk/build/Microsoft.Orleans.Sdk.targets
+++ b/src/Orleans.Sdk/build/Microsoft.Orleans.Sdk.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable' ">
+  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable' or '$(ImplicitUsings)' == 'true'">
     <Using Include="Orleans"/>
     <Using Include="Orleans.Hosting"/>
   </ItemGroup>


### PR DESCRIPTION
According to our docs, _implicit usings_ are enabled one of two ways; `enable` or `true`.

https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#using

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8041)