### PR TITLE
Introduce new helper methods for GetStream

### DIFF
--- a/src/Orleans.Streaming/Providers/IStreamProvider.cs
+++ b/src/Orleans.Streaming/Providers/IStreamProvider.cs
@@ -39,10 +39,48 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The stream element type.</typeparam>
         /// <param name="streamProvider">The stream provider.</param>
-        /// <param name="id">The identifier.</param>
+        /// <param name="id">The identifier.</param> 
         /// <param name="ns">The namespace.</param>
         /// <returns>The stream.</returns>
         public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id, string ns) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id) => streamProvider.GetStream<T>(StreamId.Create(null, id));
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="ns">The namespace.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, Guid id) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string id) => streamProvider.GetStream<T>(StreamId.Create(null, id));
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="ns">The namespace.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, string id) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
     }
 }
 

--- a/src/Orleans.Streaming/Providers/IStreamProvider.cs
+++ b/src/Orleans.Streaming/Providers/IStreamProvider.cs
@@ -39,16 +39,6 @@ namespace Orleans.Streams
         /// </summary>
         /// <typeparam name="T">The stream element type.</typeparam>
         /// <param name="streamProvider">The stream provider.</param>
-        /// <param name="id">The identifier.</param> 
-        /// <param name="ns">The namespace.</param>
-        /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id, string ns) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
-
-        /// <summary>
-        /// Gets the stream with the specified identity and namespace.
-        /// </summary>
-        /// <typeparam name="T">The stream element type.</typeparam>
-        /// <param name="streamProvider">The stream provider.</param>
         /// <param name="id">The identifier.</param>
         /// <returns>The stream.</returns>
         public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id) => streamProvider.GetStream<T>(StreamId.Create(null, id));

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -172,7 +172,7 @@ namespace DefaultCluster.Tests.General
 
             var handle = new AsyncResultHandle();
             var vals = new List<int>();
-            var stream0 = client.GetStreamProvider("MemStream").GetStream<int>(Guid.Empty, "hi");
+            var stream0 = client.GetStreamProvider("MemStream").GetStream<int>("hi", Guid.Empty);
             await stream0.SubscribeAsync(
                 (val, token) =>
                 {
@@ -180,7 +180,7 @@ namespace DefaultCluster.Tests.General
                     if (vals.Count >= 2) handle.Done = true;
                     return Task.CompletedTask;
                 });
-            var stream = client.GetStreamProvider("MemStream").GetStream<int>(Guid.Empty, "hi");
+            var stream = client.GetStreamProvider("MemStream").GetStream<int>("hi", Guid.Empty);
             await stream.OnNextAsync(1);
             await stream.OnNextAsync(409);
             Assert.True(await handle.WaitForFinished(_timeout));

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -103,7 +103,7 @@ namespace ServiceBus.Tests.StreamingTests
             IStreamProvider streamProvider = this.fixture.HostedCluster.ServiceProvider.GetServiceByName<IStreamProvider>(StreamProviderName);
             IAsyncStream<GeneratedEvent>[] producers =
                 Enumerable.Range(0, streamCount)
-                    .Select(i => streamProvider.GetStream<GeneratedEvent>(Guid.NewGuid(), streamNamespace))
+                    .Select(i => streamProvider.GetStream<GeneratedEvent>(streamNamespace, Guid.NewGuid()))
                     .ToArray();
 
             for (int i = 0; i < eventsInStream - 1; i++)

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -112,7 +112,7 @@ namespace ServiceBus.Tests.StreamingTests
             IStreamProvider streamProvider = this.fixture.Client.GetStreamProvider(StreamProviderName);
             IAsyncStream<int>[] producers =
                 Enumerable.Range(0, streamCount)
