### PR TITLE
Bumped KubernetesClient to v9.0.38

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="ZooKeeperNetEx" Version="3.4.12.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.70" />
-    <PackageVersion Include="KubernetesClient" Version="7.0.7" />
+    <PackageVersion Include="KubernetesClient" Version="9.0.38" />
     <!-- Test related packages -->
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -1,5 +1,5 @@
 using k8s;
-using Microsoft.Rest;
+using k8s.Autorest;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -215,7 +215,7 @@ namespace Orleans.Hosting.Kubernetes
                         break;
                     }
 
-                    var pods = await _client.ListNamespacedPodWithHttpMessagesAsync(
+                    var pods = await _client.CoreV1.ListNamespacedPodWithHttpMessagesAsync(
                         namespaceParameter: _podNamespace,
                         labelSelector: _podLabelSelector,
                         watch: true,

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -51,18 +51,7 @@ namespace Orleans.Hosting
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, KubernetesClusterAgent>();
 
             // Configure the Kubernetes client.
-            services.AddHttpClient("Orleans.Kubernetes.Agent")
-                .AddTypedClient<IKubernetes>((httpClient, serviceProvider) =>
-                {
-                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
-                    return new k8s.Kubernetes(
-                        config,
-                        httpClient);
-                }).ConfigurePrimaryHttpMessageHandler(serviceProvider =>
-                {
-                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
-                    return config.CreateDefaultHttpClientHandler();
-                });
+            //services.AddSingleton<IKubernetes>(_ => new k8s.Kubernetes(KubernetesClientConfig);
 
             return services;
         }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -50,9 +50,6 @@ namespace Orleans.Hosting
 
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, KubernetesClusterAgent>();
 
-            // Configure the Kubernetes client.
-            //services.AddSingleton<IKubernetes>(_ => new k8s.Kubernetes(KubernetesClientConfig);
-
             return services;
         }
     }


### PR DESCRIPTION
Fix for #8193

The `KubernetesClient` version in use is stale and does not work with current versions of Kubernetes.
I tested this against Kubernetes 1.25.2 (AKS).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8199)