### PR TITLE
Guard and check for GenerateCodeForDeclaringAssembly when type has no declaring assembly

### DIFF
--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
@@ -11,5 +11,5 @@ ORLEANS0104 | Usage | Error | The proxy base class specified is not a valid prox
 ORLEANS0105 | Usage | Error | RPC interfaces must not contain properties
 ORLEANS0106 | Usage | Error | An error is preventing implicit field identifier generation
 ORLEANS0107 | Usage | Error | Serializable type is not accessible from generated code
-ORLEANS0108 | Usage | Error | No delcaring assembly for type passed to GenerateCodeForDeclaringAssemblyAttribute
+ORLEANS0108 | Usage | Error | No declaring assembly for type passed to GenerateCodeForDeclaringAssemblyAttribute
 

--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Shipped.md
@@ -11,4 +11,5 @@ ORLEANS0104 | Usage | Error | The proxy base class specified is not a valid prox
 ORLEANS0105 | Usage | Error | RPC interfaces must not contain properties
 ORLEANS0106 | Usage | Error | An error is preventing implicit field identifier generation
 ORLEANS0107 | Usage | Error | Serializable type is not accessible from generated code
+ORLEANS0108 | Usage | Error | No delcaring assembly for type passed to GenerateCodeForDeclaringAssemblyAttribute
 

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -443,7 +443,16 @@ namespace Orleans.CodeGenerator
                     var type = (ITypeSymbol)param.Value;
 
                     // Recurse on the assemblies which the type was declared in.
-                    ComputeAssembliesToExamine(type.OriginalDefinition.ContainingAssembly, expandedAssemblies);
+                    var declaringAsm = type.OriginalDefinition.ContainingAssembly;
+                    if (declaringAsm is null)
+                    {
+                        var diagnostic = GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic.CreateDiagnostic(attr, type);
+                        throw new OrleansGeneratorDiagnosticAnalysisException(diagnostic);
+                    }
+                    else
+                    {
+                        ComputeAssembliesToExamine(declaringAsm, expandedAssemblies);
+                    }
                 }
             }
         }

--- a/src/Orleans.CodeGenerator/Diagnostics/GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic.cs
@@ -1,0 +1,15 @@
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic
+{
+    public const string DiagnosticId = "ORLEANS0108";
+    public const string Title = "Types passed to GenerateCodeForDeclaringAssemblyAttribute must have a declaring assembly";
+    public const string MessageFormat = "The type {0} provided as an argument to {1} does not have a declaring assembly";
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+    internal static Diagnostic CreateDiagnostic(AttributeData attribute, ITypeSymbol type) => Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference.SyntaxTree.GetLocation(attribute.ApplicationSyntaxReference.Span), type.ToDisplayString(), attribute.ToString());
+}


### PR DESCRIPTION
Fixes #8153, adding an analyzer error for the case

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8156)