### PR TITLE
Add MembershipVersion to GrainDirectoryEntity

### DIFF
--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
@@ -22,7 +22,8 @@ namespace Orleans.GrainDirectory.AzureStorage
         internal class GrainDirectoryEntity : ITableEntity
         {
             public string SiloAddress { get; set; }
-            public string  ActivationId { get; set; }
+            public string ActivationId { get; set; }
+            public long MembershipVersion { get; set; }
             public string PartitionKey { get; set; }
             public string RowKey { get; set; }
             public DateTimeOffset? Timestamp { get; set; }
@@ -35,6 +36,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                     GrainId = RowKeyToGrainId(this.RowKey),
                     SiloAddress = Runtime.SiloAddress.FromParsableString(this.SiloAddress),
                     ActivationId = Runtime.ActivationId.FromParsableString(this.ActivationId),
+                    MembershipVersion = new MembershipVersion(this.MembershipVersion)
                 };
             }
 
@@ -46,6 +48,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                     RowKey = GrainIdToRowKey(address.GrainId),
                     SiloAddress = address.SiloAddress.ToParsableString(),
                     ActivationId = address.ActivationId.ToParsableString(),
+                    MembershipVersion = address.MembershipVersion.Value,
                 };
             }
 

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
@@ -19,7 +19,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         private readonly AzureTableDataManager<GrainDirectoryEntity> tableDataManager;
         private readonly string clusterId;
 
-        private class GrainDirectoryEntity : ITableEntity
+        internal class GrainDirectoryEntity : ITableEntity
         {
             public string SiloAddress { get; set; }
             public string  ActivationId { get; set; }

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Properties/AssemblyInfo.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tester.AzureUtils")]

--- a/test/Extensions/TesterAzureUtils/AzureGrainDirectoryTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureGrainDirectoryTests.cs
@@ -45,8 +45,8 @@ namespace Tester.AzureUtils
         [SkippableFact]
         public async Task UnregisterMany()
         {
-            const int N = 250;
-            const int R = 40;
+            const int N = 25;
+            const int R = 4;
 
             // Create and insert N entries
             var addresses = new List<GrainAddress>();
@@ -56,7 +56,8 @@ namespace Tester.AzureUtils
                 {
                     ActivationId = ActivationId.NewId(),
                     GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
-                    SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                    SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                    MembershipVersion = new MembershipVersion(51)
                 };
                 addresses.Add(addr);
                 await this.grainDirectory.Register(addr);

--- a/test/Extensions/TesterAzureUtils/AzureGrainDirectoryTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureGrainDirectoryTests.cs
@@ -92,5 +92,19 @@ namespace Tester.AzureUtils
                 }
             }
         }
+
+        [Fact]
+        public void ConversionTest()
+        {
+            var addr = new GrainAddress
+            {
+                ActivationId = ActivationId.NewId(),
+                GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(806)
+            };
+            var entity = AzureTableGrainDirectory.GrainDirectoryEntity.FromGrainAddress("MyClusterId", addr);
+            Assert.Equal(addr, entity.ToGrainAddress());
+        }
     }
 }

--- a/test/Tester/Directories/GrainDirectoryTests.cs
+++ b/test/Tester/Directories/GrainDirectoryTests.cs
@@ -31,7 +31,8 @@ namespace Tester.Directories
             {
                 ActivationId = ActivationId.NewId(),
                 GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             Assert.Equal(expected, await this.grainDirectory.Register(expected));
@@ -50,21 +51,24 @@ namespace Tester.Directories
             {
                 ActivationId = ActivationId.NewId(),
                 GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             var differentActivation = new GrainAddress
             {
                 ActivationId = ActivationId.NewId(),
                 GrainId = expected.GrainId,
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             var differentSilo = new GrainAddress
             {
                 ActivationId = expected.ActivationId,
                 GrainId = expected.GrainId,
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.14:1000@4583")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.14:1000@4583"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             Assert.Equal(expected, await this.grainDirectory.Register(expected));
@@ -81,14 +85,16 @@ namespace Tester.Directories
             {
                 ActivationId = ActivationId.NewId(),
                 GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             var otherEntry = new GrainAddress
             {
                 ActivationId = ActivationId.NewId(),
                 GrainId = expected.GrainId,
-                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678")
+                SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+                MembershipVersion = new MembershipVersion(51)
             };
 
             Assert.Equal(expected, await this.grainDirectory.Register(expected));


### PR DESCRIPTION
Fix #8148 

`MembershipVersion` is missing from the entity stored in table, so when Orleans is reading it from storage, `MembershipVersion` is set to its default value.

After inserting an entry to the directory, Orleans will check that the entry in storage is equal to the entry it expected to insert. Since `MembershipVersion` was always set to the default value when reading from storage, the equality check failed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8151)