### PR TITLE
Make NullableCodec and UriCodec well-known.

### DIFF
--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -48,17 +48,17 @@ namespace Orleans.CodeGenerator
                 classDeclaration = classDeclaration.AddMembers(ctor);
 
             classDeclaration = AddOptionalMembers(classDeclaration,
-                    GenerateGetArgumentCount(libraryTypes, method),
+                    GenerateGetArgumentCount(method),
                     GenerateGetMethodName(libraryTypes, method),
                     GenerateGetInterfaceName(libraryTypes, method),
                     GenerateGetActivityName(libraryTypes, method),
                     GenerateGetInterfaceType(libraryTypes, method),
                     GenerateGetMethod(libraryTypes),
                     GenerateSetTargetMethod(libraryTypes, interfaceDescription, targetField),
-                    GenerateGetTargetMethod(libraryTypes, targetField),
-                    GenerateDisposeMethod(libraryTypes, fieldDescriptions, baseClassType),
-                    GenerateGetArgumentMethod(libraryTypes, method, fieldDescriptions),
-                    GenerateSetArgumentMethod(libraryTypes, method, fieldDescriptions),
+                    GenerateGetTargetMethod(targetField),
+                    GenerateDisposeMethod(fieldDescriptions, baseClassType),
+                    GenerateGetArgumentMethod(method, fieldDescriptions),
+                    GenerateSetArgumentMethod(method, fieldDescriptions),
                     GenerateInvokeInnerMethod(libraryTypes, method, fieldDescriptions, targetField));
 
             var typeParametersWithNames = method.AllTypeParameters;
@@ -191,16 +191,16 @@ namespace Orleans.CodeGenerator
                     SyntaxKind.SimpleAssignmentExpression,
                     IdentifierName(targetField.FieldName),
                     getTarget);
-            return MethodDeclaration(libraryTypes.Void.ToTypeSyntax(), "SetTarget")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "SetTarget")
                 .WithParameterList(ParameterList(SingletonSeparatedList(Parameter(holderParameter).WithType(libraryTypes.ITargetHolder.ToTypeSyntax()))))
                 .WithExpressionBody(ArrowExpressionClause(body))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)));
         }
 
-        private static MemberDeclarationSyntax GenerateGetTargetMethod(LibraryTypes libraryTypes, TargetFieldDescription targetField)
+        private static MemberDeclarationSyntax GenerateGetTargetMethod(TargetFieldDescription targetField)
         {
-            return MethodDeclaration(libraryTypes.Object.ToTypeSyntax(), "GetTarget")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.ObjectKeyword)), "GetTarget")
                 .WithParameterList(ParameterList())
                 .WithExpressionBody(ArrowExpressionClause(IdentifierName(targetField.FieldName)))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
@@ -208,7 +208,6 @@ namespace Orleans.CodeGenerator
         }
 
         private static MemberDeclarationSyntax GenerateGetArgumentMethod(
-            LibraryTypes libraryTypes,
             MethodDescription methodDescription,
             List<InvokerFieldDescripton> fields)
         {
@@ -260,17 +259,16 @@ namespace Orleans.CodeGenerator
                                                         Math.Max(0, methodDescription.Method.Parameters.Length - 1))))
                                         })))))));
             var body = SwitchStatement(index, new SyntaxList<SwitchSectionSyntax>(cases));
-            return MethodDeclaration(libraryTypes.Object.ToTypeSyntax(), "GetArgument")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.ObjectKeyword)), "GetArgument")
                 .WithParameterList(
                     ParameterList(
                         SingletonSeparatedList(
-                            Parameter(Identifier("index")).WithType(libraryTypes.Int32.ToTypeSyntax()))))
+                            Parameter(Identifier("index")).WithType(PredefinedType(Token(SyntaxKind.IntKeyword))))))
                 .WithBody(Block(body))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)));
         }
 
         private static MemberDeclarationSyntax GenerateSetArgumentMethod(
-            LibraryTypes libraryTypes,
             MethodDescription methodDescription,
             List<InvokerFieldDescripton> fields)
         {
@@ -334,14 +332,14 @@ namespace Orleans.CodeGenerator
                             ReturnStatement()
                         })));
             var body = SwitchStatement(index, new SyntaxList<SwitchSectionSyntax>(cases));
