### PR TITLE
Various improvements to Redis providers

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ICientBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ICientBuilder.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using Orleans;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
 using Orleans.Messaging;
 using Orleans.Clustering.Redis;
+using StackExchange.Redis;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -25,7 +26,7 @@ namespace Microsoft.Extensions.Hosting
                 }
 
                 services
-                    .AddRedis()
+                    .AddRedisClustering()
                     .AddSingleton<IGatewayListProvider, RedisGatewayListProvider>();
             });
         }
@@ -38,10 +39,10 @@ namespace Microsoft.Extensions.Hosting
             return builder.ConfigureServices(services => services
                 .Configure<RedisClusteringOptions>(opt =>
                 {
-                    opt.ConnectionString = redisConnectionString;
-                    opt.Database = db;
+                    opt.ConfigurationOptions = ConfigurationOptions.Parse(redisConnectionString);
+                    opt.ConfigurationOptions.DefaultDatabase = db;
                 })
-                .AddRedis()
+                .AddRedisClustering()
                 .AddSingleton<IGatewayListProvider, RedisGatewayListProvider>());
         }
 

--- a/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ICientBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ICientBuilder.cs
@@ -34,13 +34,12 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Configures Redis as the clustering provider.
         /// </summary>
-        public static IClientBuilder UseRedisClustering(this IClientBuilder builder, string redisConnectionString, int db = 0)
+        public static IClientBuilder UseRedisClustering(this IClientBuilder builder, string redisConnectionString)
         {
             return builder.ConfigureServices(services => services
                 .Configure<RedisClusteringOptions>(opt =>
                 {
                     opt.ConfigurationOptions = ConfigurationOptions.Parse(redisConnectionString);
-                    opt.ConfigurationOptions.DefaultDatabase = db;
                 })
                 .AddRedisClustering()
                 .AddSingleton<IGatewayListProvider, RedisGatewayListProvider>());

--- a/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ISiloBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/HostingExtensions.ISiloBuilder.cs
@@ -31,13 +31,12 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Configures Redis as the clustering provider.
         /// </summary>
-        public static ISiloBuilder UseRedisClustering(this ISiloBuilder builder, string redisConnectionString, int db = 0)
+        public static ISiloBuilder UseRedisClustering(this ISiloBuilder builder, string redisConnectionString)
         {
             return builder.ConfigureServices(services => services
                 .Configure<RedisClusteringOptions>(options =>
                 {
                     options.ConfigurationOptions = ConfigurationOptions.Parse(redisConnectionString);
-                    options.ConfigurationOptions.DefaultDatabase = db;
                 })
                 .AddRedisClustering());
         }

--- a/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
+++ b/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
@@ -7,6 +7,7 @@
     <PackageTags>$(PackageTags) Redis Clustering</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -58,7 +58,7 @@ namespace Orleans.Clustering.Redis
         {
             if (_options.ConfigurationOptions == null)
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(RedisClusteringOptions)} values for {nameof(RedisMembershipTable)}. {nameof(_options.ConfigurationOptions)} is required.");
+                throw new OrleansConfigurationException($"Invalid configuration for {nameof(RedisMembershipTable)}. {nameof(RedisClusteringOptions)}.{nameof(_options.ConfigurationOptions)} is required.");
             }
         }
     }

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -1,3 +1,4 @@
+using Orleans.Runtime;
 using StackExchange.Redis;
 using System;
 using System.Threading.Tasks;
