### PR TITLE
Support `DateOnly` and `TimeOnly`

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -352,11 +352,6 @@ namespace Orleans.CodeGenerator
             else if (namedType.IsGenericType)
             {
                 var def = namedType.ConstructedFrom;
-                if (def.SpecialType == SpecialType.System_Nullable_T)
-                {
-                    return _shallowCopyableTypes[type] = AreShallowCopyable(namedType.TypeArguments);
-                }
-
                 foreach (var t in ImmutableContainerTypes)
                 {
                     if (SymbolEqualityComparer.Default.Equals(t, def))

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -66,6 +66,14 @@ namespace Orleans.CodeGenerator
                 Task_1 = Type("System.Threading.Tasks.Task`1"),
                 Type = Type("System.Type"),
                 Uri = Type("System.Uri"),
+                DateOnly = Type("System.DateOnly"),
+                DateTimeOffset = Type("System.DateTimeOffset"),
+                BitVector32 = Type("System.Collections.Specialized.BitVector32"),
+                Guid = Type("System.Guid"),
+                CompareInfo = Type("System.Globalization.CompareInfo"),
+                CultureInfo = Type("System.Globalization.CultureInfo"),
+                Version = Type("System.Version"),
+                TimeOnly = Type("System.TimeOnly"),
                 ICodecProvider = Type("Orleans.Serialization.Serializers.ICodecProvider"),
                 ValueSerializer = Type("Orleans.Serialization.Serializers.IValueSerializer`1"),
                 ValueTask = Type("System.Threading.Tasks.ValueTask"),
@@ -96,6 +104,8 @@ namespace Orleans.CodeGenerator
                     new(compilation.GetSpecialType(SpecialType.System_DateTime), Type("Orleans.Serialization.Codecs.DateTimeCodec")),
                     new(Type("System.TimeSpan"), Type("Orleans.Serialization.Codecs.TimeSpanCodec")),
                     new(Type("System.DateTimeOffset"), Type("Orleans.Serialization.Codecs.DateTimeOffsetCodec")),
+                    new(Type("System.DateOnly"), Type("Orleans.Serialization.Codecs.DateOnlyCodec")),
+                    new(Type("System.TimeOnly"), Type("Orleans.Serialization.Codecs.TimeOnlyCodec")),
                     new(Type("System.Guid"), Type("Orleans.Serialization.Codecs.GuidCodec")),
                     new(Type("System.Type"), Type("Orleans.Serialization.Codecs.TypeSerializerCodec")),
                     new(Type("System.ReadOnlyMemory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.ReadOnlyMemoryOfByteCodec")),
@@ -135,6 +145,7 @@ namespace Orleans.CodeGenerator
                 CancellationToken = Type("System.Threading.CancellationToken"),
                 ImmutableContainerTypes = new[]
                 {
+                    Type("System.Nullable`1"),
                     Type("System.Tuple`1"),
                     Type("System.Tuple`2"),
                     Type("System.Tuple`3"),
@@ -208,6 +219,9 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol Task_1 { get; private set; }
         public INamedTypeSymbol Type { get; private set; }
         private INamedTypeSymbol Uri;
+        private INamedTypeSymbol DateOnly;
+        private INamedTypeSymbol DateTimeOffset;
+        private INamedTypeSymbol TimeOnly;
         public INamedTypeSymbol MethodInfo { get; private set; }
         public INamedTypeSymbol ICodecProvider { get; private set; }
         public INamedTypeSymbol ValueSerializer { get; private set; }
@@ -237,6 +251,31 @@ namespace Orleans.CodeGenerator
         private INamedTypeSymbol IPEndPoint;
         private INamedTypeSymbol CancellationToken;
         private INamedTypeSymbol[] ImmutableContainerTypes;
+        private INamedTypeSymbol Guid;
+        private INamedTypeSymbol BitVector32;
+        private INamedTypeSymbol CompareInfo;
+        private INamedTypeSymbol CultureInfo;
+        private INamedTypeSymbol Version;
+        private INamedTypeSymbol[] _regularShallowCopyableTypes;
+        private INamedTypeSymbol[] RegularShallowCopyableType => _regularShallowCopyableTypes ??= new[]
+        {
+            TimeSpan,
+            DateOnly,
+            TimeOnly,
+            DateTimeOffset,
+            Guid,
+            BitVector32,
+            CompareInfo,
+            CultureInfo,
+            Version,
+            IPAddress,
+            IPEndPoint,
+            CancellationToken,
+            Type,
+            Uri
+        };
+
+
         public INamedTypeSymbol[] ImmutableAttributes { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }
         public INamedTypeSymbol ApplicationPartAttribute { get; private set; }
@@ -283,14 +322,12 @@ namespace Orleans.CodeGenerator
                 return result;
             }
 
-            if (SymbolEqualityComparer.Default.Equals(TimeSpan, type)
-                || SymbolEqualityComparer.Default.Equals(IPAddress, type)
-                || SymbolEqualityComparer.Default.Equals(IPEndPoint, type)
-                || SymbolEqualityComparer.Default.Equals(CancellationToken, type)
-                || SymbolEqualityComparer.Default.Equals(Type, type)
-                || SymbolEqualityComparer.Default.Equals(Uri, type))
+            foreach (var shallowCopyable in RegularShallowCopyableType)
             {
-                return _shallowCopyableTypes[type] = true;
+                if (SymbolEqualityComparer.Default.Equals(shallowCopyable, type))
+                {
+                    return _shallowCopyableTypes[type] = true;
+                }
             }
 
             if (type.IsSealed && type.HasAnyAttribute(ImmutableAttributes))

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -274,6 +274,8 @@ namespace Orleans.Serialization.Cloning
         {
             [typeof(decimal)] = true,
             [typeof(DateTime)] = true,
+            [typeof(DateOnly)] = true,
+            [typeof(TimeOnly)] = true,
             [typeof(DateTimeOffset)] = true,
             [typeof(TimeSpan)] = true,
             [typeof(IPAddress)] = true,

--- a/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Buffers;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
+
+namespace Orleans.Serialization.Codecs;
+
+/// <summary>
+/// Serializer for <see cref="DateOnly"/>.
+/// </summary>
+[RegisterSerializer]
+public sealed class DateOnlyCodec : IFieldCodec<DateOnly>
+{
+    /// <summary>
+    /// The codec field type
+    /// </summary>
+    public static readonly Type CodecFieldType = typeof(DateOnly);
+
+    /// <inheritdoc/>
+    void IFieldCodec<DateOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateOnly value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+
+    /// <inheritdoc/>
+    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateOnly value) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
+        writer.WriteInt32(value.DayNumber);
+    }
+
+    /// <inheritdoc/>
+    DateOnly IFieldCodec<DateOnly>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
+
+    /// <inheritdoc/>
+    public static DateOnly ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        ReferenceCodec.MarkValueField(reader.Session);
+        if (field.WireType != WireType.Fixed32)
+        {
+            ThrowUnsupportedWireTypeException(field);
+        }
+
+        return DateOnly.FromDayNumber(reader.ReadInt32());
+    }
+
+    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
+        $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {nameof(DateOnly)} fields. {field}");
+}

