### PR TITLE
netstandard 2.1 support for Orleans.Serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Build
       run: dotnet build
     - uses: actions/upload-artifact@v3
@@ -49,6 +53,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -85,6 +93,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -117,6 +129,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -153,6 +169,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -187,6 +207,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&Category=${{ matrix.suite }}" --framework ${{ matrix.framework }} --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -220,6 +244,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -253,6 +281,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:
@@ -287,6 +319,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          7.0.x
     - name: Test
       run: dotnet test --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)" --blame-hang-timeout 10m --logger "trx" -- -parallel none -noshadow
       env:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="System.IO.Pipelines" Version="7.0.0" />
     <PackageVersion Include="System.Memory.Data" Version="7.0.0" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <!-- Microsoft packages -->
     <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
@@ -27,6 +28,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
+    <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Connections.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationVersion)" />

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -66,17 +67,17 @@ namespace Orleans.CodeGenerator
                 Task_1 = Type("System.Threading.Tasks.Task`1"),
                 Type = Type("System.Type"),
                 Uri = Type("System.Uri"),
-                Int128 = Type("System.Int128"),
-                UInt128 = Type("System.UInt128"),
-                Half = Type("System.Half"),
-                DateOnly = Type("System.DateOnly"),
+                Int128 = TypeOrDefault("System.Int128"),
+                UInt128 = TypeOrDefault("System.UInt128"),
+                Half = TypeOrDefault("System.Half"),
+                DateOnly = TypeOrDefault("System.DateOnly"),
                 DateTimeOffset = Type("System.DateTimeOffset"),
                 BitVector32 = Type("System.Collections.Specialized.BitVector32"),
                 Guid = Type("System.Guid"),
                 CompareInfo = Type("System.Globalization.CompareInfo"),
                 CultureInfo = Type("System.Globalization.CultureInfo"),
                 Version = Type("System.Version"),
-                TimeOnly = Type("System.TimeOnly"),
+                TimeOnly = TypeOrDefault("System.TimeOnly"),
                 ICodecProvider = Type("Orleans.Serialization.Serializers.ICodecProvider"),
                 ValueSerializer = Type("Orleans.Serialization.Serializers.IValueSerializer`1"),
                 ValueTask = Type("System.Threading.Tasks.ValueTask"),
@@ -86,7 +87,7 @@ namespace Orleans.CodeGenerator
                 Writer = Type("Orleans.Serialization.Buffers.Writer`1"),
                 FSharpSourceConstructFlagsOrDefault = TypeOrDefault("Microsoft.FSharp.Core.SourceConstructFlags"),
                 FSharpCompilationMappingAttributeOrDefault = TypeOrDefault("Microsoft.FSharp.Core.CompilationMappingAttribute"),
-                StaticCodecs = new WellKnownCodecDescription[]
+                StaticCodecs = new List<WellKnownCodecDescription>
                 {
                     new(compilation.GetSpecialType(SpecialType.System_Object), Type("Orleans.Serialization.Codecs.ObjectCodec")),
                     new(compilation.GetSpecialType(SpecialType.System_Boolean), Type("Orleans.Serialization.Codecs.BoolCodec")),
@@ -107,19 +108,19 @@ namespace Orleans.CodeGenerator
                     new(compilation.GetSpecialType(SpecialType.System_DateTime), Type("Orleans.Serialization.Codecs.DateTimeCodec")),
                     new(Type("System.TimeSpan"), Type("Orleans.Serialization.Codecs.TimeSpanCodec")),
                     new(Type("System.DateTimeOffset"), Type("Orleans.Serialization.Codecs.DateTimeOffsetCodec")),
-                    new(Type("System.DateOnly"), Type("Orleans.Serialization.Codecs.DateOnlyCodec")),
-                    new(Type("System.TimeOnly"), Type("Orleans.Serialization.Codecs.TimeOnlyCodec")),
+                    new(TypeOrDefault("System.DateOnly"), TypeOrDefault("Orleans.Serialization.Codecs.DateOnlyCodec")),
+                    new(TypeOrDefault("System.TimeOnly"), TypeOrDefault("Orleans.Serialization.Codecs.TimeOnlyCodec")),
                     new(Type("System.Guid"), Type("Orleans.Serialization.Codecs.GuidCodec")),
                     new(Type("System.Type"), Type("Orleans.Serialization.Codecs.TypeSerializerCodec")),
                     new(Type("System.ReadOnlyMemory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.ReadOnlyMemoryOfByteCodec")),
                     new(Type("System.Memory`1").Construct(compilation.GetSpecialType(SpecialType.System_Byte)), Type("Orleans.Serialization.Codecs.MemoryOfByteCodec")),
                     new(Type("System.Net.IPAddress"), Type("Orleans.Serialization.Codecs.IPAddressCodec")),
                     new(Type("System.Net.IPEndPoint"), Type("Orleans.Serialization.Codecs.IPEndPointCodec")),
-                    new(Type("System.UInt128"), Type("Orleans.Serialization.Codecs.UInt128Codec")),
-                    new(Type("System.Int128"), Type("Orleans.Serialization.Codecs.Int128Codec")),
-                    new(Type("System.Half"), Type("Orleans.Serialization.Codecs.HalfCodec")),
+                    new(TypeOrDefault("System.UInt128"), TypeOrDefault("Orleans.Serialization.Codecs.UInt128Codec")),
+                    new(TypeOrDefault("System.Int128"), TypeOrDefault("Orleans.Serialization.Codecs.Int128Codec")),
+                    new(TypeOrDefault("System.Half"), TypeOrDefault("Orleans.Serialization.Codecs.HalfCodec")),
                     new(Type("System.Uri"), Type("Orleans.Serialization.Codecs.UriCodec")),
-                },
+                }.Where(desc => desc.UnderlyingType is {} && desc.CodecType is {}).ToArray(),
                 WellKnownCodecs = new WellKnownCodecDescription[]
                 {
                     new(Type("System.Exception"), Type("Orleans.Serialization.ExceptionCodec")),
@@ -266,7 +267,7 @@ namespace Orleans.CodeGenerator
         private INamedTypeSymbol UInt128;
         private INamedTypeSymbol Half;
         private INamedTypeSymbol[] _regularShallowCopyableTypes;
-        private INamedTypeSymbol[] RegularShallowCopyableType => _regularShallowCopyableTypes ??= new[]
+        private INamedTypeSymbol[] RegularShallowCopyableType => _regularShallowCopyableTypes ??= new List<INamedTypeSymbol>
         {
             TimeSpan,
             DateOnly,
@@ -285,7 +286,7 @@ namespace Orleans.CodeGenerator
             UInt128,
             Int128,
             Half
-        };
+        }.Where(t => t is {}).ToArray();
 
         public INamedTypeSymbol[] ImmutableAttributes { get; private set; }
         public INamedTypeSymbol Exception { get; private set; }

--- a/src/Orleans.Serialization.FSharp/Orleans.Serialization.FSharp.csproj
+++ b/src/Orleans.Serialization.FSharp/Orleans.Serialization.FSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization.FSharp</PackageId>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageDescription>F# core type support for Orleans.Serialization</PackageDescription>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>