@@ -10,14 +11,10 @@ namespace Orleans.Clustering.Redis
     public class RedisClusteringOptions
     {
         /// <summary>
-        /// Specifies the database identi
+        /// Gets or sets the Redis client configuration.
         /// </summary>
-        public int Database { get; set; }
-
-        /// <summary>
-        /// The connection string.
-        /// </summary>
-        public string ConnectionString { get; set; } = "localhost:6379";
+        [RedactRedisConfigurationOptions]
+        public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
         /// The delegate used to create a Redis connection multiplexer.
@@ -25,11 +22,44 @@ namespace Orleans.Clustering.Redis
         public Func<RedisClusteringOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
+        /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
+        /// Setting a value different from null will cause entries to be deleted after some period of time.
+        /// </summary>
+        public TimeSpan? EntryExpiry { get; set; } = null;
+
+        /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
         public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisClusteringOptions options)
         {
-            return await ConnectionMultiplexer.ConnectAsync(options.ConnectionString);
+            return await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        }
+    }
+
+    internal class RedactRedisConfigurationOptions : RedactAttribute
+    {
+        public override string Redact(object value) => value is ConfigurationOptions cfg ? cfg.ToString(includePassword: false) : base.Redact(value);
+    }
+
+    /// <summary>
+    /// Configuration validator for <see cref="RedisClusteringOptions"/>.
+    /// </summary>
+    public class RedisClusteringOptionsValidator : IConfigurationValidator
+    {
+        private readonly RedisClusteringOptions _options;
+
+        public RedisClusteringOptionsValidator(RedisClusteringOptions options)
+        {
+            _options = options;
+        }
+
+        /// <inheritdoc/>
+        public void ValidateConfiguration()
+        {
+            if (_options.ConfigurationOptions == null)
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(RedisClusteringOptions)} values for {nameof(RedisMembershipTable)}. {nameof(_options.ConfigurationOptions)} is required.");
+            }
         }
     }
 }

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -6,8 +6,8 @@ using Orleans.Configuration;
 using Newtonsoft.Json;
 using System.Linq;
 using Microsoft.Extensions.Options;
-using System.Runtime.CompilerServices;
 using System.Globalization;
+using System.Text;
 
 namespace Orleans.Clustering.Redis
 {
@@ -26,7 +26,7 @@ namespace Orleans.Clustering.Redis
         {
             _redisOptions = redisOptions.Value;
             _clusterOptions = clusterOptions.Value;
-            _clusterKey = $"{_clusterOptions.ServiceId}/{_clusterOptions.ClusterId}";
+            _clusterKey = Encoding.UTF8.GetBytes($"{_clusterOptions.ServiceId}/members/{_clusterOptions.ClusterId}");
             _jsonSerializerSettings = JsonSettings.JsonSerializerSettings;
         }
 
@@ -40,11 +40,12 @@ namespace Orleans.Clustering.Redis
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
             _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
-            _db = _muxer.GetDatabase(_redisOptions.Database);
+            _db = _muxer.GetDatabase();
 
             if (tryInitTableVersion)
             {
                 await _db.HashSetAsync(_clusterKey, TableVersionKey, SerializeVersion(DefaultTableVersion), When.NotExists);
+                await _db.KeyExpireAsync(_clusterKey, _redisOptions.EntryExpiry);
             }
 
             this.IsInitialized = true;

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -45,7 +45,11 @@ namespace Orleans.Clustering.Redis
             if (tryInitTableVersion)
             {
                 await _db.HashSetAsync(_clusterKey, TableVersionKey, SerializeVersion(DefaultTableVersion), When.NotExists);
-                await _db.KeyExpireAsync(_clusterKey, _redisOptions.EntryExpiry);
+
+                if (_redisOptions.EntryExpiry is { } expiry)
+                {
+                    await _db.KeyExpireAsync(_clusterKey, expiry);
+                }
             }
 
             this.IsInitialized = true;

--- a/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryExtensions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryExtensions.cs
@@ -62,7 +62,7 @@ namespace Orleans.Hosting
         {
             configureOptions.Invoke(services.AddOptions<RedisGrainDirectoryOptions>(name));
             services
-                .AddTransient<IConfigurationValidator>(sp => new RedisGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<RedisGrainDirectoryOptions>>().Get(name)))
+                .AddTransient<IConfigurationValidator>(sp => new RedisGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<RedisGrainDirectoryOptions>>().Get(name), name))
                 .ConfigureNamedOptionForLogging<RedisGrainDirectoryOptions>(name)
                 .AddSingletonNamedService<IGrainDirectory>(name, (sp, name) => ActivatorUtilities.CreateInstance<RedisGrainDirectory>(sp, sp.GetOptionsByName<RedisGrainDirectoryOptions>(name)))
                 .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainDirectory>(n));

