### PR TITLE
Delete empty statements as they are treated as errors by some analyzers

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -35,7 +35,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         {
             this.providerName = name;
             this.options = options ?? throw new ArgumentNullException(nameof(options));
-            this.dataAdapter = dataAdapter ?? throw new ArgumentNullException(nameof(dataAdapter)); ;
+            this.dataAdapter = dataAdapter ?? throw new ArgumentNullException(nameof(dataAdapter));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.streamQueueMapper = new(options.QueueNames, providerName);
             this.adapterCache = new SimpleQueueAdapterCache(cacheOptions, this.providerName, this.loggerFactory);

--- a/src/Orleans.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MetadataModel.cs
@@ -141,7 +141,7 @@ namespace Orleans.CodeGenerator
             }
             else
             {
-                return _children[key] = new CompoundTypeAliasTree(key, value); ;
+                return _children[key] = new CompoundTypeAliasTree(key, value);
             }
         }
     }

--- a/src/Orleans.Core/Networking/Shared/MemoryPoolSlab.cs
+++ b/src/Orleans.Core/Networking/Shared/MemoryPoolSlab.cs
@@ -56,7 +56,7 @@ namespace Orleans.Networking.Shared
             _isDisposed = true;
 
             Array = null;
-            NativePointer = IntPtr.Zero; ;
+            NativePointer = IntPtr.Zero;
 
             if (_gcHandle.IsAllocated)
             {

--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -97,7 +97,7 @@ public class CompoundTypeAliasTree
         }
         else
         {
-            return _children[key] = new CompoundTypeAliasTree(key, value);;
+            return _children[key] = new CompoundTypeAliasTree(key, value);
         }
     }
 }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -63,7 +63,7 @@ namespace Orleans.Streams
             pubSubCache = new Dictionary<QualifiedStreamId, StreamConsumerCollection>();
             this.options = options;
             this.queueAdapter = queueAdapter ?? throw new ArgumentNullException(nameof(queueAdapter));
-            this.streamFailureHandler = streamFailureHandler ?? throw new ArgumentNullException(nameof(streamFailureHandler)); ;
+            this.streamFailureHandler = streamFailureHandler ?? throw new ArgumentNullException(nameof(streamFailureHandler));
             this.queueAdapterCache = queueAdapterCache;
             numMessages = 0;
 

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageServiceCollectionExtensions.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Orleans.Hosting
             services.ConfigureNamedOptionForLogging<MemoryGrainStorageOptions>(name);
             services.ConfigureNamedOptionForLogging<FaultInjectionGrainStorageOptions>(name);
             services.AddSingletonNamedService<IGrainStorage>(name, (svc, n) => FaultInjectionGrainStorageFactory.Create(svc, n, MemoryGrainStorageFactory.Create))
-                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n)); ;
+                .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
             return services;
         }
     }

--- a/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceCastTests.cs
@@ -248,7 +248,7 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public void CastAsyncGrainRefCastFromSelf()
         {
-            IAddressable grain = this.GrainFactory.GetGrain<ISimpleGrain>(Random.Shared.Next(), SimpleGrain.SimpleGrainNamePrefix); ;
+            IAddressable grain = this.GrainFactory.GetGrain<ISimpleGrain>(Random.Shared.Next(), SimpleGrain.SimpleGrainNamePrefix);
             ISimpleGrain cast = grain.AsReference<ISimpleGrain>();
 
             Task<int> successfulCallPromise = cast.GetA();

--- a/test/Extensions/TesterAdoNet/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests.StorageTests.Relational
         {
             //This way of using the hasher is like ADO.NET Storage provider would use it. This tests
             //the hasher is thread safe.
-            var adonetDefaultHasher = new StorageHasherPicker(new[] { new OrleansDefaultHasher() }); ;
+            var adonetDefaultHasher = new StorageHasherPicker(new[] { new OrleansDefaultHasher() });
             const int TestGrainHash = -201809205;
             var grainType = "Grains.PersonGrain";
             Parallel.For(0, 1000000, i =>

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -252,7 +252,7 @@ namespace UnitTests.Grains
 
         public ReminderTestCopyGrain(IServiceProvider services, ILoggerFactory loggerFactory)
         {
-            this.unvalidatedReminderRegistry = new UnvalidatedReminderRegistry(services); ;
+            this.unvalidatedReminderRegistry = new UnvalidatedReminderRegistry(services);
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
         }
 


### PR DESCRIPTION
Empty statements (just extra semicolon) after return statements are treated as errors by ReSharper so one should always silence them. Some other analyzers such as SonarCube can also be triggered by statements like these so it is better to just delete them.

This PR deletes all empty semicolon statements.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8192)