### PR TITLE
Verify WireType in all codecs

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -20,7 +20,6 @@ namespace Orleans.CodeGenerator
                 Action_2 = Type("System.Action`2"),
                 ITypeManifestProvider = Type("Orleans.Serialization.Configuration.ITypeManifestProvider"),
                 Field = Type("Orleans.Serialization.WireProtocol.Field"),
-                WireType = Type("Orleans.Serialization.WireProtocol.WireType"),
                 FieldCodec_1 = Type("Orleans.Serialization.Codecs.IFieldCodec`1"),
                 AbstractTypeSerializer = Type("Orleans.Serialization.Serializers.AbstractTypeSerializer`1"),
                 DeepCopier_1 = Type("Orleans.Serialization.Cloning.IDeepCopier`1"),
@@ -195,7 +194,6 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol Action_2 { get; private set; }
         public INamedTypeSymbol ITypeManifestProvider { get; private set; }
         public INamedTypeSymbol Field { get; private set; }
-        public INamedTypeSymbol WireType { get; private set; }
         public INamedTypeSymbol DeepCopier_1 { get; private set; }
         public INamedTypeSymbol ShallowCopier { get; private set; }
         public INamedTypeSymbol FieldCodec_1 { get; private set; }

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -595,7 +595,7 @@ namespace Orleans.CodeGenerator
 
                     ExpressionSyntax readValueExpression = InvocationExpression(
                         codecExpression.Member("ReadValue"),
-                        ArgumentList(SeparatedList(new[] { Argument(null, Token(SyntaxKind.RefKeyword), readerParam), Argument(headerVar) })));
+                        ArgumentList(SeparatedList(new[] { Argument(readerParam).WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)), Argument(headerVar) })));
                     if (!codec.UnderlyingType.Equals(member.TypeSyntax))
                     {
                         // If the member type type differs from the codec type (eg because the member is an array), cast the result.

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -458,8 +458,6 @@ namespace Orleans.CodeGenerator
             var instanceParam = "instance".ToIdentifierName();
             var idVar = "id".ToIdentifierName();
             var headerVar = "header".ToIdentifierName();
-            var readHeaderLocalFunc = "ReadHeader".ToIdentifierName();
-            var readHeaderEndLocalFunc = "ReadHeaderExpectingEndBaseOrEndObject".ToIdentifierName();
 
             var body = new List<StatementSyntax>();
 
@@ -479,52 +477,39 @@ namespace Orleans.CodeGenerator
 
             AddSerializationCallbacks(type, instanceParam, "OnDeserializing", body);
 
-            // C#: int id = 0;
-            body.Add(LocalDeclarationStatement(
-                VariableDeclaration(
-                    PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    SingletonSeparatedList(VariableDeclarator(idVar.Identifier)
-                        .WithInitializer(EqualsValueClause(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0))))))));
-
-            // C#: Field header = default;
-            body.Add(LocalDeclarationStatement(
-                VariableDeclaration(
-                    libraryTypes.Field.ToTypeSyntax(),
-                    SingletonSeparatedList(VariableDeclarator(headerVar.Identifier)
-                        .WithInitializer(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression)))))));
-
-            int emptyBodyCount = 2;
-
-            if (type.SupportsPrimaryConstructorParameters)
+            int emptyBodyCount;
+            var normalMembers = members.FindAll(m => !m.IsPrimaryConstructorParameter);
+            if (members.Count == 0 || normalMembers.Count == 0 && !type.SupportsPrimaryConstructorParameters)
             {
-                body.Add(WhileStatement(LiteralExpression(SyntaxKind.TrueLiteralExpression), Block(GetDeserializerLoopBody(members.Where(m => m.IsPrimaryConstructorParameter)))));
-                body.Add(ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName(idVar.Identifier), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)))));
-
-                body.Add(
-                    IfStatement(
-                        IdentifierName(headerVar.Identifier).Member("IsEndBaseFields"),
-                        WhileStatement(LiteralExpression(SyntaxKind.TrueLiteralExpression), Block(GetDeserializerLoopBody(members.Where(m => !m.IsPrimaryConstructorParameter))))));
+                // C#: reader.ConsumeEndBaseOrEndObject();
+                body.Add(ExpressionStatement(InvocationExpression(readerParam.Member("ConsumeEndBaseOrEndObject"))));
+                emptyBodyCount = 1;
             }
             else
             {
-                var normalMembers = members.FindAll(m => !m.IsPrimaryConstructorParameter);
-                if (normalMembers.Count == 0 && type.IsAbstractType)
+                // C#: uint id = 0;
+                body.Add(LocalDeclarationStatement(
+                    VariableDeclaration(
+                        PredefinedType(Token(SyntaxKind.UIntKeyword)),
+                        SingletonSeparatedList(VariableDeclarator(idVar.Identifier, null, EqualsValueClause(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0))))))));
+
+                // C#: Field header = default;
+                body.Add(LocalDeclarationStatement(
+                    VariableDeclaration(
+                        libraryTypes.Field.ToTypeSyntax(),
+                        SingletonSeparatedList(VariableDeclarator(headerVar.Identifier, null, EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression)))))));
+
+                emptyBodyCount = 2;
+
+                if (type.SupportsPrimaryConstructorParameters)
                 {
-                    emptyBodyCount = 1;
-                    // C#: base.Deserialize(ref reader, instance);
-                    body.RemoveRange(body.Count - 2, 2);
-                    body.Add(
-                        ExpressionStatement(
-                            InvocationExpression(
-                                IdentifierName("base").Member(DeserializeMethodName),
-                                ArgumentList(SeparatedList(new[] { Argument(readerParam).WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)), Argument(instanceParam) })))));
+                    body.Add(GetDeserializerLoop(members.FindAll(m => m.IsPrimaryConstructorParameter)));
+                    body.Add(ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, idVar, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)))));
+                    body.Add(IfStatement(headerVar.Member("IsEndBaseFields"), GetDeserializerLoop(normalMembers)));
                 }
                 else
                 {
-                    body.Add(WhileStatement(LiteralExpression(SyntaxKind.TrueLiteralExpression), Block(GetDeserializerLoopBody(normalMembers))));
-
-                    if (normalMembers.Count == 0)
-                        emptyBodyCount++;
+                    body.Add(GetDeserializerLoop(normalMembers));
                 }
             }
 
@@ -558,36 +543,36 @@ namespace Orleans.CodeGenerator
             return res;
 
             // Create the loop body.