-                    .Select(i => streamProvider.GetStream<int>(Guid.NewGuid(), null))
+                    .Select(i => streamProvider.GetStream<int>(Guid.NewGuid()))
                     .ToArray();
 
             for (int i = 0; i < eventsInStream; i++)

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -173,7 +173,7 @@ namespace ServiceBus.Tests.StreamingTests
         {
             IStreamProvider streamProvider = this.Client.GetStreamProvider(StreamProviderName);
             IAsyncStream<GeneratedEvent>[] producers = streamGuids
-                    .Select(streamGuid => streamProvider.GetStream<GeneratedEvent>(streamGuid, streamNamespace))
+                    .Select(streamGuid => streamProvider.GetStream<GeneratedEvent>(streamNamespace, streamGuid))
                     .ToArray();
 
             for (int i = 0; i < eventsInStream - 1; i++)

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -71,7 +71,7 @@ namespace UnitTests.Grains
                 throw new ArgumentNullException("providerToUse");
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            IAsyncStream<int> stream = streamProvider.GetStream<int>(streamId, StreamNamespace);
+            IAsyncStream<int> stream = streamProvider.GetStream<int>(StreamNamespace, streamId);
             _consumer = stream;
             _subscriptionHandle = await _consumer.SubscribeAsync(new AsyncObserver<int>(EventArrived));
         }

--- a/test/Grains/TestGrains/FaultableConsumerGrain.cs
+++ b/test/Grains/TestGrains/FaultableConsumerGrain.cs
@@ -52,7 +52,7 @@ namespace UnitTests.Grains
         {
             logger.LogInformation("BecomeConsumer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
+            consumer = streamProvider.GetStream<int>(streamNamespace, streamId);
             consumerHandle = await consumer.SubscribeAsync(
                 OnNextAsync,
                 OnErrorAsync,

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
             foreach (var streamNamespace in streamNamespaces)
             {
                 counters[streamNamespace] = 0;
-                var stream = streamProvider.GetStream<int>(this.GetPrimaryKey(), streamNamespace);
+                var stream = streamProvider.GetStream<int>(streamNamespace, this.GetPrimaryKey());
                 await stream.SubscribeAsync(
                     (e, t) =>
                     {

--- a/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
+++ b/test/Grains/TestGrains/FilteredImplicitSubscriptionWithExtensionGrain.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
             var streamProvider = this.GetStreamProvider("SMSProvider");
 
             var streamIdentity = this.GetImplicitStreamIdentity();
-            var stream = streamProvider.GetStream<int>(streamIdentity.Guid, streamIdentity.Namespace);
+            var stream = streamProvider.GetStream<int>(streamIdentity.Namespace, streamIdentity.Guid);
             await stream.SubscribeAsync(
                 (e, t) =>
                 {

--- a/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
@@ -33,7 +33,7 @@ namespace TestGrains
             logger.LogInformation("OnActivateAsync");
 
             var streamProvider = this.GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
-            stream = streamProvider.GetStream<GeneratedEvent>(this.GetPrimaryKey(), StreamNamespace);
+            stream = streamProvider.GetStream<GeneratedEvent>(StreamNamespace, this.GetPrimaryKey());
 
             IList<StreamSubscriptionHandle<GeneratedEvent>> handles = await stream.GetAllSubscriptionHandles();
             if (handles.Count == 0)

--- a/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -52,7 +52,7 @@ namespace TestGrains
             }
 
             var streamProvider = this.GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
-            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
+            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamNamespace, State.StreamGuid);
 
             await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
         }

--- a/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
@@ -44,7 +44,7 @@ namespace TestGrains
             }
 
             var streamProvider = this.GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
-            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
+            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamNamespace, State.StreamGuid);
 
             await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
         }

--- a/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -96,7 +96,7 @@ namespace TestGrains
             }
 
             var streamProvider = this.GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
-            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
+            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamNamespace, State.StreamGuid);
             foreach (StreamSubscriptionHandle<GeneratedEvent> handle in await stream.GetAllSubscriptionHandles())
             {
                 await handle.ResumeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);

--- a/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -28,8 +28,8 @@ namespace UnitTests.Grains
             logger.LogInformation("OnActivateAsync");
 
             var streamProvider = this.GetStreamProvider("SMSProvider");
