### PR TITLE
Fix version suffix in build.yaml

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -22,6 +22,9 @@ parameters:
     displayName: Version prefix
     type: string
     default: 7.0.0
+  - name: version_suffix
+    displayName: Version suffix
+    type: string
   - name: codesign
     displayName: Enable code signing
     type: boolean
@@ -74,6 +77,7 @@ jobs:
       arguments: '$(build_flags) /bl:${{parameters.build_configuration}}-Build.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
     env:
       VersionPrefix: ${{parameters.version_prefix}}
+      VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
   # DLL code signing
   - ${{ if eq(parameters.codesign, true) }}:
@@ -152,6 +156,7 @@ jobs:
     inputs:
       script: 'dotnet pack --no-build --no-restore $(build_flags) /bl:${{parameters.build_configuration}}-Pack.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
     env:
+      VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
   # NuGet code signing
   - ${{ if eq(parameters.codesign, true) }}:

--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -22,6 +22,10 @@ parameters:
     displayName: Version prefix
     type: string
     default: 7.0.0
+  - name: include_suffix
+    displayName: Append version suffix
+    type: boolean
+    default: true
   - name: version_suffix
     displayName: Version suffix
     type: string
@@ -78,7 +82,8 @@ jobs:
       arguments: '$(build_flags) /bl:${{parameters.build_configuration}}-Build.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
     env:
       VersionPrefix: ${{parameters.version_prefix}}
-      VersionSuffix: ${{parameters.version_suffix}}
+      ${{ if eq(parameters.include_suffix, true) }}:
+        VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
   # DLL code signing
   - ${{ if eq(parameters.codesign, true) }}:
@@ -157,7 +162,8 @@ jobs:
     inputs:
       script: 'dotnet pack --no-build --no-restore $(build_flags) /bl:${{parameters.build_configuration}}-Pack.binlog /p:Configuration=${{parameters.build_configuration}} $(solution)'
     env:
-      VersionSuffix: ${{parameters.version_suffix}}
+      ${{ if eq(parameters.include_suffix, true) }}:
+        VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
   # NuGet code signing
   - ${{ if eq(parameters.codesign, true) }}:

--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -25,6 +25,7 @@ parameters:
   - name: version_suffix
     displayName: Version suffix
     type: string
+    default: ci.$(Build.BuildNumber)
   - name: codesign
     displayName: Enable code signing
     type: boolean


### PR DESCRIPTION
Since parameters cannot be empty, the solution is to add another flag to disable the version suffix entirely.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8113)