### PR TITLE
Make most IGrainFactory methods extensions instead

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainExtensions.cs
@@ -62,7 +62,7 @@ namespace Orleans
             }
 
             var grainReference = grain.AsReference();
-            return (TGrainInterface)grainReference.Runtime.Cast(grain, typeof(TGrainInterface));
+            return (TGrainInterface)grainReference.Runtime.AsReference(grain, typeof(TGrainInterface));
         }
 
         /// <summary>
@@ -76,6 +76,7 @@ namespace Orleans
         /// If the provided value is already grain reference, this will create a new reference which implements the provided interface.
         /// </remarks>
         /// <returns>A strongly typed reference to the provided grain which implements <typeparamref name="TGrainInterface"/>.</returns>
+        [Obsolete("Use AsReference<TGrainInterface>() instead.")]
         public static TGrainInterface Cast<TGrainInterface>(this IAddressable grain) => grain.AsReference<TGrainInterface>();
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace Orleans
         /// If the provided value is already grain reference, this will create a new reference which implements the provided interface.
         /// </remarks>
         /// <returns>A strongly typed reference to the provided grain which implements <paramref name="interfaceType"/>.</returns>
-        public static object AsReference(this IAddressable grain, Type interfaceType) => grain.AsReference().Runtime.Cast(grain, interfaceType);
+        public static object AsReference(this IAddressable grain, Type interfaceType) => grain.AsReference().Runtime.AsReference(grain, interfaceType);
 
         /// <summary>
         /// Returns a typed reference to the provided grain.
@@ -101,7 +102,8 @@ namespace Orleans
         /// If the provided value is already grain reference, this will create a new reference which implements the provided interface.
         /// </remarks>
         /// <returns>A strongly typed reference to the provided grain which implements <paramref name="interfaceType"/>.</returns>
-        public static object Cast(this IAddressable grain, Type interfaceType) => grain.AsReference().Runtime.Cast(grain, interfaceType);
+        [Obsolete("Use AsReference(Type) instead.")]
+        private static object Cast(this IAddressable grain, Type interfaceType) => grain.AsReference(interfaceType);
 
         /// <summary>
         /// Returns the grain id corresponding to the provided grain.

--- a/src/Orleans.Core.Abstractions/Core/GrainFactoryExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainFactoryExtensions.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Extensions for <see cref="IGrainFactory"/>.
+    /// </summary>
+    public static class GrainFactoryExtensions
+    {
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, string primaryKey, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithStringKey
+        {
+            var grainKey = IdSpan.Create(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithGuidCompoundKey
+        {
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string keyExtension, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithIntegerCompoundKey
+        {
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey);
+            return (IGrain)grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey);
+            return (IGrain)grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, string grainPrimaryKey)
+        {
+            var grainKey = IdSpan.Create(grainPrimaryKey);
+            return (IGrain)grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey, keyExtension);
+            return (IGrain)grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey, keyExtension);
+            return (IGrain)grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Validates the provided grain key extension.
+        /// </summary>
+        /// <param name="keyExt">The grain key extension.</param>
+        /// <exception cref="ArgumentNullException">The key is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The key is empty or contains only whitespace.</exception>
+        private static void ValidateGrainKeyExtension(string keyExt)
+        {
+            if (!string.IsNullOrWhiteSpace(keyExt)) return;
+
+            if (null == keyExt)
+            {
+                throw new ArgumentNullException(nameof(keyExt)); 
+            }
+            
+            throw new ArgumentException("Key extension is empty or white space.", nameof(keyExt));
+        }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -10,51 +10,16 @@ namespace Orleans
     public interface IGrainFactory
     {
         /// <summary>
-        /// Gets a reference to a grain.
+        /// Returns a reference to the specified grain which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
         /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidCompoundKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerCompoundKey;
+        /// <remarks>
+        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="interfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
+        /// </remarks>
+        /// <param name="interfaceType">The interface type which the returned grain reference will implement.</param>
+        /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
+        /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
+        /// <returns>A grain reference which implements the provided interface.</returns>
+        IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix);
 
         /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.
@@ -75,82 +40,6 @@ namespace Orleans
         /// <param name="obj">The reference being deleted.</param>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
         void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension);
 
         /// <summary>
         /// Returns a reference to the specified grain which implements the specified interface.

