### PR TITLE
Use default interface methods for untyped IDeepCopier

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -23,7 +23,7 @@ namespace Orleans.CodeGenerator
                 WireType = Type("Orleans.Serialization.WireProtocol.WireType"),
                 FieldCodec_1 = Type("Orleans.Serialization.Codecs.IFieldCodec`1"),
                 DeepCopier_1 = Type("Orleans.Serialization.Cloning.IDeepCopier`1"),
-                IOptionalDeepCopier = Type("Orleans.Serialization.Cloning.IOptionalDeepCopier"),
+                ShallowCopier = Type("Orleans.Serialization.Cloning.ShallowCopier`1"),
                 CompoundTypeAliasAttribute = Type("Orleans.CompoundTypeAliasAttribute"),
                 CopyContext = Type("Orleans.Serialization.Cloning.CopyContext"),
                 MethodInfo = Type("System.Reflection.MethodInfo"),
@@ -115,30 +115,9 @@ namespace Orleans.CodeGenerator
                 StaticCopiers = new WellKnownCopierDescription[]
                 {
                     new(compilation.GetSpecialType(SpecialType.System_Object), Type("Orleans.Serialization.Codecs.ObjectCopier")),
-                    new(compilation.GetSpecialType(SpecialType.System_Boolean), Type("Orleans.Serialization.Codecs.BoolCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Char), Type("Orleans.Serialization.Codecs.CharCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Byte), Type("Orleans.Serialization.Codecs.ByteCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_SByte), Type("Orleans.Serialization.Codecs.SByteCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Int16), Type("Orleans.Serialization.Codecs.Int16Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Int32), Type("Orleans.Serialization.Codecs.Int32Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Int64), Type("Orleans.Serialization.Codecs.Int64Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_UInt16), Type("Orleans.Serialization.Codecs.UInt16Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_UInt32), Type("Orleans.Serialization.Codecs.UInt32Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_UInt64), Type("Orleans.Serialization.Codecs.UInt64Codec")),
-                    new(compilation.GetSpecialType(SpecialType.System_String), Type("Orleans.Serialization.Codecs.StringCopier")),
                     new(compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Byte), 1), Type("Orleans.Serialization.Codecs.ByteArrayCopier")),
-                    new(compilation.GetSpecialType(SpecialType.System_Single), Type("Orleans.Serialization.Codecs.FloatCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Double), Type("Orleans.Serialization.Codecs.DoubleCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_Decimal), Type("Orleans.Serialization.Codecs.DecimalCodec")),
-                    new(compilation.GetSpecialType(SpecialType.System_DateTime), Type("Orleans.Serialization.Codecs.DateTimeCodec")),
-                    new(Type("System.TimeSpan"), Type("Orleans.Serialization.Codecs.TimeSpanCopier")),
-                    new(Type("System.DateTimeOffset"), Type("Orleans.Serialization.Codecs.DateTimeOffsetCopier")),
-                    new(Type("System.Guid"), Type("Orleans.Serialization.Codecs.GuidCopier")),
-                    new(Type("System.Type"), Type("Orleans.Serialization.Codecs.TypeCopier")),
                     new(Type("System.ReadOnlyMemory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.ReadOnlyMemoryOfByteCopier")),
                     new(Type("System.Memory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.MemoryOfByteCopier")),
-                    new(Type("System.Net.IPAddress"), Type("Orleans.Serialization.Codecs.IPAddressCopier")),
-                    new(Type("System.Net.IPEndPoint"), Type("Orleans.Serialization.Codecs.IPEndPointCopier")),
                 },
                 WellKnownCopiers = new WellKnownCopierDescription[]
                 {
@@ -206,7 +185,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol Field { get; private set; }
         public INamedTypeSymbol WireType { get; private set; }
         public INamedTypeSymbol DeepCopier_1 { get; private set; }
-        public INamedTypeSymbol IOptionalDeepCopier { get; private set; }
+        public INamedTypeSymbol ShallowCopier { get; private set; }
         public INamedTypeSymbol FieldCodec_1 { get; private set; }
         public INamedTypeSymbol Func_2 { get; private set; }
         public INamedTypeSymbol CompoundTypeAliasAttribute { get; private set; }

--- a/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
@@ -9,6 +9,7 @@ namespace Orleans
     /// <summary>
     /// An analogue to <see cref="CancellationToken"/> which can be sent between grains.
     /// </summary>
+    [Immutable]
     public sealed class GrainCancellationToken : IDisposable
     {
         /// <summary>

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -3,7 +3,6 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 using Orleans.Serialization;
 using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
@@ -15,8 +14,7 @@ namespace Orleans.Runtime.Serialization
     /// Serializer and deserializer for <see cref="SiloAddress"/> instances.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class SiloAddressCodec : IFieldCodec<SiloAddress>, IDeepCopier<SiloAddress>, IOptionalDeepCopier
+    public sealed class SiloAddressCodec : IFieldCodec<SiloAddress>
     {
         private static readonly Type _codecFieldType = typeof(SiloAddress);
 
@@ -77,8 +75,5 @@ namespace Orleans.Runtime.Serialization
 
             return SiloAddress.New(address, port, generation);
         }
-
-        /// <inheritdoc />
-        public SiloAddress DeepCopy(SiloAddress input, CopyContext context) => input;
     }
 }

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -114,15 +114,8 @@ namespace Orleans.Runtime
         }
     }
 
-    /// <summary>
-    /// Copier implementation for <see cref="GrainReference"/> and derived classes.
-    /// </summary>
     [RegisterCopier]
-    internal sealed class GrainReferenceCopier : IDeepCopier<GrainReference>, IDerivedTypeCopier, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public GrainReference DeepCopy(GrainReference input, CopyContext context) => input;
-    }
+    internal sealed class GrainReferenceCopier : ShallowCopier<GrainReference>, IDerivedTypeCopier { }
 
     /// <summary>
     /// Provides specialized copier instances for grain reference types.

--- a/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
@@ -91,12 +91,6 @@ namespace Orleans.Runtime
         }
     }
 
-    [RegisterCopier]
-    internal sealed class GrainCancellationTokenCopier : IDeepCopier<GrainCancellationToken>, IOptionalDeepCopier
-    {
-        public GrainCancellationToken DeepCopy(GrainCancellationToken input, CopyContext context) => input;
-    }
-
     [GenerateSerializer]
     internal struct GrainCancellationTokenSurrogate
     {

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -187,7 +187,7 @@ namespace Orleans.Serialization
         }
 
         internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -57,12 +57,10 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
         // Note that the codec is responsible for serializing the type of the value itself.
         writer.WriteFieldHeader(fieldIdDelta, expectedType, SelfType, WireType.TagDelimited);
 
-        var type = value.GetType();
-
         // Write the type name
         ReferenceCodec.MarkValueField(writer.Session);
-        writer.WriteFieldHeader(0, typeof(byte[]), typeof(byte[]), WireType.LengthPrefixed);
-        writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, type);
+        writer.WriteFieldHeaderExpected(0, WireType.LengthPrefixed);
+        writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value.GetType());
 
         // Write the serialized payload
         var serializedValue = JsonConvert.SerializeObject(value, _options.SerializerSettings);
@@ -146,32 +144,33 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
     }
 
     /// <inheritdoc/>
-    object IDeepCopier<object>.DeepCopy(object input, CopyContext context)
+    object IDeepCopier.DeepCopy(object input, CopyContext context)
     {
-        if (input is null) return null;
+        if (context.TryGetCopy(input, out object result))
+            return result;
 
         var stream = PooledBufferStream.Rent();
         try
         {
             var type = input.GetType();
-            using var streamWriter = new StreamWriter(stream);
-            using var textWriter = new JsonTextWriter(streamWriter);
-            _serializer.Serialize(textWriter, input, type);
-            textWriter.Flush();
+            var streamWriter = new StreamWriter(stream);
+            using (var textWriter = new JsonTextWriter(streamWriter) { CloseOutput = false })
+                _serializer.Serialize(textWriter, input, type);
+            streamWriter.Flush();
 
             stream.Position = 0;
 
-            using var streamReader = new StreamReader(stream);
+            var streamReader = new StreamReader(stream);
             using var jsonReader = new JsonTextReader(streamReader);
-            var result = _serializer.Deserialize(jsonReader, type);
-
-            context.RecordCopy(input, result);
-            return result;
+            result = _serializer.Deserialize(jsonReader, type);
         }
         finally
         {
             PooledBufferStream.Return(stream);
         }
+
+        context.RecordCopy(input, result);
+        return result;
     }
 
     /// <inheritdoc/>
