### PR TITLE
Optimize static codec serialization

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -118,6 +118,7 @@ namespace Orleans.CodeGenerator
                     new(Type("System.UInt128"), Type("Orleans.Serialization.Codecs.UInt128Codec")),
                     new(Type("System.Int128"), Type("Orleans.Serialization.Codecs.Int128Codec")),
                     new(Type("System.Half"), Type("Orleans.Serialization.Codecs.HalfCodec")),
+                    new(Type("System.Uri"), Type("Orleans.Serialization.Codecs.UriCodec")),
                 },
                 WellKnownCodecs = new WellKnownCodecDescription[]
                 {
@@ -126,7 +127,6 @@ namespace Orleans.CodeGenerator
                     new(Type("System.Collections.Generic.List`1"), Type("Orleans.Serialization.Codecs.ListCodec`1")),
                     new(Type("System.Collections.Generic.HashSet`1"), Type("Orleans.Serialization.Codecs.HashSetCodec`1")),
                     new(compilation.GetSpecialType(SpecialType.System_Nullable_T), Type("Orleans.Serialization.Codecs.NullableCodec`1")),
-                    new(Type("System.Uri"), Type("Orleans.Serialization.Codecs.UriCodec")),
                 },
                 StaticCopiers = new WellKnownCopierDescription[]
                 {

--- a/src/Orleans.CodeGenerator/Model/ICodecDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ICodecDescription.cs
@@ -2,11 +2,6 @@ using Microsoft.CodeAnalysis;
 
 namespace Orleans.CodeGenerator
 {
-    internal interface ICodecDescription
-    {
-        ITypeSymbol UnderlyingType { get; }
-    }
-
     internal interface ICopierDescription
     {
         ITypeSymbol UnderlyingType { get; }

--- a/src/Orleans.CodeGenerator/Model/WellKnownCodecDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/WellKnownCodecDescription.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Orleans.CodeGenerator
 {
-    internal class WellKnownCodecDescription : ICodecDescription
+    internal sealed class WellKnownCodecDescription
     {
         public WellKnownCodecDescription(ITypeSymbol underlyingType, INamedTypeSymbol codecType)
         {
@@ -10,12 +10,11 @@ namespace Orleans.CodeGenerator
             CodecType = codecType;
         }
 
-        public ITypeSymbol UnderlyingType { get; }
-
-        public INamedTypeSymbol CodecType { get; }
+        public readonly ITypeSymbol UnderlyingType;
+        public readonly INamedTypeSymbol CodecType;
     }
 
-    internal class WellKnownCopierDescription : ICopierDescription
+    internal sealed class WellKnownCopierDescription : ICopierDescription
     {
         public WellKnownCopierDescription(ITypeSymbol underlyingType, INamedTypeSymbol codecType)
         {

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -410,7 +410,8 @@ namespace Orleans.CodeGenerator
                     codecExpression = IdentifierName(instanceCodec.FieldName);
                 }
 
-               // When a static codec is available, we can call it directly and can skip passing the expected type, since it is known to be the static codec's field type:
+               // When a static codec is available, we can call it directly and can skip passing the expected type,
+               // since it is known to be the static codec's field type:
                //   C#: <staticCodec>.WriteField(ref writer, <fieldIdDelta, <member>)
                // When no static codec is available:
                //   C#: <codecField>.WriteField(ref writer, <fieldIdDelta>, <expectedType>, <member>)

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -410,6 +410,10 @@ namespace Orleans.CodeGenerator
                     codecExpression = IdentifierName(instanceCodec.FieldName);
                 }
 
+               // When a static codec is available, we can call it directly and can skip passing the expected type, since it is known to be the static codec's field type:
+               //   C#: <staticCodec>.WriteField(ref writer, <fieldIdDelta, <member>)
+               // When no static codec is available:
+               //   C#: <codecField>.WriteField(ref writer, <fieldIdDelta>, <expectedType>, <member>)
                 var writeFieldArgs = new List<ArgumentSyntax> {
                     Argument(writerParam).WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)),
                     Argument(fieldIdDeltaExpr)

--- a/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
@@ -28,7 +28,7 @@ public sealed class IdSpanCodec : IFieldCodec<IdSpan>
         ReferenceCodec.MarkValueField(writer.Session);
         writer.WriteFieldHeader(fieldIdDelta, expectedType, _codecType, WireType.LengthPrefixed);
         var bytes = value.AsSpan();
-        if (bytes.IsEmpty) writer.WriteByte(1); // writer.WriteVarUInt32(0);
+        if (bytes.IsEmpty) writer.WriteByte(1); // Equivalent to `writer.WriteVarUInt32(0);`
         else
         {
             writer.WriteVarUInt32((uint)(sizeof(int) + bytes.Length));

--- a/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IdSpanCodec.cs
@@ -28,7 +28,7 @@ public sealed class IdSpanCodec : IFieldCodec<IdSpan>
         ReferenceCodec.MarkValueField(writer.Session);
         writer.WriteFieldHeader(fieldIdDelta, expectedType, _codecType, WireType.LengthPrefixed);
         var bytes = value.AsSpan();
-        if (bytes.IsEmpty) writer.WriteVarUInt32(0);
+        if (bytes.IsEmpty) writer.WriteByte(1); // writer.WriteVarUInt32(0);
         else
         {
             writer.WriteVarUInt32((uint)(sizeof(int) + bytes.Length));

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddressCodec.cs
@@ -16,8 +16,6 @@ namespace Orleans.Runtime.Serialization
     [RegisterSerializer]
     public sealed class SiloAddressCodec : IFieldCodec<SiloAddress>
     {
-        private static readonly Type _codecFieldType = typeof(SiloAddress);
-
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, SiloAddress? value) where TBufferWriter : IBufferWriter<byte>
@@ -29,11 +27,11 @@ namespace Orleans.Runtime.Serialization
             }
 
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteStartObject(fieldIdDelta, expectedType, _codecFieldType);
-            IPAddressCodec.WriteField(ref writer, 0, IPAddressCodec.CodecFieldType, value.Endpoint.Address);
+            writer.WriteStartObject(fieldIdDelta, expectedType, typeof(SiloAddress));
+            IPAddressCodec.WriteField(ref writer, 0, value.Endpoint.Address);
             uint delta = 2;
-            if (value.Endpoint.Port != 0) UInt16Codec.WriteField(ref writer, delta = 1, UInt16Codec.CodecFieldType, (ushort)value.Endpoint.Port);
-            if (value.Generation != 0) Int32Codec.WriteField(ref writer, delta, Int32Codec.CodecFieldType, value.Generation);
+            if (value.Endpoint.Port != 0) UInt16Codec.WriteField(ref writer, delta = 1, (ushort)value.Endpoint.Port);
+            if (value.Generation != 0) Int32Codec.WriteField(ref writer, delta, value.Generation);
             writer.WriteEndObject();
         }
 

--- a/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
@@ -108,7 +108,7 @@ namespace Orleans.Runtime.Messaging
             var currentTimestamp = Environment.TickCount64;
             if (value is null)
             {
-                writer.WriteVarUInt32(0);
+                writer.WriteByte(1); // writer.WriteVarUInt32(0);
                 return;
             }
 
@@ -158,7 +158,7 @@ namespace Orleans.Runtime.Messaging
             IPAddressCodec.WriteRaw(ref writer, ep.Address);
 
             // Port
-            writer.WriteVarUInt32((uint)ep.Port);
+            writer.WriteVarUInt16((ushort)ep.Port);
 
             // Generation
             writer.WriteInt32(value.Generation);

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -347,7 +347,7 @@ namespace Orleans.Runtime.Messaging
         {
             if (value is null)
             {
-                writer.WriteByte(1); // writer.WriteVarUInt32(0);
+                writer.WriteByte(1); // Equivalent to `writer.WriteVarUInt32(0);`
                 return;
             }
 

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -339,18 +339,7 @@ namespace Orleans.Runtime.Messaging
                 return string.Empty;
             }
 
-            string result;
-            if (reader.TryReadBytes(length, out var span))
-            {
-                result = Encoding.UTF8.GetString(span);
-            }
-            else
-            {
-                var bytes = reader.ReadBytes((uint)length);
-                result = Encoding.UTF8.GetString(bytes);
-            }
-
-            return result;
+            return StringCodec.ReadRaw(ref reader, (uint)length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -358,32 +347,13 @@ namespace Orleans.Runtime.Messaging
         {
             if (value is null)
             {
-                writer.WriteVarUInt32(0);
+                writer.WriteByte(1); // writer.WriteVarUInt32(0);
                 return;
             }
 
             var numBytes = Encoding.UTF8.GetByteCount(value);
             writer.WriteVarUInt32((uint)numBytes + 1);
-            if (numBytes < 512)
-            {
-                writer.EnsureContiguous(numBytes);
-            }
-
-            var currentSpan = writer.WritableSpan;
-
-            // If there is enough room in the current span for the encoded data,
-            // then encode directly into the output buffer.
-            if (numBytes <= currentSpan.Length)
-            {
-                Encoding.UTF8.GetBytes(value, currentSpan);
-                writer.AdvanceSpan(numBytes);
-            }
-            else
-            {
-                // Note: there is room for optimization here.
-                Span<byte> bytes = Encoding.UTF8.GetBytes(value);
-                writer.Write(bytes);
-            }
+            StringCodec.WriteRaw(ref writer, value, numBytes);
         }
 
         private static void WriteRequestContext<TBufferWriter>(ref Writer<TBufferWriter> writer, Dictionary<string, object> value) where TBufferWriter : IBufferWriter<byte>
@@ -392,7 +362,7 @@ namespace Orleans.Runtime.Messaging
             foreach (var entry in value)
             {
                 WriteString(ref writer, entry.Key);
-                ObjectCodec.WriteField(ref writer, 0, null, entry.Value);
+                ObjectCodec.WriteField(ref writer, 0, entry.Value);
             }
         }
 

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -64,7 +64,7 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
 
         // Write the serialized payload
         var serializedValue = JsonConvert.SerializeObject(value, _options.SerializerSettings);
-        StringCodec.WriteField(ref writer, 1, typeof(string), serializedValue);
+        StringCodec.WriteField(ref writer, 1, serializedValue);
 
         writer.WriteEndObject();
     }

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -162,7 +162,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     private SequenceSegment Grow(int sizeHint)
     {
         Commit();
-        var newBuffer = SequenceSegmentPool.Shared.Rent(sizeHint);
+        var newBuffer = SequenceSegment.Rent(sizeHint);
         return _current = newBuffer;
     }
 
@@ -190,65 +190,18 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         _currentPosition = 0;
     }
 
-    private sealed class SequenceSegmentPool
-    {
-        public static SequenceSegmentPool Shared { get; } = new();
-        public const int MinimumBlockSize = 4096;
-        private readonly ConcurrentQueue<SequenceSegment> _blocks = new();
-        private readonly ConcurrentQueue<SequenceSegment> _largeBlocks = new();
-
-        private SequenceSegmentPool() { }
-
-        public SequenceSegment Rent(int size = -1)
-        {
-            SequenceSegment block;
-            if (size <= MinimumBlockSize)
-            {
-                if (!_blocks.TryDequeue(out block))
-                {
-                    block = new SequenceSegment(size);
-                }
-            }
-            else if (_largeBlocks.TryDequeue(out block))
-            {
-                block.InitializeLargeSegment(size);
-                return block;
-            }
-
-            return block ?? new SequenceSegment(size);
-        }
-
-        internal void Return(SequenceSegment block)
-        {
-            if (block.IsStandardSize)
-            {
-                _blocks.Enqueue(block);
-            }
-            else
-            {
-                _largeBlocks.Enqueue(block);
-            }
-        }
-    }
-
     private sealed class SequenceSegment : ReadOnlySequenceSegment<byte>
     {
-        internal SequenceSegment(int length)
-        {
-            InitializeSegment(length);
-        }
+        private const int MinimumBlockSize = 4096;
+        private static readonly ConcurrentBag<SequenceSegment> Blocks = new();
 
-        public void InitializeLargeSegment(int length)
-        {
-            InitializeSegment((int)BitOperations.RoundUpToPowerOf2((uint)length));
-        }
+        public static SequenceSegment Rent(int size = -1) => size <= MinimumBlockSize && Blocks.TryTake(out var block) ? block : new(size);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void InitializeSegment(int length)
+        private SequenceSegment(int length)
         {
-            if (length <= SequenceSegmentPool.MinimumBlockSize)
+            if (length <= MinimumBlockSize)
             {
-                var pinnedArray = GC.AllocateUninitializedArray<byte>(SequenceSegmentPool.MinimumBlockSize, pinned: true);
+                var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
                 Array = pinnedArray;
             }
             else
@@ -261,7 +214,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
 
         public ReadOnlyMemory<byte> CommittedMemory => base.Memory;
 
-        public bool IsStandardSize => Array.Length == SequenceSegmentPool.MinimumBlockSize;
+        private bool IsStandardSize => Array.Length == MinimumBlockSize;
 
         public Memory<byte> AsMemory(int offset)
         {
@@ -299,7 +252,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
 
             if (IsStandardSize)
             {
-                SequenceSegmentPool.Shared.Return(this);
+                Blocks.Add(this);
             }
             else
             {

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -739,7 +739,7 @@ namespace Orleans.Serialization.Buffers
         /// Fills <paramref name="destination"/> with bytes read from the input.
         /// </summary>
         /// <param name="destination">The destination.</param>
-        public void ReadBytes(Span<byte> destination)
+        public void ReadBytes(scoped Span<byte> destination)
         {
             if (IsReadOnlySequenceInput || IsSpanInput)
             {
@@ -762,7 +762,7 @@ namespace Orleans.Serialization.Buffers
             }
         }
 
-        private void ReadBytesMultiSegment(Span<byte> dest)
+        private void ReadBytesMultiSegment(scoped Span<byte> dest)
         {
             while (true)
             {

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -39,7 +39,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Length > 0)
             {
-                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Length);
+                UInt32Codec.WriteField(ref writer, 0, (uint)value.Length);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {
@@ -196,7 +196,7 @@ namespace Orleans.Serialization.Codecs
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecType, WireType.TagDelimited);
 
-            UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Length);
+            UInt32Codec.WriteField(ref writer, 0, (uint)value.Length);
             uint innerFieldIdDelta = 1;
             foreach (var element in value.Span)
             {
@@ -358,7 +358,7 @@ namespace Orleans.Serialization.Codecs
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecType, WireType.TagDelimited);
 
-            UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Length);
+            UInt32Codec.WriteField(ref writer, 0, (uint)value.Length);
             uint innerFieldIdDelta = 1;
             foreach (var element in value.Span)
             {
@@ -522,7 +522,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 0, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value.AsSpan())
                 {

--- a/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
+++ b/src/Orleans.Serialization/Codecs/BitVector32Codec.cs
@@ -1,9 +1,8 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Collections.Specialized;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -14,17 +13,7 @@ namespace Orleans.Serialization.Codecs
     public sealed class BitVector32Codec : IFieldCodec<BitVector32>
     {
         /// <inheritdoc />
-        void IFieldCodec<BitVector32>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, BitVector32 value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-        /// <summary>
-        /// Writes a field.
-        /// </summary>
-        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
-        /// <param name="writer">The writer.</param>
-        /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
-        /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, BitVector32 value) where TBufferWriter : IBufferWriter<byte>
+        public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, BitVector32 value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(BitVector32), WireType.Fixed32);
@@ -32,16 +21,7 @@ namespace Orleans.Serialization.Codecs
         }
 
         /// <inheritdoc/>
-        BitVector32 IFieldCodec<BitVector32>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
-
-        /// <summary>
-        /// Reads a value.
-        /// </summary>
-        /// <typeparam name="TInput">The reader input type.</typeparam>
-        /// <param name="reader">The reader.</param>
-        /// <param name="field">The field.</param>
-        /// <returns>The value.</returns>
-        public static BitVector32 ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+        public BitVector32 ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             field.EnsureWireType(WireType.Fixed32);

--- a/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CompareInfoCodec.cs
@@ -60,7 +60,7 @@ namespace Orleans.Serialization.Codecs
             }
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, value.GetType(), WireType.TagDelimited);
-            StringCodec.WriteField(ref writer, 0, StringCodec.CodecFieldType, value.Name);
+            StringCodec.WriteField(ref writer, 0, value.Name);
             writer.WriteEndObject();
         }
     }

