### PR TITLE
correct code documentation which incorrectly refers to azure blob storage

### DIFF
--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageServiceCollectionExtensions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Orleans.Hosting
     public static class RedisGrainStorageServiceCollectionExtensions
     {
         /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
+        /// Configure silo to use Redis as the default grain storage.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorageAsDefault(this IServiceCollection services, Action<RedisStorageOptions> configureOptions)
         {
@@ -25,7 +25,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
+        /// Configure silo to use Redis for grain storage.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorage(this IServiceCollection services, string name, Action<RedisStorageOptions> configureOptions)
         {
@@ -33,7 +33,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
+        /// Configure silo to use Redis as the default grain storage.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {
@@ -41,7 +41,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
+        /// Configure silo to use Redis for grain storage.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorage(this IServiceCollection services, string name,
             Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisSiloBuilderExtensions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisSiloBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Orleans.Hosting
     public static class RedisSiloBuilderExtensions
     {
         /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
+        /// Configure silo to use Redis as the default grain storage.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorageAsDefault(this ISiloBuilder builder, Action<RedisStorageOptions> configureOptions)
         {
@@ -19,7 +19,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
+        /// Configure silo to use Redis for grain storage.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorage(this ISiloBuilder builder, string name, Action<RedisStorageOptions> configureOptions)
         {
@@ -27,7 +27,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage as the default grain storage.
+        /// Configure silo to use Redis as the default grain storage.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {
@@ -35,7 +35,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use azure blob storage for grain storage.
+        /// Configure silo to use Redis for grain storage.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {


### PR DESCRIPTION
The Redis provider for Orleans 7.0 was based on the Azure blob storage provider, a handful of code documentation was copied without modification and still refer to azure blob storage. This PR changes those to refer to Redis.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8258)