--- a/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryExtensions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryExtensions.cs
@@ -8,10 +8,13 @@ using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Extensions for configuring Redis as a grain directory provider.
+    /// </summary>
     public static class RedisGrainDirectoryExtensions
     {
         /// <summary>
-        /// Use a Redis data-store as the default Grain Directory
+        /// Adds a default grain directory which persists entries in Redis.
         /// </summary>
         public static ISiloBuilder UseRedisGrainDirectoryAsDefault(
             this ISiloBuilder builder,
@@ -21,7 +24,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Use a Redis data-store as the default Grain Directory
+        /// Adds a default grain directory which persists entries in Redis.
         /// </summary>
         public static ISiloBuilder UseRedisGrainDirectoryAsDefault(
             this ISiloBuilder builder,
@@ -31,7 +34,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Add a Redis data-store as a named Grain Directory
+        /// Adds a named grain directory which persists entries in Redis.
         /// </summary>
         public static ISiloBuilder AddRedisGrainDirectory(
             this ISiloBuilder builder,
@@ -42,7 +45,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Add a Redis data-store as a named Grain Directory
+        /// Adds a named grain directory which persists entries in Redis.
         /// </summary>
         public static ISiloBuilder AddRedisGrainDirectory(
             this ISiloBuilder builder,

--- a/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
@@ -45,10 +45,12 @@ namespace Orleans.Configuration
     public class RedisGrainDirectoryOptionsValidator : IConfigurationValidator
     {
         private readonly RedisGrainDirectoryOptions _options;
+        private readonly string _name;
 
-        public RedisGrainDirectoryOptionsValidator(RedisGrainDirectoryOptions options)
+        public RedisGrainDirectoryOptionsValidator(RedisGrainDirectoryOptions options, string name)
         {
             _options = options;
+            _name = name;
         }
 
         /// <inheritdoc/>
@@ -56,7 +58,7 @@ namespace Orleans.Configuration
         {
             if (_options.ConfigurationOptions == null)
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(RedisGrainDirectoryOptions)} values for {nameof(RedisGrainDirectory)}. {nameof(_options.ConfigurationOptions)} is required.");
+                throw new OrleansConfigurationException($"Invalid configuration for {nameof(RedisGrainDirectory)} with name {_name}. {nameof(RedisGrainDirectoryOptions)}.{nameof(_options.ConfigurationOptions)} is required.");
             }
         }
     }

--- a/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
@@ -7,6 +7,7 @@
     <PackageTags>$(PackageTags) Redis Grain Directory</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.GrainDirectory.Redis/Properties/AssemblyInfo.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tester.Redis")]

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageServiceCollectionExtensions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Orleans.Hosting
     public static class RedisGrainStorageServiceCollectionExtensions
     {
         /// <summary>
-        /// Configure silo to use Redis as the default grain storage.
+        /// Configures Redis as the default grain storage provider.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorageAsDefault(this IServiceCollection services, Action<RedisStorageOptions> configureOptions)
         {
@@ -25,7 +25,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis for grain storage.
+        /// Configures Redis as a grain storage provider.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorage(this IServiceCollection services, string name, Action<RedisStorageOptions> configureOptions)
         {
@@ -33,7 +33,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis as the default grain storage.
+        /// Configures Redis as the default grain storage provider.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorageAsDefault(this IServiceCollection services, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {
@@ -41,7 +41,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis for grain storage.
+        /// Configures Redis as a grain storage provider.
         /// </summary>
         public static IServiceCollection AddRedisGrainStorage(this IServiceCollection services, string name,
             Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisSiloBuilderExtensions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisSiloBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Orleans.Hosting
     public static class RedisSiloBuilderExtensions
     {
         /// <summary>
-        /// Configure silo to use Redis as the default grain storage.
+        /// Configures Redis as the default grain storage provider.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorageAsDefault(this ISiloBuilder builder, Action<RedisStorageOptions> configureOptions)
         {
@@ -19,7 +19,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis for grain storage.
+        /// Configures Redis as a grain storage provider.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorage(this ISiloBuilder builder, string name, Action<RedisStorageOptions> configureOptions)
         {
@@ -27,7 +27,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis as the default grain storage.
+        /// Configures Redis as the default grain storage provider.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorageAsDefault(this ISiloBuilder builder, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {
@@ -35,7 +35,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure silo to use Redis for grain storage.
+        /// Configures Redis as a grain storage provider.
         /// </summary>
         public static ISiloBuilder AddRedisGrainStorage(this ISiloBuilder builder, string name, Action<OptionsBuilder<RedisStorageOptions>> configureOptions = null)
         {

--- a/src/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.csproj
+++ b/src/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Microsoft.Orleans.Persistance.Redis</PackageId>
-    <Title>Microsoft Orleans Persistance Redis Provider</Title>
-    <Description>Microsoft Orleans Persistance implementation that uses Redis</Description>
-    <PackageTags>$(PackageTags) Redis Persistance</PackageTags>
+    <PackageId>Microsoft.Orleans.Persistence.Redis</PackageId>
+    <Title>Microsoft Orleans Persistence Redis Provider</Title>
+    <Description>Microsoft Orleans Persistence implementation that uses Redis</Description>
+    <PackageTags>$(PackageTags) Redis Persistence</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -1,4 +1,7 @@
-﻿using Orleans.Storage;
+using System;
+using System.Threading.Tasks;
+using Orleans.Storage;
+using StackExchange.Redis;
 
 namespace Orleans.Persistence
 {
@@ -8,19 +11,9 @@ namespace Orleans.Persistence
     public class RedisStorageOptions : IStorageProviderSerializerOptions
     {
         /// <summary>
-        /// The connection string.
-        /// </summary>
-        public string ConnectionString { get; set; } = "localhost:6379";
-
-        /// <summary>
         /// Whether or not to delete state during a clear operation.
         /// </summary>
         public bool DeleteOnClear { get; set; }
-
-        /// <summary>
-        /// The database number.
-        /// </summary>
-        public int? DatabaseNumber { get; set; }
 
         /// <summary>
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
@@ -29,5 +22,32 @@ namespace Orleans.Persistence
 
         /// <inheritdoc/>
         public IGrainStorageSerializer GrainStorageSerializer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Redis client configuration.
+        /// </summary>
+        [RedactRedisConfigurationOptions]
+        public ConfigurationOptions ConfigurationOptions { get; set; }
+
+        /// <summary>
+        /// The delegate used to create a Redis connection multiplexer.
+        /// </summary>
+        public Func<RedisStorageOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+
+        /// <summary>
+        /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
+        /// Setting a value different from null will cause duplicate activations in the cluster.
+        /// </summary>
+        public TimeSpan? EntryExpiry { get; set; } = null;
+
+        /// <summary>
+        /// The default multiplexer creation delegate.
+        /// </summary>
+        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+    }
+
+    internal class RedactRedisConfigurationOptions : RedactAttribute
+    {
+        public override string Redact(object value) => value is ConfigurationOptions cfg ? cfg.ToString(includePassword: false) : base.Redact(value);
     }
 }

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptionsValidator.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptionsValidator.cs
@@ -17,7 +17,7 @@ namespace Orleans.Persistence
         {
             if (_options.ConfigurationOptions == null)
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(RedisStorageOptions)} values for {nameof(RedisGrainStorage)} with name {_name}. {nameof(_options.ConfigurationOptions)} is required.");
+                throw new OrleansConfigurationException($"Invalid configuration for {nameof(RedisGrainStorage)} with name {_name}. {nameof(RedisStorageOptions)}.{nameof(_options.ConfigurationOptions)} is required.");
             }
         }
     }

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptionsValidator.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptionsValidator.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 
 namespace Orleans.Persistence
 {
@@ -9,27 +9,15 @@ namespace Orleans.Persistence
 
         public RedisStorageOptionsValidator(RedisStorageOptions options, string name)
         {
-            this._options = options;
-            this._name = name;
+            _options = options;
+            _name = name;
         }
 
         public void ValidateConfiguration()
         {
-            var msg = $"Configuration for {nameof(RedisGrainStorage)} - {_name} is invalid";
-
-            if (_options == null)
+            if (_options.ConfigurationOptions == null)
             {
-                throw new OrleansConfigurationException($"{msg} - {nameof(RedisStorageOptions)} is null");
-            }
-
-            if (string.IsNullOrWhiteSpace(_options.ConnectionString))
-            {
-                throw new OrleansConfigurationException($"{msg} - {nameof(_options.ConnectionString)} is null or empty");
-            }
-
-            if (!_options.ConnectionString.Contains(':')) // host:port delimiter
-            {
-                throw new OrleansConfigurationException($"{msg} - {nameof(_options.ConnectionString)} invalid format: {_options.ConnectionString}, should contain host and port delimited by ':'");
+                throw new OrleansConfigurationException($"Invalid {nameof(RedisStorageOptions)} values for {nameof(RedisGrainStorage)} with name {_name}. {nameof(_options.ConfigurationOptions)} is required.");
             }
         }
     }

--- a/src/Redis/Orleans.Reminders.Redis/Hosting/SiloBuilderReminderExtensions.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Hosting/SiloBuilderReminderExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 
 using Microsoft.Extensions.DependencyInjection;
-
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Reminders.Redis;
@@ -47,6 +47,7 @@ namespace Orleans.Hosting
         {
             services.AddSingleton<IReminderTable, RedisReminderTable>();
             services.Configure<RedisReminderTableOptions>(configure);
+            services.AddSingleton<IConfigurationValidator, RedisReminderTableOptionsValidator>();
             services.ConfigureFormatter<RedisReminderTableOptions>();
             return services;
         }

--- a/src/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.csproj
+++ b/src/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.csproj
@@ -7,6 +7,7 @@
     <PackageTags>$(PackageTags) Redis Reminders</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
@@ -55,7 +55,7 @@ namespace Orleans.Configuration
         {
             if (_options.ConfigurationOptions == null)
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(RedisReminderTableOptions)} values for {nameof(RedisReminderTable)}. {nameof(_options.ConfigurationOptions)} is required.");
+                throw new OrleansConfigurationException($"Invalid configuration for {nameof(RedisReminderTable)}. {nameof(RedisReminderTableOptions)}.{nameof(_options.ConfigurationOptions)} is required.");
             }
         }
     }

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -54,7 +54,10 @@ namespace Orleans.Reminders.Redis
                 _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
                 _db = _muxer.GetDatabase();
 
-                await _db.KeyExpireAsync(_hashSetKey, _redisOptions.EntryExpiry);
+                if (_redisOptions.EntryExpiry is { } expiry)
+                {
+                    await _db.KeyExpireAsync(_hashSetKey, expiry);
+                }
             }
             catch (Exception exception)
             {
@@ -230,7 +233,6 @@ namespace Orleans.Reminders.Redis
             string to = prefix + ",#";
             return (from, to);
         }
-
 
         private (string eTag, string value) ConvertFromEntry(ReminderEntry entry)
         {

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisRemindersException.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisRemindersException.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Orleans.Reminders.Redis
+{
+    /// <summary>
+    /// Exception thrown from <see cref="RedisReminderTable"/>.
+    /// </summary>
+    [GenerateSerializer]
+    public class RedisRemindersException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="RedisRemindersException"/>.
+        /// </summary>
+        public RedisRemindersException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RedisRemindersException"/>.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public RedisRemindersException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RedisRemindersException"/>.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="inner">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public RedisRemindersException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        /// <inheritdoc />
+        protected RedisRemindersException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/test/Extensions/Tester.Redis/Clustering/RedisMembershipTableTests.cs
+++ b/test/Extensions/Tester.Redis/Clustering/RedisMembershipTableTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using UnitTests.MembershipTests;
 using TestExtensions;
 using UnitTests;
+using StackExchange.Redis;
 
 namespace Tester.Redis.Clustering
 {
@@ -32,7 +33,11 @@ namespace Tester.Redis.Clustering
             TestUtils.CheckForRedis();
 
             membershipTable = new RedisMembershipTable(
-                Options.Create(new RedisClusteringOptions() { ConnectionString = GetConnectionString().Result }),
+                Options.Create(new RedisClusteringOptions()
+                {
+                    ConfigurationOptions = ConfigurationOptions.Parse(GetConnectionString().Result),
+                    EntryExpiry = TimeSpan.FromHours(1)
+                }),
                 this.clusterOptions);
 
             return membershipTable;

--- a/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
+++ b/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
@@ -1,16 +1,11 @@
-using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.GrainDirectory;
 using Orleans.GrainDirectory.Redis;
-using Orleans.Hosting;
-using Orleans.TestingHost;
 using StackExchange.Redis;
 using Tester.Directories;
-using Tester.Redis.Utility;
 using TestExtensions;
-using UnitTests.Grains.Directories;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Tester.Redis.GrainDirectory

--- a/test/Extensions/Tester.Redis/GrainDirectory/RedisMultipleGrainDirectoriesTests.cs
+++ b/test/Extensions/Tester.Redis/GrainDirectory/RedisMultipleGrainDirectoriesTests.cs
@@ -1,17 +1,10 @@
-using System;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Orleans.Configuration;
 using Orleans.GrainDirectory.Redis;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using StackExchange.Redis;
 using Tester.Directories;
-using Tester.Redis.Utility;
 using TestExtensions;
 using UnitTests.Grains.Directories;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Tester.Redis.GrainDirectory
 {

--- a/test/Extensions/Tester.Redis/Persistence/GrainState.cs
+++ b/test/Extensions/Tester.Redis/Persistence/GrainState.cs
@@ -1,4 +1,3 @@
-using System;
 using UnitTests.GrainInterfaces;
 
 namespace Tester.Redis.Persistence

--- a/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
+++ b/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
@@ -1,16 +1,10 @@
-using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Reminders.Redis;
-using Orleans.Runtime;
-using Orleans.TestingHost;
-using Tester.Redis.Utility;
+using StackExchange.Redis;
 using TestExtensions;
 using UnitTests;
-using UnitTests.GrainInterfaces;
 using UnitTests.RemindersTest;
 using Xunit;
 
@@ -37,8 +31,11 @@ namespace Tester.Redis.Reminders
             RedisReminderTable reminderTable = new(
                 this.loggerFactory.CreateLogger<RedisReminderTable>(),
                 this.clusterOptions,
-                Options.Create(new RedisReminderTableOptions() {  ConnectionString = GetConnectionString().Result })
-                );
+                Options.Create(new RedisReminderTableOptions()
+                {
+                    ConfigurationOptions = ConfigurationOptions.Parse(GetConnectionString().Result),
+                    EntryExpiry = TimeSpan.FromHours(1)
+                })); 
 
             if (reminderTable == null)
             {

--- a/test/Extensions/Tester.Redis/Utility/TestExtensions.cs
+++ b/test/Extensions/Tester.Redis/Utility/TestExtensions.cs
@@ -1,8 +1,5 @@
 using Orleans.Runtime;
-using System;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Tester.Redis.Utility
 {

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -356,7 +356,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 
@@ -388,7 +388,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 
@@ -427,7 +427,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 
@@ -463,7 +463,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 
@@ -495,7 +495,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 
@@ -534,7 +534,7 @@ namespace UnitTests.Grains
 
         public Task DoDelete()
         {
-            return ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle
+            return ClearStateAsync();
         }
     }
 

--- a/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistentStateTestGrains.cs
@@ -38,7 +38,7 @@ namespace UnitTests.PersistentState.Grains
 
         public Task DoDelete()
         {
-            return this.persistentState.ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle 
+            return this.persistentState.ClearStateAsync();
         }
     }
 
@@ -82,7 +82,7 @@ namespace UnitTests.PersistentState.Grains
 
         public Task DoDelete()
         {
-            return this.persistentState.ClearStateAsync(); // Automatically marks this grain as DeactivateOnIdle 
+            return this.persistentState.ClearStateAsync();
         }
     }
 }

--- a/test/Tester/Directories/GrainDirectoryTests.cs
+++ b/test/Tester/Directories/GrainDirectoryTests.cs
@@ -30,7 +30,7 @@ namespace Tester.Directories
             var expected = new GrainAddress
             {
                 ActivationId = ActivationId.NewId(),
-                GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
+                GrainId = GrainId.Parse("user/somerandomuser_" + Guid.NewGuid().ToString("N")),
                 SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
                 MembershipVersion = new MembershipVersion(51)
             };
@@ -50,7 +50,7 @@ namespace Tester.Directories
             var expected = new GrainAddress
             {
                 ActivationId = ActivationId.NewId(),
-                GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
+                GrainId = GrainId.Parse("user/somerandomuser_" + Guid.NewGuid().ToString("N")),
                 SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
                 MembershipVersion = new MembershipVersion(51)
             };
@@ -84,7 +84,7 @@ namespace Tester.Directories
             var expected = new GrainAddress
             {
                 ActivationId = ActivationId.NewId(),
-                GrainId = GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N")),
+                GrainId = GrainId.Parse("user/somerandomuser_" + Guid.NewGuid().ToString("N")),
                 SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
                 MembershipVersion = new MembershipVersion(51)
             };
@@ -105,7 +105,7 @@ namespace Tester.Directories
         [SkippableFact]
         public async Task LookupNotFound()
         {
-            Assert.Null(await this.grainDirectory.Lookup(GrainId.Parse("user/someraondomuser_" + Guid.NewGuid().ToString("N"))));
+            Assert.Null(await this.grainDirectory.Lookup(GrainId.Parse("user/somerandomuser_" + Guid.NewGuid().ToString("N"))));
         }
     }
 }

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -369,16 +369,24 @@ namespace UnitTests.MembershipTests
 
             await Task.WhenAll(Enumerable.Range(1, 19).Select(async i =>
             {
-                bool done;
+                var done = false;
                 do
                 {
                     var updatedTableData = await membershipTable.ReadAll();
                     var updatedRow = updatedTableData.TryGet(data.SiloAddress);
 
-                    TableVersion tableVersion = updatedTableData.Version.Next();
-
                     await Task.Delay(10);
-                    try { done = await membershipTable.UpdateRow(updatedRow.Item1, updatedRow.Item2, tableVersion); } catch { done = false; }
+                    if (updatedRow is null) continue;
+
+                    TableVersion tableVersion = updatedTableData.Version.Next();
+                    try
+                    {
+                        done = await membershipTable.UpdateRow(updatedRow.Item1, updatedRow.Item2, tableVersion);
+                    }
+                    catch
+                    {
+                        done = false;
+                    }
                 } while (!done);
             })).WithTimeout(TimeSpan.FromSeconds(30));
 

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -110,7 +110,7 @@ namespace UnitTests.RemindersTest
             Assert.False(removeRowRes, "should have failed. reminder shouldn't exist");
         }
 
-        protected async Task RemindersRange(int iterations=1000)
+        protected async Task RemindersRange(int iterations = 1000)
         {
             await Task.WhenAll(Enumerable.Range(1, iterations).Select(async i =>
             {
@@ -119,7 +119,7 @@ namespace UnitTests.RemindersTest
                 await RetryHelper.RetryOnExceptionAsync(10, RetryOperation.Sigmoid, async () =>
                 {
                     await remindersTable.UpsertRow(CreateReminder(grainRef, i.ToString()));
-                    return Task.CompletedTask;
+                    return 0;
                 });
             }));
 


### PR DESCRIPTION
* Use consistent configuration pattern
* Add/update configuration validators
* Use unique key prefixes for all providers
* Add expiry to all keys for testing
* Consistently throw serializable exceptions
* Update doc comments
* Mark classes which do not need to be public as internal
* Avoid clobbering the entire Redis instance during test runs
* Other minor cleanups

Note: this change breaks backwards compatibility with the existing Redis grain directory. It also breaks compatibility with the OrleansContrib redis providers. I think this is acceptable, since it is a new set of providers and grain directory entries become invalidated after a full cluster upgrade anyway. cc @benjaminpetit

Also note that all Redis providers are marked as `-beta1` currently. Should we remove that label?

I do not consider the Reminders provider suitable for large scale use since it puts all values into a single hash set (with one key in the hash set per reminder entry). This is fine for single instance Redis servers, but it is likely not ideal for Redis Cluster. Should we aim to update this before marking it as stable?

cc @mgravell & @willg1983