-            redStream = streamProvider.GetStream<int>(this.GetPrimaryKey(), "red");
-            blueStream = streamProvider.GetStream<int>(this.GetPrimaryKey(), "blue");
+            redStream = streamProvider.GetStream<int>("red", this.GetPrimaryKey());
+            blueStream = streamProvider.GetStream<int>("blue", this.GetPrimaryKey());
 
             await redStream.SubscribeAsync(
                 (e, t) =>

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Grains
 
             // get stream
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            var stream = streamProvider.GetStream<int>(streamId, streamNamespace);
+            var stream = streamProvider.GetStream<int>(streamNamespace, streamId);
 
             int countCapture = consumerCount;
             consumerCount++;
@@ -114,7 +114,7 @@ namespace UnitTests.Grains
 
             // get stream
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            var stream = streamProvider.GetStream<int>(streamId, streamNamespace);
+            var stream = streamProvider.GetStream<int>(streamNamespace, streamId);
 
             // get all active subscription handles for this stream.
             return stream.GetAllSubscriptionHandles();

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -42,7 +42,7 @@ namespace UnitTests.Grains
                 throw new ArgumentNullException("providerToUse");
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            IAsyncStream<int> stream = streamProvider.GetStream<int>(streamId, ConsumerEventCountingGrain.StreamNamespace);
+            IAsyncStream<int> stream = streamProvider.GetStream<int>(ConsumerEventCountingGrain.StreamNamespace, streamId);
             _producer = stream;
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -36,7 +36,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
         {
             logger.LogInformation("BecomeProducer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            producer = streamProvider.GetStream<T>(streamId, streamNamespace);
+            producer = streamProvider.GetStream<T>(streamNamespace, streamId);
             return Task.CompletedTask;
         }
 

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -152,7 +152,7 @@ namespace UnitTests.Grains
         }
 
         IAsyncStream<string> GetStream() => 
-            this.GetStreamProvider("sms").GetStream<string>(Guid.Empty, "test-stream-interleave");
+            this.GetStreamProvider("sms").GetStream<string>("test-stream-interleave", Guid.Empty);
 
         public Task SetSelf(IMayInterleavePredicateGrain self)
         {

--- a/test/Grains/TestGrains/SampleStreamingGrain.cs
+++ b/test/Grains/TestGrains/SampleStreamingGrain.cs
@@ -64,7 +64,7 @@ namespace UnitTests.Grains
         {
             logger.LogInformation("BecomeProducer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            producer = streamProvider.GetStream<int>(streamId, streamNamespace);
+            producer = streamProvider.GetStream<int>(streamNamespace, streamId);
             return Task.CompletedTask;
         }
 
@@ -146,7 +146,7 @@ namespace UnitTests.Grains
             logger.LogInformation("BecomeConsumer");
             consumerObserver = new SampleConsumerObserver<int>(this);
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
+            consumer = streamProvider.GetStream<int>(streamNamespace, streamId);
             consumerHandle = await consumer.SubscribeAsync(consumerObserver);
         }
 
@@ -196,7 +196,7 @@ namespace UnitTests.Grains
         {
             logger.LogInformation( "BecomeConsumer" );
             IStreamProvider streamProvider = this.GetStreamProvider( providerToUse );
-            consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
+            consumer = streamProvider.GetStream<int>(streamNamespace, streamId);
             consumerHandle = await consumer.SubscribeAsync( OnNextAsync, OnErrorAsync, OnCompletedAsync );
         }
 

--- a/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
+++ b/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
@@ -40,7 +40,7 @@ namespace UnitTests.Grains
             logger.LogInformation("BecomeConsumer");
             ConsumerObserver = new SlowObserver<int>(this, logger);
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
-            var consumer = streamProvider.GetStream<int>(streamId, streamNamespace);
+            var consumer = streamProvider.GetStream<int>(streamNamespace, streamId);
             ConsumerHandle = await consumer.SubscribeAsync(ConsumerObserver);
         }
 

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
 
         public async Task BecomeConsumer(Guid streamId, string providerToUse)
         {
-            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(streamId, StreamNamespace);
+            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(StreamNamespace, streamId);
             _ = await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
         }
     }