@@ -194,7 +193,7 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
     }
 
     private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for JSON fields. {field}");
+        $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for JSON fields. {field}");
 
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -59,12 +59,10 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         // Note that the codec is responsible for serializing the type of the value itself.
         writer.WriteFieldHeader(fieldIdDelta, expectedType, SelfType, WireType.TagDelimited);
 
-        var type = value.GetType();
-
         // Write the type name
         ReferenceCodec.MarkValueField(writer.Session);
-        writer.WriteFieldHeader(0, typeof(byte[]), typeof(byte[]), WireType.LengthPrefixed);
-        writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, type);
+        writer.WriteFieldHeaderExpected(0, WireType.LengthPrefixed);
+        writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value.GetType());
 
         // Write the serialized payload
         // Note that the Utf8JsonWriter and PooledArrayBufferWriter could be pooled as long as they're correctly
@@ -72,12 +70,12 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         var bufferWriter = new BufferWriterBox<PooledArrayBufferWriter>(new PooledArrayBufferWriter());
         try
         {
-            using var jsonWriter = new Utf8JsonWriter(bufferWriter);
+            var jsonWriter = new Utf8JsonWriter(bufferWriter);
             JsonSerializer.Serialize(jsonWriter, value, _options.SerializerOptions);
             jsonWriter.Flush();
 
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(1, typeof(byte[]), typeof(byte[]), WireType.LengthPrefixed);
+            writer.WriteFieldHeaderExpected(1, WireType.LengthPrefixed);
             writer.WriteVarUInt32((uint)bufferWriter.Value.Length);
             bufferWriter.Value.CopyTo(ref writer);
         }
@@ -180,25 +178,30 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
     }
 
     /// <inheritdoc/>
-    object IDeepCopier<object>.DeepCopy(object input, CopyContext context)
+    object IDeepCopier.DeepCopy(object input, CopyContext context)
     {
-        if (input is null) return null;
+        if (context.TryGetCopy(input, out object result))
+            return result;
+
 
         var bufferWriter = new BufferWriterBox<PooledArrayBufferWriter>(new PooledArrayBufferWriter());
-        using var jsonWriter = new Utf8JsonWriter(bufferWriter);
-        JsonSerializer.Serialize(jsonWriter, input, _options.SerializerOptions);
-        var sequence = bufferWriter.Value.AsReadOnlySequence();
         try
         {
+            var jsonWriter = new Utf8JsonWriter(bufferWriter);
+            JsonSerializer.Serialize(jsonWriter, input, _options.SerializerOptions);
+            jsonWriter.Flush();
+
+            var sequence = bufferWriter.Value.AsReadOnlySequence();
             var jsonReader = new Utf8JsonReader(sequence, _options.ReaderOptions);
-            var result = JsonSerializer.Deserialize(ref jsonReader, input.GetType(), _options.SerializerOptions);
-            context.RecordCopy(input, result);
-            return result;
+            result = JsonSerializer.Deserialize(ref jsonReader, input.GetType(), _options.SerializerOptions);
         }
         finally
         {
             bufferWriter.Value.Dispose();
         }
+
+        context.RecordCopy(input, result);
+        return result;
     }
 
     /// <inheritdoc/>
@@ -224,7 +227,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
     bool? ITypeFilter.IsTypeAllowed(Type type) => (((IGeneralizedCopier)this).IsSupportedType(type) || ((IGeneralizedCodec)this).IsSupportedType(type)) ? true : null;
 
     private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for JSON fields. {field}");
+        $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for JSON fields. {field}");
 
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 }

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -120,7 +120,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -276,7 +276,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -444,7 +444,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -615,7 +615,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");

--- a/src/Orleans.Serialization/Codecs/ArrayListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayListCodec.cs
@@ -45,17 +45,6 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class ArrayListCopier : IDeepCopier<ArrayList>, IBaseCopier<ArrayList>
     {
-        private readonly IDeepCopier<object> _copier;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArrayListCopier"/> class.
-        /// </summary>
-        /// <param name="copier">The copier.</param>
-        public ArrayListCopier(IDeepCopier<object> copier)
-        {
-            _copier = copier;
-        }
-
         /// <inheritdoc/>
         public ArrayList DeepCopy(ArrayList input, CopyContext context)
         {
@@ -73,7 +62,7 @@ namespace Orleans.Serialization.Codecs
             context.RecordCopy(input, result);
             foreach (var item in input)
             {
-                result.Add(_copier.DeepCopy(item, context));
+                result.Add(ObjectCopier.DeepCopy(item, context));
             }
 
             return result;
@@ -84,7 +73,7 @@ namespace Orleans.Serialization.Codecs
         {
             foreach (var item in input)
             {
-                output.Add(_copier.DeepCopy(item, context));
+                output.Add(ObjectCopier.DeepCopy(item, context));
             }
         }
     }

--- a/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
+++ b/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
@@ -55,14 +55,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {nameof(BitVector32)} fields. {field}");
     }
-
-    /// <summary>
-    /// Copier for <see cref="BitVector32"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class BitVector32Copier : IDeepCopier<BitVector32>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public BitVector32 DeepCopy(BitVector32 input, CopyContext _) => new(input);
-    }
 }

--- a/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
@@ -68,16 +68,6 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for {nameof(CompareInfo)} fields. {field}");
-    }
-
-    /// <summary>
-    /// Copier for <see cref="CompareInfo"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class CompareInfoCopier : IDeepCopier<CompareInfo>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public CompareInfo DeepCopy(CompareInfo input, CopyContext context) => input;
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(CompareInfo)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/CultureInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CultureInfoCodec.cs
@@ -39,13 +39,6 @@ namespace Orleans.Serialization.Codecs
         public string Name;
     }
 
-    /// <summary>
-    /// Copier for <see cref="CultureInfo"/>.
-    /// </summary>
     [RegisterCopier]
-    public sealed class CultureInfoCopier : IDeepCopier<CultureInfo>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public CultureInfo DeepCopy(CultureInfo input, CopyContext _) => input;
-    }
+    internal sealed class CultureInfoCopier : ShallowCopier<CultureInfo>, IDerivedTypeCopier { }
 }

--- a/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
@@ -46,14 +46,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(DateTime)} fields. {field}");
     }
-
-    /// <summary>
-    /// Copier for <see cref="DateTime"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class DateTimeCopier : IDeepCopier<DateTime>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public DateTime DeepCopy(DateTime input, CopyContext _) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
@@ -67,16 +67,6 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for {nameof(DateTimeOffset)} fields. {field}");
-    }
-
-    /// <summary>
-    /// Copier for <see cref="DateTimeOffset"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class DateTimeOffsetCopier : IDeepCopier<DateTimeOffset>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public DateTimeOffset DeepCopy(DateTimeOffset input, CopyContext _) => input;
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(DateTimeOffset)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -145,7 +145,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
+++ b/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
@@ -13,8 +13,7 @@ namespace Orleans.Serialization.Codecs
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <seealso cref="Orleans.Serialization.Codecs.IFieldCodec{T}" />
-    /// <seealso cref="Orleans.Serialization.Cloning.IDeepCopier{T}" />
-    public abstract class Enum32BaseCodec<T> : IFieldCodec<T>, IDeepCopier<T>, IOptionalDeepCopier where T : Enum
+    public abstract class Enum32BaseCodec<T> : IFieldCodec<T> where T : Enum
     {
         /// <summary>
         /// The codec field type
@@ -55,9 +54,6 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        /// <inheritdoc/>
-        public T DeepCopy(T input, CopyContext context) => input;
-
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {typeof(T).GetType()} fields. {field}");
 
@@ -73,17 +69,11 @@ namespace Orleans.Serialization.Codecs
     /// Serializer and copier for <see cref="DateTimeKind"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class DateTimeKindCodec : Enum32BaseCodec<DateTimeKind>
-    {
-    }
+    public sealed class DateTimeKindCodec : Enum32BaseCodec<DateTimeKind> { }
 
     /// <summary>
     /// Serializer and copier for <see cref="DayOfWeek"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class DayOfWeekCodec : Enum32BaseCodec<DayOfWeek>
-    {
-    }
+    public sealed class DayOfWeekCodec : Enum32BaseCodec<DayOfWeek> { }
 }

