### PR TITLE
Fix SDK packaging

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,7 +35,7 @@
 
   <Import Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' " Project="$(MSBuildThisFileDirectory)src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props" />
   <Import Condition=" '$(OrleansBuildTimeCodeGen)' == 'msbuild' " Project="$(MSBuildThisFileDirectory)src/Orleans.CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets" />
-
+  <Import Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' or '$(OrleansBuildTimeCodeGen)' == 'msbuild' " Project="$(MSBuildThisFileDirectory)src/Orleans.Sdk/build/Microsoft.Orleans.Sdk.targets" />
   <ItemGroup>
     <!-- Enable code generator -->
     <ProjectReference

--- a/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
+++ b/src/Orleans.CodeGenerator.MSBuild/Orleans.CodeGenerator.MSBuild.csproj
@@ -22,11 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="buildMultiTargeting\Orleans.CodeGenerator.MSBuild.props" />
-    <None Remove="build\Orleans.CodeGenerator.MSBuild.props" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Orleans.CodeGenerator.MSBuild/buildMultiTransitive/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/Orleans.CodeGenerator.MSBuild/buildMultiTransitive/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.CodeGenerator.MSBuild.targets" />
+</Project>

--- a/src/Orleans.CodeGenerator/buildTransitive/Microsoft.Orleans.CodeGenerator.props
+++ b/src/Orleans.CodeGenerator/buildTransitive/Microsoft.Orleans.CodeGenerator.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.CodeGenerator.props" />
+</Project>

--- a/src/Orleans.Sdk/Orleans.Sdk.csproj
+++ b/src/Orleans.Sdk/Orleans.Sdk.csproj
@@ -13,6 +13,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="buildTransitive\Microsoft.Orleans.Sdk.targets">
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="build\Microsoft.Orleans.Sdk.targets">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+    <Content Include="buildMultiTargeting\Microsoft.Orleans.Sdk.targets">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
     <ProjectReference Include="..\Orleans.Analyzers\Orleans.Analyzers.csproj" PrivateAssets="None" />
     <ProjectReference Include="..\Orleans.CodeGenerator\Orleans.CodeGenerator.csproj" PrivateAssets="None" />

--- a/src/Orleans.Sdk/buildTransitive/Microsoft.Orleans.Sdk.targets
+++ b/src/Orleans.Sdk/buildTransitive/Microsoft.Orleans.Sdk.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.Sdk.targets" />
+</Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,6 +10,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);FS2003;1591</NoWarn>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <!-- For test project we still need to target various desktop .Net versions instead of .Net Standard -->

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -6,6 +6,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes the SDK package such that it correctly configures global usings even when included transitively (eg, via the *Microsoft.Orleans.Server* metapackage)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8071)