### PR TITLE
Add diagnostic for unexpected codegen exceptions and known user errors

### DIFF
--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
@@ -1,6 +1,14 @@
-## Release 4.0.0
+## Release 7.0.0
 
 ### New Rules
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
+ORLEANS0101 | Usage | Error | Serializable properties with bodies must be settable
+ORLEANS0102 | Usage | Error | Invalid return type for RPC interface method
+ORLEANS0103 | Usage | Error | An unhandled source generation exception occurred
+ORLEANS0104 | Usage | Error | The proxy base class specified is not a valid proxy base class
+ORLEANS0105 | Usage | Error | RPC interfaces must not contain properties
+ORLEANS0106 | Usage | Error | An error is preventing implicit field identifier generation
+ORLEANS0107 | Usage | Error | Serializable type is not accessible from generated code
+

--- a/src/Orleans.CodeGenerator/Diagnostics/CanNotGenerateImplicitFieldIdsDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/CanNotGenerateImplicitFieldIdsDiagnostic.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class CanNotGenerateImplicitFieldIdsDiagnostic
+{
+    public const string DiagnosticId = "ORLEANS0106";
+    public const string Title = "Implicit field identifiers could not be generated";
+    public const string MessageFormat = "Could not generate implicit field identifiers for the type {0}: {reason}";
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+    internal static Diagnostic CreateDiagnostic(ISymbol symbol, string reason) => Diagnostic.Create(Rule, symbol.Locations.First(), symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), reason);
+}

--- a/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSerializableTypeDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSerializableTypeDiagnostic.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class InaccessibleSerializableTypeDiagnostic
+{
+    public const string RuleId = "ORLEANS0107"; 
+    public const string Title = "Serializable type must be accessible from generated code";
+    public const string MessageFormat = "The type {0} is marked as being serializable but it is inaccessible from generated code";
+    public const string Descsription = "Source generation requires that all types marked as serializable are accessible from generated code. Either make the type public or make it internal and ensure that internals are visible to the generated code.";
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Descsription);
+
+    internal static Diagnostic CreateDiagnostic(ISymbol symbol) => Diagnostic.Create(Rule, symbol.Locations.First(), symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+}

--- a/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSetterDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSetterDiagnostic.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Orleans.CodeGenerator.Diagnostics;
 
-public class InaccessibleSetterDiagnostic
+public static class InaccessibleSetterDiagnostic
 {
     public const string RuleId = "ORLEANS0101"; 
     private const string Category = "Usage";
@@ -10,7 +10,7 @@ public class InaccessibleSetterDiagnostic
     private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InaccessibleSetterMessageFormat), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InaccessibleSetterDescription), Resources.ResourceManager, typeof(Resources));
 
-    internal static DiagnosticDescriptor Rule { get; } = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     public static Diagnostic CreateDiagnostic(Location location, string identifier) => Diagnostic.Create(Rule, location, identifier);
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/IncorrectProxyBaseClassSpecificationDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/IncorrectProxyBaseClassSpecificationDiagnostic.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class IncorrectProxyBaseClassSpecificationDiagnostic
+{
+    public const string RuleId = "ORLEANS0104"; 
+    private const string Category = "Usage";
+    private static readonly LocalizableString Title = "The proxy base class specified is not a valid proxy base class";
+    private static readonly LocalizableString MessageFormat = "Proxy base class {0} does not conform to requirements: {1}";
+    private static readonly LocalizableString Description = "Proxy base clases must conform. Please report this bug by opening an issue https://github.com/dotnet/orleans/issues/new.";
+
+    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+    internal static Diagnostic CreateDiagnostic(INamedTypeSymbol baseClass, Location location, string complaint) => Diagnostic.Create(Rule, location, baseClass.ToDisplayString(), complaint);
+}

--- a/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcMethodReturnTypeDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcMethodReturnTypeDiagnostic.cs
@@ -3,15 +3,15 @@ using Microsoft.CodeAnalysis;
 
 namespace Orleans.CodeGenerator.Diagnostics;
 