--- a/src/Orleans.Serialization.NewtonsoftJson/Orleans.Serialization.NewtonsoftJson.csproj
+++ b/src/Orleans.Serialization.NewtonsoftJson/Orleans.Serialization.NewtonsoftJson.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization.NewtonsoftJson</PackageId>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageDescription>Newtonsoft.Json integration for Orleans.Serialization</PackageDescription>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>

--- a/src/Orleans.Serialization.SystemTextJson/Orleans.Serialization.SystemTextJson.csproj
+++ b/src/Orleans.Serialization.SystemTextJson/Orleans.Serialization.SystemTextJson.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization.SystemTextJson</PackageId>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageDescription>System.Text.Json integration for Orleans.Serialization</PackageDescription>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -18,7 +18,11 @@ namespace Orleans.Serialization.TestKit
 
         protected CopierTester(ITestOutputHelper output)
         {
+#if NET6_0_OR_GREATER
             var seed = Random.Shared.Next();
+#else
+            var seed = new Random().Next();
+#endif
             output.WriteLine($"Random seed: {seed}");
             Random = new(seed);
             var services = new ServiceCollection();
@@ -51,7 +55,7 @@ namespace Orleans.Serialization.TestKit
         protected virtual bool Equals(TValue left, TValue right) => EqualityComparer<TValue>.Default.Equals(left, right);
 
         protected virtual Action<Action<TValue>> ValueProvider { get; }
-        
+
         [Fact]
         public void CopiedValuesAreEqual()
         {

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -26,7 +26,11 @@ namespace Orleans.Serialization.TestKit
 
         protected FieldCodecTester(ITestOutputHelper output)
         {
+#if NET6_0_OR_GREATER
             var seed = Random.Shared.Next();
+#else
+            var seed = new Random().Next();
+#endif
             output.WriteLine($"Random seed: {seed}");
             Random = new(seed);
             var services = new ServiceCollection();
@@ -121,7 +125,7 @@ namespace Orleans.Serialization.TestKit
         public void CorrectlyAdvancesReferenceCounter()
         {
             var pipe = new Pipe();
-            using var writerSession = _sessionPool.GetSession(); 
+            using var writerSession = _sessionPool.GetSession();
             var writer = Writer.Create(pipe.Writer, writerSession);
             var writerCodec = CreateCodec();
             var beforeReference = writer.Session.ReferencedObjects.CurrentReferenceId;
@@ -139,7 +143,7 @@ namespace Orleans.Serialization.TestKit
             pipe.Writer.Complete();
 
             _ = pipe.Reader.TryRead(out var readResult);
-            using var readerSession = _sessionPool.GetSession(); 
+            using var readerSession = _sessionPool.GetSession();
             var reader = Reader.Create(readResult.Buffer, readerSession);
 
             var previousPos = reader.Position;

--- a/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
+++ b/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization.TestKit</PackageId>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageDescription>Test kit for projects using Orleans.Serialization</PackageDescription>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
   </PropertyGroup>

--- a/src/Orleans.Serialization/Activators/DefaultActivator.cs
+++ b/src/Orleans.Serialization/Activators/DefaultActivator.cs
@@ -21,7 +21,7 @@ namespace Orleans.Serialization.Activators
             var il = method.GetILGenerator();
             il.Emit(OpCodes.Newobj, ctor);
             il.Emit(OpCodes.Ret);
-            return method.CreateDelegate<Func<T>>();
+            return (Func<T>)method.CreateDelegate(typeof(Func<T>));
         }
 
         public T Create() => _constructor is { } ctor ? ctor() : Unsafe.As<T>(FormatterServices.GetUninitializedObject(_type));

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -204,8 +204,8 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
 #if NET6_0_OR_GREATER
                 var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
 #else
+                // Note: Not actually pinned in this case since it just a potential fragmentation optimization
                 var pinnedArray = new byte[MinimumBlockSize];
-                GCHandle.Alloc(pinnedArray, GCHandleType.Pinned);
 #endif
                 Array = pinnedArray;
             }
@@ -223,20 +223,24 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
 
         public Memory<byte> AsMemory(int offset)
         {
+#if NET6_0_OR_GREATER
             if (IsStandardSize)
             {
                 return MemoryMarshal.CreateFromPinnedArray(Array, offset, Array.Length);
             }
+#endif
 
             return Array.AsMemory(offset);
         }
 
         public Memory<byte> AsMemory(int offset, int length)
         {
+#if NET6_0_OR_GREATER
             if (IsStandardSize)
             {
                 return MemoryMarshal.CreateFromPinnedArray(Array, offset, length);
             }
+#endif
 
             return Array.AsMemory(offset, length);
         }

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -195,51 +195,18 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         private const int MinimumBlockSize = 4096;
         private static readonly ConcurrentBag<SequenceSegment> Blocks = new();
 
-<<<<<<< HEAD
         public static SequenceSegment Rent(int size = -1) => size <= MinimumBlockSize && Blocks.TryTake(out var block) ? block : new(size);
-=======
-#if NET6_0_OR_GREATER
-        public void InitializeLargeSegment(int length)
-        {
-            InitializeSegment((int)BitOperations.RoundUpToPowerOf2((uint)length));
-        }
-#else
-        public void InitializeLargeSegment(int length)
-        {
-            InitializeSegment(NextPowerOf2(length));
-
-            int NextPowerOf2(int n)
-            {
-                if (n < 0) return 0;
-
-                n--;
-                n |= n >> 1;
-                n |= n >> 2;
-                n |= n >> 4;
-                n |= n >> 8;
-                n |= n >> 16;
-                n++;
-
-                return n;
-            }
-        }
-#endif
->>>>>>> netstandard2.1 compatible serialization
 
         private SequenceSegment(int length)
         {
             if (length <= MinimumBlockSize)
             {
-<<<<<<< HEAD
-                var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
-=======
 #if NET6_0_OR_GREATER
-                var pinnedArray = GC.AllocateUninitializedArray<byte>(SequenceSegmentPool.MinimumBlockSize, pinned: true);
+                var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
 #else
-                var pinnedArray = new byte[SequenceSegmentPool.MinimumBlockSize];
+                var pinnedArray = new byte[MinimumBlockSize];
                 GCHandle.Alloc(pinnedArray, GCHandleType.Pinned);
 #endif
->>>>>>> netstandard2.1 compatible serialization
                 Array = pinnedArray;
             }
             else

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -195,13 +195,51 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         private const int MinimumBlockSize = 4096;
         private static readonly ConcurrentBag<SequenceSegment> Blocks = new();
 
+<<<<<<< HEAD
         public static SequenceSegment Rent(int size = -1) => size <= MinimumBlockSize && Blocks.TryTake(out var block) ? block : new(size);
+=======
+#if NET6_0_OR_GREATER
+        public void InitializeLargeSegment(int length)
+        {
+            InitializeSegment((int)BitOperations.RoundUpToPowerOf2((uint)length));
+        }
+#else
+        public void InitializeLargeSegment(int length)
+        {
+            InitializeSegment(NextPowerOf2(length));
+
+            int NextPowerOf2(int n)
+            {
+                if (n < 0) return 0;
+
+                n--;
+                n |= n >> 1;
+                n |= n >> 2;
+                n |= n >> 4;
+                n |= n >> 8;
+                n |= n >> 16;
+                n++;
+
+                return n;
+            }
+        }
+#endif
+>>>>>>> netstandard2.1 compatible serialization
 
         private SequenceSegment(int length)
         {
             if (length <= MinimumBlockSize)
             {
+<<<<<<< HEAD
                 var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
+=======
+#if NET6_0_OR_GREATER
+                var pinnedArray = GC.AllocateUninitializedArray<byte>(SequenceSegmentPool.MinimumBlockSize, pinned: true);
+#else
+                var pinnedArray = new byte[SequenceSegmentPool.MinimumBlockSize];
+                GCHandle.Alloc(pinnedArray, GCHandleType.Pinned);
+#endif
+>>>>>>> netstandard2.1 compatible serialization
                 Array = pinnedArray;
             }
             else

--- a/src/Orleans.Serialization/Buffers/BufferWriterExtensions.cs
+++ b/src/Orleans.Serialization/Buffers/BufferWriterExtensions.cs
@@ -20,7 +20,11 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Writer<TBufferWriter> CreateWriter<TBufferWriter>(this TBufferWriter buffer, SerializerSession session) where TBufferWriter : IBufferWriter<byte>
         {
+#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(session);
+#else
+            if (session is null) throw new ArgumentNullException(nameof(session));
+#endif
             return Writer.Create(buffer, session);
         }
     }

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -274,8 +274,10 @@ namespace Orleans.Serialization.Cloning
         {
             [typeof(decimal)] = true,
             [typeof(DateTime)] = true,
+#if NET6_0_OR_GREATER
             [typeof(DateOnly)] = true,
             [typeof(TimeOnly)] = true,
+#endif
             [typeof(DateTimeOffset)] = true,
             [typeof(TimeSpan)] = true,
             [typeof(IPAddress)] = true,
@@ -288,9 +290,13 @@ namespace Orleans.Serialization.Cloning
             [typeof(CultureInfo)] = true,
             [typeof(Version)] = true,
             [typeof(Uri)] = true,
+#if NET7_0_OR_GREATER
             [typeof(UInt128)] = true,
             [typeof(Int128)] = true,
+#endif
+#if NET5_0_OR_GREATER
             [typeof(Half)] = true,
+#endif
         };
 
         public static bool Contains(Type type)
@@ -365,7 +371,7 @@ namespace Orleans.Serialization.Cloning
     /// <summary>
     /// Object pool for <see cref="CopyContext"/> instances.
     /// </summary>
-    public sealed class CopyContextPool 
+    public sealed class CopyContextPool
     {
         private readonly ConcurrentObjectPool<CopyContext, PoolPolicy> _pool;
 

--- a/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
@@ -27,7 +27,11 @@ namespace Orleans.Serialization.Codecs
 
         /// <inheritdoc/>
         public override void ConvertToSurrogate(ConcurrentDictionary<TKey, TValue> value, ref ConcurrentDictionarySurrogate<TKey, TValue> surrogate)
+#if NET6_0_OR_GREATER
             => surrogate.Values = new(value, value.Comparer);
+#else
+            => surrogate.Values = new(value);
+#endif
     }
 
     /// <summary>
@@ -81,7 +85,11 @@ namespace Orleans.Serialization.Codecs
                 return context.DeepCopy(input);
             }
 
+#if NET6_0_OR_GREATER
             result = new(input.Comparer);
+#else
+            result = new();
+#endif
             context.RecordCopy(input, result);
             foreach (var pair in input)
             {

--- a/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DateOnlyCodec.cs
@@ -1,3 +1,4 @@
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -41,3 +42,4 @@ public sealed class DateOnlyCodec : IFieldCodec<DateOnly>
         return DateOnly.FromDayNumber(reader.ReadInt32());
     }
 }
+#endif

--- a/src/Orleans.Serialization/Codecs/FloatCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FloatCodec.cs
@@ -19,7 +19,11 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(float), WireType.Fixed32);
+#if NET6_0_OR_GREATER
             writer.WriteUInt32(BitConverter.SingleToUInt32Bits(value));