-            List<StatementSyntax> GetDeserializerLoopBody(IEnumerable<ISerializableMember> members)
+            StatementSyntax GetDeserializerLoop(List<ISerializableMember> members)
             {
+                var refHeaderVar = ArgumentList(SingletonSeparatedList(Argument(null, Token(SyntaxKind.RefKeyword), headerVar)));
+                if (members.Count == 0)
+                {
+                    // C#: reader.ReadFieldHeader(ref header);
+                    // C#: reader.ConsumeEndBaseOrEndObject(ref header);
+                    return Block(
+                        ExpressionStatement(InvocationExpression(readerParam.Member("ReadFieldHeader"), refHeaderVar)),
+                        ExpressionStatement(InvocationExpression(readerParam.Member("ConsumeEndBaseOrEndObject"), refHeaderVar)));
+                }
+
                 var loopBody = new List<StatementSyntax>();
                 var codecs = serializerFields.OfType<ICodecDescription>()
                         .Concat(libraryTypes.StaticCodecs)
                         .ToList();
 
-                var orderedMembers = members.OrderBy(m => m.Member.FieldId).ToList();
-                var lastMember = orderedMembers.LastOrDefault();
+                // C#: reader.ReadFieldHeader(ref header);
+                // C#: if (header.IsEndBaseOrEndObject) break;
+                // C#: id += header.FieldIdDelta;
+                var readFieldHeader = ExpressionStatement(InvocationExpression(readerParam.Member("ReadFieldHeader"), ArgumentList(SingletonSeparatedList(Argument(null, Token(SyntaxKind.RefKeyword), headerVar)))));
+                var endObjectCheck = IfStatement(headerVar.Member("IsEndBaseOrEndObject"), BreakStatement());
+                var idUpdate = ExpressionStatement(AssignmentExpression(SyntaxKind.AddAssignmentExpression, idVar, headerVar.Member("FieldIdDelta")));
+                loopBody.Add(readFieldHeader);
+                loopBody.Add(endObjectCheck);
+                loopBody.Add(idUpdate);
 
-                // C#: id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, id);
-                {
-                    var readHeaderMethodName = orderedMembers.Count == 0 ? "ReadHeaderExpectingEndBaseOrEndObject" : "ReadHeader";
-                    var readFieldHeader =
-                        ExpressionStatement(
-                            AssignmentExpression(
-                                SyntaxKind.SimpleAssignmentExpression,
-                                IdentifierName(idVar.Identifier),
-                                InvocationExpression(
-                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("OrleansGeneratedCodeHelper"), IdentifierName(readHeaderMethodName)),
-                                    ArgumentList(SeparatedList(new[]
-                                    {
-                                        Argument(readerParam).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),
-                                        Argument(headerVar).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),
-                                        Argument(idVar)
-                                    })))));
-                    loopBody.Add(readFieldHeader);
-                }
-
-                foreach (var member in orderedMembers)
+                members.Sort((x, y) => x.Member.FieldId.CompareTo(y.Member.FieldId));
+                var contigousIds = members[members.Count - 1].Member.FieldId == members.Count - 1;
+                foreach (var member in members)
                 {
                     var description = member.Member;
 
@@ -610,7 +595,7 @@ namespace Orleans.CodeGenerator
 
                     ExpressionSyntax readValueExpression = InvocationExpression(
                         codecExpression.Member("ReadValue"),
-                        ArgumentList(SeparatedList(new[] { Argument(readerParam).WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)), Argument(headerVar) })));
+                        ArgumentList(SeparatedList(new[] { Argument(null, Token(SyntaxKind.RefKeyword), readerParam), Argument(headerVar) })));
                     if (!codec.UnderlyingType.Equals(member.TypeSyntax))
                     {
                         // If the member type type differs from the codec type (eg because the member is an array), cast the result.
@@ -619,41 +604,25 @@ namespace Orleans.CodeGenerator
 
                     var memberAssignment = ExpressionStatement(member.GetSetter(instanceParam, readValueExpression));
 
-                    var readHeaderMethodName = ReferenceEquals(member, lastMember) ? "ReadHeaderExpectingEndBaseOrEndObject" : "ReadHeader";
-                    var readFieldHeader =
-                        ExpressionStatement(
-                            AssignmentExpression(
-                                SyntaxKind.SimpleAssignmentExpression,
-                                IdentifierName(idVar.Identifier),
-                                InvocationExpression(
-                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("OrleansGeneratedCodeHelper"), IdentifierName(readHeaderMethodName)),
-                                    ArgumentList(SeparatedList(new[]
-                                    {
-                                        Argument(readerParam).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),
-                                        Argument(headerVar).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),
-                                        Argument(idVar)
-                                    })))));
+                    if (member == members[members.Count - 1])
+                        idUpdate = ExpressionStatement(PostfixUnaryExpression(SyntaxKind.PostIncrementExpression, idVar));
 
-                    var ifBody = Block(memberAssignment, readFieldHeader);
+                    var ifBody = Block(memberAssignment, readFieldHeader, endObjectCheck, idUpdate);
 
                     // C#: if (id == <fieldId>) { ... }
-                    var ifStatement = IfStatement(BinaryExpression(SyntaxKind.EqualsExpression, IdentifierName(idVar.Identifier), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)description.FieldId))),
+                    var ifStatement = IfStatement(BinaryExpression(SyntaxKind.EqualsExpression, idVar, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)description.FieldId))),
                         ifBody);
 
                     loopBody.Add(ifStatement);
                 }
 
-                // C#: if (id == -1) break;
-                loopBody.Add(IfStatement(BinaryExpression(SyntaxKind.EqualsExpression, IdentifierName(idVar.Identifier), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(-1))),
-                    BreakStatement()));
-
                 // Consume any unknown fields
                 // C#: reader.ConsumeUnknownField(header);
                 var consumeUnknown = ExpressionStatement(InvocationExpression(readerParam.Member("ConsumeUnknownField"),
-                    ArgumentList(SeparatedList(new[] { Argument(headerVar) }))));
+                    ArgumentList(SingletonSeparatedList(Argument(headerVar)))));
                 loopBody.Add(consumeUnknown);
 
-                return loopBody;
+                return WhileStatement(LiteralExpression(SyntaxKind.TrueLiteralExpression), Block(loopBody));
             }
         }
 
@@ -846,6 +815,9 @@ namespace Orleans.CodeGenerator
                             })))))
                     );
             }
+
+            // C#: field.EnsureWireTypeTagDelimited();
+            body.Add(ExpressionStatement(InvocationExpression(fieldParam.Member("EnsureWireTypeTagDelimited"))));
 
             ExpressionSyntax createValueExpression = type.UseActivator switch
             {

--- a/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
@@ -78,6 +78,7 @@ public sealed class IdSpanCodec : IFieldCodec<IdSpan>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe IdSpan ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
+        field.EnsureWireType(WireType.LengthPrefixed);
         ReferenceCodec.MarkValueField(reader.Session);
 
         var length = reader.ReadVarUInt32();

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -51,27 +51,28 @@ namespace Orleans.Runtime.Serialization
             Field header = default;
             int port = 0, generation = 0;
 
-            var id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, 0);
-            if (id != 0) throw new RequiredFieldMissingException("Serialized SiloAddress is missing its address field.");
+            reader.ReadFieldHeader(ref header);
+            if (!header.HasFieldId || header.FieldIdDelta != 0) throw new RequiredFieldMissingException("Serialized SiloAddress is missing its address field.");
             var address = IPAddressCodec.ReadValue(ref reader, header);
 
-            id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, id);
-            if (id == 1)
+            reader.ReadFieldHeader(ref header);
+            if (!field.IsEndBaseOrEndObject)
             {
-                port = UInt16Codec.ReadValue(ref reader, header);
-                id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, id);
-            }
+                var id = field.FieldIdDelta;
+                if (id == 1)
+                {
+                    port = UInt16Codec.ReadValue(ref reader, header);
+                    reader.ReadFieldHeader(ref header);
+                    if (field.HasFieldId) id += field.FieldIdDelta;
+                }
 
-            if (id == 2)
-            {
-                generation = Int32Codec.ReadValue(ref reader, header);
-                id = OrleansGeneratedCodeHelper.ReadHeaderExpectingEndBaseOrEndObject(ref reader, ref header, id);
-            }
+                if (id == 2)
+                {
+                    generation = Int32Codec.ReadValue(ref reader, header);
+                    reader.ReadFieldHeader(ref header);
+                }
 
