### PR TITLE
Use code generated or compiled regular expressions where possible

### DIFF
--- a/src/Azure/Shared/Storage/AzureBlobUtils.cs
+++ b/src/Azure/Shared/Storage/AzureBlobUtils.cs
@@ -18,13 +18,14 @@ namespace Orleans.Streaming.AzureStorage
     /// <summary>
     /// General utility functions related to Azure Blob storage.
     /// </summary>
-    internal static class AzureBlobUtils
+    internal static partial class AzureBlobUtils
     {
-        private static readonly Regex ContainerNameRegex = new Regex("^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.ExplicitCapture | RegexOptions.Singleline | RegexOptions.CultureInvariant);
+        [GeneratedRegex("^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.ExplicitCapture | RegexOptions.Singleline | RegexOptions.CultureInvariant)]
+        private static partial Regex ContainerNameRegex();
 
         internal static void ValidateContainerName(string containerName)
         {
-            if (string.IsNullOrWhiteSpace(containerName) || containerName.Length < 3 || containerName.Length > 63 || !ContainerNameRegex.IsMatch(containerName))
+            if (string.IsNullOrWhiteSpace(containerName) || containerName.Length < 3 || containerName.Length > 63 || !ContainerNameRegex().IsMatch(containerName))
             {
                 throw new ArgumentException("Invalid container name", nameof(containerName));
             }

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -48,7 +48,7 @@ namespace Orleans.GrainDirectory.AzureStorage
     /// <summary>
     /// General utility functions related to Azure Table storage (also applies to Table endpoints in Cosmos DB).
     /// </summary>
-    internal static class AzureTableUtils
+    internal static partial class AzureTableUtils
     {
         /// <summary>
         /// ETag of value "*" to match any etag for conditional table operations (update, merge, delete).
@@ -186,10 +186,13 @@ namespace Orleans.GrainDirectory.AzureStorage
             return false;
         }
 
+        [GeneratedRegex("^[A-Za-z][A-Za-z0-9]{2,62}$")]
+        private static partial Regex TableNameRegex();
+
         internal static void ValidateTableName(string tableName)
         {
             // Regular expression from documentation: https://docs.microsoft.com/rest/api/storageservices/understanding-the-table-service-data-model#table-names
-            if (!Regex.IsMatch(tableName, "^[A-Za-z][A-Za-z0-9]{2,62}$"))
+            if (!TableNameRegex().IsMatch(tableName))
             {
                 throw new ArgumentException($"Table name \"{tableName}\" is invalid according to the following rules:"
                     + " 1. Table names may contain only alphanumeric characters."

--- a/src/Orleans.CodeGenerator/PropertyUtility.cs
+++ b/src/Orleans.CodeGenerator/PropertyUtility.cs
@@ -9,6 +9,8 @@ namespace Orleans.CodeGenerator
 {
     public static class PropertyUtility
     {
+        private static readonly Regex PropertyMatchRegex = new("^<([^>]+)>.*$", RegexOptions.Compiled);
+
         public static IPropertySymbol? GetMatchingProperty(IFieldSymbol field)
         {
             if (field.ContainingType is null)
@@ -18,7 +20,7 @@ namespace Orleans.CodeGenerator
 
         public static IPropertySymbol? GetMatchingProperty(IFieldSymbol field, IEnumerable<ISymbol> memberSymbols)
         {
-            var propertyName = Regex.Match(field.Name, "^<([^>]+)>.*$");
+            var propertyName = PropertyMatchRegex.Match(field.Name);
             if (!propertyName.Success)
             {
                 return null;

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
@@ -116,6 +116,8 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             }
         }
 
-        public static string SanitizeIdentifierName(string input) => Regex.Replace(input, "[-\\.]", "_");
+        private static readonly Regex SanitizeIdentifierRegex = new("[-\\.]", RegexOptions.Compiled);
+
+        public static string SanitizeIdentifierName(string input) => SanitizeIdentifierRegex.Replace(input, "");
     }
 }

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionOptions.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionOptions.cs
@@ -7,7 +7,7 @@ using Orleans.Networking.Shared;
 
 namespace Orleans.TestingHost.UnixSocketTransport;
 
-public class UnixSocketConnectionOptions
+public partial class UnixSocketConnectionOptions
 {
     /// <summary>
     /// Get or sets to function used to get a filename given an endpoint
@@ -19,5 +19,8 @@ public class UnixSocketConnectionOptions
     /// </summary>
     internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => KestrelMemoryPool.Create();
 
-    private static string DefaultConvertEndpointToPath(EndPoint endPoint) => Path.Combine(Path.GetTempPath(), Regex.Replace(endPoint.ToString(), "[^a-zA-Z0-9]", "_"));
+    [GeneratedRegex("[^a-zA-Z0-9]")]
+    private static partial Regex ConvertEndpointRegex();
+
+    private static string DefaultConvertEndpointToPath(EndPoint endPoint) => Path.Combine(Path.GetTempPath(), ConvertEndpointRegex().Replace(endPoint.ToString(), "_"));
 }


### PR DESCRIPTION
This PR replaces all regular expression usages in the project with source generated or at least dynamically compiled ones. It should increase performance a bit, especially in code generator which is now using source generators, isn't it? Also projects using Orleans will have more room for their regexps' cache because global Regex cache's size is quite small (15) and Orleans will not use it now.

As it is my first contribution to Orleans, I still have questions:
* I have doubts about using source generated regexps due to the fact that classes containing regexps need to be made partial. Is this OK? Should I change that usages to ordinary regexps with Compiled option?
* I have some more low-hanging fruits in mind to fix. Should I create an issue for that (including this PR)?

I'm planning to do more meaningful contributions (such as analyzers) so any feedback is appreciated. Thanks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8141)