--- a/src/Orleans.Serialization/Codecs/FloatCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FloatCodec.cs
@@ -90,16 +90,6 @@ namespace Orleans.Serialization.Codecs
     }
 
     /// <summary>
-    /// Copier for <see cref="float"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class FloatCopier : IDeepCopier<float>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public float DeepCopy(float input, CopyContext _) => input;
-    }
-
-    /// <summary>
     /// Serializer for <see cref="double"/>.
     /// </summary>
     [RegisterSerializer]
@@ -166,16 +156,6 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new ArgumentOutOfRangeException(
             $"{nameof(wireType)} {wireType} is not supported by this codec.");
-    }
-
-    /// <summary>
-    /// Copier for <see cref="double"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class DoubleCopier : IDeepCopier<double>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public double DeepCopy(double input, CopyContext _) => input;
     }
 
     /// <summary>
@@ -280,15 +260,5 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowValueOutOfRange<T>(T value) => throw new ArgumentOutOfRangeException(
             $"The {typeof(T)} value has a magnitude too high {value} to be converted to {typeof(decimal)}.");
-    }
-
-    /// <summary>
-    /// Copier for <see cref="decimal"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class DecimalCopier : IDeepCopier<decimal>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public decimal DeepCopy(decimal input, CopyContext _) => input;
     }
 }

--- a/src/Orleans.Serialization/Codecs/GuidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GuidCodec.cs
@@ -124,14 +124,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for {nameof(Guid)} fields. {field}");
     }
-
-    /// <summary>
-    /// Copier for <see cref="Guid"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class GuidCopier : IDeepCopier<Guid>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public Guid DeepCopy(Guid input, CopyContext _) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -125,7 +125,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -96,13 +96,6 @@ namespace Orleans.Serialization.Codecs
         }
     }
 
-    /// <summary>
-    /// Copier for <see cref="IPAddress"/>.
-    /// </summary>
     [RegisterCopier]
-    public sealed class IPAddressCopier : IDeepCopier<IPAddress>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public IPAddress DeepCopy(IPAddress input, CopyContext _) => input;
-    }
+    internal sealed class IPAddressCopier : ShallowCopier<IPAddress>, IDerivedTypeCopier { }
 }

--- a/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
@@ -12,7 +12,7 @@ namespace Orleans.Serialization.Codecs
     /// Serializer for <see cref="IPEndPoint"/>.
     /// </summary>
     [RegisterSerializer]
-    public sealed class IPEndPointCodec : IFieldCodec<IPEndPoint>
+    public sealed class IPEndPointCodec : IFieldCodec<IPEndPoint>, IDerivedTypeCodec
     {
         /// <summary>
         /// The codec field type
@@ -75,7 +75,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         public static void WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, IPEndPoint value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, CodecFieldType, value))
             {
                 return;
             }
@@ -87,23 +87,6 @@ namespace Orleans.Serialization.Codecs
         }
     }
 
-    /// <summary>
-    /// Copier for <see cref="IPEndPoint"/>.
-    /// </summary>
     [RegisterCopier]
-    public sealed class IPEndPointCopier : IDeepCopier<IPEndPoint>, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public IPEndPoint DeepCopy(IPEndPoint input, CopyContext _) => input;
-    }
-
-    /// <summary>
-    /// Copier for <see cref="EndPoint"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class EndPointCopier : IDeepCopier<EndPoint>, IDerivedTypeCopier, IOptionalDeepCopier
-    {
-        /// <inheritdoc/>
-        public EndPoint DeepCopy(EndPoint input, CopyContext _) => input;
-    }
+    internal sealed class EndPointCopier : ShallowCopier<EndPoint>, IDerivedTypeCopier { }
 }

--- a/src/Orleans.Serialization/Codecs/ImmutableArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ImmutableArrayCodec.cs
@@ -58,6 +58,15 @@ namespace Orleans.Serialization.Codecs
 
         public bool IsShallowCopyable() => _copier is null;
 
+        object IDeepCopier.DeepCopy(object input, CopyContext context)
+        {
+            if (_copier is null)
+                return input;
+
+            var array = (ImmutableArray<T>)input;
+            return array.IsDefaultOrEmpty ? input : DeepCopy(array, context);
+        }
+
         /// <inheritdoc/>
         public ImmutableArray<T> DeepCopy(ImmutableArray<T> input, CopyContext context)
             => _copier is null || input.IsDefaultOrEmpty ? input : ImmutableArray.CreateRange(input, (i, s) => s._copier.DeepCopy(i, s.context), (_copier, context));

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -11,8 +11,7 @@ namespace Orleans.Serialization.Codecs
     /// Serializer for <see cref="bool"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class BoolCodec : TypedCodecBase<bool>, IFieldCodec<bool>, IDeepCopier<bool>, IOptionalDeepCopier
+    public sealed class BoolCodec : TypedCodecBase<bool>, IFieldCodec<bool>
     {
         private static readonly Type CodecFieldType = typeof(bool);
 
@@ -53,17 +52,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt8(field.WireType) == 1;
         }
