### PR TITLE
Fix F# codecs and some array codecs.

### DIFF
--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -57,7 +57,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                Int32Codec.WriteField(ref writer, 1, typeof(int), value.Count);
+                UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -104,7 +104,7 @@ namespace Orleans.Serialization.Codecs
                         comparer = _comparerCodec.ReadValue(ref reader, header);
                         break;
                     case 1:
-                        var length = Int32Codec.ReadValue(ref reader, header);
+                        var length = (int)UInt32Codec.ReadValue(ref reader, header);
                         if (length > 10240 && length > reader.Length)
                         {
                             ThrowInvalidSizeException(length);

--- a/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FieldHeaderCodec.cs
@@ -152,7 +152,7 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Field ReadFieldHeader<TInput>(ref this Reader<TInput> reader)
         {
-            Field field = default;
+            Unsafe.SkipInit(out Field field);
             var tag = reader.ReadByte();
             field.Tag = tag;
             // If the id or schema type are required and were not encoded into the tag, read the extended header data.
@@ -256,7 +256,7 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (Field Field, string Type) ReadFieldHeaderForAnalysis<TInput>(ref this Reader<TInput> reader)
         {
-            Field field = default;
+            Unsafe.SkipInit(out Field field);
             string type = default;
             var tag = reader.ReadByte();
             if (tag < (byte)WireType.Extended && ((tag & Tag.FieldIdCompleteMask) == Tag.FieldIdCompleteMask || (tag & Tag.SchemaTypeMask) != (byte)SchemaType.Expected))

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -49,7 +49,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                Int32Codec.WriteField(ref writer, 1, typeof(int), value.Count);
+                UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -93,7 +93,7 @@ namespace Orleans.Serialization.Codecs
                         comparer = _comparerCodec.ReadValue(ref reader, header);
                         break;
                     case 1:
-                        var length = Int32Codec.ReadValue(ref reader, header);
+                        var length = (int)UInt32Codec.ReadValue(ref reader, header);
                         if (length > 10240 && length > reader.Length)
                         {
                             ThrowInvalidSizeException(length);

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -387,7 +387,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class UInt32Codec : TypedCodecBase<uint>, IFieldCodec<uint>, IDeepCopier<uint>, IOptionalDeepCopier
     {
-        private static readonly Type CodecFieldType = typeof(uint);
+        public static readonly Type CodecFieldType = typeof(uint);
 
         /// <inheritdoc/>
         void IFieldCodec<uint>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -42,7 +42,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                Int32Codec.WriteField(ref writer, 0, Int32Codec.CodecFieldType, value.Count);
+                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -82,7 +82,7 @@ namespace Orleans.Serialization.Codecs
                 switch (fieldId)
                 {
                     case 0:
-                        var length = Int32Codec.ReadValue(ref reader, header);
+                        var length = (int)UInt32Codec.ReadValue(ref reader, header);
                         if (length > 10240 && length > reader.Length)
                         {
                             ThrowInvalidSizeException(length);

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -39,7 +39,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                Int32Codec.WriteField(ref writer, 0, Int32Codec.CodecFieldType, value.Count);
+                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -79,7 +79,7 @@ namespace Orleans.Serialization.Codecs
                 switch (fieldId)
                 {
                     case 0:
-                        var length = Int32Codec.ReadValue(ref reader, header);
+                        var length = (int)UInt32Codec.ReadValue(ref reader, header);
                         result = new Queue<T>(length);
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
                         break;

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -42,7 +42,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                Int32Codec.WriteField(ref writer, 0, Int32Codec.CodecFieldType, value.Count);
+                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -82,7 +82,7 @@ namespace Orleans.Serialization.Codecs
                 switch (fieldId)
                 {
                     case 0:
-                        var length = Int32Codec.ReadValue(ref reader, header);
+                        var length = (int)UInt32Codec.ReadValue(ref reader, header);
                         if (length > 10240 && length > reader.Length)
                         {
                             ThrowInvalidSizeException(length);

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -77,7 +77,7 @@ namespace Orleans.Serialization.Codecs
                         type = UInt32Codec.ReadValue(ref reader, header);
                         break;
                     case 1:
-                        options = (CompareOptions)UInt64Codec.ReadValue(ref reader, header);
+                        options = (CompareOptions)UInt32Codec.ReadValue(ref reader, header);
                         break;
                     case 2:
                         lcid = Int32Codec.ReadValue(ref reader, header);
@@ -191,8 +191,8 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(WellKnownStringComparerCodec), WireType.TagDelimited);
 
-            UInt32Codec.WriteField(ref writer, 0, typeof(int), type);
-            UInt64Codec.WriteField(ref writer, 1, typeof(ulong), (ulong)compareOptions);
+            UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, type);
+            UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)compareOptions);
 
             if (compareInfo is not null)
             {

--- a/src/Orleans.Serialization/ISerializableSerializer/ValueTypeSerializer.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ValueTypeSerializer.cs
@@ -56,8 +56,7 @@ namespace Orleans.Serialization
             var info = new SerializationInfo(Type, _formatterConverter);
             ((ISerializable)value).GetObjectData(info, _streamingContext);
 
-            Int32Codec.WriteField(ref writer, 0, typeof(int), 0);
-            TypeSerializerCodec.WriteField(ref writer, 1, typeof(Type), info.ObjectType);
+            TypeSerializerCodec.WriteField(ref writer, 0, typeof(Type), info.ObjectType);
 
             var first = true;
             foreach (var field in info)


### PR DESCRIPTION
* Add a specialized codec for `FSharpOption<T>` to avoid value type serialization for `FSharpOption<T>.None`.
* Fix `FSharpResult<T, TError>` encoding.
* Fix `ArraySegment<T>` and `[ReadOnly]Memory<T>` reference encoding.
* Use `UInt32Codec` to encode collection lengths.
* Use field IDs instead of separate tag fields for choice types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8056)