### PR TITLE
Optimize message header encoding

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -46,6 +46,9 @@ namespace Orleans.Runtime.Serialization
                 return ReferenceCodec.ReadReference<SiloAddress, TReaderInput>(ref reader, field);
             }
 
+            if (field.WireType != WireType.TagDelimited)
+                ThrowUnsupportedWireTypeException(field);
+
             ReferenceCodec.MarkValueField(reader.Session);
             Field header = default;
             int port = 0, generation = 0;
@@ -75,5 +78,8 @@ namespace Orleans.Runtime.Serialization
 
             return SiloAddress.New(address, port, generation);
         }
+
+        private static void ThrowUnsupportedWireTypeException(Field field)
+            => throw new UnsupportedWireTypeException($"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(SiloAddress)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -482,12 +482,12 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(writer.Session);
             if (value > 1 << 20 || -value > 1 << 20)
             {
-                writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed32);
+                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
                 writer.WriteInt32(value);
             }
             else
             {
-                writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
+                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
                 writer.WriteVarInt32(value);
             }
         }

--- a/src/Orleans.Serialization/Session/SerializerSessionPool.cs
+++ b/src/Orleans.Serialization/Session/SerializerSessionPool.cs
@@ -21,9 +21,15 @@ namespace Orleans.Serialization.Session
         /// <param name="codecProvider">The codec provider.</param>
         public SerializerSessionPool(TypeCodec typeCodec, WellKnownTypeCollection wellKnownTypes, CodecProvider codecProvider)
         {
+            CodecProvider = codecProvider;
             var sessionPoolPolicy = new SerializerSessionPoolPolicy(typeCodec, wellKnownTypes, codecProvider, ReturnSession);
             _sessionPool = new ConcurrentObjectPool<SerializerSession, SerializerSessionPoolPolicy>(sessionPoolPolicy);
         }
+
+        /// <summary>
+        /// Gets the codec provider.
+        /// </summary>
+        public CodecProvider CodecProvider { get; }
 
         /// <summary>
         /// Gets a serializer session from the pool.

--- a/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
@@ -20,7 +20,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="writer">The writer.</param>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteVarInt8<TBufferWriter>(ref this Writer<TBufferWriter> writer, sbyte value) where TBufferWriter : IBufferWriter<byte> => WriteVarUInt8(ref writer, ZigZagEncode(value));
+        public static void WriteVarInt8<TBufferWriter>(ref this Writer<TBufferWriter> writer, sbyte value) where TBufferWriter : IBufferWriter<byte> => WriteVarUInt16(ref writer, ZigZagEncode(value));
 
         /// <summary>
         /// Writes a variable-width <see cref="short"/>.
@@ -56,21 +56,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="writer">The writer.</param>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteVarUInt8<TBufferWriter>(ref this Writer<TBufferWriter> writer, byte value) where TBufferWriter : IBufferWriter<byte>
-        {
-            writer.EnsureContiguous(sizeof(ushort));
-
-            var span = writer.WritableSpan;
-            var neededBytes = BitOperations.Log2(value) / 7;
-
-            ushort lower = value;
-            lower <<= 1;
-            lower |= 0x01;
-            lower <<= neededBytes;
-
-            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(span), lower);
-            writer.AdvanceSpan(neededBytes + 1);
-        }
+        public static void WriteVarUInt8<TBufferWriter>(ref this Writer<TBufferWriter> writer, byte value) where TBufferWriter : IBufferWriter<byte> => WriteVarUInt16(ref writer, (ushort)value);
 
         /// <summary>
         /// Writes a variable-width <see cref="ushort"/>.


### PR DESCRIPTION
* Remove unnecessary wrapping from `CachingIdSpanCodec` and optimize `IdSpanCodec`.
* Simplify `CachingSiloAddressCodec` and `IPAddress` codecs.
* Fix some expected vs actual type encoding issues and simplify serializer helpers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8073)