### PR TITLE
Fix diagnostic for invalid grain method return types

### DIFF
--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -156,7 +156,7 @@ namespace Orleans.CodeGenerator
                 return baseClassType;
             }
 
-            if (namedMethodReturnType.ConstructedFrom is { } constructedFrom)
+            if (namedMethodReturnType.ConstructedFrom is { IsGenericType: true, IsUnboundGenericType: false } constructedFrom)
             {
                 var unbound = constructedFrom.ConstructUnboundGenericType();
                 if (method.InvokableBaseTypes.TryGetValue(unbound, out baseClassType))


### PR DESCRIPTION
Fixes cases where the C# analyzer isn't able to run (eg, building code for an F# project) and an unsupported grain interface return type is being used.

Fixes: #8233

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8234)