### PR TITLE
[3.x] Add CodeQL3000 tasks

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -6,7 +6,7 @@ trigger:
 
 schedules:
 - cron: "0 0 * * *"
-  displayName: Daily midnight build
+  displayName: Daily midnight build (including CodeQL)
   branches:
     include:
     - main
@@ -54,9 +54,13 @@ parameters:
     - BVT
     - SlowBVT
     - Functional
+  - name: runCodeQL3000
+    default: false
+    displayName: Run CodeQL3000 tasks
+    type: boolean
 
 variables:
-  build_flags: ' /m /v:m' 
+  build_flags: ' /m /v:m'
   solution: 'Orleans.sln'
   codesign_runtime: '2.1.x'
   ${{ if eq(variables['System.TeamProject'], 'GitHub - PR Builds') }}:
@@ -65,6 +69,18 @@ variables:
   ${{ else }}:
     pool_name: 'orleans-build-hosted-pool'
     official_build: true
+    # Do not let CodeQL3000 Extension gate scan frequency.
+    Codeql.Cadence: 0
+    # Enable CodeQL3000 unconditionally so it may be run on any branch.
+    Codeql.Enabled: true
+    # Ignore test and infrastructure code.
+    Codeql.SourceRoot: src
+    # CodeQL3000 needs this plumbed along as a variable to enable TSA. Don't use TSA in manual builds.
+    Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+    # Default expects tsaoptions.json under SourceRoot.
+    Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
+    # Do not slow builds down w/ the CodeQL3000 tasks unless this is a nightly build or it's requested.
+    runCodeQL3000: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
 
 jobs:
 
@@ -78,6 +94,14 @@ jobs:
     displayName: 'Use .NET Core sdk'
     inputs:
       useGlobalJson: true
+  - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+    - task: CodeQL3000Init@0
+      displayName: CodeQL Initialize
+    # This task only tags a build if it actually does CodeQL3000 work.
+    # Those tasks no-op while the analysis is considered up to date i.e. for runs w/in a few days of each other.
+    - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+      displayName: 'Set CI CodeQL3000 tag'
+      condition: ne(variables.CODEQL_DIST,'')
   - task: DotNetCoreCLI@2
     displayName: Build
     inputs:
@@ -88,7 +112,10 @@ jobs:
       ${{ if eq(parameters.include_suffix, true) }}:
         VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
-  # DLL code signing 
+  - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+    - task: CodeQL3000Finalize@0
+      displayName: CodeQL Finalize
+  # DLL code signing
   - ${{ if eq(parameters.codesign, true) }}:
     - task: UseDotNet@2
       displayName: 'Codesign: Use .NET Core'
@@ -211,7 +238,7 @@ jobs:
         ArtifactName: nuget
 
 # Tests
-- ${{ if eq(parameters.skip_test, false) }}:
+- ${{ if and(eq(parameters.skip_test, false), ne(variables.runCodeQL3000, 'true')) }}:
   - ${{ each category in parameters.tests_categories }}:
     - ${{ each framework in parameters.frameworks }}:
       - job:
@@ -252,5 +279,3 @@ jobs:
           ${{ if ne(variables['System.TeamProject'], 'GitHub - PR Builds') }}:
             env:
               ORLEANS_SECRETFILE: $(secretFile.secureFilePath)
-
-  

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,13 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core",
+  "codebaseName": "Orleans",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "bpetit@microsoft.com",
+    "reuben.bond@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "Orleans",
+  "template": "TFSDEVDIV"
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,5 +1,5 @@
 {
-  "areaPath": "DevDiv\\ASP.NET Core",
+  "areaPath": "DevDiv\\ASP.NET Core\\Orleans",
   "codebaseName": "Orleans",
   "instanceUrl": "https://devdiv.visualstudio.com/",
   "iterationPath": "DevDiv",


### PR DESCRIPTION
- enable CodeQL in this branch
  - use explicit tasks because this is not the repo's default branch
- add a new top-level parameter to enable CodeQL3000 in manual builds
- tag CodeQL3000 builds that do actual CodeQL3000 work
- add a tsaoptions.json file
  - initial area path value is certainly wrong = other values may be incorrect too

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8159)