### PR TITLE
Bumped KubernetesClient to v9.0.38 on Orleans 3.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -131,7 +131,7 @@
     <ZooKeeperNetExVersion>3.4.12.4</ZooKeeperNetExVersion>
     <StackExchangeRedis>2.2.88</StackExchangeRedis>
     <Netstandard20KubernetesClientVersion>4.0.5</Netstandard20KubernetesClientVersion>
-    <KubernetesClientVersion>6.0.23</KubernetesClientVersion>
+    <KubernetesClientVersion>9.0.38</KubernetesClientVersion>
 
     <!-- Test related packages -->
     <FluentAssertionsVersion>6.2.0</FluentAssertionsVersion>

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -1,5 +1,9 @@
 using k8s;
+#if NETSTANDARD2_0
 using Microsoft.Rest;
+#else
+using k8s.Autorest;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -215,11 +215,19 @@ namespace Orleans.Hosting.Kubernetes
                         break;
                     }
 
+#if NETSTANDARD2_0
                     var pods = await _client.ListNamespacedPodWithHttpMessagesAsync(
                         namespaceParameter: _podNamespace,
                         labelSelector: _podLabelSelector,
                         watch: true,
                         cancellationToken: _shutdownToken.Token);
+#else
+                    var pods = await _client.CoreV1.ListNamespacedPodWithHttpMessagesAsync(
+                        namespaceParameter: _podNamespace,
+                        labelSelector: _podLabelSelector,
+                        watch: true,
+                        cancellationToken: _shutdownToken.Token);
+#endif
 
                     await foreach (var (eventType, pod) in pods.WatchAsync<V1PodList, V1Pod>(_shutdownToken.Token))
                     {

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingExtensions.cs
@@ -1,10 +1,9 @@
-using k8s;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting.Kubernetes;
 using Orleans.Runtime;
-using System;
 
 namespace Orleans.Hosting
 {
@@ -49,25 +48,6 @@ namespace Orleans.Hosting
             services.AddSingleton<IValidateOptions<KubernetesHostingOptions>, KubernetesHostingOptionsValidator>();
 
             services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, KubernetesClusterAgent>();
-
-            // Configure the Kubernetes client.
-            services.AddHttpClient("Orleans.Kubernetes.Agent")
-                .AddTypedClient<IKubernetes>((httpClient, serviceProvider) =>
-                {
-                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
-                    return new k8s.Kubernetes(
-                        config,
-                        httpClient);
-                }).ConfigurePrimaryHttpMessageHandler(serviceProvider =>
-                {
-                    var config = serviceProvider.GetRequiredService<KubernetesHostingOptions>().ClientConfiguration;
-                    return config.CreateDefaultHttpClientHandler();
-                })
-#if NETSTANDARD2_0
-                .AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);
-#else
-                ;
-#endif
 
             return services;
         }


### PR DESCRIPTION
Following discussion on #8199 this is an attempt to upgrade KubernetesClient to v9.0.38 on Orleans 3.x.

I have tried to follow #8199 as much as possible to keep a standard therefore I have also removed the named `HttpClient` `Orleans.Kubernetes.Agent` and `TypedClient` `IKubernetes`

I would be very glad if someone could help me test this:

- I do not have a Kubernetes 1.25.2 cluster
- Testing on .NET Standard 2
- It's my first time contributing to a big project

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8249)