### PR TITLE
Implement SchemaType.Referenced

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -122,10 +122,7 @@ namespace Orleans
             services.AddSingleton<IPostConfigureOptions<OrleansJsonSerializerOptions>, ConfigureOrleansJsonSerializerOptions>();
             services.AddSingleton<OrleansJsonSerializer>();
 
-            services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(
-                sp,
-                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageHeaderSize,
-                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageBodySize));
+            services.TryAddTransient<IMessageSerializer, MessageSerializer>();
             services.TryAddSingleton<ConnectionFactory, ClientOutboundConnectionFactory>();
             services.TryAddSingleton<ClientMessageCenter>(sp => sp.GetRequiredService<OutsideRuntimeClient>().MessageCenter);
             services.TryAddFromExisting<IMessageCenter, ClientMessageCenter>();

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -122,7 +122,9 @@ namespace Orleans
             services.AddSingleton<IPostConfigureOptions<OrleansJsonSerializerOptions>, ConfigureOrleansJsonSerializerOptions>();
             services.AddSingleton<OrleansJsonSerializer>();
 
-            services.TryAddTransient<IMessageSerializer, MessageSerializer>();
+            services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(
+                sp,
+                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value));
             services.TryAddSingleton<ConnectionFactory, ClientOutboundConnectionFactory>();
             services.TryAddSingleton<ClientMessageCenter>(sp => sp.GetRequiredService<OutsideRuntimeClient>().MessageCenter);
             services.TryAddFromExisting<IMessageCenter, ClientMessageCenter>();

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Networking.Shared;
 using Orleans.Serialization;
@@ -37,7 +36,6 @@ namespace Orleans.Runtime.Messaging
         private readonly MemoryPool<byte> _memoryPool;
         private readonly int _maxHeaderLength;
         private readonly int _maxBodyLength;
-        private readonly SerializerSessionPool _sessionPool;
         private readonly DictionaryCodec<string, object> _requestContextCodec;
         private object? _bufferWriter;
 
@@ -48,7 +46,7 @@ namespace Orleans.Runtime.Messaging
             IServiceProvider services,
             Serializer<GrainAddress> activationAddressSerializer,
             ICodecProvider codecProvider,
-            IOptions<ClientMessagingOptions> options)
+            MessagingOptions options)
         {
             _readerSiloAddressCodec = new CachingSiloAddressCodec();
             _writerSiloAddressCodec = new CachingSiloAddressCodec();
@@ -60,10 +58,8 @@ namespace Orleans.Runtime.Messaging
             _deserializationSession = sessionPool.GetSession();
             _memoryPool = memoryPool.Pool;
             _bodySerializer = bodySerializer;
-            var optionsValue = options.Value;
-            _maxHeaderLength = optionsValue.MaxMessageHeaderSize;
-            _maxBodyLength = optionsValue.MaxMessageBodySize;
-            _sessionPool = sessionPool;
+            _maxHeaderLength = options.MaxMessageHeaderSize;
+            _maxBodyLength = options.MaxMessageBodySize;
             _requestContextCodec = OrleansGeneratedCodeHelper.GetService<DictionaryCodec<string, object>>(this, codecProvider);
         }
 

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -373,6 +373,7 @@ namespace Orleans.Runtime.Messaging
                             inflight.Add(message);
                             var (headerLength, bodyLength) = serializer.Write(ref output, message);
                             RecordMessageSend(message, headerLength + bodyLength, headerLength);
+                            message = null;
                         }
                     }
                     catch (Exception exception) when (message != default)

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -371,10 +371,7 @@ namespace Orleans.Hosting
             services.AddSingleton<IPostConfigureOptions<OrleansJsonSerializerOptions>, ConfigureOrleansJsonSerializerOptions>();
             services.AddSingleton<OrleansJsonSerializer>();
 