--- a/test/Grains/TestGrains/StatelessWorkerStreamProducerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamProducerGrain.cs
@@ -23,7 +23,7 @@ namespace UnitTests.Grains
 
         public async Task Produce(Guid streamId, string providerToUse, string message)
         {
-            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(streamId, StreamNamespace);
+            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(StreamNamespace, streamId);
             await stream.OnNextAsync(message);
         }
     }

--- a/test/Grains/TestGrains/StreamInterceptionGrain.cs
+++ b/test/Grains/TestGrains/StreamInterceptionGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains
         public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var streams = this.GetStreamProvider("SMSProvider");
-            var stream = streams.GetStream<int>(this.GetPrimaryKey(), "InterceptedStream");
+            var stream = streams.GetStream<int>("InterceptedStream", this.GetPrimaryKey());
             await stream.SubscribeAsync(
                 (value, token) =>
                 {

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -286,7 +286,7 @@ namespace UnitTests.Grains
 #if USE_GENERICS
                 State.Stream = streamProvider.GetStream<T>(streamId);
 #else
-                State.Stream = streamProvider.GetStream<int>(streamId, StreamNamespace);
+                State.Stream = streamProvider.GetStream<int>(StreamNamespace, streamId);
 #endif
             }
         }
@@ -385,7 +385,7 @@ namespace UnitTests.Grains
             {
                 logger.LogInformation("InitStream StreamId={StreamId} StreamProvider={ProviderName}", streamId, providerName);
                 IStreamProvider streamProvider = this.GetStreamProvider(providerName);
-                State.Stream = streamProvider.GetStream<int>(streamId, StreamNamespace);
+                State.Stream = streamProvider.GetStream<int>(StreamNamespace, streamId);
             }
 
             var observer = new MyStreamObserver<int>(logger);

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -119,7 +119,7 @@ namespace UnitTests.Grains
             _streamId = streamId;
             ProviderName = streamProvider.Name;
             _streamNamespace = string.IsNullOrWhiteSpace(streamNamespace) ? null : streamNamespace.Trim();
-            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(streamId, streamNamespace);
+            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(streamNamespace, streamId);
 
             _subscription = await stream.SubscribeAsync(this);
         }
@@ -128,7 +128,7 @@ namespace UnitTests.Grains
         {
             _logger = logger;
             _logger.LogInformation("RenewConsumer");
-            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamId, _streamNamespace);
+            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamNamespace, _streamId);
             _subscription = await stream.SubscribeAsync(this);
         }
 
@@ -208,7 +208,7 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             _logger.LogInformation("BecomeProducer");
-            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(streamId, streamNamespace);
+            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(streamNamespace, streamId);
             _observer = stream;
             _logger.LogInformation("ProducerObserver.BecomeProducer: producer requires no disposal; test short-circuited.");
             _observerDisposedYet = true; // TODO BPETIT remove that
@@ -223,7 +223,7 @@ namespace UnitTests.Grains
 
             _logger = logger;
             _logger.LogInformation("RenewProducer");
-            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamId, _streamNamespace);
+            IAsyncStream<StreamItem> stream = streamProvider.GetStream<StreamItem>(_streamNamespace, _streamId);
             _observer = stream;
             _observerDisposedYet = true; // TODO BPETIT remove that
         }