-            while (id >= 0)
-            {
-                reader.ConsumeUnknownField(header);
-                id = OrleansGeneratedCodeHelper.ReadHeaderExpectingEndBaseOrEndObject(ref reader, ref header, id);
+                reader.ConsumeEndBaseOrEndObject(ref field);
             }
 
             return SiloAddress.New(address, port, generation);

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -56,14 +56,14 @@ namespace Orleans.Runtime.Serialization
             var address = IPAddressCodec.ReadValue(ref reader, header);
 
             reader.ReadFieldHeader(ref header);
-            if (!field.IsEndBaseOrEndObject)
+            if (!header.IsEndBaseOrEndObject)
             {
-                var id = field.FieldIdDelta;
+                var id = header.FieldIdDelta;
                 if (id == 1)
                 {
                     port = UInt16Codec.ReadValue(ref reader, header);
                     reader.ReadFieldHeader(ref header);
-                    if (field.HasFieldId) id += field.FieldIdDelta;
+                    if (header.HasFieldId) id += header.FieldIdDelta;
                 }
 
                 if (id == 2)
@@ -72,7 +72,7 @@ namespace Orleans.Runtime.Serialization
                     reader.ReadFieldHeader(ref header);
                 }
 
-                reader.ConsumeEndBaseOrEndObject(ref field);
+                reader.ConsumeEndBaseOrEndObject(ref header);
             }
 
             return SiloAddress.New(address, port, generation);

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -46,9 +46,7 @@ namespace Orleans.Runtime.Serialization
                 return ReferenceCodec.ReadReference<SiloAddress, TReaderInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-                ThrowUnsupportedWireTypeException(field);
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             Field header = default;
             int port = 0, generation = 0;
@@ -78,8 +76,5 @@ namespace Orleans.Runtime.Serialization
 
             return SiloAddress.New(address, port, generation);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field)
-            => throw new UnsupportedWireTypeException($"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(SiloAddress)} fields. {field}");
     }
 }

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -438,7 +438,7 @@ namespace Orleans.Runtime.Messaging
 
             public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
             {
-                field.EnsureWireType(WireType.TagDelimited);
+                field.EnsureWireTypeTagDelimited();
                 reader.ReadFieldHeader(ref field);
 
                 var holder = ResponsePool.Get<T>();

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -52,8 +52,7 @@ namespace Orleans.Serialization
             if (field.WireType == WireType.Reference)
                 return ReferenceCodec.ReadReference<FSharpOption<T>, TInput>(ref reader, field);
 
-            if (field.WireType != WireType.TagDelimited)
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var result = FSharpOption<T>.None;
@@ -155,11 +154,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         FSharpValueOption<T> IFieldCodec<FSharpValueOption<T>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             var result = FSharpValueOption<T>.None;
             uint fieldId = 0;
@@ -185,9 +180,6 @@ namespace Orleans.Serialization
 
             return result;
         }
-
-        internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported");
     }
 
     /// <summary>
@@ -271,10 +263,7 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference<FSharpChoice<T1, T2>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             FSharpChoice<T1, T2> result = default;
@@ -380,10 +369,7 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference<FSharpChoice<T1, T2, T3>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             FSharpChoice<T1, T2, T3> result = default;
@@ -501,10 +487,7 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference<FSharpChoice<T1, T2, T3, T4>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             FSharpChoice<T1, T2, T3, T4> result = default;
@@ -632,10 +615,7 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference<FSharpChoice<T1, T2, T3, T4, T5>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             FSharpChoice<T1, T2, T3, T4, T5> result = default;
@@ -773,10 +753,7 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference<FSharpChoice<T1, T2, T3, T4, T5, T6>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             FSharpChoice<T1, T2, T3, T4, T5, T6> result = default;
@@ -1112,11 +1089,7 @@ namespace Orleans.Serialization
 
         FSharpResult<T, TError> IFieldCodec<FSharpResult<T, TError>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                FSharpValueOptionCodec<int>.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             FSharpResult<T, TError> result = default;
             uint fieldId = 0;

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -76,10 +76,7 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
             return ReferenceCodec.ReadReference(ref reader, field, null);
         }
 
-        if (field.WireType != WireType.TagDelimited)
-        {
-            ThrowUnsupportedWireTypeException(field);
-        }
+        field.EnsureWireTypeTagDelimited();
 
         var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
         object result = null;
@@ -191,9 +188,6 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
 
         return false;
     }
-
-    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for JSON fields. {field}");
 
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -71,9 +71,9 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
 
     object IFieldCodec.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
-        if (field.WireType == WireType.Reference)
+        if (field.IsReference)
         {
-            return ReferenceCodec.ReadReference(ref reader, field, null);
+            return ReferenceCodec.ReadReference(ref reader, field.FieldType);
         }
 
         field.EnsureWireTypeTagDelimited();

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -90,9 +90,9 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
     /// <inheritdoc/>
     object IFieldCodec.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
-        if (field.WireType == WireType.Reference)
+        if (field.IsReference)
         {
-            return ReferenceCodec.ReadReference(ref reader, field, null);
+            return ReferenceCodec.ReadReference(ref reader, field.FieldType);
         }
 
         field.EnsureWireTypeTagDelimited();

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -95,10 +95,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
             return ReferenceCodec.ReadReference(ref reader, field, null);
         }
 
-        if (field.WireType != WireType.TagDelimited)
-        {
-            ThrowUnsupportedWireTypeException(field);
-        }
+        field.EnsureWireTypeTagDelimited();
 
         var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
         object result = null;
@@ -225,9 +222,6 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
 
     /// <inheritdoc/>
     bool? ITypeFilter.IsTypeAllowed(Type type) => (((IGeneralizedCopier)this).IsSupportedType(type) || ((IGeneralizedCodec)this).IsSupportedType(type)) ? true : null;
-
-    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for JSON fields. {field}");
 
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
 }

--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -352,6 +352,7 @@ namespace Orleans.Serialization.Buffers
             int bufferPos = _bufferPos;
             if ((uint)bufferPos < (uint)_currentSpan.Length)
             {
+                // https://github.com/dotnet/runtime/issues/72004
                 Unsafe.Add(ref MemoryMarshal.GetReference(_currentSpan), (uint)bufferPos) = value;
                 _bufferPos = bufferPos + 1;
             }

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -59,10 +59,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             T[] result = null;
@@ -118,9 +115,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -221,10 +215,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             T[] result = null;
@@ -274,9 +265,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -389,10 +377,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             T[] result = null;
@@ -442,9 +427,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
@@ -560,10 +542,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             T[] result = null;
@@ -613,9 +592,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");

--- a/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
+++ b/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
@@ -44,15 +44,8 @@ namespace Orleans.Serialization.Codecs
         public static BitVector32 ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            if (field.WireType != WireType.Fixed32)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.Fixed32);
             return new BitVector32(reader.ReadInt32());
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {nameof(BitVector32)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
@@ -34,11 +34,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<byte[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.LengthPrefixed)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.LengthPrefixed);
             var length = reader.ReadVarUInt32();
             var result = reader.ReadBytes(length);
             ReferenceCodec.RecordObject(reader.Session, result);