--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -10,18 +10,6 @@ namespace Orleans
     public interface IGrainFactory
     {
         /// <summary>
-        /// Returns a reference to the specified grain which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
-        /// </summary>
-        /// <remarks>
-        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="interfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
-        /// </remarks>
-        /// <param name="interfaceType">The interface type which the returned grain reference will implement.</param>
-        /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
-        /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
-        /// <returns>A grain reference which implements the provided interface.</returns>
-        IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix);
-
-        /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.
         /// </summary>
         /// <typeparam name="TGrainObserverInterface">
@@ -42,6 +30,18 @@ namespace Orleans
         void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         /// <summary>
+        /// Returns a reference to the specified grain which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
+        /// </summary>
+        /// <remarks>
+        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="interfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
+        /// </remarks>
+        /// <param name="interfaceType">The interface type which the returned grain reference will implement.</param>
+        /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
+        /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
+        /// <returns>A grain reference which implements the provided interface.</returns>
+        IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix);
+
+        /// <summary>
         /// Returns a reference to the specified grain which implements the specified interface.
         /// </summary>
         /// <param name="grainId">
@@ -54,17 +54,6 @@ namespace Orleans
         /// A reference to the specified grain which implements the specified interface.
         /// </returns>
         TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable;
-
-        /// <summary>
-        /// Returns an untyped reference for the provided grain id.
-        /// </summary>
-        /// <param name="grainId">
-        /// The grain id.
-        /// </param>
-        /// <returns>
-        /// An untyped reference for the provided grain id.
-        /// </returns>
-        IAddressable GetGrain(GrainId grainId);
 
         /// <summary>
         /// Returns a reference for the provided grain id which implements the specified interface type.

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -147,7 +147,7 @@ namespace Orleans.Runtime
 
             var addressable = (IAddressable)input;
             var grainReference = addressable.AsReference();
-            return (TInterface)grainReference.Runtime.Cast(addressable, typeof(TInterface));
+            return (TInterface)grainReference.Runtime.AsReference(addressable, typeof(TInterface));
         }
     }
 
@@ -321,7 +321,7 @@ namespace Orleans.Runtime
         /// <returns>A new grain reference which implements the specified interface type.</returns>
         public virtual TGrainInterface Cast<TGrainInterface>()
             where TGrainInterface : IAddressable
-            => (TGrainInterface)_shared.Runtime.Cast(this, typeof(TGrainInterface));
+            => (TGrainInterface)_shared.Runtime.AsReference(this, typeof(TGrainInterface));
 
         /// <summary>
         /// Tests this reference for equality to another object.

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
@@ -36,6 +36,6 @@ namespace Orleans.Runtime
         /// <param name="grain">The grain.</param>
         /// <param name="interfaceType">The resulting interface type.</param>
         /// <returns>A reference to <paramref name="grain"/> which implements <paramref name="interfaceType"/>.</returns>
-        object Cast(IAddressable grain, Type interfaceType);
+        object AsReference(IAddressable grain, Type interfaceType);
     }
 }

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -91,26 +91,6 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver => ((IGrainFactory)_runtimeClient.InternalGrainFactory).CreateObjectReference<TGrainObserverInterface>(obj);
 
@@ -127,33 +107,10 @@ namespace Orleans
         public TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId) where TGrainInterface : ISystemTarget => _runtimeClient.InternalGrainFactory.GetSystemTarget<TGrainInterface>(grainId);
 
         /// <inheritdoc />
-        TGrainInterface IInternalGrainFactory.Cast<TGrainInterface>(IAddressable grain) => _runtimeClient.InternalGrainFactory.Cast<TGrainInterface>(grain);
-
-        /// <inheritdoc />
         TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(grainId);
 
         /// <inheritdoc />
         IAddressable IGrainFactory.GetGrain(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain(grainId);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
 
         /// <inheritdoc />
         public object Cast(IAddressable grain, Type outputGrainInterfaceType)
@@ -162,5 +119,9 @@ namespace Orleans
         /// <inheritdoc />
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
             => _runtimeClient.InternalGrainFactory.GetGrain(grainId, interfaceType);
+
+        /// <inheritdoc />
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix)
+            => _runtimeClient.InternalGrainFactory.GetGrain(interfaceType, grainKey, grainClassNamePrefix);
     }
 }

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -110,13 +110,6 @@ namespace Orleans
         TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(grainId);
 
         /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain(grainId);