-public class InvalidGrainMethodReturnTypeDiagnostic
+public static class InvalidRpcMethodReturnTypeDiagnostic
 {
     public const string RuleId = "ORLEANS0102"; 
     private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InvalidGrainMethodReturnTypeDescription), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.InvalidRpcMethodReturnTypeTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InvalidRpcMethodReturnTypeMessageFormat), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InvalidRpcMethodReturnTypeDescription), Resources.ResourceManager, typeof(Resources));
 
-    internal static DiagnosticDescriptor Rule { get; } = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     public static Diagnostic CreateDiagnostic(Location location, string returnType, string methodIdentifier, string supportedReturnTypeList) => Diagnostic.Create(Rule, location, returnType, methodIdentifier, supportedReturnTypeList);
 

--- a/src/Orleans.CodeGenerator/Diagnostics/RpcInterfacePropertyDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/RpcInterfacePropertyDiagnostic.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class RpcInterfacePropertyDiagnostic
+{
+    public const string DiagnosticId = "ORLEANS0105";
+    public const string Title = "RPC interfaces must not contain properties";
+    public const string MessageFormat = "The interface {0} contains a property {1}. RPC interfaces must not contain properties.";
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+    internal static Diagnostic CreateDiagnostic(INamedTypeSymbol interfaceSymbol, IPropertySymbol property) => Diagnostic.Create(Rule, property.Locations.First(), interfaceSymbol.ToDisplayString(), property.ToDisplayString());
+}

--- a/src/Orleans.CodeGenerator/Diagnostics/UnhandledCodeGenerationExceptionDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/UnhandledCodeGenerationExceptionDiagnostic.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class UnhandledCodeGenerationExceptionDiagnostic
+{
+    public const string RuleId = "ORLEANS0103"; 
+    private const string Category = "Usage";
+    private static readonly LocalizableString Title = "An unhandled source generation exception occurred";
+    private static readonly LocalizableString MessageFormat = "An unhandled exception occurred while generating source for your project: {0}";
+    private static readonly LocalizableString Description = "Please report this bug by opening an issue https://github.com/dotnet/orleans/issues/new.";
+
+    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+    internal static Diagnostic CreateDiagnostic(Exception exception) => Diagnostic.Create(Rule, location: null, messageArgs: new[] { exception.ToString() });
+}

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -18,9 +18,7 @@ internal class FieldIdAssignmentHelper
     private readonly ImmutableArray<IParameterSymbol> _constructorParameters;
     private readonly LibraryTypes _libraryTypes;
     private readonly ISymbol[] _memberSymbols;
-#pragma warning disable RS1024 // Compare symbols correctly
     private readonly Dictionary<ISymbol, (uint, bool)> _symbols = new(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024 // Compare symbols correctly
 
     public bool IsValidForSerialization { get; }
     public string? FailureReason { get; private set; }

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -148,9 +148,9 @@ namespace Orleans.CodeGenerator
             var methodReturnType = method.Method.ReturnType;
             if (methodReturnType is not INamedTypeSymbol namedMethodReturnType)
             {
-                var diagnostic = InvalidGrainMethodReturnTypeDiagnostic.CreateDiagnostic(method);
-                throw new OrleansGeneratorDiagnosticAnalysisException(diagnostic);
+                throw new OrleansGeneratorDiagnosticAnalysisException(InvalidRpcMethodReturnTypeDiagnostic.CreateDiagnostic(method));
             }
+
             if (method.InvokableBaseTypes.TryGetValue(namedMethodReturnType, out var baseClassType))
             {
                 return baseClassType;
@@ -164,8 +164,8 @@ namespace Orleans.CodeGenerator
                     return baseClassType.ConstructedFrom.Construct(namedMethodReturnType.TypeArguments.ToArray());
                 }
             }
