### PR TITLE
AsyncTimer monitoring: measure overshoot only when waiting for timer

### DIFF
--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -142,19 +142,12 @@ namespace Orleans.Runtime.MembershipService
 
             if ((int)threadPoolDelaySeconds >= 1)
             {
-                if ((int)threadPoolDelaySeconds >= 10)
-                {
-                    // Log as an error if the delay is massive.
-                    _log.LogError(
-                        ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",
-                        threadPoolDelaySeconds);
-                }
-                else
-                {
-                    _log.LogWarning(
-                        ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",
-                        threadPoolDelaySeconds);
-                }
+                // Log as an error if the delay is massive.
+                var logLevel = (int)threadPoolDelaySeconds >= 10 ? LogLevel.Error : LogLevel.Warning;
+                _log.Log(
+                    logLevel,
+                    ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.",
+                    threadPoolDelaySeconds);
 
                 complaints?.Add(
                     $".NET Thread Pool is exhibiting delays of {threadPoolDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.");

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.MembershipService
                         var dateLimit = DateTime.UtcNow - this.clusterMembershipOptions.DefunctSiloExpiration;
                         await this.membershipTableProvider.CleanupDefunctSiloEntries(dateLimit);
                     }
-                    catch (Exception exception) when (exception is NotImplementedException || exception is MissingMethodException)
+                    catch (Exception exception) when (exception is NotImplementedException or MissingMethodException)
                     {
                         this.cleanupDefunctSilosTimer.Dispose();
                         this.log.LogWarning(

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.MembershipService
         /// <summary>
         /// The time since the last ping response was received from either the node being monitored or an intermediary.
         /// </summary>
-        public TimeSpan? ElapsedSinceLastResponse => _elapsedSinceLastSuccessfulResponse.IsRunning ? (Nullable<TimeSpan>)_elapsedSinceLastSuccessfulResponse.Elapsed : null;
+        public TimeSpan? ElapsedSinceLastResponse => _elapsedSinceLastSuccessfulResponse.IsRunning ? (TimeSpan?)_elapsedSinceLastSuccessfulResponse.Elapsed : null;
 
         /// <summary>
         /// The duration of time measured from just prior to sending the last probe which received a response until just after receiving and processing the response.


### PR DESCRIPTION
Currently, we will count time spent firing the timer itself towards overshoot, so if the callback is slower than the `TimerDelaySlack` (hard coded to 3s), that will count as a health degradation. We shouldn't do this, since we do not know how much work the timer callback has to do or whether it is ever supposed to fire again (eg, maybe it will decide it doesn't need to wait for any more ticks and it's complete).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8103)