### PR TITLE
[3.x] Implement `IGrainActivationContextAccessor`, providing access to `IGrainActivationContext`

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -58,6 +58,7 @@ namespace Orleans
             services.TryAddSingleton<IStreamSubscriptionManagerAdmin, StreamSubscriptionManagerAdmin>();
             services.TryAddSingleton<IInternalClusterClient, ClusterClient>();
             services.TryAddFromExisting<IClusterClient, IInternalClusterClient>();
+            services.AddSingleton<IGrainActivationContextAccessor, GrainActivationContextAccessor>();
 
             // Serialization
             services.TryAddSingleton<SerializationManager>(sp => ActivatorUtilities.CreateInstance<SerializationManager>(sp,

--- a/src/Orleans.Core/Runtime/IGrainActivationContext.cs
+++ b/src/Orleans.Core/Runtime/IGrainActivationContext.cs
@@ -31,4 +31,27 @@ namespace Orleans.Runtime
         /// </summary>
         IGrainLifecycle ObservableLifecycle { get; }
     }
+
+    /// <summary>
+    /// Provides access to the <see cref="IGrainActivationContext"/> of the currently executing grain activation.
+    /// </summary>
+    public interface IGrainActivationContextAccessor
+    {
+        /// <summary>
+        /// Gets the <see cref="IGrainActivationContext"/> of the currently executing grain activation.
+        /// </summary>
+        /// <remarks>
+        /// The resulting value will be <see langword="null"/> if the current execution context is not associated with a grain activation.
+        /// </remarks>
+        IGrainActivationContext GrainActivationContext { get; }
+    }
+
+    /// <summary>
+    /// Provides access to the <see cref="IGrainActivationContext"/> of the currently executing grain activation.
+    /// </summary>
+    internal sealed class GrainActivationContextAccessor : IGrainActivationContextAccessor
+    {
+        /// <inheritdoc/>
+        public IGrainActivationContext GrainActivationContext => RuntimeContext.CurrentGrainContext as IGrainActivationContext;
+    }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -243,6 +243,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<IGrainActivator, DefaultGrainActivator>();
             services.TryAddScoped<ActivationData.GrainActivationContextFactory>();
             services.TryAddScoped<IGrainActivationContext>(sp => sp.GetRequiredService<ActivationData.GrainActivationContextFactory>().Context);
+            services.AddSingleton<IGrainActivationContextAccessor, GrainActivationContextAccessor>();
             services.AddSingleton<IncomingRequestMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, IncomingRequestMonitor>();
 

--- a/test/Grains/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -51,6 +51,7 @@ namespace UnitTests.GrainInterfaces
     {
         Task<string> ThrowIfGreaterThanZero(int value);
         Task<string> GetRequestContext();
+        Task<string> GetGrainId();
     }
 
     public interface IHungryGrain<T> : IGrainWithIntegerKey

--- a/test/Grains/TestGrains/MethodInterceptionGrain.cs
+++ b/test/Grains/TestGrains/MethodInterceptionGrain.cs
@@ -199,6 +199,8 @@ namespace UnitTests.Grains
                 }
             }
         }
+
+        public Task<string> GetGrainId() => Task.FromResult(RequestContext.Get("id") as string);
     }
 
     public class CaterpillarGrain : Grain, ICaterpillarGrain, IIncomingGrainCallFilter


### PR DESCRIPTION
Fixes #8075 

This functionality is supported in 7.0 and later via `IGrainContextAccessor`