### PR TITLE
DynamoDB grain state storage using compression

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBSiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBSiloBuilderExtensions.cs
@@ -6,6 +6,11 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
+using Orleans.Persistence.DynamoDB.Provider.Compression;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+using System.Collections.Generic;
+using Orleans.Persistence.DynamoDB.Provider.Serialization;
+using Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces;
 
 namespace Orleans.Hosting
 {
@@ -14,7 +19,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static ISiloHostBuilder AddDynamoDBGrainStorageAsDefault(this ISiloHostBuilder builder, Action<DynamoDBStorageOptions> configureOptions)
+        public static ISiloHostBuilder AddDynamoDBGrainStorageAsDefault(this ISiloHostBuilder builder,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
             return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
         }
@@ -22,7 +28,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage for grain storage.
         /// </summary>
-        public static ISiloHostBuilder AddDynamoDBGrainStorage(this ISiloHostBuilder builder, string name, Action<DynamoDBStorageOptions> configureOptions)
+        public static ISiloHostBuilder AddDynamoDBGrainStorage(this ISiloHostBuilder builder, string name,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
             return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
         }
@@ -30,7 +37,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static ISiloHostBuilder AddDynamoDBGrainStorageAsDefault(this ISiloHostBuilder builder, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        public static ISiloHostBuilder AddDynamoDBGrainStorageAsDefault(this ISiloHostBuilder builder,
+            Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
         }
@@ -38,7 +46,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage for grain storage.
         /// </summary>
-        public static ISiloHostBuilder AddDynamoDBGrainStorage(this ISiloHostBuilder builder, string name, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        public static ISiloHostBuilder AddDynamoDBGrainStorage(this ISiloHostBuilder builder, string name,
+            Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
         }
@@ -46,7 +55,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<DynamoDBStorageOptions> configureOptions)
+        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
             return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
         }
@@ -54,7 +64,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage for grain storage.
         /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<DynamoDBStorageOptions> configureOptions)
+        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
             return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
         }
@@ -62,7 +73,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        public static ISiloBuilder AddDynamoDBGrainStorageAsDefault(this ISiloBuilder builder,
+            Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             return builder.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
         }
@@ -70,7 +82,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage for grain storage.
         /// </summary>
-        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        public static ISiloBuilder AddDynamoDBGrainStorage(this ISiloBuilder builder, string name,
+            Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             return builder.ConfigureServices(services => services.AddDynamoDBGrainStorage(name, configureOptions));
         }
@@ -78,15 +91,18 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static IServiceCollection AddDynamoDBGrainStorageAsDefault(this IServiceCollection services, Action<DynamoDBStorageOptions> configureOptions)
+        public static IServiceCollection AddDynamoDBGrainStorageAsDefault(this IServiceCollection services,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
-            return services.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, ob => ob.Configure(configureOptions));
+            return services.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME,
+                ob => ob.Configure(configureOptions));
         }
 
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage for grain storage.
         /// </summary>
-        public static IServiceCollection AddDynamoDBGrainStorage(this IServiceCollection services, string name, Action<DynamoDBStorageOptions> configureOptions)
+        public static IServiceCollection AddDynamoDBGrainStorage(this IServiceCollection services, string name,
+            Action<DynamoDBStorageOptions> configureOptions)
         {
             return services.AddDynamoDBGrainStorage(name, ob => ob.Configure(configureOptions));
         }
@@ -94,7 +110,8 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use AWS DynamoDB storage as the default grain storage.
         /// </summary>
-        public static IServiceCollection AddDynamoDBGrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
+        public static IServiceCollection AddDynamoDBGrainStorageAsDefault(this IServiceCollection services,
+            Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             return services.AddDynamoDBGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
         }
@@ -106,15 +123,60 @@ namespace Orleans.Hosting
             Action<OptionsBuilder<DynamoDBStorageOptions>> configureOptions = null)
         {
             configureOptions?.Invoke(services.AddOptions<DynamoDBStorageOptions>(name));
-            services.AddTransient<IConfigurationValidator>(sp => new DynamoDBGrainStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(name), name));
+            services.AddTransient<IConfigurationValidator>(sp =>
+                new DynamoDBGrainStorageOptionsValidator(
+                    sp.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(name), name));
             services.ConfigureNamedOptionForLogging<DynamoDBStorageOptions>(name);