-            
-            throw new InvalidOperationException($"Unsupported return type {methodReturnType} for method {method.Method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
+
+            throw new OrleansGeneratorDiagnosticAnalysisException(InvalidRpcMethodReturnTypeDiagnostic.CreateDiagnostic(method));
         }
 
         private static MemberDeclarationSyntax GenerateSetTargetMethod(

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -293,9 +293,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol FSharpSourceConstructFlagsOrDefault { get; private set; }
         public INamedTypeSymbol FormatterServices { get; private set; }
 
-#pragma warning disable RS1024 // Compare symbols correctly
         private readonly ConcurrentDictionary<ITypeSymbol, bool> _shallowCopyableTypes = new(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024 // Compare symbols correctly
 
         public bool IsShallowCopyable(ITypeSymbol type)
         {

--- a/src/Orleans.CodeGenerator/Model/MethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/MethodDescription.cs
@@ -34,18 +34,13 @@ namespace Orleans.CodeGenerator
                 MethodTypeParameters.Add((tpName, tp));
             }
 
-#pragma warning disable RS1024 // Compare symbols correctly
             TypeParameterSubstitutions = new(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024 // Compare symbols correctly
-
             foreach (var tp in AllTypeParameters)
             {
                 TypeParameterSubstitutions[tp.Parameter] = tp.Name;
             }
 
-#pragma warning disable RS1024 // Compare symbols correctly
             InvokableBaseTypes = new Dictionary<INamedTypeSymbol, INamedTypeSymbol>(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024 // Compare symbols correctly
 
             // Set defaults from the interface type.
             foreach (var pair in containingType.InvokableBaseTypes)

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Orleans.CodeGenerator.Diagnostics;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -71,25 +72,13 @@ namespace Orleans.CodeGenerator
 
             static bool HandleException(GeneratorExecutionContext context, Exception exception)
             {
-                Console.WriteLine(exception);
-
                 if (exception is OrleansGeneratorDiagnosticAnalysisException analysisException)
                 {
                     context.ReportDiagnostic(analysisException.Diagnostic);
                     return true;
                 }
-                else if (exception is AggregateException aggregateException)
-                {
-                    var handled = true;
-                    var flattened = aggregateException.Flatten();
-                    foreach (var innerException in flattened.InnerExceptions)
-                    {
-                        handled &= HandleException(context, innerException);
-                    }
 
-                    return handled;
-                }
-
+                context.ReportDiagnostic(UnhandledCodeGenerationExceptionDiagnostic.CreateDiagnostic(exception));
                 return false;
             }
         }

--- a/src/Orleans.CodeGenerator/ProxyGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxyGenerator.cs
@@ -221,7 +221,7 @@ namespace Orleans.CodeGenerator
             var methodReturnType = methodDescription.Method.ReturnType;
             if (methodReturnType is not INamedTypeSymbol namedMethodReturnType)
             {
-                var diagnostic = InvalidGrainMethodReturnTypeDiagnostic.CreateDiagnostic(methodDescription);
+                var diagnostic = InvalidRpcMethodReturnTypeDiagnostic.CreateDiagnostic(methodDescription);
                 throw new OrleansGeneratorDiagnosticAnalysisException(diagnostic);
             }
 

--- a/src/Orleans.CodeGenerator/Resources.Designer.cs
+++ b/src/Orleans.CodeGenerator/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace Orleans.CodeGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Serializable property {0} does not have an accessible setter..
+        ///   Looks up a localized string similar to Serializable property {0} does not have an accessible setter.
         /// </summary>
         internal static string InaccessibleSetterMessageFormat {
             get {
@@ -79,7 +79,7 @@ namespace Orleans.CodeGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Serializable properties with bodies must be settable..
+        ///   Looks up a localized string similar to Serializable properties with bodies must be settable.
         /// </summary>
         internal static string InaccessibleSetterTitle {
             get {
@@ -88,29 +88,29 @@ namespace Orleans.CodeGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The return type of a grain method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;..
+        ///   Looks up a localized string similar to The return type of an RPC method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;..
         /// </summary>
-        internal static string InvalidGrainMethodReturnTypeDescription {
+        internal static string InvalidRpcMethodReturnTypeDescription {
             get {
-                return ResourceManager.GetString("InvalidGrainMethodReturnTypeDescription", resourceCulture);
+                return ResourceManager.GetString("InvalidRpcMethodReturnTypeDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type {0} for the grain interface method {1} cannot be used as a grain method return type. Grain methods must return one of the following types: {2}..
+        ///   Looks up a localized string similar to The return type {0} for the RPC interface method {1} is unsupported and must be changed to one of the following types: {2}.
         /// </summary>
-        internal static string InvalidGrainMethodReturnTypeMessageFormat {
+        internal static string InvalidRpcMethodReturnTypeMessageFormat {
             get {
-                return ResourceManager.GetString("InvalidGrainMethodReturnTypeMessageFormat", resourceCulture);
+                return ResourceManager.GetString("InvalidRpcMethodReturnTypeMessageFormat", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid return type for grain interface method..
+        ///   Looks up a localized string similar to Invalid return type for RPC interface method.
         /// </summary>
-        internal static string InvalidGrainMethodReturnTypeTitle {
+        internal static string InvalidRpcMethodReturnTypeTitle {
             get {
-                return ResourceManager.GetString("InvalidGrainMethodReturnTypeTitle", resourceCulture);
+                return ResourceManager.GetString("InvalidRpcMethodReturnTypeTitle", resourceCulture);
             }
         }
     }

--- a/src/Orleans.CodeGenerator/Resources.resx
+++ b/src/Orleans.CodeGenerator/Resources.resx
@@ -121,18 +121,18 @@
     <value>Serializable properties must have accessible setters. Ensure that the property has a non-private set method.</value>
   </data>
   <data name="InaccessibleSetterMessageFormat" xml:space="preserve">
-    <value>Serializable property {0} does not have an accessible setter.</value>
+    <value>Serializable property {0} does not have an accessible setter</value>
   </data>
   <data name="InaccessibleSetterTitle" xml:space="preserve">
-    <value>Serializable properties with bodies must be settable.</value>
+    <value>Serializable properties with bodies must be settable</value>
   </data>
-  <data name="InvalidGrainMethodReturnTypeDescription" xml:space="preserve">
-    <value>The return type of a grain method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;.</value>
+  <data name="InvalidRpcMethodReturnTypeDescription" xml:space="preserve">
+    <value>The return type of an RPC method must conform to the list of supported types, such as Task, Task&lt;T&gt;, ValueTask, and ValueTask&lt;T&gt;.</value>
   </data>
-  <data name="InvalidGrainMethodReturnTypeMessageFormat" xml:space="preserve">
-    <value>The type {0} for the grain interface method {1} cannot be used as a grain method return type. Grain methods must return one of the following types: {2}.</value>
+  <data name="InvalidRpcMethodReturnTypeMessageFormat" xml:space="preserve">
+    <value>The return type {0} for the RPC interface method {1} is unsupported and must be changed to one of the following types: {2}</value>
   </data>
-  <data name="InvalidGrainMethodReturnTypeTitle" xml:space="preserve">
-    <value>Invalid return type for grain interface method.</value>
+  <data name="InvalidRpcMethodReturnTypeTitle" xml:space="preserve">
+    <value>Invalid return type for RPC interface method</value>
   </data>
 </root>

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -13,10 +13,8 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
 {
     internal static class SymbolExtensions
     {
-#pragma warning disable RS1024 // Compare symbols correctly
         private static readonly ConcurrentDictionary<ITypeSymbol, TypeSyntax> TypeCache = new(SymbolEqualityComparer.Default);
         private static readonly ConcurrentDictionary<ISymbol, string> NameCache = new(SymbolEqualityComparer.Default);
-#pragma warning restore RS1024 // Compare symbols correctly
 
         public struct DisplayNameOptions
         {

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -184,7 +184,7 @@ namespace UnitTests.StreamingTests
 
         [Serializable]
         [Orleans.GenerateSerializer]
-        private class DummyStreamProducerExtension : IStreamProducerExtension
+        public class DummyStreamProducerExtension : IStreamProducerExtension
         {
             [Orleans.Id(0)]
             private readonly Guid id;


### PR DESCRIPTION
* Add a catch-all diagnostic for unhandled exceptions so that users do not need to look through build logs
* Fail the build when a type is marked `[GenerateSerializer]` but it is inaccessible from generated code (#8085)
* Add diagnostics for known user errors. Some of these overlap with Orleans.Analyzers diagnostics, but since Orleans.CodeGenerator is not Orleans-specific (knows nothing about grains, for example), they use different wording.

Addresses https://github.com/dotnet/orleans/issues/8080#issuecomment-1294389308
Fixes #8085

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8087)