### PR TITLE
Improve `SingleWaiterAutoResetEvent` implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-postgres:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
@@ -103,6 +104,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-mariadb:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
@@ -138,6 +140,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-sqlserver:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
@@ -173,6 +176,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-azure-storage:
     if: ${{ false }}
     name: Azure Storage provider tests
@@ -210,6 +214,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-consul:
     name: Consul provider tests
     runs-on: ubuntu-latest
@@ -244,6 +249,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-zookeeper:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
@@ -275,6 +281,7 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*
   test-dynamodb:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
@@ -314,3 +321,4 @@ jobs:
         retention-days: 5
         path: |
           **/TestResults/*
+          **/logs/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build
     - uses: actions/upload-artifact@v3
       with:
-        name: test_output
+        name: build_output
         retention-days: 5
         path: |
           **/*.binlog
@@ -64,8 +64,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-postgres:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
@@ -101,8 +100,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-mariadb:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
@@ -135,8 +133,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-sqlserver:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
@@ -169,8 +166,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-azure-storage:
     if: ${{ false }}
     name: Azure Storage provider tests
@@ -205,8 +201,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-consul:
     name: Consul provider tests
     runs-on: ubuntu-latest
@@ -238,8 +233,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-zookeeper:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
@@ -268,8 +262,7 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*
   test-dynamodb:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
@@ -306,5 +299,4 @@ jobs:
         name: test_output
         retention-days: 5
         path: |
-          **/*.log
-          **/*.dmp
+          **/TestResults/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
         include-prerelease: true
     - name: Build
       run: dotnet build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.binlog
+          **/*.log
+          **/*.dmp
   test-redis:
     name: Redis provider tests
     runs-on: ubuntu-latest
@@ -51,6 +58,12 @@ jobs:
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
         ORLEANSREDISCONNECTIONSTRING: "localhost:6379,ssl=False,abortConnect=False"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-postgres:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
@@ -81,6 +94,12 @@ jobs:
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="False positive")]
         ORLEANSPOSTGRESCONNECTIONSTRING: "Server=127.0.0.1;Port=5432;Integrated Security=true;Pooling=false;User Id=postgres;Password=postgres;SSL Mode=Disable"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-mariadb:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
@@ -108,6 +127,12 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSMYSQLCONNECTIONSTRING: "Server=127.0.0.1;Port=3306;UId=root;Pwd=mariadb;"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-sqlserver:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
@@ -135,6 +160,12 @@ jobs:
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
         ORLEANSMSSQLCONNECTIONSTRING: "Server=127.0.0.1,1433;User Id=SA;Password=yourWeak(!)Password;"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-azure-storage:
     if: ${{ false }}
     name: Azure Storage provider tests
@@ -164,6 +195,12 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSDATACONNECTIONSTRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-consul:
     name: Consul provider tests
     runs-on: ubuntu-latest
@@ -190,6 +227,12 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSCONSULCONNECTIONSTRING: "http://localhost:8500"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-zookeeper:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
@@ -213,6 +256,12 @@ jobs:
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
         ORLEANSZOOKEEPERCONNECTIONSTRING: "localhost:2181"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp
   test-dynamodb:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
@@ -244,3 +293,9 @@ jobs:
         ORLEANSDYNAMODBACCESSKEY: "root"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
         ORLEANSDYNAMODBSECRETKEY: "pass"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test_output
+        path: |
+          **/*.log
+          **/*.dmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: build_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/*.binlog
   test-redis:
@@ -62,7 +62,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -101,7 +101,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -137,7 +137,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -173,7 +173,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -211,7 +211,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -246,7 +246,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -278,7 +278,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*
@@ -318,7 +318,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_output
-        retention-days: 5
+        retention-days: 1
         path: |
           **/TestResults/*
           **/logs/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.binlog
           **/*.log
@@ -61,6 +62,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -97,6 +99,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -130,6 +133,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -163,6 +167,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -198,6 +203,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -230,6 +236,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -259,6 +266,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp
@@ -296,6 +304,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: test_output
+        retention-days: 5
         path: |
           **/*.log
           **/*.dmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
       matrix:
         provider: ["DynamoDB"]
     services:
-      postgres:
+      dynamodb:
         image: amazon/dynamodb-local:latest
         ports:
         - 8000:8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         retention-days: 5
         path: |
           **/*.binlog
-          **/*.log
-          **/*.dmp
   test-redis:
     name: Redis provider tests
     runs-on: ubuntu-latest
