### PR TITLE
Keep a copy of Sql Grain persistence for MsOrleans 3.x.x

### DIFF
--- a/src/AdoNet/Shared/3.x.x/MySQL-Persistence.sql
+++ b/src/AdoNet/Shared/3.x.x/MySQL-Persistence.sql
@@ -1,0 +1,309 @@
+-- The design criteria for this table are:
+--
+-- 1. It can contain arbitrary content serialized as binary, XML or JSON. These formats
+-- are supported to allow one to take advantage of in-storage processing capabilities for
+-- these types if required. This should not incur extra cost on storage.
+--
+-- 2. The table design should scale with the idea of tens or hundreds (or even more) types
+-- of grains that may operate with even hundreds of thousands of grain IDs within each
+-- type of a grain.
+--
+-- 3. The table and its associated operations should remain stable. There should not be
+-- structural reason for unexpected delays in operations. It should be possible to also
+-- insert data reasonably fast without resource contention.
+--
+-- 4. For reasons in 2. and 3., the index should be as narrow as possible so it fits well in
+-- memory and should it require maintenance, isn't resource intensive. For this
+-- reason the index is narrow by design (ideally non-clustered). Currently the entity
+-- is recognized in the storage by the grain type and its ID, which are unique in Orleans silo.
+-- The ID is the grain ID bytes (if string type UTF-8 bytes) and possible extension key as UTF-8
+-- bytes concatenated with the ID and then hashed.
+--
+-- Reason for hashing: Database engines usually limit the length of the column sizes, which
+-- would artificially limit the length of IDs or types. Even when within limitations, the
+-- index would be thick and consume more memory.
+--
+-- In the current setup the ID and the type are hashed into two INT type instances, which
+-- are made a compound index. When there are no collisions, the index can quickly locate
+-- the unique row. Along with the hashed index values, the NVARCHAR(nnn) values are also
+-- stored and they are used to prune hash collisions down to only one result row.
+--
+-- 5. The design leads to duplication in the storage. It is reasonable to assume there will
+-- a low number of services with a given service ID operational at any given time. Or that
+-- compared to the number of grain IDs, there are a fairly low number of different types of
+-- grain. The catch is that were these data separated to another table, it would make INSERT
+-- and UPDATE operations complicated and would require joins, temporary variables and additional
+-- indexes or some combinations of them to make it work. It looks like fitting strategy
+-- could be to use table compression.
+--
+-- 6. For the aforementioned reasons, grain state DELETE will set NULL to the data fields
+-- and updates the Version number normally. This should alleviate the need for index or
+-- statistics maintenance with the loss of some bytes of storage space. The table can be scrubbed
+-- in a separate maintenance operation.
+--
+-- 7. In the storage operations queries the columns need to be in the exact same order
+-- since the storage table operations support optionally streaming.
+CREATE TABLE OrleansStorage
+(
+    -- These are for the book keeping. Orleans calculates
+    -- these hashes (see RelationalStorageProvide implementation),
+    -- which are signed 32 bit integers mapped to the *Hash fields.
+    -- The mapping is done in the code. The
+    -- *String columns contain the corresponding clear name fields.
+    --
+    -- If there are duplicates, they are resolved by using GrainIdN0,
+    -- GrainIdN1, GrainIdExtensionString and GrainTypeString fields.
+    -- It is assumed these would be rarely needed.
+    GrainIdHash                INT NOT NULL,
+    GrainIdN0                BIGINT NOT NULL,
+    GrainIdN1                BIGINT NOT NULL,
+    GrainTypeHash            INT NOT NULL,
+    GrainTypeString            NVARCHAR(512) NOT NULL,
+    GrainIdExtensionString    NVARCHAR(512) NULL,
+    ServiceId                NVARCHAR(150) NOT NULL,
+
+    -- The usage of the Payload records is exclusive in that
+    -- only one should be populated at any given time and two others
+    -- are NULL. The types are separated to advantage on special
+    -- processing capabilities present on database engines (not all might
+    -- have both JSON and XML types.
+    --
+    -- One is free to alter the size of these fields.
+    PayloadBinary    BLOB NULL,
+    PayloadXml        LONGTEXT NULL,
+    PayloadJson        LONGTEXT NULL,
+
+    -- Informational field, no other use.
+    ModifiedOn DATETIME NOT NULL,
+
+    -- The version of the stored payload.
+    Version INT NULL
+
+    -- The following would in principle be the primary key, but it would be too thick
+    -- to be indexed, so the values are hashed and only collisions will be solved
+    -- by using the fields. That is, after the indexed queries have pinpointed the right
+    -- rows down to [0, n] relevant ones, n being the number of collided value pairs.
+) ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 16;
+ALTER TABLE OrleansStorage ADD INDEX IX_OrleansStorage (GrainIdHash, GrainTypeHash);
+
+-- The following alters the column to JSON format if MySQL is at least of version 5.7.8.
+-- See more at https://dev.mysql.com/doc/refman/5.7/en/json.html for JSON and
+-- http://dev.mysql.com/doc/refman/5.7/en/comments.html for the syntax.
+/*!50708 ALTER TABLE OrleansStorage MODIFY COLUMN PayloadJson JSON */;
+
+DELIMITER $$
+
+CREATE PROCEDURE ClearStorage
+(
+    in _GrainIdHash INT,
+    in _GrainIdN0 BIGINT,
+    in _GrainIdN1 BIGINT,
+    in _GrainTypeHash INT,
+    in _GrainTypeString NVARCHAR(512),
+    in _GrainIdExtensionString NVARCHAR(512),
+    in _ServiceId NVARCHAR(150),
+    in _GrainStateVersion INT
+)
+BEGIN
+    DECLARE _newGrainStateVersion INT;
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; RESIGNAL; END;
+    DECLARE EXIT HANDLER FOR SQLWARNING BEGIN ROLLBACK; RESIGNAL; END;
+
+    SET _newGrainStateVersion = _GrainStateVersion;
+
+    -- Default level is REPEATABLE READ and may cause Gap Lock issues
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    START TRANSACTION;
+    UPDATE OrleansStorage
+    SET
+        PayloadBinary = NULL,
+        PayloadJson = NULL,
+        PayloadXml = NULL,
+        Version = Version + 1
+    WHERE
+        GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
+        AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
+        AND GrainIdN0 = _GrainIdN0 AND _GrainIdN0 IS NOT NULL
+        AND GrainIdN1 = _GrainIdN1 AND _GrainIdN1 IS NOT NULL
+        AND GrainTypeString = _GrainTypeString AND _GrainTypeString IS NOT NULL
+        AND ((_GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = _GrainIdExtensionString) OR _GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = _ServiceId AND _ServiceId IS NOT NULL
+        AND Version IS NOT NULL AND Version = _GrainStateVersion AND _GrainStateVersion IS NOT NULL
+        LIMIT 1;
+
+    IF ROW_COUNT() > 0
+    THEN
+        SET _newGrainStateVersion = _GrainStateVersion + 1;
+    END IF;
+
+    SELECT _newGrainStateVersion AS NewGrainStateVersion;
+    COMMIT;
+END$$
+
+DELIMITER $$
+CREATE PROCEDURE WriteToStorage
+(
+    in _GrainIdHash INT,
+    in _GrainIdN0 BIGINT,
+    in _GrainIdN1 BIGINT,
+    in _GrainTypeHash INT,
+    in _GrainTypeString NVARCHAR(512),
+    in _GrainIdExtensionString NVARCHAR(512),
+    in _ServiceId NVARCHAR(150),
+    in _GrainStateVersion INT,
+    in _PayloadBinary BLOB,
+    in _PayloadJson LONGTEXT,
+    in _PayloadXml LONGTEXT
+)
+BEGIN
+    DECLARE _newGrainStateVersion INT;
+    DECLARE _rowCount INT;
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; RESIGNAL; END;
+    DECLARE EXIT HANDLER FOR SQLWARNING BEGIN ROLLBACK; RESIGNAL; END;
+
+    SET _newGrainStateVersion = _GrainStateVersion;
+
+    -- Default level is REPEATABLE READ and may cause Gap Lock issues
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    START TRANSACTION;
+
+    -- Grain state is not null, so the state must have been read from the storage before.
+    -- Let's try to update it.
+    --
+    -- When Orleans is running in normal, non-split state, there will
+    -- be only one grain with the given ID and type combination only. This
+    -- grain saves states mostly serially if Orleans guarantees are upheld. Even
+    -- if not, the updates should work correctly due to version number.
+    --
+    -- In split brain situations there can be a situation where there are two or more
+    -- grains with the given ID and type combination. When they try to INSERT
+    -- concurrently, the table needs to be locked pessimistically before one of
+    -- the grains gets @GrainStateVersion = 1 in return and the other grains will fail
+    -- to update storage. The following arrangement is made to reduce locking in normal operation.
+    --
+    -- If the version number explicitly returned is still the same, Orleans interprets it so the update did not succeed
+    -- and throws an InconsistentStateException.
+    --
+    -- See further information at https://docs.microsoft.com/dotnet/orleans/grains/grain-persistence.
+    IF _GrainStateVersion IS NOT NULL
+    THEN
+        UPDATE OrleansStorage
+        SET
+            PayloadBinary = _PayloadBinary,
+            PayloadJson = _PayloadJson,
+            PayloadXml = _PayloadXml,
+            ModifiedOn = UTC_TIMESTAMP(),
+            Version = Version + 1
+        WHERE
+            GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
+            AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
+            AND GrainIdN0 = _GrainIdN0 AND _GrainIdN0 IS NOT NULL
+            AND GrainIdN1 = _GrainIdN1 AND _GrainIdN1 IS NOT NULL
+            AND GrainTypeString = _GrainTypeString AND _GrainTypeString IS NOT NULL
+            AND ((_GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = _GrainIdExtensionString) OR _GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+            AND ServiceId = _ServiceId AND _ServiceId IS NOT NULL
+            AND Version IS NOT NULL AND Version = _GrainStateVersion AND _GrainStateVersion IS NOT NULL
+            LIMIT 1;
+
+        IF ROW_COUNT() > 0
+        THEN
+            SET _newGrainStateVersion = _GrainStateVersion + 1;
+            SET _GrainStateVersion = _newGrainStateVersion;
+        END IF;
+    END IF;
+
+    -- The grain state has not been read. The following locks rather pessimistically
+    -- to ensure only on INSERT succeeds.
+    IF _GrainStateVersion IS NULL
+    THEN
+        INSERT INTO OrleansStorage
+        (
+            GrainIdHash,
+            GrainIdN0,
+            GrainIdN1,
+            GrainTypeHash,
+            GrainTypeString,
+            GrainIdExtensionString,
+            ServiceId,
+            PayloadBinary,
+            PayloadJson,
+            PayloadXml,
+            ModifiedOn,
+            Version
+        )
+        SELECT * FROM ( SELECT
+            _GrainIdHash,
+            _GrainIdN0,
+            _GrainIdN1,
+            _GrainTypeHash,
+            _GrainTypeString,
+            _GrainIdExtensionString,
+            _ServiceId,
+            _PayloadBinary,
+            _PayloadJson,
+            _PayloadXml,
+            UTC_TIMESTAMP(),
+            1) AS TMP
+        WHERE NOT EXISTS
+        (
+            -- There should not be any version of this grain state.
+            SELECT 1
+            FROM OrleansStorage
+            WHERE
+                GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
+                AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
+                AND GrainIdN0 = _GrainIdN0 AND _GrainIdN0 IS NOT NULL
+                AND GrainIdN1 = _GrainIdN1 AND _GrainIdN1 IS NOT NULL
+                AND GrainTypeString = _GrainTypeString AND _GrainTypeString IS NOT NULL
+                AND ((_GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = _GrainIdExtensionString) OR _GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+                AND ServiceId = _ServiceId AND _ServiceId IS NOT NULL
+        ) LIMIT 1;
+
+        IF ROW_COUNT() > 0
+        THEN
+            SET _newGrainStateVersion = 1;
+        END IF;
+    END IF;
+
+    SELECT _newGrainStateVersion AS NewGrainStateVersion;
+    COMMIT;
+END$$
+
+DELIMITER ;
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadFromStorageKey',
+    'SELECT
+        PayloadBinary,
+        PayloadXml,
+        PayloadJson,
+        UTC_TIMESTAMP(),
+        Version
+    FROM
+        OrleansStorage
+    WHERE
+        GrainIdHash = @GrainIdHash
+        AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+        AND GrainIdN0 = @GrainIdN0 AND @GrainIdN0 IS NOT NULL
+        AND GrainIdN1 = @GrainIdN1 AND @GrainIdN1 IS NOT NULL
+        AND GrainTypeString = @GrainTypeString AND GrainTypeString IS NOT NULL
+        AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        LIMIT 1;'
+);
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'WriteToStorageKey','
+    call WriteToStorage(@GrainIdHash, @GrainIdN0, @GrainIdN1, @GrainTypeHash, @GrainTypeString, @GrainIdExtensionString, @ServiceId, @GrainStateVersion, @PayloadBinary, @PayloadJson, @PayloadXml);'
+);
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ClearStorageKey','
+    call ClearStorage(@GrainIdHash, @GrainIdN0, @GrainIdN1, @GrainTypeHash, @GrainTypeString, @GrainIdExtensionString, @ServiceId, @GrainStateVersion);'
+);

--- a/src/AdoNet/Shared/3.x.x/Oracle-Persistence.sql
+++ b/src/AdoNet/Shared/3.x.x/Oracle-Persistence.sql
@@ -1,0 +1,267 @@
+-- The design criteria for this table are:
+--
+-- 1. It can contain arbitrary content serialized as binary, XML or JSON. These formats
+-- are supported to allow one to take advantage of in-storage processing capabilities for
+-- these types if required. This should not incur extra cost on storage.
+--
+-- 2. The table design should scale with the idea of tens or hundreds (or even more) types
+-- of grains that may operate with even hundreds of thousands of grain IDs within each
+-- type of a grain.
+--
+-- 3. The table and its associated operations should remain stable. There should not be
+-- structural reason for unexpected delays in operations. It should be possible to also
+-- insert data reasonably fast without resource contention.
+--
+-- 4. For reasons in 2. and 3., the index should be as narrow as possible so it fits well in
+-- memory and should it require maintenance, isn't resource intensive. For this
+-- reason the index is narrow by design (ideally non-clustered). Currently the entity
+-- is recognized in the storage by the grain type and its ID, which are unique in Orleans silo.
+-- The ID is the grain ID bytes (if string type UTF-8 bytes) and possible extension key as UTF-8
+-- bytes concatenated with the ID and then hashed.
+--
+-- Reason for hashing: Database engines usually limit the length of the column sizes, which
+-- would artificially limit the length of IDs or types. Even when within limitations, the
+-- index would be thick and consume more memory.
+--
+-- In the current setup the ID and the type are hashed into two INT type instances, which
+-- are made a compound index. When there are no collisions, the index can quickly locate
+-- the unique row. Along with the hashed index values, the NVARCHAR(nnn) values are also
+-- stored and they are used to prune hash collisions down to only one result row.
+--
+-- 5. The design leads to duplication in the storage. It is reasonable to assume there will
+-- a low number of services with a given service ID operational at any given time. Or that
+-- compared to the number of grain IDs, there are a fairly low number of different types of
+-- grain. The catch is that were these data separated to another table, it would make INSERT
+-- and UPDATE operations complicated and would require joins, temporary variables and additional
+-- indexes or some combinations of them to make it work. It looks like fitting strategy
+-- could be to use table compression.
+--
+-- 6. For the aforementioned reasons, grain state DELETE will set NULL to the data fields
+-- and updates the Version number normally. This should alleviate the need for index or
+-- statistics maintenance with the loss of some bytes of storage space. The table can be scrubbed
+-- in a separate maintenance operation.
+--
+-- 7. In the storage operations queries the columns need to be in the exact same order
+-- since the storage table operations support optionally streaming.
+CREATE TABLE "ORLEANSSTORAGE"
+(
+
+    -- These are for the book keeping. Orleans calculates
+    -- these hashes (see RelationalStorageProvide implementation),
+    -- which are signed 32 bit integers mapped to the *Hash fields.
+    -- The mapping is done in the code. The
+    -- *String columns contain the corresponding clear name fields.
+    --
+    -- If there are duplicates, they are resolved by using GrainIdN0,
+    -- GrainIdN1, GrainIdExtensionString and GrainTypeString fields.
+    -- It is assumed these would be rarely needed.
+    "GRAINIDHASH" NUMBER(*,0) NOT NULL ENABLE,
+    "GRAINIDN0" NUMBER(19,0) NOT NULL ENABLE,
+    "GRAINIDN1" NUMBER(19,0) NOT NULL ENABLE,
+    "GRAINTYPEHASH" NUMBER(*,0) NOT NULL ENABLE,
+    "GRAINTYPESTRING" NVARCHAR2(512) NOT NULL ENABLE,
+    "GRAINIDEXTENSIONSTRING" NVARCHAR2(512),
+    "SERVICEID" NVARCHAR2(150) NOT NULL ENABLE,
+
+
+    -- The usage of the Payload records is exclusive in that
+    -- only one should be populated at any given time and two others
+    -- are NULL. The types are separated to advantage on special
+    -- processing capabilities present on database engines (not all might
+    -- have both JSON and XML types.
+    --
+    -- One is free to alter the size of these fields.
+    "PAYLOADBINARY" BLOB,
+    "PAYLOADXML" CLOB,
+    "PAYLOADJSON" CLOB,
+    -- Informational field, no other use.
+    "MODIFIEDON" TIMESTAMP (6) NOT NULL ENABLE,
+    -- The version of the stored payload.
+    "VERSION" NUMBER(*,0)
+
+    -- The following would in principle be the primary key, but it would be too thick
+    -- to be indexed, so the values are hashed and only collisions will be solved
+    -- by using the fields. That is, after the indexed queries have pinpointed the right
+    -- rows down to [0, n] relevant ones, n being the number of collided value pairs.
+);
+CREATE INDEX "IX_ORLEANSSTORAGE" ON "ORLEANSSTORAGE" ("GRAINIDHASH", "GRAINTYPEHASH") PARALLEL
+COMPRESS;
+/
+
+CREATE OR REPLACE FUNCTION WriteToStorage(PARAM_GRAINIDHASH IN NUMBER, PARAM_GRAINIDN0 IN NUMBER, PARAM_GRAINIDN1 IN NUMBER, PARAM_GRAINTYPEHASH IN NUMBER, PARAM_GRAINTYPESTRING IN NVARCHAR2,
+                                             PARAM_GRAINIDEXTENSIONSTRING IN NVARCHAR2, PARAM_SERVICEID IN VARCHAR2, PARAM_GRAINSTATEVERSION IN NUMBER, PARAM_PAYLOADBINARY IN BLOB,
+                                             PARAM_PAYLOADJSON IN CLOB, PARAM_PAYLOADXML IN CLOB)
+  RETURN NUMBER IS
+  rowcount NUMBER;
+  newGrainStateVersion NUMBER := PARAM_GRAINSTATEVERSION;
+  PRAGMA AUTONOMOUS_TRANSACTION;
+  BEGIN
+    -- When Orleans is running in normal, non-split state, there will
+    -- be only one grain with the given ID and type combination only. This
+    -- grain saves states mostly serially if Orleans guarantees are upheld. Even
+    -- if not, the updates should work correctly due to version number.
+    --
+    -- In split brain situations there can be a situation where there are two or more
+    -- grains with the given ID and type combination. When they try to INSERT
+    -- concurrently, the table needs to be locked pessimistically before one of
+    -- the grains gets @GrainStateVersion = 1 in return and the other grains will fail
+    -- to update storage. The following arrangement is made to reduce locking in normal operation.
+    --
+    -- If the version number explicitly returned is still the same, Orleans interprets it so the update did not succeed
+    -- and throws an InconsistentStateException.
+    --
+    -- See further information at https://docs.microsoft.com/dotnet/orleans/grains/grain-persistence.
+
+
+    -- If the @GrainStateVersion is not zero, this branch assumes it exists in this database.
+    -- The NULL value is supplied by Orleans when the state is new.
+    IF newGrainStateVersion IS NOT NULL THEN
+        UPDATE OrleansStorage
+        SET
+            PayloadBinary = PARAM_PAYLOADBINARY,
+            PayloadJson = PARAM_PAYLOADJSON,
+            PayloadXml = PARAM_PAYLOADXML,
+            ModifiedOn = sys_extract_utc(systimestamp),
+            Version = Version + 1
+        WHERE
+            GrainIdHash = PARAM_GRAINIDHASH AND PARAM_GRAINIDHASH IS NOT NULL
+            AND GrainTypeHash = PARAM_GRAINTYPEHASH AND PARAM_GRAINTYPEHASH IS NOT NULL
+            AND (GrainIdN0 = PARAM_GRAINIDN0 OR PARAM_GRAINIDN0 IS NULL)
+            AND (GrainIdN1 = PARAM_GRAINIDN1 OR PARAM_GRAINIDN1 IS NULL)
+            AND (GrainTypeString = PARAM_GRAINTYPESTRING OR PARAM_GRAINTYPESTRING IS NULL)
+            AND ((PARAM_GRAINIDEXTENSIONSTRING IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = PARAM_GRAINIDEXTENSIONSTRING) OR PARAM_GRAINIDEXTENSIONSTRING IS NULL AND GrainIdExtensionString IS NULL)
+            AND ServiceId = PARAM_SERVICEID AND PARAM_SERVICEID IS NOT NULL
+            AND Version IS NOT NULL AND Version = PARAM_GRAINSTATEVERSION AND PARAM_GRAINSTATEVERSION IS NOT NULL
+    RETURNING Version INTO newGrainStateVersion;
+
+    rowcount := SQL%ROWCOUNT;
+
+    IF rowcount = 1 THEN
+      COMMIT;
+      RETURN(newGrainStateVersion);
+    END IF;
+    END IF;
+
+    -- The grain state has not been read. The following locks rather pessimistically
+    -- to ensure only one INSERT succeeds.
+    IF PARAM_GRAINSTATEVERSION IS NULL THEN
+        INSERT INTO OrleansStorage
+        (
+            GrainIdHash,
+            GrainIdN0,
+            GrainIdN1,
+            GrainTypeHash,
+            GrainTypeString,
+            GrainIdExtensionString,
+            ServiceId,
+            PayloadBinary,
+            PayloadJson,
+            PayloadXml,
+            ModifiedOn,
+            Version
+        )
+        SELECT
+            PARAM_GRAINIDHASH,
+            PARAM_GRAINIDN0,
+            PARAM_GRAINIDN1,
+            PARAM_GRAINTYPEHASH,
+            PARAM_GRAINTYPESTRING,
+            PARAM_GRAINIDEXTENSIONSTRING,
+            PARAM_SERVICEID,
+            PARAM_PAYLOADBINARY,
+            PARAM_PAYLOADJSON,
+            PARAM_PAYLOADXML,
+            sys_extract_utc(systimestamp),
+            1 FROM DUAL
+         WHERE NOT EXISTS
+         (
+            -- There should not be any version of this grain state.
+            SELECT 1
+            FROM OrleansStorage
+            WHERE
+                GrainIdHash = PARAM_GRAINIDHASH AND PARAM_GRAINIDHASH IS NOT NULL
+                AND GrainTypeHash = PARAM_GRAINTYPEHASH AND PARAM_GRAINTYPEHASH IS NOT NULL
+                AND (GrainIdN0 = PARAM_GRAINIDN0 OR PARAM_GRAINIDN0 IS NULL)
+                AND (GrainIdN1 = PARAM_GRAINIDN1 OR PARAM_GRAINIDN1 IS NULL)
+                AND (GrainTypeString = PARAM_GRAINTYPESTRING OR PARAM_GRAINTYPESTRING IS NULL)
+                AND ((PARAM_GRAINIDEXTENSIONSTRING IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = PARAM_GRAINIDEXTENSIONSTRING) OR PARAM_GRAINIDEXTENSIONSTRING IS NULL AND GrainIdExtensionString IS NULL)
+                AND ServiceId = PARAM_SERVICEID AND PARAM_SERVICEID IS NOT NULL
+         );
+
+     rowCount := SQL%ROWCOUNT;
+
+        IF rowCount > 0 THEN
+            newGrainStateVersion := 1;
+        END IF;
+    END IF;
+  COMMIT;
+    RETURN(newGrainStateVersion);
+  END;
+/
+
+CREATE OR REPLACE FUNCTION ClearStorage(PARAM_GRAINIDHASH IN NUMBER, PARAM_GRAINIDN0 IN NUMBER, PARAM_GRAINIDN1 IN NUMBER, PARAM_GRAINTYPEHASH IN NUMBER, PARAM_GRAINTYPESTRING IN NVARCHAR2,
+                                             PARAM_GRAINIDEXTENSIONSTRING IN NVARCHAR2, PARAM_SERVICEID IN VARCHAR2, PARAM_GRAINSTATEVERSION IN NUMBER)
+  RETURN NUMBER IS
+  rowcount NUMBER;
+  newGrainStateVersion NUMBER := PARAM_GRAINSTATEVERSION;
+  PRAGMA AUTONOMOUS_TRANSACTION;
+  BEGIN
+    UPDATE OrleansStorage
+    SET
+        PayloadBinary = NULL,
+        PayloadJson = NULL,
+        PayloadXml = NULL,
+        ModifiedOn = sys_extract_utc(systimestamp),
+        Version = Version + 1
+    WHERE GrainIdHash = PARAM_GRAINIDHASH AND PARAM_GRAINIDHASH IS NOT NULL
+      AND GrainTypeHash = PARAM_GRAINTYPEHASH AND PARAM_GRAINTYPEHASH IS NOT NULL
+      AND (GrainIdN0 = PARAM_GRAINIDN0 OR PARAM_GRAINIDN0 IS NULL)
+      AND (GrainIdN1  = PARAM_GRAINIDN1 OR PARAM_GRAINIDN1 IS NULL)
+      AND (GrainTypeString = PARAM_GRAINTYPESTRING OR PARAM_GRAINTYPESTRING IS NULL)
+      AND ((PARAM_GRAINIDEXTENSIONSTRING IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = PARAM_GRAINIDEXTENSIONSTRING) OR PARAM_GRAINIDEXTENSIONSTRING IS NULL AND GrainIdExtensionString IS NULL)
+      AND ServiceId = PARAM_SERVICEID AND PARAM_SERVICEID IS NOT NULL
+      AND Version IS NOT NULL AND Version = PARAM_GRAINSTATEVERSION AND PARAM_GRAINSTATEVERSION IS NOT NULL
+    RETURNING Version INTO newGrainStateVersion;
+
+    COMMIT;
+    RETURN(newGrainStateVersion);
+  END;
+/
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'WriteToStorageKey','
+  SELECT WriteToStorage(:GrainIdHash, :GrainIdN0, :GrainIdN1, :GrainTypeHash, :GrainTypeString,
+                                             :GrainIdExtensionString, :ServiceId, :GrainStateVersion, :PayloadBinary,
+                                             :PayloadJson, :PayloadXml) AS NewGrainStateVersion FROM DUAL
+');
+/
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ClearStorageKey',
+    'SELECT ClearStorage(:GrainIdHash, :GrainIdN0, :GrainIdN1, :GrainTypeHash, :GrainTypeString,
+                                             :GrainIdExtensionString, :ServiceId, :GrainStateVersion) AS Version FROM DUAL'
+);
+/
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadFromStorageKey',
+    '
+     SELECT PayloadBinary, PayloadXml, PayloadJson, Version
+     FROM OrleansStorage
+     WHERE GrainIdHash = :GrainIdHash AND :GrainIdHash IS NOT NULL
+       AND (GrainIdN0 = :GrainIdN0 OR :GrainIdN0 IS NULL)
+       AND (GrainIdN1 = :GrainIdN1 OR :GrainIdN1 IS NULL)
+       AND GrainTypeHash = :GrainTypeHash AND :GrainTypeHash IS NOT NULL
+       AND (GrainTypeString = :GrainTypeString OR :GrainTypeString IS NULL)
+       AND ((:GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = :GrainIdExtensionString) OR :GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+       AND ServiceId = :ServiceId AND :ServiceId IS NOT NULL'
+);
+/
+
+COMMIT;