+#else
+            writer.WriteUInt32((uint)BitConverter.SingleToInt32Bits(value));
+#endif
         }
 
         /// <summary>
@@ -33,12 +37,8 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, float value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-<<<<<<< HEAD
             writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed32);
-=======
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
 #if NET6_0_OR_GREATER
->>>>>>> netstandard2.1 compatible serialization
             writer.WriteUInt32(BitConverter.SingleToUInt32Bits(value));
 #else
             writer.WriteUInt32((uint)BitConverter.SingleToInt32Bits(value));
@@ -75,9 +75,10 @@ namespace Orleans.Serialization.Codecs
 
                 case WireType.LengthPrefixed:
                     return (float)DecimalCodec.ReadDecimalRaw(ref reader);
-
+#if NET6_0_OR_GREATER
                 case WireType.VarInt:
                     return (float)HalfCodec.ReadHalfRaw(ref reader);
+#endif
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);
                     return 0;
@@ -114,7 +115,11 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(writer.Session);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(double), WireType.Fixed64);
+#if NET6_0_OR_GREATER
             writer.WriteUInt64(BitConverter.DoubleToUInt64Bits(value));
+#else
+            writer.WriteUInt64((ulong)BitConverter.DoubleToInt64Bits(value));
+#endif
         }
 
         /// <summary>
@@ -128,12 +133,8 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, double value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-<<<<<<< HEAD
             writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed64);
-=======
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
 #if NET6_0_OR_GREATER
->>>>>>> netstandard2.1 compatible serialization
             writer.WriteUInt64(BitConverter.DoubleToUInt64Bits(value));
 #else
             writer.WriteUInt64((ulong)BitConverter.DoubleToInt64Bits(value));
@@ -161,8 +162,10 @@ namespace Orleans.Serialization.Codecs
                     return ReadDoubleRaw(ref reader);
                 case WireType.LengthPrefixed:
                     return (double)DecimalCodec.ReadDecimalRaw(ref reader);
+#if NET6_0_OR_GREATER
                 case WireType.VarInt:
                     return (double)HalfCodec.ReadHalfRaw(ref reader);
+#endif
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);
                     return 0;
@@ -221,11 +224,13 @@ namespace Orleans.Serialization.Codecs
         {
             writer.WriteVarUInt7(Width);
 
+#if NET6_0_OR_GREATER
             if (BitConverter.IsLittleEndian)
             {
                 writer.Write(MemoryMarshal.AsBytes(new Span<decimal>(ref value)));
                 return;
             }
+#endif
 
             ref var holder = ref Unsafe.As<decimal, DecimalConverter>(ref value);
             writer.WriteUInt32(holder.Flags);
@@ -270,8 +275,10 @@ namespace Orleans.Serialization.Codecs
                     }
                 case WireType.LengthPrefixed:
                     return ReadDecimalRaw(ref reader);
+#if NET6_0_OR_GREATER
                 case WireType.VarInt:
                     return (decimal)HalfCodec.ReadHalfRaw(ref reader);
+#endif
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);
                     return 0;