@@ -67,9 +63,6 @@ namespace Orleans.Serialization.Codecs
             writer.WriteVarUInt32((uint)value.Length);
             writer.Write(value);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for byte[] fields. {field}");
     }
 
     /// <summary>
@@ -129,11 +122,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<byte[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.LengthPrefixed)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.LengthPrefixed);
             var length = reader.ReadVarUInt32();
             var result = reader.ReadBytes(length);
             ReferenceCodec.RecordObject(reader.Session, result);
@@ -162,9 +151,6 @@ namespace Orleans.Serialization.Codecs
             writer.WriteVarUInt32((uint)value.Length);
             writer.Write(value.Span);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for ReadOnlyMemory<byte> fields. {field}");
     }
 
     /// <summary>
@@ -244,11 +230,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<byte[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.LengthPrefixed)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.LengthPrefixed);
             var length = reader.ReadVarUInt32();
             var result = reader.ReadBytes(length);
             ReferenceCodec.RecordObject(reader.Session, result);
@@ -277,9 +259,6 @@ namespace Orleans.Serialization.Codecs
             writer.WriteVarUInt32((uint)value.Length);
             writer.Write(value.Span);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for ReadOnlyMemory<byte> fields. {field}");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
@@ -21,10 +21,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<CompareInfo, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             uint fieldId = 0;
@@ -66,8 +63,5 @@ namespace Orleans.Serialization.Codecs
             StringCodec.WriteField(ref writer, 0, StringCodec.CodecFieldType, value.Name);
             writer.WriteEndObject();
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(CompareInfo)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/ConsumeFieldExtension.cs
+++ b/src/Orleans.Serialization/Codecs/ConsumeFieldExtension.cs
@@ -14,7 +14,15 @@ namespace Orleans.Serialization.Codecs
         /// <typeparam name="TInput">The reader input type.</typeparam>
         /// <param name="reader">The reader.</param>
         /// <param name="field">The field.</param>
-        public static void ConsumeUnknownField<TInput>(this ref Reader<TInput> reader, Field field)
+        public static void ConsumeUnknownField<TInput>(this ref Reader<TInput> reader, Field field) => ConsumeUnknownField(ref reader, ref field);
+
+        /// <summary>
+        /// Consumes an unknown field.
+        /// </summary>
+        /// <typeparam name="TInput">The reader input type.</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <param name="field">The field.</param>
+        public static void ConsumeUnknownField<TInput>(this ref Reader<TInput> reader, scoped ref Field field)
         {
             // References cannot themselves be referenced.
             if (field.WireType == WireType.Reference)

--- a/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
@@ -34,14 +34,7 @@ public sealed class DateOnlyCodec : IFieldCodec<DateOnly>
     public static DateOnly ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
         ReferenceCodec.MarkValueField(reader.Session);
-        if (field.WireType != WireType.Fixed32)
-        {
-            ThrowUnsupportedWireTypeException(field);
-        }
-
+        field.EnsureWireType(WireType.Fixed32);
         return DateOnly.FromDayNumber(reader.ReadInt32());
     }
-
-    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {nameof(DateOnly)} fields. {field}");
 }

--- a/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
@@ -34,15 +34,8 @@ namespace Orleans.Serialization.Codecs
         public static DateTime ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            if (field.WireType != WireType.Fixed64)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.Fixed64);
             return DateTime.FromBinary(reader.ReadInt64());
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(DateTime)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeOffsetCodec.cs
@@ -32,10 +32,7 @@ namespace Orleans.Serialization.Codecs
         public static DateTimeOffset ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             uint fieldId = 0;
             TimeSpan offset = default;
@@ -65,8 +62,5 @@ namespace Orleans.Serialization.Codecs
 
             return new DateTimeOffset(dateTime, offset);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for {nameof(DateTimeOffset)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -78,10 +78,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Dictionary<TKey, TValue>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             TKey key = default;
@@ -143,9 +140,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
+++ b/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
@@ -44,18 +44,11 @@ namespace Orleans.Serialization.Codecs
         public static T ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            if (field.WireType != WireType.Fixed32)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.Fixed32);
             var intValue = reader.ReadInt32();
             var result = Unsafe.As<int, T>(ref intValue);
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.Fixed32} is supported for {typeof(T).GetType()} fields. {field}");
 
         [StructLayout(LayoutKind.Sequential)]
         private struct HolderStruct

--- a/src/Orleans.Serialization/Codecs/GeneralizedReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GeneralizedReferenceTypeSurrogateCodec.cs
@@ -33,6 +33,8 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
             }
 
+            field.EnsureWireTypeTagDelimited();
+
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             TSurrogate surrogate = default;
             _surrogateSerializer.Deserialize(ref reader, ref surrogate);

--- a/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
@@ -28,6 +28,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             TSurrogate surrogate = default;
             _surrogateSerializer.Deserialize(ref reader, ref surrogate);

--- a/src/Orleans.Serialization/Codecs/GuidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GuidCodec.cs
@@ -59,10 +59,7 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(reader.Session);
 
-            if (field.WireType != WireType.LengthPrefixed)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireType(WireType.LengthPrefixed);
 
             uint length = reader.ReadVarUInt32();
             if (length != Width)
@@ -120,8 +117,5 @@ namespace Orleans.Serialization.Codecs
             return new Guid(reader.ReadBytes(Width));
 #endif
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for {nameof(Guid)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -69,10 +69,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<HashSet<T>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             HashSet<T> result = null;
@@ -123,9 +120,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -36,9 +36,7 @@ namespace Orleans.Serialization.Codecs
                 return (IPAddress)ReferenceCodec.ReadReference(ref reader, field, CodecFieldType);
             }
 
-            if (field.WireType != WireType.LengthPrefixed)
-                ThrowUnsupportedWireTypeException(field);
-
+            field.EnsureWireType(WireType.LengthPrefixed);
             var result = ReadRaw(ref reader);
             ReferenceCodec.RecordObject(reader.Session, result);
             return result;
@@ -105,9 +103,6 @@ namespace Orleans.Serialization.Codecs
         }
 
         private static void ThrowNotSupported() => throw new NotSupportedException();
-
-        private static void ThrowUnsupportedWireTypeException(Field field)
-            => throw new UnsupportedWireTypeException($"Only a {nameof(WireType)} value of {nameof(WireType.LengthPrefixed)} is supported for {nameof(IPAddress)} fields. {field}");
 
     }
 

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -31,9 +31,9 @@ namespace Orleans.Serialization.Codecs
         /// <returns>The value.</returns>
         public static IPAddress ReadValue<TInput>(ref Buffers.Reader<TInput> reader, Field field)
         {
-            if (field.WireType == WireType.Reference)
+            if (field.IsReference)
             {
-                return (IPAddress)ReferenceCodec.ReadReference(ref reader, field, CodecFieldType);
+                return ReferenceCodec.ReadReference<IPAddress, TInput>(ref reader, field);
             }
 
             field.EnsureWireType(WireType.LengthPrefixed);

--- a/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
@@ -34,9 +34,9 @@ namespace Orleans.Serialization.Codecs
         /// <returns>The value.</returns>
         public static IPEndPoint ReadValue<TInput>(ref Buffers.Reader<TInput> reader, Field field)
         {
-            if (field.WireType == WireType.Reference)
+            if (field.IsReference)
             {
-                return (IPEndPoint)ReferenceCodec.ReadReference(ref reader, field, CodecFieldType);
+                return ReferenceCodec.ReadReference<IPEndPoint, TInput>(ref reader, field);
             }
 
             field.EnsureWireTypeTagDelimited();

--- a/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
@@ -56,7 +56,7 @@ namespace Orleans.Serialization.Codecs
                 reader.ReadFieldHeader(ref header);
             }
 
-            reader.ConsumeEndBaseOrEndObject(ref field);
+            reader.ConsumeEndBaseOrEndObject(ref header);
 
             var result = new IPEndPoint(address, port);
             ReferenceCodec.RecordObject(reader.Session, result, referencePlaceholder);

--- a/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPEndPointCodec.cs
@@ -39,26 +39,24 @@ namespace Orleans.Serialization.Codecs
                 return (IPEndPoint)ReferenceCodec.ReadReference(ref reader, field, CodecFieldType);
             }
 