-
-        /// <inheritdoc/>
-        public bool DeepCopy(bool input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="char"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class CharCodec : TypedCodecBase<char>, IFieldCodec<char>, IDeepCopier<char>, IOptionalDeepCopier
+    public sealed class CharCodec : TypedCodecBase<char>, IFieldCodec<char>
     {
         private static readonly Type CodecFieldType = typeof(char);
 
@@ -104,17 +99,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return (char)reader.ReadUInt16(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public char DeepCopy(char input, CopyContext _) => input; 
     }
 
     /// <summary>
     /// Serializer for <see cref="byte"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class ByteCodec : TypedCodecBase<byte>, IFieldCodec<byte>, IDeepCopier<byte>, IOptionalDeepCopier
+    public sealed class ByteCodec : TypedCodecBase<byte>, IFieldCodec<byte>
     {
         private static readonly Type CodecFieldType = typeof(byte);
 
@@ -171,17 +162,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt8(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public byte DeepCopy(byte input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="sbyte"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class SByteCodec : TypedCodecBase<sbyte>, IFieldCodec<sbyte>, IDeepCopier<sbyte>, IOptionalDeepCopier
+    public sealed class SByteCodec : TypedCodecBase<sbyte>, IFieldCodec<sbyte>
     {
         private static readonly Type CodecFieldType = typeof(sbyte);
 
@@ -238,17 +225,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt8(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public sbyte DeepCopy(sbyte input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="ushort"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class UInt16Codec : TypedCodecBase<ushort>, IFieldCodec<ushort>, IDeepCopier<ushort>, IOptionalDeepCopier
+    public sealed class UInt16Codec : TypedCodecBase<ushort>, IFieldCodec<ushort>
     {
         /// <summary>
         /// The codec field type
@@ -308,17 +291,13 @@ namespace Orleans.Serialization.Codecs
             writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
             writer.WriteVarUInt32(value);
         }
-
-        /// <inheritdoc/>
-        public ushort DeepCopy(ushort input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="short"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class Int16Codec : TypedCodecBase<short>, IFieldCodec<short>, IDeepCopier<short>, IOptionalDeepCopier
+    public sealed class Int16Codec : TypedCodecBase<short>, IFieldCodec<short>
     {
         private static readonly Type CodecFieldType = typeof(short);
 
@@ -375,17 +354,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt16(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public short DeepCopy(short input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serialzier for <see cref="uint"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class UInt32Codec : TypedCodecBase<uint>, IFieldCodec<uint>, IDeepCopier<uint>, IOptionalDeepCopier
+    public sealed class UInt32Codec : TypedCodecBase<uint>, IFieldCodec<uint>
     {
         public static readonly Type CodecFieldType = typeof(uint);
 
@@ -458,17 +433,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt32(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public uint DeepCopy(uint input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="int"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class Int32Codec : TypedCodecBase<int>, IFieldCodec<int>, IDeepCopier<int>, IOptionalDeepCopier
+    public sealed class Int32Codec : TypedCodecBase<int>, IFieldCodec<int>
     {
         /// <summary>
         /// The codec field type
@@ -566,17 +537,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt32(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public int DeepCopy(int input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="long"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class Int64Codec : TypedCodecBase<long>, IFieldCodec<long>, IDeepCopier<long>, IOptionalDeepCopier
+    public sealed class Int64Codec : TypedCodecBase<long>, IFieldCodec<long>
     {
         private static readonly Type CodecFieldType = typeof(long);
 
@@ -672,17 +639,13 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt64(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public long DeepCopy(long input, CopyContext _) => input;
     }
 
     /// <summary>
     /// Serializer for <see cref="long"/>.
     /// </summary>
     [RegisterSerializer]
-    [RegisterCopier]
-    public sealed class UInt64Codec : TypedCodecBase<ulong>, IFieldCodec<ulong>, IDeepCopier<ulong>, IOptionalDeepCopier
+    public sealed class UInt64Codec : TypedCodecBase<ulong>, IFieldCodec<ulong>
     {
         private static readonly Type CodecFieldType = typeof(ulong);
 
@@ -781,8 +744,5 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt64(field.WireType);
         }
-
-        /// <inheritdoc/>
-        public ulong DeepCopy(ulong input, CopyContext _) => input;
     }
 }

--- a/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
+++ b/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
@@ -86,7 +86,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
     }
 
     /// <summary>
@@ -112,6 +112,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _keyCopier is null && _valueCopier is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy((KeyValuePair<TKey, TValue>)input, context);
 
         /// <inheritdoc/>
         public KeyValuePair<TKey, TValue> DeepCopy(KeyValuePair<TKey, TValue> input, CopyContext context)

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -115,7 +115,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -160,7 +160,7 @@ namespace Orleans.Serialization.Codecs
             $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static T ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }
@@ -171,17 +171,6 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="T">The array element type.</typeparam>
     internal sealed class MultiDimensionalArrayCopier<T> : IGeneralizedCopier
     {
-        private readonly IDeepCopier<object> _elementCopier;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MultiDimensionalArrayCopier{T}"/> class.
-        /// </summary>
-        /// <param name="elementCopier">The element copier.</param>
-        public MultiDimensionalArrayCopier(IDeepCopier<object> elementCopier)
-        {
-            _elementCopier = OrleansGeneratedCodeHelper.UnwrapService(this, elementCopier);
-        }
-
         /// <inheritdoc/>
         public object DeepCopy(object original, CopyContext context)
         {
@@ -213,7 +202,7 @@ namespace Orleans.Serialization.Codecs
             {
                 for (var i = 0; i < lengths[0]; i++)
                 {
-                    result.SetValue(_elementCopier.DeepCopy(originalArray.GetValue(i), context), i);
+                    result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(i), context), i);
                 }
             }
             else if (rank == 2)
@@ -222,7 +211,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     for (var j = 0; j < lengths[1]; j++)
                     {
-                        result.SetValue(_elementCopier.DeepCopy(originalArray.GetValue(i, j), context), i, j);
+                        result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(i, j), context), i, j);
                     }
                 }
             }
@@ -246,7 +235,7 @@ namespace Orleans.Serialization.Codecs
                         index[n] = offset;
                     }
 
-                    result.SetValue(_elementCopier.DeepCopy(originalArray.GetValue(index), context), index);
+                    result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(index), context), index);
                 }
             }
 

--- a/src/Orleans.Serialization/Codecs/NullableCodec.cs
+++ b/src/Orleans.Serialization/Codecs/NullableCodec.cs
@@ -79,15 +79,9 @@ namespace Orleans.Serialization.Codecs
 
         public bool IsShallowCopyable() => _copier is null;
 
-        /// <inheritdoc/>
-        public T? DeepCopy(T? input, CopyContext context)
-        {
-            if (input is null || _copier is null)
-            {
-                return input;
-            }
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => input is null || _copier is null ? input : _copier.DeepCopy(input, context);
 
-            return _copier.DeepCopy(input.GetValueOrDefault(), context);
-        }
+        /// <inheritdoc/>
+        public T? DeepCopy(T? input, CopyContext context) => input is null || _copier is null ? input : _copier.DeepCopy(input.GetValueOrDefault(), context);
     }
 }

--- a/src/Orleans.Serialization/Codecs/ObjectCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ObjectCodec.cs
@@ -87,14 +87,17 @@ namespace Orleans.Serialization.Codecs
         /// <returns>A copy of <paramref name="input" />.</returns>
         public static object DeepCopy(object input, CopyContext context)
         {
-            if (context.TryGetCopy<object>(input, out var result))
-            {
-                return result;
-            }
-
-            return input.GetType() == typeof(object) ? input : context.DeepCopy(input);
+            return context.TryGetCopy<object>(input, out var result) ? result
+                : input.GetType() == typeof(object) ? input : context.DeepCopy(input);
         }
 
-        object IDeepCopier<object>.DeepCopy(object input, CopyContext context) => DeepCopy(input, context);
+        object IDeepCopier<object>.DeepCopy(object input, CopyContext context)
+        {
+            return context.TryGetCopy<object>(input, out var result) ? result
+                : input.GetType() == typeof(object) ? input : context.DeepCopy(input);
+        }
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context)
+            => input is null || input.GetType() == typeof(object) ? input : context.DeepCopy(input);
     }
 }

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -107,7 +107,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
     }

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -115,7 +115,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for string fields. {field}");
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/StringCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StringCodec.cs
@@ -115,22 +115,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for string fields. {field}");
     }
-
-    /// <summary>
-    /// Copier for <see cref="string"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class StringCopier : IDeepCopier<string>, IOptionalDeepCopier
-    {
-        /// <summary>
-        /// Creates a copy of the provided input.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="copyContext">The copy context.</param>
-        /// <returns>A copy of the provided value.</returns>
-        public static string DeepCopy(string input, CopyContext copyContext) => input;
-
-        /// <inheritdoc />
-        string IDeepCopier<string>.DeepCopy(string input, CopyContext _) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
@@ -59,14 +59,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
             $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(TimeSpan)} fields. {field}");
     }
-
-    /// <summary>
-    /// Copier for <see cref="TimeSpan"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class TimeSpanCopier : IDeepCopier<TimeSpan>, IOptionalDeepCopier
-    {
-        /// <inheritdoc />
-        public TimeSpan DeepCopy(TimeSpan input, CopyContext _) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -139,14 +139,4 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowUnknownWellKnownType(uint id) => throw new UnknownWellKnownTypeException(id);
         private static void ThrowMissingType() => throw new TypeMissingException();
     }
-
-    /// <summary>
-    /// Copier for <see cref="Type"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class TypeCopier : IDeepCopier<Type>, IDerivedTypeCopier, IOptionalDeepCopier
-    {
-        /// <inheritdoc />
-        public Type DeepCopy(Type input, CopyContext context) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/UriCodec.cs
+++ b/src/Orleans.Serialization/Codecs/UriCodec.cs
@@ -39,13 +39,6 @@ namespace Orleans.Serialization.Codecs
         public string Value;
     }
 
-    /// <summary>
-    /// Copier for <see cref="Uri"/>.
-    /// </summary>
     [RegisterCopier]
-    public sealed class UriCopier : IDeepCopier<Uri>, IDerivedTypeCopier, IOptionalDeepCopier
-    {
-        /// <inheritdoc />
-        public Uri DeepCopy(Uri input, CopyContext context) => input;
-    }
+    internal sealed class UriCopier : ShallowCopier<Uri>, IDerivedTypeCopier { }
 }