@@ -292,12 +299,14 @@ namespace Orleans.Serialization.Codecs
                 throw new UnexpectedLengthPrefixValueException("decimal", Width, length);
             }
 
+#if NET6_0_OR_GREATER
             if (BitConverter.IsLittleEndian)
             {
                 Unsafe.SkipInit(out decimal res);
                 reader.ReadBytes(MemoryMarshal.AsBytes(new Span<decimal>(ref res)));
                 return res;
             }
+#endif
 
             DecimalConverter holder;
             holder.Flags = reader.ReadUInt32();
@@ -320,6 +329,7 @@ namespace Orleans.Serialization.Codecs
             $"The {typeof(T)} value has a magnitude too high {value} to be converted to {typeof(decimal)}.");
     }
 
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Serializer for <see cref="Half"/>.
     /// </summary>
@@ -416,4 +426,5 @@ namespace Orleans.Serialization.Codecs
         private static void ThrowValueOutOfRange<T>(T value) => throw new OverflowException(
             $"The {typeof(T)} value has a magnitude too high {value} to be converted to {typeof(Half)}.");
     }
+#endif
 }

--- a/src/Orleans.Serialization/Codecs/FloatCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FloatCodec.cs
@@ -33,8 +33,16 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, float value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
+<<<<<<< HEAD
             writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed32);
+=======
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed32);
+#if NET6_0_OR_GREATER
+>>>>>>> netstandard2.1 compatible serialization
             writer.WriteUInt32(BitConverter.SingleToUInt32Bits(value));
+#else
+            writer.WriteUInt32((uint)BitConverter.SingleToInt32Bits(value));
+#endif
         }
 
         /// <inheritdoc/>
@@ -83,7 +91,11 @@ namespace Orleans.Serialization.Codecs
         /// <param name="reader">The reader.</param>
         /// <returns>The value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NET6_0_OR_GREATER
         public static float ReadFloatRaw<TInput>(ref Reader<TInput> reader) => BitConverter.UInt32BitsToSingle(reader.ReadUInt32());
+#else
+        public static float ReadFloatRaw<TInput>(ref Reader<TInput> reader) => BitConverter.Int32BitsToSingle((int)reader.ReadUInt32());
+#endif
 
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new UnsupportedWireTypeException(
             $"WireType {wireType} is not supported by this codec.");
@@ -116,8 +128,16 @@ namespace Orleans.Serialization.Codecs
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, double value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
+<<<<<<< HEAD
             writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed64);
+=======
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, CodecFieldType, WireType.Fixed64);
+#if NET6_0_OR_GREATER
+>>>>>>> netstandard2.1 compatible serialization
             writer.WriteUInt64(BitConverter.DoubleToUInt64Bits(value));
+#else
+            writer.WriteUInt64((ulong)BitConverter.DoubleToInt64Bits(value));
+#endif
         }
 
         /// <inheritdoc/>
@@ -156,7 +176,11 @@ namespace Orleans.Serialization.Codecs
         /// <param name="reader">The reader.</param>
         /// <returns>The value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NET6_0_OR_GREATER
         public static double ReadDoubleRaw<TInput>(ref Reader<TInput> reader) => BitConverter.UInt64BitsToDouble(reader.ReadUInt64());
+#else
+        public static double ReadDoubleRaw<TInput>(ref Reader<TInput> reader) => BitConverter.Int64BitsToDouble((long)reader.ReadUInt64());
+#endif
 
         private static void ThrowWireTypeOutOfRange(WireType wireType) => throw new UnsupportedWireTypeException(
             $"WireType {wireType} is not supported by this codec.");

--- a/src/Orleans.Serialization/Codecs/GuidCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GuidCodec.cs
@@ -115,10 +115,7 @@ namespace Orleans.Serialization.Codecs
             }
 
             Span<byte> bytes = stackalloc byte[Width];
-            for (var i = 0; i < Width; i++)
-            {
-                bytes[i] = reader.ReadByte();
-            }
+            reader.ReadBytes(bytes);
 
             return new Guid(bytes);
 #endif

--- a/src/Orleans.Serialization/Codecs/IntegerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/IntegerCodec.cs
@@ -664,6 +664,7 @@ namespace Orleans.Serialization.Codecs
         }
     }
 
+#if NET7_0_OR_GREATER
     /// <summary>
     /// Serializer for <see cref="Int128"/>.
     /// </summary>
@@ -851,4 +852,5 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryReadLittleEndian<T>(ReadOnlySpan<byte> source, out T value) where T : IBinaryInteger<T> => T.TryReadLittleEndian(source, isUnsigned: true, out value);
     }
+#endif
 }

--- a/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TimeOnlyCodec.cs
@@ -1,3 +1,4 @@
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -41,3 +42,4 @@ public sealed class TimeOnlyCodec : IFieldCodec<TimeOnly>
         return new TimeOnly(reader.ReadInt64());
     }
 }
+#endif

--- a/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Orleans.Serialization/Codecs/WellKnownStringComparerCodec.cs
@@ -9,6 +9,10 @@ using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 
+#if !NET6_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
+
 namespace Orleans.Serialization.Codecs
 {
     /// <summary>

--- a/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
+++ b/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
@@ -37,8 +37,10 @@ namespace Orleans.Serialization.Configuration
             wellKnownTypes[25] = typeof(int[]);
             wellKnownTypes[26] = typeof(string[]);
             wellKnownTypes[27] = typeof(Type);
+#if NET6_0_OR_GREATER
             wellKnownTypes[28] = typeof(DateOnly);
             wellKnownTypes[29] = typeof(TimeOnly);
+#endif
             wellKnownTypes[30] = typeof(DayOfWeek);
             wellKnownTypes[31] = typeof(Uri);
             wellKnownTypes[32] = typeof(Version);
@@ -46,9 +48,13 @@ namespace Orleans.Serialization.Configuration
             wellKnownTypes[34] = typeof(IPEndPoint);
             wellKnownTypes[35] = typeof(ExceptionResponse);
             wellKnownTypes[36] = typeof(CompletedResponse);
+#if NET7_0_OR_GREATER
             wellKnownTypes[37] = typeof(Int128);
             wellKnownTypes[38] = typeof(UInt128);
+#endif
+#if NET5_0_OR_GREATER
             wellKnownTypes[39] = typeof(Half);
+#endif
 
             var allowedTypes = typeManifest.AllowedTypes;
             allowedTypes.Add("System.Globalization.CompareOptions");

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
@@ -83,7 +83,7 @@ namespace Orleans.Serialization
                 if (!asm.IsDefined(typeof(ApplicationPartAttribute)) || !assemblies.Add(asm))
                 {
                     continue;
-                } 
+                }
 
                 AddAssembly(parts, asm);
             }

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
@@ -60,22 +60,22 @@ namespace Orleans.Serialization
 
                 if (method.IsDefined(typeof(OnDeserializingAttribute), false))
                 {
-                    onDeserializing = GetSerializationMethod(type, method, owner).CreateDelegate<TDelegate>();
+                    onDeserializing = (TDelegate)GetSerializationMethod(type, method, owner).CreateDelegate(typeof(TDelegate));
                 }
 
                 if (method.IsDefined(typeof(OnDeserializedAttribute), false))
                 {
-                    onDeserialized = GetSerializationMethod(type, method, owner).CreateDelegate<TDelegate>();
+                    onDeserialized = (TDelegate)GetSerializationMethod(type, method, owner).CreateDelegate(typeof(TDelegate));
                 }
 
                 if (method.IsDefined(typeof(OnSerializingAttribute), false))
                 {
-                    onSerializing = GetSerializationMethod(type, method, owner).CreateDelegate<TDelegate>();
+                    onSerializing = (TDelegate)GetSerializationMethod(type, method, owner).CreateDelegate(typeof(TDelegate));
                 }
 
                 if (method.IsDefined(typeof(OnSerializedAttribute), false))
                 {
-                    onSerialized = GetSerializationMethod(type, method, owner).CreateDelegate<TDelegate>();
+                    onSerialized = (TDelegate)GetSerializationMethod(type, method, owner).CreateDelegate(typeof(TDelegate));
                 }
             }
 