--- a/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.WireProtocol;
 
@@ -11,19 +12,21 @@ namespace Orleans.Serialization.Codecs;
 [RegisterSerializer]
 public sealed class DateOnlyCodec : IFieldCodec<DateOnly>
 {
-    /// <summary>
-    /// The codec field type
-    /// </summary>
-    public static readonly Type CodecFieldType = typeof(DateOnly);
-
-    /// <inheritdoc/>
-    void IFieldCodec<DateOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateOnly value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-    /// <inheritdoc/>
-    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateOnly value) where TBufferWriter : IBufferWriter<byte>
+    void IFieldCodec<DateOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateOnly value)
     {
         ReferenceCodec.MarkValueField(writer.Session);
-        writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(DateOnly), WireType.Fixed32);
+        writer.WriteInt32(value.DayNumber);
+    }
+
+    /// <summary>
+    /// Writes a field without type info (expected type is statically known).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, DateOnly value) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed32);
         writer.WriteInt32(value.DayNumber);
     }
 

--- a/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateTimeCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.WireProtocol;
 
@@ -11,19 +12,21 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class DateTimeCodec : IFieldCodec<DateTime>
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(DateTime);
-
-        /// <inheritdoc/>
-        void IFieldCodec<DateTime>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateTime value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-        /// <inheritdoc/>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateTime value) where TBufferWriter : IBufferWriter<byte>
+        void IFieldCodec<DateTime>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, DateTime value)
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(DateTime), WireType.Fixed64);
+            writer.WriteInt64(value.ToBinary());
+        }
+
+        /// <summary>
+        /// Writes a field without type info (expected type is statically known).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, DateTime value) where TBufferWriter : IBufferWriter<byte>
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed64);
             writer.WriteInt64(value.ToBinary());
         }
 

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -50,14 +50,14 @@ namespace Orleans.Serialization.Codecs
 
             writer.WriteFieldHeader(fieldIdDelta, expectedType, value.GetType(), WireType.TagDelimited);
 