-            return MethodDeclaration(libraryTypes.Void.ToTypeSyntax(), "SetArgument")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "SetArgument")
                 .WithParameterList(
                     ParameterList(
                         SeparatedList(
                             new[]
                             {
-                                Parameter(Identifier("index")).WithType(libraryTypes.Int32.ToTypeSyntax()),
-                                Parameter(Identifier("value")).WithType(libraryTypes.Object.ToTypeSyntax())
+                                Parameter(Identifier("index")).WithType(PredefinedType(Token(SyntaxKind.IntKeyword))),
+                                Parameter(Identifier("value")).WithType(PredefinedType(Token(SyntaxKind.ObjectKeyword)))
                             }
                         )))
                 .WithBody(Block(body))
@@ -386,7 +384,6 @@ namespace Orleans.CodeGenerator
         }
 
         private static MemberDeclarationSyntax GenerateDisposeMethod(
-            LibraryTypes libraryTypes,
             List<InvokerFieldDescripton> fields,
             INamedTypeSymbol baseClassType)
         {
@@ -412,14 +409,14 @@ namespace Orleans.CodeGenerator
                 body.Add(ExpressionStatement(InvocationExpression(BaseExpression().Member("Dispose")).WithArgumentList(ArgumentList())));
             }
 
-            return MethodDeclaration(libraryTypes.Void.ToTypeSyntax(), "Dispose")
+            return MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Dispose")
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithBody(Block(body));
         }
 
-        private static MemberDeclarationSyntax GenerateGetArgumentCount(LibraryTypes libraryTypes, MethodDescription methodDescription)
+        private static MemberDeclarationSyntax GenerateGetArgumentCount(MethodDescription methodDescription)
             => methodDescription.Method.Parameters.Length is var count and not 0 ?
-            MethodDeclaration(libraryTypes.Int32.ToTypeSyntax(), "GetArgumentCount")
+            MethodDeclaration(PredefinedType(Token(SyntaxKind.IntKeyword)), "GetArgumentCount")
                 .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(count))))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)) : null;

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -68,6 +68,7 @@ namespace Orleans.CodeGenerator
                 Task = Type("System.Threading.Tasks.Task"),
                 Task_1 = Type("System.Threading.Tasks.Task`1"),
                 Type = Type("System.Type"),
+                Uri = Type("System.Uri"),
                 ICodecProvider = Type("Orleans.Serialization.Serializers.ICodecProvider"),
                 ValueSerializer = Type("Orleans.Serialization.Serializers.IValueSerializer`1"),
                 ValueTask = Type("System.Threading.Tasks.ValueTask"),
@@ -109,6 +110,9 @@ namespace Orleans.CodeGenerator
                 {
                     new(Type("System.Collections.Generic.Dictionary`2"), Type("Orleans.Serialization.Codecs.DictionaryCodec`2")),
                     new(Type("System.Collections.Generic.List`1"), Type("Orleans.Serialization.Codecs.ListCodec`1")),
+                    new(Type("System.Collections.Generic.HashSet`1"), Type("Orleans.Serialization.Codecs.HashSetCodec`1")),
+                    new(Type("System.Nullable`1"), Type("Orleans.Serialization.Codecs.NullableCodec`1")),
+                    new(Type("System.Uri"), Type("Orleans.Serialization.Codecs.UriCodec")),
                 },
                 StaticCopiers = new WellKnownCopierDescription[]
                 {
@@ -142,6 +146,8 @@ namespace Orleans.CodeGenerator
                 {
                     new(Type("System.Collections.Generic.Dictionary`2"), Type("Orleans.Serialization.Codecs.DictionaryCopier`2")),
                     new(Type("System.Collections.Generic.List`1"), Type("Orleans.Serialization.Codecs.ListCopier`1")),
+                    new(Type("System.Collections.Generic.HashSet`1"), Type("Orleans.Serialization.Codecs.HashSetCopier`1")),
+                    new(Type("System.Nullable`1"), Type("Orleans.Serialization.Codecs.NullableCopier`1")),
                 },
                 Exception = Type("System.Exception"),
                 ImmutableAttributes = options.ImmutableAttributes.Select(Type).ToArray(),
@@ -224,6 +230,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol Task { get; private set; }
         public INamedTypeSymbol Task_1 { get; private set; }
         public INamedTypeSymbol Type { get; private set; }
+        private INamedTypeSymbol Uri;
         public INamedTypeSymbol MethodInfo { get; private set; }
         public INamedTypeSymbol ICodecProvider { get; private set; }
         public INamedTypeSymbol ValueSerializer { get; private set; }
@@ -296,18 +303,19 @@ namespace Orleans.CodeGenerator
                     return true;
             }
 