@@ -154,7 +154,7 @@ namespace Orleans.Serialization
             public readonly TDelegate OnSerializing;
 
             /// <summary>
-            /// Gets the callback invoked once a value has been serialized. 
+            /// Gets the callback invoked once a value has been serialized.
             /// </summary>
             public readonly TDelegate OnSerialized;
         }

--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" /><!-- TODO build property -->
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.Serialization</PackageId>
     <PackageDescription>Fast, flexible, and version-tolerant serializer for .NET</PackageDescription>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
@@ -15,6 +15,10 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="System.IO.Hashing" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" /><!-- TODO build property -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedObjectCollection.cs
@@ -121,8 +121,7 @@ namespace Orleans.Serialization.Session
                 }
                 else
                 {
-                    reference = nextReference;
-                    overflow[value] = reference;
+                    overflow[value] = nextReference;
                     Unsafe.SkipInit(out reference);
                     return false;
                 }
@@ -204,18 +203,13 @@ namespace Orleans.Serialization.Session
 
                 refValue = value;
 #else
-                if (overflow.TryGetValue(reference, out var existing))
+                if (overflow.TryGetValue(reference, out var existing) && value is not UnknownFieldMarker && existing is not UnknownFieldMarker)
                 {
-                    if (value is not UnknownFieldMarker && existing is not UnknownFieldMarker)
-                    {
-                        // Unknown field markers can be replaced once the type is known.
-                        ThrowReferenceExistsException(reference);
-                    }
+                    // Unknown field markers can be replaced once the type is known.
+                    ThrowReferenceExistsException(reference);
                 }
-                else
-                {
-                    overflow[reference] = value;
-                }
+
+                overflow[reference] = value;
 #endif
             }
             else
@@ -260,6 +254,7 @@ namespace Orleans.Serialization.Session
             }
         }
 
+        [DoesNotReturn]
         private static void ThrowReferenceExistsException(uint reference) => throw new InvalidOperationException($"Reference {reference} already exists");
 
         /// <summary>

--- a/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
+++ b/src/Orleans.Serialization/Session/ReferencedTypeCollection.cs
@@ -56,11 +56,22 @@ namespace Orleans.Serialization.Session
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint GetOrAddTypeReference(Type type)
         {
+#if NET6_0_OR_GREATER
             ref var refValue = ref CollectionsMarshal.GetValueRefOrAddDefault(_referencedTypeToIdMap, type, out var exists);
             if (exists)
                 return refValue;
 
             refValue = ++_currentReferenceId;
+#else
+            if (_referencedTypeToIdMap.TryGetValue(type, out var existing))
+            {
+                return existing;
+            }
+            else
+            {
+                _referencedTypeToIdMap[type] = ++_currentReferenceId;
+            }
+#endif
             return 0;
         }
 

--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -82,7 +82,11 @@ public class CompoundTypeAliasTree
     private CompoundTypeAliasTree AddInternal(object key) => AddInternal(key, default);
     private CompoundTypeAliasTree AddInternal(object key, Type? value)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(key, nameof(key));
+#else
+        if (key is null) throw new ArgumentNullException(nameof(key));
+#endif
         _children ??= new();
 
         if (_children.TryGetValue(key, out var existing))