-            if (value.Comparer != EqualityComparer<TKey>.Default)
+            if (value.Comparer is var comparer && comparer != EqualityComparer<TKey>.Default)
             {
-                _comparerCodec.WriteField(ref writer, 0, typeof(IEqualityComparer<TKey>), value.Comparer);
+                _comparerCodec.WriteField(ref writer, 0, null, comparer);
             }
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 1, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {

--- a/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
+++ b/src/Orleans.Serialization/Codecs/Enum32BaseCodec.cs
@@ -1,10 +1,8 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -13,41 +11,24 @@ namespace Orleans.Serialization.Codecs
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <seealso cref="Orleans.Serialization.Codecs.IFieldCodec{T}" />
-    public abstract class Enum32BaseCodec<T> : IFieldCodec<T> where T : Enum
+    public abstract class Enum32BaseCodec<T> : IFieldCodec<T> where T : unmanaged, Enum
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(T);
+        private readonly Type CodecFieldType = typeof(T);
 
         /// <inheritdoc/>
-        void IFieldCodec<T>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, T value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-        /// <inheritdoc/>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, T value) where TBufferWriter : IBufferWriter<byte>
+        public unsafe void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, T value) where TBufferWriter : IBufferWriter<byte>
         {
-            ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-            var holder = new HolderStruct
-            {
-                Value = value
-            };
-
-            var intValue = Unsafe.As<T, int>(ref holder.Value);
-            writer.WriteInt32(intValue);
+            HolderStruct holder;
+            holder.Value = value;
+            var intValue = *(int*)&holder;
+            Int32Codec.WriteField(ref writer, fieldIdDelta, expectedType, intValue, CodecFieldType);
         }
 
         /// <inheritdoc/>
-        T IFieldCodec<T>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
-
-        /// <inheritdoc/>
-        public static T ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+        public unsafe T ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
-            ReferenceCodec.MarkValueField(reader.Session);
-            field.EnsureWireType(WireType.Fixed32);
-            var intValue = reader.ReadInt32();
-            var result = Unsafe.As<int, T>(ref intValue);
-            return result;
+            var intValue = Int32Codec.ReadValue(ref reader, field);
+            return *(T*)&intValue;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -62,11 +43,11 @@ namespace Orleans.Serialization.Codecs
     /// Serializer and copier for <see cref="DateTimeKind"/>.
     /// </summary>
     [RegisterSerializer]
-    public sealed class DateTimeKindCodec : Enum32BaseCodec<DateTimeKind> { }
+    internal sealed class DateTimeKindCodec : Enum32BaseCodec<DateTimeKind> { }
 
     /// <summary>
     /// Serializer and copier for <see cref="DayOfWeek"/>.
     /// </summary>
     [RegisterSerializer]
-    public sealed class DayOfWeekCodec : Enum32BaseCodec<DayOfWeek> { }
+    internal sealed class DayOfWeekCodec : Enum32BaseCodec<DayOfWeek> { }
 }

--- a/src/Orleans.Serialization/Codecs/GuidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GuidCodec.cs
@@ -1,8 +1,10 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -12,37 +14,29 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class GuidCodec : IFieldCodec<Guid>
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(Guid);
         private const int Width = 16;
 
-        /// <inheritdoc/>
-        void IFieldCodec<Guid>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Guid value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<Guid>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Guid value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Guid), WireType.LengthPrefixed);
+            writer.WriteVarUInt7(Width);
+            WriteRaw(ref writer, value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Guid value) where TBufferWriter : IBufferWriter<byte>
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Guid value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Guid), WireType.LengthPrefixed);
-            writer.WriteVarUInt32(Width);
-#if NETCOREAPP3_1_OR_GREATER
-            writer.EnsureContiguous(Width);
-            if (value.TryWriteBytes(writer.WritableSpan))
-            {
-                writer.AdvanceSpan(Width);
-                return;
-            }
-#endif
-            writer.Write(value.ToByteArray());
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.LengthPrefixed);
+            writer.WriteVarUInt7(Width);
+            WriteRaw(ref writer, value);
         }
 
         /// <inheritdoc/>
@@ -67,55 +61,42 @@ namespace Orleans.Serialization.Codecs
                 throw new UnexpectedLengthPrefixValueException(nameof(Guid), Width, length);
             }
 
-#if NETCOREAPP3_1_OR_GREATER
-            if (reader.TryReadBytes(Width, out var readOnly))
-            {
-                return new Guid(readOnly);
-            }
-
-            Span<byte> bytes = stackalloc byte[Width];
-            for (var i = 0; i < Width; i++)
-            {
-                bytes[i] = reader.ReadByte();
-            }
-
-            return new Guid(bytes);
-#else
-            return new Guid(reader.ReadBytes(Width));
-#endif
+            return ReadRaw(ref reader);
         }
 
+        /// <summary>
+        /// Writes the raw GUID content.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteRaw<TBufferWriter>(ref Writer<TBufferWriter> writer, Guid value) where TBufferWriter : IBufferWriter<byte>
         {
-#if NETCOREAPP3_1_OR_GREATER
-            writer.EnsureContiguous(Width);
-            if (value.TryWriteBytes(writer.WritableSpan))
+            if (BitConverter.IsLittleEndian)
             {
-                writer.AdvanceSpan(Width);
-                return;
+                writer.Write(MemoryMarshal.AsBytes(new Span<Guid>(ref value)));
             }
-#endif
-            writer.Write(value.ToByteArray());
+            else
+            {
+                writer.EnsureContiguous(Width);
+                var done = value.TryWriteBytes(writer.WritableSpan);
+                Debug.Assert(done);
+                writer.AdvanceSpan(Width);
+            }
         }
 
+        /// <summary>
+        /// Reads the raw GUID content.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Guid ReadRaw<TInput>(ref Reader<TInput> reader)
         {
-#if NETCOREAPP3_1_OR_GREATER
-            if (reader.TryReadBytes(Width, out var readOnly))
-            {
-                return new Guid(readOnly);
-            }
+            Unsafe.SkipInit(out Guid res);
+            var bytes = MemoryMarshal.AsBytes(new Span<Guid>(ref res));
+            reader.ReadBytes(bytes);
 
-            Span<byte> bytes = stackalloc byte[Width];
-            for (var i = 0; i < Width; i++)
-            {
-                bytes[i] = reader.ReadByte();
-            }
+            if (BitConverter.IsLittleEndian)
+                return res;
 
             return new Guid(bytes);
-#else
-            return new Guid(reader.ReadBytes(Width));
-#endif
         }
     }
 }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -49,7 +49,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 1, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {

--- a/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IPAddressCodec.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Net;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
 
@@ -14,12 +13,6 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class IPAddressCodec : IFieldCodec<IPAddress>, IDerivedTypeCodec
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(IPAddress);
-
-        /// <inheritdoc/>
         IPAddress IFieldCodec<IPAddress>.ReadValue<TInput>(ref Buffers.Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
         /// <summary>
@@ -56,35 +49,33 @@ namespace Orleans.Serialization.Codecs
             return new(reader.ReadBytes(length));
         }
 
-        /// <summary>
-        /// Writes a field.
-        /// </summary>
-        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
-        /// <param name="writer">The writer.</param>
-        /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
-        /// <param name="value">The value.</param>
         void IFieldCodec<IPAddress>.WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, IPAddress value)
         {
-            WriteField(ref writer, fieldIdDelta, expectedType, value);
-        }
-
-        /// <summary>
-        /// Writes a field.
-        /// </summary>
-        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
-        /// <param name="writer">The writer.</param>
-        /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
-        /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, IPAddress value) where TBufferWriter : IBufferWriter<byte>
-        {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, CodecFieldType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, typeof(IPAddress), value))
             {
                 return;
             }
 
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(IPAddress), WireType.LengthPrefixed);
+            WriteRaw(ref writer, value);
+        }
+
+        /// <summary>
+        /// Writes a field without type info (expected type is statically known).
+        /// </summary>
+        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
+        /// <param name="writer">The writer.</param>
+        /// <param name="fieldIdDelta">The field identifier delta.</param>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, IPAddress value) where TBufferWriter : IBufferWriter<byte>
+        {
+            if (ReferenceCodec.TryWriteReferenceFieldExpected(ref writer, fieldIdDelta, value))
+            {
+                return;
+            }
+
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.LengthPrefixed);
             WriteRaw(ref writer, value);
         }
 
@@ -94,16 +85,14 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteRaw<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, IPAddress value) where TBufferWriter : IBufferWriter<byte>
         {
-            Span<byte> buffer = stackalloc byte[16];
-            if (!value.TryWriteBytes(buffer, out var length)) ThrowNotSupported();
-            buffer = buffer[..length];
-
-            writer.WriteVarUInt32((uint)buffer.Length);
-            writer.Write(buffer);
+            writer.EnsureContiguous(1 + 16);
+            var span = writer.WritableSpan;
+            if (!value.TryWriteBytes(span.Slice(1), out var length)) ThrowNotSupported();
+            span[0] = (byte)(length * 2 + 1); // VarInt length
+            writer.AdvanceSpan(1 + length);
         }
 
         private static void ThrowNotSupported() => throw new NotSupportedException();
