### PR TITLE
Add configuration methods for memory stream

### DIFF
--- a/src/Orleans.Streaming/Hosting/ClientBuilderStreamingExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/ClientBuilderStreamingExtensions.cs
@@ -21,6 +21,22 @@ namespace Orleans.Hosting
         public static IClientBuilder AddStreaming(this IClientBuilder builder) => builder.ConfigureServices(services => services.AddClientStreaming());
 
         /// <summary>
+        /// Adds a new in-memory stream provider to the client, using the default message serializer
+        /// (<see cref="DefaultMemoryMessageBodySerializer"/>).
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">The configuration delegate.</param>
+        /// <returns>The client builder.</returns>
+        public static IClientBuilder AddMemoryStreams(
+            this IClientBuilder builder,
+            string name,
+            Action<IClusterClientMemoryStreamConfigurator> configure = null)
+        {
+            return AddMemoryStreams<DefaultMemoryMessageBodySerializer>(builder, name, configure);
+        }
+
+        /// <summary>
         /// Adds a new in-memory stream provider to the client.
         /// </summary>
         /// <typeparam name="TSerializer">The type of the t serializer.</typeparam>

--- a/src/Orleans.Streaming/Hosting/SiloBuilderMemoryStreamExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/SiloBuilderMemoryStreamExtensions.cs
@@ -8,6 +8,22 @@ namespace Orleans.Hosting
     /// </summary>
     public static class SiloBuilderMemoryStreamExtensions
     {
+
+        /// <summary>
+        /// Configure silo to use memory streams, using the default message serializer
+        /// (<see cref="DefaultMemoryMessageBodySerializer"/>).
+        /// </summary>
+        /// using the default built-in serializer
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">The configuration delegate.</param>
+        /// <returns>The silo builder.</returns>
+        public static ISiloBuilder AddMemoryStreams(this ISiloBuilder builder, string name,
+                Action<ISiloMemoryStreamConfigurator> configure = null)
+        {
+            return AddMemoryStreams<DefaultMemoryMessageBodySerializer>(builder, name, configure);
+        }
+
         /// <summary>
         /// Configure silo to use memory streams.
         /// </summary>


### PR DESCRIPTION
Since I don't expect a lot of people to change the message body serializer, I think providing these overrides will make configuration easier.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8095)