+            if (_shallowCopyableTypes.TryGetValue(type, out var result))
+            {
+                return result;
+            }
+
             if (SymbolEqualityComparer.Default.Equals(TimeSpan, type)
                 || SymbolEqualityComparer.Default.Equals(IPAddress, type)
                 || SymbolEqualityComparer.Default.Equals(IPEndPoint, type)
                 || SymbolEqualityComparer.Default.Equals(CancellationToken, type)
-                || SymbolEqualityComparer.Default.Equals(Type, type))
+                || SymbolEqualityComparer.Default.Equals(Type, type)
+                || SymbolEqualityComparer.Default.Equals(Uri, type))
             {
-                return true;
-            }
-
-            if (_shallowCopyableTypes.TryGetValue(type, out var result))
-            {
-                return result;
+                return _shallowCopyableTypes[type] = true;
             }
 
             if (type.IsSealed && type.HasAnyAttribute(ImmutableAttributes))

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -18,7 +18,6 @@ namespace Orleans.CodeGenerator
                 Compilation = compilation,
                 ApplicationPartAttribute = Type("Orleans.ApplicationPartAttribute"),
                 Action_2 = Type("System.Action`2"),
-                Byte = compilation.GetSpecialType(SpecialType.System_Byte),
                 ITypeManifestProvider = Type("Orleans.Serialization.Configuration.ITypeManifestProvider"),
                 Field = Type("Orleans.Serialization.WireProtocol.Field"),
                 WireType = Type("Orleans.Serialization.WireProtocol.WireType"),
@@ -56,15 +55,9 @@ namespace Orleans.CodeGenerator
                 UseActivatorAttribute = Type("Orleans.UseActivatorAttribute"),
                 SuppressReferenceTrackingAttribute = Type("Orleans.SuppressReferenceTrackingAttribute"),
                 OmitDefaultMemberValuesAttribute = Type("Orleans.OmitDefaultMemberValuesAttribute"),
-                Int32 = compilation.GetSpecialType(SpecialType.System_Int32),
-                UInt32 = compilation.GetSpecialType(SpecialType.System_UInt32),
-                InvalidOperationException = Type("System.InvalidOperationException"),
-                InvokablePool = Type("Orleans.Serialization.Invocation.InvokablePool"),
-                IResponseCompletionSource = Type("Orleans.Serialization.Invocation.IResponseCompletionSource"),
                 ITargetHolder = Type("Orleans.Serialization.Invocation.ITargetHolder"),
                 TypeManifestProviderAttribute = Type("Orleans.Serialization.Configuration.TypeManifestProviderAttribute"),
                 NonSerializedAttribute = Type("System.NonSerializedAttribute"),
-                Object = compilation.GetSpecialType(SpecialType.System_Object),
                 ObsoleteAttribute = Type("System.ObsoleteAttribute"),
                 BaseCodec_1 = Type("Orleans.Serialization.Serializers.IBaseCodec`1"),
                 BaseCopier_1 = Type("Orleans.Serialization.Cloning.IBaseCopier`1"),
@@ -81,7 +74,6 @@ namespace Orleans.CodeGenerator
                 ValueTask_1 = Type("System.Threading.Tasks.ValueTask`1"),
                 ValueTypeGetter_2 = Type("Orleans.Serialization.Utilities.ValueTypeGetter`2"),
                 ValueTypeSetter_2 = Type("Orleans.Serialization.Utilities.ValueTypeSetter`2"),
