### PR TITLE
Make use of scoped keyword in generated serialization code optional

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -23,6 +23,7 @@ namespace Orleans.CodeGenerator
         public List<string> ImmutableAttributes { get; } = new() { "Orleans.ImmutableAttribute" };
         public List<string> ConstructorAttributes { get; } = new() { "Orleans.OrleansConstructorAttribute", "Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute" };
         public GenerateFieldIds GenerateFieldIds { get; set; }
+        public bool UseScopedKeyword { get; set; } = true;
     }
 
     public class CodeGenerator

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -178,6 +178,7 @@ namespace Orleans.CodeGenerator
                     Type("System.Collections.Immutable.ImmutableSortedSet`1"),
                     Type("System.Collections.Immutable.ImmutableStack`1"),
                 },
+                UseScopedKeyword = options.UseScopedKeyword,
             };
 
             INamedTypeSymbol Type(string metadataName)
@@ -302,6 +303,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol FSharpCompilationMappingAttributeOrDefault { get; private set; }
         public INamedTypeSymbol FSharpSourceConstructFlagsOrDefault { get; private set; }
         public INamedTypeSymbol FormatterServices { get; private set; }
+        public bool UseScopedKeyword { get; private set; }
 
         private readonly ConcurrentDictionary<ITypeSymbol, bool> _shallowCopyableTypes = new(SymbolEqualityComparer.Default);
 

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -60,6 +60,15 @@ namespace Orleans.CodeGenerator
                         options.GenerateFieldIds = fieldIdOption;
                 }
 
+                if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_usescopedkeyword",
+                        out var useScopedKeyword) && useScopedKeyword is { Length: > 0 })
+                {
+                    if (bool.TryParse(useScopedKeyword, out var useScopedKeywordOption))
+                    {
+                        options.UseScopedKeyword = useScopedKeywordOption;
+                    }
+                }
+
                 var codeGenerator = new CodeGenerator(context.Compilation, options);
                 var syntax = codeGenerator.GenerateCode(context.CancellationToken);
                 var sourceString = syntax.NormalizeWhitespace().ToFullString();

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -359,7 +359,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(libraryTypes.UseScopedKeyword ? TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)) : TokenList(Token(SyntaxKind.RefKeyword)));
             }
 
             var res = MethodDeclaration(returnType, SerializeMethodName)
@@ -529,7 +529,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(libraryTypes.UseScopedKeyword ? TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)) : TokenList(Token(SyntaxKind.RefKeyword)));
             }
 
             var res = MethodDeclaration(returnType, DeserializeMethodName)
@@ -709,7 +709,7 @@ namespace Orleans.CodeGenerator
                                     })))),
                                 ReturnStatement()))
                     );
-                    
+
                     // C#: ReferenceCodec.MarkValueField(reader.Session);
                     innerBody.Add(ExpressionStatement(InvocationExpression(IdentifierName("ReferenceCodec").Member("MarkValueField"), ArgumentList(SingletonSeparatedList(Argument(writerParam.Member("Session")))))));
                 }
@@ -1015,7 +1015,7 @@ namespace Orleans.CodeGenerator
             public override bool IsInjected { get; }
         }
 
-        internal sealed class ActivatorFieldDescription : GeneratedFieldDescription 
+        internal sealed class ActivatorFieldDescription : GeneratedFieldDescription
         {
             public ActivatorFieldDescription(TypeSyntax fieldType, string fieldName) : base(fieldType, fieldName)
             {
@@ -1040,7 +1040,7 @@ namespace Orleans.CodeGenerator
             public TypeFieldDescription(TypeSyntax fieldType, string fieldName, TypeSyntax underlyingTypeSyntax, ITypeSymbol underlyingType) : base(fieldType, fieldName)
             {
                 UnderlyingType = underlyingType;
-                UnderlyingTypeSyntax = underlyingTypeSyntax; 
+                UnderlyingTypeSyntax = underlyingTypeSyntax;
             }
 
             public TypeSyntax UnderlyingTypeSyntax { get; }
@@ -1216,22 +1216,22 @@ namespace Orleans.CodeGenerator
             private bool IsProperty => Member.Symbol is IPropertySymbol;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents an accessible field. 
+            /// Gets a value indicating whether or not this member represents an accessible field.
             /// </summary>
             private bool IsGettableField => Field is { } field && _model.IsAccessible(0, field) && !IsObsolete;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents an accessible, mutable field. 
+            /// Gets a value indicating whether or not this member represents an accessible, mutable field.
             /// </summary>
             private bool IsSettableField => Field is { } field && IsGettableField && !field.IsReadOnly;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete getter. 
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete getter.
             /// </summary>
             private bool IsGettableProperty => Property?.GetMethod is { } getMethod && _model.IsAccessible(0, getMethod) && !IsObsolete;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete setter. 
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete setter.
             /// </summary>
             private bool IsSettableProperty => Property?.SetMethod is { } setMethod && _model.IsAccessible(0, setMethod) && !setMethod.IsInitOnly && !IsObsolete;
 
@@ -1239,7 +1239,7 @@ namespace Orleans.CodeGenerator
             /// Gets syntax representing the type of this field.
             /// </summary>
             public TypeSyntax TypeSyntax => Member.Type.TypeKind == TypeKind.Dynamic
-                ? PredefinedType(Token(SyntaxKind.ObjectKeyword)) 
+                ? PredefinedType(Token(SyntaxKind.ObjectKeyword))
                 : _member.GetTypeSyntax(Member.Type);
 
             /// <summary>

--- a/src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props
+++ b/src/Orleans.CodeGenerator/build/Microsoft.Orleans.CodeGenerator.props
@@ -9,6 +9,7 @@
     <CompilerVisibleProperty Include="Orleans_AliasAttributes" />
     <CompilerVisibleProperty Include="Orleans_GenerateSerializerAttributes" />
     <CompilerVisibleProperty Include="Orleans_ConstructorAttributes" />
+    <CompilerVisibleProperty Include="Orleans_UseScopedKeyword" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -19,6 +20,7 @@
     <Orleans_AliasAttributes>$(OrleansAliasAttributes)</Orleans_AliasAttributes>
     <Orleans_GenerateSerializerAttributes>$(OrleansGenerateSerializerAttributes)</Orleans_GenerateSerializerAttributes>
     <Orleans_ConstructorAttributes>$(OrleansConstructorAttributes)</Orleans_ConstructorAttributes>
+    <Orleans_UseScopedKeyword>$(OrleansUseScopedKeyword)</Orleans_UseScopedKeyword>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The `scoped` keyword requires C#11. This allows to opt out of using it if you need to support earlier C# versions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8263)