-
     }
 
     [RegisterCopier]

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -1,14 +1,11 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Serializers;
-using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
+using System.Runtime.InteropServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -18,27 +15,26 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class BoolCodec : IFieldCodec<bool>
     {
-        private static readonly Type CodecFieldType = typeof(bool);
-
-        /// <inheritdoc/>
-        void IFieldCodec<bool>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            bool value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<bool>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, bool value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(bool), WireType.VarInt);
+            writer.WriteByte(value ? (byte)3 : (byte)1); // writer.WriteVarUInt32(value ? 1U : 0U);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, bool value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, bool value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-            writer.WriteVarUInt32(value ? 1U : 0U);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
+            writer.WriteByte(value ? (byte)3 : (byte)1); // writer.WriteVarUInt32(value ? 1U : 0U);
         }
 
         /// <inheritdoc/>
@@ -55,7 +51,7 @@ namespace Orleans.Serialization.Codecs
         public static bool ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
-            return reader.ReadUInt8(field.WireType) == 1;
+            return reader.ReadUInt8(field.WireType) != 0;
         }
     }
 
@@ -65,27 +61,26 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class CharCodec : IFieldCodec<char>
     {
-        private static readonly Type CodecFieldType = typeof(char);
-
-        /// <inheritdoc/>
-        void IFieldCodec<char>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            char value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<char>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, char value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(char), WireType.VarInt);
+            writer.WriteVarUInt28(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, char value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, char value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-            writer.WriteVarUInt32(value);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
+            writer.WriteVarUInt28(value);
         }
 
         /// <inheritdoc/>
@@ -112,27 +107,26 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class ByteCodec : IFieldCodec<byte>
     {
-        private static readonly Type CodecFieldType = typeof(byte);
-
-        /// <inheritdoc/>
-        void IFieldCodec<byte>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            byte value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<byte>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, byte value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(byte), WireType.VarInt);
+            writer.WriteVarUInt28(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, byte value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, byte value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-            writer.WriteVarUInt32(value);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
+            writer.WriteVarUInt28(value);
         }
 
         /// <summary>
@@ -145,11 +139,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         /// <param name="actualType">The actual type.</param>
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, byte value, Type actualType) where TBufferWriter : IBufferWriter<byte>
-        {
-            ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-            writer.WriteVarUInt32(value);
-        }
+            => UInt16Codec.WriteField(ref writer, fieldIdDelta, expectedType, value, actualType);
 
         /// <inheritdoc/>
         byte IFieldCodec<byte>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
@@ -175,26 +165,25 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class SByteCodec : IFieldCodec<sbyte>
     {
-        private static readonly Type CodecFieldType = typeof(sbyte);
-
-        /// <inheritdoc/>
-        void IFieldCodec<sbyte>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            sbyte value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<sbyte>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, sbyte value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(sbyte), WireType.VarInt);
+            writer.WriteVarInt8(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, sbyte value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, sbyte value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
             writer.WriteVarInt8(value);
         }
 
@@ -208,11 +197,7 @@ namespace Orleans.Serialization.Codecs
         /// <param name="value">The value.</param>
         /// <param name="actualType">The actual type.</param>
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, sbyte value, Type actualType) where TBufferWriter : IBufferWriter<byte>
-        {
-            ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-            writer.WriteVarInt8(value);
-        }
+            => Int16Codec.WriteField(ref writer, fieldIdDelta, expectedType, value, actualType);
 
         /// <inheritdoc/>
         sbyte IFieldCodec<sbyte>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
@@ -238,11 +223,6 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class UInt16Codec : IFieldCodec<ushort>
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(ushort);
-
         /// <inheritdoc/>
         ushort IFieldCodec<ushort>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
@@ -260,25 +240,26 @@ namespace Orleans.Serialization.Codecs
             return reader.ReadUInt16(field.WireType);
         }
 
-        /// <inheritdoc/>
-        void IFieldCodec<ushort>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            ushort value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<ushort>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ushort value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(ushort), WireType.VarInt);
+            writer.WriteVarUInt28(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ushort value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, ushort value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-            writer.WriteVarUInt32(value);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
+            writer.WriteVarUInt28(value);
         }
 
         /// <summary>
@@ -294,7 +275,7 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-            writer.WriteVarUInt32(value);
+            writer.WriteVarUInt28(value);
         }
     }
 
@@ -304,26 +285,25 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class Int16Codec : IFieldCodec<short>
     {
-        private static readonly Type CodecFieldType = typeof(short);
-
-        /// <inheritdoc/>
-        void IFieldCodec<short>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            short value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+        void IFieldCodec<short>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, short value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(short), WireType.VarInt);
+            writer.WriteVarInt16(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, short value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, short value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.VarInt);
             writer.WriteVarInt16(value);
         }
 
@@ -367,35 +347,30 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class UInt32Codec : IFieldCodec<uint>
     {
-        public static readonly Type CodecFieldType = typeof(uint);
+        void IFieldCodec<uint>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, uint value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(uint), value < 1 << 21 ? WireType.VarInt : WireType.Fixed32);
 
-        /// <inheritdoc/>
-        void IFieldCodec<uint>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            uint value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+            if (value < 1 << 21) writer.WriteVarUInt28(value);
+            else writer.WriteUInt32(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, uint value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, uint value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value > 1U << 20)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-                writer.WriteUInt32(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                writer.WriteVarUInt32(value);
-            }
+            writer.WriteFieldHeaderExpected(fieldIdDelta, value < 1 << 21 ? WireType.VarInt : WireType.Fixed32);
+
+            if (value < 1 << 21) writer.WriteVarUInt28(value);
+            else writer.WriteUInt32(value);
         }
 
         /// <summary>
@@ -410,16 +385,10 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, uint value, Type actualType) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value > 1U << 20)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed32);
-                writer.WriteUInt32(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                writer.WriteVarUInt32(value);
-            }
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, value < 1 << 21 ? WireType.VarInt : WireType.Fixed32);
+
+            if (value < 1 << 21) writer.WriteVarUInt28(value);
+            else writer.WriteUInt32(value);
         }
 
         /// <inheritdoc/>
@@ -446,55 +415,32 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class Int32Codec : IFieldCodec<int>
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(int);
-
-        /// <inheritdoc/>
-        void IFieldCodec<int>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            int value)
+        void IFieldCodec<int>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, int value)
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value > 1 << 20 || -value > 1 << 20)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-                writer.WriteInt32(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                writer.WriteVarInt32(value);
-            }
+            var wireType = value < 1 << 20 && value > -1 << 20 ? WireType.VarInt : WireType.Fixed32;
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(int), wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt28(Writer<TBufferWriter>.ZigZagEncode(value));
+            else writer.WriteInt32(value);
         }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(
-            ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            int value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, int value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value > 1 << 20 || -value > 1 << 20)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-                writer.WriteInt32(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                writer.WriteVarInt32(value);
-            }
+            var wireType = value < 1 << 20 && value > -1 << 20 ? WireType.VarInt : WireType.Fixed32;
+            writer.WriteFieldHeaderExpected(fieldIdDelta, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt28(Writer<TBufferWriter>.ZigZagEncode(value));
+            else writer.WriteInt32(value);
         }
 
         /// <summary>
@@ -506,24 +452,14 @@ namespace Orleans.Serialization.Codecs
         /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
         /// <param name="actualType">The actual type.</param>
-        public static void WriteField<TBufferWriter>(
-            ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            int value,
-            Type actualType) where TBufferWriter : IBufferWriter<byte>
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, int value, Type actualType) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value > 1 << 20 || -value > 1 << 20)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed32);
-                writer.WriteInt32(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                writer.WriteVarInt32(value);
-            }
+            var wireType = value < 1 << 20 && value > -1 << 20 ? WireType.VarInt : WireType.Fixed32;
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt28(Writer<TBufferWriter>.ZigZagEncode(value));
+            else writer.WriteInt32(value);
         }
 
         /// <inheritdoc/>
@@ -550,45 +486,46 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class Int64Codec : IFieldCodec<long>
     {
-        private static readonly Type CodecFieldType = typeof(long);
+        void IFieldCodec<long>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, long value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            var wireType = value switch
+            {
+                < 1 << 20 and > -1 << 20 => WireType.VarInt,
+                <= int.MaxValue and >= int.MinValue => WireType.Fixed32,
+                < 1L << 48 and > -1L << 48 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(long), wireType);
 
-        /// <inheritdoc/>
-        void IFieldCodec<long>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, long value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(Writer<TBufferWriter>.ZigZagEncode(value));
+            else if (wireType == WireType.Fixed32) writer.WriteInt32((int)value);
+            else writer.WriteInt64(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, long value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, long value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value is <= int.MaxValue and >= int.MinValue)
+            var wireType = value switch
             {
-                if (value > 1L << 20 || -value > 1L << 20)
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-                    writer.WriteInt32((int)value);
-                }
-                else
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                    writer.WriteVarInt64(value);
-                }
-            }
-            else if (value > 1L << 41 || -value > 1L << 41)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
-                writer.WriteInt64(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                writer.WriteVarInt64(value);
-            }
+                < 1 << 20 and > -1 << 20 => WireType.VarInt,
+                <= int.MaxValue and >= int.MinValue => WireType.Fixed32,
+                < 1L << 48 and > -1L << 48 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeaderExpected(fieldIdDelta, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(Writer<TBufferWriter>.ZigZagEncode(value));
+            else if (wireType == WireType.Fixed32) writer.WriteInt32((int)value);
+            else writer.WriteInt64(value);
         }
 
         /// <summary>