-                Void = compilation.GetSpecialType(SpecialType.System_Void),
                 Writer = Type("Orleans.Serialization.Buffers.Writer`1"),
                 FSharpSourceConstructFlagsOrDefault = TypeOrDefault("Microsoft.FSharp.Core.SourceConstructFlags"),
                 FSharpCompilationMappingAttributeOrDefault = TypeOrDefault("Microsoft.FSharp.Core.CompilationMappingAttribute"),
@@ -205,7 +197,6 @@ namespace Orleans.CodeGenerator
         }
 
         public INamedTypeSymbol Action_2 { get; private set; }
-        public INamedTypeSymbol Byte { get; private set; }
         public INamedTypeSymbol ITypeManifestProvider { get; private set; }
         public INamedTypeSymbol Field { get; private set; }
         public INamedTypeSymbol WireType { get; private set; }
@@ -220,15 +211,9 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol IActivator_1 { get; private set; }
         public INamedTypeSymbol IBufferWriter { get; private set; }
         public INamedTypeSymbol IInvokable { get; private set; }
-        public INamedTypeSymbol Int32 { get; private set; }
-        public INamedTypeSymbol UInt32 { get; private set; }
-        public INamedTypeSymbol InvalidOperationException { get; private set; }
-        public INamedTypeSymbol InvokablePool { get; private set; }
-        public INamedTypeSymbol IResponseCompletionSource { get; private set; }
         public INamedTypeSymbol ITargetHolder { get; private set; }
         public INamedTypeSymbol TypeManifestProviderAttribute { get; private set; }
         public INamedTypeSymbol NonSerializedAttribute { get; private set; }
-        public INamedTypeSymbol Object { get; private set; }
         public INamedTypeSymbol ObsoleteAttribute { get; private set; }
         public INamedTypeSymbol BaseCodec_1 { get; private set; }
         public INamedTypeSymbol BaseCopier_1 { get; private set; }
@@ -246,7 +231,6 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol ValueTask_1 { get; private set; }
         public INamedTypeSymbol ValueTypeGetter_2 { get; private set; }
         public INamedTypeSymbol ValueTypeSetter_2 { get; private set; }
-        public INamedTypeSymbol Void { get; private set; }
         public INamedTypeSymbol Writer { get; private set; }
         public INamedTypeSymbol[] IdAttributeTypes { get; private set; }
         public INamedTypeSymbol[] ConstructorAttributeTypes { get; private set; }

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -370,7 +370,7 @@ namespace Orleans.CodeGenerator
 
             res = type.IsAbstractType
                 ? res.AddModifiers(Token(SyntaxKind.OverrideKeyword))
-                : res.AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.Construct(libraryTypes.Byte).ToTypeSyntax())));
+                : res.AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.ToTypeSyntax(PredefinedType(Token(SyntaxKind.ByteKeyword))))));
 
             return res;
         }
@@ -431,7 +431,7 @@ namespace Orleans.CodeGenerator
                     ExpressionSyntax condition = member.IsValueType switch
                     {
                         true => BinaryExpression(SyntaxKind.NotEqualsExpression, member.GetGetter(instanceParam), LiteralExpression(SyntaxKind.DefaultLiteralExpression)),
-                        false => IsPatternExpression(member.GetGetter(instanceParam), TypePattern(libraryTypes.Object.ToTypeSyntax()))
+                        false => IsPatternExpression(member.GetGetter(instanceParam), TypePattern(PredefinedType(Token(SyntaxKind.ObjectKeyword))))
                     };
 
                     body.Add(IfStatement(
@@ -801,7 +801,7 @@ namespace Orleans.CodeGenerator
             var parameters = new[]
             {
                 Parameter("writer".ToIdentifier()).WithType(libraryTypes.Writer.ToTypeSyntax()).WithModifiers(TokenList(Token(SyntaxKind.RefKeyword))),
-                Parameter("fieldIdDelta".ToIdentifier()).WithType(libraryTypes.UInt32.ToTypeSyntax()),
+                Parameter("fieldIdDelta".ToIdentifier()).WithType(PredefinedType(Token(SyntaxKind.UIntKeyword))),
                 Parameter("expectedType".ToIdentifier()).WithType(libraryTypes.Type.ToTypeSyntax()),
                 Parameter("value".ToIdentifier()).WithType(type.TypeSyntax)
             };
@@ -810,7 +810,7 @@ namespace Orleans.CodeGenerator
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddParameterListParameters(parameters)
                 .AddTypeParameterListParameters(TypeParameter("TBufferWriter"))
-                .AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.Construct(libraryTypes.Byte).ToTypeSyntax())))
+                .AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.ToTypeSyntax(PredefinedType(Token(SyntaxKind.ByteKeyword))))))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetMethodImplAttributeSyntax())))
                 .AddBodyStatements(body.ToArray());
         }