--- a/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
@@ -36,16 +36,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.TagDelimited} is supported for tuple fields.");
-    }
-
-    /// <summary>
-    /// Copier for <see cref="ValueTuple"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class ValueTupleCopier : IDeepCopier<ValueTuple>, IOptionalDeepCopier
-    {
-        public ValueTuple DeepCopy(ValueTuple input, CopyContext _) => input;
+            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -134,6 +125,8 @@ namespace Orleans.Serialization.Codecs
         public ValueTupleCopier(IDeepCopier<T> copier) => _copier = OrleansGeneratedCodeHelper.GetOptionalCopier(copier);
 
         public bool IsShallowCopyable() => _copier is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy((ValueTuple<T>)input, context);
 
         /// <inheritdoc />
         public ValueTuple<T> DeepCopy(ValueTuple<T> input, CopyContext context)
@@ -241,6 +234,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2> DeepCopy(ValueTuple<T1, T2> input, CopyContext context)
@@ -366,6 +361,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2, T3))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3> DeepCopy(ValueTuple<T1, T2, T3> input, CopyContext context)
@@ -505,6 +502,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null && _copier4 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2, T3, T4))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3, T4> DeepCopy(ValueTuple<T1, T2, T3, T4> input, CopyContext context)
@@ -657,6 +656,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null && _copier4 is null && _copier5 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2, T3, T4, T5))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3, T4, T5> DeepCopy(ValueTuple<T1, T2, T3, T4, T5> input, CopyContext context)
@@ -824,6 +825,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null && _copier4 is null && _copier5 is null && _copier6 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2, T3, T4, T5, T6))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3, T4, T5, T6> DeepCopy(ValueTuple<T1, T2, T3, T4, T5, T6> input, CopyContext context)
@@ -1007,6 +1010,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null && _copier4 is null && _copier5 is null && _copier6 is null && _copier7 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy(((T1, T2, T3, T4, T5, T6, T7))input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3, T4, T5, T6, T7> DeepCopy(ValueTuple<T1, T2, T3, T4, T5, T6, T7> input, CopyContext context)
@@ -1203,6 +1208,8 @@ namespace Orleans.Serialization.Codecs
         }
 
         public bool IsShallowCopyable() => _copier1 is null && _copier2 is null && _copier3 is null && _copier4 is null && _copier5 is null && _copier6 is null && _copier7 is null && _copier8 is null;
+
+        object IDeepCopier.DeepCopy(object input, CopyContext context) => IsShallowCopyable() ? input : DeepCopy((ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>)input, context);
 
         /// <inheritdoc />
         public ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> DeepCopy(ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> input, CopyContext context)

--- a/src/Orleans.Serialization/Codecs/VersionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/VersionCodec.cs
@@ -84,14 +84,4 @@ namespace Orleans.Serialization.Codecs
         [Id(3)]
         public int Revision;
     }
-
-    /// <summary>
-    /// Copier for <see cref="Version"/>.
-    /// </summary>
-    [RegisterCopier]
-    public sealed class VersionCopier : IDeepCopier<Version>, IOptionalDeepCopier
-    {
-        /// <inheritdoc />
-        public Version DeepCopy(Version input, CopyContext context) => input;
-    }
 }

--- a/src/Orleans.Serialization/Codecs/VoidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/VoidCodec.cs
@@ -9,7 +9,7 @@ namespace Orleans.Serialization.Codecs
     /// <summary>
     /// Serializer for unknown types.
     /// </summary>
-    public sealed class VoidCodec : IFieldCodec<object>
+    internal sealed class VoidCodec : IFieldCodec<object>
     {
         /// <inheritdoc />
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
@@ -40,7 +40,7 @@ namespace Orleans.Serialization.Codecs
     /// <summary>
     /// Copier for unknown types.
     /// </summary>
-    public sealed class VoidCopier : IDeepCopier<object>
+    internal sealed class VoidCopier : IDeepCopier
     {
         public object DeepCopy(object input, CopyContext context)
         {

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -295,14 +295,6 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         }
 
         /// <summary>
-        /// Default copier for shallow-copyable types
-        /// </summary>
-        public sealed class DefaultShallowCopier<T> : IDeepCopier<T>
-        {
-            public T DeepCopy(T input, CopyContext _) => input;
-        }
-
-        /// <summary>
         /// Default codec implementation for abstract classes
         /// </summary>
         public abstract class AbstractCodec<T> : IFieldCodec<T>, IBaseCodec<T> where T : class

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -201,6 +201,8 @@ namespace Orleans.Serialization
 
             public T DeepCopy(T original, CopyContext context) => Value.DeepCopy(original, context);
 
+            public object DeepCopy(object original, CopyContext context) => Value.DeepCopy(original, context);
+
             public bool IsShallowCopyable() => (Value as IOptionalDeepCopier)?.IsShallowCopyable() ?? false;
 
             public IDeepCopier<T> Value => _copier ??= _codecProvider.GetDeepCopier<T>();

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -98,13 +98,6 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
     }
 
-    public class DateTimeCopierTests : CopierTester<DateTime, DateTimeCopier>
-    {
-        protected override DateTime CreateValue() => DateTime.UtcNow;
-        protected override DateTime[] TestValues => new[] { DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0) };
-        protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
-    }
-
     public class TimeSpanTests : FieldCodecTester<TimeSpan, TimeSpanCodec>
     {
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
@@ -112,28 +105,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
     }
 
-    public class TimeSpanCopierTests : CopierTester<TimeSpan, TimeSpanCopier>
-    {
-        protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
-        protected override TimeSpan[] TestValues => new[] { TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345) };
-        protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
-    }
-
     public class DateTimeOffsetTests : FieldCodecTester<DateTimeOffset, DateTimeOffsetCodec>
-    {
-        protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
-        protected override DateTimeOffset[] TestValues => new[]
-        {
-            DateTimeOffset.MinValue,
-            DateTimeOffset.MaxValue,
-            new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0), TimeSpan.FromHours(11.5)),
-            new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0), TimeSpan.FromHours(-11.5)),
-        };
-
-        protected override Action<Action<DateTimeOffset>> ValueProvider => Gen.DateTimeOffset.ToValueProvider();
-    }
-
-    public class DateTimeOffsetCopierTests : CopierTester<DateTimeOffset, DateTimeOffsetCopier>
     {
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues => new[]
@@ -164,43 +136,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
     }
 
-    public class VersionCopierTests : CopierTester<Version, VersionCopier>
-    {
-        protected override Version CreateValue() => new();
-        protected override Version[] TestValues => new[]
-        {
-            new Version(),
-            new Version(1, 2),
-            new Version(1, 2, 3),
-            new Version(1, 2, 3, 4),
-            new Version("1.2"),
-            new Version("1.2.3"),
-            new Version("1.2.3.4")
-        };
-
-        protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
-
-        protected override bool IsImmutable => true;
-    }
-
     public class BitVector32Tests: FieldCodecTester<BitVector32, BitVector32Codec>
-    {
-        protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
-
-        protected override BitVector32[] TestValues => new[]
-        {
-            new BitVector32(0),
-            new BitVector32(100),
-            new BitVector32(-100),
-            CreateValue(),
-            CreateValue(),
-            CreateValue()
-        };
-
-        protected override bool Equals(BitVector32 left, BitVector32 right) => left.Equals(right) && left.GetHashCode() == right.GetHashCode();
-    }
-
-    public class BitVector32CopierTests: CopierTester<BitVector32, BitVector32Copier>
     {
         protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
 
@@ -816,27 +752,11 @@ namespace Orleans.Serialization.UnitTests
         protected override bool[] TestValues => new[] { false, true };
     }
 
-    public class BoolCopierTests : CopierTester<bool, BoolCodec>
-    {
-        protected override bool CreateValue() => true;
-        protected override bool Equals(bool left, bool right) => left == right;
-        protected override bool[] TestValues => new[] { false, true };
-    }
-
     public class StringCodecTests : FieldCodecTester<string, StringCodec>
     {
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
-    }
-
-    public class StringCopierTests : CopierTester<string, StringCopier>
-    {
-        protected override string CreateValue() => Guid.NewGuid().ToString();
-        protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
-        protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
-
-        protected override bool IsImmutable => true;
     }
 
     public class ObjectCodecTests : FieldCodecTester<object, ObjectCodec>