@@ -603,29 +540,18 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, long value, Type actualType) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value is <= int.MaxValue and >= int.MinValue)
+            var wireType = value switch
             {
-                if (value > 1L << 20 || -value > 1L << 20)
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed32);
-                    writer.WriteInt32((int)value);
-                }
-                else
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                    writer.WriteVarInt64(value);
-                }
-            }
-            else if (value > 1L << 41 || -value > 1L << 41)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed64);
-                writer.WriteInt64(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                writer.WriteVarInt64(value);
-            }
+                < 1 << 20 and > -1 << 20 => WireType.VarInt,
+                <= int.MaxValue and >= int.MinValue => WireType.Fixed32,
+                < 1L << 48 and > -1L << 48 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(Writer<TBufferWriter>.ZigZagEncode(value));
+            else if (wireType == WireType.Fixed32) writer.WriteInt32((int)value);
+            else writer.WriteInt64(value);
         }
 
         /// <inheritdoc/>
@@ -652,48 +578,46 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class UInt64Codec : IFieldCodec<ulong>
     {
-        private static readonly Type CodecFieldType = typeof(ulong);
+        void IFieldCodec<ulong>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ulong value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            var wireType = value switch
+            {
+                < 1 << 21 => WireType.VarInt,
+                <= uint.MaxValue => WireType.Fixed32,
+                < 1UL << 49 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(ulong), wireType);
 
-        /// <inheritdoc/>
-        void IFieldCodec<ulong>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
-            uint fieldIdDelta,
-            Type expectedType,
-            ulong value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(value);
+            else if (wireType == WireType.Fixed32) writer.WriteUInt32((uint)value);
+            else writer.WriteUInt64(value);
+        }
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ulong value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, ulong value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value <= uint.MaxValue)
+            var wireType = value switch
             {
-                if (value > 1UL << 20)
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
-                    writer.WriteUInt32((uint)value);
-                }
-                else
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                    writer.WriteVarUInt32((uint)value);
-                }
-            }
-            else if (value > 1UL << 41)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
-                writer.WriteUInt64(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.VarInt);
-                writer.WriteVarUInt64(value);
-            }
+                < 1 << 21 => WireType.VarInt,
+                <= uint.MaxValue => WireType.Fixed32,
+                < 1UL << 49 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeaderExpected(fieldIdDelta, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(value);
+            else if (wireType == WireType.Fixed32) writer.WriteUInt32((uint)value);
+            else writer.WriteUInt64(value);
         }
 
         /// <summary>
@@ -708,29 +632,18 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, ulong value, Type actualType) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            if (value <= uint.MaxValue)
+            var wireType = value switch
             {
-                if (value > 1UL << 20)
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed32);
-                    writer.WriteUInt32((uint)value);
-                }
-                else
-                {
-                    writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                    writer.WriteVarUInt32((uint)value);
-                }
-            }
-            else if (value > 1UL << 41)
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.Fixed64);
-                writer.WriteUInt64(value);
-            }
-            else
-            {
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, WireType.VarInt);
-                writer.WriteVarUInt64(value);
-            }
+                < 1 << 21 => WireType.VarInt,
+                <= uint.MaxValue => WireType.Fixed32,
+                < 1UL << 49 => WireType.VarInt,
+                _ => WireType.Fixed64,
+            };
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, actualType, wireType);
+
+            if (wireType == WireType.VarInt) writer.WriteVarUInt56(value);
+            else if (wireType == WireType.Fixed32) writer.WriteUInt32((uint)value);
+            else writer.WriteUInt64(value);
         }
 
         /// <inheritdoc/>
@@ -757,35 +670,43 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class Int128Codec : IFieldCodec<Int128>
     {
-        private static readonly Type CodecFieldType = typeof(Int128);
-
         /// <inheritdoc/>
         void IFieldCodec<Int128>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Int128 value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Int128 value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Int128 value) where TBufferWriter : IBufferWriter<byte>
+            => WriteField(ref writer, fieldIdDelta, typeof(Int128), value);
+
+        private static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Int128 value) where TBufferWriter : IBufferWriter<byte>
         {
             if (value <= (Int128)long.MaxValue && value >= (Int128)long.MinValue)
             {
-                Int64Codec.WriteField(ref writer, fieldIdDelta, expectedType, (long)value, CodecFieldType);
+                Int64Codec.WriteField(ref writer, fieldIdDelta, expectedType, (long)value, typeof(Int128));
             }
             else
             {
                 ReferenceCodec.MarkValueField(writer.Session);
-                var byteCount = ((IBinaryInteger<Int128>)value).GetByteCount();
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
-                writer.WriteVarUInt32((uint)byteCount);
-                Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(0, byteCount) : new byte[byteCount];
-                ((IBinaryInteger<Int128>)value).TryWriteLittleEndian(bytes, out var bytesWritten);
-                Debug.Assert(bytesWritten == byteCount);
-                writer.Write(bytes);
+                const int byteCount = 128 / 8;
+                writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Int128), WireType.LengthPrefixed);
+                writer.WriteVarUInt7(byteCount);
+                if (BitConverter.IsLittleEndian)
+                {
+                    writer.Write(MemoryMarshal.AsBytes(new Span<Int128>(ref value)));
+                }
+                else
+                {
+                    writer.EnsureContiguous(byteCount);
+                    ((IBinaryInteger<Int128>)value).TryWriteLittleEndian(writer.WritableSpan, out var bytesWritten);
+                    Debug.Assert(bytesWritten == byteCount);
+                    writer.AdvanceSpan(byteCount);
+                }
             }
         }
 
@@ -820,25 +741,21 @@ namespace Orleans.Serialization.Codecs
         internal static Int128 ReadRaw<TInput>(ref Reader<TInput> reader)
         {
             var byteCount = reader.ReadVarUInt32();
-            ReadOnlySpan<byte> bytes;
-            if (!reader.TryReadBytes((int)byteCount, out bytes))
-            {
-                bytes = reader.ReadBytes(byteCount);
-            }
+            if (byteCount != 128 / 8) throw new UnexpectedLengthPrefixValueException(nameof(Int128), 128 / 8, byteCount);
+            Unsafe.SkipInit(out Int128 res);
+            var bytes = MemoryMarshal.AsBytes(new Span<Int128>(ref res));
+            reader.ReadBytes(bytes);
 
-            if (!TryReadLittleEndian<Int128>(bytes, out var value))
-            {
-                ThrowReadFailure();
-            }
+            if (BitConverter.IsLittleEndian)
+                return res;
 
+            var done = TryReadLittleEndian<Int128>(bytes, out var value);
+            Debug.Assert(done);
             return value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryReadLittleEndian<T>(ReadOnlySpan<byte> source, out T value) where T : IBinaryInteger<T> => T.TryReadLittleEndian(source, isUnsigned: false, out value);
-
-        [DoesNotReturn]
-        private static void ThrowReadFailure() => throw new ArgumentException($"Failed to read {nameof(Int128)} value");
     }
 
     /// <summary>
@@ -847,35 +764,43 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class UInt128Codec : IFieldCodec<UInt128>
     {
-        private static readonly Type CodecFieldType = typeof(UInt128);
-
         /// <inheritdoc/>
         void IFieldCodec<UInt128>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, UInt128 value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
 
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, UInt128 value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, UInt128 value) where TBufferWriter : IBufferWriter<byte>
+            => WriteField(ref writer, fieldIdDelta, typeof(UInt128), value);
+
+        private static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, UInt128 value) where TBufferWriter : IBufferWriter<byte>
         {
             if (value <= (UInt128)ulong.MaxValue)
             {
-                UInt64Codec.WriteField(ref writer, fieldIdDelta, expectedType, (ulong)value, CodecFieldType);
+                UInt64Codec.WriteField(ref writer, fieldIdDelta, expectedType, (ulong)value, typeof(UInt128));
             }
             else
             {
                 ReferenceCodec.MarkValueField(writer.Session);
-                var byteCount = ((IBinaryInteger<UInt128>)value).GetByteCount();
-                writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.LengthPrefixed);
-                writer.WriteVarUInt32((uint)byteCount);
-                Span<byte> bytes = byteCount < 64 ? stackalloc byte[64].Slice(0, byteCount) : new byte[byteCount];
-                ((IBinaryInteger<UInt128>)value).TryWriteLittleEndian(bytes, out var bytesWritten);
-                Debug.Assert(bytesWritten == byteCount);
-                writer.Write(bytes);
+                const int byteCount = 128 / 8;
+                writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(UInt128), WireType.LengthPrefixed);
+                writer.WriteVarUInt7(byteCount);
+                if (BitConverter.IsLittleEndian)
+                {
+                    writer.Write(MemoryMarshal.AsBytes(new Span<UInt128>(ref value)));
+                }
+                else
+                {
+                    writer.EnsureContiguous(byteCount);
+                    ((IBinaryInteger<UInt128>)value).TryWriteLittleEndian(writer.WritableSpan, out var bytesWritten);
+                    Debug.Assert(bytesWritten == byteCount);
+                    writer.AdvanceSpan(byteCount);
+                }
             }
         }
 