--- a/test/Grains/TestInternalGrains/StreamingImmutabilityTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingImmutabilityTestGrain.cs
@@ -13,7 +13,7 @@ namespace UnitTests.Grains
 
         public async Task SubscribeToStream(Guid guid, string providerName)
         {
-            var stream = this.GetStreamProvider(providerName).GetStream<StreamImmutabilityTestObject>(guid, "Namespace");
+            var stream = this.GetStreamProvider(providerName).GetStream<StreamImmutabilityTestObject>("Namespace", guid);
             _streamSubscriptionHandle = await stream.SubscribeAsync(OnNextAsync);
         }
 
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
 
         public async Task SendTestObject(string providerName)
         {
-            var stream = this.GetStreamProvider(providerName).GetStream<StreamImmutabilityTestObject>(this.GetPrimaryKey(), "Namespace");
+            var stream = this.GetStreamProvider(providerName).GetStream<StreamImmutabilityTestObject>("Namespace", this.GetPrimaryKey());
             await stream.OnNextAsync(_myObject);
         }
 

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -205,7 +205,7 @@ namespace UnitTests.General
         {
             var streamProvider = this.fixture.Client.GetStreamProvider("SMSProvider");
             var id = Guid.NewGuid();
-            var stream = streamProvider.GetStream<int>(id, "InterceptedStream");
+            var stream = streamProvider.GetStream<int>("InterceptedStream", id);
             var grain = this.fixture.GrainFactory.GetGrain<IStreamInterceptionGrain>(id);
 
             // The intercepted grain should double the value passed to the stream.

--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -106,7 +106,7 @@ namespace Tester.StreamingTests
             Func<int, StreamSequenceToken, Task> onNextAsync)
         {
             IStreamProvider streamProvider = this.testHost.Client.GetStreamProvider(streamProviderName);
-            IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamNamespace, streamGuid);
             return stream.SubscribeAsync(onNextAsync);
         }
 
