### PR TITLE
Support `IGrainStorageSerializer` for memory grain storage

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Globalization;
+using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
 
 namespace Orleans.Streaming.EventHubs
@@ -38,10 +39,11 @@ namespace Orleans.Streaming.EventHubs
         /// Offset of the message within an EventHub partition
         /// </summary>
         [Id(0)]
+        [JsonProperty]
         public string EventHubOffset { get; }
 
         /// <summary>
-        /// Constructor
+        /// Initializes a new instance of the <see cref="EventHubSequenceToken" /> class.
         /// </summary>
         /// <param name="eventHubOffset">EventHub offset within the partition from which this message came.</param>
         /// <param name="sequenceNumber">EventHub sequenceNumber for this message.</param>
@@ -50,6 +52,16 @@ namespace Orleans.Streaming.EventHubs
             : base(sequenceNumber, eventIndex)
         {
             EventHubOffset = eventHubOffset;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubSequenceToken" /> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is exposed for serializer use only.
+        /// </remarks>
+        public EventHubSequenceToken() : base()
+        {
         }
 
         /// <summary>Returns a string that represents the current object.</summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -1,6 +1,4 @@
 using System;
-using Orleans.CodeGeneration;
-using Orleans.Serialization;
 
 namespace Orleans.Streaming.EventHubs
 {
@@ -18,13 +16,23 @@ namespace Orleans.Streaming.EventHubs
     public class EventHubSequenceTokenV2 : EventHubSequenceToken
     {
         /// <summary>
-        /// Constructor
+        /// Initializes a new instance of the <see cref="EventHubSequenceTokenV2" /> class.
         /// </summary>
         /// <param name="eventHubOffset">EventHub offset within the partition from which this message came.</param>
         /// <param name="sequenceNumber">EventHub sequenceNumber for this message.</param>
         /// <param name="eventIndex">Index into a batch of events, if multiple events were delivered within a single EventHub message.</param>
         public EventHubSequenceTokenV2(string eventHubOffset, long sequenceNumber, int eventIndex)
             : base(eventHubOffset, sequenceNumber, eventIndex)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubSequenceTokenV2" /> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is exposed for serializer use only.
+        /// </remarks>
+        public EventHubSequenceTokenV2() : base()
         {
         }
     }

--- a/src/Orleans.Persistence.Memory/Hosting/MemoryGrainStorageSiloBuilderExtensions.cs
+++ b/src/Orleans.Persistence.Memory/Hosting/MemoryGrainStorageSiloBuilderExtensions.cs
@@ -61,6 +61,7 @@ namespace Orleans.Hosting
                 .ConfigureServices(services =>
                 {
                     configureOptions?.Invoke(services.AddOptions<MemoryGrainStorageOptions>(name));
+                    services.AddTransient<IPostConfigureOptions<MemoryGrainStorageOptions>, DefaultStorageProviderSerializerOptionsConfigurator<MemoryGrainStorageOptions>>();
                     services.ConfigureNamedOptionForLogging<MemoryGrainStorageOptions>(name);
                     if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
                     {

--- a/src/Orleans.Persistence.Memory/Options/MemoryGrainStorageOptions.cs
+++ b/src/Orleans.Persistence.Memory/Options/MemoryGrainStorageOptions.cs
@@ -6,7 +6,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Options for MemoryGrainStorage
     /// </summary>
-    public class MemoryGrainStorageOptions
+    public class MemoryGrainStorageOptions : IStorageProviderSerializerOptions
     {
         /// <summary>
         /// Default number of queue storage grains.
@@ -22,6 +22,9 @@ namespace Orleans.Configuration
         /// Gets or sets the stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
         /// </summary>
         public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
+
+        /// <inheritdoc/>
+        public IGrainStorageSerializer GrainStorageSerializer { get; set; }
 
         /// <summary>
         /// Default init stage

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -114,7 +114,7 @@ namespace Orleans.Storage
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
             try
             {
-                await storageGrain.DeleteStateAsync<GrainState<ReadOnlyMemory<byte>>>(key, grainState.ETag);
+                await storageGrain.DeleteStateAsync<ReadOnlyMemory<byte>>(key, grainState.ETag);
                 grainState.ETag = null;
                 grainState.RecordExists = false;
             }

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -74,7 +74,7 @@ namespace Orleans.Storage
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Read Keys={Keys}", key);
 
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
-            var state = await storageGrain.ReadStateAsync<BinaryData>(key);
+            var state = await storageGrain.ReadStateAsync<ReadOnlyMemory<byte>>(key);
             if (state != null)
             {
                 var loadedState = ConvertFromStorageFormat<T>(state.State);
@@ -93,7 +93,7 @@ namespace Orleans.Storage
             try
             {
                 var data = ConvertToStorageFormat<T>(grainState.State);
-                var binaryGrainState = new GrainState<BinaryData>(data, grainState.ETag)
+                var binaryGrainState = new GrainState<ReadOnlyMemory<byte>>(data, grainState.ETag)
                 {
                     RecordExists = grainState.RecordExists
                 };
@@ -139,7 +139,7 @@ namespace Orleans.Storage
         /// Deserialize from binary data
         /// </summary>
         /// <param name="data">The serialized stored data</param>
-        internal T ConvertFromStorageFormat<T>(BinaryData data)
+        internal T ConvertFromStorageFormat<T>(ReadOnlyMemory<byte> data)
         {
 
             T dataValue = default;
@@ -168,7 +168,7 @@ namespace Orleans.Storage
         }
 
         /// <summary>
-        /// Serialize to Azure storage format in either binary or JSON format.
+        /// Serialize to the storage format.
         /// </summary>
         /// <param name="grainState">The grain state data to be serialized</param>
         /// <remarks>
@@ -176,7 +176,7 @@ namespace Orleans.Storage
         /// http://msdn.microsoft.com/en-us/library/system.web.script.serialization.javascriptserializer.aspx
         /// for more on the JSON serializer.
         /// </remarks>
-        internal BinaryData ConvertToStorageFormat<T>(T grainState)
+        internal ReadOnlyMemory<byte> ConvertToStorageFormat<T>(T grainState)
         {
             // Convert to binary format
             return this.storageSerializer.Serialize<T>(grainState);

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -35,6 +37,7 @@ namespace Orleans.Storage
     {
         private Lazy<IMemoryStorageGrain>[] storageGrains;
         private readonly ILogger logger;
+        private readonly IGrainStorageSerializer storageSerializer;
 
         /// <summary> Name of this storage provider instance. </summary>
         private readonly string name;
@@ -50,6 +53,7 @@ namespace Orleans.Storage
         {
             this.name = name;
             this.logger = logger;
+            this.storageSerializer = options.GrainStorageSerializer;
 
             //Init
             logger.LogInformation("Init: Name={Name} NumStorageGrains={NumStorageGrains}", name, options.NumStorageGrains);
@@ -70,11 +74,12 @@ namespace Orleans.Storage
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("Read Keys={Keys}", key);
 
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
-            var state = await storageGrain.ReadStateAsync<T>(key);
+            var state = await storageGrain.ReadStateAsync<BinaryData>(key);
             if (state != null)
             {
+                var loadedState = ConvertFromStorageFormat<T>(state.State);
                 grainState.ETag = state.ETag;
-                grainState.State = (T)state.State;
+                grainState.State = loadedState ?? Activator.CreateInstance<T>();
                 grainState.RecordExists = true;
             }
         }
@@ -87,7 +92,12 @@ namespace Orleans.Storage
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
             try
             {
-                grainState.ETag = await storageGrain.WriteStateAsync(key, grainState);
+                var data = ConvertToStorageFormat<T>(grainState.State);
+                var binaryGrainState = new GrainState<BinaryData>(data, grainState.ETag)
+                {
+                    RecordExists = grainState.RecordExists
+                };
+                grainState.ETag = await storageGrain.WriteStateAsync(key, binaryGrainState);
                 grainState.RecordExists = true;
             }
             catch (MemoryStorageEtagMismatchException e)
@@ -124,6 +134,53 @@ namespace Orleans.Storage
 
         /// <inheritdoc/>
         public void Dispose() => storageGrains = null;
+
+        /// <summary>
+        /// Deserialize from binary data
+        /// </summary>
+        /// <param name="data">The serialized stored data</param>
+        internal T ConvertFromStorageFormat<T>(BinaryData data)
+        {
+
+            T dataValue = default;
+            try
+            {
+                dataValue = this.storageSerializer.Deserialize<T>(data);
+            }
+            catch (Exception exc)
+            {
+                var sb = new StringBuilder();
+                if (data.ToArray().Length > 0)
+                {
+                    sb.AppendFormat("Unable to convert from storage format GrainStateEntity.Data={0}", data);
+                }
+
+                if (dataValue != null)
+                {
+                    sb.AppendFormat("Data Value={0} Type={1}", dataValue, dataValue.GetType());
+                }
+
+                logger.LogError(exc, "{Message}", sb.ToString());
+                throw new AggregateException(sb.ToString(), exc);
+            }
+
+            return dataValue;
+        }
+
+        /// <summary>
+        /// Serialize to Azure storage format in either binary or JSON format.
+        /// </summary>
+        /// <param name="grainState">The grain state data to be serialized</param>
+        /// <remarks>
+        /// See:
+        /// http://msdn.microsoft.com/en-us/library/system.web.script.serialization.javascriptserializer.aspx
+        /// for more on the JSON serializer.
+        /// </remarks>
+        internal BinaryData ConvertToStorageFormat<T>(T grainState)
+        {
+            // Convert to binary format
+            return this.storageSerializer.Serialize<T>(grainState);
+        }
     }
 
     /// <summary>

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -49,11 +49,12 @@ namespace Orleans.Storage
         /// <param name="options">The options.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="grainFactory">The grain factory.</param>
-        public MemoryGrainStorage(string name, MemoryGrainStorageOptions options, ILogger<MemoryGrainStorage> logger, IGrainFactory grainFactory)
+        /// <param name="defaultGrainStorageSerializer">The default grain storage serializer.</param>
+        public MemoryGrainStorage(string name, MemoryGrainStorageOptions options, ILogger<MemoryGrainStorage> logger, IGrainFactory grainFactory, IGrainStorageSerializer defaultGrainStorageSerializer)
         {
             this.name = name;
             this.logger = logger;
-            this.storageSerializer = options.GrainStorageSerializer;
+            this.storageSerializer = options.GrainStorageSerializer ?? defaultGrainStorageSerializer;
 
             //Init
             logger.LogInformation("Init: Name={Name} NumStorageGrains={NumStorageGrains}", name, options.NumStorageGrains);

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -114,7 +114,7 @@ namespace Orleans.Storage
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
             try
             {
-                await storageGrain.DeleteStateAsync<T>(key, grainState.ETag);
+                await storageGrain.DeleteStateAsync<GrainState<ReadOnlyMemory<byte>>>(key, grainState.ETag);
                 grainState.ETag = null;
                 grainState.RecordExists = false;
             }

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -47,10 +47,14 @@ namespace Orleans.Storage
         private MemoryGrainStorage baseGranStorage;
         private MemoryStorageWithLatencyOptions options;
         /// <summary> Default constructor. </summary>
-        public MemoryGrainStorageWithLatency(string name, MemoryStorageWithLatencyOptions options,
-            ILoggerFactory loggerFactory, IGrainFactory grainFactory)
+        public MemoryGrainStorageWithLatency(
+            string name,
+            MemoryStorageWithLatencyOptions options,
+            ILoggerFactory loggerFactory,
+            IGrainFactory grainFactory,
+            IGrainStorageSerializer defaultGrainStorageSerialzier)
         {
-            this.baseGranStorage = new MemoryGrainStorage(name, options, loggerFactory.CreateLogger<MemoryGrainStorage>(), grainFactory);
+            this.baseGranStorage = new MemoryGrainStorage(name, options, loggerFactory.CreateLogger<MemoryGrainStorage>(), grainFactory, defaultGrainStorageSerialzier);
             this.options = options;
         }
 

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Orleans.Streams;
+using Newtonsoft.Json;
 
 namespace Orleans.Providers.Streams.Common
 {
@@ -15,34 +16,46 @@ namespace Orleans.Providers.Streams.Common
         /// Gets the number of event batches in stream prior to this event batch
         /// </summary>
         [Id(0)]
+        [JsonProperty]
         public override long SequenceNumber { get; protected set; }
 
         /// <summary>
         /// Gets the number of events in batch prior to this event
         /// </summary>
         [Id(1)]
+        [JsonProperty]
         public override int EventIndex { get; protected set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventSequenceToken"/> class.
         /// </summary>
-        /// <param name="seqNumber">The sequence number.</param>
-        public EventSequenceToken(long seqNumber)
+        /// <param name="sequenceNumber">The sequence number.</param>
+        public EventSequenceToken(long sequenceNumber)
         {
-            SequenceNumber = seqNumber;
+            SequenceNumber = sequenceNumber;
             EventIndex = 0;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventSequenceToken" /> class.
         /// </summary>
-        /// <param name="seqNumber">The sequence number.</param>
-        /// <param name="eventInd">The event index, for events which are part of a batch.</param>
-        public EventSequenceToken(long seqNumber, int eventInd)
+        /// <param name="sequenceNumber">The sequence number.</param>
+        /// <param name="eventIndex">The event index, for events which are part of a batch.</param>
+        public EventSequenceToken(long sequenceNumber, int eventIndex)
         {
-            SequenceNumber = seqNumber;
-            EventIndex = eventInd;
+            SequenceNumber = sequenceNumber;
+            EventIndex = eventIndex;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventSequenceToken" /> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is exposed for serializer use only.
+        /// </remarks>
+        [JsonConstructor]
+        public EventSequenceToken()
+        { }
 
         /// <summary>
         /// Creates a sequence token for a specific event in the current batch.

--- a/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using Newtonsoft.Json;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
@@ -15,12 +16,14 @@ namespace Orleans.Providers.Streams.Common
         /// Gets the number of event batches in stream prior to this event batch
         /// </summary>
         [Id(0)]
+        [JsonProperty]
         public override long SequenceNumber { get; protected set; }
 
         /// <summary>
         /// Gets the number of events in batch prior to this event
         /// </summary>
         [Id(1)]
+        [JsonProperty]
         public override int EventIndex { get; protected set; }
 
         /// <summary>
@@ -42,6 +45,16 @@ namespace Orleans.Providers.Streams.Common
         {
             SequenceNumber = seqNumber;
             EventIndex = eventInd;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventSequenceTokenV2"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is for serializer use only.
+        /// </remarks>
+        public EventSequenceTokenV2()
+        {
         }
 
         /// <summary>

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -214,7 +214,7 @@ namespace DefaultCluster.Tests.General
             this.Logger.LogInformation("GetMultipleGrainInterfaces_Array() worked");
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"),
+        [Fact, TestCategory("SlowBVT"), TestCategory("ActivateDeactivate"),
          TestCategory("Reentrancy")]
         public void BasicActivation_Reentrant_RecoveryAfterExpiredMessage()
         {

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -108,7 +108,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT")]
         public async Task ObserverTest_DoubleSubscriptionSameReference()
         {
             TestInitialize();
@@ -156,7 +156,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT")]
         public async Task ObserverTest_SubscribeUnsubscribe()
         {
             TestInitialize();
@@ -249,7 +249,7 @@ namespace DefaultCluster.Tests.General
                 result.Done = true;
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT")]
         public async Task ObserverTest_DeleteObject()
         {
             TestInitialize();

--- a/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
@@ -39,7 +39,7 @@ namespace DefaultCluster.Tests
             object obj = this.HostedCluster.DeepCopy(data);
 
             Assert.IsAssignableFrom<ValueTypeTestData>(obj);
-            Assert.Equal<int>(4, ((ValueTypeTestData)obj).GetValue());
+            Assert.Equal<int>(4, ((ValueTypeTestData)obj).Value);
         }
 
         [Fact, TestCategory("Serialization")]
@@ -50,7 +50,7 @@ namespace DefaultCluster.Tests
             object copy = this.HostedCluster.RoundTripSerializationForTesting(data);
 
             Assert.IsAssignableFrom<ValueTypeTestData>(copy);
-            Assert.Equal<int>(4, ((ValueTypeTestData)copy).GetValue());
+            Assert.Equal<int>(4, ((ValueTypeTestData)copy).Value);
         }
     }
 }

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -19,7 +19,7 @@ namespace DefaultCluster.Tests.TimerTests
             this.output = output;
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
         public async Task TimerOrleansTest_Basic()
         {
             for (int i = 0; i < 10; i++)
@@ -133,7 +133,7 @@ namespace DefaultCluster.Tests.TimerTests
                 ". Actual ticks = " + last);
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
         public async Task AsyncTimerTest_GrainCall()
         {
             const string testName = "AsyncTimerTest_GrainCall";

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -223,11 +223,16 @@ namespace Tester.AzureUtils.Persistence
         {
             const string testName = nameof(PersistenceProvider_Memory_FixedLatency_WriteRead);
             TimeSpan expectedLatency = TimeSpan.FromMilliseconds(200);
-            MemoryGrainStorageWithLatency store = new MemoryGrainStorageWithLatency(testName, new MemoryStorageWithLatencyOptions()
-            {
-                Latency = expectedLatency,
-                MockCallsOnly = true
-            }, NullLoggerFactory.Instance, this.providerRuntime.ServiceProvider.GetService<IGrainFactory>());
+            MemoryGrainStorageWithLatency store = new MemoryGrainStorageWithLatency(
+                testName,
+                new MemoryStorageWithLatencyOptions()
+                {
+                    Latency = expectedLatency,
+                    MockCallsOnly = true
+                },
+                NullLoggerFactory.Instance,
+                this.providerRuntime.ServiceProvider.GetService<IGrainFactory>(),
+                this.providerRuntime.ServiceProvider.GetService<IGrainStorageSerializer>());
 
             var reference = (GrainId)LegacyGrainId.NewId();
             var state = TestStoreGrainState.NewRandomState();

--- a/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
@@ -12,16 +13,12 @@ namespace UnitTests.GrainInterfaces
     public struct ValueTypeTestData
     {
         [Id(0)]
-        private readonly int intValue;
+        [Newtonsoft.Json.JsonProperty]
+        public int Value { get; set; }
 
         public ValueTypeTestData(int i)
         {
-            intValue = i;
-        }
-
-        public int GetValue()
-        {
-            return intValue;
+            Value = i;
         }
     }
 

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -97,7 +97,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Identifiers")]
         public void GrainId_ToFromPrintableString()
         {
             Guid guid = Guid.NewGuid();

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Tester.HeterogeneousSilosTests.UpgradeTests
 {
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class RuntimeStrategyChangeTests : UpgradeTestsBase
     {
         protected override Type VersionSelectorStrategy => typeof(LatestVersion);

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tester.HeterogeneousSilosTests.UpgradeTests
 {
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class MinimumVersionTests : UpgradeTestsBase
     {
         protected override Type VersionSelectorStrategy => typeof(MinimumVersion);
@@ -21,7 +21,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         }
     }
 
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class LatestVersionTests : UpgradeTestsBase
     {
         protected override Type VersionSelectorStrategy => typeof(LatestVersion);
@@ -51,7 +51,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         }
     }
 
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class AllVersionsCompatibleTests : UpgradeTestsBase
     {
         protected override Type VersionSelectorStrategy => typeof(LatestVersion);
@@ -74,7 +74,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         }
     }
 
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class RandomCompatibleVersionTests : UpgradeTestsBase
     {
         protected override Type VersionSelectorStrategy => typeof(AllCompatibleVersions);

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/VersionPlacementTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/VersionPlacementTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tester.HeterogeneousSilosTests.UpgradeTests
 {
-    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT"), TestCategory("Functional")]
+    [TestCategory("Versioning"), TestCategory("ExcludeXAML"), TestCategory("SlowBVT")]
     public class VersionPlacementTests : UpgradeTestsBase
     {
         protected override short SiloCount => 3;

--- a/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -60,7 +60,7 @@ namespace UnitTests.StreamingTests
                 Fixture.StreamProviderName);
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWithTransientErrorsTest()
         {
             this.fixture.Logger.LogInformation("************************ Recoverable100EventStreamsWithTransientErrorsTest *********************************");
@@ -70,7 +70,7 @@ namespace UnitTests.StreamingTests
                 100);
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWith1NonTransientErrorTest()
         {
             this.fixture.Logger.LogInformation("************************ Recoverable100EventStreamsWith1NonTransientErrorTest *********************************");

--- a/test/Tester/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamResumeTests.cs
@@ -7,7 +7,7 @@ using Orleans.TestingHost;
 
 namespace Tester.StreamingTests
 {
-    [TestCategory("Functional"), TestCategory("Streaming"), TestCategory("StreamingResume")]
+    [TestCategory("SlowBVT"), TestCategory("Streaming"), TestCategory("StreamingResume")]
     public class MemoryStreamResumeTests : StreamingResumeTests
     {
         protected override void ConfigureTestCluster(TestClusterBuilder builder)

--- a/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -72,7 +72,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             Assert.True(age.TotalMilliseconds < 2000, "Should be newly activated grain");
         }
 
-        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT")]
         public async Task DeactivateOnIdleTest_Stress_1()
         {
             Initialize();


### PR DESCRIPTION
A lightweight code change to implement the IStorageProviderSerializerOptions interface to MemoryGrainStorageOptions. Issue: https://github.com/dotnet/orleans/issues/8101

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8250)