@@ -910,24 +835,20 @@ namespace Orleans.Serialization.Codecs
         internal static UInt128 ReadRaw<TInput>(ref Reader<TInput> reader)
         {
             var byteCount = reader.ReadVarUInt32();
-            ReadOnlySpan<byte> bytes;
-            if (!reader.TryReadBytes((int)byteCount, out bytes))
-            {
-                bytes = reader.ReadBytes(byteCount);
-            }
+            if (byteCount != 128 / 8) throw new UnexpectedLengthPrefixValueException(nameof(UInt128), 128 / 8, byteCount);
+            Unsafe.SkipInit(out UInt128 res);
+            var bytes = MemoryMarshal.AsBytes(new Span<UInt128>(ref res));
+            reader.ReadBytes(bytes);
 
-            if (!TryReadLittleEndian<UInt128>(bytes, out var value))
-            {
-                ThrowReadFailure();
-            }
+            if (BitConverter.IsLittleEndian)
+                return res;
 
+            var done = TryReadLittleEndian<UInt128>(bytes, out var value);
+            Debug.Assert(done);
             return value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryReadLittleEndian<T>(ReadOnlySpan<byte> source, out T value) where T : IBinaryInteger<T> => T.TryReadLittleEndian(source, isUnsigned: true, out value);
-
-        [DoesNotReturn]
-        private static void ThrowReadFailure() => throw new ArgumentException($"Failed to read {nameof(UInt128)} value");
     }
 }

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -42,7 +42,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 0, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -39,7 +39,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 0, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {

--- a/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReferenceCodec.cs
@@ -20,6 +20,23 @@ namespace Orleans.Serialization.Codecs
         public static void MarkValueField(SerializerSession session) => session.ReferencedObjects.MarkValueField();
 
         /// <summary>
+        /// Write an object reference if <paramref name="value"/> has already been written.
+        /// This overload is suitable only for static codecs where expected type is statically known.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryWriteReferenceFieldExpected<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldId, object value) where TBufferWriter : IBufferWriter<byte>
+        {
+            if (!writer.Session.ReferencedObjects.GetOrAddReference(value, out var reference))
+            {
+                return false;
+            }
+
+            writer.WriteFieldHeaderExpected(fieldId, WireType.Reference);
+            writer.WriteVarUInt32(reference);
+            return true;
+        }
+
+        /// <summary>
         /// Write an object reference if <paramref name="value"/> has already been written and has been tracked via <see cref="RecordObject(SerializerSession, object)"/>.
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -42,7 +42,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Count > 0)
             {
-                UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, (uint)value.Count);
+                UInt32Codec.WriteField(ref writer, 0, (uint)value.Count);
                 uint innerFieldIdDelta = 1;
                 foreach (var element in value)
                 {

--- a/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.WireProtocol;
 
@@ -11,19 +12,21 @@ namespace Orleans.Serialization.Codecs;
 [RegisterSerializer]
 public sealed class TimeOnlyCodec : IFieldCodec<TimeOnly>
 {
-    /// <summary>
-    /// The codec field type
-    /// </summary>
-    public static readonly Type CodecFieldType = typeof(TimeOnly);
-
-    /// <inheritdoc/>
-    void IFieldCodec<TimeOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeOnly value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-    /// <inheritdoc/>
-    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeOnly value) where TBufferWriter : IBufferWriter<byte>
+    void IFieldCodec<TimeOnly>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeOnly value)
     {
         ReferenceCodec.MarkValueField(writer.Session);
-        writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(TimeOnly), WireType.Fixed64);
+        writer.WriteInt64(value.Ticks);
+    }
+
+    /// <summary>
+    /// Writes a field without type info (expected type is statically known).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, TimeOnly value) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed64);
         writer.WriteInt64(value.Ticks);
     }
 

--- a/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeSpanCodec.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
@@ -12,26 +12,25 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TimeSpanCodec : IFieldCodec<TimeSpan>
     {
-        /// <summary>
-        /// The codec field type
-        /// </summary>
-        public static readonly Type CodecFieldType = typeof(TimeSpan);
+        void IFieldCodec<TimeSpan>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeSpan value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(TimeSpan), WireType.Fixed64);
+            writer.WriteInt64(value.Ticks);
+        }
 
-        /// <inheritdoc />
-        void IFieldCodec<TimeSpan>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeSpan value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
         /// <summary>
-        /// Writes a field.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
         /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
         /// <param name="writer">The writer.</param>
         /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
         /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TimeSpan value) where TBufferWriter : IBufferWriter<byte>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, TimeSpan value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed64);
             writer.WriteInt64(value.Ticks);
         }
 

--- a/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TypeSerializerCodec.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Cloning;
 using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
@@ -12,36 +12,44 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TypeSerializerCodec : IFieldCodec<Type>, IDerivedTypeCodec
     {
-        private static readonly Type ByteType = typeof(byte);
-        private static readonly Type TypeType = typeof(Type);
-        private static readonly Type UIntType = typeof(uint);
-
-        /// <inheritdoc />
-        void IFieldCodec<Type>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Type value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
-
-        /// <summary>
-        /// Writes a field.
-        /// </summary>
-        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
-        /// <param name="writer">The writer.</param>
-        /// <param name="fieldIdDelta">The field identifier delta.</param>
-        /// <param name="expectedType">The expected type.</param>
-        /// <param name="value">The value.</param>
-        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Type value) where TBufferWriter : IBufferWriter<byte>
+        void IFieldCodec<Type>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Type value)
         {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, TypeType, value))
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, typeof(Type), value))
             {
                 return;
             }
 
-            writer.WriteStartObject(fieldIdDelta, expectedType, TypeType);
+            writer.WriteStartObject(fieldIdDelta, expectedType, typeof(Type));
+            WriteField(ref writer, value);
+        }
 
+        /// <summary>
+        /// Writes a field without type info (expected type is statically known).
+        /// </summary>
+        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
+        /// <param name="writer">The writer.</param>
+        /// <param name="fieldIdDelta">The field identifier delta.</param>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type value) where TBufferWriter : IBufferWriter<byte>
+        {
+            if (ReferenceCodec.TryWriteReferenceFieldExpected(ref writer, fieldIdDelta, value))
+            {
+                return;
+            }
+
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.TagDelimited);
+            WriteField(ref writer, value);
+        }
+
+        private static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, Type value) where TBufferWriter : IBufferWriter<byte>
+        {
             var schemaType = writer.Session.WellKnownTypes.TryGetWellKnownTypeId(value, out var id) ? SchemaType.WellKnown
                 : writer.Session.ReferencedTypes.TryGetTypeReference(value, out id) ? SchemaType.Referenced
                 : SchemaType.Encoded;
 
             // Write the encoding type.
-            ByteCodec.WriteField(ref writer, 0, ByteType, (byte)schemaType);
+            ByteCodec.WriteField(ref writer, 0, (byte)schemaType);
 
             if (schemaType == SchemaType.Encoded)
             {
@@ -53,7 +61,7 @@ namespace Orleans.Serialization.Codecs
             else
             {
                 // If the type is referenced or well-known, write it as a varint.
-                UInt32Codec.WriteField(ref writer, 2, UIntType, id);
+                UInt32Codec.WriteField(ref writer, 2, id);
             }
 
             writer.WriteEndObject();

--- a/src/Orleans.Serialization/Codecs/UriCodec.cs
+++ b/src/Orleans.Serialization/Codecs/UriCodec.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Serializers;
+using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.WireProtocol;
 
 namespace Orleans.Serialization.Codecs
 {
@@ -8,35 +11,55 @@ namespace Orleans.Serialization.Codecs
     /// Serializer for <see cref="Uri"/>.
     /// </summary>
     [RegisterSerializer]
-    public sealed class UriCodec : GeneralizedReferenceTypeSurrogateCodec<Uri, UriSurrogate>
+    public sealed class UriCodec : IFieldCodec<Uri>, IDerivedTypeCodec
     {
+        Uri IFieldCodec<Uri>.ReadValue<TInput>(ref Buffers.Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="UriCodec"/> class.
+        /// Reads a value.
         /// </summary>
-        /// <param name="surrogateSerializer">The surrogate serializer.</param>
-        public UriCodec(IValueSerializer<UriSurrogate> surrogateSerializer) : base(surrogateSerializer)
+        public static Uri ReadValue<TInput>(ref Buffers.Reader<TInput> reader, Field field)
         {
+            if (field.WireType == WireType.Reference)
+                return ReferenceCodec.ReadReference<Uri, TInput>(ref reader, field);
+
+            field.EnsureWireTypeTagDelimited();
+            var referencePlaceholder = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+
+            reader.ReadFieldHeader(ref field);
+            if (!field.HasFieldId || field.FieldIdDelta != 0) throw new RequiredFieldMissingException("Serialized Uri is missing its value.");
+            var uriString = StringCodec.ReadValue(ref reader, field);
+            reader.ReadFieldHeader(ref field);
+            reader.ConsumeEndBaseOrEndObject(ref field);
+
+            var result = new Uri(uriString, UriKind.RelativeOrAbsolute);
+            ReferenceCodec.RecordObject(reader.Session, result, referencePlaceholder);
+            return result;
         }
 
-        /// <inheritdoc />
-        public override Uri ConvertFromSurrogate(ref UriSurrogate surrogate) => new(surrogate.Value, UriKind.RelativeOrAbsolute);
+        void IFieldCodec<Uri>.WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, Uri value)
+        {
+            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, typeof(Uri), value))
+                return;
 
-        /// <inheritdoc />
-        public override void ConvertToSurrogate(Uri value, ref UriSurrogate surrogate) => surrogate.Value = value.OriginalString;
-    }
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Uri), WireType.TagDelimited);
+            StringCodec.WriteField(ref writer, 0, value.OriginalString);
+            writer.WriteEndObject();
+        }
 