@@ -898,40 +818,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt64CodecTests : FieldCodecTester<ulong, UInt64Codec>
     {
-        protected override ulong CreateValue()
-        {
-            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
-            var lsb = (ulong)Guid.NewGuid().GetHashCode();
-            return msb | lsb;
-        }
-
-        protected override ulong[] TestValues => new ulong[]
-        {
-            0,
-            1,
-            (ulong)byte.MaxValue - 1,
-            byte.MaxValue,
-            (ulong)byte.MaxValue + 1,
-            (ulong)ushort.MaxValue - 1,
-            ushort.MaxValue,
-            (ulong)ushort.MaxValue + 1,
-            (ulong)uint.MaxValue - 1,
-            uint.MaxValue,
-            (ulong)uint.MaxValue + 1,
-            ulong.MaxValue,
-        };
-
-        protected override Action<Action<ulong>> ValueProvider => Gen.ULong.ToValueProvider();
-    }
-
-    public class UInt64CopierTests : CopierTester<ulong, UInt64Codec>
-    {
-        protected override ulong CreateValue()
-        {
-            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
-            var lsb = (ulong)Guid.NewGuid().GetHashCode();
-            return msb | lsb;
-        }
+        protected override ulong CreateValue() => (ulong)Random.Shared.NextInt64();
 
         protected override ulong[] TestValues => new ulong[]
         {
@@ -972,44 +859,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
     }
 
-    public class UInt32CopiercTests : CopierTester<uint, UInt32Codec>
-    {
-        protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
-
-        protected override uint[] TestValues => new uint[]
-        {
-            0,
-            1,
-            (uint)byte.MaxValue - 1,
-            byte.MaxValue,
-            (uint)byte.MaxValue + 1,
-            (uint)ushort.MaxValue - 1,
-            ushort.MaxValue,
-            (uint)ushort.MaxValue + 1,
-            uint.MaxValue,
-        };
-
-        protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
-    }
-
     public class UInt16CodecTests : FieldCodecTester<ushort, UInt16Codec>
-    {
-        protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
-        protected override ushort[] TestValues => new ushort[]
-        {
-            0,
-            1,
-            byte.MaxValue - 1,
-            byte.MaxValue,
-            byte.MaxValue + 1,
-            ushort.MaxValue - 1,
-            ushort.MaxValue,
-        };
-
-        protected override Action<Action<ushort>> ValueProvider => Gen.UShort.ToValueProvider();
-    }
-
-    public class UInt16CopierTests : CopierTester<ushort, UInt16Codec>
     {
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues => new ushort[]
@@ -1034,52 +884,9 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
     }
 
-    public class ByteCopierTests : CopierTester<byte, ByteCodec>
-    {
-        protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
-        protected override byte[] TestValues => new byte[] { 0, 1, byte.MaxValue - 1, byte.MaxValue };
-
-        protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
-    }
-
     public class Int64CodecTests : FieldCodecTester<long, Int64Codec>
     {
-        protected override long CreateValue()
-        {
-            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
-            var lsb = (ulong)Guid.NewGuid().GetHashCode();
-            return (long)(msb | lsb);
-        }
-
-        protected override long[] TestValues => new[]
-        {
-            long.MinValue,
-            -1,
-            0,
-            1,
-            (long)sbyte.MaxValue - 1,
-            sbyte.MaxValue,
-            (long)sbyte.MaxValue + 1,
-            (long)short.MaxValue - 1,
-            short.MaxValue,
-            (long)short.MaxValue + 1,
-            (long)int.MaxValue - 1,
-            int.MaxValue,
-            (long)int.MaxValue + 1,
-            long.MaxValue,
-        };
-
-        protected override Action<Action<long>> ValueProvider => Gen.Long.ToValueProvider();
-    }
-
-    public class Int64CopierTests : CopierTester<long, Int64Codec>
-    {
-        protected override long CreateValue()
-        {
-            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
-            var lsb = (ulong)Guid.NewGuid().GetHashCode();
-            return (long)(msb | lsb);
-        }
+        protected override long CreateValue() => Random.Shared.NextInt64();
 
         protected override long[] TestValues => new[]
         {
@@ -1153,50 +960,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class Int32CopierTests : CopierTester<int, Int32Codec>
-    {
-        protected override int CreateValue() => Guid.NewGuid().GetHashCode();
-
-        protected override int[] TestValues => new[]
-        {
-            int.MinValue,
-            -1,
-            0,
-            1,
-            sbyte.MaxValue - 1,
-            sbyte.MaxValue,
-            sbyte.MaxValue + 1,
-            short.MaxValue - 1,
-            short.MaxValue,
-            short.MaxValue + 1,
-            int.MaxValue - 1,
-            int.MaxValue,
-        };
-
-        protected override Action<Action<int>> ValueProvider => Gen.Int.ToValueProvider();
-    }
-
     public class Int16CodecTests : FieldCodecTester<short, Int16Codec>
-    {
-        protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
-
-        protected override short[] TestValues => new short[]
-        {
-            short.MinValue,
-            -1,
-            0,
-            1,
-            sbyte.MaxValue - 1,
-            sbyte.MaxValue,
-            sbyte.MaxValue + 1,
-            short.MaxValue - 1,
-            short.MaxValue
-        };
-
-        protected override Action<Action<short>> ValueProvider => Gen.Short.ToValueProvider();
-    }
-
-    public class Int16CopierTests : CopierTester<short, Int16Codec>
     {
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
@@ -1233,23 +997,6 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
     }
 
-    public class SByteCopierTests : CopierTester<sbyte, SByteCodec>
-    {
-        protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
-
-        protected override sbyte[] TestValues => new sbyte[]
-        {
-            sbyte.MinValue,
-            -1,
-            0,
-            1,
-            sbyte.MaxValue - 1,
-            sbyte.MaxValue
-        };
-
-        protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
-    }
-
     public class CharCodecTests : FieldCodecTester<char, CharCodec>
     {
         private int _createValueCount;
@@ -1268,38 +1015,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
     }
 
-    public class CharCopierTests : CopierTester<char, CharCodec>
-    {
-        private int _createValueCount;
-        protected override char CreateValue() => (char)('!' + _createValueCount++ % ('~' - '!'));
-        protected override char[] TestValues => new[]
-        {
-            (char)0,
-            (char)1,
-            (char)(byte.MaxValue - 1),
-            (char)byte.MaxValue,
-            (char)(byte.MaxValue + 1),
-            (char)(ushort.MaxValue - 1),
-            (char)ushort.MaxValue,
-        };
-
-        protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
-    }
-
     public class GuidCodecTests : FieldCodecTester<Guid, GuidCodec>
-    {
-        protected override Guid CreateValue() => Guid.NewGuid();
-        protected override Guid[] TestValues => new[]
-        {
-            Guid.Empty,
-            Guid.Parse("4DEBD074-5DBB-45F6-ACB7-ED97D2AEE02F"),
-            Guid.Parse("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
-        };
-
-        protected override Action<Action<Guid>> ValueProvider => Gen.Guid.ToValueProvider();
-    }
-
-    public class GuidCopierTests : CopierTester<Guid, GuidCopier>
     {
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues => new[]
@@ -1336,41 +1052,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Type[] TestValues => _values;
     }
 
-    public class TypeCopierTests : CopierTester<Type, TypeCopier>
-    {
-        private readonly Type[] _values =
-        {
-            null,
-            typeof(Dictionary<Guid, List<string>>),
-            typeof(Type).MakeByRefType(),
-            typeof(Guid),
-            typeof(int).MakePointerType(),
-            typeof(string[]),
-            typeof(string[,]),
-            typeof(string[,]).MakePointerType(),
-            typeof(string[,]).MakeByRefType(),
-            typeof(Dictionary<,>),
-            typeof(List<>),
-            typeof(string)
-        };
-
-        private int _valueIndex;
-
-        protected override Type CreateValue() => _values[_valueIndex++ % _values.Length];
-        protected override Type[] TestValues => _values;
-
-        protected override bool IsImmutable => true;
-    }
-
     public class FloatCodecTests : FieldCodecTester<float, FloatCodec>
-    {
-        protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
-        protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
-
-        protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
-    }
-
-    public class FloatCopierTests : CopierTester<float, FloatCopier>
     {
         protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
@@ -1386,22 +1068,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
     }
 
-    public class DoubleCopierTests : CopierTester<double, DoubleCopier>
-    {
-        protected override double CreateValue() => double.MaxValue * new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
-        protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
-
-        protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
-    }
-
     public class DecimalCodecTests : FieldCodecTester<decimal, DecimalCodec>
-    {
-        protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
-        protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
-        protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
-    }
-
-    public class DecimalCopierTests : CopierTester<decimal, DecimalCopier>
     {
         protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
@@ -1823,30 +1490,6 @@ namespace Orleans.Serialization.UnitTests
         } 
     }
 
-    public class IPAddressCopierTests : CopierTester<IPAddress, IPAddressCopier>
-    {
-        protected override IPAddress[] TestValues => new[] { null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue() };
-
-        protected override IPAddress CreateValue()
-        {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
-            byte[] bytes;
-            if (rand.Next(1) == 0)
-            {
-                bytes = new byte[4];
-            }
-            else
-            {
-                bytes = new byte[16];
-            }
-
-            rand.NextBytes(bytes);
-            return new IPAddress(bytes);
-        }
-
-        protected override bool IsImmutable => true;
-    }
-
     public class HashSetTests : FieldCodecTester<HashSet<string>, HashSetCodec<string>>
     {
         protected override HashSet<string> CreateValue()
@@ -1954,17 +1597,6 @@ namespace Orleans.Serialization.UnitTests
         protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
 
         protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
-    }
-
-    public class UriCopierTests : CopierTester<Uri, UriCopier>
-    {
-        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
-
-        protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
-
-        protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
-
-        protected override bool IsImmutable => true;
     }
 
     public class FSharpOptionTests : FieldCodecTester<FSharpOption<Guid>, FSharpOptionCodec<Guid>>

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -98,6 +98,14 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
     }
 
+    public class DateTimeCopierTests : CopierTester<DateTime, IDeepCopier<DateTime>>
+    {
+        protected override DateTime CreateValue() => DateTime.UtcNow;
+        protected override DateTime[] TestValues => new[] { DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0) };
+        protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
+    }
+
+
     public class TimeSpanTests : FieldCodecTester<TimeSpan, TimeSpanCodec>
     {
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
@@ -105,7 +113,28 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
     }
 
+    public class TimeSpanCopierTests : CopierTester<TimeSpan, IDeepCopier<TimeSpan>>
+    {
+        protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
+        protected override TimeSpan[] TestValues => new[] { TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345) };
+        protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
+    }
+
     public class DateTimeOffsetTests : FieldCodecTester<DateTimeOffset, DateTimeOffsetCodec>