+            
             if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
             {
                 services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+                services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStateCompressionManager>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+                services.TryAddSingleton(sp => sp.GetServiceByName<IGrainStateSerializationManager>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+                services.TryAddSingleton(sp => sp.GetServiceByName<IEnumerable<IProvideGrainStateRecordCompression>>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+                services.TryAddSingleton(sp => sp.GetServiceByName<IEnumerable<IProvideGrainStateRecordSerialization>>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             }
 
-            return services.AddSingletonNamedService(name, DynamoDBGrainStorageFactory.Create)
-                           .AddSingletonNamedService(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));
+            return services
+                .AddSingletonNamedService(name, DynamoDBGrainStorageFactory.Create)
+                .AddSingletonNamedService(name,
+                    (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n))
+                .AddSingletonNamedService<IGrainStateCompressionManager>(
+                    name,
+                    (provider, s) => ActivatorUtilities.CreateInstance<GrainStateCompressionManager>(
+                        provider,
+                        provider.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(s)))
+                .AddSingletonNamedService<IGrainStateSerializationManager>(
+                    name,
+                    (provider, s) => ActivatorUtilities.CreateInstance<GrainStateSerializationManager>(
+                        provider,
+                        provider.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(s)))
+                .AddSingletonNamedService<IEnumerable<IProvideGrainStateRecordCompression>>(name, (provider, s) =>
+                {
+                    var options = provider.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(s);
+                    return new IProvideGrainStateRecordCompression[]
+                    {
+                        ActivatorUtilities.CreateInstance<GrainStateRecordGzipCompressionService>(
+                            provider,
+                            options),
+                        ActivatorUtilities.CreateInstance<GrainStateRecordDeflateCompressionService>(
+                            provider,
+                            options)
+                    };
+                })
+                .AddSingletonNamedService<IEnumerable<IProvideGrainStateRecordSerialization>>(name, (provider, s) =>
+                {
+                    var options = provider.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(s);
+                    return new IProvideGrainStateRecordSerialization[]
+                    {
+                        ActivatorUtilities.CreateInstance<GrainStateRecordBinarySerializationService>(
+                            provider,
+                            options),
+                        ActivatorUtilities.CreateInstance<GrainStateRecordJsonSerializationService>(
+                            provider,
+                            options)
+                    };
+                });
         }
     }
 }

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBGrainStorageOptionsValidator.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBGrainStorageOptionsValidator.cs
@@ -1,0 +1,41 @@
+using Orleans.Runtime;
+
+namespace Orleans.Configuration;
+
+/// <summary>
+/// Configuration validator for DynamoDBStorageOptions
+/// </summary>
+public class DynamoDBGrainStorageOptionsValidator : IConfigurationValidator
+{
+    private readonly DynamoDBStorageOptions options;
+    private readonly string name;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="options">The option to be validated.</param>
+    /// <param name="name">The option name to be validated.</param>
+    public DynamoDBGrainStorageOptionsValidator(DynamoDBStorageOptions options, string name)
+    {
+        this.options = options;
+        this.name = name;
+    }
+
+    public void ValidateConfiguration()
+    {
+        if (string.IsNullOrWhiteSpace(this.options.TableName))
+            throw new OrleansConfigurationException(
+                $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.TableName)} is not valid.");
+
+        if (this.options.UseProvisionedThroughput)
+        {
+            if (this.options.ReadCapacityUnits == 0)
+                throw new OrleansConfigurationException(
+                    $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.ReadCapacityUnits)} is not valid.");
+
+            if (this.options.WriteCapacityUnits == 0)
+                throw new OrleansConfigurationException(
+                    $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.WriteCapacityUnits)} is not valid.");
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs
@@ -1,7 +1,6 @@
 using System;
 using Newtonsoft.Json;
 using Orleans.Persistence.DynamoDB;
-using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -68,57 +67,21 @@ namespace Orleans.Configuration
         /// <summary>
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
         /// </summary>
-        public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
-        public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
+        public int InitStage { get; set; } = DefaultInitStage;
+        public const int DefaultInitStage = ServiceLifecycleStage.ApplicationServices;
 
         public bool UseJson { get; set; }
         public bool UseFullAssemblyNames { get; set; }
         public bool IndentJson { get; set; }
         public TypeNameHandling? TypeNameHandling { get; set; }
+        public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+
+        public StateCompressionPolicy StateCompressionPolicy { get; set; } = null;
 
         /// <summary>
         /// Specifies a time span in which the item would be expired in the future
         /// every StateWrite will increase the TTL of the grain
         /// </summary>
         public TimeSpan? TimeToLive { get; set; }
