### PR TITLE
Add codecs for Int128, UInt128, and Half

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -66,6 +66,9 @@ namespace Orleans.CodeGenerator
                 Task_1 = Type("System.Threading.Tasks.Task`1"),
                 Type = Type("System.Type"),
                 Uri = Type("System.Uri"),
+                Int128 = Type("System.Int128"),
+                UInt128 = Type("System.UInt128"),
+                Half = Type("System.Half"),
                 DateOnly = Type("System.DateOnly"),
                 DateTimeOffset = Type("System.DateTimeOffset"),
                 BitVector32 = Type("System.Collections.Specialized.BitVector32"),
@@ -112,6 +115,9 @@ namespace Orleans.CodeGenerator
                     new(Type("System.Memory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.MemoryOfByteCodec")),
                     new(Type("System.Net.IPAddress"), Type("Orleans.Serialization.Codecs.IPAddressCodec")),
                     new(Type("System.Net.IPEndPoint"), Type("Orleans.Serialization.Codecs.IPEndPointCodec")),
+                    new(Type("System.UInt128"), Type("Orleans.Serialization.Codecs.UInt128Codec")),
+                    new(Type("System.Int128"), Type("Orleans.Serialization.Codecs.Int128Codec")),
+                    new(Type("System.Half"), Type("Orleans.Serialization.Codecs.HalfCodec")),
                 },
                 WellKnownCodecs = new WellKnownCodecDescription[]
                 {
@@ -256,6 +262,9 @@ namespace Orleans.CodeGenerator
         private INamedTypeSymbol CompareInfo;
         private INamedTypeSymbol CultureInfo;
         private INamedTypeSymbol Version;
+        private INamedTypeSymbol Int128;
+        private INamedTypeSymbol UInt128;
+        private INamedTypeSymbol Half;
         private INamedTypeSymbol[] _regularShallowCopyableTypes;
         private INamedTypeSymbol[] RegularShallowCopyableType => _regularShallowCopyableTypes ??= new[]
         {
@@ -272,9 +281,11 @@ namespace Orleans.CodeGenerator
             IPEndPoint,
             CancellationToken,
             Type,
-            Uri
+            Uri,
+            UInt128,
+            Int128,
+            Half
         };
-
 
         public INamedTypeSymbol[] ImmutableAttributes { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.TestKit
 {
@@ -15,8 +16,11 @@ namespace Orleans.Serialization.TestKit
         private readonly IServiceProvider _serviceProvider;
         private readonly CodecProvider _codecProvider;
 
-        protected CopierTester()
+        protected CopierTester(ITestOutputHelper output)
         {
+            var seed = Random.Shared.Next();
+            output.WriteLine($"Random seed: {seed}");
+            Random = new(seed);
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.Copiers.Add(typeof(TCopier))));
 
@@ -30,6 +34,8 @@ namespace Orleans.Serialization.TestKit
             _serviceProvider = services.BuildServiceProvider();
             _codecProvider = _serviceProvider.GetRequiredService<CodecProvider>();
         }
+
+        protected Random Random { get; }
 
         protected IServiceProvider ServiceProvider => _serviceProvider;
 

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using Orleans.Serialization.Serializers;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.TestKit
 {
@@ -23,8 +24,11 @@ namespace Orleans.Serialization.TestKit
         private readonly IServiceProvider _serviceProvider;
         private readonly SerializerSessionPool _sessionPool;
 
-        protected FieldCodecTester()
+        protected FieldCodecTester(ITestOutputHelper output)
         {
+            var seed = Random.Shared.Next();
+            output.WriteLine($"Random seed: {seed}");
+            Random = new(seed);
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.FieldCodecs.Add(typeof(TCodec))));
 
@@ -38,6 +42,8 @@ namespace Orleans.Serialization.TestKit
             _serviceProvider = services.BuildServiceProvider();
             _sessionPool = _serviceProvider.GetService<SerializerSessionPool>();
         }
+
+        protected Random Random { get; }
 
         protected IServiceProvider ServiceProvider => _serviceProvider;
 

--- a/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
@@ -4,11 +4,16 @@ using Microsoft.Extensions.DependencyInjection;
 using System.IO.Pipelines;
 using Xunit;
 using Orleans.Serialization.Serializers;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.TestKit
 {
     public abstract class ValueTypeFieldCodecTester<TField, TCodec> : FieldCodecTester<TField, TCodec> where TField : struct where TCodec : class, IFieldCodec<TField>
     {
+        protected ValueTypeFieldCodecTester(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void ValueSerializerRoundTrip()
         {

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -837,6 +837,12 @@ namespace Orleans.Serialization.Buffers
 
                 ulong result = Unsafe.ReadUnaligned<ulong>(ref readHead);
                 var bytesNeeded = BitOperations.TrailingZeroCount((uint)result) + 1;
+
+                if (bytesNeeded > 9)
+                {
+                    ThrowOverflowException();
+                }
+
                 result >>= bytesNeeded;
                 _bufferPos = pos + bytesNeeded;
 
@@ -850,6 +856,8 @@ namespace Orleans.Serialization.Buffers
                 return ReadVarUInt32Slow();
             }
         }
+
+        private void ThrowOverflowException() => throw new OverflowException();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private uint ReadVarUInt32Slow()
@@ -870,7 +878,7 @@ namespace Orleans.Serialization.Buffers
             }
 
             result >>= numBytes;
-            return (uint)result;
+            return checked((uint)result);
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -288,6 +288,9 @@ namespace Orleans.Serialization.Cloning
             [typeof(CultureInfo)] = true,
             [typeof(Version)] = true,
             [typeof(Uri)] = true,
+            [typeof(UInt128)] = true,
+            [typeof(Int128)] = true,
+            [typeof(Half)] = true,
         };
 
         public static bool Contains(Type type)

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -670,7 +670,7 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ulong value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value <= int.MaxValue)
+            if (value <= uint.MaxValue)
             {
                 if (value > 1UL << 20)
                 {
@@ -680,7 +680,7 @@ namespace Orleans.Serialization.Codecs
                 else
                 {
                     writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                    writer.WriteVarUInt64(value);
+                    writer.WriteVarUInt32((uint)value);
                 }
             }
             else if (value > 1UL << 41)
@@ -707,7 +707,7 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ulong value, Type actualType) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value <= int.MaxValue)
+            if (value <= uint.MaxValue)
             {
                 if (value > 1UL << 20)
                 {
@@ -717,7 +717,7 @@ namespace Orleans.Serialization.Codecs
                 else
                 {
                     writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                    writer.WriteVarUInt64(value);
+                    writer.WriteVarUInt32((uint)value);
                 }
             }
             else if (value > 1UL << 41)

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -4,6 +4,7 @@ using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -782,7 +783,8 @@ namespace Orleans.Serialization.Codecs
                 writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
                 writer.WriteVarUInt32((uint)byteCount);
                 Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(0, byteCount) : new byte[byteCount];
-                ((IBinaryInteger<Int128>)value).WriteLittleEndian(bytes);
+                ((IBinaryInteger<Int128>)value).TryWriteLittleEndian(bytes, out var bytesWritten);
+                Debug.Assert(bytesWritten == byteCount);
                 writer.Write(bytes);
             }
         }
@@ -871,7 +873,8 @@ namespace Orleans.Serialization.Codecs
                 writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
                 writer.WriteVarUInt32((uint)byteCount);
                 Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(0, byteCount) : new byte[byteCount];
-                ((IBinaryInteger<UInt128>)value).WriteLittleEndian(bytes);
+                ((IBinaryInteger<UInt128>)value).TryWriteLittleEndian(bytes, out var bytesWritten);
+                Debug.Assert(bytesWritten == byteCount);
                 writer.Write(bytes);
             }
         }

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -898,7 +898,7 @@ namespace Orleans.Serialization.Codecs
             var byteCount = value.GetByteCount();
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(T), WireType.LengthPrefixed);
             writer.WriteVarUInt32((uint)byteCount);
-            Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(byteCount) : new byte[byteCount];
+            Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(0, byteCount) : new byte[byteCount];
             value.WriteLittleEndian(bytes);
             writer.Write(bytes);
         }

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -898,7 +898,7 @@ namespace Orleans.Serialization.Codecs
             var byteCount = value.GetByteCount();
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(T), WireType.LengthPrefixed);
             writer.WriteVarUInt32((uint)byteCount);
-            Span<byte> bytes = byteCount < 64 ? stackalloc byte[byteCount] : new byte[byteCount];
+            Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(byteCount) : new byte[byteCount];
             value.WriteLittleEndian(bytes);
             writer.Write(bytes);
         }

--- a/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
+++ b/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
@@ -46,6 +46,9 @@ namespace Orleans.Serialization.Configuration
             wellKnownTypes[34] = typeof(IPEndPoint);
             wellKnownTypes[35] = typeof(ExceptionResponse);
             wellKnownTypes[36] = typeof(CompletedResponse);