+    {
+        protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
+        protected override DateTimeOffset[] TestValues => new[]
+        {
+            DateTimeOffset.MinValue,
+            DateTimeOffset.MaxValue,
+            new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0), TimeSpan.FromHours(11.5)),
+            new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0), TimeSpan.FromHours(-11.5)),
+        };
+
+        protected override Action<Action<DateTimeOffset>> ValueProvider => Gen.DateTimeOffset.ToValueProvider();
+    }
+
+    public class DateTimeOffsetCopierTests : CopierTester<DateTimeOffset, IDeepCopier<DateTimeOffset>>
     {
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues => new[]
@@ -136,7 +165,43 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
     }
 
+    public class VersionCopierTests : CopierTester<Version, IDeepCopier<Version>>
+    {
+        protected override Version CreateValue() => new();
+        protected override Version[] TestValues => new[]
+        {
+            new Version(),
+            new Version(1, 2),
+            new Version(1, 2, 3),
+            new Version(1, 2, 3, 4),
+            new Version("1.2"),
+            new Version("1.2.3"),
+            new Version("1.2.3.4")
+        };
+
+        protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
+
+        protected override bool IsImmutable => true;
+    }
+
     public class BitVector32Tests: FieldCodecTester<BitVector32, BitVector32Codec>
+    {
+        protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
+
+        protected override BitVector32[] TestValues => new[]
+        {
+            new BitVector32(0),
+            new BitVector32(100),
+            new BitVector32(-100),
+            CreateValue(),
+            CreateValue(),
+            CreateValue()
+        };
+
+        protected override bool Equals(BitVector32 left, BitVector32 right) => left.Equals(right) && left.GetHashCode() == right.GetHashCode();
+    }
+
+    public class BitVector32CopierTests: CopierTester<BitVector32, IDeepCopier<BitVector32>>
     {
         protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
 
@@ -752,11 +817,27 @@ namespace Orleans.Serialization.UnitTests
         protected override bool[] TestValues => new[] { false, true };
     }
 
+    public class BoolCopierTests : CopierTester<bool, IDeepCopier<bool>>
+    {
+        protected override bool CreateValue() => true;
+        protected override bool Equals(bool left, bool right) => left == right;
+        protected override bool[] TestValues => new[] { false, true };
+    }
+
     public class StringCodecTests : FieldCodecTester<string, StringCodec>
     {
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
+    }
+
+    public class StringCopierTests : CopierTester<string, IDeepCopier<string>>
+    {
+        protected override string CreateValue() => Guid.NewGuid().ToString();
+        protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
+        protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
+
+        protected override bool IsImmutable => true;
     }
 
     public class ObjectCodecTests : FieldCodecTester<object, ObjectCodec>
