### PR TITLE
Add a test to ensure records can be serialized identically to classes

### DIFF
--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -41,6 +41,25 @@ public record Person3(int Age, string Name)
 [GenerateSerializer]
 public record Person4(int Age, string Name);
 
+[GenerateSerializer(IncludePrimaryConstructorParameters = false)]
+public record Person5([property: Id(0)] int Age, [property: Id(1)] string Name)
+{
+    [Id(2)]
+    public string FavouriteColor { get; init; }
+
+    [Id(3)]
+    public string StarSign { get; init; }
+}
+
+[GenerateSerializer]
+public class Person5_Class
+{
+    [Id(0)] public int Age { get; init; }
+    [Id(1)] public string Name { get; init; }
+    [Id(2)] public string FavouriteColor { get; init; }
+    [Id(3)] public string StarSign { get; init; }
+}
+
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
 public sealed class MyJsonSerializableAttribute : Attribute
 {


### PR DESCRIPTION
If a record's primary constructor has explicit property ids specified, we do not use the two-layer serialization which records otherwise use. This allows records to be serialized identically to a regular class. This PR adds a test showing that the results are bitwise identical.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8062)