-
-        /// <inheritdoc />
-        public object Cast(IAddressable grain, Type outputGrainInterfaceType)
-            => _runtimeClient.InternalGrainFactory.Cast(grain, outputGrainInterfaceType);
-
-        /// <inheritdoc />
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
             => _runtimeClient.InternalGrainFactory.GetGrain(grainId, interfaceType);
 

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -39,49 +39,6 @@ namespace Orleans
         private GrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ??= (GrainReferenceRuntime)this.runtimeClient.GrainReferenceRuntime;
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey
-        {
-            var grainKey = IdSpan.Create(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey
-        {
-            ValidateGrainKeyExtension(keyExtension);
-
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey, keyExtension);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey
-        {
-            ValidateGrainKeyExtension(keyExtension);
-
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey, keyExtension);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-
-        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver
         {
@@ -149,41 +106,6 @@ namespace Orleans
         public IAddressable GetGrain(GrainId grainId) => this.referenceActivator.CreateReference(grainId, default);
 
         /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid key)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long key)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string key)
-        {
-            var grainKey = IdSpan.Create(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid key, string keyExtension)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(key, keyExtension);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long key, string keyExtension)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(key, keyExtension);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
         {
             return this.referenceActivator.CreateReference(grainId, interfaceType);
@@ -200,7 +122,7 @@ namespace Orleans
         /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
         /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
         /// <returns>A grain reference which implements the provided interface.</returns>
-        private IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix)
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix)
         {
             var grainInterfaceType = this.interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
 
@@ -251,24 +173,6 @@ namespace Orleans
             }
 
             return this.Cast(this.runtimeClient.CreateObjectReference(obj), interfaceType);
-        }
-
-        /// <summary>
-        /// Validates the provided grain key extension.
-        /// </summary>
-        /// <param name="keyExt">The grain key extension.</param>
-        /// <exception cref="ArgumentNullException">The key is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException">The key is empty or contains only whitespace.</exception>
-        private static void ValidateGrainKeyExtension(string keyExt)
-        {
-            if (!string.IsNullOrWhiteSpace(keyExt)) return;
-
-            if (null == keyExt)
-            {
-                throw new ArgumentNullException(nameof(keyExt)); 
-            }
-            
-            throw new ArgumentException("Key extension is empty or white space.", nameof(keyExt));
         }
     }
 }

--- a/src/Orleans.Core/Core/IInternalGrainFactory.cs
+++ b/src/Orleans.Core/Core/IInternalGrainFactory.cs
@@ -37,16 +37,6 @@ namespace Orleans
         TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId) where TGrainInterface : ISystemTarget;
 
         /// <summary>
-        /// Casts the provided <paramref name="grain"/> to the specified interface
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The target grain interface type.</typeparam>
-        /// <param name="grain">The grain reference being cast.</param>
-        /// <returns>
-        /// A reference to <paramref name="grain"/> which implements <typeparamref name="TGrainInterface"/>.
-        /// </returns>
-        TGrainInterface Cast<TGrainInterface>(IAddressable grain);
-
-        /// <summary>
         /// Casts the provided <paramref name="grain"/> to the provided <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="grain">The grain.</param>

--- a/src/Orleans.Core/Core/IInternalGrainFactory.cs
+++ b/src/Orleans.Core/Core/IInternalGrainFactory.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Orleans.Runtime;
 
 namespace Orleans
@@ -35,13 +33,5 @@ namespace Orleans
         /// <param name="grainId">The id of the target.</param>
         /// <returns>A reference to the specified system target.</returns>
         TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId) where TGrainInterface : ISystemTarget;
-
-        /// <summary>
-        /// Casts the provided <paramref name="grain"/> to the provided <paramref name="interfaceType"/>.
-        /// </summary>
-        /// <param name="grain">The grain.</param>
-        /// <param name="interfaceType">The resulting interface type.</param>
-        /// <returns>A reference to <paramref name="grain"/> which implements <paramref name="interfaceType"/>.</returns>
-        object Cast(IAddressable grain, Type interfaceType);
     }
 }