+            field.EnsureWireTypeTagDelimited();
+
             var referencePlaceholder = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             Field header = default;
             var port = 0;
 
-            var id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, 0);
-            if (id != 0) throw new RequiredFieldMissingException("Serialized IPEndPoint is missing its address field.");
+            reader.ReadFieldHeader(ref header);
+            if (!header.HasFieldId || header.FieldIdDelta != 0) throw new RequiredFieldMissingException("Serialized IPEndPoint is missing its address field.");
             var address = IPAddressCodec.ReadValue(ref reader, header);
 
-            id = OrleansGeneratedCodeHelper.ReadHeader(ref reader, ref header, id);
-            if (id == 1)
+            reader.ReadFieldHeader(ref header);
+            if (header.HasFieldId && header.FieldIdDelta == 1)
             {
                 port = UInt16Codec.ReadValue(ref reader, header);
-                id = OrleansGeneratedCodeHelper.ReadHeaderExpectingEndBaseOrEndObject(ref reader, ref header, id);
+                reader.ReadFieldHeader(ref header);
             }
 
-            while (id >= 0)
-            {
-                reader.ConsumeUnknownField(header);
-                id = OrleansGeneratedCodeHelper.ReadHeaderExpectingEndBaseOrEndObject(ref reader, ref header, id);
-            }
+            reader.ConsumeEndBaseOrEndObject(ref field);
 
             var result = new IPEndPoint(address, port);
             ReferenceCodec.RecordObject(reader.Session, result, referencePlaceholder);

--- a/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
+++ b/src/Orleans.Serialization/Codecs/KeyValuePairCodec.cs
@@ -50,11 +50,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public KeyValuePair<TKey, TValue> ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             var key = default(TKey);
             var value = default(TValue);
@@ -84,9 +80,6 @@ namespace Orleans.Serialization.Codecs
 
             return new KeyValuePair<TKey, TValue>(key, value);
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported. {field}");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -62,10 +62,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<List<T>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             List<T> result = null;
@@ -113,9 +110,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -91,10 +91,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             Array result = null;
@@ -158,9 +155,6 @@ namespace Orleans.Serialization.Codecs
 
         private static object ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static T ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }

--- a/src/Orleans.Serialization/Codecs/ObjectCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ObjectCodec.cs
@@ -27,9 +27,9 @@ namespace Orleans.Serialization.Codecs
         /// <returns>The value.</returns>
         public static object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType == WireType.Reference)
+            if (field.IsReference)
             {
-                return ReferenceCodec.ReadReference(ref reader, field, ObjectType);
+                return ReferenceCodec.ReadReference(ref reader, field.FieldType ?? ObjectType);
             }
 
             if (field.FieldType is null || field.FieldType == ObjectType)

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -59,10 +59,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Queue<T>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             Queue<T> result = null;
@@ -105,9 +102,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
     }

--- a/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
@@ -70,7 +70,7 @@ namespace Orleans.Serialization.Codecs
             }
             else
             {
-                OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value);
+                writer.SerializeUnexpectedType(fieldIdDelta, expectedType, value);
             }
         }
 

--- a/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceTypeSurrogateCodec.cs
@@ -34,10 +34,11 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
             }
 
-            var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var fieldType = field.FieldType;
             if (fieldType is null || fieldType == CodecFieldType)
             {
+                field.EnsureWireTypeTagDelimited();
+                var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
                 TSurrogate surrogate = default;
                 _surrogateSerializer.Deserialize(ref reader, ref surrogate);
                 var result = ConvertFromSurrogate(ref surrogate);

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -62,10 +62,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Stack<T>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             Stack<T> result = null;
@@ -113,9 +110,6 @@ namespace Orleans.Serialization.Codecs
 
             return result;
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for string fields. {field}");
 
         private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");

--- a/src/Orleans.Serialization/Codecs/StringCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StringCodec.cs
@@ -37,11 +37,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<string, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.LengthPrefixed)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.LengthPrefixed);
             var length = reader.ReadVarUInt32();
 
             string result;
@@ -111,8 +107,5 @@ namespace Orleans.Serialization.Codecs
 #endif
 
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for string fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.WireProtocol;
@@ -34,14 +34,7 @@ public sealed class TimeOnlyCodec : IFieldCodec<TimeOnly>
     public static TimeOnly ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
         ReferenceCodec.MarkValueField(reader.Session);
-        if (field.WireType != WireType.Fixed64)
-        {
-            ThrowUnsupportedWireTypeException(field);
-        }
-
+        field.EnsureWireType(WireType.Fixed64);
         return new TimeOnly(reader.ReadInt64());
     }
-
-    private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-        $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(TimeOnly)} fields. {field}");
 }

--- a/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
@@ -48,15 +48,8 @@ namespace Orleans.Serialization.Codecs
         public static TimeSpan ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            if (field.WireType != WireType.Fixed64)
-            {
-                ThrowUnsupportedWireTypeException(field);
-            }
-
+            field.EnsureWireType(WireType.Fixed64);
             return TimeSpan.FromTicks(reader.ReadInt64());
         }
-
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.Fixed64} is supported for {nameof(TimeSpan)} fields. {field}");
     }
 }

--- a/src/Orleans.Serialization/Codecs/TupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TupleCodec.cs
@@ -50,10 +50,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T);
@@ -172,10 +169,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -315,10 +309,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -478,10 +469,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3, T4>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -661,10 +649,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3, T4, T5>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -861,10 +846,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3, T4, T5, T6>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -1079,10 +1061,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3, T4, T5, T6, T7>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);
@@ -1313,10 +1292,7 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>, TInput>(ref reader, field);
             }
 
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             var item1 = default(T1);

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -76,6 +76,8 @@ namespace Orleans.Serialization.Codecs
                 return ReferenceCodec.ReadReference<Type, TInput>(ref reader, field);
             }
 
+            field.EnsureWireTypeTagDelimited();
+
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             uint fieldId = 0;
             var schemaType = default(SchemaType);

--- a/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
@@ -24,19 +24,13 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public ValueTuple ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.VarInt)
-            {
-                ThrowUnsupportedWireTypeException();
-            }
+            field.EnsureWireType(WireType.VarInt);
 
             ReferenceCodec.MarkValueField(reader.Session);
             _ = reader.ReadVarUInt64();
 
             return default;
         }
-
-        internal static void ThrowUnsupportedWireTypeException() => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {nameof(WireType.TagDelimited)} is supported for tuple fields.");
     }
 
     /// <summary>