@@ -59,7 +57,9 @@ jobs:
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
         ORLEANSREDISCONNECTIONSTRING: "localhost:6379,ssl=False,abortConnect=False"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -95,7 +95,9 @@ jobs:
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="False positive")]
         ORLEANSPOSTGRESCONNECTIONSTRING: "Server=127.0.0.1;Port=5432;Integrated Security=true;Pooling=false;User Id=postgres;Password=postgres;SSL Mode=Disable"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -128,7 +130,9 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSMYSQLCONNECTIONSTRING: "Server=127.0.0.1;Port=3306;UId=root;Pwd=mariadb;"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -161,7 +165,9 @@ jobs:
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
         ORLEANSMSSQLCONNECTIONSTRING: "Server=127.0.0.1,1433;User Id=SA;Password=yourWeak(!)Password;"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -196,7 +202,9 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSDATACONNECTIONSTRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -228,7 +236,9 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CSCAN0090:ConfigFile", Justification="Not a secret")]
 # [SuppressMessage("Microsoft.Security", "CSCAN0220:DefaultPasswordContexts", Justification="Not a secret")]
         ORLEANSCONSULCONNECTIONSTRING: "http://localhost:8500"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -257,7 +267,9 @@ jobs:
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
         ORLEANSZOOKEEPERCONNECTIONSTRING: "localhost:2181"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5
@@ -294,7 +306,9 @@ jobs:
         ORLEANSDYNAMODBACCESSKEY: "root"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
         ORLEANSDYNAMODBSECRETKEY: "pass"
-    - uses: actions/upload-artifact@v3
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
       with:
         name: test_output
         retention-days: 5

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -237,6 +237,7 @@ namespace Orleans.Runtime.Placement
 
             private async Task ProcessLoop()
             {
+                Action signalWaiter = _workSignal.Signal;
                 while (true)
                 {
                     try
@@ -263,7 +264,7 @@ namespace Orleans.Runtime.Placement
                                     workItem.Result = GetOrPlaceActivationAsync(message.Message);
 
                                     // Wake up this processing loop when the task completes
-                                    workItem.Result.SignalOnCompleted(_workSignal);
+                                    workItem.Result.GetAwaiter().UnsafeOnCompleted(signalWaiter);
                                 }
                             }
                         }

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -104,7 +104,7 @@ namespace Orleans.Runtime
             var status = Interlocked.And(ref _status, ResetMask);
 
             // If both the "Waiting" and "Signaled" flags were not already set, something has gone catastrophically wrong.