+            wellKnownTypes[37] = typeof(Int128);
+            wellKnownTypes[38] = typeof(UInt128);
+            wellKnownTypes[39] = typeof(Half);
 
             var allowedTypes = typeManifest.AllowedTypes;
             allowedTypes.Add("System.Globalization.CompareOptions");

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Buffers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Orleans.Serialization.Activators;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
@@ -7,15 +12,6 @@ using Orleans.Serialization.Serializers;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Serialization.WireProtocol;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-using System.Security.Cryptography.X509Certificates;
-using System.Reflection;
-using System.Threading.Tasks;
 
 namespace Orleans.Serialization
 {

--- a/src/Orleans.Serialization/Utilities/VarIntReaderExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntReaderExtensions.cs
@@ -1,4 +1,5 @@
 using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Codecs;
 using Orleans.Serialization.WireProtocol;
 using System.Runtime.CompilerServices;
 
@@ -16,7 +17,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="reader">The reader.</param>
         /// <returns>A variable-width integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static sbyte ReadVarInt8<TInput>(this ref Reader<TInput> reader) => ZigZagDecode((byte)reader.ReadVarUInt32());
+        public static sbyte ReadVarInt8<TInput>(this ref Reader<TInput> reader) => ZigZagDecode(checked((byte)reader.ReadVarUInt32()));
 
         /// <summary>
         /// Reads a variable-width <see cref="ushort"/>.
@@ -25,7 +26,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="reader">The reader.</param>
         /// <returns>A variable-width integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadVarInt16<TInput>(this ref Reader<TInput> reader) => ZigZagDecode((ushort)reader.ReadVarUInt32());
+        public static short ReadVarInt16<TInput>(this ref Reader<TInput> reader) => ZigZagDecode(checked((ushort)reader.ReadVarUInt32()));
 
         /// <summary>
         /// Reads a variable-width <see cref="byte"/>.
@@ -34,7 +35,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="reader">The reader.</param>
         /// <returns>A variable-width integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte ReadVarUInt8<TInput>(this ref Reader<TInput> reader) => (byte)reader.ReadVarUInt32();
+        public static byte ReadVarUInt8<TInput>(this ref Reader<TInput> reader) => checked((byte)reader.ReadVarUInt32());
 
         /// <summary>
         /// Reads a variable-width <see cref="ushort"/>.
@@ -43,7 +44,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="reader">The reader.</param>
         /// <returns>A variable-width integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadVarUInt16<TInput>(this ref Reader<TInput> reader) => (ushort)reader.ReadVarUInt32();
+        public static ushort ReadVarUInt16<TInput>(this ref Reader<TInput> reader) => checked((ushort)reader.ReadVarUInt32());
 
         /// <summary>
         /// Reads a variable-width <see cref="int"/>.
@@ -74,8 +75,9 @@ namespace Orleans.Serialization.Buffers
         public static byte ReadUInt8<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarUInt8(),
-            WireType.Fixed32 => (byte)reader.ReadUInt32(),
-            WireType.Fixed64 => (byte)reader.ReadUInt64(),
+            WireType.Fixed32 => checked((byte)reader.ReadUInt32()),
+            WireType.Fixed64 => checked((byte)reader.ReadUInt64()),
+            WireType.LengthPrefixed => checked((byte)UInt128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<byte>(nameof(wireType)),
         };
 
@@ -90,8 +92,9 @@ namespace Orleans.Serialization.Buffers
         public static ushort ReadUInt16<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarUInt16(),
-            WireType.Fixed32 => (ushort)reader.ReadUInt32(),
-            WireType.Fixed64 => (ushort)reader.ReadUInt64(),
+            WireType.Fixed32 => checked((ushort)reader.ReadUInt32()),
+            WireType.Fixed64 => checked((ushort)reader.ReadUInt64()),
+            WireType.LengthPrefixed => checked((ushort)UInt128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<ushort>(nameof(wireType)),
         };
 
@@ -107,7 +110,8 @@ namespace Orleans.Serialization.Buffers
         {
             WireType.VarInt => reader.ReadVarUInt32(),
             WireType.Fixed32 => reader.ReadUInt32(),
-            WireType.Fixed64 => (uint)reader.ReadUInt64(),
+            WireType.Fixed64 => checked((uint)reader.ReadUInt64()),
+            WireType.LengthPrefixed => checked((uint)UInt128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<uint>(nameof(wireType)),
         };
 
@@ -124,6 +128,7 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarUInt64(),
             WireType.Fixed32 => reader.ReadUInt32(),
             WireType.Fixed64 => reader.ReadUInt64(),
+            WireType.LengthPrefixed => checked((ulong)UInt128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<ulong>(nameof(wireType)),
         };
 
@@ -138,8 +143,9 @@ namespace Orleans.Serialization.Buffers
         public static sbyte ReadInt8<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarInt8(),
-            WireType.Fixed32 => (sbyte)reader.ReadInt32(),
-            WireType.Fixed64 => (sbyte)reader.ReadInt64(),
+            WireType.Fixed32 => checked((sbyte)reader.ReadInt32()),
+            WireType.Fixed64 => checked((sbyte)reader.ReadInt64()),
+            WireType.LengthPrefixed => checked((sbyte)Int128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<sbyte>(nameof(wireType)),
         };
 
@@ -154,8 +160,9 @@ namespace Orleans.Serialization.Buffers
         public static short ReadInt16<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarInt16(),
-            WireType.Fixed32 => (short)reader.ReadInt32(),
-            WireType.Fixed64 => (short)reader.ReadInt64(),
+            WireType.Fixed32 => checked((short)reader.ReadInt32()),
+            WireType.Fixed64 => checked((short)reader.ReadInt64()),
+            WireType.LengthPrefixed => checked((short)Int128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<short>(nameof(wireType)),
         };
 
@@ -181,7 +188,8 @@ namespace Orleans.Serialization.Buffers
         private static int ReadInt32Slower<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.Fixed32 => reader.ReadInt32(),
-            WireType.Fixed64 => (int)reader.ReadInt64(),
+            WireType.Fixed64 => checked((int)reader.ReadInt64()),
+            WireType.LengthPrefixed => checked((int)Int128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<int>(nameof(wireType)),
         };
 
@@ -198,6 +206,7 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarInt64(),
             WireType.Fixed32 => reader.ReadInt32(),
             WireType.Fixed64 => reader.ReadInt64(),
+            WireType.LengthPrefixed => checked((long)Int128Codec.ReadRaw(ref reader)),
             _ => ExceptionHelper.ThrowArgumentOutOfRange<long>(nameof(wireType)),
         };
 

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Net;
 using Xunit;
 using Microsoft.FSharp.Collections;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests
 {
@@ -35,8 +36,12 @@ namespace Orleans.Serialization.UnitTests
 
     public class EnumTests : FieldCodecTester<MyEnum, IFieldCodec<MyEnum>>
     {
+        public EnumTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IFieldCodec<MyEnum> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<MyEnum>();
-        protected override MyEnum CreateValue() => (MyEnum)(Random.Shared.Next((int)MyEnum.None, (int)MyEnum.Two));
+        protected override MyEnum CreateValue() => (MyEnum)Random.Next((int)MyEnum.None, (int)MyEnum.Two);
         protected override MyEnum[] TestValues => new[] { MyEnum.None, MyEnum.One, MyEnum.Two, (MyEnum)(-1), (MyEnum)10_000};
         protected override void Configure(ISerializerBuilder builder)
         {
@@ -48,8 +53,12 @@ namespace Orleans.Serialization.UnitTests
 
     public class EnumCopierTests : CopierTester<MyEnum, IDeepCopier<MyEnum>>
     {
+        public EnumCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IDeepCopier<MyEnum> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyEnum>();
-        protected override MyEnum CreateValue() => (MyEnum)(Random.Shared.Next((int)MyEnum.None, (int)MyEnum.Two));
+        protected override MyEnum CreateValue() => (MyEnum)Random.Next((int)MyEnum.None, (int)MyEnum.Two);
         protected override MyEnum[] TestValues => new[] { MyEnum.None, MyEnum.One, MyEnum.Two, (MyEnum)(-1), (MyEnum)10_000};
         protected override void Configure(ISerializerBuilder builder)
         {
@@ -61,8 +70,12 @@ namespace Orleans.Serialization.UnitTests
 
     public class DayOfWeekTests : FieldCodecTester<DayOfWeek, IFieldCodec<DayOfWeek>>
     {
+        public DayOfWeekTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IFieldCodec<DayOfWeek> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<DayOfWeek>();
-        protected override DayOfWeek CreateValue() => (DayOfWeek)(Random.Shared.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
+        protected override DayOfWeek CreateValue() => (DayOfWeek)Random.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday);
         protected override DayOfWeek[] TestValues => new[] { DayOfWeek.Monday, DayOfWeek.Sunday, (DayOfWeek)(-1), (DayOfWeek)10_000};
 
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
@@ -70,8 +83,12 @@ namespace Orleans.Serialization.UnitTests
 
     public class DayOfWeekCopierTests : CopierTester<DayOfWeek, IDeepCopier<DayOfWeek>>
     {
+        public DayOfWeekCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IDeepCopier<DayOfWeek> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<DayOfWeek>();
-        protected override DayOfWeek CreateValue() => (DayOfWeek)(Random.Shared.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
+        protected override DayOfWeek CreateValue() => (DayOfWeek)Random.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday);
         protected override DayOfWeek[] TestValues => new[] { DayOfWeek.Monday, DayOfWeek.Sunday, (DayOfWeek)(-1), (DayOfWeek)10_000};
 
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
@@ -79,20 +96,32 @@ namespace Orleans.Serialization.UnitTests
 
     public class NullableIntTests : FieldCodecTester<int?, IFieldCodec<int?>>
     {
+        public NullableIntTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IFieldCodec<int?> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<int?>();
-        protected override int? CreateValue() => TestValues[Random.Shared.Next(TestValues.Length)];
+        protected override int? CreateValue() => TestValues[Random.Next(TestValues.Length)];
         protected override int?[] TestValues => new int?[] { null, 1, 2, -3 };
     }
 
     public class NullableIntCopierTests : CopierTester<int?, IDeepCopier<int?>>
     {
+        public NullableIntCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IDeepCopier<int?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<int?>();
-        protected override int? CreateValue() => TestValues[Random.Shared.Next(TestValues.Length)];
+        protected override int? CreateValue() => TestValues[Random.Next(TestValues.Length)];
         protected override int?[] TestValues => new int?[] { null, 1, 2, -3 };
     }
 
     public class DateTimeTests : FieldCodecTester<DateTime, DateTimeCodec>
     {
+        public DateTimeTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateTime CreateValue() => DateTime.UtcNow;
         protected override DateTime[] TestValues => new[] { DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0) };
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
@@ -100,6 +129,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class DateTimeCopierTests : CopierTester<DateTime, IDeepCopier<DateTime>>
     {
+        public DateTimeCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateTime CreateValue() => DateTime.UtcNow;
         protected override DateTime[] TestValues => new[] { DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0) };
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
@@ -107,6 +140,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class DateOnlyTests : FieldCodecTester<DateOnly, DateOnlyCodec>
     {
+        public DateOnlyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
         protected override DateOnly[] TestValues => new[] { DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue() };
         protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
@@ -114,6 +151,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class TimeOnlyTests : FieldCodecTester<TimeOnly, TimeOnlyCodec>
     {
+        public TimeOnlyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
         protected override TimeOnly[] TestValues => new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue() };
         protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
@@ -121,6 +162,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class DateOnlyCopierTests : CopierTester<DateOnly, IDeepCopier<DateOnly>>
     {
+        public DateOnlyCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
         protected override DateOnly[] TestValues => new[] { DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue() };
         protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
@@ -128,6 +173,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class TimeOnlyCopierTests : CopierTester<TimeOnly, IDeepCopier<TimeOnly>>
     {
+        public TimeOnlyCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
         protected override TimeOnly[] TestValues => new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue() };
         protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
@@ -135,6 +184,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class TimeSpanTests : FieldCodecTester<TimeSpan, TimeSpanCodec>
     {
+        public TimeSpanTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
         protected override TimeSpan[] TestValues => new[] { TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345) };
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
@@ -142,6 +195,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class TimeSpanCopierTests : CopierTester<TimeSpan, IDeepCopier<TimeSpan>>
     {
+        public TimeSpanCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
         protected override TimeSpan[] TestValues => new[] { TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345) };
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
@@ -149,6 +206,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class DateTimeOffsetTests : FieldCodecTester<DateTimeOffset, DateTimeOffsetCodec>
     {
+        public DateTimeOffsetTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues => new[]
         {
@@ -163,6 +224,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class DateTimeOffsetCopierTests : CopierTester<DateTimeOffset, IDeepCopier<DateTimeOffset>>
     {
+        public DateTimeOffsetCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues => new[]
         {
@@ -177,6 +242,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class VersionTests : FieldCodecTester<Version, VersionCodec>
     {
+        public VersionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Version CreateValue() => new();
         protected override Version[] TestValues => new[]
         {
@@ -194,6 +263,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class VersionCopierTests : CopierTester<Version, IDeepCopier<Version>>
     {
+        public VersionCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Version CreateValue() => new();
         protected override Version[] TestValues => new[]
         {
@@ -213,7 +286,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class BitVector32Tests: FieldCodecTester<BitVector32, BitVector32Codec>
     {
-        protected override BitVector32 CreateValue() => new(Random.Shared.Next());
+        public BitVector32Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override BitVector32 CreateValue() => new(Random.Next());
 
         protected override BitVector32[] TestValues => new[]
         {
@@ -230,7 +307,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class BitVector32CopierTests: CopierTester<BitVector32, IDeepCopier<BitVector32>>
     {
-        protected override BitVector32 CreateValue() => new(Random.Shared.Next());
+        public BitVector32CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override BitVector32 CreateValue() => new(Random.Next());
 
         protected override BitVector32[] TestValues => new[]
         {
@@ -247,6 +328,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple1Tests : FieldCodecTester<Tuple<string>, TupleCodec<string>>
     {
+        public Tuple1Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString());
 
         protected override Tuple<string>[] TestValues => new[]
@@ -260,6 +345,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple1CopierTests : CopierTester<Tuple<string>, TupleCopier<string>>
     {
+        public Tuple1CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString());
 
         protected override Tuple<string>[] TestValues => new[]
@@ -275,6 +364,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple2Tests : FieldCodecTester<Tuple<string, string>, TupleCodec<string, string>>
     {
+        public Tuple2Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
         protected override Tuple<string, string>[] TestValues => new[]
@@ -289,6 +382,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple2CopierTests : CopierTester<Tuple<string, string>, TupleCopier<string, string>>
     {
+        public Tuple2CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
         protected override Tuple<string, string>[] TestValues => new[]
@@ -305,6 +402,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple3Tests : FieldCodecTester<Tuple<string, string, string>, TupleCodec<string, string, string>>
     {
+        public Tuple3Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -322,6 +423,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple3CopierTests : CopierTester<Tuple<string, string, string>, TupleCopier<string, string, string>>
     {
+        public Tuple3CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -341,6 +446,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple4Tests : FieldCodecTester<Tuple<string, string, string, string>, TupleCodec<string, string, string, string>>
     {
+        public Tuple4Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -359,6 +468,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple4CopierTests : CopierTester<Tuple<string, string, string, string>, TupleCopier<string, string, string, string>>
     {
+        public Tuple4CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -379,6 +492,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple5Tests : FieldCodecTester<Tuple<string, string, string, string, string>, TupleCodec<string, string, string, string, string>>
     {
+        public Tuple5Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -398,6 +515,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple5CopierTests : CopierTester<Tuple<string, string, string, string, string>, TupleCopier<string, string, string, string, string>>
     {
+        public Tuple5CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -419,6 +540,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple6Tests : FieldCodecTester<Tuple<string, string,string, string, string, string>, TupleCodec<string, string, string, string, string, string>>
     {
+        public Tuple6Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -439,6 +564,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple6CopierTests : CopierTester<Tuple<string, string,string, string, string, string>, TupleCopier<string, string, string, string, string, string>>
     {
+        public Tuple6CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -461,6 +590,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple7Tests : FieldCodecTester<Tuple<string, string, string, string, string, string, string>, TupleCodec<string, string, string, string, string, string, string>>
     {
+        public Tuple7Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -482,6 +615,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple7CopierTests : CopierTester<Tuple<string, string, string, string, string, string, string>, TupleCopier<string, string, string, string, string, string, string>>
     {
+        public Tuple7CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -505,6 +642,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple8Tests : FieldCodecTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCodec<string, string, string, string, string, string, string, Tuple<string>>>
     {
+        public Tuple8Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -518,7 +659,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>>[] TestValues => new[]
         {
             null,
-            new Tuple<string, string, string, string, string, string, string, Tuple<string>>(default(string), default(string), default(string), default(string), default(string), default(string), default(string), new Tuple<string>(default(string))),
+            new Tuple<string, string, string, string, string, string, string, Tuple<string>>(default, default, default, default, default, default, default, new Tuple<string>(default)),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "foo", Tuple.Create("foo")),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>("foo", "bar", "baz", "4", "5", "6", "7", Tuple.Create("8")),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>("foo", "foo", "foo", "foo", "foo", "foo", "foo", Tuple.Create("foo"))
@@ -527,6 +668,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Tuple8CopierTests : CopierTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCopier<string, string, string, string, string, string, string, Tuple<string>>>
     {
+        public Tuple8CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -540,7 +685,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>>[] TestValues => new[]
         {
             null,
-            new Tuple<string, string, string, string, string, string, string, Tuple<string>>(default(string), default(string), default(string), default(string), default(string), default(string), default(string), new Tuple<string>(default(string))),
+            new Tuple<string, string, string, string, string, string, string, Tuple<string>>(default, default, default, default, default, default, default, new Tuple<string>(default)),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "foo", Tuple.Create("foo")),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>("foo", "bar", "baz", "4", "5", "6", "7", Tuple.Create("8")),
             new Tuple<string, string, string, string, string, string, string, Tuple<string>>("foo", "foo", "foo", "foo", "foo", "foo", "foo", Tuple.Create("foo"))
@@ -551,6 +696,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple1Tests : FieldCodecTester<ValueTuple<string>, ValueTupleCodec<string>>
     {
+        public ValueTuple1Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString());
 
         protected override ValueTuple<string>[] TestValues => new[]
@@ -564,6 +713,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple1CopierTests : CopierTester<ValueTuple<string>, ValueTupleCopier<string>>
     {
+        public ValueTuple1CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString());
 
         protected override ValueTuple<string>[] TestValues => new[]
@@ -577,6 +730,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple2Tests : FieldCodecTester<ValueTuple<string, string>, ValueTupleCodec<string, string>>
     {
+        public ValueTuple2Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
         protected override ValueTuple<string, string>[] TestValues => new[]
@@ -591,6 +748,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple2CopierTests : CopierTester<ValueTuple<string, string>, ValueTupleCopier<string, string>>
     {
+        public ValueTuple2CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
         protected override ValueTuple<string, string>[] TestValues => new[]
@@ -605,6 +766,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple3Tests : FieldCodecTester<ValueTuple<string, string, string>, ValueTupleCodec<string, string, string>>
     {
+        public ValueTuple3Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -622,6 +787,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple3CopierTests : CopierTester<ValueTuple<string, string, string>, ValueTupleCopier<string, string, string>>
     {
+        public ValueTuple3CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -639,6 +808,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple4Tests : FieldCodecTester<ValueTuple<string, string, string, string>, ValueTupleCodec<string, string, string, string>>
     {
+        public ValueTuple4Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -657,6 +830,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple4CopierTests : CopierTester<ValueTuple<string, string, string, string>, ValueTupleCopier<string, string, string, string>>
     {
+        public ValueTuple4CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -675,6 +852,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple5Tests : FieldCodecTester<ValueTuple<string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string>>
     {
+        public ValueTuple5Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -694,6 +875,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple5CopierTests : CopierTester<ValueTuple<string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string>>
     {
+        public ValueTuple5CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -713,6 +898,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple6Tests : FieldCodecTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string>>
     {
+        public ValueTuple6Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -733,6 +922,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple6CopierTests : CopierTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string>>
     {
+        public ValueTuple6CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -753,6 +946,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple7Tests : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string, string>>
     {
+        public ValueTuple7Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -774,6 +971,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple7opierTests : CopierTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string, string>>
     {
+        public ValueTuple7opierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -795,6 +996,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple8Tests : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCodec<string, string, string, string, string, string, string, ValueTuple<string>>>
     {
+        public ValueTuple8Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -808,7 +1013,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>[] TestValues => new[]
         {
             default,
-            new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(default(string), default(string), default(string), default(string), default(string), default(string), default(string), ValueTuple.Create(default(string))),
+            new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(default, default, default, default, default, default, default, ValueTuple.Create(default(string))),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "foo", ValueTuple.Create("foo")),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>("foo", "bar", "baz", "4", "5", "6", "7", ValueTuple.Create("8")),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>("foo", "foo", "foo", "foo", "foo", "foo", "foo", ValueTuple.Create("foo"))
@@ -817,6 +1022,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ValueTuple8CopierTests : CopierTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCopier<string, string, string, string, string, string, string, ValueTuple<string>>>
     {
+        public ValueTuple8CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
             Guid.NewGuid().ToString(),
@@ -830,7 +1039,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>[] TestValues => new[]
         {
             default,
-            new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(default(string), default(string), default(string), default(string), default(string), default(string), default(string), ValueTuple.Create(default(string))),
+            new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(default, default, default, default, default, default, default, ValueTuple.Create(default(string))),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "foo", ValueTuple.Create("foo")),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>("foo", "bar", "baz", "4", "5", "6", "7", ValueTuple.Create("8")),
             new ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>("foo", "foo", "foo", "foo", "foo", "foo", "foo", ValueTuple.Create("foo"))
@@ -839,6 +1048,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class BoolCodecTests : FieldCodecTester<bool, BoolCodec>
     {
+        public BoolCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override bool CreateValue() => true;
         protected override bool Equals(bool left, bool right) => left == right;
         protected override bool[] TestValues => new[] { false, true };
@@ -846,6 +1059,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class BoolCopierTests : CopierTester<bool, IDeepCopier<bool>>
     {
+        public BoolCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override bool CreateValue() => true;
         protected override bool Equals(bool left, bool right) => left == right;
         protected override bool[] TestValues => new[] { false, true };
@@ -853,6 +1070,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class StringCodecTests : FieldCodecTester<string, StringCodec>
     {
+        public StringCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
@@ -860,6 +1081,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class StringCopierTests : CopierTester<string, IDeepCopier<string>>
     {
+        public StringCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
@@ -869,6 +1094,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ObjectCodecTests : FieldCodecTester<object, ObjectCodec>
     {
+        public ObjectCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override object CreateValue() => new();
         protected override bool Equals(object left, object right) => ReferenceEquals(left, right) || typeof(object) == left?.GetType() && typeof(object) == right?.GetType();
         protected override object[] TestValues => new[] { null, new object() };
@@ -876,6 +1105,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ObjectCopierTests : CopierTester<object, ObjectCopier>
     {
+        public ObjectCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override object CreateValue() => new();
         protected override bool Equals(object left, object right) => ReferenceEquals(left, right) || typeof(object) == left?.GetType() && typeof(object) == right?.GetType();
         protected override object[] TestValues => new[] { null, new object() };
@@ -884,6 +1117,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ByteArrayCodecTests : FieldCodecTester<byte[], ByteArrayCodec>
     {
+        public ByteArrayCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override byte[] CreateValue() => Guid.NewGuid().ToByteArray();
 
         protected override bool Equals(byte[] left, byte[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
@@ -898,6 +1135,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ByteArrayCopierTests : CopierTester<byte[], ByteArrayCopier>
     {
+        public ByteArrayCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override byte[] CreateValue() => Guid.NewGuid().ToByteArray();
 
         protected override bool Equals(byte[] left, byte[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
@@ -912,21 +1153,33 @@ namespace Orleans.Serialization.UnitTests
 
     public class ArrayCodecTests : FieldCodecTester<int[], ArrayCodec<int>>
     {
-        protected override int[] CreateValue() => Enumerable.Range(0, Random.Shared.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
+        public ArrayCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override int[] CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => new[] { null, Array.Empty<int>(), CreateValue(), CreateValue(), CreateValue() };
     }
 
     public class ArrayCopierTests : CopierTester<int[], ArrayCopier<int>>
     {
-        protected override int[] CreateValue() => Enumerable.Range(0, Random.Shared.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
+        public ArrayCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override int[] CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => new[] { null, Array.Empty<int>(), CreateValue(), CreateValue(), CreateValue() };
     }
 
     public class UInt128CodecTests : FieldCodecTester<UInt128, UInt128Codec>
     {
-        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+        public UInt128CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
         protected override UInt128[] TestValues => new UInt128[]
         {
@@ -949,7 +1202,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt128CopierTests : CopierTester<UInt128, IDeepCopier<UInt128>>
     {
-        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+        public UInt128CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
         protected override UInt128[] TestValues => new UInt128[]
         {
@@ -972,6 +1229,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt64CodecTests : FieldCodecTester<ulong, UInt64Codec>
     {
+        public UInt64CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ulong CreateValue()
         {
             var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
@@ -1000,6 +1261,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt64CopierTests : CopierTester<ulong, IDeepCopier<ulong>>
     {
+        public UInt64CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ulong CreateValue()
         {
             var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
@@ -1028,6 +1293,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt32CodecTests : FieldCodecTester<uint, UInt32Codec>
     {
+        public UInt32CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
 
         protected override uint[] TestValues => new uint[]
@@ -1048,6 +1317,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt32CopiercTests : CopierTester<uint, IDeepCopier<uint>>
     {
+        public UInt32CopiercTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
 
         protected override uint[] TestValues => new uint[]
@@ -1068,6 +1341,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt16CodecTests : FieldCodecTester<ushort, UInt16Codec>
     {
+        public UInt16CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues => new ushort[]
         {
@@ -1085,6 +1362,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UInt16CopierTests : CopierTester<ushort, IDeepCopier<ushort>>
     {
+        public UInt16CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues => new ushort[]
         {
@@ -1102,6 +1383,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ByteCodecTests : FieldCodecTester<byte, ByteCodec>
     {
+        public ByteCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
         protected override byte[] TestValues => new byte[] { 0, 1, byte.MaxValue - 1, byte.MaxValue };
 
@@ -1110,6 +1395,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class ByteCopierTests : CopierTester<byte, IDeepCopier<byte>>
     {
+        public ByteCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
         protected override byte[] TestValues => new byte[] { 0, 1, byte.MaxValue - 1, byte.MaxValue };
 
@@ -1118,7 +1407,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int128CodecTests : FieldCodecTester<Int128, Int128Codec>
     {
-        protected override Int128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+        public Int128CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override Int128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
         protected override Int128[] TestValues => new Int128[]
         {
@@ -1141,7 +1434,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int128CopierTests : CopierTester<Int128, IDeepCopier<Int128>>
     {
-        protected override Int128 CreateValue() => new Int128(unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+        public Int128CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override Int128 CreateValue() => new Int128(unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
         protected override Int128[] TestValues => new Int128[]
         {
@@ -1164,6 +1461,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int64CodecTests : FieldCodecTester<long, Int64Codec>
     {
+        public Int64CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override long CreateValue()
         {
             var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
@@ -1194,6 +1495,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int64CopierTests : CopierTester<long, IDeepCopier<long>>
     {
+        public Int64CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override long CreateValue()
         {
             var msb = (ulong)Guid.NewGuid().GetHashCode() << 32;
@@ -1224,6 +1529,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int32CodecTests : FieldCodecTester<int, Int32Codec>
     {
+        public Int32CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override int CreateValue() => Guid.NewGuid().GetHashCode();
 
         protected override int[] TestValues => new[]
@@ -1275,6 +1584,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int32CopierTests : CopierTester<int, IDeepCopier<int>>
     {
+        public Int32CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override int CreateValue() => Guid.NewGuid().GetHashCode();
 
         protected override int[] TestValues => new[]
@@ -1298,6 +1611,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int16CodecTests : FieldCodecTester<short, Int16Codec>
     {
+        public Int16CodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
         protected override short[] TestValues => new short[]
@@ -1318,6 +1635,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class Int16CopierTests : CopierTester<short, IDeepCopier<short>>
     {
+        public Int16CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
         protected override short[] TestValues => new short[]
@@ -1338,6 +1659,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class SByteCodecTests : FieldCodecTester<sbyte, SByteCodec>
     {
+        public SByteCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
 
         protected override sbyte[] TestValues => new sbyte[]
@@ -1355,6 +1680,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class SByteCopierTests : CopierTester<sbyte, IDeepCopier<sbyte>>
     {
+        public SByteCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
 
         protected override sbyte[] TestValues => new sbyte[]
@@ -1373,6 +1702,11 @@ namespace Orleans.Serialization.UnitTests
     public class CharCodecTests : FieldCodecTester<char, CharCodec>
     {
         private int _createValueCount;
+
+        public CharCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override char CreateValue() => (char)('!' + _createValueCount++ % ('~' - '!'));
         protected override char[] TestValues => new[]
         {
@@ -1391,6 +1725,11 @@ namespace Orleans.Serialization.UnitTests
     public class CharCopierTests : CopierTester<char, IDeepCopier<char>>
     {
         private int _createValueCount;
+
+        public CharCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override char CreateValue() => (char)('!' + _createValueCount++ % ('~' - '!'));
         protected override char[] TestValues => new[]
         {
@@ -1408,6 +1747,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class GuidCodecTests : FieldCodecTester<Guid, GuidCodec>
     {
+        public GuidCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues => new[]
         {
@@ -1421,6 +1764,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class GuidCopierTests : CopierTester<Guid, IDeepCopier<Guid>>
     {
+        public GuidCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues => new[]
         {
@@ -1452,6 +1799,10 @@ namespace Orleans.Serialization.UnitTests
 
         private int _valueIndex;
 
+        public TypeCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Type CreateValue() => _values[_valueIndex++ % _values.Length];
         protected override Type[] TestValues => _values;
     }
@@ -1476,6 +1827,10 @@ namespace Orleans.Serialization.UnitTests
 
         private int _valueIndex;
 
+        public TypeCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Type CreateValue() => _values[_valueIndex++ % _values.Length];
         protected override Type[] TestValues => _values;
 
@@ -1484,7 +1839,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class FloatCodecTests : FieldCodecTester<float, FloatCodec>
     {
-        protected override float CreateValue() => float.MaxValue * (float)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public FloatCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override float CreateValue() => float.MaxValue * (float)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
 
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
@@ -1492,7 +1851,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class FloatCopierTests : CopierTester<float, IDeepCopier<float>>
     {
-        protected override float CreateValue() => float.MaxValue * (float)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public FloatCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override float CreateValue() => float.MaxValue * (float)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
 
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
@@ -1500,7 +1863,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class HalfCodecTests : FieldCodecTester<Half, HalfCodec>
     {
-        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Shared.Next(ushort.MinValue, ushort.MaxValue));
+        public HalfCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Next(ushort.MinValue, ushort.MaxValue));
         protected override Half[] TestValues => new[] { Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue };
 
         protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
@@ -1508,7 +1875,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class HalfCopierTests : CopierTester<Half, IDeepCopier<Half>>
     {
-        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Shared.Next(ushort.MinValue, ushort.MaxValue));
+        public HalfCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Next(ushort.MinValue, ushort.MaxValue));
         protected override Half[] TestValues => new[] { Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue };
 
         protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
@@ -1516,7 +1887,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class DoubleCodecTests : FieldCodecTester<double, DoubleCodec>
     {
-        protected override double CreateValue() => double.MaxValue * Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public DoubleCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override double CreateValue() => double.MaxValue * Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
 
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
@@ -1524,7 +1899,11 @@ namespace Orleans.Serialization.UnitTests
 
     public class DoubleCopierTests : CopierTester<double, IDeepCopier<double>>
     {
-        protected override double CreateValue() => double.MaxValue * Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public DoubleCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override double CreateValue() => double.MaxValue * Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
 
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
@@ -1532,26 +1911,38 @@ namespace Orleans.Serialization.UnitTests
 
     public class DecimalCodecTests : FieldCodecTester<decimal, DecimalCodec>
     {
-        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public DecimalCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
 
     public class DecimalCopierTests : CopierTester<decimal, IDeepCopier<decimal>>
     {
-        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        public DecimalCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
 
     public class ListCodecTests : FieldCodecTester<List<int>, ListCodec<int>>
     {
+        public ListCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override List<int> CreateValue()
         {
             var result = new List<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Add(Random.Shared.Next());
+                result.Add(Random.Next());
             }
 
             return result;
@@ -1563,12 +1954,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ListCopierTests : CopierTester<List<int>, ListCopier<int>>
     {
+        public ListCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override List<int> CreateValue()
         {
             var result = new List<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Add(Random.Shared.Next());
+                result.Add(Random.Next());
             }
 
             return result;
@@ -1580,12 +1975,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class QueueCodecTests : FieldCodecTester<Queue<int>, QueueCodec<int>>
     {
+        public QueueCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Queue<int> CreateValue()
         {
             var result = new Queue<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Enqueue(Random.Shared.Next());
+                result.Enqueue(Random.Next());
             }
 
             return result;
@@ -1597,12 +1996,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class QueueCopierTests : CopierTester<Queue<int>, QueueCopier<int>>
     {
+        public QueueCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Queue<int> CreateValue()
         {
             var result = new Queue<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Enqueue(Random.Shared.Next());
+                result.Enqueue(Random.Next());
             }
 
             return result;
@@ -1614,12 +2017,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ConcurrentQueueCodecTests : FieldCodecTester<ConcurrentQueue<int>, ConcurrentQueueCodec<int>>
     {
+        public ConcurrentQueueCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ConcurrentQueue<int> CreateValue()
         {
             var result = new ConcurrentQueue<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Enqueue(Random.Shared.Next());
+                result.Enqueue(Random.Next());
             }
 
             return result;
@@ -1631,12 +2038,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ConcurrentQueueCopierTests : CopierTester<ConcurrentQueue<int>, ConcurrentQueueCopier<int>>
     {
+        public ConcurrentQueueCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ConcurrentQueue<int> CreateValue()
         {
             var result = new ConcurrentQueue<int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result.Enqueue(Random.Shared.Next());
+                result.Enqueue(Random.Next());
             }
 
             return result;
@@ -1648,12 +2059,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class DictionaryCodecTests : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>
     {
+        public DictionaryCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Dictionary<string, int> CreateValue()
         {
             var result = new Dictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1665,12 +2080,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class DictionaryCopierTests : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>
     {
+        public DictionaryCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Dictionary<string, int> CreateValue()
         {
             var result = new Dictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1700,15 +2119,19 @@ namespace Orleans.Serialization.UnitTests
 #endif
         };
 
+        public DictionaryWithComparerCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Dictionary<string, int> CreateValue()
         {
             var eqComparer = _comparers[_nextComparer++ % _comparers.Length];
             var result = new Dictionary<string, int>(eqComparer);
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
                 var key = Guid.NewGuid().ToString();
-                result[key.ToLowerInvariant()] = Random.Shared.Next();
-                result[key.ToUpperInvariant()] = Random.Shared.Next();
+                result[key.ToLowerInvariant()] = Random.Next();
+                result[key.ToUpperInvariant()] = Random.Next();
             }
 
             return result;
@@ -1758,13 +2181,17 @@ namespace Orleans.Serialization.UnitTests
 
     public class DictionaryWithComparerCopierTests : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>
     {
+        public DictionaryWithComparerCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Dictionary<string, int> CreateValue()
         {
             var eqComparer = new DictionaryWithComparerCodecTests.CaseInsensitiveEqualityComparer();
             var result = new Dictionary<string, int>(eqComparer);
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1777,12 +2204,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ConcurrentDictionaryCodecTests : FieldCodecTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCodec<string, int>>
     {
+        public ConcurrentDictionaryCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
             var result = new ConcurrentDictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1816,12 +2247,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ConcurrentDictionaryCopierTests : CopierTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCopier<string, int>>
     {
+        public ConcurrentDictionaryCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
             var result = new ConcurrentDictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1855,12 +2290,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ReadOnlyDictionaryCodecTests : FieldCodecTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCodec<string, int>>
     {
+        public ReadOnlyDictionaryCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
             var dict = new Dictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                dict[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                dict[Random.Next().ToString()] = Random.Next();
             }
 
             return new ReadOnlyDictionary<string, int>(dict);
@@ -1872,12 +2311,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ReadOnlyDictionaryCopierTests : CopierTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCopier<string, int>>
     {
+        public ReadOnlyDictionaryCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
             var dict = new Dictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                dict[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                dict[Random.Next().ToString()] = Random.Next();
             }
 
             return new ReadOnlyDictionary<string, int>(dict);
@@ -1889,12 +2332,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class SortedDictionaryCodecTests : FieldCodecTester<SortedDictionary<string, int>, SortedDictionaryCodec<string, int>>
     {
+        public SortedDictionaryCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override SortedDictionary<string, int> CreateValue()
         {
             var result = new SortedDictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1906,12 +2353,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class SortedDictionaryCopierTests : CopierTester<SortedDictionary<string, int>, SortedDictionaryCopier<string, int>>
     {
+        public SortedDictionaryCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override SortedDictionary<string, int> CreateValue()
         {
             var result = new SortedDictionary<string, int>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
+                result[Random.Next().ToString()] = Random.Next();
             }
 
             return result;
@@ -1923,12 +2374,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class IPAddressTests : FieldCodecTester<IPAddress, IPAddressCodec>
     {
+        public IPAddressTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IPAddress[] TestValues => new[] { null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue() };
 
         protected override IPAddress CreateValue()
         {
             byte[] bytes;
-            if (Random.Shared.Next(1) == 0)
+            if (Random.Next(1) == 0)
             {
                 bytes = new byte[4];
             }
@@ -1936,19 +2391,23 @@ namespace Orleans.Serialization.UnitTests
             {
                 bytes = new byte[16];
             }
-            Random.Shared.NextBytes(bytes);
+            Random.NextBytes(bytes);
             return new IPAddress(bytes);
         } 
     }
 
     public class IPAddressCopierTests : CopierTester<IPAddress, IDeepCopier<IPAddress>>
     {
+        public IPAddressCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override IPAddress[] TestValues => new[] { null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue() };
 
         protected override IPAddress CreateValue()
         {
             byte[] bytes;
-            if (Random.Shared.Next(1) == 0)
+            if (Random.Next(1) == 0)
             {
                 bytes = new byte[4];
             }
@@ -1956,7 +2415,7 @@ namespace Orleans.Serialization.UnitTests
             {
                 bytes = new byte[16];
             }
-            Random.Shared.NextBytes(bytes);
+            Random.NextBytes(bytes);
             return new IPAddress(bytes);
         }
 
@@ -1965,12 +2424,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class HashSetTests : FieldCodecTester<HashSet<string>, HashSetCodec<string>>
     {
+        public HashSetTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override HashSet<string> CreateValue()
         {
             var result = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = result.Add(Random.Shared.Next().ToString());
+                _ = result.Add(Random.Next().ToString());
             }
 
             return result;
@@ -1983,12 +2446,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class HashSetCopierTests : CopierTester<HashSet<string>, HashSetCopier<string>>
     {
+        public HashSetCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override HashSet<string> CreateValue()
         {
             var result = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = result.Add(Random.Shared.Next().ToString());
+                _ = result.Add(Random.Next().ToString());
             }
 
             return result;
@@ -2001,12 +2468,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ImmutableHashSetTests : FieldCodecTester<ImmutableHashSet<string>, ImmutableHashSetCodec<string>>
     {
+        public ImmutableHashSetTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ImmutableHashSet<string> CreateValue()
         {
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(Random.Shared.Next().ToString());
+                _ = hashSet.Add(Random.Next().ToString());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -2019,12 +2490,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class ImmutableHashSetCopierTests : CopierTester<ImmutableHashSet<string>, ImmutableHashSetCopier<string>>
     {
+        public ImmutableHashSetCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ImmutableHashSet<string> CreateValue()
         {
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(Random.Shared.Next().ToString());
+                _ = hashSet.Add(Random.Next().ToString());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -2039,12 +2514,16 @@ namespace Orleans.Serialization.UnitTests
 
     public sealed class ImmutableHashSetMutableCopierTests : CopierTester<ImmutableHashSet<object>, ImmutableHashSetCopier<object>>
     {
+        public ImmutableHashSetMutableCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override ImmutableHashSet<object> CreateValue()
         {
             var hashSet = new HashSet<object>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(Random.Shared.Next());
+                _ = hashSet.Add(Random.Next());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -2059,6 +2538,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UriTests : FieldCodecTester<Uri, UriCodec>
     {
+        public UriTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override int[] MaxSegmentSizes => new[] { 128 };
         protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
 
@@ -2069,6 +2552,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class UriCopierTests : CopierTester<Uri, IDeepCopier<Uri>>
     {
+        public UriCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
 
         protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
@@ -2080,6 +2567,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpOptionTests : FieldCodecTester<FSharpOption<Guid>, FSharpOptionCodec<Guid>>
     {
+        public FSharpOptionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpOption<Guid>[] TestValues => new[] { null, FSharpOption<Guid>.None, FSharpOption<Guid>.Some(Guid.Empty), FSharpOption<Guid>.Some(Guid.NewGuid()) };
 
         protected override FSharpOption<Guid> CreateValue() => FSharpOption<Guid>.Some(Guid.NewGuid());
@@ -2087,6 +2578,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpOptionCopierTests : CopierTester<FSharpOption<Guid>, FSharpOptionCopier<Guid>>
     {
+        public FSharpOptionCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpOption<Guid>[] TestValues => new[] { null, FSharpOption<Guid>.None, FSharpOption<Guid>.Some(Guid.Empty), FSharpOption<Guid>.Some(Guid.NewGuid()) };
 
         protected override FSharpOption<Guid> CreateValue() => FSharpOption<Guid>.Some(Guid.NewGuid());
@@ -2096,6 +2591,10 @@ namespace Orleans.Serialization.UnitTests
     
     public class FSharpOptionTests2 : FieldCodecTester<FSharpOption<object>, FSharpOptionCodec<object>>
     {
+        public FSharpOptionTests2(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpOption<object>[] TestValues => new[] { null, FSharpOption<object>.Some(null), FSharpOption<object>.None, FSharpOption<object>.Some(Guid.Empty), FSharpOption<object>.Some(Guid.NewGuid()) };
 
         protected override FSharpOption<object> CreateValue() => FSharpOption<object>.Some(Guid.NewGuid());
@@ -2103,6 +2602,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpRefTests : FieldCodecTester<FSharpRef<Guid>, FSharpRefCodec<Guid>>
     {
+        public FSharpRefTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpRef<Guid>[] TestValues => new[] { null, new FSharpRef<Guid>(default), new FSharpRef<Guid>(Guid.Empty), new FSharpRef<Guid>(Guid.NewGuid()) };
 
         protected override FSharpRef<Guid> CreateValue() => new(Guid.NewGuid());
@@ -2112,6 +2615,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpRefCopierTests : CopierTester<FSharpRef<Guid>, FSharpRefCopier<Guid>>
     {
+        public FSharpRefCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpRef<Guid>[] TestValues => new[] { null, new FSharpRef<Guid>(default), new FSharpRef<Guid>(Guid.Empty), new FSharpRef<Guid>(Guid.NewGuid()) };
 
         protected override FSharpRef<Guid> CreateValue() => new(Guid.NewGuid());
@@ -2121,6 +2628,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpValueOptionTests : FieldCodecTester<FSharpValueOption<Guid>, FSharpValueOptionCodec<Guid>>
     {
+        public FSharpValueOptionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpValueOption<Guid>[] TestValues => new[] { default, FSharpValueOption<Guid>.None, FSharpValueOption<Guid>.Some(Guid.Empty), FSharpValueOption<Guid>.Some(Guid.NewGuid()) };
 
         protected override FSharpValueOption<Guid> CreateValue() => FSharpValueOption<Guid>.Some(Guid.NewGuid());
@@ -2128,6 +2639,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpValueOptionCopierTests : CopierTester<FSharpValueOption<Guid>, FSharpValueOptionCopier<Guid>>
     {
+        public FSharpValueOptionCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpValueOption<Guid>[] TestValues => new[] { default, FSharpValueOption<Guid>.None, FSharpValueOption<Guid>.Some(Guid.Empty), FSharpValueOption<Guid>.Some(Guid.NewGuid()) };
 
         protected override FSharpValueOption<Guid> CreateValue() => FSharpValueOption<Guid>.Some(Guid.NewGuid());
@@ -2137,6 +2652,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice2Tests : FieldCodecTester<FSharpChoice<int, Guid>, FSharpChoiceCodec<int, Guid>>
     {
+        public FSharpChoice2Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid>[] TestValues => new[] { FSharpChoice<int, Guid>.NewChoice1Of2(-1), FSharpChoice<int, Guid>.NewChoice2Of2(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid> CreateValue() => FSharpChoice<int, Guid>.NewChoice1Of2(0);
@@ -2144,6 +2663,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice2CopierTests : CopierTester<FSharpChoice<int, Guid>, FSharpChoiceCopier<int, Guid>>
     {
+        public FSharpChoice2CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid>[] TestValues => new[] { FSharpChoice<int, Guid>.NewChoice1Of2(-1), FSharpChoice<int, Guid>.NewChoice2Of2(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid> CreateValue() => FSharpChoice<int, Guid>.NewChoice1Of2(0);
@@ -2151,6 +2674,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice3Tests : FieldCodecTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid>>
     {
+        public FSharpChoice3Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid>.NewChoice1Of3(-1), FSharpChoice<int, Guid, Guid>.NewChoice3Of3(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid>.NewChoice1Of3(0);
@@ -2158,6 +2685,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice3CopierTests : CopierTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid>>
     {
+        public FSharpChoice3CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid>.NewChoice1Of3(-1), FSharpChoice<int, Guid, Guid>.NewChoice3Of3(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid>.NewChoice1Of3(0);
@@ -2165,6 +2696,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice4Tests : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid>>
     {
+        public FSharpChoice4Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(-1), FSharpChoice<int, Guid, Guid, Guid>.NewChoice4Of4(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(0);
@@ -2172,6 +2707,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice4CopierTests : CopierTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid>>
     {
+        public FSharpChoice4CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(-1), FSharpChoice<int, Guid, Guid, Guid>.NewChoice4Of4(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(0);
@@ -2179,6 +2718,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice5Tests : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid>>
     {
+        public FSharpChoice5Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(-1), FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice5Of5(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(0);
@@ -2186,6 +2729,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice5CopierTests : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid>>
     {
+        public FSharpChoice5CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(-1), FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice5Of5(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(0);
@@ -2193,6 +2740,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice6Tests : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid, Guid>>
     {
+        public FSharpChoice6Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(-1), FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice6Of6(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(0);
@@ -2200,6 +2751,10 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpChoice6CopierTests : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid, Guid>>
     {
+        public FSharpChoice6CopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>[] TestValues => new[] { FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(-1), FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice6Of6(Guid.NewGuid()) };
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(0);
@@ -2207,12 +2762,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpSetTests : FieldCodecTester<FSharpSet<string>, FSharpSetCodec<string>>
     {
+        public FSharpSetTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpSet<string> CreateValue()
         {
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(Random.Shared.Next().ToString());
+                _ = hashSet.Add(Random.Next().ToString());
             }
 
             return SetModule.OfSeq(hashSet);
@@ -2225,12 +2784,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpSetCopierTests : CopierTester<FSharpSet<string>, FSharpSetCopier<string>>
     {
+        public FSharpSetCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpSet<string> CreateValue()
         {
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(Random.Shared.Next().ToString());
+                _ = hashSet.Add(Random.Next().ToString());
             }
 
             return SetModule.OfSeq(hashSet);
@@ -2243,12 +2806,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpMapTests : FieldCodecTester<FSharpMap<string, string>, FSharpMapCodec<string, string>>
     {
+        public FSharpMapTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override int[] MaxSegmentSizes => new[] { 128 };
 
         protected override FSharpMap<string, string> CreateValue()
         {
             var collection = new List<Tuple<string, string>>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
                 collection.Add(Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
             }
@@ -2263,10 +2830,14 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpMapCopierTests : CopierTester<FSharpMap<string, string>, FSharpMapCopier<string, string>>
     {
+        public FSharpMapCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpMap<string, string> CreateValue()
         {
             var collection = new List<Tuple<string, string>>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
                 collection.Add(Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
             }
@@ -2281,12 +2852,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpListTests : FieldCodecTester<FSharpList<string>, FSharpListCodec<string>>
     {
+        public FSharpListTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpList<string> CreateValue()
         {
             var list = new List<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                list.Add(Random.Shared.Next().ToString());
+                list.Add(Random.Next().ToString());
             }
 
             return ListModule.OfSeq(list);
@@ -2299,12 +2874,16 @@ namespace Orleans.Serialization.UnitTests
 
     public class FSharpListCopierTests : CopierTester<FSharpList<string>, FSharpListCopier<string>>
     {
+        public FSharpListCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override FSharpList<string> CreateValue()
         {
             var list = new List<string>();
-            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Next(17) + 5; i++)
             {
-                list.Add(Random.Shared.Next().ToString());
+                list.Add(Random.Next().ToString());
             }
 
             return ListModule.OfSeq(list);

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -36,7 +36,7 @@ namespace Orleans.Serialization.UnitTests
     public class EnumTests : FieldCodecTester<MyEnum, IFieldCodec<MyEnum>>
     {
         protected override IFieldCodec<MyEnum> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<MyEnum>();
-        protected override MyEnum CreateValue() => (MyEnum)(new Random(Guid.NewGuid().GetHashCode()).Next((int)MyEnum.None, (int)MyEnum.Two));
+        protected override MyEnum CreateValue() => (MyEnum)(Random.Shared.Next((int)MyEnum.None, (int)MyEnum.Two));
         protected override MyEnum[] TestValues => new[] { MyEnum.None, MyEnum.One, MyEnum.Two, (MyEnum)(-1), (MyEnum)10_000};
         protected override void Configure(ISerializerBuilder builder)
         {
@@ -49,7 +49,7 @@ namespace Orleans.Serialization.UnitTests
     public class EnumCopierTests : CopierTester<MyEnum, IDeepCopier<MyEnum>>
     {
         protected override IDeepCopier<MyEnum> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyEnum>();
-        protected override MyEnum CreateValue() => (MyEnum)(new Random(Guid.NewGuid().GetHashCode()).Next((int)MyEnum.None, (int)MyEnum.Two));
+        protected override MyEnum CreateValue() => (MyEnum)(Random.Shared.Next((int)MyEnum.None, (int)MyEnum.Two));
         protected override MyEnum[] TestValues => new[] { MyEnum.None, MyEnum.One, MyEnum.Two, (MyEnum)(-1), (MyEnum)10_000};
         protected override void Configure(ISerializerBuilder builder)
         {
@@ -62,7 +62,7 @@ namespace Orleans.Serialization.UnitTests
     public class DayOfWeekTests : FieldCodecTester<DayOfWeek, IFieldCodec<DayOfWeek>>
     {
         protected override IFieldCodec<DayOfWeek> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<DayOfWeek>();
-        protected override DayOfWeek CreateValue() => (DayOfWeek)(new Random(Guid.NewGuid().GetHashCode()).Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
+        protected override DayOfWeek CreateValue() => (DayOfWeek)(Random.Shared.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
         protected override DayOfWeek[] TestValues => new[] { DayOfWeek.Monday, DayOfWeek.Sunday, (DayOfWeek)(-1), (DayOfWeek)10_000};
 
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
@@ -71,7 +71,7 @@ namespace Orleans.Serialization.UnitTests
     public class DayOfWeekCopierTests : CopierTester<DayOfWeek, IDeepCopier<DayOfWeek>>
     {
         protected override IDeepCopier<DayOfWeek> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<DayOfWeek>();
-        protected override DayOfWeek CreateValue() => (DayOfWeek)(new Random(Guid.NewGuid().GetHashCode()).Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
+        protected override DayOfWeek CreateValue() => (DayOfWeek)(Random.Shared.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday));
         protected override DayOfWeek[] TestValues => new[] { DayOfWeek.Monday, DayOfWeek.Sunday, (DayOfWeek)(-1), (DayOfWeek)10_000};
 
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
@@ -80,14 +80,14 @@ namespace Orleans.Serialization.UnitTests
     public class NullableIntTests : FieldCodecTester<int?, IFieldCodec<int?>>
     {
         protected override IFieldCodec<int?> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<int?>();
-        protected override int? CreateValue() => TestValues[new Random(Guid.NewGuid().GetHashCode()).Next(TestValues.Length)];
+        protected override int? CreateValue() => TestValues[Random.Shared.Next(TestValues.Length)];
         protected override int?[] TestValues => new int?[] { null, 1, 2, -3 };
     }
 
     public class NullableIntCopierTests : CopierTester<int?, IDeepCopier<int?>>
     {
         protected override IDeepCopier<int?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<int?>();
-        protected override int? CreateValue() => TestValues[new Random(Guid.NewGuid().GetHashCode()).Next(TestValues.Length)];
+        protected override int? CreateValue() => TestValues[Random.Shared.Next(TestValues.Length)];
         protected override int?[] TestValues => new int?[] { null, 1, 2, -3 };
     }
 
@@ -213,7 +213,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class BitVector32Tests: FieldCodecTester<BitVector32, BitVector32Codec>
     {
-        protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
+        protected override BitVector32 CreateValue() => new(Random.Shared.Next());
 
         protected override BitVector32[] TestValues => new[]
         {
@@ -230,7 +230,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class BitVector32CopierTests: CopierTester<BitVector32, IDeepCopier<BitVector32>>
     {
-        protected override BitVector32 CreateValue() => new(new Random(Guid.NewGuid().GetHashCode()).Next());
+        protected override BitVector32 CreateValue() => new(Random.Shared.Next());
 
         protected override BitVector32[] TestValues => new[]
         {
@@ -912,16 +912,62 @@ namespace Orleans.Serialization.UnitTests
 
     public class ArrayCodecTests : FieldCodecTester<int[], ArrayCodec<int>>
     {
-        protected override int[] CreateValue() => Enumerable.Range(0, new Random(Guid.NewGuid().GetHashCode()).Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
+        protected override int[] CreateValue() => Enumerable.Range(0, Random.Shared.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => new[] { null, Array.Empty<int>(), CreateValue(), CreateValue(), CreateValue() };
     }
 
     public class ArrayCopierTests : CopierTester<int[], ArrayCopier<int>>
     {
-        protected override int[] CreateValue() => Enumerable.Range(0, new Random(Guid.NewGuid().GetHashCode()).Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
+        protected override int[] CreateValue() => Enumerable.Range(0, Random.Shared.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => new[] { null, Array.Empty<int>(), CreateValue(), CreateValue(), CreateValue() };
+    }
+
+    public class UInt128CodecTests : FieldCodecTester<UInt128, UInt128Codec>
+    {
+        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+
+        protected override UInt128[] TestValues => new UInt128[]
+        {
+            0,
+            1,
+            (UInt128)byte.MaxValue - 1,
+            byte.MaxValue,
+            (UInt128)byte.MaxValue + 1,
+            (UInt128)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (UInt128)ushort.MaxValue + 1,
+            (UInt128)uint.MaxValue - 1,
+            uint.MaxValue,
+            (UInt128)uint.MaxValue + 1,
+            UInt128.MaxValue,
+        };
+
+        protected override Action<Action<UInt128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
+    }
+
+    public class UInt128CopierTests : CopierTester<UInt128, IDeepCopier<UInt128>>
+    {
+        protected override UInt128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+
+        protected override UInt128[] TestValues => new UInt128[]
+        {
+            0,
+            1,
+            (UInt128)byte.MaxValue - 1,
+            byte.MaxValue,
+            (UInt128)byte.MaxValue + 1,
+            (UInt128)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (UInt128)ushort.MaxValue + 1,
+            (UInt128)uint.MaxValue - 1,
+            uint.MaxValue,
+            (UInt128)uint.MaxValue + 1,
+            UInt128.MaxValue,
+        };
+
+        protected override Action<Action<UInt128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
     }
 
     public class UInt64CodecTests : FieldCodecTester<ulong, UInt64Codec>
@@ -1068,6 +1114,52 @@ namespace Orleans.Serialization.UnitTests
         protected override byte[] TestValues => new byte[] { 0, 1, byte.MaxValue - 1, byte.MaxValue };
 
         protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
+    }
+
+    public class Int128CodecTests : FieldCodecTester<Int128, Int128Codec>
+    {
+        protected override Int128 CreateValue() => new (unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+
+        protected override Int128[] TestValues => new Int128[]
+        {
+            0,
+            1,
+            (Int128)byte.MaxValue - 1,
+            byte.MaxValue,
+            (Int128)byte.MaxValue + 1,
+            (Int128)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (Int128)ushort.MaxValue + 1,
+            (Int128)uint.MaxValue - 1,
+            uint.MaxValue,
+            (Int128)uint.MaxValue + 1,
+            Int128.MaxValue,
+        };
+
+        protected override Action<Action<Int128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
+    }
+
+    public class Int128CopierTests : CopierTester<Int128, IDeepCopier<Int128>>
+    {
+        protected override Int128 CreateValue() => new Int128(unchecked((ulong)Random.Shared.NextInt64()), unchecked((ulong)Random.Shared.NextInt64()));
+
+        protected override Int128[] TestValues => new Int128[]
+        {
+            0,
+            1,
+            (Int128)byte.MaxValue - 1,
+            byte.MaxValue,
+            (Int128)byte.MaxValue + 1,
+            (Int128)ushort.MaxValue - 1,
+            ushort.MaxValue,
+            (Int128)ushort.MaxValue + 1,
+            (Int128)uint.MaxValue - 1,
+            uint.MaxValue,
+            (Int128)uint.MaxValue + 1,
+            Int128.MaxValue,
+        };
+
+        protected override Action<Action<Int128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
     }
 
     public class Int64CodecTests : FieldCodecTester<long, Int64Codec>
@@ -1392,7 +1484,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class FloatCodecTests : FieldCodecTester<float, FloatCodec>
     {
-        protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override float CreateValue() => float.MaxValue * (float)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
 
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
@@ -1400,15 +1492,31 @@ namespace Orleans.Serialization.UnitTests
 
     public class FloatCopierTests : CopierTester<float, IDeepCopier<float>>
     {
-        protected override float CreateValue() => float.MaxValue * (float)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override float CreateValue() => float.MaxValue * (float)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => new[] { float.MinValue, 0, 1.0f, float.MaxValue };
 
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
     }
 
+    public class HalfCodecTests : FieldCodecTester<Half, HalfCodec>
+    {
+        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Shared.Next(ushort.MinValue, ushort.MaxValue));
+        protected override Half[] TestValues => new[] { Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue };
+
+        protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
+    }
+
+    public class HalfCopierTests : CopierTester<Half, IDeepCopier<Half>>
+    {
+        protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Shared.Next(ushort.MinValue, ushort.MaxValue));
+        protected override Half[] TestValues => new[] { Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue };
+
+        protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
+    }
+
     public class DoubleCodecTests : FieldCodecTester<double, DoubleCodec>
     {
-        protected override double CreateValue() => double.MaxValue * new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override double CreateValue() => double.MaxValue * Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
 
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
@@ -1416,7 +1524,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class DoubleCopierTests : CopierTester<double, IDeepCopier<double>>
     {
-        protected override double CreateValue() => double.MaxValue * new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override double CreateValue() => double.MaxValue * Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => new[] { double.MinValue, 0, 1.0, double.MaxValue };
 
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
@@ -1424,14 +1532,14 @@ namespace Orleans.Serialization.UnitTests
 
     public class DecimalCodecTests : FieldCodecTester<decimal, DecimalCodec>
     {
-        protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
 
     public class DecimalCopierTests : CopierTester<decimal, IDeepCopier<decimal>>
     {
-        protected override decimal CreateValue() => decimal.MaxValue * (decimal)new Random(Guid.NewGuid().GetHashCode()).NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
+        protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.Shared.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => new[] { decimal.MinValue, 0, 1.0M, decimal.MaxValue };
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
@@ -1440,11 +1548,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override List<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new List<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Add(rand.Next());
+                result.Add(Random.Shared.Next());
             }
 
             return result;
@@ -1458,11 +1565,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override List<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new List<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Add(rand.Next());
+                result.Add(Random.Shared.Next());
             }
 
             return result;
@@ -1476,11 +1582,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override Queue<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new Queue<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Enqueue(rand.Next());
+                result.Enqueue(Random.Shared.Next());
             }
 
             return result;
@@ -1494,11 +1599,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override Queue<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new Queue<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Enqueue(rand.Next());
+                result.Enqueue(Random.Shared.Next());
             }
 
             return result;
@@ -1512,11 +1616,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ConcurrentQueue<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new ConcurrentQueue<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Enqueue(rand.Next());
+                result.Enqueue(Random.Shared.Next());
             }
 
             return result;
@@ -1530,11 +1633,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ConcurrentQueue<int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new ConcurrentQueue<int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result.Enqueue(rand.Next());
+                result.Enqueue(Random.Shared.Next());
             }
 
             return result;
@@ -1548,11 +1650,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override Dictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new Dictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1566,11 +1667,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override Dictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new Dictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1602,14 +1702,13 @@ namespace Orleans.Serialization.UnitTests
 
         protected override Dictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var eqComparer = _comparers[_nextComparer++ % _comparers.Length];
             var result = new Dictionary<string, int>(eqComparer);
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
                 var key = Guid.NewGuid().ToString();
-                result[key.ToLowerInvariant()] = rand.Next();
-                result[key.ToUpperInvariant()] = rand.Next();
+                result[key.ToLowerInvariant()] = Random.Shared.Next();
+                result[key.ToUpperInvariant()] = Random.Shared.Next();
             }
 
             return result;
@@ -1661,12 +1760,11 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override Dictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var eqComparer = new DictionaryWithComparerCodecTests.CaseInsensitiveEqualityComparer();
             var result = new Dictionary<string, int>(eqComparer);
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1681,11 +1779,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new ConcurrentDictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1721,11 +1818,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new ConcurrentDictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1761,11 +1857,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var dict = new Dictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                dict[rand.Next().ToString()] = rand.Next();
+                dict[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return new ReadOnlyDictionary<string, int>(dict);
@@ -1779,11 +1874,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var dict = new Dictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                dict[rand.Next().ToString()] = rand.Next();
+                dict[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return new ReadOnlyDictionary<string, int>(dict);
@@ -1797,11 +1891,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override SortedDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new SortedDictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1815,11 +1908,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override SortedDictionary<string, int> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new SortedDictionary<string, int>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                result[rand.Next().ToString()] = rand.Next();
+                result[Random.Shared.Next().ToString()] = Random.Shared.Next();
             }
 
             return result;
@@ -1835,9 +1927,8 @@ namespace Orleans.Serialization.UnitTests
 
         protected override IPAddress CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             byte[] bytes;
-            if (rand.Next(1) == 0)
+            if (Random.Shared.Next(1) == 0)
             {
                 bytes = new byte[4];
             }
@@ -1845,8 +1936,7 @@ namespace Orleans.Serialization.UnitTests
             {
                 bytes = new byte[16];
             }
-
-            rand.NextBytes(bytes);
+            Random.Shared.NextBytes(bytes);
             return new IPAddress(bytes);
         } 
     }
@@ -1857,9 +1947,8 @@ namespace Orleans.Serialization.UnitTests
 
         protected override IPAddress CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             byte[] bytes;
-            if (rand.Next(1) == 0)
+            if (Random.Shared.Next(1) == 0)
             {
                 bytes = new byte[4];
             }
@@ -1867,8 +1956,7 @@ namespace Orleans.Serialization.UnitTests
             {
                 bytes = new byte[16];
             }
-
-            rand.NextBytes(bytes);
+            Random.Shared.NextBytes(bytes);
             return new IPAddress(bytes);
         }
 
@@ -1879,11 +1967,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override HashSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = result.Add(rand.Next().ToString());
+                _ = result.Add(Random.Shared.Next().ToString());
             }
 
             return result;
@@ -1898,11 +1985,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override HashSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var result = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = result.Add(rand.Next().ToString());
+                _ = result.Add(Random.Shared.Next().ToString());
             }
 
             return result;
@@ -1917,11 +2003,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ImmutableHashSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(rand.Next().ToString());
+                _ = hashSet.Add(Random.Shared.Next().ToString());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -1936,11 +2021,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ImmutableHashSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(rand.Next().ToString());
+                _ = hashSet.Add(Random.Shared.Next().ToString());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -1957,11 +2041,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override ImmutableHashSet<object> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var hashSet = new HashSet<object>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(rand.Next());
+                _ = hashSet.Add(Random.Shared.Next());
             }
 
             return hashSet.ToImmutableHashSet();
@@ -2126,11 +2209,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override FSharpSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(rand.Next().ToString());
+                _ = hashSet.Add(Random.Shared.Next().ToString());
             }
 
             return SetModule.OfSeq(hashSet);
@@ -2145,11 +2227,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override FSharpSet<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var hashSet = new HashSet<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                _ = hashSet.Add(rand.Next().ToString());
+                _ = hashSet.Add(Random.Shared.Next().ToString());
             }
 
             return SetModule.OfSeq(hashSet);
@@ -2166,9 +2247,8 @@ namespace Orleans.Serialization.UnitTests
 
         protected override FSharpMap<string, string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var collection = new List<Tuple<string, string>>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
                 collection.Add(Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
             }
@@ -2185,9 +2265,8 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override FSharpMap<string, string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var collection = new List<Tuple<string, string>>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
                 collection.Add(Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
             }
@@ -2204,11 +2283,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override FSharpList<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var list = new List<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                list.Add(rand.Next().ToString());
+                list.Add(Random.Shared.Next().ToString());
             }
 
             return ListModule.OfSeq(list);
@@ -2223,11 +2301,10 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override FSharpList<string> CreateValue()
         {
-            var rand = new Random(Guid.NewGuid().GetHashCode());
             var list = new List<string>();
-            for (var i = 0; i < rand.Next(17) + 5; i++)
+            for (var i = 0; i < Random.Shared.Next(17) + 5; i++)
             {
-                list.Add(rand.Next().ToString());
+                list.Add(Random.Shared.Next().ToString());
             }
 
             return ListModule.OfSeq(list);

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -1254,7 +1254,10 @@ namespace Orleans.Serialization.UnitTests
             uint.MaxValue,
             (ulong)uint.MaxValue + 1,
             ulong.MaxValue,
-        };
+        }
+        .Concat(Enumerable.Range(1, 63).Select(i => 1ul << i))
+        .ToArray();
+
 
         protected override Action<Action<ulong>> ValueProvider => Gen.ULong.ToValueProvider();
     }
@@ -1310,14 +1313,16 @@ namespace Orleans.Serialization.UnitTests
             ushort.MaxValue,
             (uint)ushort.MaxValue + 1,
             uint.MaxValue,
-        };
+        }
+        .Concat(Enumerable.Range(1, 31).Select(i => 1u << i))
+        .ToArray();
 
         protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
     }
 
-    public class UInt32CopiercTests : CopierTester<uint, IDeepCopier<uint>>
+    public class UInt32CopierTests : CopierTester<uint, IDeepCopier<uint>>
     {
-        public UInt32CopiercTests(ITestOutputHelper output) : base(output)
+        public UInt32CopierTests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -4,11 +4,16 @@ using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests;
 
 public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IFieldCodec<MyForeignLibraryType>>
 {
+    public ConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override MyForeignLibraryType CreateValue() => new(12, "hi", DateTimeOffset.Now);
     protected override bool Equals(MyForeignLibraryType left, MyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
@@ -16,6 +21,10 @@ public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IField
 
 public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopier<MyForeignLibraryType>>
 {
+    public ConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override MyForeignLibraryType CreateValue() => new(12, "hi", DateTimeOffset.Now);
     protected override bool Equals(MyForeignLibraryType left, MyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
@@ -23,6 +32,10 @@ public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopi
 
 public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibraryType, IFieldCodec<WrapsMyForeignLibraryType>>
 {
+    public WrappedConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override WrapsMyForeignLibraryType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
     protected override bool Equals(WrapsMyForeignLibraryType left, WrapsMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
@@ -30,6 +43,10 @@ public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibrary
 
 public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryType, IDeepCopier<WrapsMyForeignLibraryType>>
 {
+    public WrappedConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override WrapsMyForeignLibraryType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
     protected override bool Equals(WrapsMyForeignLibraryType left, WrapsMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
@@ -37,6 +54,10 @@ public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryTyp
 
 public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibraryValueType, IFieldCodec<MyForeignLibraryValueType>>
 {
+    public StructConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override MyForeignLibraryValueType CreateValue() => new(12, "hi", DateTimeOffset.Now);
     protected override bool Equals(MyForeignLibraryValueType left, MyForeignLibraryValueType right) => left.Equals(right);
     protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
@@ -44,6 +65,10 @@ public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibr
 
 public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType, IDeepCopier<MyForeignLibraryValueType>>
 {
+    public StructConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override MyForeignLibraryValueType CreateValue() => new(12, "hi", DateTimeOffset.Now);
     protected override bool Equals(MyForeignLibraryValueType left, MyForeignLibraryValueType right) => left.Equals(right);
     protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
@@ -51,6 +76,10 @@ public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType
 
 public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsMyForeignLibraryValueType, IFieldCodec<WrapsMyForeignLibraryValueType>>
 {
+    public WrappedStructConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override WrapsMyForeignLibraryValueType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryValueType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
     protected override bool Equals(WrapsMyForeignLibraryValueType left, WrapsMyForeignLibraryValueType right) => left.Equals(right);
     protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
@@ -58,6 +87,10 @@ public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsM
 
 public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibraryValueType, IDeepCopier<WrapsMyForeignLibraryValueType>>
 {
+    public WrappedStructConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override WrapsMyForeignLibraryValueType CreateValue() => new() { IntValue = 12, ForeignValue = new MyForeignLibraryValueType(12, "hi", DateTimeOffset.Now), OtherIntValue = 7468249 };
     protected override bool Equals(WrapsMyForeignLibraryValueType left, WrapsMyForeignLibraryValueType right) => left.Equals(right);
     protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
@@ -65,6 +98,10 @@ public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibr
 
 public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignLibraryType, IFieldCodec<DerivedFromMyForeignLibraryType>>
 {
+    public DerivedConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override DerivedFromMyForeignLibraryType CreateValue() => new(658, 12, "hi", DateTimeOffset.Now);
     protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
@@ -72,6 +109,10 @@ public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignL
 
 public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibraryType, IDeepCopier<DerivedFromMyForeignLibraryType>>
 {
+    public DerivedConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     protected override DerivedFromMyForeignLibraryType CreateValue() => new(658, 12, "hi", DateTimeOffset.Now);
     protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };

--- a/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
@@ -5,12 +5,17 @@ using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests
 {
     [Trait("Category", "BVT")]
     public class JsonCodecTests : FieldCodecTester<MyJsonClass, IFieldCodec<MyJsonClass>>
     {
+        public JsonCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
@@ -73,6 +78,10 @@ namespace Orleans.Serialization.UnitTests
     [Trait("Category", "BVT")]
     public class JsonCodecCopierTests : CopierTester<MyJsonClass, IDeepCopier<MyJsonClass>>
     {
+        public JsonCodecCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);

--- a/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
@@ -5,12 +5,17 @@ using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests
 {
     [Trait("Category", "BVT")]
     public class NewtonsoftJsonCodecTests : FieldCodecTester<MyJsonClass, IFieldCodec<MyJsonClass>>
     {
+        public NewtonsoftJsonCodecTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddNewtonsoftJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
@@ -75,6 +80,10 @@ namespace Orleans.Serialization.UnitTests
     [Trait("Category", "BVT")]
     public class NewtonsoftJsonCodecCopierTests : CopierTester<MyJsonClass, IDeepCopier<MyJsonClass>>
     {
+        public NewtonsoftJsonCodecCopierTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override void Configure(ISerializerBuilder builder)
         {
             builder.AddNewtonsoftJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);

--- a/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+/// <summary>
+/// Ensures that numeric fields (integers, floats, etc) can be widened and narrowed in a version tolerant manner.
+/// </summary>
+public class NumericsWideningAndNarrowingTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly Serializer _serializer;
+
+    public NumericsWideningAndNarrowingTests()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSerializer();
+        _serviceProvider = services.BuildServiceProvider();
+        _serializer = _serviceProvider.GetRequiredService<Serializer>();
+    }
+
+    /// <summary>
+    /// Tests that unsigned integers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void UnsignedIntegerWideningAndNarrowingVersionToleranceTests()
+    {
+        ConversionRoundTrip<byte, ushort>();
+        ConversionRoundTrip<byte, uint>();
+        ConversionRoundTrip<byte, ulong>();
+        ConversionRoundTrip<byte, UInt128>();
+
+        ConversionRoundTrip<ushort, uint>();
+        ConversionRoundTrip<ushort, ulong>();
+        ConversionRoundTrip<ushort, UInt128>();
+
+        ConversionRoundTrip<uint, ulong>();
+        ConversionRoundTrip<uint, UInt128>();
+
+        ConversionRoundTrip<ulong, UInt128>();
+    }
+
+    /// <summary>
+    /// Tests that signed integers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void SignedIntegerWideningAndNarrowingVersionToleranceTests()
+    {
+        ConversionRoundTrip<sbyte, short>();
+        ConversionRoundTrip<sbyte, int>();
+        ConversionRoundTrip<sbyte, long>();
+        ConversionRoundTrip<sbyte, Int128>();
+
+        ConversionRoundTrip<short, int>();
+        ConversionRoundTrip<short, long>();
+        ConversionRoundTrip<short, Int128>();
+
+        ConversionRoundTrip<int, long>();
+        ConversionRoundTrip<int, Int128>();
+
+        ConversionRoundTrip<long, Int128>();
+    }
+
+    /// <summary>
+    /// Tests that floating point numbers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void FloatWideningAndNarrowingVersionToleranceTests()
+    {
+        FloatConversionRoundTrip<Half, decimal>();
+        FloatConversionRoundTrip<Half, float>();
+        FloatConversionRoundTrip<Half, double>();
+
+        FloatConversionRoundTrip<decimal, float>();
+        FloatConversionRoundTrip<decimal, double>();
+
+        FloatConversionRoundTrip<float, double>();
+    }
+
+    private void ConversionRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        WideningRoundTrip<N, W>();
+        NarrowingRoundTrip<N, W>();
+        NarrowingOverflow<N, W>();
+    }
+
+    private void FloatConversionRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        FloatWideningRoundTrip<N, W>();
+        FloatNarrowingRoundTrip<N, W>();
+        NarrowingOverflow<N, W>();
+    }
+
+    private void WideningRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        var two = N.MultiplicativeIdentity + N.MultiplicativeIdentity;
+        var values = new List<N>
+        {
+            N.MinValue,
+            default(N),
+            N.MaxValue / two,
+            N.MaxValue,
+        };
+
+        foreach (var value in values)
+        {
+            RoundTripValue<N, W>(value);
+        }
+    }
+
+    private void NarrowingRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        var two = N.MultiplicativeIdentity + N.MultiplicativeIdentity;
+        var values = (new N[]
+        {
+            N.MinValue,
+            default(N),
+            N.MaxValue / two,
+            N.MaxValue,
+        }).Select(W.CreateTruncating).ToList();
+
+        foreach (var value in values)
+        {
+            RoundTripValue<W, N>(value);
+        }
+    }
+
+    private void NarrowingOverflow<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        var values = W.Sign(W.MinValue) switch
+        {
+            -1 => new[] { W.MinValue, W.MaxValue },
+            _ => new[] { W.MaxValue }
+        };
+
+        foreach (var value in values)
+        {
+            Assert.Throws<OverflowException>(() => RoundTripValueDirectly<W, N>(value));
+            Assert.Throws<OverflowException>(() => RoundTripValueIndirectly<W, N>(value));
+        }
+    }
+
+    private void FloatWideningRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        var two = N.MultiplicativeIdentity + N.MultiplicativeIdentity;
+        var buffer = N.MaxValue / (two * two * two);
+        var values = new List<N>
+        {
+            N.MinValue + buffer,
+            N.MinValue / two,
+            default(N),
+            N.MaxValue / two,
+            N.MaxValue - buffer,
+        };
+
+        foreach (var value in values)
+        {
+            RoundTripValue<N, W>(value);
+        }
+    }
+
+    private void FloatNarrowingRoundTrip<N, W>()
+        where N : INumber<N>, IMinMaxValue<N>
+        where W : INumber<W>, IMinMaxValue<W>
+    {
+        var two = N.MultiplicativeIdentity + N.MultiplicativeIdentity;
+        var buffer = N.MaxValue / (two * two * two);
+        var values = new List<N>
+        {
+            N.MinValue + buffer,
+            N.MinValue / two,
+            default(N),
+            N.MaxValue / two,
+            N.MaxValue - buffer,
+        }.Select(W.CreateTruncating).ToList();
+
+        foreach (var value in values)
+        {
+            RoundTripValue<W, N>(value);
+        }
+    }
+
+    private void RoundTripValue<TLeft, TRight>(TLeft leftValue)
+        where TLeft : INumber<TLeft>, IMinMaxValue<TLeft>
+        where TRight : INumber<TRight>, IMinMaxValue<TRight>
+    {
+        RoundTripValueDirectly<TLeft, TRight>(leftValue);
+        RoundTripValueIndirectly<TLeft, TRight>(leftValue);
+    }
+
+    private void RoundTripValueDirectly<TLeft, TRight>(TLeft leftValue)
+        where TLeft : INumber<TLeft>, IMinMaxValue<TLeft>
+        where TRight : INumber<TRight>, IMinMaxValue<TRight>
+    {
+        // Round-trip the value, converting it along the way.
+        var payload = _serializer.SerializeToArray(leftValue);
+        var result = _serializer.Deserialize<TRight>(payload);
+
+        var asRight = TRight.CreateTruncating(leftValue);
+        Assert.Equal(asRight, result);
+
+        var asLeft = TLeft.CreateTruncating(result);
+        var expected = TLeft.CreateTruncating(TRight.CreateTruncating(leftValue));
+        Assert.Equal(expected, asLeft);
+    }
+
+    private void RoundTripValueIndirectly<TLeft, TRight>(TLeft leftValue)
+        where TLeft : INumber<TLeft>, IMinMaxValue<TLeft>
+        where TRight : INumber<TRight>, IMinMaxValue<TRight>
+    {
+        // Wrap the value and round-trip the wrapped value, converting it along the way.
+        var payload = _serializer.SerializeToArray(new ValueHolder<TLeft> { Value = leftValue });
+        var result = _serializer.Deserialize<ValueHolder<TRight>>(payload).Value;
+
+        var asRight = TRight.CreateTruncating(leftValue);
+        Assert.Equal(asRight, result);
+
+        var asLeft = TLeft.CreateTruncating(result);
+        var expected = TLeft.CreateTruncating(TRight.CreateTruncating(leftValue));
+        Assert.Equal(expected, asLeft);
+    }
+
+    [GenerateSerializer]
+    public sealed class ValueHolder<T>
+    {
+        [Id(0)]
+        public T Value;
+    }
+}
+


### PR DESCRIPTION
This PR adds codecs for some standard library numeric types, `Int128`, `UInt128`, and `Half`.
It also adds widening & narrowing tests for all existing supported types: the current versioning rules allow numeric fields to be widened and narrowed (with a runtime exception for overflow) but do not allow changing signedness or between integer & floating point types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8100)