### PR TITLE
Fix mariadb tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         provider: ["MySql"]
     services:
       mariadb:
-        image: mariadb
+        image: mariadb:10.6
         ports:
           - 3306:3306
         env:

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/MySqlStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/MySqlStorageForTesting.cs
@@ -10,7 +10,7 @@ namespace UnitTests.General
     internal class MySqlStorageForTesting : RelationalStorageForTesting
     {
         protected override string ProviderMoniker => "MySQL";
-        public MySqlStorageForTesting(string connectionString) : base(AdoNetInvariants.InvariantNameMySql, connectionString)
+        public MySqlStorageForTesting(string connectionString) : base(AdoNetInvariants.InvariantNameMySql, connectionString ?? TestDefaultConfiguration.MySqlConnectionString)
         {
         }
 
@@ -33,8 +33,6 @@ namespace UnitTests.General
         {
             get { return @"DROP DATABASE `{0}`"; }
         }
-
-        public override string DefaultConnectionString => TestDefaultConfiguration.MySqlConnectionString;
          
         protected override string ExistsDatabaseTemplate
         {

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/PostgreSqlStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/PostgreSqlStorageForTesting.cs
@@ -11,11 +11,9 @@ namespace Tester.RelationalUtilities
         protected override string ProviderMoniker => "PostgreSQL";
 
         public PostgreSqlStorageForTesting(string connectionString)
-            : base(AdoNetInvariants.InvariantNamePostgreSql, connectionString)
+            : base(AdoNetInvariants.InvariantNamePostgreSql, connectionString ?? TestDefaultConfiguration.PostgresConnectionString)
         {
         }
-
-        public override string DefaultConnectionString => TestDefaultConfiguration.PostgresConnectionString;
 
         public override string CancellationTestQuery { get { return "SELECT pg_sleep(10); SELECT 1; "; } }
 

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -11,11 +11,9 @@ namespace UnitTests.General
         protected override string ProviderMoniker => "SQLServer";
 
         public SqlServerStorageForTesting(string connectionString)
-            : base(AdoNetInvariants.InvariantNameSqlServer, connectionString)
+            : base(AdoNetInvariants.InvariantNameSqlServer, connectionString ?? TestDefaultConfiguration.MsSqlConnectionString)
         {
         }
-
-        public override string DefaultConnectionString => TestDefaultConfiguration.MsSqlConnectionString;
 
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
 

--- a/test/Extensions/TesterAdoNet/StorageTests/MySqlRelationalStoreTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/MySqlRelationalStoreTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,14 +20,7 @@ namespace UnitTests.StorageTests.AdoNet
         {
             public Fixture()
             {
-                try
-                {
-                    Storage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Failed to initialize {AdoNetInvariantName} for testing: {ex}");
-                }
+                Storage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
             }
 
             public RelationalStorageForTesting Storage { get; private set; }

--- a/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.StorageTests.AdoNet
 
         protected static Task<bool>[] InsertAndReadStreamsAndCheckMatch(RelationalStorageForTesting sut, int streamSize, int countOfStreams, CancellationToken cancellationToken)
         {
-            Skip.If(sut == null, "Database was not initialized correctly");
+            Skip.If(string.IsNullOrEmpty(sut.CurrentConnectionString), "Database was not initialized correctly");
 
             //Stream in and steam out three binary streams in parallel.
             var streamChecks = new Task<bool>[countOfStreams];
@@ -52,7 +52,7 @@ namespace UnitTests.StorageTests.AdoNet
 
         protected static async Task InsertIntoDatabaseUsingStream(RelationalStorageForTesting sut, int streamId, byte[] dataToInsert, CancellationToken cancellationToken)
         {
-            Skip.If(sut == null, "Database was not initialized correctly");
+            Skip.If(string.IsNullOrEmpty(sut.CurrentConnectionString), "Database was not initialized correctly");
             //The dataToInsert could be inserted here directly, but it wouldn't be streamed.
             using (var ms = new MemoryStream(dataToInsert))
             {
@@ -80,7 +80,7 @@ namespace UnitTests.StorageTests.AdoNet
 
         protected static async Task<StreamingTest> ReadFromDatabaseUsingAsyncStream(RelationalStorageForTesting sut, int streamId, CancellationToken cancellationToken)
         {
-            Skip.If(sut == null, "Database was not initialized correctly");
+            Skip.If(string.IsNullOrEmpty(sut.CurrentConnectionString), "Database was not initialized correctly");
             return (await sut.Storage.ReadAsync(sut.StreamTestSelect, command =>
             {
                 var p = command.CreateParameter();
@@ -105,7 +105,7 @@ namespace UnitTests.StorageTests.AdoNet
 
         protected static Task CancellationTokenTest(RelationalStorageForTesting sut, TimeSpan timeoutLimit)
         {
-            Skip.If(sut == null, "Database was not initialized correctly");
+            Skip.If(string.IsNullOrEmpty(sut.CurrentConnectionString), "Database was not initialized correctly");
             using (var tokenSource = new CancellationTokenSource(timeoutLimit))
             {
                 try

--- a/test/TesterInternal/ConnectionStringFixture.cs
+++ b/test/TesterInternal/ConnectionStringFixture.cs
@@ -25,17 +25,10 @@ namespace UnitTests
                         $"{nameof(InitializeConnectionStringAccessor)} was not called before accessing the connection string");
                 }
 
-                try
+                var connString = this.connectionStringLazy.Value.Result;
+                if (connString != null)
                 {
-                    var connString = this.connectionStringLazy.Value.Result;
-                    if (connString != null)
-                    {
-                        return connString;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    throw new SkipException("Environment is not correctly set up to run these tests. " + ex);
+                    return connString;
                 }
 
                 throw new SkipException("Environment is not correctly set up to run these tests. Connection string is empty.");

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -59,6 +59,10 @@ namespace UnitTests.MembershipTests
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
+            if (string.IsNullOrEmpty(this.connectionString))
+            {
+                throw new SkipException("No connection string configured");
+            }
             this.clusterOptions = Options.Create(new ClusterOptions { ClusterId = this.clusterId });
             var adoVariant = GetAdoInvariant();
 


### PR DESCRIPTION
- Some tests were skipped if the setup failed. Tests should fail, not skip in this case.
- Failures started when 10.10 was released. I think we should target our tests against the latest LTS version (currently 10.6)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8198)