-    /// <summary>
-    /// Surrogate type for <see cref="UriCodec"/>.
-    /// </summary>
-    [GenerateSerializer]
-    public struct UriSurrogate
-    {
         /// <summary>
-        /// Gets or sets the value.
+        /// Writes a field without type info (expected type is statically known).
         /// </summary>
-        /// <value>The value.</value>
-        [Id(0)]
-        public string Value;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, Uri value) where TBufferWriter : IBufferWriter<byte>
+        {
+            if (ReferenceCodec.TryWriteReferenceFieldExpected(ref writer, fieldIdDelta, value))
+                return;
+
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.TagDelimited);
+            StringCodec.WriteField(ref writer, 0, value.OriginalString);
+            writer.WriteEndObject();
+        }
     }
 
     [RegisterCopier]

--- a/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ValueTupleCodec.cs
@@ -18,7 +18,7 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, value.GetType(), WireType.VarInt);
-            writer.WriteVarUInt32(0);
+            writer.WriteVarUInt7(0);
         }
 
         /// <inheritdoc />
@@ -27,7 +27,8 @@ namespace Orleans.Serialization.Codecs
             field.EnsureWireType(WireType.VarInt);
 
             ReferenceCodec.MarkValueField(reader.Session);
-            _ = reader.ReadVarUInt64();
+            var length = reader.ReadVarUInt32();
+            if (length != 0) throw new UnexpectedLengthPrefixValueException(nameof(ValueTuple), 0, length);
 
             return default;
         }

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
+using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 
@@ -192,12 +193,12 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(WellKnownStringComparerCodec), WireType.TagDelimited);
 
-            UInt32Codec.WriteField(ref writer, 0, UInt32Codec.CodecFieldType, type);
-            UInt32Codec.WriteField(ref writer, 1, UInt32Codec.CodecFieldType, (uint)compareOptions);
+            UInt32Codec.WriteField(ref writer, 0, type);
+            UInt32Codec.WriteField(ref writer, 1, (uint)compareOptions);
 
             if (compareInfo is not null)
             {
-                Int32Codec.WriteField(ref writer, 1, typeof(int), compareInfo.LCID);
+                Int32Codec.WriteField(ref writer, 1, compareInfo.LCID);
             }
 
             writer.WriteEndObject();
@@ -249,25 +250,13 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="T">The element type.</typeparam>
     [RegisterCopier]
     [RegisterSerializer]
-    public class EqualityComparerBaseCodec<T> : IBaseCodec<EqualityComparer<T>>, IBaseCopier<EqualityComparer<T>>
+    internal sealed class EqualityComparerBaseCodec<T> : IBaseCodec<EqualityComparer<T>>, IBaseCopier<EqualityComparer<T>>
     {
         /// <inheritdoc />
         public void DeepCopy(EqualityComparer<T> input, EqualityComparer<T> output, CopyContext context) { }
 
         /// <inheritdoc />
-        public void Deserialize<TInput>(ref Reader<TInput> reader, EqualityComparer<T> value)
-        {
-            while (true)
-            {
-                var header = reader.ReadFieldHeader();
-                if (header.IsEndBaseOrEndObject)
-                {
-                    break;
-                }
-
-                reader.ConsumeUnknownField(header);
-            }
-        }
+        public void Deserialize<TInput>(ref Reader<TInput> reader, EqualityComparer<T> value) => reader.ConsumeEndBaseOrEndObject();
 
         /// <inheritdoc />
         public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, EqualityComparer<T> value) where TBufferWriter : IBufferWriter<byte>
@@ -281,25 +270,13 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="T">The element type.</typeparam>
     [RegisterCopier]
     [RegisterSerializer]
-    public class ComparerBaseCodec<T> : IBaseCodec<Comparer<T>>, IBaseCopier<Comparer<T>>
+    internal sealed class ComparerBaseCodec<T> : IBaseCodec<Comparer<T>>, IBaseCopier<Comparer<T>>
     {
         /// <inheritdoc />
         public void DeepCopy(Comparer<T> input, Comparer<T> output, CopyContext context) { }
 
         /// <inheritdoc />
-        public void Deserialize<TInput>(ref Reader<TInput> reader, Comparer<T> value)
-        {
-            while (true)
-            {
-                var header = reader.ReadFieldHeader();
-                if (header.IsEndBaseOrEndObject)
-                {
-                    break;
-                }
-
-                reader.ConsumeUnknownField(header);
-            }
-        }
+        public void Deserialize<TInput>(ref Reader<TInput> reader, Comparer<T> value) => reader.ConsumeEndBaseOrEndObject();
 
         /// <inheritdoc />
         public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Comparer<T> value) where TBufferWriter : IBufferWriter<byte>

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -177,11 +177,11 @@ namespace Orleans.Serialization
             {
                 // For exceptions, the type is serialized as a string to facilitate safe deserialization.
                 var typeName = _typeConverter.Format(info.ObjectType);
-                StringCodec.WriteField(ref writer, 1, typeof(string), typeName);
+                StringCodec.WriteField(ref writer, 1, typeName);
             }
             else
             {
-                TypeSerializerCodec.WriteField(ref writer, 0, typeof(Type), info.ObjectType);
+                TypeSerializerCodec.WriteField(ref writer, 0, info.ObjectType);
             }
 
             callbacks.OnSerializing?.Invoke(value, _streamingContext);
@@ -197,7 +197,7 @@ namespace Orleans.Serialization
                     ObjectType = field.ObjectType
                 };
 
