### PR TITLE
Activity source split for User/Runtime grain calls

### DIFF
--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -15,16 +15,16 @@ namespace Orleans.Runtime
 
         internal const string RpcSystem = "orleans";
         internal const string OrleansNamespacePrefix = "Orleans";
-        internal const string UserGrainActivitySourceName = "Microsoft.Orleans.User";
+        internal const string ApplicationGrainActivitySourceName = "Microsoft.Orleans.Application";
         internal const string RuntimeActivitySourceName = "Microsoft.Orleans.Runtime";
 
-        protected static readonly ActivitySource UserGrainSource = new(UserGrainActivitySourceName, "1.0.0");
+        protected static readonly ActivitySource ApplicationGrainSource = new(ApplicationGrainActivitySourceName, "1.0.0");
         protected static readonly ActivitySource RuntimeGrainSource = new(RuntimeActivitySourceName, "1.0.0");
 
         protected static ActivitySource GetActivitySource(IGrainCallContext context) =>
             context.Request.GetInterfaceType().Namespace?.StartsWith(OrleansNamespacePrefix) == true
                 ? RuntimeGrainSource
-                : UserGrainSource;
+                : ApplicationGrainSource;
 
         protected static async Task Process(IGrainCallContext context, Activity activity)
         {

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -14,9 +14,17 @@ namespace Orleans.Runtime
         protected const string TraceStateHeaderName = "tracestate";
 
         internal const string RpcSystem = "orleans";
-        internal const string ActivitySourceName = "Microsoft.Orleans";
+        internal const string OrleansNamespacePrefix = "Orleans";
+        internal const string UserGrainActivitySourceName = "Microsoft.Orleans.User";
+        internal const string RuntimeActivitySourceName = "Microsoft.Orleans.Runtime";
 
-        protected static readonly ActivitySource Source = new(ActivitySourceName);
+        protected static readonly ActivitySource UserGrainSource = new(UserGrainActivitySourceName, "1.0.0");
+        protected static readonly ActivitySource RuntimeGrainSource = new(RuntimeActivitySourceName, "1.0.0");
+
+        protected static ActivitySource GetActivitySource(IGrainCallContext context) =>
+            context.Request.GetInterfaceType().Namespace?.StartsWith(OrleansNamespacePrefix) == true
+                ? RuntimeGrainSource
+                : UserGrainSource;
 
         protected static async Task Process(IGrainCallContext context, Activity activity)
         {
@@ -86,7 +94,8 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public Task Invoke(IOutgoingGrainCallContext context)
         {
-            var activity = Source.StartActivity(context.Request.GetActivityName(), ActivityKind.Client);
+            var source = GetActivitySource(context);
+            var activity = source.StartActivity(context.Request.GetActivityName(), ActivityKind.Client);
 
             if (activity is not null)
             {
@@ -129,9 +138,10 @@ namespace Orleans.Runtime
                 out var traceParent,
                 out var traceState);
 
+            var source = GetActivitySource(context);
             if (!string.IsNullOrEmpty(traceParent))
             {
-                activity = Source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, traceParent);
+                activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, traceParent);
 
                 if (activity is not null)
                 {
@@ -157,7 +167,7 @@ namespace Orleans.Runtime
             }
             else
             {
-                activity = Source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server);
+                activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server);
             }
 
             activity?.Start();

--- a/test/Tester/ActivityPropagationTests.cs
+++ b/test/Tester/ActivityPropagationTests.cs
@@ -23,7 +23,7 @@ namespace UnitTests.General
         {
             Listener = new()
             {
-                ShouldListenTo = p => p.Name == ActivityPropagationGrainCallFilter.ActivitySourceName,
+                ShouldListenTo = p => p.Name == ActivityPropagationGrainCallFilter.UserGrainActivitySourceName,
                 Sample = Sample,
                 SampleUsingParentId = SampleUsingParentId,
             };

--- a/test/Tester/ActivityPropagationTests.cs
+++ b/test/Tester/ActivityPropagationTests.cs
@@ -23,7 +23,7 @@ namespace UnitTests.General
         {
             Listener = new()
             {
-                ShouldListenTo = p => p.Name == ActivityPropagationGrainCallFilter.UserGrainActivitySourceName,
+                ShouldListenTo = p => p.Name == ActivityPropagationGrainCallFilter.ApplicationGrainActivitySourceName,
                 Sample = Sample,
                 SampleUsingParentId = SampleUsingParentId,
             };


### PR DESCRIPTION
This allows for selectively choosing activity for runtime grains (like `IMembershipTable`, `IRemoteGrainDirectory`, or `IDeploymentLoadPublisher`) or only user created grains (what the user has created for their system/application).

It is assumed that consumers will primarily want the user grain Activity and not also the runtime/internal grain calls.

Mechanically, this is achieved by looking to see if the namespace of the grain starts with "Orleans". There is the possibility that a user can create their own grain in a namespace starting with "Orleans" (ex. `Orleans.MyCompany.MyApp`) but this is not an idiomatic pattern for namespace naming so it may be sufficient to document this behavior.

This does introduce a breaking change for current consumers of ActivitySources. 
For example, users using OpenTelemetry (and similarly for directly listening with an ActivityListener) currently add the "Microsoft.Orleans" source and get all runtime and user grain Activity.

This PR would require those users to do one of the following in their code:
* Make no changes and stop getting any Orleans related Activity
* Add the source as "Microsoft.Orleans.*" instead (note the asterisk/wildcard added) to get the existing set of both user and runtime grain Activity
* Add the source as "Microsoft.Orleans.User" to get only the user grain Activity
* Add the source as "Microsoft.Orleans.Runtime" to get only the runtime grain Activity

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8043)