@@ -967,7 +967,7 @@ namespace Orleans.CodeGenerator
             var parameters = new[]
             {
                 Parameter("writer".ToIdentifier()).WithType(libraryTypes.Writer.ToTypeSyntax()).WithModifiers(TokenList(Token(SyntaxKind.RefKeyword))),
-                Parameter("fieldIdDelta".ToIdentifier()).WithType(libraryTypes.UInt32.ToTypeSyntax()),
+                Parameter("fieldIdDelta".ToIdentifier()).WithType(PredefinedType(Token(SyntaxKind.UIntKeyword))),
                 Parameter("expectedType".ToIdentifier()).WithType(libraryTypes.Type.ToTypeSyntax()),
                 Parameter("value".ToIdentifier()).WithType(type.TypeSyntax)
             };
@@ -976,7 +976,7 @@ namespace Orleans.CodeGenerator
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddParameterListParameters(parameters)
                 .AddTypeParameterListParameters(TypeParameter("TBufferWriter"))
-                .AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.Construct(libraryTypes.Byte).ToTypeSyntax())))
+                .AddConstraintClauses(TypeParameterConstraintClause("TBufferWriter").AddConstraints(TypeConstraint(libraryTypes.IBufferWriter.ToTypeSyntax(PredefinedType(Token(SyntaxKind.ByteKeyword))))))
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(CodeGenerator.GetMethodImplAttributeSyntax())))
                 .AddBodyStatements(body.ToArray());
         }

--- a/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
@@ -3,7 +3,6 @@ using System.Buffers;
 using System.Globalization;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
@@ -12,11 +11,8 @@ namespace Orleans.Serialization.Codecs
     /// Serializer for <see cref="CompareInfo"/>.
     /// </summary>
     [RegisterSerializer]
-    public sealed class CompareInfoCodec : IFieldCodec<CompareInfo>, IGeneralizedCodec
+    public sealed class CompareInfoCodec : IFieldCodec<CompareInfo>
     {
-        /// <inheritdoc/>
-        public bool IsSupportedType(Type type) => typeof(CompareInfo).IsAssignableFrom(type);
-
         /// <inheritdoc/>
         public CompareInfo ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
@@ -73,12 +69,6 @@ namespace Orleans.Serialization.Codecs
             writer.WriteEndObject();
         }
 
-        /// <inheritdoc/>
-        public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte> => WriteField(ref writer, fieldIdDelta, expectedType, value as CompareInfo);
-
-        /// <inheritdoc/>
-        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
-
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for {nameof(CompareInfo)} fields. {field}");
     }
@@ -87,15 +77,9 @@ namespace Orleans.Serialization.Codecs
     /// Copier for <see cref="CompareInfo"/>.
     /// </summary>
     [RegisterCopier]
-    public sealed class CompareInfoCopier : IDeepCopier<CompareInfo>, IGeneralizedCopier, IOptionalDeepCopier
+    public sealed class CompareInfoCopier : IDeepCopier<CompareInfo>, IOptionalDeepCopier
     {
         /// <inheritdoc/>
         public CompareInfo DeepCopy(CompareInfo input, CopyContext context) => input;
-
-        /// <inheritdoc/>
-        public object DeepCopy(object input, CopyContext context) => input;
-
-        /// <inheritdoc/>
-        public bool IsSupportedType(Type type) => typeof(CompareInfo).IsAssignableFrom(type);
     }
 }

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -154,7 +154,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         /// <inheritdoc/>
-        public bool IsSupportedType(Type type) => type.IsArray && type.GetArrayRank() > 1;
+        public bool IsSupportedType(Type type) => type.IsArray && !type.IsSZArray;
 
         private static object ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