@@ -77,11 +71,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public ValueTuple<T> ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             var item1 = default(T);
             uint fieldId = 0;
@@ -180,11 +170,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public (T1, T2) ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2) res = default;
             uint fieldId = 0;
@@ -299,11 +285,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public (T1, T2, T3) ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2, T3) res = default;
             uint fieldId = 0;
@@ -434,11 +416,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public (T1, T2, T3, T4) ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2, T3, T4) res = default;
             uint fieldId = 0;
@@ -582,11 +560,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public (T1, T2, T3, T4, T5) ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2, T3, T4, T5) res = default;
             uint fieldId = 0;
@@ -745,11 +719,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public (T1, T2, T3, T4, T5, T6) ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2, T3, T4, T5, T6) res = default;
             uint fieldId = 0;
@@ -924,11 +894,7 @@ namespace Orleans.Serialization.Codecs
             ref Reader<TInput> reader,
             Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             (T1, T2, T3, T4, T5, T6, T7) res = default;
             uint fieldId = 0;
@@ -1116,11 +1082,7 @@ namespace Orleans.Serialization.Codecs
         public ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> ReadValue<TInput>(ref Reader<TInput> reader,
             Field field)
         {
-            if (field.WireType != WireType.TagDelimited)
-            {
-                ValueTupleCodec.ThrowUnsupportedWireTypeException();
-            }
-
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> res = default;
             uint fieldId = 0;

--- a/src/Orleans.Serialization/Codecs/VoidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/VoidCodec.cs
@@ -23,15 +23,9 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType != WireType.Reference)
-            {
-                ThrowInvalidWireType(field);
-            }
-
+            field.EnsureWireType(WireType.Reference);
             return ReferenceCodec.ReadReference(ref reader, field, null);
         }
-
-        private static void ThrowInvalidWireType(Field field) => throw new UnsupportedWireTypeException($"Expected a reference, but encountered wire type of '{field.WireType}'.");
 
         private static void ThrowNotNullException(object value) => throw new InvalidOperationException(
             $"Expected a value of null, but encountered a value of '{value}'.");

--- a/src/Orleans.Serialization/Codecs/VoidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/VoidCodec.cs
@@ -24,7 +24,7 @@ namespace Orleans.Serialization.Codecs
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             field.EnsureWireType(WireType.Reference);
-            return ReferenceCodec.ReadReference(ref reader, field, null);
+            return ReferenceCodec.ReadReference(ref reader, field.FieldType);
         }
 
         private static void ThrowNotNullException(object value) => throw new InvalidOperationException(

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -57,6 +57,7 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc />
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             uint type = default;
             CompareOptions options = default;
@@ -234,10 +235,6 @@ namespace Orleans.Serialization.Codecs
             return false;
         }
 #endif
-
-        [DoesNotReturn]
-        private static void ThrowUnsupportedWireTypeException(Field field) => throw new UnsupportedWireTypeException(
-            $"Only a {nameof(WireType)} value of {WireType.LengthPrefixed} is supported for OrdinalComparer fields. {field}");
 
         [DoesNotReturn]
         private static void ThrowNotSupported(Field field, uint value) => throw new NotSupportedException($"Values of type {field.FieldType} are not supported. Value: {value}");

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -151,43 +151,36 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
             => throw new ArgumentOutOfRangeException(message: $"The argument index value {index} must be between 0 and {maxArgs}", null);
 
         /// <summary>
-        /// Reads a field header.
+        /// Expects empty content (a single field header of either <see cref="ExtendedWireType.EndBaseFields"/> or <see cref="ExtendedWireType.EndTagDelimited"/>),
+        /// but will consume any unexpected fields also.
         /// </summary>
-        /// <typeparam name="TInput">The reader input type.</typeparam>
-        /// <param name="reader">The reader.</param>
-        /// <param name="header">The header.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>The field id, if a new field header was written, otherwise <c>-1</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadHeader<TInput>(ref Reader<TInput> reader, scoped ref Field header, int id)
+        public static void ConsumeEndBaseOrEndObject<TInput>(this ref Reader<TInput> reader)
         {
-            reader.ReadFieldHeader(ref header);
-            if (header.IsEndBaseOrEndObject)
-            {
-                return -1;
-            }
-
-            return (int)(id + header.FieldIdDelta);
+            Unsafe.SkipInit(out Field field);
+            reader.ReadFieldHeader(ref field);
+            reader.ConsumeEndBaseOrEndObject(ref field);
         }
 
         /// <summary>
-        /// Reads the header expecting an end base tag or end object tag.
+        /// Expects empty content (a single field header of either <see cref="ExtendedWireType.EndBaseFields"/> or <see cref="ExtendedWireType.EndTagDelimited"/>),
+        /// but will consume any unexpected fields also.
         /// </summary>
-        /// <typeparam name="TInput">The reader input type.</typeparam>
-        /// <param name="reader">The reader.</param>
-        /// <param name="header">The header.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>The field id, if a new field header was written, otherwise <c>-1</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadHeaderExpectingEndBaseOrEndObject<TInput>(ref Reader<TInput> reader, scoped ref Field header, int id)
+        public static void ConsumeEndBaseOrEndObject<TInput>(this ref Reader<TInput> reader, scoped ref Field field)
         {
-            reader.ReadFieldHeader(ref header);
-            if (header.IsEndBaseOrEndObject)
-            {
-                return -1;
-            }
+            if (!field.IsEndBaseOrEndObject)
+                ConsumeUnexpectedContent(ref reader, ref field);
+        }
 
-            return (int)(id + header.FieldIdDelta);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ConsumeUnexpectedContent<TInput>(this ref Reader<TInput> reader, scoped ref Field field)
+        {
+            do
+            {
+                reader.ConsumeUnknownField(field);
+                reader.ReadFieldHeader(ref field);
+            } while (!field.IsEndBaseOrEndObject);
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -178,7 +178,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         {
             do
             {
-                reader.ConsumeUnknownField(field);
+                reader.ConsumeUnknownField(ref field);
                 reader.ReadFieldHeader(ref field);
             } while (!field.IsEndBaseOrEndObject);
         }

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -192,7 +192,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void SerializeUnexpectedType<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
+        public static void SerializeUnexpectedType<TBufferWriter>(this ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
         {
             var specificSerializer = writer.Session.CodecProvider.GetCodec(value.GetType());
             specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
@@ -207,7 +207,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// <param name="field">The field.</param>
         /// <returns>The value.</returns>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static TField DeserializeUnexpectedType<TInput, TField>(ref Reader<TInput> reader, Field field) where TField : class
+        public static TField DeserializeUnexpectedType<TInput, TField>(this ref Reader<TInput> reader, scoped ref Field field) where TField : class
         {
             var specificSerializer = reader.Session.CodecProvider.GetCodec(field.FieldType);
             return (TField)specificSerializer.ReadValue(ref reader, field);

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -83,6 +83,8 @@ namespace Orleans.Serialization
                 return ReferenceCodec.ReadReference(ref reader, field, null);
             }
 
+            field.EnsureWireTypeTagDelimited();
+
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             Type type;
             var header = reader.ReadFieldHeader();

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -78,9 +78,9 @@ namespace Orleans.Serialization
         [SecurityCritical]
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType == WireType.Reference)
+            if (field.IsReference)
             {
-                return ReferenceCodec.ReadReference(ref reader, field, null);
+                return ReferenceCodec.ReadReference(ref reader, field.FieldType);
             }
 
             field.EnsureWireTypeTagDelimited();

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -315,6 +315,7 @@ namespace Orleans.Serialization
                                 
         public Exception DeserializeException<TInput>(ref Reader<TInput> reader, Field field)
         {
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
 
             uint fieldId = 0;

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -299,7 +299,7 @@ namespace Orleans.Serialization
                 return DeserializeException(ref reader, field);
             }
 
-            return OrleansGeneratedCodeHelper.DeserializeUnexpectedType<TInput, Exception>(ref reader, field);
+            return reader.DeserializeUnexpectedType<TInput, Exception>(ref field);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -229,7 +229,7 @@ namespace Orleans.Serialization
             }
             else
             {
-                OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value);
+                writer.SerializeUnexpectedType(fieldIdDelta, expectedType, value);
             }
         }
 

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationEntryCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationEntryCodec.cs
@@ -32,6 +32,7 @@ namespace Orleans.Serialization
         [SecurityCritical]
         public SerializationEntrySurrogate ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