-            Debug.Assert((status & (WaitingFlag | SignaledFlag)) != (WaitingFlag | SignaledFlag));
+            Debug.Assert((status & (WaitingFlag | SignaledFlag)) == (WaitingFlag | SignaledFlag));
         }
 
         private static void ThrowConcurrentWaitersNotSupported() => throw new InvalidOperationException("Concurrent waiters are not supported");

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -1,15 +1,29 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace Orleans.Runtime
 {
+    /// <summary>
+    /// Represents a synchronization event that, when signalled, resets automatically after releasing a single waiter.
+    /// This type supports concurrent signallers but only a single waiter.
+    /// </summary>
     internal sealed class SingleWaiterAutoResetEvent : IValueTaskSource
     {
-        private Action _signalAction;
+        // Signalled indicates that the event has been signalled and not yet reset.
+        private const uint SignalledFlag = 1;
+
+        // Waiting indicates that a waiter is present and waiting for the event to be signalled.
+        private const uint WaitingFlag = 1 << 1;
+
+        // ResetMask is used to clear both status flags.
+        private const uint ResetMask = ~SignalledFlag & ~WaitingFlag;
+
         private ManualResetValueTaskSourceCore<bool> _waitSource;
-        private int _hasWaiter = 1;
+        private volatile uint _status;
 
         public bool RunContinuationsAsynchronously
         {
@@ -17,52 +31,82 @@ namespace Orleans.Runtime
             set => _waitSource.RunContinuationsAsynchronously = value;
         }
 
-        public Action SignalAction => _signalAction ??= Signal;
-
         ValueTaskSourceStatus IValueTaskSource.GetStatus(short token) => _waitSource.GetStatus(token);
 
         void IValueTaskSource.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) => _waitSource.OnCompleted(continuation, state, token, flags);
 
         void IValueTaskSource.GetResult(short token)
         {
+            // Reset the wait source.
             _waitSource.GetResult(token);
-            if (_hasWaiter != 0)
-            {
-                ThrowConcurrencyViolation();
-            }
-
             _waitSource.Reset();
-            Volatile.Write(ref _hasWaiter, 1);
+
+            // Reset the status.
+            ResetStatus();
         }
 
+        /// <summary>
+        /// Signal the waiter.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Signal()
         {
-            if (Interlocked.Exchange(ref _hasWaiter, 0) == 1)
+            // Set the signalled flag.
+            var status = Interlocked.Or(ref _status, SignalledFlag);
+
+            // If there was a waiter and the signalled flag was unset, wake the waiter now.
+            if ((status & SignalledFlag) != SignalledFlag && (status & WaitingFlag) == WaitingFlag)
             {
+                // Note that in this assert we are checking the volatile _status field.
+                // This is a sanity check to ensure that the signalling conditions are true:
+                // that "Signalled" and "Waiting" flags are both set.
+                Debug.Assert((_status & (SignalledFlag | WaitingFlag)) == (SignalledFlag | WaitingFlag));
                 _waitSource.SetResult(true);
             }
         }
 
-        public ValueTask WaitAsync() => new(this, _waitSource.Version);
+        /// <summary>
+        /// Wait for the event to be signalled.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask WaitAsync()
+        {
+            // Indicate that there is a waiter.
+            var status = Interlocked.Or(ref _status, WaitingFlag);
+
+            // If there was already a waiter, that is a catastrophic error since this class is designed for use with a single waiter.
+            if ((status & WaitingFlag) == WaitingFlag)
+            {
+                ThrowConcurrencyViolation();
+            }
+
+            // If the event was already signalled, immediately wake the waiter.
+            if ((status & SignalledFlag) == SignalledFlag)
+            {
+                // Reset just the status because the _waitSource has not been set.
+                // We know this _waitSource has not been set because _waitSource is only set when
+                // Signal() observes that the "Waiting" flag had been set but not the "Signalled" flag.
+                ResetStatus();
+                return default;
+            }
+
+            return new(this, _waitSource.Version);
+        }
+
+        /// <summary>
+        /// Called when a waiter handles the event signal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ResetStatus()
+        {
+            // The event is being handled, so clear the "Signalled" flag now.
+            // The waiter is no longer waiting, so clear the "Waiting" flag, too.
+            var status = Interlocked.And(ref _status, ResetMask);
+
+            // If both the "Waiting" and "Signalled" flags were not already set, something has gone catastrophically wrong.
+            Debug.Assert((status & (WaitingFlag | SignalledFlag)) != (WaitingFlag | SignalledFlag));
+        }
 
         private static void ThrowConcurrencyViolation() => throw new InvalidOperationException("Concurrent use is not supported");
-    }
-
-    internal static class SingleWaiterSemaphoreExtensions
-    {
-        public static void SignalOnCompleted(this Task task, SingleWaiterAutoResetEvent semaphore)
-        {
-            task.GetAwaiter().UnsafeOnCompleted(semaphore.SignalAction);
-        }
-
-        public static void SignalOnCompleted(this ValueTask task, SingleWaiterAutoResetEvent semaphore)
-        {
-            task.GetAwaiter().UnsafeOnCompleted(semaphore.SignalAction);
-        }
-
-        public static void SignalOnCompleted<T>(this ValueTask<T> task, SingleWaiterAutoResetEvent semaphore)
-        {
-            task.GetAwaiter().UnsafeOnCompleted(semaphore.SignalAction);
-        }
     }
 }

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
             // Indicate that there is a waiter.
             var status = Interlocked.Or(ref _status, WaitingFlag);
 
-            // If there was already a waiter, that is a catastrophic error since this class is designed for use with a single waiter.
+            // If there was already a waiter, that is an error since this class is designed for use with a single waiter.
             if ((status & WaitingFlag) == WaitingFlag)
             {
                 ThrowConcurrentWaitersNotSupported();
@@ -84,7 +84,7 @@ namespace Orleans.Runtime
             if ((status & SignaledFlag) == SignaledFlag)
             {
                 // Reset just the status because the _waitSource has not been set.
-                // We know this _waitSource has not been set because _waitSource is only set when
+                // We know that _waitSource has not been set because _waitSource is only set when
                 // Signal() observes that the "Waiting" flag had been set but not the "Signaled" flag.
                 ResetStatus();
                 return default;

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime
             // If there was already a waiter, that is a catastrophic error since this class is designed for use with a single waiter.
             if ((status & WaitingFlag) == WaitingFlag)
             {
-                ThrowConcurrencyViolation();
+                ThrowConcurrentWaitersNotSupported();
             }
 
             // If the event was already signaled, immediately wake the waiter.
@@ -107,6 +107,6 @@ namespace Orleans.Runtime
             Debug.Assert((status & (WaitingFlag | SignaledFlag)) != (WaitingFlag | SignaledFlag));
         }
 
-        private static void ThrowConcurrencyViolation() => throw new InvalidOperationException("Concurrent use is not supported");
+        private static void ThrowConcurrentWaitersNotSupported() => throw new InvalidOperationException("Concurrent waiters are not supported");
     }
 }


### PR DESCRIPTION
* If `Signal` is called before `WaitAsync`, skip the `IValueTaskSource` infrastructure and return a default (completed) `ValueTask`
  * This avoids interface dispatch and unnecessary work to reset the `IValueTaskSource`
* Fix implementation: the current implementation may swallow signals without waking the waiter in some cases
* Add clarifying comments & doc comments 
* Add additional assertions
* Remove `_signalAction` field since it is not necessary
* Inline `SignalOnCompleted` extension method into the one call site and remove the unused overloads

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8105)