--- a/src/Orleans.Serialization/Utilities/BitOperations.cs
+++ b/src/Orleans.Serialization/Utilities/BitOperations.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace Orleans.Serialization.Utilities
 {
 #if NETCOREAPP3_1_OR_GREATER

--- a/src/Orleans.Serialization/Utilities/VarIntReaderExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntReaderExtensions.cs
@@ -77,7 +77,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarUInt8(),
             WireType.Fixed32 => checked((byte)reader.ReadUInt32()),
             WireType.Fixed64 => checked((byte)reader.ReadUInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((byte)UInt128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<byte>(nameof(wireType)),
         };
 
@@ -94,7 +96,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarUInt16(),
             WireType.Fixed32 => checked((ushort)reader.ReadUInt32()),
             WireType.Fixed64 => checked((ushort)reader.ReadUInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((ushort)UInt128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<ushort>(nameof(wireType)),
         };
 
@@ -111,7 +115,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarUInt32(),
             WireType.Fixed32 => reader.ReadUInt32(),
             WireType.Fixed64 => checked((uint)reader.ReadUInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((uint)UInt128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<uint>(nameof(wireType)),
         };
 
@@ -128,7 +134,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarUInt64(),
             WireType.Fixed32 => reader.ReadUInt32(),
             WireType.Fixed64 => reader.ReadUInt64(),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((ulong)UInt128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<ulong>(nameof(wireType)),
         };
 
@@ -145,7 +153,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarInt8(),
             WireType.Fixed32 => checked((sbyte)reader.ReadInt32()),
             WireType.Fixed64 => checked((sbyte)reader.ReadInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((sbyte)Int128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<sbyte>(nameof(wireType)),
         };
 
@@ -162,7 +172,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarInt16(),
             WireType.Fixed32 => checked((short)reader.ReadInt32()),
             WireType.Fixed64 => checked((short)reader.ReadInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((short)Int128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<short>(nameof(wireType)),
         };
 
@@ -178,7 +190,7 @@ namespace Orleans.Serialization.Buffers
         {
             if (wireType == WireType.VarInt)
             {
-                return reader.ReadVarInt32(); 
+                return reader.ReadVarInt32();
             }
 
             return ReadInt32Slower(ref reader, wireType);
@@ -189,7 +201,9 @@ namespace Orleans.Serialization.Buffers
         {
             WireType.Fixed32 => reader.ReadInt32(),
             WireType.Fixed64 => checked((int)reader.ReadInt64()),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((int)Int128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<int>(nameof(wireType)),
         };
 
@@ -206,7 +220,9 @@ namespace Orleans.Serialization.Buffers
             WireType.VarInt => reader.ReadVarInt64(),
             WireType.Fixed32 => reader.ReadInt32(),
             WireType.Fixed64 => reader.ReadInt64(),
+#if NET7_0_OR_GREATER
             WireType.LengthPrefixed => checked((long)Int128Codec.ReadRaw(ref reader)),
+#endif
             _ => ExceptionHelper.ThrowArgumentOutOfRange<long>(nameof(wireType)),
         };
 

--- a/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
@@ -1,10 +1,4 @@
 using System.Runtime.CompilerServices;
-<<<<<<< HEAD
-=======
-using System.Runtime.InteropServices;
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Utilities;
->>>>>>> netstandard2.1 compatible serialization
 
 namespace Orleans.Serialization.Buffers
 {

--- a/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/VarIntWriterExtensions.cs
@@ -1,4 +1,10 @@
 using System.Runtime.CompilerServices;
+<<<<<<< HEAD
+=======
+using System.Runtime.InteropServices;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Utilities;
+>>>>>>> netstandard2.1 compatible serialization
 
 namespace Orleans.Serialization.Buffers
 {

--- a/src/Orleans.Serialization/WireProtocol/Field.cs
+++ b/src/Orleans.Serialization/WireProtocol/Field.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Orleans.Serialization.WireProtocol
 {
@@ -247,6 +248,7 @@ namespace Orleans.Serialization.WireProtocol
         /// <inheritdoc/>
         public override string ToString()
         {
+#if NET6_0_OR_GREATER
             var builder = new DefaultInterpolatedStringHandler(0, 0);
             builder.AppendLiteral("[");
             builder.AppendFormatted(WireType);
@@ -277,6 +279,38 @@ namespace Orleans.Serialization.WireProtocol
 
             builder.AppendLiteral("]");
             return builder.ToStringAndClear();
+#else
+            var builder = new StringBuilder();
+            builder.Append("[");
+            builder.Append(WireType);
+
+            if (HasFieldId)
+            {
+                builder.Append(", IdDelta:");
+                builder.Append(FieldIdDelta);
+            }
+
+            if (IsSchemaTypeValid)
+            {
+                builder.Append(", SchemaType:");
+                builder.Append(SchemaType);
+            }
+
+            if (HasExtendedSchemaType)
+            {
+                builder.Append(", RuntimeType:");
+                builder.Append(FieldType);
+            }
+
+            if (WireType == WireType.Extended)
+            {
+                builder.Append(": ");
+                builder.Append(ExtendedWireType);
+            }
+
+            builder.Append("]");
+            return builder.ToString();
+#endif
         }
     }
 }

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -138,6 +138,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
     }
 
+#if NET6_0_OR_GREATER
     public class DateOnlyTests : FieldCodecTester<DateOnly, DateOnlyCodec>
     {
         public DateOnlyTests(ITestOutputHelper output) : base(output)
@@ -181,6 +182,7 @@ namespace Orleans.Serialization.UnitTests
         protected override TimeOnly[] TestValues => new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue() };
         protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
     }
+#endif
 
     public class TimeSpanTests : FieldCodecTester<TimeSpan, TimeSpanCodec>
     {
@@ -1173,6 +1175,7 @@ namespace Orleans.Serialization.UnitTests
         protected override int[][] TestValues => new[] { null, Array.Empty<int>(), CreateValue(), CreateValue(), CreateValue() };
     }
 
+#if NET7_0_OR_GREATER
     public class UInt128CodecTests : FieldCodecTester<UInt128, UInt128Codec>
     {
         public UInt128CodecTests(ITestOutputHelper output) : base(output)
@@ -1226,6 +1229,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override Action<Action<UInt128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
     }
+#endif
 
     public class UInt64CodecTests : FieldCodecTester<ulong, UInt64Codec>
     {
@@ -1410,6 +1414,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
     }
 
+#if NET7_0_OR_GREATER
     public class Int128CodecTests : FieldCodecTester<Int128, Int128Codec>
     {
         public Int128CodecTests(ITestOutputHelper output) : base(output)
@@ -1463,6 +1468,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override Action<Action<Int128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.V0, value.V1)));
     }
+#endif
 
     public class Int64CodecTests : FieldCodecTester<long, Int64Codec>
     {
@@ -1866,6 +1872,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
     }
 
+#if NET5_0_OR_GREATER
     public class HalfCodecTests : FieldCodecTester<Half, HalfCodec>
     {
         public HalfCodecTests(ITestOutputHelper output) : base(output)
@@ -1889,6 +1896,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
     }
+#endif
 
     public class DoubleCodecTests : FieldCodecTester<double, DoubleCodec>
     {
@@ -2245,7 +2253,7 @@ namespace Orleans.Serialization.UnitTests
                     return false;
                 }
             }
-            
+
             return true;
         }
     }
@@ -2288,7 +2296,7 @@ namespace Orleans.Serialization.UnitTests
                     return false;
                 }
             }
-            
+
             return true;
         }
     }
@@ -2400,7 +2408,7 @@ namespace Orleans.Serialization.UnitTests
             }
             Random.NextBytes(bytes);
             return new IPAddress(bytes);
-        } 
+        }
     }
 
     public class IPAddressCopierTests : CopierTester<IPAddress, IDeepCopier<IPAddress>>
@@ -2595,7 +2603,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override bool Equals(FSharpOption<Guid> left, FSharpOption<Guid> right) => object.ReferenceEquals(left, right) || left.GetType() == right.GetType() && left.Value.Equals(right.Value);
     }
-    
+
     public class FSharpOptionTests2 : FieldCodecTester<FSharpOption<object>, FSharpOptionCodec<object>>
     {
         public FSharpOptionTests2(ITestOutputHelper output) : base(output)

--- a/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
@@ -1,3 +1,4 @@
+#if NET7_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -244,3 +245,4 @@ public class NumericsWideningAndNarrowingTests
     }
 }
 
+#endif

--- a/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NumericsWideningAndNarrowingTests.cs
@@ -244,5 +244,443 @@ public class NumericsWideningAndNarrowingTests
         public T Value;
     }
 }