+            field.EnsureWireTypeTagDelimited();
             ReferenceCodec.MarkValueField(reader.Session);
             var result = new SerializationEntrySurrogate();
             uint fieldId = 0;

--- a/src/Orleans.Serialization/Serializers/AbstractTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/AbstractTypeSerializer.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Codecs;
+using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Serializers
@@ -21,18 +21,7 @@ namespace Orleans.Serialization.Serializers
 
         public virtual void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, TField instance) where TBufferWriter : IBufferWriter<byte> { }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void Deserialize<TReaderInput>(ref Reader<TReaderInput> reader, TField instance)
-        {
-            while (true)
-            {
-                var header = reader.ReadFieldHeader();
-                if (header.IsEndBaseOrEndObject)
-                    break;
-
-                reader.ConsumeUnknownField(header);
-            }
-        }
+        public virtual void Deserialize<TReaderInput>(ref Reader<TReaderInput> reader, TField instance) => reader.ConsumeEndBaseOrEndObject();
     }
 
     // without the class type constraint

--- a/src/Orleans.Serialization/Serializers/AbstractTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/AbstractTypeSerializer.cs
@@ -55,8 +55,8 @@ namespace Orleans.Serialization.Serializers
 
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference(ref reader, field, _fieldType);
+            if (field.IsReference)
+                return ReferenceCodec.ReadReference(ref reader, field.FieldType ?? _fieldType);
 
             var fieldType = field.FieldType;
             if (fieldType is null)

--- a/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
@@ -67,7 +67,7 @@ namespace Orleans.Serialization.Serializers
                 return result;
             }
 
-            return OrleansGeneratedCodeHelper.DeserializeUnexpectedType<TInput, TField>(ref reader, field);
+            return reader.DeserializeUnexpectedType<TInput, TField>(ref field);
         }
 
         public TField ReadValueSealed<TInput>(ref Reader<TInput> reader, Field field)

--- a/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
@@ -46,7 +46,7 @@ namespace Orleans.Serialization.Serializers
             }
             else
             {
-                OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value);
+                writer.SerializeUnexpectedType(fieldIdDelta, expectedType, value);
             }
         }
 

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -100,7 +100,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
         }
         else
         {
-            OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value);
+            writer.SerializeUnexpectedType(fieldIdDelta, expectedType, value);
         }
     }
 

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -80,7 +80,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
             return result;
         }
 
-        return OrleansGeneratedCodeHelper.DeserializeUnexpectedType<TInput, TField>(ref reader, field);
+        return reader.DeserializeUnexpectedType<TInput, TField>(ref field);
     }
 
     /// <inheritdoc/>

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -1,12 +1,11 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
+using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.WireProtocol;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization.Serializers;
 
@@ -70,10 +69,10 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
             return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
         }
 
-        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
-        var fieldType = field.FieldType;
-        if (fieldType is null || fieldType == _fieldType)
+        if (field.FieldType is null || field.FieldType == _fieldType)
         {
+            field.EnsureWireTypeTagDelimited();
+            var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
             TSurrogate surrogate = default;
             _surrogateSerializer.Deserialize(ref reader, ref surrogate);
             var result = _converter.ConvertFromSurrogate(in surrogate);
@@ -81,12 +80,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
             return result;
         }
 
-        // The type is a descendant, not an exact match, so get the specific serializer for it.
-        var specificSerializer = reader.Session.CodecProvider.GetCodec(fieldType);
-        if (specificSerializer == null)
-            ThrowSerializerNotFoundException(fieldType);
-
-        return (TField)specificSerializer.ReadValue(ref reader, field);
+        return OrleansGeneratedCodeHelper.DeserializeUnexpectedType<TInput, TField>(ref reader, field);
     }
 
     /// <inheritdoc/>
@@ -97,36 +91,16 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
             return;
         }
 
-        var fieldType = value.GetType();
-        if (fieldType == _fieldType)
+        if (value.GetType() == typeof(TField))
         {
-            writer.WriteStartObject(fieldIdDelta, expectedType, fieldType);
+            writer.WriteStartObject(fieldIdDelta, expectedType, _fieldType);
             var surrogate = _converter.ConvertToSurrogate(in value);
             _surrogateSerializer.Serialize(ref writer, ref surrogate);
             writer.WriteEndObject();
         }
         else
         {
-            SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value, fieldType);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void SerializeUnexpectedType<TBufferWriter>(
-        ref Writer<TBufferWriter> writer,
-        uint fieldIdDelta,
-        Type expectedType,
-        TField value,
-        Type fieldType) where TBufferWriter : IBufferWriter<byte>
-    {
-        var specificSerializer = writer.Session.CodecProvider.GetCodec(fieldType);
-        if (specificSerializer != null)
-        {
-            specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
-        }
-        else
-        {
-            ThrowSerializerNotFoundException(fieldType);
+            OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, fieldIdDelta, expectedType, value);
         }
     }
 
@@ -158,9 +132,6 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
         var copy = _surrogateCopier.DeepCopy(surrogate, context);
         _populator.Populate(copy, output);
     }
-
-    [DoesNotReturn]
-    private static void ThrowSerializerNotFoundException(Type type) => throw new KeyNotFoundException($"Could not find a serializer of type {type}.");
 
     [DoesNotReturn]
     private static void ThrowNoPopulatorException() => throw new NotSupportedException($"Surrogate type {typeof(TConverter)} does not implement {typeof(IPopulator<TField, TSurrogate>)} and therefore cannot be used in an inheritance hierarchy.");

--- a/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/ValueTypeSurrogateCodec.cs
@@ -62,6 +62,7 @@ public sealed class ValueTypeSurrogateCodec<TField, TSurrogate, TConverter>
     /// <inheritdoc/>
     public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
+        field.EnsureWireTypeTagDelimited();
         ReferenceCodec.MarkValueField(reader.Session);
         TField result = default;
         Deserialize(ref reader, ref result);

--- a/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
+++ b/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
@@ -106,7 +106,7 @@ namespace Orleans.Serialization.Utilities
             res.Append(indentString);
 
             // References cannot themselves be referenced.