-            services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(
-                sp,
-                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageHeaderSize,
-                sp.GetRequiredService<IOptions<ClientMessagingOptions>>().Value.MaxMessageBodySize));
+            services.TryAddTransient<IMessageSerializer, MessageSerializer>();
             services.TryAddSingleton<ConnectionFactory, SiloConnectionFactory>();
             services.AddSingleton<NetworkingTrace>();
             services.AddSingleton<RuntimeMessagingTrace>();

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -371,7 +371,9 @@ namespace Orleans.Hosting
             services.AddSingleton<IPostConfigureOptions<OrleansJsonSerializerOptions>, ConfigureOrleansJsonSerializerOptions>();
             services.AddSingleton<OrleansJsonSerializer>();
 
-            services.TryAddTransient<IMessageSerializer, MessageSerializer>();
+            services.TryAddTransient<IMessageSerializer>(sp => ActivatorUtilities.CreateInstance<MessageSerializer>(
+                sp,
+                sp.GetRequiredService<IOptions<SiloMessagingOptions>>().Value));
             services.TryAddSingleton<ConnectionFactory, SiloConnectionFactory>();
             services.AddSingleton<NetworkingTrace>();
             services.AddSingleton<RuntimeMessagingTrace>();

--- a/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
@@ -51,7 +51,7 @@ namespace Orleans.Serialization.Codecs
 
                 writer.WriteVarUInt32(typeOrReferenceId);
             }
