### PR TITLE
Remove default version suffix for Azure DevOps pipeline

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -25,7 +25,6 @@ parameters:
   - name: version_suffix
     displayName: Version suffix
     type: string
-    default: ci.$(Build.BuildNumber)
   - name: codesign
     displayName: Enable code signing
     type: boolean


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8109)