### PR TITLE
Enable Azure Storage tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,6 @@ jobs:
           **/TestResults/*
           **/logs/*
   test-azure-storage:
-    if: ${{ false }}
     name: Azure Storage provider tests
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This is a test to see whether Azurite (the Azure Storage emulator) supports everything we need and the tests are stable enough on GitHub agents