@@ -254,6 +254,6 @@ namespace Orleans.Serialization.Codecs
         }
 
         /// <inheritdoc/>
-        public bool IsSupportedType(Type type) => type.IsArray && type.GetArrayRank() > 1;
+        public bool IsSupportedType(Type type) => type.IsArray && !type.IsSZArray;
     }
 }

--- a/src/Orleans.Serialization/Codecs/UriCodec.cs
+++ b/src/Orleans.Serialization/Codecs/UriCodec.cs
@@ -43,15 +43,9 @@ namespace Orleans.Serialization.Codecs
     /// Copier for <see cref="Uri"/>.
     /// </summary>
     [RegisterCopier]
-    public sealed class UriCopier : IDeepCopier<Uri>, IGeneralizedCopier, IOptionalDeepCopier
+    public sealed class UriCopier : IDeepCopier<Uri>, IDerivedTypeCopier, IOptionalDeepCopier
     {
         /// <inheritdoc />
         public Uri DeepCopy(Uri input, CopyContext context) => input;
-
-        /// <inheritdoc />
-        public object DeepCopy(object input, CopyContext context) => input;
-
-        /// <inheritdoc />
-        public bool IsSupportedType(Type type) => typeof(Uri).IsAssignableFrom(type);
     }
 }

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -74,8 +74,6 @@ namespace Orleans.Serialization
                 services.TryAddSingleton<SerializerSessionPool>();
                 services.TryAddSingleton<CopyContextPool>();
 
-                services.AddSingleton<IGeneralizedCodec, CompareInfoCodec>();
-                services.AddSingleton<IGeneralizedCopier, CompareInfoCopier>();
                 services.AddSingleton<IGeneralizedCodec, WellKnownStringComparerCodec>();
 
                 services.AddSingleton<ExceptionCodec>();

--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -744,8 +744,8 @@ namespace Orleans.Serialization.Serializers
             }
             else if (fieldType.IsArray)
             {
-                // Depending on the rank of the array (1 or higher), select the base array codec or the multi-dimensional codec.
-                var arrayCodecType = fieldType.GetArrayRank() == 1 ? typeof(ArrayCodec<>) : typeof(MultiDimensionalArrayCodec<>);
+                // Depending on the type of the array, select the base array codec or the multi-dimensional codec.
+                var arrayCodecType = fieldType.IsSZArray ? typeof(ArrayCodec<>) : typeof(MultiDimensionalArrayCodec<>);
                 codecType = arrayCodecType.MakeGenericType(fieldType.GetElementType());
             }
             else if (fieldType.IsEnum)
@@ -849,8 +849,8 @@ namespace Orleans.Serialization.Serializers
             }
             else if (fieldType.IsArray)
             {
-                // Depending on the rank of the array (1 or higher), select the base array copier or the multi-dimensional copier.
-                var arrayCopierType = fieldType.GetArrayRank() == 1 ? typeof(ArrayCopier<>) : typeof(MultiDimensionalArrayCopier<>);
+                // Depending on the type of the array, select the base array copier or the multi-dimensional copier.
+                var arrayCopierType = fieldType.IsSZArray ? typeof(ArrayCopier<>) : typeof(MultiDimensionalArrayCopier<>);
                 copierType = arrayCopierType.MakeGenericType(fieldType.GetElementType());
             }
             else if (TryGetSurrogateCodec(fieldType, searchType, out var surrogateCodecType, out constructorArguments))


### PR DESCRIPTION
* Make `NullableCodec` well-known.
* Make `UriCodec` well-known and mark `Uri` immutable.
* Cleanup some `IGeneralizedCodec/IGeneralizedCopier` misuse.
* Cleanup `LibraryTypes`.
* Fix SZ/MD array checks.