### PR TITLE
Extract the type from the Grain key instead of the CLR type

### DIFF
--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -81,7 +81,7 @@ namespace Orleans.Runtime
             if (grainContext is null) throw new ArgumentNullException(nameof(grainContext));
             var grainType = grainContext.GrainInstance?.GetType() ?? throw new ArgumentNullException(nameof(IGrainContext.GrainInstance));
             IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(grainType, ServiceProvider);
-            string grainTypeName = grainContext.GrainInstance.GetType().FullName;
+            var grainTypeName = grainContext.GrainId.Type.ToString();
             return new StateStorageBridge<TGrainState>(grainTypeName, grainContext.GrainId, grainStorage, this.loggerFactory);
         }
 


### PR DESCRIPTION
Right now, if a grain class is implementing `Grain<T>` to store a state, this state will be lost if the class is renamed.

With this fix, the developer can customize the type name used by the storage provider using this attribute:
```csharp
[GrainType("my-old-class")]
``` 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8083)