-            if (field.IsReference)
+            if (field.WireType == WireType.Reference)
             {
                 ReferenceCodec.MarkValueField(reader.Session);
                 var refId = reader.ReadVarUInt32();

--- a/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
+++ b/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
@@ -106,14 +106,21 @@ namespace Orleans.Serialization.Utilities
             res.Append(indentString);
 
             // References cannot themselves be referenced.
-            if (field.WireType == WireType.Reference)
+            if (field.IsReference)
             {
                 ReferenceCodec.MarkValueField(reader.Session);
                 var refId = reader.ReadVarUInt32();
-                var exists = reader.Session.ReferencedObjects.TryGetReferencedObject(refId, out var refd);
                 res.Append('[');
                 FormatFieldHeader(res, reader.Session, field, id, typeName);
-                res.Append($" Reference: {refId} ({(exists ? $"{refd}" : "unknown")})");
+                if (refId == 0)
+                {
+                    res.Append($" Reference: 0");
+                }
+                else
+                {
+                    var refd = reader.Session.ReferencedObjects.TryGetReferencedObject(refId);
+                    res.Append($" Reference: {refId} ({refd}{(refd is null ? "unknown" : null)})");
+                }
                 res.Append(']');
                 return;
             }

--- a/src/Orleans.Serialization/WireProtocol/Field.cs
+++ b/src/Orleans.Serialization/WireProtocol/Field.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks.Dataflow;
 
 namespace Orleans.Serialization.WireProtocol
 {

--- a/src/Orleans.Serialization/WireProtocol/Field.cs
+++ b/src/Orleans.Serialization/WireProtocol/Field.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Dataflow;
 
 namespace Orleans.Serialization.WireProtocol
 {
@@ -221,6 +222,22 @@ namespace Orleans.Serialization.WireProtocol
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Tag.HasExtendedWireType/* && Tag.ExtendedWireType <= ExtendedWireType.EndBaseFields*/;
+        }
+
+        /// <summary>
+        /// Ensures that the wire type is <see cref="WireType.TagDelimited"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void EnsureWireTypeTagDelimited()
+        {
+            if (Tag.WireType != WireType.TagDelimited)
+                UnsupportedWireType(Tag, FieldIdDeltaRaw);
+        }
+
+        private static void UnsupportedWireType(Tag tag, uint fieldIdDeltaRaw)
+        {
+            var field = new Field(tag, fieldIdDeltaRaw, null);
+            throw new UnsupportedWireTypeException($"A WireType value of {nameof(WireType.TagDelimited)} is expected by this codec. {field}");
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/WireProtocol/Tag.cs
+++ b/src/Orleans.Serialization/WireProtocol/Tag.cs
@@ -24,12 +24,12 @@ namespace Orleans.Serialization.WireProtocol
         /// <summary>
         /// The field identifier mask.
         /// </summary>
-        public const byte FieldIdMask = 0b000_0111; // The final 3 bits are used for the field id delta, if the delta is expected.
+        public const byte FieldIdMask = 0b0000_0111; // The final 3 bits are used for the field id delta, if the delta is expected.
 
         /// <summary>
         /// The field identifier complete mask.
         /// </summary>
-        public const byte FieldIdCompleteMask = 0b0000_0111;
+        public const byte FieldIdCompleteMask = FieldIdMask;
 
         /// <summary>
         /// The extended wire type mask.
@@ -41,16 +41,15 @@ namespace Orleans.Serialization.WireProtocol
         /// </summary>
         public const int MaxEmbeddedFieldIdDelta = 6;
 
-        private byte _tag;
+        private uint _tag;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag"/> struct.
         /// </summary>
         /// <param name="tag">The tag byte.</param>
-        public Tag(byte tag)
-        {
-            _tag = tag;
-        }
+        public Tag(byte tag) => _tag = tag;
+
+        internal Tag(uint tag) => _tag = tag;
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="System.Byte"/> to <see cref="Tag"/>.
@@ -64,7 +63,7 @@ namespace Orleans.Serialization.WireProtocol
         /// </summary>
         /// <param name="tag">The tag.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator byte(Tag tag) => tag._tag;
+        public static implicit operator byte(Tag tag) => (byte)tag._tag;
 
         /// <summary>
         /// Gets or sets the wire type of the data following this tag.
@@ -73,7 +72,7 @@ namespace Orleans.Serialization.WireProtocol
         {
             get => (WireType)(_tag & WireTypeMask);
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _tag = (byte)((_tag & ~WireTypeMask) | ((byte)value & WireTypeMask));
+            set => _tag = (_tag & ~(uint)WireTypeMask) | ((uint)value & WireTypeMask);
         }
 
         /// <summary>
@@ -95,7 +94,7 @@ namespace Orleans.Serialization.WireProtocol
             get => (ExtendedWireType)(_tag & ExtendedWireTypeMask);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _tag = (byte)((_tag & ~ExtendedWireTypeMask) | ((byte)value & ExtendedWireTypeMask));
+            set => _tag = (_tag & ~(uint)ExtendedWireTypeMask) | ((uint)value & ExtendedWireTypeMask);
         }
 
         internal bool IsEndBaseFields => _tag == ((byte)WireType.Extended | (byte)ExtendedWireType.EndBaseFields);
@@ -111,7 +110,7 @@ namespace Orleans.Serialization.WireProtocol
             get => (SchemaType)(_tag & SchemaTypeMask);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _tag = (byte)((_tag & ~SchemaTypeMask) | ((byte)value & SchemaTypeMask));
+            set => _tag = (_tag & ~(uint)SchemaTypeMask) | ((uint)value & SchemaTypeMask);
         }
 
         /// <summary>
@@ -133,10 +132,10 @@ namespace Orleans.Serialization.WireProtocol
         public uint FieldIdDelta
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (uint)(_tag & FieldIdMask);
+            get => _tag & FieldIdMask;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _tag = (byte)((_tag & ~FieldIdMask) | ((byte)value & FieldIdMask));
+            set => _tag = (_tag & ~(uint)FieldIdMask) | (value & FieldIdMask);
         }
 
         /// <summary>
@@ -153,7 +152,7 @@ namespace Orleans.Serialization.WireProtocol
         /// </value>
         /// <remarks>
         /// If all bits are set in the field id portion of the tag, this field id is not valid and this tag must be followed by a field id.
-        /// Therefore, field ids 0-7 can be represented without additional bytes.
+        /// Therefore, field ids 0-6 can be represented without additional bytes.
         /// </remarks>
         public bool IsFieldIdValid
         {

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -427,7 +427,7 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal(original.UntypedValue, result.UntypedValue);
             Assert.Equal(original.Type2, result.Type2);
 
-            Assert.Contains("[#2 Reference Id: 1 SchemaType: Expected Reference: 0 ()]", formattedBitStream); // Type1
+            Assert.Contains("[#2 Reference Id: 1 SchemaType: Expected Reference: 0]", formattedBitStream); // Type1
             Assert.Contains("[#3 TagDelimited Id: 2 SchemaType: Encoded RuntimeType: MyValue", formattedBitStream); // UntypedValue
             Assert.Contains("[#5 TagDelimited Id: 3 SchemaType: Expected]", formattedBitStream); // Type2
             Assert.Contains("[#7 VarInt Id: 2 SchemaType: Expected] Value: 2", formattedBitStream); // type reference from Type2 field pointing to the encoded field type of UntypedValue


### PR DESCRIPTION
* Verify `WireType` in all codecs (including generated codecs).
* Reduce branching in generated codec `ReadValue` and `Deserialize` methods.
* Make deserialization code flow linear for objects with contiguous field IDs.
* Various small deserialization optimizations.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8089)