@@ -128,7 +128,7 @@ namespace Tester.StreamingTests
         private async Task GenerateEvents(string streamProviderName, Guid streamGuid, string streamNamespace, int produceCount)
         {
             IStreamProvider streamProvider = this.testHost.Client.GetStreamProvider(streamProviderName);
-            IAsyncObserver<int> observer = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            IAsyncObserver<int> observer = streamProvider.GetStream<int>(streamNamespace, streamGuid);
             for (int i = 0; i < produceCount; i++)
             {
                 await observer.OnNextAsync(i);

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -91,7 +91,7 @@ namespace UnitTests.StreamingTests
             var count = new Counter();
             // get stream and subscribe
             IStreamProvider streamProvider = this.client.GetStreamProvider(streamProviderName);
-            var stream = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            var stream = streamProvider.GetStream<int>(streamNamespace, streamGuid);
             StreamSubscriptionHandle<int> subscriptionHandle = await stream.SubscribeAsync((e, t) => count.Increment());
 
             // produce one message (PubSubRendezvousGrain will have one consumer and one producer)

--- a/test/Tester/StreamingTests/StreamBatchingTestRunner.cs
+++ b/test/Tester/StreamingTests/StreamBatchingTestRunner.cs
@@ -30,7 +30,7 @@ namespace UnitTests.StreamingTests
             Guid streamGuid = Guid.NewGuid();
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
-            IAsyncStream<string> stream = provider.GetStream<string>(streamGuid, StreamBatchingTestConst.BatchingNameSpace);
+            IAsyncStream<string> stream = provider.GetStream<string>(StreamBatchingTestConst.BatchingNameSpace, streamGuid);
             for(int i = 0; i< ExpectedConsumed; i++)
             {
                 await stream.OnNextAsync(i.ToString());
@@ -48,7 +48,7 @@ namespace UnitTests.StreamingTests
             Guid streamGuid = Guid.NewGuid();
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
-            IAsyncStream<string> stream = provider.GetStream<string>(streamGuid, StreamBatchingTestConst.NonBatchingNameSpace);
+            IAsyncStream<string> stream = provider.GetStream<string>(StreamBatchingTestConst.NonBatchingNameSpace, streamGuid);
             for (int i = 0; i < BatchesSent; i++)
             {
                 await stream.OnNextBatchAsync(Enumerable.Range(i, ItemsPerBatch).Select(v => v.ToString()));
@@ -66,7 +66,7 @@ namespace UnitTests.StreamingTests
             Guid streamGuid = Guid.NewGuid();
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
-            IAsyncStream<string> stream = provider.GetStream<string>(streamGuid, StreamBatchingTestConst.BatchingNameSpace);
+            IAsyncStream<string> stream = provider.GetStream<string>(StreamBatchingTestConst.BatchingNameSpace, streamGuid);
             for (int i = 0; i < BatchesSent; i++)
             {
                 await stream.OnNextBatchAsync(Enumerable.Range(i, ItemsPerBatch).Select(v => v.ToString()));

--- a/test/Tester/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Tester/StreamingTests/StreamingCacheMissTests.cs
@@ -43,13 +43,13 @@ namespace Tester.StreamingTests
 
             // Tested stream and corresponding grain
             var key = Guid.NewGuid();
-            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
             var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
 
             // We need multiple streams, so at least another one will be handled by the same PullingAgent than "stream"
             var otherStreams = new List<IAsyncStream<byte[]>>();
             for (var i = 0; i < 20; i++)
-                otherStreams.Add(streamProvider.GetStream<byte[]>(Guid.NewGuid(), nameof(IImplicitSubscriptionCounterGrain)));
+                otherStreams.Add(streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), Guid.NewGuid()));
 
             // Data that will be sent to the grains
             var interestingData = new byte[1024];
@@ -78,13 +78,13 @@ namespace Tester.StreamingTests
 
             // Tested stream and corresponding grain
             var key = Guid.NewGuid();
-            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
             var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
 
             // We need multiple streams, so at least another one will be handled by the same PullingAgent than "stream"
             var otherStreams = new List<IAsyncStream<byte[]>>();
             for (var i = 0; i < 20; i++)
-                otherStreams.Add(streamProvider.GetStream<byte[]>(Guid.NewGuid(), nameof(IImplicitSubscriptionCounterGrain)));
+                otherStreams.Add(streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), Guid.NewGuid()));
 
             // Data that will always be filtered
             var skippedData = new byte[1024];

--- a/test/Tester/StreamingTests/StreamingResumeTests.cs
+++ b/test/Tester/StreamingTests/StreamingResumeTests.cs
@@ -24,7 +24,7 @@ namespace Tester.StreamingTests
 
             // Tested stream and corresponding grain
             var key = Guid.NewGuid();
-            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
             var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
 
             // Data that will be sent to the grains
@@ -52,7 +52,7 @@ namespace Tester.StreamingTests
 
             // Tested stream and corresponding grain
             var key = Guid.NewGuid();
-            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
             var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
 
             // Data that will be sent to the grains
@@ -81,8 +81,8 @@ namespace Tester.StreamingTests
 
             // Tested stream and corresponding grain
             var key = Guid.NewGuid();
-            var stream = streamProvider.GetStream<byte[]>(key, nameof(IImplicitSubscriptionCounterGrain));
-            var otherStream = streamProvider.GetStream<byte[]>(Guid.NewGuid(), nameof(IImplicitSubscriptionCounterGrain));
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
+            var otherStream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), Guid.NewGuid());
             var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
             await grain.DeactivateOnEvent(true);
 

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -313,7 +313,7 @@ namespace UnitTests.StreamingTests
             int eventCount = 0;
 
             var provider = this.testCluster.Client.ServiceProvider.GetServiceByName<IStreamProvider>(streamProviderName);
-            var stream = provider.GetStream<int>(streamGuid, streamNamespace);
+            var stream = provider.GetStream<int>(streamNamespace, streamGuid);
             var handle = await stream.SubscribeAsync((e,t) =>
             {
                 eventCount++;

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,7 +74,7 @@ namespace Tester.StreamingTests
             foreach(Guid streamId in streamIds)
             {
                 IStreamProvider streamProvider = this.fixture.Client.GetStreamProvider(Fixture.StreamProviderName);
-                IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamId, null);
+                IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamId);
                 await stream.SubscribeAsync(OnNextAsync);
             }
 


### PR DESCRIPTION
* Introduction of `GetStream<T>(string, string)` and `GetStream<T>(string, Guid)`
* Removal of `GetStream<T>(Guid, string)` to avoid confusion

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8079)