-        public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
-    }
-
-    /// <summary>
-    /// Configuration validator for DynamoDBStorageOptions
-    /// </summary>
-    public class DynamoDBGrainStorageOptionsValidator : IConfigurationValidator
-    {
-        private readonly DynamoDBStorageOptions options;
-        private readonly string name;
-
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="options">The option to be validated.</param>
-        /// <param name="name">The option name to be validated.</param>
-        public DynamoDBGrainStorageOptionsValidator(DynamoDBStorageOptions options, string name)
-        {
-            this.options = options;
-            this.name = name;
-        }
-
-        public void ValidateConfiguration()
-        {
-            if (string.IsNullOrWhiteSpace(this.options.TableName))
-                throw new OrleansConfigurationException(
-                    $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.TableName)} is not valid.");
-
-            if (this.options.UseProvisionedThroughput)
-            {
-                if (this.options.ReadCapacityUnits == 0)
-                    throw new OrleansConfigurationException(
-                        $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.ReadCapacityUnits)} is not valid.");
-
-                if (this.options.WriteCapacityUnits == 0)
-                    throw new OrleansConfigurationException(
-                        $"Configuration for DynamoDBGrainStorage {this.name} is invalid. {nameof(this.options.WriteCapacityUnits)} is not valid.");
-            }
-        }
     }
 }