--- a/src/AdoNet/Shared/3.x.x/PostgreSQL-Persistence.sql
+++ b/src/AdoNet/Shared/3.x.x/PostgreSQL-Persistence.sql
@@ -1,0 +1,196 @@
+CREATE TABLE OrleansStorage
+(
+    grainidhash integer NOT NULL,
+    grainidn0 bigint NOT NULL,
+    grainidn1 bigint NOT NULL,
+    graintypehash integer NOT NULL,
+    graintypestring character varying(512)  NOT NULL,
+    grainidextensionstring character varying(512) ,
+    serviceid character varying(150)  NOT NULL,
+    payloadbinary bytea,
+    payloadxml xml,
+    payloadjson text,
+    modifiedon timestamp without time zone NOT NULL,
+    version integer
+);
+
+CREATE INDEX ix_orleansstorage
+    ON orleansstorage USING btree
+    (grainidhash, graintypehash);
+
+CREATE OR REPLACE FUNCTION writetostorage(
+    _grainidhash integer,
+    _grainidn0 bigint,
+    _grainidn1 bigint,
+    _graintypehash integer,
+    _graintypestring character varying,
+    _grainidextensionstring character varying,
+    _serviceid character varying,
+    _grainstateversion integer,
+    _payloadbinary bytea,
+    _payloadjson text,
+    _payloadxml xml)
+    RETURNS TABLE(newgrainstateversion integer)
+    LANGUAGE 'plpgsql'
+AS $function$
+    DECLARE
+     _newGrainStateVersion integer := _GrainStateVersion;
+     RowCountVar integer := 0;
+
+    BEGIN
+
+    -- Grain state is not null, so the state must have been read from the storage before.
+    -- Let's try to update it.
+    --
+    -- When Orleans is running in normal, non-split state, there will
+    -- be only one grain with the given ID and type combination only. This
+    -- grain saves states mostly serially if Orleans guarantees are upheld. Even
+    -- if not, the updates should work correctly due to version number.
+    --
+    -- In split brain situations there can be a situation where there are two or more
+    -- grains with the given ID and type combination. When they try to INSERT
+    -- concurrently, the table needs to be locked pessimistically before one of
+    -- the grains gets @GrainStateVersion = 1 in return and the other grains will fail
+    -- to update storage. The following arrangement is made to reduce locking in normal operation.
+    --
+    -- If the version number explicitly returned is still the same, Orleans interprets it so the update did not succeed
+    -- and throws an InconsistentStateException.
+    --
+    -- See further information at https://docs.microsoft.com/dotnet/orleans/grains/grain-persistence.
+    IF _GrainStateVersion IS NOT NULL
+    THEN
+        UPDATE OrleansStorage
+        SET
+            PayloadBinary = _PayloadBinary,
+            PayloadJson = _PayloadJson,
+            PayloadXml = _PayloadXml,
+            ModifiedOn = (now() at time zone 'utc'),
+            Version = Version + 1
+
+        WHERE
+            GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
+            AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
+            AND GrainIdN0 = _GrainIdN0 AND _GrainIdN0 IS NOT NULL
+            AND GrainIdN1 = _GrainIdN1 AND _GrainIdN1 IS NOT NULL
+            AND GrainTypeString = _GrainTypeString AND _GrainTypeString IS NOT NULL
+            AND ((_GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = _GrainIdExtensionString) OR _GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+            AND ServiceId = _ServiceId AND _ServiceId IS NOT NULL
+            AND Version IS NOT NULL AND Version = _GrainStateVersion AND _GrainStateVersion IS NOT NULL;
+
+        GET DIAGNOSTICS RowCountVar = ROW_COUNT;
+        IF RowCountVar > 0
+        THEN
+            _newGrainStateVersion := _GrainStateVersion + 1;
+        END IF;
+    END IF;
+
+    -- The grain state has not been read. The following locks rather pessimistically
+    -- to ensure only one INSERT succeeds.
+    IF _GrainStateVersion IS NULL
+    THEN
+        INSERT INTO OrleansStorage
+        (
+            GrainIdHash,
+            GrainIdN0,
+            GrainIdN1,
+            GrainTypeHash,
+            GrainTypeString,
+            GrainIdExtensionString,
+            ServiceId,
+            PayloadBinary,
+            PayloadJson,
+            PayloadXml,
+            ModifiedOn,
+            Version
+        )
+        SELECT
+            _GrainIdHash,
+            _GrainIdN0,
+            _GrainIdN1,
+            _GrainTypeHash,
+            _GrainTypeString,
+            _GrainIdExtensionString,
+            _ServiceId,
+            _PayloadBinary,
+            _PayloadJson,
+            _PayloadXml,
+           (now() at time zone 'utc'),
+            1
+        WHERE NOT EXISTS
+         (
+            -- There should not be any version of this grain state.
+            SELECT 1
+            FROM OrleansStorage
+            WHERE
+                GrainIdHash = _GrainIdHash AND _GrainIdHash IS NOT NULL
+                AND GrainTypeHash = _GrainTypeHash AND _GrainTypeHash IS NOT NULL
+                AND GrainIdN0 = _GrainIdN0 AND _GrainIdN0 IS NOT NULL
+                AND GrainIdN1 = _GrainIdN1 AND _GrainIdN1 IS NOT NULL
+                AND GrainTypeString = _GrainTypeString AND _GrainTypeString IS NOT NULL
+                AND ((_GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = _GrainIdExtensionString) OR _GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+                AND ServiceId = _ServiceId AND _ServiceId IS NOT NULL
+         );
+
+        GET DIAGNOSTICS RowCountVar = ROW_COUNT;
+        IF RowCountVar > 0
+        THEN
+            _newGrainStateVersion := 1;
+        END IF;
+    END IF;
+
+    RETURN QUERY SELECT _newGrainStateVersion AS NewGrainStateVersion;
+END
+
+$function$;
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'WriteToStorageKey','
+
+        select * from WriteToStorage(@GrainIdHash, @GrainIdN0, @GrainIdN1, @GrainTypeHash, @GrainTypeString, @GrainIdExtensionString, @ServiceId, @GrainStateVersion, @PayloadBinary, @PayloadJson, CAST(@PayloadXml AS xml));
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadFromStorageKey','
+    SELECT
+        PayloadBinary,
+        PayloadXml,
+        PayloadJson,
+        (now() at time zone ''utc''),
+        Version
+    FROM
+        OrleansStorage
+    WHERE
+        GrainIdHash = @GrainIdHash
+        AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+        AND GrainIdN0 = @GrainIdN0 AND @GrainIdN0 IS NOT NULL
+        AND GrainIdN1 = @GrainIdN1 AND @GrainIdN1 IS NOT NULL
+        AND GrainTypeString = @GrainTypeString AND GrainTypeString IS NOT NULL
+        AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ClearStorageKey','
+    UPDATE OrleansStorage
+    SET
+        PayloadBinary = NULL,
+        PayloadJson = NULL,
+        PayloadXml = NULL,
+        Version = Version + 1
+    WHERE
+        GrainIdHash = @GrainIdHash AND @GrainIdHash IS NOT NULL
+        AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+        AND GrainIdN0 = @GrainIdN0 AND @GrainIdN0 IS NOT NULL
+        AND GrainIdN1 = @GrainIdN1 AND @GrainIdN1 IS NOT NULL
+        AND GrainTypeString = @GrainTypeString AND @GrainTypeString IS NOT NULL
+        AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND Version IS NOT NULL AND Version = @GrainStateVersion AND @GrainStateVersion IS NOT NULL
+    Returning Version as NewGrainStateVersion
+');

--- a/src/AdoNet/Shared/3.x.x/SQLServer-Persistence.sql
+++ b/src/AdoNet/Shared/3.x.x/SQLServer-Persistence.sql
@@ -1,0 +1,266 @@
+-- The design criteria for this table are:
+--
+-- 1. It can contain arbitrary content serialized as binary, XML or JSON. These formats
+-- are supported to allow one to take advantage of in-storage processing capabilities for
+-- these types if required. This should not incur extra cost on storage.
+--
+-- 2. The table design should scale with the idea of tens or hundreds (or even more) types
+-- of grains that may operate with even hundreds of thousands of grain IDs within each
+-- type of a grain.
+--
+-- 3. The table and its associated operations should remain stable. There should not be
+-- structural reason for unexpected delays in operations. It should be possible to also
+-- insert data reasonably fast without resource contention.
+--
+-- 4. For reasons in 2. and 3., the index should be as narrow as possible so it fits well in
+-- memory and should it require maintenance, isn't resource intensive. For this
+-- reason the index is narrow by design (ideally non-clustered). Currently the entity
+-- is recognized in the storage by the grain type and its ID, which are unique in Orleans silo.
+-- The ID is the grain ID bytes (if string type UTF-8 bytes) and possible extension key as UTF-8
+-- bytes concatenated with the ID and then hashed.
+--
+-- Reason for hashing: Database engines usually limit the length of the column sizes, which
+-- would artificially limit the length of IDs or types. Even when within limitations, the
+-- index would be thick and consume more memory.
+--
+-- In the current setup the ID and the type are hashed into two INT type instances, which
+-- are made a compound index. When there are no collisions, the index can quickly locate
+-- the unique row. Along with the hashed index values, the NVARCHAR(nnn) values are also
+-- stored and they are used to prune hash collisions down to only one result row.
+--
+-- 5. The design leads to duplication in the storage. It is reasonable to assume there will
+-- a low number of services with a given service ID operational at any given time. Or that
+-- compared to the number of grain IDs, there are a fairly low number of different types of
+-- grain. The catch is that were these data separated to another table, it would make INSERT
+-- and UPDATE operations complicated and would require joins, temporary variables and additional
+-- indexes or some combinations of them to make it work. It looks like fitting strategy
+-- could be to use table compression.
+--
+-- 6. For the aforementioned reasons, grain state DELETE will set NULL to the data fields
+-- and updates the Version number normally. This should alleviate the need for index or
+-- statistics maintenance with the loss of some bytes of storage space. The table can be scrubbed
+-- in a separate maintenance operation.
+--
+-- 7. In the storage operations queries the columns need to be in the exact same order
+-- since the storage table operations support optionally streaming.
+CREATE TABLE OrleansStorage
+(
+    -- These are for the book keeping. Orleans calculates
+    -- these hashes (see RelationalStorageProvide implementation),
+    -- which are signed 32 bit integers mapped to the *Hash fields.
+    -- The mapping is done in the code. The
+    -- *String columns contain the corresponding clear name fields.
+    --
+    -- If there are duplicates, they are resolved by using GrainIdN0,
+    -- GrainIdN1, GrainIdExtensionString and GrainTypeString fields.
+    -- It is assumed these would be rarely needed.
+    GrainIdHash                INT NOT NULL,
+    GrainIdN0                BIGINT NOT NULL,
+    GrainIdN1                BIGINT NOT NULL,
+    GrainTypeHash            INT NOT NULL,
+    GrainTypeString            NVARCHAR(512) NOT NULL,
+    GrainIdExtensionString    NVARCHAR(512) NULL,
+    ServiceId                NVARCHAR(150) NOT NULL,
+
+    -- The usage of the Payload records is exclusive in that
+    -- only one should be populated at any given time and two others
+    -- are NULL. The types are separated to advantage on special
+    -- processing capabilities present on database engines (not all might
+    -- have both JSON and XML types.
+    --
+    -- One is free to alter the size of these fields.
+    PayloadBinary    VARBINARY(MAX) NULL,
+    PayloadXml        XML NULL,
+    PayloadJson        NVARCHAR(MAX) NULL,
+
+    -- Informational field, no other use.
+    ModifiedOn DATETIME2(3) NOT NULL,
+
+    -- The version of the stored payload.
+    Version INT NULL
+
+    -- The following would in principle be the primary key, but it would be too thick
+    -- to be indexed, so the values are hashed and only collisions will be solved
+    -- by using the fields. That is, after the indexed queries have pinpointed the right
+    -- rows down to [0, n] relevant ones, n being the number of collided value pairs.
+);
+
+CREATE NONCLUSTERED INDEX IX_OrleansStorage ON OrleansStorage(GrainIdHash, GrainTypeHash);
+
+-- This ensures lock escalation will not lock the whole table, which can potentially be enormous.
+-- See more information at https://www.littlekendra.com/2016/02/04/why-rowlock-hints-can-make-queries-slower-and-blocking-worse-in-sql-server/.
+ALTER TABLE OrleansStorage SET(LOCK_ESCALATION = DISABLE);
+
+-- A feature with ID is compression. If it is supported, it is used for OrleansStorage table. This is an Enterprise feature.
+-- This consumes more processor cycles, but should save on space on GrainIdString, GrainTypeString and ServiceId, which
+-- contain mainly the same values. Also the payloads will be compressed.
+IF EXISTS (SELECT 1 FROM sys.dm_db_persisted_sku_features WHERE feature_id = 100)
+BEGIN
+    ALTER TABLE OrleansStorage REBUILD PARTITION = ALL WITH(DATA_COMPRESSION = PAGE);
+END
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'WriteToStorageKey',
+    '-- When Orleans is running in normal, non-split state, there will
+    -- be only one grain with the given ID and type combination only. This
+    -- grain saves states mostly serially if Orleans guarantees are upheld. Even
+    -- if not, the updates should work correctly due to version number.
+    --
+    -- In split brain situations there can be a situation where there are two or more
+    -- grains with the given ID and type combination. When they try to INSERT
+    -- concurrently, the table needs to be locked pessimistically before one of
+    -- the grains gets @GrainStateVersion = 1 in return and the other grains will fail
+    -- to update storage. The following arrangement is made to reduce locking in normal operation.
+    --
+    -- If the version number explicitly returned is still the same, Orleans interprets it so the update did not succeed
+    -- and throws an InconsistentStateException.
+    --
+    -- See further information at https://docs.microsoft.com/dotnet/orleans/grains/grain-persistence.
+    BEGIN TRANSACTION;
+    SET XACT_ABORT, NOCOUNT ON;
+
+    DECLARE @NewGrainStateVersion AS INT = @GrainStateVersion;
+
+
+    -- If the @GrainStateVersion is not zero, this branch assumes it exists in this database.
+    -- The NULL value is supplied by Orleans when the state is new.
+    IF @GrainStateVersion IS NOT NULL
+    BEGIN
+        UPDATE OrleansStorage
+        SET
+            PayloadBinary = @PayloadBinary,
+            PayloadJson = @PayloadJson,
+            PayloadXml = @PayloadXml,
+            ModifiedOn = GETUTCDATE(),
+            Version = Version + 1,
+            @NewGrainStateVersion = Version + 1,
+            @GrainStateVersion = Version + 1
+        WHERE
+            GrainIdHash = @GrainIdHash AND @GrainIdHash IS NOT NULL
+            AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+            AND (GrainIdN0 = @GrainIdN0 OR @GrainIdN0 IS NULL)
+            AND (GrainIdN1 = @GrainIdN1 OR @GrainIdN1 IS NULL)
+            AND (GrainTypeString = @GrainTypeString OR @GrainTypeString IS NULL)
+            AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+            AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+            AND Version IS NOT NULL AND Version = @GrainStateVersion AND @GrainStateVersion IS NOT NULL
+            OPTION(FAST 1, OPTIMIZE FOR(@GrainIdHash UNKNOWN, @GrainTypeHash UNKNOWN));
+    END
+
+    -- The grain state has not been read. The following locks rather pessimistically
+    -- to ensure only one INSERT succeeds.
+    IF @GrainStateVersion IS NULL
+    BEGIN
+        INSERT INTO OrleansStorage
+        (
+            GrainIdHash,
+            GrainIdN0,
+            GrainIdN1,
+            GrainTypeHash,
+            GrainTypeString,
+            GrainIdExtensionString,
+            ServiceId,
+            PayloadBinary,
+            PayloadJson,
+            PayloadXml,
+            ModifiedOn,
+            Version
+        )
+        SELECT
+            @GrainIdHash,
+            @GrainIdN0,
+            @GrainIdN1,
+            @GrainTypeHash,
+            @GrainTypeString,
+            @GrainIdExtensionString,
+            @ServiceId,
+            @PayloadBinary,
+            @PayloadJson,
+            @PayloadXml,
+            GETUTCDATE(),
+            1
+         WHERE NOT EXISTS
+         (
+            -- There should not be any version of this grain state.
+            SELECT 1
+            FROM OrleansStorage WITH(XLOCK, ROWLOCK, HOLDLOCK, INDEX(IX_OrleansStorage))
+            WHERE
+                GrainIdHash = @GrainIdHash AND @GrainIdHash IS NOT NULL
+                AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+                AND (GrainIdN0 = @GrainIdN0 OR @GrainIdN0 IS NULL)
+                AND (GrainIdN1 = @GrainIdN1 OR @GrainIdN1 IS NULL)
+                AND (GrainTypeString = @GrainTypeString OR @GrainTypeString IS NULL)
+                AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+                AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+         ) OPTION(FAST 1, OPTIMIZE FOR(@GrainIdHash UNKNOWN, @GrainTypeHash UNKNOWN));
+
+        IF @@ROWCOUNT > 0
+        BEGIN
+            SET @NewGrainStateVersion = 1;
+        END
+    END
+
+    SELECT @NewGrainStateVersion AS NewGrainStateVersion;
+    COMMIT TRANSACTION;'
+);
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ClearStorageKey',
+    'BEGIN TRANSACTION;
+    SET XACT_ABORT, NOCOUNT ON;
+    DECLARE @NewGrainStateVersion AS INT = @GrainStateVersion;
+    UPDATE OrleansStorage
+    SET
+        PayloadBinary = NULL,
+        PayloadJson = NULL,
+        PayloadXml = NULL,
+        ModifiedOn = GETUTCDATE(),
+        Version = Version + 1,
+        @NewGrainStateVersion = Version + 1
+    WHERE
+        GrainIdHash = @GrainIdHash AND @GrainIdHash IS NOT NULL
+        AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+        AND (GrainIdN0 = @GrainIdN0 OR @GrainIdN0 IS NULL)
+        AND (GrainIdN1 = @GrainIdN1 OR @GrainIdN1 IS NULL)
+        AND (GrainTypeString = @GrainTypeString OR @GrainTypeString IS NULL)
+        AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND Version IS NOT NULL AND Version = @GrainStateVersion AND @GrainStateVersion IS NOT NULL
+        OPTION(FAST 1, OPTIMIZE FOR(@GrainIdHash UNKNOWN, @GrainTypeHash UNKNOWN));
+
+    SELECT @NewGrainStateVersion;
+    COMMIT TRANSACTION;'
+);
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadFromStorageKey',
+    '-- The application code will deserialize the relevant result. Not that the query optimizer
+    -- estimates the result of rows based on its knowledge on the index. It does not know there
+    -- will be only one row returned. Forcing the optimizer to process the first found row quickly
+    -- creates an estimate for a one-row result and makes a difference on multi-million row tables.
+    -- Also the optimizer is instructed to always use the same plan via index using the OPTIMIZE
+    -- FOR UNKNOWN flags. These hints are only available in SQL Server 2008 and later. They
+    -- should guarantee the execution time is robustly basically the same from query-to-query.
+    SELECT
+        PayloadBinary,
+        PayloadXml,
+        PayloadJson,
+        Version
+    FROM
+        OrleansStorage
+    WHERE
+        GrainIdHash = @GrainIdHash AND @GrainIdHash IS NOT NULL
+        AND GrainTypeHash = @GrainTypeHash AND @GrainTypeHash IS NOT NULL
+        AND (GrainIdN0 = @GrainIdN0 OR @GrainIdN0 IS NULL)
+        AND (GrainIdN1 = @GrainIdN1 OR @GrainIdN1 IS NULL)
+        AND (GrainTypeString = @GrainTypeString OR @GrainTypeString IS NULL)
+        AND ((@GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString IS NOT NULL AND GrainIdExtensionString = @GrainIdExtensionString) OR @GrainIdExtensionString IS NULL AND GrainIdExtensionString IS NULL)
+        AND ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        OPTION(FAST 1, OPTIMIZE FOR(@GrainIdHash UNKNOWN, @GrainTypeHash UNKNOWN));'
+);


### PR DESCRIPTION
Hello, the idea is to  maintain a copy of the scripts that keeps the PayloadJson and PayloadXml columns for users that still want to use MsOrleans 3.x.x
The objective is to use this scripts and include references in MS documentation (https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration?source=docs#persistence) to prevent confusion for new devs that cannot use .net7 with MsOrleans 7 yet.
Regards,
Fabrizzio

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8139)