-            else if (writer.Session.ReferencedTypes.TryGetTypeReference(actualType, out typeOrReferenceId))
+            else if (writer.Session.ReferencedTypes.GetOrAddTypeReference(actualType, out typeOrReferenceId))
             {
                 writer.WriteByte((byte)(tag | (byte)SchemaType.Referenced));
                 if (hasExtendedFieldId)
@@ -130,15 +130,13 @@ namespace Orleans.Serialization.Codecs
         public static void ReadFieldHeader<TInput>(ref this Reader<TInput> reader, scoped ref Field field)
         {
             var tag = reader.ReadByte();
-
-            if (tag != (byte)WireType.Extended && ((tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask || (tag & Tag.SchemaTypeMask) != (byte)SchemaType.Expected))
+            field.Tag = tag;
+            if (tag < (byte)WireType.Extended && (tag & (Tag.FieldIdCompleteMask | Tag.SchemaTypeMask)) >= Tag.FieldIdCompleteMask)
             {
-                field.Tag = tag;
                 ReadExtendedFieldHeader(ref reader, ref field);
             }
             else
             {
-                field.Tag = tag;
                 field.FieldIdDeltaRaw = default;
                 field.FieldTypeRaw = default;
             }
@@ -155,14 +153,13 @@ namespace Orleans.Serialization.Codecs
         {
             Field field = default;
             var tag = reader.ReadByte();
-            if (tag != (byte)WireType.Extended && ((tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask || (tag & Tag.SchemaTypeMask) != (byte)SchemaType.Expected))
+            field.Tag = tag;
+            if (tag < (byte)WireType.Extended && (tag & (Tag.FieldIdCompleteMask | Tag.SchemaTypeMask)) >= Tag.FieldIdCompleteMask)
             {
-                field.Tag = tag;
                 ReadExtendedFieldHeader(ref reader, ref field);
             }
             else
             {
-                field.Tag = tag;
                 field.FieldIdDeltaRaw = default;
                 field.FieldTypeRaw = default;
             }
@@ -177,11 +174,9 @@ namespace Orleans.Serialization.Codecs
         /// <param name="reader">The reader.</param>
         /// <param name="field">The field.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static void ReadExtendedFieldHeader<TInput>(ref this Reader<TInput> reader, scoped ref Field field)
+        private static void ReadExtendedFieldHeader<TInput>(ref this Reader<TInput> reader, scoped ref Field field)
         {
-            // If all of the field id delta bits are set and the field isn't an extended wiretype field, read the extended field id delta
-            var notExtended = (field.Tag & (byte)WireType.Extended) != (byte)WireType.Extended;
-            if ((field.Tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask && notExtended)
+            if ((field.Tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask)
             {
                 field.FieldIdDeltaRaw = reader.ReadVarUInt32NoInlining();
             }
@@ -192,7 +187,7 @@ namespace Orleans.Serialization.Codecs
 
             // If schema type is valid, read the type.
             var schemaType = (SchemaType)(field.Tag & Tag.SchemaTypeMask);
-            if (notExtended && schemaType != SchemaType.Expected)
+            if (schemaType != SchemaType.Expected)
             {
                 field.FieldTypeRaw = reader.ReadType(schemaType);
             }
@@ -207,13 +202,12 @@ namespace Orleans.Serialization.Codecs
         {
             switch (schemaType)
             {
-                case SchemaType.Expected:
-                    return null;
                 case SchemaType.WellKnown:
                     var typeId = reader.ReadVarUInt32();
                     return reader.Session.WellKnownTypes.GetWellKnownType(typeId);
                 case SchemaType.Encoded:
-                    _ = reader.Session.TypeCodec.TryRead(ref reader, out Type encoded);
+                    var encoded = reader.Session.TypeCodec.TryRead(ref reader);
+                    reader.Session.ReferencedTypes.RecordReferencedType(encoded);
                     return encoded;
                 case SchemaType.Referenced:
                     var reference = reader.ReadVarUInt32();
@@ -228,30 +222,23 @@ namespace Orleans.Serialization.Codecs
         {
             switch (schemaType)
             {
-                case SchemaType.Expected:
-                    return (null, "Expected");
                 case SchemaType.WellKnown:
                     { 
                         var typeId = reader.ReadVarUInt32();
-                        if (reader.Session.WellKnownTypes.TryGetWellKnownType(typeId, out var type))
-                        {
-                            return (type, $"WellKnown {typeId} ({(type is null ? "null" : RuntimeTypeNameFormatter.Format(type))})");
-                        }
-                        else
-                        {
-                            return (null, $"WellKnown {typeId} (unknown)");
-                        }
+                        var found = reader.Session.WellKnownTypes.TryGetWellKnownType(typeId, out var type);
+                        return (type, $"WellKnown {typeId} ({(found ? type is null ? "null" : RuntimeTypeNameFormatter.Format(type) : "unknown")})");
                     }
                 case SchemaType.Encoded:
                     {
                         var found = reader.Session.TypeCodec.TryReadForAnalysis(ref reader, out Type encoded, out var typeString);
-                        return (encoded, $"Encoded \"{typeString}\" ({(found ? RuntimeTypeNameFormatter.Format(encoded) : "not found")})");
+                        reader.Session.ReferencedTypes.RecordReferencedType(encoded);
+                        return (encoded, $"Encoded \"{typeString}\" ({(found ? encoded is null ? "null" : RuntimeTypeNameFormatter.Format(encoded) : "not found")})");
                     }
                 case SchemaType.Referenced:
                     {
                         var reference = reader.ReadVarUInt32();
                         var found = reader.Session.ReferencedTypes.TryGetReferencedType(reference, out var type);
-                        return (type, $"Referenced {reference} ({(found ? RuntimeTypeNameFormatter.Format(type) : "not found")})");
+                        return (type, $"Referenced {reference} ({(found ? type is null ? "null" : RuntimeTypeNameFormatter.Format(type) : "not found")})");
                     }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(schemaType));
@@ -270,7 +257,7 @@ namespace Orleans.Serialization.Codecs
             Field field = default;
             string type = default;
             var tag = reader.ReadByte();
-            if (tag != (byte)WireType.Extended && ((tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask || (tag & Tag.SchemaTypeMask) != (byte)SchemaType.Expected))
+            if (tag < (byte)WireType.Extended && ((tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask || (tag & Tag.SchemaTypeMask) != (byte)SchemaType.Expected))
             {
                 field.Tag = tag;
                 ReadFieldHeaderForAnalysisSlow(ref reader, ref field, ref type);
@@ -289,8 +276,7 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ReadFieldHeaderForAnalysisSlow<TInput>(ref this Reader<TInput> reader, scoped ref Field field, scoped ref string type)
         {
-            var notExtended = (field.Tag & (byte)WireType.Extended) != (byte)WireType.Extended;
-            if ((field.Tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask && notExtended)
+            if ((field.Tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask)
             {
                 field.FieldIdDeltaRaw = reader.ReadVarUInt32NoInlining();
             }
@@ -301,13 +287,14 @@ namespace Orleans.Serialization.Codecs
 
             // If schema type is valid, read the type.
             var schemaType = (SchemaType)(field.Tag & Tag.SchemaTypeMask);
-            if (notExtended && schemaType != SchemaType.Expected)
+            if (schemaType != SchemaType.Expected)
             {
                 (field.FieldTypeRaw, type) = reader.ReadTypeForAnalysis(schemaType);
             }
             else
             {
                 field.FieldTypeRaw = default;
+                type = "Expected";
             }
         }
     }

--- a/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
@@ -131,6 +131,7 @@ namespace Orleans.Serialization.Codecs
         {
             var tag = reader.ReadByte();
             field.Tag = tag;
+            // If the id or schema type are required and were not encoded into the tag, read the extended header data.
             if (tag < (byte)WireType.Extended && (tag & (Tag.FieldIdCompleteMask | Tag.SchemaTypeMask)) >= Tag.FieldIdCompleteMask)
             {
                 ReadExtendedFieldHeader(ref reader, ref field);

--- a/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
@@ -154,6 +154,7 @@ namespace Orleans.Serialization.Codecs
             Field field = default;
             var tag = reader.ReadByte();
             field.Tag = tag;
+            // If the id or schema type are required and were not encoded into the tag, read the extended header data.
             if (tag < (byte)WireType.Extended && (tag & (Tag.FieldIdCompleteMask | Tag.SchemaTypeMask)) >= Tag.FieldIdCompleteMask)
             {
                 ReadExtendedFieldHeader(ref reader, ref field);

--- a/src/Orleans.Serialization/Codecs/GeneralizedReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GeneralizedReferenceTypeSurrogateCodec.cs
@@ -44,7 +44,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, CodecFieldType, value))
             {
                 return;
             }

--- a/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
@@ -11,7 +11,7 @@ namespace Orleans.Serialization.Codecs
     /// </summary>
     /// <typeparam name="TField">The type which the implementation of this class supports.</typeparam>
     /// <typeparam name="TSurrogate">The surrogate type serialized in place of <typeparamref name="TField"/>.</typeparam>
-    public abstract class GeneralizedValueTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField>, IDerivedTypeCodec where TField : struct where TSurrogate : struct
+    public abstract class GeneralizedValueTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField> where TField : struct where TSurrogate : struct
     {
         private static readonly Type CodecFieldType = typeof(TField);
         private readonly IValueSerializer<TSurrogate> _surrogateSerializer;

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -79,7 +79,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         public static void WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, IPAddress value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, CodecFieldType, value))
             {
                 return;
             }

--- a/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
@@ -46,6 +46,35 @@ namespace Orleans.Serialization.Codecs
         }
 
         /// <summary>
+        /// Write an object reference if <paramref name="value"/> has already been written and has been tracked via <see cref="RecordObject(SerializerSession, object)"/>.        /// 
+        /// </summary>
+        /// <remarks>This overload allows specifying a fixed reference type for codecs that implement <see cref="IDerivedTypeCodec"/>.</remarks>
+        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
+        /// <param name="writer">The writer.</param>
+        /// <param name="fieldId">The field identifier.</param>
+        /// <param name="expectedType">The expected type.</param>
+        /// <param name="actualType">The actual type.</param>
+        /// <param name="value">The value.</param>
+        /// <returns><see langword="true" /> if a reference was written, <see langword="false" /> otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteReferenceField<TBufferWriter>(
+            ref Writer<TBufferWriter> writer,
+            uint fieldId,
+            Type expectedType,
+            Type actualType,
+            object value) where TBufferWriter : IBufferWriter<byte>
+        {
+            if (!writer.Session.ReferencedObjects.GetOrAddReference(value, out var reference))
+            {
+                return false;
+            }
+
+            writer.WriteFieldHeader(fieldId, expectedType, value is null ? null : actualType, WireType.Reference);
+            writer.WriteVarUInt32(reference);
+            return true;
+        }
+
+        /// <summary>
         /// Writes the null reference.
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -47,7 +47,7 @@ namespace Orleans.Serialization.Codecs
             {
                 // If the type is encoded, write the length-prefixed bytes.
                 ReferenceCodec.MarkValueField(writer.Session);
-                writer.WriteFieldHeader(1, null, null, WireType.LengthPrefixed);
+                writer.WriteFieldHeaderExpected(1, WireType.LengthPrefixed);
                 writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value);
             }
             else

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -29,7 +29,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Type value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, TypeType, value))
             {
                 return;
             }

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -1,9 +1,9 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Session;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
+using System.Reflection.PortableExecutable;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -13,9 +13,8 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TypeSerializerCodec : IFieldCodec<Type>, IDerivedTypeCodec
     {
-        private static readonly Type SchemaTypeType = typeof(SchemaType);
+        private static readonly Type ByteType = typeof(byte);
         private static readonly Type TypeType = typeof(Type);
-        private static readonly Type ByteArrayType = typeof(byte[]);
         private static readonly Type UIntType = typeof(uint);
 
         /// <inheritdoc />
@@ -36,27 +35,26 @@ namespace Orleans.Serialization.Codecs
                 return;
             }
 
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, TypeType, WireType.TagDelimited);
-            var (schemaType, id) = GetSchemaType(writer.Session, value);
+            writer.WriteStartObject(fieldIdDelta, expectedType, TypeType);
+
+            var schemaType = writer.Session.WellKnownTypes.TryGetWellKnownTypeId(value, out var id) ? SchemaType.WellKnown
+                : writer.Session.ReferencedTypes.GetOrAddTypeReference(value, out id) ? SchemaType.Referenced
+                : SchemaType.Encoded;
 
             // Write the encoding type.
-            ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(0, SchemaTypeType, SchemaTypeType, WireType.VarInt);
-            writer.WriteVarUInt32((uint)schemaType);
+            ByteCodec.WriteField(ref writer, 0, ByteType, (byte)schemaType);
 
             if (schemaType == SchemaType.Encoded)
             {
                 // If the type is encoded, write the length-prefixed bytes.
                 ReferenceCodec.MarkValueField(writer.Session);
-                writer.WriteFieldHeader(1, ByteArrayType, ByteArrayType, WireType.LengthPrefixed);
+                writer.WriteFieldHeader(1, null, null, WireType.LengthPrefixed);
                 writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value);
             }
             else
             {
                 // If the type is referenced or well-known, write it as a varint.
-                ReferenceCodec.MarkValueField(writer.Session);
-                writer.WriteFieldHeader(2, UIntType, UIntType, WireType.VarInt);
-                writer.WriteVarUInt32((uint)id);
+                UInt32Codec.WriteField(ref writer, 2, UIntType, id);
             }
 
             writer.WriteEndObject();
@@ -86,27 +84,27 @@ namespace Orleans.Serialization.Codecs
             Type result = null;
             while (true)
             {
-                var header = reader.ReadFieldHeader();
-                if (header.IsEndBaseOrEndObject)
+                reader.ReadFieldHeader(ref field);
+                if (field.IsEndBaseOrEndObject)
                 {
                     break;
                 }
 
-                ReferenceCodec.MarkValueField(reader.Session);
-                fieldId += header.FieldIdDelta;
+                fieldId += field.FieldIdDelta;
                 switch (fieldId)
                 {
                     case 0:
-                        schemaType = (SchemaType)reader.ReadVarUInt32();
+                        schemaType = (SchemaType)ByteCodec.ReadValue(ref reader, field);
                         break;
                     case 1:
+                        ReferenceCodec.MarkValueField(reader.Session);
                         result = reader.Session.TypeCodec.ReadLengthPrefixed(ref reader);
                         break;
                     case 2:
-                        id = reader.ReadVarUInt32();
+                        id = UInt32Codec.ReadValue(ref reader, field);
                         break;
                     default:
-                        reader.ConsumeUnknownField(header);
+                        reader.ConsumeUnknownField(field);
                         break;
                 }
             }
@@ -114,55 +112,33 @@ namespace Orleans.Serialization.Codecs
             switch (schemaType)
             {
                 case SchemaType.Referenced:
-                    if (reader.Session.ReferencedTypes.TryGetReferencedType(id, out result))
-                    {
-                        break;
-                    }
+                    result = reader.Session.ReferencedTypes.GetReferencedType(id);
+                    break;
 
-                    return ThrowUnknownReferencedType(id);
                 case SchemaType.WellKnown:
-                    if (reader.Session.WellKnownTypes.TryGetWellKnownType(id, out result))
-                    {
-                        break;
-                    }
+                    if (!reader.Session.WellKnownTypes.TryGetWellKnownType(id, out result))
+                        ThrowUnknownWellKnownType(id);
+                    break;
 
-                    return ThrowUnknownWellKnownType(id);
                 case SchemaType.Encoded:
-                    if (result is not null)
-                    {
-                        break;
-                    }
+                    reader.Session.ReferencedTypes.RecordReferencedType(result);
+                    break;
 
-                    return ThrowMissingType();
                 default:
-                    return ThrowInvalidSchemaType(schemaType);
+                    ThrowInvalidSchemaType(schemaType);
+                    break;
             }
 
+            if (result is null) ThrowMissingType();
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
 
-        private static (SchemaType, uint) GetSchemaType(SerializerSession session, Type actualType)
-        {
-            if (session.WellKnownTypes.TryGetWellKnownTypeId(actualType, out uint typeId))
-            {
-                return (SchemaType.WellKnown, typeId);
-            }
-
-            if (session.ReferencedTypes.TryGetTypeReference(actualType, out uint reference))
-            {
-                return (SchemaType.Referenced, reference);
-            }
-
-            return (SchemaType.Encoded, 0);
-        }
-
-        private static Type ThrowInvalidSchemaType(SchemaType schemaType) => throw new NotSupportedException(
+        private static void ThrowInvalidSchemaType(SchemaType schemaType) => throw new NotSupportedException(
             $"SchemaType {schemaType} is not supported by {nameof(TypeSerializerCodec)}.");
 
-        private static Type ThrowUnknownReferencedType(uint id) => throw new UnknownReferencedTypeException(id);
-        private static Type ThrowUnknownWellKnownType(uint id) => throw new UnknownWellKnownTypeException(id);
-        private static Type ThrowMissingType() => throw new TypeMissingException();
+        private static void ThrowUnknownWellKnownType(uint id) => throw new UnknownWellKnownTypeException(id);
+        private static void ThrowMissingType() => throw new TypeMissingException();
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Reflection.PortableExecutable;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
@@ -38,7 +37,7 @@ namespace Orleans.Serialization.Codecs
             writer.WriteStartObject(fieldIdDelta, expectedType, TypeType);
 
             var schemaType = writer.Session.WellKnownTypes.TryGetWellKnownTypeId(value, out var id) ? SchemaType.WellKnown
-                : writer.Session.ReferencedTypes.GetOrAddTypeReference(value, out id) ? SchemaType.Referenced
+                : writer.Session.ReferencedTypes.TryGetTypeReference(value, out id) ? SchemaType.Referenced
                 : SchemaType.Encoded;
 
             // Write the encoding type.
@@ -121,7 +120,7 @@ namespace Orleans.Serialization.Codecs
                     break;
 
                 case SchemaType.Encoded:
-                    reader.Session.ReferencedTypes.RecordReferencedType(result);
+                    // Type codec should not update the type reference map, otherwise unknown-field deserialization could be broken
                     break;
 
                 default:

--- a/src/Orleans.Serialization/Codecs/UnknownFieldMarker.cs
+++ b/src/Orleans.Serialization/Codecs/UnknownFieldMarker.cs
@@ -5,7 +5,7 @@ namespace Orleans.Serialization.Codecs
     /// <summary>
     /// Marker object used to denote an unknown field and its position into a stream of data.
     /// </summary>
-    public class UnknownFieldMarker
+    public sealed class UnknownFieldMarker
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnknownFieldMarker"/> class.

--- a/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
@@ -42,6 +42,14 @@ namespace Orleans.Serialization.Session
         public void RecordReferencedType(Type type) => _referencedTypes.Add(++_currentReferenceId, type);
 
         /// <summary>
+        /// Gets the identifier for the specified type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="reference">The reference.</param>
+        /// <returns><see langword="true" /> if the type has been previoulsy referenced, <see langword="false" /> otherwise.</returns>
+        public bool TryGetTypeReference(Type type, out uint reference) => _referencedTypeToIdMap.TryGetValue(type, out reference);
+
+        /// <summary>
         /// Gets or adds the identifier for the specified type.
         /// </summary>
         public bool GetOrAddTypeReference(Type type, out uint reference)

--- a/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Orleans.Serialization.Session
 {
@@ -8,15 +9,24 @@ namespace Orleans.Serialization.Session
     /// </summary>
     public sealed class ReferencedTypeCollection
     {
-        private readonly Dictionary<uint, Type> _referencedTypes = new Dictionary<uint, Type>();
-        private readonly Dictionary<Type, uint> _referencedTypeToIdMap = new Dictionary<Type, uint>();
+        private readonly Dictionary<uint, Type> _referencedTypes = new();
+        private readonly Dictionary<Type, uint> _referencedTypeToIdMap = new();
+
+        private uint _currentReferenceId;
 
         /// <summary>
         /// Gets the type with the specified reference id.
         /// </summary>
         /// <param name="reference">The reference id.</param>
         /// <returns>The referenced type.</returns>
-        public Type GetReferencedType(uint reference) => _referencedTypes[reference];
+        public Type GetReferencedType(uint reference)
+        {
+            if (!_referencedTypes.TryGetValue(reference, out var type))
+                ThrowUnknownReferencedType(reference);
+            return type;
+        }
+
+        private static void ThrowUnknownReferencedType(uint id) => throw new UnknownReferencedTypeException(id);
 
         /// <summary>
         /// Gets the type with the specified reference id.
@@ -27,27 +37,34 @@ namespace Orleans.Serialization.Session
         public bool TryGetReferencedType(uint reference, out Type type) => _referencedTypes.TryGetValue(reference, out type);
 
         /// <summary>
-        /// Gets the identifier for the specified type.
+        /// Records a type with the specified identifier.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <param name="reference">The reference.</param>
-        /// <returns><see langword="true" /> if the type has been previoulsy referenced, <see langword="false" /> otherwise.</returns>
-        public bool TryGetTypeReference(Type type, out uint reference) => _referencedTypeToIdMap.TryGetValue(type, out reference);
+        public void RecordReferencedType(Type type) => _referencedTypes.Add(++_currentReferenceId, type);
+
+        /// <summary>
+        /// Gets or adds the identifier for the specified type.
+        /// </summary>
+        public bool GetOrAddTypeReference(Type type, out uint reference)
+        {
+            ref var refValue = ref CollectionsMarshal.GetValueRefOrAddDefault(_referencedTypeToIdMap, type, out var exists);
+            if (exists)
+            {
+                reference = refValue;
+                return true;
+            }
+
+            refValue = reference = ++_currentReferenceId;
+            return false;
+        }
 
         /// <summary>
         /// Resets this instance.
         /// </summary>
         public void Reset()
         {
-            if (_referencedTypes.Count > 0)
-            {
-                _referencedTypes.Clear();
-            }
-
-            if (_referencedTypeToIdMap.Count > 0)
-            {
-                _referencedTypeToIdMap.Clear();
-            }
+            _currentReferenceId = 0;
+            _referencedTypes.Clear();
+            _referencedTypeToIdMap.Clear();
         }
     }
 }

--- a/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
@@ -66,9 +66,8 @@ namespace Orleans.Serialization.TypeSystem
         /// </summary>
         /// <typeparam name="TInput">The reader input type.</typeparam>
         /// <param name="reader">The reader.</param>
-        /// <param name="type">The type.</param>
-        /// <returns><see langword="true" /> if a type was successfully read, <see langword="false" /> otherwise.</returns>
-        public unsafe bool TryRead<TInput>(ref Reader<TInput> reader, [NotNullWhen(true)] out Type type)
+        /// <returns>The type if it was successfully read, <see langword="null" /> otherwise.</returns>
+        public unsafe Type TryRead<TInput>(ref Reader<TInput> reader)
         {
             var version = reader.ReadByte();
             if (version != Version1)
@@ -96,8 +95,7 @@ namespace Orleans.Serialization.TypeSystem
 
                 if (existingKey.TypeName.AsSpan().SequenceEqual(typeName))
                 {
-                    type = entry.Type;
-                    return true;
+                    return entry.Type;
                 }
 
                 // Try the next entry.
@@ -111,19 +109,16 @@ namespace Orleans.Serialization.TypeSystem
                 typeNameString = Encoding.UTF8.GetString(typeNameBytes, typeName.Length);
             }
 
-            _ = _typeConverter.TryParse(typeNameString, out type);
-            if (type is not null)
+            if (_typeConverter.TryParse(typeNameString, out var type))
             {
                 var key = new TypeKey(hashCode, typeName.ToArray());
                 while (!_typeKeyCache.TryAdd(candidateHashCode++, (key, type)))
                 {
                     // Insert the type at the first available position.
                 }
-
-                return true;
             }
 
-            return false;
+            return type;
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -258,12 +258,7 @@ namespace Orleans.Serialization.TypeSystem
         /// <returns><see langword="true"/> if the type was parsed and loaded; otherwise <see langword="false"/>.</returns>
         public bool TryParse(string formatted, [NotNullWhen(true)] out Type result)
         {
-            if (ParseInternal(formatted, out result))
-            {
-                return true;
-            }
-
-            return false;
+            return ParseInternal(formatted, out result);
         }
 
         private string FormatInternal(Type type, Func<TypeSpec, TypeSpec> rewriter = null)

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -527,4 +527,12 @@ namespace Orleans.Serialization.UnitTests
 
         public override string ToString() => $"{nameof(StringValue)}: {StringValue}, {nameof(EnumValue)}: {EnumValue}";
     }
+
+    [GenerateSerializer]
+    public sealed class ClassWithTypeFields
+    {
+        [Id(1)] public Type Type1;
+        [Id(2)] public object UntypedValue;
+        [Id(3)] public Type Type2;
+    }
 }


### PR DESCRIPTION
`SchemaType.Referenced` is currently unsupported and although there looks to be some code for it, it's actually non-working and any such type references would fail on deserialization.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8052)