+#else
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+/// <summary>
+/// Ensures that numeric fields (integers, floats, etc) can be widened and narrowed in a version tolerant manner.
+/// </summary>
+public class NumericsWideningAndNarrowingTests
+{
+    private static readonly ByteNumber ByteType = new();
+    private static readonly ShortNumber ShortType = new();
+    private static readonly IntNumber IntType = new();
+    private static readonly LongNumber LongType = new();
+    private static readonly SByteNumber SByteType = new();
+    private static readonly UShortNumber UShortType = new();
+    private static readonly UIntNumber UIntType = new();
+    private static readonly ULongNumber ULongType = new();
+    private static readonly FloatNumber FloatType = new();
+    private static readonly DoubleNumber DoubleType = new();
+    private static readonly DecimalNumber DecimalType = new();
+#if NET5_0_OR_GREATER
+    private static readonly HalfNumber HalfType = new();
+#endif
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly Serializer _serializer;
+
+    public NumericsWideningAndNarrowingTests()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSerializer();
+        _serviceProvider = services.BuildServiceProvider();
+        _serializer = _serviceProvider.GetRequiredService<Serializer>();
+    }
+
+    /// <summary>
+    /// Tests that unsigned integers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void UnsignedIntegerWideningAndNarrowingVersionToleranceTests()
+    {
+        ConversionRoundTrip(ByteType, UShortType);
+        ConversionRoundTrip(ByteType, UIntType);
+        ConversionRoundTrip(ByteType, ULongType);
+
+        ConversionRoundTrip(UShortType, UIntType);
+        ConversionRoundTrip(UShortType, ULongType);
+
+        ConversionRoundTrip(UIntType, ULongType);
+    }
+
+    /// <summary>
+    /// Tests that signed integers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void SignedIntegerWideningAndNarrowingVersionToleranceTests()
+    {
+        ConversionRoundTrip(SByteType, ShortType);
+        ConversionRoundTrip(SByteType, IntType);
+        ConversionRoundTrip(SByteType, LongType);
+
+        ConversionRoundTrip(ShortType, IntType);
+        ConversionRoundTrip(ShortType, LongType);
+
+        ConversionRoundTrip(IntType, LongType);
+    }
+
+    /// <summary>
+    /// Tests that floating point numbers can be widened and narrowed and maintain compatibility.
+    /// </summary>
+    [Fact]
+    public void FloatWideningAndNarrowingVersionToleranceTests()
+    {
+#if NET5_0_OR_GREATER
+        FloatConversionRoundTrip(HalfType, DecimalType);
+        FloatConversionRoundTrip(HalfType, FloatType);
+        FloatConversionRoundTrip(HalfType, DoubleType);
+#endif
+
+        FloatConversionRoundTrip(DecimalType, FloatType);
+        FloatConversionRoundTrip(DecimalType, DoubleType);
+
+        FloatConversionRoundTrip(FloatType, DoubleType);
+    }
+
+    private void ConversionRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        WideningRoundTrip(n, w);
+        NarrowingRoundTrip(n, w);
+        NarrowingOverflow(n, w);
+    }
+
+    private void FloatConversionRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        FloatWideningRoundTrip(n, w);
+        FloatNarrowingRoundTrip(n, w);
+        NarrowingOverflow(n, w);
+    }
+
+    private void WideningRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        var two = n.Add(n.MultiplicativeIdentity, n.MultiplicativeIdentity);
+        var values = new List<N>
+        {
+            n.MinValue,
+            default(N),
+            n.Divide(n.MaxValue, two),
+            n.MaxValue,
+        };
+
+        foreach (var value in values)
+        {
+            RoundTripValue(value, n, w);
+        }
+    }
+
+    private void NarrowingRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        var two = n.Add(n.MultiplicativeIdentity, n.MultiplicativeIdentity);
+        var values = (new N[]
+        {
+            n.MinValue,
+            default(N),
+            n.Divide(n.MaxValue, two),
+            n.MaxValue,
+        }).Select(w.CreateTruncating).ToList();
+
+        foreach (var value in values)
+        {
+            RoundTripValue(value, w, n);
+        }
+    }
+
+    private void NarrowingOverflow<N, W>(INumber<N> n, INumber<W> w)
+    {
+        var values = w.Sign(w.MinValue) switch
+        {
+            -1 => new[] { w.MinValue, w.MaxValue },
+            _ => new[] { w.MaxValue }
+        };
+
+        foreach (var value in values)
+        {
+            Assert.Throws<OverflowException>(() => RoundTripValueDirectly(value, w, n));
+            Assert.Throws<OverflowException>(() => RoundTripValueIndirectly(value, w, n));
+        }
+    }
+
+    private void FloatWideningRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        var two = n.Add(n.MultiplicativeIdentity, n.MultiplicativeIdentity);
+        var buffer = n.Divide(n.Divide(n.Divide(n.MaxValue, two), two), two);
+        var values = new List<N>
+        {
+            n.Add(n.MinValue, buffer),
+            n.Divide(n.MinValue, two),
+            default(N),
+            n.Divide(n.MaxValue, two),
+            n.Subtract(n.MaxValue, buffer),
+        };
+
+        foreach (var value in values)
+        {
+            RoundTripValue(value, n, w);
+        }
+    }
+
+    private void FloatNarrowingRoundTrip<N, W>(INumber<N> n, INumber<W> w)
+    {
+        var two = n.Add(n.MultiplicativeIdentity, n.MultiplicativeIdentity);
+        var buffer = n.Divide(n.Divide(n.Divide(n.MaxValue, two), two), two);
+        var values = new List<N>
+        {
+            n.Add(n.MinValue, buffer),
+            n.Divide(n.MinValue, two),
+            default(N),
+            n.Divide(n.MaxValue, two),
+            n.Subtract(n.MaxValue, buffer),
+        }.Select(w.CreateTruncating).ToList();
+
+        foreach (var value in values)
+        {
+            RoundTripValue(value, w, n);
+        }
+    }
+
+    private void RoundTripValue<TLeft, TRight>(TLeft leftValue, INumber<TLeft> left, INumber<TRight> right)
+    {
+        RoundTripValueDirectly(leftValue, left, right);
+        RoundTripValueIndirectly(leftValue, left, right);
+    }
+
+    private void RoundTripValueDirectly<TLeft, TRight>(TLeft leftValue, INumber<TLeft> left, INumber<TRight> right)
+    {
+        // Round-trip the value, converting it along the way.
+        var payload = _serializer.SerializeToArray(leftValue);
+        var result = _serializer.Deserialize<TRight>(payload);
+
+        var asRight = right.CreateTruncating(leftValue);
+        Assert.Equal(asRight, result);
+
+        var asLeft = left.CreateTruncating(result);
+        var expected = left.CreateTruncating(right.CreateTruncating(leftValue));
+        Assert.Equal(expected, asLeft);
+    }
+
+    private void RoundTripValueIndirectly<TLeft, TRight>(TLeft leftValue, INumber<TLeft> left, INumber<TRight> right)
+    {
+        // Wrap the value and round-trip the wrapped value, converting it along the way.
+        var payload = _serializer.SerializeToArray(new ValueHolder<TLeft> { Value = leftValue });
+        var result = _serializer.Deserialize<ValueHolder<TRight>>(payload).Value;
+
+        var asRight = right.CreateTruncating(leftValue);
+        Assert.Equal(asRight, result);
+
+        var asLeft = left.CreateTruncating(result);
+        var expected = left.CreateTruncating(right.CreateTruncating(leftValue));
+        Assert.Equal(expected, asLeft);
+    }
+
+    [GenerateSerializer]
+    public sealed class ValueHolder<T>
+    {
+        [Id(0)]
+        public T Value;
+    }
+
+    public interface INumber<T>
+    {
+        public T MinValue { get; }
+        public T MaxValue { get; }
+        public T MultiplicativeIdentity { get; }
+        public int Sign(T value);
+        public T Add(T x, T y);
+        public T Subtract(T x, T y);
+        public T Divide(T x, T y);
+        public T CreateTruncating<TFrom>(TFrom from);
+    }
+
+    public sealed class ByteNumber : INumber<byte>
+    {
+        public byte MinValue => byte.MinValue;
+        public byte MaxValue => byte.MaxValue;
+        public byte MultiplicativeIdentity => 1;
+        public int Sign(byte value) => Math.Sign(value);
+
+        public byte Add(byte x, byte y) => (byte)(x + y);
+
+        public byte Subtract(byte x, byte y) => (byte)(x - y);
+
+        public byte Divide(byte x, byte y) => (byte)(x / y);
+
+        public byte CreateTruncating<TFrom>(TFrom from) => (byte)Convert.ChangeType(from, typeof(byte));
+    }
+
+    public sealed class UShortNumber : INumber<ushort>
+    {
+        public ushort MinValue => ushort.MinValue;
+        public ushort MaxValue => ushort.MaxValue;
+        public ushort MultiplicativeIdentity => 1;
+        public int Sign(ushort value) => 1;
+
+        public ushort Add(ushort x, ushort y) => (ushort)(x + y);
+
+        public ushort Subtract(ushort x, ushort y) => (ushort)(x - y);
+
+        public ushort Divide(ushort x, ushort y) => (ushort)(x / y);
+
+        public ushort CreateTruncating<TFrom>(TFrom from) => (ushort)Convert.ChangeType(from, typeof(ushort));
+    }
+
+    public sealed class UIntNumber : INumber<uint>
+    {
+        public uint MinValue => uint.MinValue;
+        public uint MaxValue => uint.MaxValue;
+        public uint MultiplicativeIdentity => 1;
+        public int Sign(uint value) => 1;
+
+        public uint Add(uint x, uint y) => x + y;
+
+        public uint Subtract(uint x, uint y) => x - y;
+
+        public uint Divide(uint x, uint y) => x / y;
+
+        public uint CreateTruncating<TFrom>(TFrom from) => (uint)Convert.ChangeType(from, typeof(uint));
+    }
+
+    public sealed class ULongNumber : INumber<ulong>
+    {
+        public ulong MinValue => ulong.MinValue;
+        public ulong MaxValue => ulong.MaxValue;
+        public ulong MultiplicativeIdentity => 1;
+        public int Sign(ulong value) => 1;
+
+        public ulong Add(ulong x, ulong y) => x + y;
+
+        public ulong Subtract(ulong x, ulong y) => x - y;
+
+        public ulong Divide(ulong x, ulong y) => x / y;
+
+        public ulong CreateTruncating<TFrom>(TFrom from) => (ulong)Convert.ChangeType(from, typeof(ulong));
+    }
+
+    public sealed class SByteNumber : INumber<sbyte>
+    {
+        public sbyte MinValue => sbyte.MinValue;
+        public sbyte MaxValue => sbyte.MaxValue;
+        public sbyte MultiplicativeIdentity => 1;
+        public int Sign(sbyte value) => Math.Sign(value);
+
+        public sbyte Add(sbyte x, sbyte y) => (sbyte)(x + y);
+
+        public sbyte Subtract(sbyte x, sbyte y) => (sbyte)(x - y);
+
+        public sbyte Divide(sbyte x, sbyte y) => (sbyte)(x / y);
+
+        public sbyte CreateTruncating<TFrom>(TFrom from) => (sbyte)Convert.ChangeType(from, typeof(sbyte));
+    }
+
+    public sealed class ShortNumber : INumber<short>
+    {
+        public short MinValue => short.MinValue;
+        public short MaxValue => short.MaxValue;
+        public short MultiplicativeIdentity => 1;
+        public int Sign(short value) => Math.Sign(value);
+
+        public short Add(short x, short y) => (short)(x + y);
+
+        public short Subtract(short x, short y) => (short)(x - y);
+
+        public short Divide(short x, short y) => (short)(x / y);
+
+        public short CreateTruncating<TFrom>(TFrom from) => (short)Convert.ChangeType(from, typeof(short));
+    }
+
+    public sealed class IntNumber : INumber<int>
+    {
+        public int MinValue => int.MinValue;
+        public int MaxValue => int.MaxValue;
+        public int MultiplicativeIdentity => 1;
+        public int Sign(int value) => Math.Sign(value);
+
+        public int Add(int x, int y) => x + y;
+
+        public int Subtract(int x, int y) => x - y;
+
+        public int Divide(int x, int y) => x / y;
+
+        public int CreateTruncating<TFrom>(TFrom from) => (int)Convert.ChangeType(from, typeof(int));
+    }
+
+    public sealed class LongNumber : INumber<long>
+    {
+        public long MinValue => long.MinValue;
+        public long MaxValue => long.MaxValue;
+        public long MultiplicativeIdentity => 1;
+        public int Sign(long value) => Math.Sign(value);
+
+        public long Add(long x, long y) => x + y;
+
+        public long Subtract(long x, long y) => x - y;
+
+        public long Divide(long x, long y) => x / y;
+
+        public long CreateTruncating<TFrom>(TFrom from) => (long)Convert.ChangeType(from, typeof(long));
+    }
+
+    public sealed class FloatNumber : INumber<float>
+    {
+        public float MinValue => float.MinValue;
+        public float MaxValue => float.MaxValue;
+        public float MultiplicativeIdentity => 1;
+        public int Sign(float value) => Math.Sign(value);
+
+        public float Add(float x, float y) => x + y;
+
+        public float Subtract(float x, float y) => x - y;
+
+        public float Divide(float x, float y) => x / y;
+
+        public float CreateTruncating<TFrom>(TFrom from) => (float)Convert.ChangeType(from, typeof(float));
+    }
+
+    public sealed class DoubleNumber : INumber<double>
+    {
+        public double MinValue => double.MinValue;
+        public double MaxValue => double.MaxValue;
+        public double MultiplicativeIdentity => 1;
+        public int Sign(double value) => Math.Sign(value);
+
+        public double Add(double x, double y) => x + y;
+
+        public double Subtract(double x, double y) => x - y;
+
+        public double Divide(double x, double y) => x / y;
+
+        public double CreateTruncating<TFrom>(TFrom from) => (double)Convert.ChangeType(from, typeof(double));
+    }
+
+    public sealed class DecimalNumber : INumber<decimal>
+    {
+        public decimal MinValue => decimal.MinValue;
+        public decimal MaxValue => decimal.MaxValue;
+        public decimal MultiplicativeIdentity => 1;
+        public int Sign(decimal value) => Math.Sign(value);
+
+        public decimal Add(decimal x, decimal y) => x + y;
+
+        public decimal Subtract(decimal x, decimal y) => x - y;
+
+        public decimal Divide(decimal x, decimal y) => x / y;
+
+        public decimal CreateTruncating<TFrom>(TFrom from) => (decimal)Convert.ChangeType(from, typeof(decimal));
+    }
+
+#if NET5_0_OR_GREATER
+    public sealed class HalfNumber : INumber<Half>
+    {
+        public Half MinValue => Half.MinValue;
+        public Half MaxValue => Half.MaxValue;
+        public Half MultiplicativeIdentity => 1;
+        public int Sign(Half value) => Math.Sign(value);
+
+        public Half Add(Half x, Half y) => x + y;
+
+        public Half Subtract(Half x, Half y) => x - y;
+
+        public Half Divide(Half x, Half y) => x / y;
+
+        public Half CreateTruncating<TFrom>(TFrom from) => (Half)Convert.ChangeType(from, typeof(Half));
+    }
+#endif
+}
 
 #endif

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>


### PR DESCRIPTION
Make Orleans.Serialization compatible with netstandard 2.1 to enable greater usage outside of Orleans.

Note: it would be possible to support netstandard 2.0; however, that requires quite a bit more conditionals or removal of some niceties.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8222)