--- a/src/Orleans.Core/Manifest/GrainInterfaceTypeResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainInterfaceTypeResolver.cs
@@ -43,6 +43,11 @@ namespace Orleans.Metadata
                 throw new ArgumentException($"Argument {nameof(type)} must be an interface. Provided value, \"{type}\", is not an interface.", nameof(type));
             }
 
+            if (type == typeof(IAddressable))
+            {
+                return default;
+            }
+
             // Configured providers take precedence
             foreach (var provider in _providers)
             {

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -20,7 +20,7 @@ namespace Orleans
             _runtimeClient = runtimeClient;
         }
 
-        public GrainReference GrainReference => _grainReference ??= (GrainReference)_runtimeClient.InternalGrainFactory.GetGrain(this.GrainId);
+        public GrainReference GrainReference => _grainReference ??= (GrainReference)_runtimeClient.InternalGrainFactory.GetGrain<IAddressable>(this.GrainId);
 
         public GrainId GrainId => _runtimeClient.CurrentActivationAddress.GrainId;
 

--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -82,7 +82,7 @@ namespace Orleans.Runtime
             await invoker.Invoke();
         }
 
-        public object Cast(IAddressable grain, Type grainInterface)
+        public object AsReference(IAddressable grain, Type grainInterface)
         {
             var grainId = grain.GetGrainId();
             if (grain is GrainReference && grainInterface.IsAssignableFrom(grain.GetType()))

--- a/src/Orleans.Core/Runtime/IRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/IRuntimeClient.cs
@@ -45,7 +45,7 @@ namespace Orleans.Runtime
 
         void ReceiveResponse(Message message);
 
-        IAddressable CreateObjectReference(IAddressable obj);
+        TAddressable CreateObjectReference<TAddressable>(TAddressable obj) where TAddressable : IAddressable;
 
         void DeleteObjectReference(IAddressable obj);
 

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -99,7 +99,7 @@ namespace Orleans
             GrainId IGrainContext.GrainId => this.ObserverId.GrainId;
 
             GrainReference IGrainContext.GrainReference =>
-                _manager.runtimeClient.InternalGrainFactory.GetGrain(ObserverId.GrainId).AsReference();
+                _manager.runtimeClient.InternalGrainFactory.GetGrain<IAddressable>(ObserverId.GrainId).AsReference();
 
             object IGrainContext.GrainInstance => this.LocalObject.Target;
 

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -347,7 +347,7 @@ namespace Orleans
         /// <inheritdoc />
         public void SetResponseTimeout(TimeSpan timeout) => this.sharedCallbackData.ResponseTimeout = timeout;
 
-        public IAddressable CreateObjectReference(IAddressable obj)
+        public TAddressable CreateObjectReference<TAddressable>(TAddressable obj) where TAddressable : IAddressable 
         {
             if (obj is GrainReference)
                 throw new ArgumentException("Argument obj is already a grain reference.", nameof(obj));
@@ -358,7 +358,7 @@ namespace Orleans
             var observerId = obj is ClientObserver clientObserver
                 ? clientObserver.GetObserverGrainId(this.clientId)
                 : ObserverGrainId.Create(this.clientId);
-            var reference = this.InternalGrainFactory.GetGrain(observerId.GrainId);
+            var reference = this.InternalGrainFactory.GetGrain<TAddressable>(observerId.GrainId);
 
             if (!localObjects.TryRegister(obj, observerId))
             {

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -95,12 +95,12 @@ namespace Orleans.Runtime
         public override string ToString() => $"{nameof(HostedClient)}_{this.Address}";
 
         /// <inheritdoc />
-        public IAddressable CreateObjectReference(IAddressable obj)
+        public TAddressable CreateObjectReference<TAddressable>(TAddressable obj) where TAddressable : IAddressable
         {
             if (obj is GrainReference) throw new ArgumentException("Argument obj is already a grain reference.");
 
             var observerId = ObserverGrainId.Create(this.ClientId);
-            var grainReference = this.grainFactory.GetGrain(observerId.GrainId);
+            var grainReference = this.grainFactory.GetGrain<TAddressable>(observerId.GrainId);
             if (!this.invokableObjects.TryRegister(obj, observerId))
             {
                 throw new ArgumentException(

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -466,9 +466,10 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public void SetResponseTimeout(TimeSpan timeout) => this.sharedCallbackData.ResponseTimeout = timeout;
 
-        public IAddressable CreateObjectReference(IAddressable obj)
+        /// <inheritdoc />
+        public TAddressable CreateObjectReference<TAddressable>(TAddressable obj) where TAddressable : IAddressable
         {
-            if (RuntimeContext.Current is null) return this.HostedClient.CreateObjectReference(obj);
+            if (RuntimeContext.Current is null) return this.HostedClient.CreateObjectReference<TAddressable>(obj);
             throw new InvalidOperationException("Cannot create a local object reference from a grain.");
         }
 

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -21,45 +21,7 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        public IGrainFactory GrainFactory => this.grainFactory;
-
-        /// <inheritdoc />
         public IServiceProvider ServiceProvider => this.runtimeClient.ServiceProvider;
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-        }
 
         /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
@@ -94,12 +56,6 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        TGrainInterface IInternalGrainFactory.Cast<TGrainInterface>(IAddressable grain)
-        {
-            return this.grainFactory.Cast<TGrainInterface>(grain);
-        }
-
-        /// <inheritdoc />
         object IInternalGrainFactory.Cast(IAddressable grain, Type interfaceType)
         {
             return this.grainFactory.Cast(grain, interfaceType);
@@ -118,38 +74,13 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceId)
         {
             return this.grainFactory.GetGrain(grainId, interfaceId);
         }
+
+        /// <inheritdoc />
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix)
+            => grainFactory.GetGrain(interfaceType, grainKey, grainClassNamePrefix);
     }
 }

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 
 namespace Orleans.Runtime
 {
@@ -56,21 +55,9 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
-        object IInternalGrainFactory.Cast(IAddressable grain, Type interfaceType)
-        {
-            return this.grainFactory.Cast(grain, interfaceType);
-        }
-
-        /// <inheritdoc />
         TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId)
         {
             return this.grainFactory.GetGrain<TGrainInterface>(grainId);
-        }
-
-        /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId)
-        {
-            return this.grainFactory.GetGrain(grainId);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -265,9 +265,7 @@ namespace Orleans.Streams
             StreamConsumerData data;
             if (!streamDataCollection.TryGetConsumer(subscriptionId, out data))
             {
-                var consumerReference = this.RuntimeClient.InternalGrainFactory
-                    .GetGrain(streamConsumer)
-                    .AsReference<IStreamConsumerExtension>();
+                var consumerReference = this.RuntimeClient.InternalGrainFactory.GetGrain<IStreamConsumerExtension>(streamConsumer);
                 data = streamDataCollection.AddConsumer(subscriptionId, streamId, consumerReference, filterData);
             }
 

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -464,9 +464,7 @@ namespace Orleans.Streams
         {
             try
             {
-                var extension = this.GrainFactory
-                    .GetGrain(producer.Producer)
-                    .AsReference<IStreamProducerExtension>();
+                var extension = this.GrainFactory.GetGrain<IStreamProducerExtension>(producer.Producer);
                 await producerTask(extension);
             }
             catch (GrainExtensionNotInstalledException)

--- a/src/Orleans.Streaming/PubSub/StreamSubscriptionManagerExtensions.cs
+++ b/src/Orleans.Streaming/PubSub/StreamSubscriptionManagerExtensions.cs
@@ -28,7 +28,7 @@ namespace Orleans.Streams.PubSub
             GrainId grainId)
             where TGrainInterface : IGrainWithGuidKey
         {
-            var grainRef = grainFactory.GetGrain(grainId) as GrainReference;
+            var grainRef = (GrainReference)grainFactory.GetGrain<IAddressable>(grainId);
             return manager.AddSubscription(streamProviderName, streamId, grainRef);
         }
 

--- a/test/DefaultCluster.Tests/ClientAddressableTests.cs
+++ b/test/DefaultCluster.Tests/ClientAddressableTests.cs
@@ -79,7 +79,7 @@ namespace DefaultCluster.Tests
         {
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = ((IInternalGrainFactory)this.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = this.GrainFactory.CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = this.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             const string expected = "o hai!";
             await proxy.SetTarget(myRef);
@@ -96,7 +96,7 @@ namespace DefaultCluster.Tests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = ((IInternalGrainFactory)this.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = this.GrainFactory.CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = this.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
 
@@ -112,7 +112,7 @@ namespace DefaultCluster.Tests
         {
             var myOb = new MyProducer();
             this.anchor = myOb;
-            var myRef = ((IInternalGrainFactory)this.GrainFactory).CreateObjectReference<IClientAddressableTestProducer>(myOb);
+            var myRef = this.GrainFactory.CreateObjectReference<IClientAddressableTestProducer>(myOb);
             var rendez = this.GrainFactory.GetGrain<IClientAddressableTestRendezvousGrain>(0);
             var consumer = this.GrainFactory.GetGrain<IClientAddressableTestConsumer>(0);
 
@@ -131,7 +131,7 @@ namespace DefaultCluster.Tests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = ((IInternalGrainFactory)this.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = this.GrainFactory.CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = this.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
             await proxy.MicroSerialStressTest(iterationCount);
@@ -146,7 +146,7 @@ namespace DefaultCluster.Tests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = ((IInternalGrainFactory)this.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = this.GrainFactory.CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = this.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
             await proxy.MicroParallelStressTest(iterationCount);

--- a/test/DefaultCluster.Tests/DebuggerHelperTests.cs
+++ b/test/DefaultCluster.Tests/DebuggerHelperTests.cs
@@ -16,7 +16,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT")]
         public async Task DebuggerHelper_GetGrainInstance()
         {
-            var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid()).Cast<IDebuggerHelperTestGrain>();
+            var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid()).AsReference<IDebuggerHelperTestGrain>();
             await grain.OrleansDebuggerHelper_GetGrainInstance_Test();
         }
     }

--- a/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
@@ -109,7 +109,7 @@ namespace DefaultCluster.Tests
                 SimpleGrain.SimpleGrainNamePrefix);
 
             // Attempting to cast a grain to a non-grain type should fail.
-            Assert.Throws<ArgumentException>(() => this.internalGrainFactory.Cast(grain, typeof(bool)));
+            Assert.Throws<ArgumentException>(() => grain.AsReference(typeof(bool)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Cast")]

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -99,7 +99,7 @@ namespace Tester.AzureUtils.TimerTests
                     var e = new ReminderEntry
                     {
                         //GrainId = LegacyGrainId.GetGrainId(new Guid(s)),
-                        GrainId = fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
+                        GrainId = fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId()).GetGrainId(),
                         ReminderName = "MY_REMINDER_" + i,
                         Period = TimeSpan.FromSeconds(5),
                         StartAt = DateTime.UtcNow
@@ -135,7 +135,7 @@ namespace Tester.AzureUtils.TimerTests
             Guid guid = Guid.NewGuid();
             return new ReminderEntry
             {
-                GrainId = fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
+                GrainId = fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId()).GetGrainId(),
                 ReminderName = string.Format("TestReminder.{0}", guid),
                 Period = TimeSpan.FromSeconds(5),
                 StartAt = DateTime.UtcNow

--- a/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
@@ -58,7 +58,7 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetSiloIdentity();
     }
 
-    public interface IMessageSerializationClientObject : IAddressable
+    public interface IMessageSerializationClientObject : IGrainObserver
     {
         Task SendUnserializable(UnserializableType input);
         Task SendUndeserializable(UndeserializableType input);

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -316,10 +316,10 @@ namespace UnitTests.General
         {
             Guid guid = Guid.NewGuid();
             GrainId regularGrainId = LegacyGrainId.GetGrainIdForTesting(guid);
-            GrainReference grainRef = (GrainReference)this.environment.InternalGrainFactory.GetGrain(regularGrainId);
+            GrainReference grainRef = (GrainReference)this.environment.InternalGrainFactory.GetGrain<IAddressable>(regularGrainId);
             TestGrainReference(grainRef);
 
-            grainRef = (GrainReference)this.environment.InternalGrainFactory.GetGrain(regularGrainId);
+            grainRef = (GrainReference)this.environment.InternalGrainFactory.GetGrain<IAddressable>(regularGrainId);
             TestGrainReference(grainRef);
         }
 

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -374,12 +374,12 @@ namespace UnitTests.Serialization
             source4[0] = new GrainReference[2];
             source4[1] = new GrainReference[3];
             source4[2] = new GrainReference[1];
-            source4[0][0] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
-            source4[0][1] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
-            source4[1][0] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
-            source4[1][1] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
-            source4[1][2] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
-            source4[2][0] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+            source4[0][0] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
+            source4[0][1] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
+            source4[1][0] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
+            source4[1][1] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
+            source4[1][2] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
+            source4[2][0] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
             deserialized = OrleansSerializationLoop(environment.Serializer, environment.DeepCopier, source4);
             ValidateArrayOfArrays(source4, deserialized, "grain reference");
 
@@ -389,7 +389,7 @@ namespace UnitTests.Serialization
                 source5[i] = new GrainReference[64];
                 for (int j = 0; j < source5[i].Length; j++)
                 {
-                    source5[i][j] = (GrainReference)environment.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+                    source5[i][j] = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
                 }
             }
             deserialized = OrleansSerializationLoop(environment.Serializer, environment.DeepCopier, source5);
@@ -556,7 +556,7 @@ namespace UnitTests.Serialization
         public void Serialize_GrainReference()
         {
             GrainId grainId = LegacyGrainId.NewId();
-            GrainReference input = (GrainReference)environment.InternalGrainFactory.GetGrain(grainId);
+            GrainReference input = (GrainReference)environment.InternalGrainFactory.GetGrain<IAddressable>(grainId);
 
             object deserialized = OrleansSerializationLoop(environment.Serializer, environment.DeepCopier,  input);
 

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -130,13 +130,13 @@ namespace Tester.HeterogeneousSilosTests
 
         private async Task CallITestGrainMethod(IGrain grain)
         {
-            var g = grain.Cast<ITestGrain>();
+            var g = grain.AsReference<ITestGrain>();
             await g.SetLabel("Hello world");
         }
 
         private async Task CallIStatelessWorkerGrainMethod(IGrain grain)
         {
-            var g = grain.Cast<IStatelessWorkerGrain>();
+            var g = grain.AsReference<IStatelessWorkerGrain>();
             await g.GetCallStats();
         }
 

--- a/test/TesterInternal/StorageTests/LocalStoreTests.cs
+++ b/test/TesterInternal/StorageTests/LocalStoreTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
             TestStoreGrainState state = new TestStoreGrainState();
             var stateProperties = AsDictionary(state);
             var keys = GetKeys(name, reference);
@@ -63,7 +63,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = (GrainReference)fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+            GrainReference reference = (GrainReference)fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
             var state = TestStoreGrainState.NewRandomState();
             Stopwatch sw = new Stopwatch();
             sw.Start();
@@ -87,7 +87,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
             var data = TestStoreGrainState.NewRandomState();
 
             output.WriteLine("Using store = {0}", store.GetType().FullName);
@@ -173,7 +173,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId());
+            GrainReference reference = (GrainReference)this.fixture.InternalGrainFactory.GetGrain<IAddressable>(LegacyGrainId.NewId());
             var grainState = TestStoreGrainState.NewRandomState();
             var state = grainState.State;
             Stopwatch sw = new Stopwatch();

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -345,7 +345,7 @@ namespace UnitTests.StreamingTests
         {
             var grainIds = targets.Distinct().Where(t => t is GrainReference).Select(t => ((GrainReference)t).GrainId).ToArray();
             IManagementGrain systemManagement = grainFactory.GetGrain<IManagementGrain>(0);
-            var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount((GrainReference)grainFactory.GetGrain(g))).ToArray();
+            var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount((GrainReference)grainFactory.GetGrain<IAddressable>(g))).ToArray();
             await Task.WhenAll(tasks);
             return tasks.Sum(t => t.Result);
         }


### PR DESCRIPTION
This PR simplifies the `IGrainFactory` interface by adding one method and moving multiple methods into an extension class.
I'm not sure we want to do this yet, but here's a PR for argument's sake.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8072)