@@ -818,7 +899,40 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt64CodecTests : FieldCodecTester<ulong, UInt64Codec>
     {
-        protected override ulong CreateValue() => (ulong)Random.Shared.NextInt64();
+        protected override ulong CreateValue()
+        {
+            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
+            var lsb = (ulong)Guid.NewGuid().GetHashCode();
+            return msb | lsb;
+        }
+
+        protected override ulong[] TestValues => new ulong[]
+        {
+            0,
+            1,
+            (ulong)byte.MaxValue - 1,
+            byte.MaxValue,
+            (ulong)byte.MaxValue + 1,
+            (ulong)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (ulong)ushort.MaxValue + 1,
+            (ulong)uint.MaxValue - 1,
+            uint.MaxValue,
+            (ulong)uint.MaxValue + 1,
+            ulong.MaxValue,
+        };
+
+        protected override Action<Action<ulong>> ValueProvider => Gen.ULong.ToValueProvider();
+    }
+
+    public class UInt64CopierTests : CopierTester<ulong, IDeepCopier<ulong>>
+    {
+        protected override ulong CreateValue()
+        {
+            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
+            var lsb = (ulong)Guid.NewGuid().GetHashCode();
+            return msb | lsb;
+        }
 
         protected override ulong[] TestValues => new ulong[]
         {
@@ -859,7 +973,44 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
     }
 
+    public class UInt32CopiercTests : CopierTester<uint, IDeepCopier<uint>>
+    {
+        protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
+
+        protected override uint[] TestValues => new uint[]
+        {
+            0,
+            1,
+            (uint)byte.MaxValue - 1,
+            byte.MaxValue,
+            (uint)byte.MaxValue + 1,
+            (uint)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (uint)ushort.MaxValue + 1,
+            uint.MaxValue,
+        };
+
+        protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
+    }
+
     public class UInt16CodecTests : FieldCodecTester<ushort, UInt16Codec>
+    {
+        protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
+        protected override ushort[] TestValues => new ushort[]
+        {
+            0,
+            1,
+            byte.MaxValue - 1,
+            byte.MaxValue,
+            byte.MaxValue + 1,
+            ushort.MaxValue - 1,
+            ushort.MaxValue,
+        };
+
+        protected override Action<Action<ushort>> ValueProvider => Gen.UShort.ToValueProvider();
+    }
+
+    public class UInt16CopierTests : CopierTester<ushort, IDeepCopier<ushort>>
     {
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues => new ushort[]
@@ -884,9 +1035,52 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
     }
 
+    public class ByteCopierTests : CopierTester<byte, IDeepCopier<byte>>
+    {
+        protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
+        protected override byte[] TestValues => new byte[] { 0, 1, byte.MaxValue - 1, byte.MaxValue };
+
+        protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
+    }
+
     public class Int64CodecTests : FieldCodecTester<long, Int64Codec>
     {
-        protected override long CreateValue() => Random.Shared.NextInt64();
+        protected override long CreateValue()
+        {
+            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
+            var lsb = (ulong)Guid.NewGuid().GetHashCode();
+            return (long)(msb | lsb);
+        }
+
+        protected override long[] TestValues => new[]
+        {
+            long.MinValue,
+            -1,
+            0,
+            1,
+            (long)sbyte.MaxValue - 1,
+            sbyte.MaxValue,
+            (long)sbyte.MaxValue + 1,
+            (long)short.MaxValue - 1,
+            short.MaxValue,
+            (long)short.MaxValue + 1,
+            (long)int.MaxValue - 1,
+            int.MaxValue,
+            (long)int.MaxValue + 1,
+            long.MaxValue,
+        };
+
+        protected override Action<Action<long>> ValueProvider => Gen.Long.ToValueProvider();
+    }
+
+    public class Int64CopierTests : CopierTester<long, IDeepCopier<long>>
+    {
+        protected override long CreateValue()
+        {
+            var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
+            var lsb = (ulong)Guid.NewGuid().GetHashCode();
+            return (long)(msb | lsb);
+        }
 
         protected override long[] TestValues => new[]
         {
@@ -960,7 +1154,50 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
+    public class Int32CopierTests : CopierTester<int, IDeepCopier<int>>
+    {
+        protected override int CreateValue() => Guid.NewGuid().GetHashCode();
+
+        protected override int[] TestValues => new[]
+        {
+            int.MinValue,
+            -1,
+            0,
+            1,
+            sbyte.MaxValue - 1,
+            sbyte.MaxValue,
+            sbyte.MaxValue + 1,
+            short.MaxValue - 1,
+            short.MaxValue,
+            short.MaxValue + 1,
+            int.MaxValue - 1,
+            int.MaxValue,
+        };
+
+        protected override Action<Action<int>> ValueProvider => Gen.Int.ToValueProvider();
+    }
+
     public class Int16CodecTests : FieldCodecTester<short, Int16Codec>
+    {
+        protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
+
+        protected override short[] TestValues => new short[]
+        {
+            short.MinValue,
+            -1,
+            0,
+            1,
+            sbyte.MaxValue - 1,
+            sbyte.MaxValue,
+            sbyte.MaxValue + 1,
+            short.MaxValue - 1,
+            short.MaxValue
+        };
+
+        protected override Action<Action<short>> ValueProvider => Gen.Short.ToValueProvider();
+    }
+
+    public class Int16CopierTests : CopierTester<short, IDeepCopier<short>>
     {
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
@@ -997,6 +1234,23 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
     }
 
+    public class SByteCopierTests : CopierTester<sbyte, IDeepCopier<sbyte>>
+    {
+        protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
+
+        protected override sbyte[] TestValues => new sbyte[]
+        {
+            sbyte.MinValue,
+            -1,
+            0,
+            1,
+            sbyte.MaxValue - 1,
+            sbyte.MaxValue
+        };
+
+        protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
+    }
+
     public class CharCodecTests : FieldCodecTester<char, CharCodec>
     {
         private int _createValueCount;
@@ -1015,7 +1269,38 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
     }
 
+    public class CharCopierTests : CopierTester<char, IDeepCopier<char>>
+    {
+        private int _createValueCount;
+        protected override char CreateValue() => (char)('!' + _createValueCount++ % ('~' - '!'));
+        protected override char[] TestValues => new[]
+        {
+            (char)0,
+            (char)1,
+            (char)(byte.MaxValue - 1),
+            (char)byte.MaxValue,
+            (char)(byte.MaxValue + 1),
+            (char)(ushort.MaxValue - 1),
+            (char)ushort.MaxValue,
+        };
+
+        protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
+    }
+
     public class GuidCodecTests : FieldCodecTester<Guid, GuidCodec>
+    {
+        protected override Guid CreateValue() => Guid.NewGuid();
+        protected override Guid[] TestValues => new[]
+        {
+            Guid.Empty,
+            Guid.Parse("4DEBD074-5DBB-45F6-ACB7-ED97D2AEE02F"),
+            Guid.Parse("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
+        };
+
+        protected override Action<Action<Guid>> ValueProvider => Gen.Guid.ToValueProvider();
+    }
+
+    public class GuidCopierTests : CopierTester<Guid, IDeepCopier<Guid>>
     {
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues => new[]
@@ -1052,7 +1337,41 @@ namespace Orleans.Serialization.UnitTests
         protected override Type[] TestValues => _values;
     }
 
+    public class TypeCopierTests : CopierTester<Type, IDeepCopier<Type>>
+    {
+        private readonly Type[] _values =
+        {
+            null,
+            typeof(Dictionary<Guid, List<string>>),
+            typeof(Type).MakeByRefType(),
+            typeof(Guid),
+            typeof(int).MakePointerType(),
+            typeof(string[]),
+            typeof(string[,]),
+            typeof(string[,]).MakePointerType(),
+            typeof(string[,]).MakeByRefType(),
+            typeof(Dictionary<,>),
+            typeof(List<>),
+            typeof(string)
+        };
+
+        private int _valueIndex;
+
+        protected override Type CreateValue() => _values[_valueIndex++ % _values.Length];
+        protected override Type[] TestValues => _values;
+
+        protected override bool IsImmutable => true;
+    }
+
     public class FloatCodecTests : FieldCodecTester<float, FloatCodec>
+    {
+        protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
+
+        protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
+    }
+
+    public class FloatCopierTests : CopierTester<float, IDeepCopier<float>>
     {
         protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
@@ -1068,7 +1387,22 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
     }
 
+    public class DoubleCopierTests : CopierTester<double, IDeepCopier<double>>
+    {
+        protected override double CreateValue() => double.MaxValue * new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
+
+        protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
+    }
+
     public class DecimalCodecTests : FieldCodecTester<decimal, DecimalCodec>
+    {
+        protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
+        protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
+    }
+
+    public class DecimalCopierTests : CopierTester<decimal, IDeepCopier<decimal>>
     {
         protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
@@ -1490,6 +1824,30 @@ namespace Orleans.Serialization.UnitTests
         } 
     }
 
+    public class IPAddressCopierTests : CopierTester<IPAddress, IDeepCopier<IPAddress>>
+    {
+        protected override IPAddress[] TestValues => new[] { null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue() };
+
+        protected override IPAddress CreateValue()
+        {
+            var rand = new Random(Guid.NewGuid().GetHashCode());
+            byte[] bytes;
+            if (rand.Next(1) == 0)
+            {
+                bytes = new byte[4];
+            }
+            else
+            {
+                bytes = new byte[16];
+            }
+
+            rand.NextBytes(bytes);
+            return new IPAddress(bytes);
+        }
+
+        protected override bool IsImmutable => true;
+    }
+
     public class HashSetTests : FieldCodecTester<HashSet<string>, HashSetCodec<string>>
     {
         protected override HashSet<string> CreateValue()
@@ -1597,6 +1955,17 @@ namespace Orleans.Serialization.UnitTests
         protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
 
         protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
+    }
+
+    public class UriCopierTests : CopierTester<Uri, IDeepCopier<Uri>>
+    {
+        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
+
+        protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+
+        protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
+
+        protected override bool IsImmutable => true;
     }
 
     public class FSharpOptionTests : FieldCodecTester<FSharpOption<Guid>, FSharpOptionCodec<Guid>>

--- a/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
@@ -9,6 +9,7 @@ using System.IO.Pipelines;
 using Xunit;
 using System.Reflection;
 using Orleans.Serialization.TestKit;
+using Orleans.Serialization.Cloning;
 
 namespace Orleans.Serialization.UnitTests
 {
@@ -75,16 +76,18 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [Trait("Category", "BVT")]
-    public class JsonCodecCopierTests : CopierTester<object, JsonCodec>
+    public class JsonCodecCopierTests : CopierTester<MyJsonClass, IDeepCopier<MyJsonClass>>
     {
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
         }
+        protected override IDeepCopier<MyJsonClass> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyJsonClass>();
 
-        protected override object CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
 
-        protected override object[] TestValues => new object[]
+        protected override MyJsonClass CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
+
+        protected override MyJsonClass[] TestValues => new MyJsonClass[]
         {
             null,
             new MyJsonClass(),

--- a/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
@@ -7,6 +7,7 @@ using System.IO.Pipelines;
 using Xunit;
 using System.Reflection;
 using Orleans.Serialization.TestKit;
+using Orleans.Serialization.Cloning;
 
 namespace Orleans.Serialization.UnitTests
 {
@@ -75,16 +76,18 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [Trait("Category", "BVT")]
-    public class NewtonsoftJsonCodecCopierTests : CopierTester<object, NewtonsoftJsonCodec>
+    public class NewtonsoftJsonCodecCopierTests : CopierTester<MyJsonClass, IDeepCopier<MyJsonClass>>
     {
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddNewtonsoftJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
         }
 
-        protected override object CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
+        protected override IDeepCopier<MyJsonClass> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyJsonClass>();
 
-        protected override object[] TestValues => new object[]
+        protected override MyJsonClass CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
+
+        protected override MyJsonClass[] TestValues => new MyJsonClass[]
         {
             null,
             new MyJsonClass(),


### PR DESCRIPTION
* Instead of using untyped wrappers support untyped copying directly on `IDeepCopier`.
* Remove unused copiers for primitive/shallow-copyable types.
* Simplify codegeneration for shallow-copyable types.
* Use a singleton untyped shallow-copier for all relevant types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8063)