--- a/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs

--- a/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Buffers;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
+
+namespace Orleans.Serialization.Codecs;
+
+/// <summary>
+/// Serializer for <see cref="TimeOnly"/>.
+/// </summary>
+[RegisterSerializer]
+public sealed class TimeOnlyCodec : IFieldCodec<TimeOnly>
+{
+    /// <summary>
+    /// The codec field type
+    /// </summary>
+    public static readonly Type CodecFieldType = typeof(TimeOnly);
+
+    /// <inheritdoc/>
+    void IFieldCodec<TimeOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeOnly value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+
+    /// <inheritdoc/>
+    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeOnly value) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
+        writer.WriteInt64(value.Ticks);
+    }
+
+    /// <inheritdoc/>
+    TimeOnly IFieldCodec<TimeOnly>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
+
+    /// <inheritdoc/>
+    public static TimeOnly ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        ReferenceCodec.MarkValueField(reader.Session);
+        if (field.WireType != WireType.Fixed64)
+        {
+            ThrowUnsupportedWireTypeException(field);
+        }
+
+        return new TimeOnly(reader.ReadInt64());
+    }
+
+    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
+        $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(TimeOnly)} fields. {field}");
+}

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -105,6 +105,33 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
     }
 
+    public class DateOnlyTests : FieldCodecTester<DateOnly, DateOnlyCodec>
+    {
+        protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
+        protected override DateOnly[] TestValues => new[] { DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue() };
+        protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
+    }
+
+    public class TimeOnlyTests : FieldCodecTester<TimeOnly, TimeOnlyCodec>
+    {
+        protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
+        protected override TimeOnly[] TestValues => new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue() };
+        protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
+    }
+
+    public class DateOnlyCopierTests : CopierTester<DateOnly, IDeepCopier<DateOnly>>
+    {
+        protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
+        protected override DateOnly[] TestValues => new[] { DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue() };
+        protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
+    }
+
+    public class TimeOnlyCopierTests : CopierTester<TimeOnly, IDeepCopier<TimeOnly>>
+    {
+        protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
+        protected override TimeOnly[] TestValues => new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue() };
+        protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
+    }
 
     public class TimeSpanTests : FieldCodecTester<TimeSpan, TimeSpanCodec>
     {


### PR DESCRIPTION
Adds support for `DateOnly` and `TimeOnly` and adds additional types to shallow-copyable lists.

Fixes #8042

Note that this is based on #8063 to prevent the merge conflicts which would have otherwise arisen.