### PR TITLE
Optimize raw message body encoding

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -105,13 +105,13 @@ namespace Orleans.Runtime.Messaging
             return connection.RunInternal();
         }
 
-        protected virtual async Task RunInternal()
+        protected virtual Task RunInternal()
         {
             _transport = this.Context.Transport;
             _processIncomingTask = this.ProcessIncoming();
             _processOutgoingTask = this.ProcessOutgoing();
             _initializationTcs.TrySetResult(0);
-            await Task.WhenAll(_processIncomingTask, _processOutgoingTask);
+            return Task.WhenAll(_processIncomingTask, _processOutgoingTask);
         }
 
         /// <summary>

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -105,13 +105,13 @@ namespace Orleans.Runtime.Messaging
             return connection.RunInternal();
         }
 
-        protected virtual Task RunInternal()
+        protected virtual async Task RunInternal()
         {
             _transport = this.Context.Transport;
             _processIncomingTask = this.ProcessIncoming();
             _processOutgoingTask = this.ProcessOutgoing();
             _initializationTcs.TrySetResult(0);
-            return Task.WhenAll(_processIncomingTask, _processOutgoingTask);
+            await Task.WhenAll(_processIncomingTask, _processOutgoingTask);
         }
 
         /// <summary>

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -39,10 +39,10 @@ namespace Orleans.Runtime.Messaging
                     var connectionBuilder = new ConnectionBuilder(this.serviceProvider);
                     connectionBuilder.Use(next =>
                     {
-                        return async context =>
+                        return context =>
                         {
                             context.Features.Set<IUnderlyingTransportFeature>(new UnderlyingConnectionTransportFeature { Transport = context.Transport });
-                            await next(context);
+                            return next(context);
                         };
                     });
                     this.ConfigureConnectionBuilder(connectionBuilder);

--- a/src/Orleans.Serialization/Invocation/Response.cs
+++ b/src/Orleans.Serialization/Invocation/Response.cs
@@ -224,7 +224,7 @@ namespace Orleans.Serialization.Invocation
             {
                 result.TypedResult = _codec.ReadValue(ref reader, field);
                 reader.ReadFieldHeader(ref field);
-                OrleansGeneratedCodeHelper.ConsumeEndBaseOrEndObject(ref reader, ref field);
+                reader.ConsumeEndBaseOrEndObject(ref field);
             }
             return result;
         }
@@ -247,7 +247,7 @@ namespace Orleans.Serialization.Invocation
             {
                 result.TypedResult = _codec.ReadValue(ref reader, field);
                 reader.ReadFieldHeader(ref field);
-                OrleansGeneratedCodeHelper.ConsumeEndBaseOrEndObject(ref reader, ref field);
+                reader.ConsumeEndBaseOrEndObject(ref field);
             }
             return result;
         }


### PR DESCRIPTION
* Don't encode PooledResponse<T> wrapper types for normal response messages, only encode T.

Fixed the issues that caused #8093.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8106)