-                _entrySerializer.WriteField(ref writer, first ? 1 : (uint)0, SerializationEntryCodec.SerializationEntryType, surrogate);
+                _entrySerializer.WriteField(ref writer, first ? 1 : (uint)0, typeof(SerializationEntrySurrogate), surrogate);
                 if (first)
                 {
                     first = false;

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -186,10 +186,10 @@ namespace Orleans.Serialization
         /// <inheritdoc />
         public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Exception value) where TBufferWriter : IBufferWriter<byte>
         {
-            StringCodec.WriteField(ref writer, 0, typeof(string), value.Message);
-            StringCodec.WriteField(ref writer, 1, typeof(string), value.StackTrace);
+            StringCodec.WriteField(ref writer, 0, value.Message);
+            StringCodec.WriteField(ref writer, 1, value.StackTrace);
             WriteField(ref writer, 1, typeof(Exception), value.InnerException);
-            Int32Codec.WriteField(ref writer, 1, typeof(int), value.HResult);
+            Int32Codec.WriteField(ref writer, 1, value.HResult);
             if (GetDataProperty(value) is { } dataDictionary)
             {
                 _dictionaryCodec.WriteField(ref writer, 1, typeof(Dictionary<object, object>), dataDictionary);
@@ -199,11 +199,11 @@ namespace Orleans.Serialization
         /// <inheritdoc />
         public void SerializeException<TBufferWriter>(ref Writer<TBufferWriter> writer, Exception value) where TBufferWriter : IBufferWriter<byte>
         {
-            StringCodec.WriteField(ref writer, 0, typeof(string), _typeConverter.Format(value.GetType()));
-            StringCodec.WriteField(ref writer, 1, typeof(string), value.Message);
-            StringCodec.WriteField(ref writer, 1, typeof(string), value.StackTrace);
+            StringCodec.WriteField(ref writer, 0, _typeConverter.Format(value.GetType()));
+            StringCodec.WriteField(ref writer, 1, value.Message);
+            StringCodec.WriteField(ref writer, 1, value.StackTrace);
             WriteField(ref writer, 1, typeof(Exception), value.InnerException);
-            Int32Codec.WriteField(ref writer, 1, typeof(int), value.HResult);
+            Int32Codec.WriteField(ref writer, 1, value.HResult);
             if (GetDataProperty(value) is { } dataDictionary)
             {
                 _dictionaryCodec.WriteField(ref writer, 1, typeof(Dictionary<object, object>), dataDictionary);

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationEntryCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationEntryCodec.cs
@@ -9,8 +9,6 @@ namespace Orleans.Serialization
 {
     internal sealed class SerializationEntryCodec : IFieldCodec<SerializationEntrySurrogate>
     {
-        public static readonly Type SerializationEntryType = typeof(SerializationEntrySurrogate);
-
         [SecurityCritical]
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
             uint fieldIdDelta,
@@ -18,12 +16,12 @@ namespace Orleans.Serialization
             SerializationEntrySurrogate value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, SerializationEntryType, WireType.TagDelimited);
-            StringCodec.WriteField(ref writer, 0, typeof(string), value.Name);
-            ObjectCodec.WriteField(ref writer, 1, typeof(object), value.Value);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(SerializationEntrySurrogate), WireType.TagDelimited);
+            StringCodec.WriteField(ref writer, 0, value.Name);
+            ObjectCodec.WriteField(ref writer, 1, value.Value);
             if (value.ObjectType is { } objectType)
             {
-                TypeSerializerCodec.WriteField(ref writer, 1, typeof(Type), objectType);
+                TypeSerializerCodec.WriteField(ref writer, 1, objectType);
             }
 
             writer.WriteEndObject();

--- a/src/Orleans.Serialization/ISerializableSerializer/ValueTypeSerializer.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ValueTypeSerializer.cs
@@ -56,7 +56,7 @@ namespace Orleans.Serialization
             var info = new SerializationInfo(Type, _formatterConverter);
             ((ISerializable)value).GetObjectData(info, _streamingContext);
 
-            TypeSerializerCodec.WriteField(ref writer, 0, typeof(Type), info.ObjectType);
+            TypeSerializerCodec.WriteField(ref writer, 0, info.ObjectType);
 
             var first = true;
             foreach (var field in info)
@@ -68,7 +68,7 @@ namespace Orleans.Serialization
                     ObjectType = field.ObjectType
                 };
 
-                _entrySerializer.WriteField(ref writer, first ? 1 : (uint)0, SerializationEntryCodec.SerializationEntryType, surrogate);
+                _entrySerializer.WriteField(ref writer, first ? 1 : (uint)0, typeof(SerializationEntrySurrogate), surrogate);
                 if (first)
                 {
                     first = false;

--- a/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
@@ -9,14 +9,14 @@ namespace Orleans.Serialization.Buffers
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteVarInt8(sbyte value) => WriteVarUInt32(ZigZagEncode(value));
+        public void WriteVarInt8(sbyte value) => WriteVarUInt28(ZigZagEncode(value));
 
         /// <summary>
         /// Writes a variable-width <see cref="short"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteVarInt16(short value) => WriteVarUInt32(ZigZagEncode(value));
+        public void WriteVarInt16(short value) => WriteVarUInt28(ZigZagEncode(value));
 
         /// <summary>
         /// Writes a variable-width <see cref="int"/>.
@@ -37,19 +37,19 @@ namespace Orleans.Serialization.Buffers
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteVarUInt8(byte value) => WriteVarUInt32(value);
+        public void WriteVarUInt8(byte value) => WriteVarUInt28(value);
 
         /// <summary>
         /// Writes a variable-width <see cref="ushort"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteVarUInt16(ushort value) => WriteVarUInt32(value);
+        public void WriteVarUInt16(ushort value) => WriteVarUInt28(value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint ZigZagEncode(int value) => (uint)((value << 1) ^ (value >> 31));
+        internal static uint ZigZagEncode(int value) => (uint)((value << 1) ^ (value >> 31));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong ZigZagEncode(long value) => (ulong)((value << 1) ^ (value >> 63));
+        internal static ulong ZigZagEncode(long value) => (ulong)((value << 1) ^ (value >> 63));
     }
 }

--- a/test/Benchmarks/Serialization/ComplexTypeBenchmarks.cs
+++ b/test/Benchmarks/Serialization/ComplexTypeBenchmarks.cs
@@ -125,7 +125,7 @@ namespace Benchmarks
         [Benchmark]
         public void OrleansMessageSerializerStructRoundTrip()
         {
-            _messageSerializer.Write(_pipe.Writer, _message);
+            _messageSerializer.Write(_pipe.Writer, _structMessage);
             _pipe.Writer.FlushAsync().AsTask().GetAwaiter().GetResult();
 
             _pipe.Reader.TryRead(out var readResult);

--- a/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IExceptionGrain.cs
@@ -91,7 +91,7 @@ namespace UnitTests.GrainInterfaces
         public UndeserializableType ReadValue<TInput>(ref Reader<TInput> reader, Field field) => throw new NotSupportedException(UndeserializableType.FailureMessage);
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, UndeserializableType value) where TBufferWriter : IBufferWriter<byte>
         {
-            Int32Codec.WriteField(ref writer, fieldIdDelta, typeof(UndeserializableType), value.Number);
+            Int32Codec.WriteField(ref writer, fieldIdDelta, value.Number);
         }
     }
 

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -2383,6 +2383,8 @@ namespace Orleans.Serialization.UnitTests
         {
         }
 
+        protected override int[] MaxSegmentSizes => new[] { 32 };
+
         protected override IPAddress[] TestValues => new[] { null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue() };
 
         protected override IPAddress CreateValue()

--- a/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
@@ -351,8 +351,8 @@ namespace Orleans.Serialization.UnitTests
             public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ObjectWithNewField obj) where TBufferWriter : IBufferWriter<byte>
             {
                 // not serializing newField to simulate a binary that's created from a previous version of the object
-                StringCodec.WriteField(ref writer, 0, typeof(string), obj.Blah);
-                Int32Codec.WriteField(ref writer, 2, typeof(int), obj.Version);
+                StringCodec.WriteField(ref writer, 0, obj.Blah);
+                Int32Codec.WriteField(ref writer, 2, obj.Version);
             }
 
             // using a generated deserializer for deserialization
@@ -383,10 +383,10 @@ namespace Orleans.Serialization.UnitTests
         {
             public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, ObjectWithoutNewField obj) where TBufferWriter : IBufferWriter<byte>
             {
-                StringCodec.WriteField(ref writer, 0, typeof(string), obj.Blah);
-                Int32Codec.WriteField(ref writer, 1, typeof(int), obj.Version);
+                StringCodec.WriteField(ref writer, 0, obj.Blah);
+                Int32Codec.WriteField(ref writer, 1, obj.Version);
                 // serializing a new field to simulate a binary that's created from a newer version of the object
-                ObjectCodec.WriteField(ref writer, 6, typeof(object), "I will be stuck in binary limbo! (I shouldn't be part of the deserialized object)");
+                ObjectCodec.WriteField(ref writer, 6, "I will be stuck in binary limbo! (I shouldn't be part of the deserialized object)");
             }
 
             // using a generated deserializer for deserialization
@@ -527,8 +527,8 @@ namespace Orleans.Serialization.UnitTests
         {
             public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, BaseType obj) where TBufferWriter : IBufferWriter<byte>
             {
-                StringCodec.WriteField(ref writer, 0, typeof(string), obj.BaseTypeString);
-                StringCodec.WriteField(ref writer, 234, typeof(string), obj.AddedLaterString);
+                StringCodec.WriteField(ref writer, 0, obj.BaseTypeString);
+                StringCodec.WriteField(ref writer, 234, obj.AddedLaterString);
             }
 
             public void Deserialize<TInput>(ref Reader<TInput> reader, BaseType obj)


### PR DESCRIPTION
* Always use `SchemaType.Expected` encoding for static codecs (when used statically).
* Make `UriCodec` a static codec.
* Optimize integer and string serialization.

Some more complex types serialization is around 10% faster, but for `MyVector3` it's 1.35-1.4x faster.

|               main |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|----------:|
|    OrleansPipeWriter | 50.46 μs | 0.264 μs | 0.234 μs |      - |     480 B |
|     OrleansSerialize | 25.99 μs | 0.057 μs | 0.053 μs | 0.4272 |   17032 B |
|  OrleansBufferWriter | 22.09 μs | 0.116 μs | 0.103 μs |      - |         - |
| OrleansBufferWriter2 | 49.57 μs | 0.540 μs | 0.505 μs |      - |         - |
| OrleansMessageSerializerStructRoundTrip | 1.096 μs | 0.0048 μs | 0.0040 μs | 0.0095 |     336 B |
|  OrleansMessageSerializerClassRoundTrip | 1.637 μs | 0.0227 μs | 0.0201 μs | 0.0114 |     448 B |

|               PR |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|----------:|
|    OrleansPipeWriter | 36.27 μs | 0.643 μs | 1.253 μs |      - |     480 B |
|     OrleansSerialize | 19.60 μs | 0.392 μs | 0.467 μs | 0.4272 |   17032 B |
|  OrleansBufferWriter | 16.67 μs | 0.263 μs | 0.246 μs |      - |         - |
| OrleansBufferWriter2 | 33.51 μs | 0.555 μs | 0.519 μs |      - |         - |
| OrleansMessageSerializerStructRoundTrip | 1.079 μs | 0.0088 μs | 0.0117 μs | 0.0095 |     336 B |
|  OrleansMessageSerializerClassRoundTrip | 1.555 μs | 0.0064 μs | 0.0060 μs | 0.0114 |     448 B |


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8206)