--- a/src/AWS/Orleans.Persistence.DynamoDB/Options/StateCompressionPolicy.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Options/StateCompressionPolicy.cs
@@ -1,0 +1,24 @@
+using System.IO.Compression;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+
+namespace Orleans.Configuration;
+
+public class StateCompressionPolicy
+{
+    /// <summary>
+    /// Compression needs to be enabled explicitly
+    /// </summary>
+    public bool IsEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Only compress the state if the uncompressed state size in bytes is above the threshold
+    /// </summary>
+    public int CompressStateIfAboveByteCount { get; set; } = 0;
+
+    public IGrainStateCompressionManager.BinaryStateCompression Compression { get; set; } = IGrainStateCompressionManager.BinaryStateCompression.GZip;
+
+    /// <summary>
+    /// Use the fastest compression by default
+    /// </summary>
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Fastest;
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateCompressionManager.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateCompressionManager.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression
+{
+    internal class GrainStateCompressionManager : IGrainStateCompressionManager
+    {
+        public const string CompressionPropertyName = "Compression";
+
+        private readonly DynamoDBStorageOptions options;
+        private readonly ILogger<GrainStateCompressionManager> logger;
+        private readonly Dictionary<IGrainStateCompressionManager.BinaryStateCompression, IProvideGrainStateRecordCompression> compressionProviders;
+        private readonly IProvideGrainStateRecordCompression compressionProviderConfigured;
+
+        public GrainStateCompressionManager(
+            DynamoDBStorageOptions options,
+            IEnumerable<IProvideGrainStateRecordCompression> compressionProviders,
+            ILogger<GrainStateCompressionManager> logger)
+        {
+            this.options = options;
+            this.logger = logger;
+
+            this.compressionProviders = compressionProviders.ToDictionary(
+                compressionProvider => compressionProvider.CompressionType);
+
+            if (this.options.StateCompressionPolicy is {IsEnabled: true}
+                && !this.compressionProviders.TryGetValue(
+                    this.options.StateCompressionPolicy.Compression,
+                    out this.compressionProviderConfigured))
+            {
+                throw new ArgumentException($"Unable to resolve the compression provider for compression of type: {this.options.StateCompressionPolicy.Compression}");
+            }
+        }
+
+        public void Compress(DynamoDBGrainStorage.GrainStateRecord record)
+        {
+            if (record?.BinaryStateProperties == null)
+            {
+                throw new ArgumentException("record or record.StateProperties is null", nameof(record));
+            }
+
+            if (record.BinaryStateProperties.ContainsKey(CompressionPropertyName))
+            {
+                this.logger.LogWarning("State properties already contains the compression property {0}", CompressionPropertyName);
+                return;
+            }
+
+            if (this.options.StateCompressionPolicy?.IsEnabled == true
+                && this.options.StateCompressionPolicy.CompressStateIfAboveByteCount < record.BinaryState.Length)
+            {
+                this.compressionProviderConfigured.Compress(record);
+            }
+        }
+
+        public void Decompress(DynamoDBGrainStorage.GrainStateRecord record)
+        {
+            if (!record.BinaryStateProperties.TryGetValue(
+                    CompressionPropertyName,
+                    out var recordCompressionTypeProperty))
+            {
+                return;
+            }
+
+            if (!Enum.TryParse<IGrainStateCompressionManager.BinaryStateCompression>(
+                    recordCompressionTypeProperty,
+                    true,
+                    out var recordCompressionType))
+            {
+                throw new ArgumentException($"Unable to parse the record compression property to {nameof(IGrainStateCompressionManager.BinaryStateCompression)}");
+            }
+
+            if (!this.compressionProviders.TryGetValue(recordCompressionType, out var compressionProvider))
+            {
+                throw new ArgumentException("Unable to determine the record compression provider");
+            }
+
+            compressionProvider.Decompress(record);
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordCompressionServiceBase.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordCompressionServiceBase.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression;
+
+public abstract class GrainStateRecordCompressionServiceBase : IProvideGrainStateRecordCompression
+{
+    private readonly ILogger logger;
+
+    protected readonly StateCompressionPolicy StateCompressionPolicy;
+
+    protected GrainStateRecordCompressionServiceBase(
+        DynamoDBStorageOptions options,
+        IGrainStateCompressionManager.BinaryStateCompression compressionType,
+        ILogger logger)
+    {
+        this.StateCompressionPolicy = options?.StateCompressionPolicy ?? new StateCompressionPolicy();
+        this.CompressionType = compressionType;
+        this.logger = logger;
+    }
+
+    public IGrainStateCompressionManager.BinaryStateCompression CompressionType { get; }
+
+    public void Compress(DynamoDBGrainStorage.GrainStateRecord record)
+    {
+        using var inputStream = new MemoryStream(record.BinaryState, false);
+        using var compressedStream = new MemoryStream();
+        using var compressorStream = this.GetCompressionStream(compressedStream, true);
+
+        inputStream.CopyTo(compressorStream);
+        compressorStream.Flush();
+
+        var binaryStateLengthBeforeCompression = record.BinaryState.Length;
+        record.BinaryState = compressedStream.ToArray();
+        var binaryStateLengthAfterCompression = record.BinaryState.Length;
+        record.BinaryStateProperties.Add(GrainStateCompressionManager.CompressionPropertyName, this.CompressionType.ToString());
+        this.logger.LogDebug("Compressed grain state with reference={0}, type={1}, etag={2} from size={3} to size={4}",
+            record.GrainReference, record.GrainType, record.ETag,
+            binaryStateLengthBeforeCompression, binaryStateLengthAfterCompression);
+    }
+
+    public void Decompress(DynamoDBGrainStorage.GrainStateRecord record)
+    {
+        if (!record.BinaryStateProperties.TryGetValue(GrainStateCompressionManager.CompressionPropertyName, out var binaryStateCompressionTypeString)
+            || !Enum.TryParse<IGrainStateCompressionManager.BinaryStateCompression>(binaryStateCompressionTypeString, true, out var binaryStateCompressionRecordProperty)
+            || binaryStateCompressionRecordProperty != this.CompressionType)
+        {
+            this.logger.LogWarning("State properties does not contain the compression property {0}={1}", GrainStateCompressionManager.CompressionPropertyName, this.CompressionType);
+            return;
+        }
+
+        using var compressedStream = new MemoryStream(record.BinaryState);
+        using var decompressorStream = this.GetDecompressionStream(compressedStream, true);
+        using var decompressedStream = new MemoryStream();
+
+        decompressorStream.CopyTo(decompressedStream);
+
+        var binaryStateLengthBeforeDecompression = record.BinaryState.Length;
+        record.BinaryState = decompressedStream.ToArray();
+        var binaryStateLengthAfterDecompression = record.BinaryState.Length;
+        record.BinaryStateProperties.Remove(GrainStateCompressionManager.CompressionPropertyName);
+
+        this.logger.LogDebug("Decompressed grain state with reference={0}, type={1}, etag={2} from size={3} to size={4}",
+            record.GrainReference, record.GrainType.Length, record.ETag,
+            binaryStateLengthBeforeDecompression, binaryStateLengthAfterDecompression);
+    }
+    
+    protected abstract Stream GetCompressionStream(Stream targetStream, bool leaveOpen);
+
+    protected abstract Stream GetDecompressionStream(Stream sourceStream, bool leaveOpen);
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordDeflateCompressionService.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordDeflateCompressionService.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression;
+
+public class GrainStateRecordDeflateCompressionService : GrainStateRecordCompressionServiceBase
+{
+    public GrainStateRecordDeflateCompressionService(
+        DynamoDBStorageOptions options,
+        ILogger<GrainStateRecordDeflateCompressionService> logger)
+        : base(options, IGrainStateCompressionManager.BinaryStateCompression.Deflate, logger)
+    {
+    }
+
+    protected override Stream GetCompressionStream(
+        Stream targetStream,
+        bool leaveOpen) =>
+        new DeflateStream(targetStream, this.StateCompressionPolicy.CompressionLevel, leaveOpen);
+
+    protected override Stream GetDecompressionStream(
+        Stream sourceStream,
+        bool leaveOpen) => new DeflateStream(sourceStream, CompressionMode.Decompress, leaveOpen);
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordGzipCompressionService.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/GrainStateRecordGzipCompressionService.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression;
+
+public class GrainStateRecordGzipCompressionService : GrainStateRecordCompressionServiceBase
+{
+    public GrainStateRecordGzipCompressionService(
+        DynamoDBStorageOptions options,
+        ILogger<GrainStateRecordGzipCompressionService> logger)
+        : base(options, IGrainStateCompressionManager.BinaryStateCompression.GZip, logger)
+    {
+    }
+
+    protected override Stream GetCompressionStream(
+        Stream targetStream,
+        bool leaveOpen) =>
+        new GZipStream(targetStream, this.StateCompressionPolicy.CompressionLevel, leaveOpen);
+
+    protected override Stream GetDecompressionStream(
+        Stream sourceStream,
+        bool leaveOpen) => new GZipStream(sourceStream, CompressionMode.Decompress, leaveOpen);
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/Interfaces/IGrainStateCompressionManager.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/Interfaces/IGrainStateCompressionManager.cs
@@ -1,0 +1,19 @@
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces;
+
+public interface IGrainStateCompressionManager
+{
+    /// <summary>
+    /// WARN: Do not rename the enum or the enum values. They are used to mark the binary state properties and they will be stored in DynamoDB along with the state binary data
+    /// </summary>
+    public enum BinaryStateCompression
+    {
+        GZip,
+        Deflate
+    }
+
+    public void Compress(DynamoDBGrainStorage.GrainStateRecord record);
+
+    public void Decompress(DynamoDBGrainStorage.GrainStateRecord record);
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/Interfaces/IProvideGrainStateRecordCompression.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Compression/Interfaces/IProvideGrainStateRecordCompression.cs
@@ -1,0 +1,14 @@
+using Orleans.Storage;
+using static Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces.IGrainStateCompressionManager;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Compression.Interfaces
+{
+    public interface IProvideGrainStateRecordCompression
+    {
+        public BinaryStateCompression CompressionType { get; }
+
+        public void Compress(DynamoDBGrainStorage.GrainStateRecord record);
+
+        public void Decompress(DynamoDBGrainStorage.GrainStateRecord record);
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorageFactory.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorageFactory.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+
+namespace Orleans.Storage;
+
+public static class DynamoDBGrainStorageFactory
+{
+    public static IGrainStorage Create(IServiceProvider services, string name)
+    {
+        var optionsMonitor = services.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>();
+        return ActivatorUtilities.CreateInstance<DynamoDBGrainStorage>(services, optionsMonitor.Get(name), name);
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateRecordBinarySerializationService.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateRecordBinarySerializationService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Serialization;
+
+public class GrainStateRecordBinarySerializationService : IProvideGrainStateRecordSerialization
+{
+    private readonly ILogger<GrainStateRecordBinarySerializationService> logger;
+    private readonly JsonSerializerSettings jsonSettings;
+
+    public GrainStateRecordBinarySerializationService(
+        ITypeResolver typeResolver,
+        IGrainFactory grainFactory,
+        DynamoDBStorageOptions options,
+        ILogger<GrainStateRecordBinarySerializationService> logger)
+    {
+        this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(
+            OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory),
+            options.UseFullAssemblyNames,
+            options.IndentJson,
+            options.TypeNameHandling);
+
+        options.ConfigureJsonSerializerSettings?.Invoke(this.jsonSettings);
+        this.logger = logger;
+        
+        this.SerializationType = IGrainStateSerializationManager.BinaryStateSerialization.Binary;
+    }
+
+    public IGrainStateSerializationManager.BinaryStateSerialization SerializationType { get; }
+
+    public void Serialize(object grainState, DynamoDBGrainStorage.GrainStateRecord record)
+    {
+        if (record?.BinaryStateProperties is null)
+        {
+            throw new ArgumentException("record or record.StateProperties is null", nameof(record));
+        }
+
+        if (record.BinaryStateProperties.ContainsKey(GrainStateSerializationManager.SerializationPropertyName))
+        {
+            this.logger.LogWarning("State properties already contains the compression property {0}", GrainStateSerializationManager.SerializationPropertyName);
+            return;
+        }
+
+        record.BinaryState = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(grainState, this.jsonSettings));
+        record.BinaryStateProperties.Add(GrainStateSerializationManager.SerializationPropertyName, this.SerializationType.ToString());
+    }
+
+    public object Deserialize(Type grainStateType, DynamoDBGrainStorage.GrainStateRecord record)
+    {
+        if (record?.BinaryStateProperties is null)
+        {
+            throw new ArgumentException("record or record.StateProperties is null", nameof(record));
+        }
+
+        if (!record.BinaryStateProperties.TryGetValue(GrainStateSerializationManager.SerializationPropertyName, out var binaryStateCompressionValue)
+            || binaryStateCompressionValue != this.SerializationType.ToString())
+        {
+            throw new ArgumentException($"Grain state has not been serialized using serialization {GrainStateSerializationManager.SerializationPropertyName}={this.SerializationType}");
+        }
+
+        return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(record.BinaryState), grainStateType, this.jsonSettings);
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateRecordJsonSerializationService.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateRecordJsonSerializationService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Serialization;
+
+public class GrainStateRecordJsonSerializationService : IProvideGrainStateRecordSerialization
+{
+    private readonly JsonSerializerSettings jsonSettings;
+
+    public GrainStateRecordJsonSerializationService(
+        ITypeResolver typeResolver,
+        IGrainFactory grainFactory,
+        DynamoDBStorageOptions options)
+    {
+        this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(
+            OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory),
+            options.UseFullAssemblyNames,
+            options.IndentJson,
+            options.TypeNameHandling);
+
+        options.ConfigureJsonSerializerSettings?.Invoke(this.jsonSettings);
+        
+        this.SerializationType = IGrainStateSerializationManager.BinaryStateSerialization.Json;
+    }
+
+    public IGrainStateSerializationManager.BinaryStateSerialization SerializationType { get; }
+
+    public void Serialize(object grainState, DynamoDBGrainStorage.GrainStateRecord entity)
+    {
+        entity.BinaryState = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(grainState, this.jsonSettings));
+        entity.BinaryStateProperties.Add(GrainStateSerializationManager.SerializationPropertyName, this.SerializationType.ToString());
+    }
+
+    public object Deserialize(Type grainStateType, DynamoDBGrainStorage.GrainStateRecord entity)
+    {
+        if (!entity.BinaryStateProperties.ContainsKey(GrainStateSerializationManager.SerializationPropertyName))
+        {
+            throw new ArgumentException("Grain state has not been serialized using JSON serialization", nameof(entity));
+        }
+
+        return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(entity.BinaryState), grainStateType, this.jsonSettings);
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateSerializationManager.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/GrainStateSerializationManager.cs
@@ -1,0 +1,73 @@
+using System;
+using Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Serialization
+{
+    internal class GrainStateSerializationManager : IGrainStateSerializationManager
+    {
+        public const string SerializationPropertyName = "Serialization";
+        
+        private readonly Dictionary<IGrainStateSerializationManager.BinaryStateSerialization, IProvideGrainStateRecordSerialization> serializationProviders;
+        private readonly IProvideGrainStateRecordSerialization serializationProviderConfigured;
+        private readonly ILogger<GrainStateSerializationManager> logger;
+
+        public GrainStateSerializationManager(
+            DynamoDBStorageOptions options,
+            IEnumerable<IProvideGrainStateRecordSerialization> serializationProviders,
+            ILogger<GrainStateSerializationManager> logger)
+        {
+            this.logger = logger;
+
+            this.serializationProviders = serializationProviders.ToDictionary(
+                serializationProvider => serializationProvider.SerializationType);
+
+            this.serializationProviderConfigured =
+                this.serializationProviders[options.UseJson
+                    ? IGrainStateSerializationManager.BinaryStateSerialization.Json
+                    : IGrainStateSerializationManager.BinaryStateSerialization.Binary];
+        }
+
+        public void Serialize(object grainState, DynamoDBGrainStorage.GrainStateRecord record)
+        {
+            if (record?.BinaryStateProperties == null)
+            {
+                throw new ArgumentException("record or record.StateProperties is null", nameof(record));
+            }
+
+            if (record.BinaryStateProperties.ContainsKey(SerializationPropertyName))
+            {
+                this.logger.LogWarning("State properties already contains the serialization property {0}", SerializationPropertyName);
+                return;
+            }
+            
+            this.serializationProviderConfigured.Serialize(grainState, record);
+        }
+
+        public object Deserialize(Type grainStateType, DynamoDBGrainStorage.GrainStateRecord record)
+        {
+            if (!record.BinaryStateProperties.TryGetValue(
+                    SerializationPropertyName,
+                    out var recordSerializationTypeProperty))
+            {
+                throw new ArgumentException("Record properties map does not have the serialization property", nameof(record));
+            }
+
+            if (!Enum.TryParse<IGrainStateSerializationManager.BinaryStateSerialization>(
+                    recordSerializationTypeProperty,
+                    true,
+                    out var recordSerializationType))
+            {
+                throw new ArgumentException($"Unable to parse the record serialization property to {nameof(IGrainStateSerializationManager.BinaryStateSerialization)}");
+            }
+
+            return this.serializationProviders.TryGetValue(recordSerializationType, out var recordSerializationProvider)
+                ? recordSerializationProvider.Deserialize(grainStateType, record)
+                : throw new ArgumentException($"Record serialization type has not been registered: {recordSerializationType}", nameof(record));
+        }
+    }
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/Interfaces/IGrainStateSerializationManager.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/Interfaces/IGrainStateSerializationManager.cs
@@ -1,0 +1,20 @@
+using System;
+using Orleans.Storage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces;
+
+public interface IGrainStateSerializationManager
+{
+    /// <summary>
+    /// WARN: Do not rename the the enum or the enum values. They are used to mark the binary state properties and they will be stored in DynamoDB along with the state binary data
+    /// </summary>
+    public enum BinaryStateSerialization
+    {
+        Json,
+        Binary
+    }
+
+    void Serialize(object grainState, DynamoDBGrainStorage.GrainStateRecord entity);
+
+    object Deserialize(Type grainStateType, DynamoDBGrainStorage.GrainStateRecord entity);
+}

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/Interfaces/IProvideGrainStateRecordSerialization.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/Serialization/Interfaces/IProvideGrainStateRecordSerialization.cs
@@ -1,0 +1,14 @@
+using System;
+using static Orleans.Storage.DynamoDBGrainStorage;
+
+namespace Orleans.Persistence.DynamoDB.Provider.Serialization.Interfaces
+{
+    public interface IProvideGrainStateRecordSerialization
+    {
+        public IGrainStateSerializationManager.BinaryStateSerialization SerializationType { get; }
+
+        void Serialize(object grainState, GrainStateRecord entity);
+
+        object Deserialize(Type grainStateType, GrainStateRecord entity);
+    }
+}


### PR DESCRIPTION
**Problem**

Reading and writing large grain states can lead to excessive resource utilization when using DynamoDB as the grain state store.

**Solution**

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-use-s3-too.html

One of the best practices when using DynamoDB is to compress the large attributes. In this specific case, this translates to compressing the BinaryState and StringState attributes.

As part of this pull request, the below items are implemented:
- Store the grain state in a byte array in DynamoDB
- Store the grain state properties in a DynamoDB Map. At the moment, we support the properties: Serialization, Compression
- Ability to store the grain state in DynamoDB in a compressed format
- Ability to control the compression parameters via the config policy
- Ability to control the serialization format via config values
- Ability to seamlessly move between serialization formats, compression formats, and compression parameters
- Seamless migration from the current storage format to the new one

Using GZIP compression with a mode of FASTEST for items of over 2048 bytes yields the below results:

- Latency

  Mean:    39.87 us
  Error:      0.784 us
  StdDev:  0.871 us
  Median: 39.73 us

- Compression ratio: 494 %

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8227)