### PR TITLE
Add Redis storage tests based on CommonStorageTests

### DIFF
--- a/src/Orleans.Core/Properties/AssemblyInfo.cs
+++ b/src/Orleans.Core/Properties/AssemblyInfo.cs
@@ -16,6 +16,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Tester")]
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
 [assembly: InternalsVisibleTo("Tester.AdoNet")]
+[assembly: InternalsVisibleTo("Tester.Redis")]
 [assembly: InternalsVisibleTo("Tester.ZooKeeperUtils")]
 [assembly: InternalsVisibleTo("TesterInternal")]
 [assembly: InternalsVisibleTo("TestExtensions")]

--- a/test/Extensions/Tester.Redis/Clustering/RedisMembershipTableTests.cs
+++ b/test/Extensions/Tester.Redis/Clustering/RedisMembershipTableTests.cs
@@ -14,9 +14,10 @@ namespace Tester.Redis.Clustering
     // Tests for operation of Orleans Membership Table using Redis
     // </summary>
     [TestCategory("Redis"), TestCategory("Clustering"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisMembershipTableTests : MembershipTableTestsBase
     {
-        public RedisMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment, CreateFilters())
+        public RedisMembershipTableTests(ConnectionStringFixture fixture, CommonFixture environment) : base(fixture, environment, CreateFilters())
         {
         }
 

--- a/test/Extensions/Tester.Redis/CollectionFixtures.cs
+++ b/test/Extensions/Tester.Redis/CollectionFixtures.cs
@@ -6,5 +6,5 @@ namespace Tester.Redis
     // Assembly collections must be defined once in each assembly
 
     [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
-    public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<CommonFixture> { }
 }

--- a/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
+++ b/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
@@ -6,11 +6,13 @@ using Orleans.GrainDirectory.Redis;
 using StackExchange.Redis;
 using Tester.Directories;
 using TestExtensions;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Tester.Redis.GrainDirectory
 {
     [TestCategory("Redis"), TestCategory("Directory"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisGrainDirectoryTests : GrainDirectoryTests<RedisGrainDirectory>
     {
         public RedisGrainDirectoryTests(ITestOutputHelper testOutput) : base(testOutput)

--- a/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
+++ b/test/Extensions/Tester.Redis/GrainDirectory/RedisGrainDirectoryTests.cs
@@ -22,7 +22,6 @@ namespace Tester.Redis.GrainDirectory
         protected override RedisGrainDirectory GetGrainDirectory()
         {
             TestUtils.CheckForRedis();
-
             var configuration = TestDefaultConfiguration.RedisConnectionString;
             var directoryOptions = new RedisGrainDirectoryOptions
             {

--- a/test/Extensions/Tester.Redis/GrainDirectory/RedisMultipleGrainDirectoriesTests.cs
+++ b/test/Extensions/Tester.Redis/GrainDirectory/RedisMultipleGrainDirectoriesTests.cs
@@ -5,10 +5,12 @@ using StackExchange.Redis;
 using Tester.Directories;
 using TestExtensions;
 using UnitTests.Grains.Directories;
+using Xunit;
 
 namespace Tester.Redis.GrainDirectory
 {
     [TestCategory("Redis"), TestCategory("Directory"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisMultipleGrainDirectoriesTests : MultipleGrainDirectoriesTests
     {
         public class SiloConfigurator : ISiloConfigurator

--- a/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 namespace Tester.Redis.Persistence
 {
     [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisPersistenceGrainTests : GrainPersistenceTestsRunner, IClassFixture<RedisPersistenceGrainTests.Fixture>
     {
         public static readonly string ServiceId = Guid.NewGuid().ToString("N");

--- a/test/Extensions/Tester.Redis/Persistence/RedisPersistenceSetupTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisPersistenceSetupTests.cs
@@ -4,10 +4,12 @@ using Xunit;
 using Orleans.Configuration;
 using Orleans.Runtime;
 using StackExchange.Redis;
+using TestExtensions;
 
 namespace Tester.Redis.Persistence
 {
     [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisPersistenceSetupTests
     {
         [SkippableTheory]

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
@@ -1,0 +1,129 @@
+using UnitTests.StorageTests.Relational;
+using UnitTests.StorageTests.Relational.TestDataSets;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.Redis.Persistence
+{
+    [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
+    public class RedisStorageTests : IClassFixture<CommonFixture>
+    {
+        private readonly CommonFixture fixture;
+        private readonly CommonStorageTests commonStorageTests;
+    
+        public RedisStorageTests(ITestOutputHelper output, CommonFixture commonFixture) 
+        {
+            this.fixture = commonFixture;
+            this.commonStorageTests = new CommonStorageTests(commonFixture.GetStorageProvider(false ).GetAwaiter().GetResult());      
+        }
+
+        [SkippableFact]
+        [TestCategory("Functional")]
+        public async Task WriteInconsistentFailsWithIncosistentStateException()
+        {
+            await Relational_WriteInconsistentFailsWithIncosistentStateException();
+        }
+
+        [SkippableFact]
+        [TestCategory("Functional")]
+        public async Task WriteRead100StatesInParallel()
+        {
+            await Relational_WriteReadWriteRead100StatesInParallel();
+        }
+        internal Task Relational_WriteReadWriteRead100StatesInParallel()
+        {
+            return commonStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
+        }
+
+        [SkippableFact]
+        [TestCategory("Functional")]
+        public async Task WriteReadCyrillic()
+        {
+            await commonStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSet2CyrillicIdsAndGrainNames<string>))]
+        [TestCategory("Functional")]
+        internal async Task DataSet2_Cyrillic_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSet2CyrillicIdsAndGrainNames<string>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
+        [TestCategory("Functional")]
+        internal async Task PersistenceStorage_StorageDataSetPlain_IntegerKey_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetPlain<long>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<Guid, string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetGeneric_GuidKey_Generic_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetGeneric<Guid, string>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<long, string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetGeneric_IntegerKey_Generic_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetGeneric<long, string>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetGeneric_StringKey_Generic_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetGeneric<string, string>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetGeneric_WriteRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetGeneric<string, string>.GetTestData(testNum);
+            await commonStorageTests.Store_WriteRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetPlain<Guid>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetPlain_GuidKey_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetPlain<Guid>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetPlain<string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetPlain_StringKey_WriteClearRead(int testNum)
+        {
+            var (grainType, getGrain, grainState) = StorageDataSetPlain<string>.GetTestData(testNum);
+            await this.commonStorageTests.Store_WriteClearRead(grainType, getGrain, grainState);
+        }
+
+        [SkippableFact]
+        [TestCategory("Functional")]
+        public async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
+        {
+            await Relational_WriteDuplicateFailsWithInconsistentStateException();
+        }
+
+        internal async Task Relational_WriteDuplicateFailsWithInconsistentStateException()
+        {
+            var exception = await commonStorageTests.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException();
+            CommonStorageUtilities.AssertRelationalInconsistentExceptionMessage(exception.Message);
+        }
+
+        internal async Task Relational_WriteInconsistentFailsWithIncosistentStateException()
+        {
+            var exception = await commonStorageTests.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException();
+            CommonStorageUtilities.AssertRelationalInconsistentExceptionMessage(exception.Message);
+        }
+    }
+}

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
@@ -1,3 +1,4 @@
+using TestExtensions;
 using UnitTests.StorageTests.Relational;
 using UnitTests.StorageTests.Relational.TestDataSets;
 using Xunit;
@@ -6,7 +7,8 @@ using Xunit.Abstractions;
 namespace Tester.Redis.Persistence
 {
     [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
-    public class RedisStorageTests : IClassFixture<CommonFixture>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    public class RedisStorageTests
     {
         private readonly CommonFixture fixture;
         private readonly CommonStorageTests commonStorageTests;

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTests.cs
@@ -15,6 +15,7 @@ namespace Tester.Redis.Persistence
     
         public RedisStorageTests(ITestOutputHelper output, CommonFixture commonFixture) 
         {
+            TestUtils.CheckForRedis();
             this.fixture = commonFixture;
             this.commonStorageTests = new CommonStorageTests(commonFixture.GetStorageProvider(false ).GetAwaiter().GetResult());      
         }

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
@@ -14,6 +14,7 @@ namespace Tester.Redis.Persistence
 
         public RedisStorageTestsOrleansSerializer(ITestOutputHelper output, CommonFixture commonFixture)
         {
+            TestUtils.CheckForRedis();
             this.fixture = commonFixture;
         }
 

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
@@ -1,3 +1,4 @@
+using TestExtensions;
 using UnitTests.StorageTests.Relational;
 using UnitTests.StorageTests.Relational.TestDataSets;
 using Xunit;
@@ -6,7 +7,8 @@ using Xunit.Abstractions;
 namespace Tester.Redis.Persistence
 {
     [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
-    public class RedisStorageTestsOrleansSerializer :  IClassFixture<CommonFixture>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    public class RedisStorageTestsOrleansSerializer
     {
         private readonly CommonFixture fixture;
 

--- a/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisStorageTestsOrleansSerializer.cs
@@ -1,0 +1,28 @@
+using UnitTests.StorageTests.Relational;
+using UnitTests.StorageTests.Relational.TestDataSets;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.Redis.Persistence
+{
+    [TestCategory("Redis"), TestCategory("Persistence"), TestCategory("Functional")]
+    public class RedisStorageTestsOrleansSerializer :  IClassFixture<CommonFixture>
+    {
+        private readonly CommonFixture fixture;
+
+        public RedisStorageTestsOrleansSerializer(ITestOutputHelper output, CommonFixture commonFixture)
+        {
+            this.fixture = commonFixture;
+        }
+
+        [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
+        [TestCategory("Functional")]
+        internal async Task StorageDataSetGeneric_WriteRead(int testNum)
+        {
+            var storageProvider = await fixture.GetStorageProvider(true);
+            var commonStorageTests = new CommonStorageTests(storageProvider);
+            var (grainType, getGrain, grainState) = StorageDataSetGeneric<string, string>.GetTestData(testNum);
+            await commonStorageTests.Store_WriteRead(grainType, getGrain, grainState);
+        }
+    }
+}

--- a/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
+++ b/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
@@ -16,6 +16,7 @@ namespace Tester.Redis.Reminders
     {
         public RedisRemindersTableTests(ConnectionStringFixture fixture, CommonFixture clusterFixture) : base (fixture, clusterFixture, CreateFilters())
         {
+            TestUtils.CheckForRedis();
         }
 
         private static LoggerFilterOptions CreateFilters()
@@ -45,6 +46,7 @@ namespace Tester.Redis.Reminders
 
             return reminderTable;
         }
+
         protected override Task<string> GetConnectionString() => Task.FromResult(TestDefaultConfiguration.RedisConnectionString);
 
         [SkippableFact]

--- a/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
+++ b/test/Extensions/Tester.Redis/Reminders/RedisReminderTableTests.cs
@@ -11,9 +11,10 @@ using Xunit;
 namespace Tester.Redis.Reminders
 {
     [TestCategory("Redis"), TestCategory("Reminders"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RedisRemindersTableTests : ReminderTableTestsBase
     {
-        public RedisRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture) : base (fixture, clusterFixture, CreateFilters())
+        public RedisRemindersTableTests(ConnectionStringFixture fixture, CommonFixture clusterFixture) : base (fixture, clusterFixture, CreateFilters())
         {
         }
 

--- a/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
+++ b/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
@@ -9,11 +9,11 @@ using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Storage;
 using StackExchange.Redis;
+using Tester;
 using TestExtensions;
 
 public class CommonFixture : TestEnvironmentFixture
 {
-
     /// <summary>
     /// Caches DefaultProviderRuntime for multiple uses.
     /// </summary>
@@ -24,6 +24,7 @@ public class CommonFixture : TestEnvironmentFixture
     /// </summary>
     public CommonFixture()
     {
+        TestUtils.CheckForRedis();
         _ = this.Services.GetRequiredService<IOptions<ClusterOptions>>();
         DefaultProviderRuntime = new ClientProviderRuntime(
             this.InternalGrainFactory,
@@ -38,13 +39,12 @@ public class CommonFixture : TestEnvironmentFixture
     /// a <em>null</em> value will be provided.</remarks>
     public async Task<IGrainStorage> GetStorageProvider(bool useOrleansSerializer = false)
     {
+
         IGrainStorageSerializer grainStorageSerializer = useOrleansSerializer ? new OrleansGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<Serializer>())
                                                                               : new JsonGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<OrleansJsonSerializer>());
-
-        var redisOptions = ConfigurationOptions.Parse(TestDefaultConfiguration.RedisConnectionString);
         var options = new RedisStorageOptions()
         {
-            ConnectionString = redisOptions.ToString(),
+            ConfigurationOptions = ConfigurationOptions.Parse(TestDefaultConfiguration.RedisConnectionString),
             GrainStorageSerializer = grainStorageSerializer
         };
 

--- a/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
+++ b/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Persistence;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+using StackExchange.Redis;
+using TestExtensions;
+
+public class CommonFixture : TestEnvironmentFixture
+{
+
+    /// <summary>
+    /// Caches DefaultProviderRuntime for multiple uses.
+    /// </summary>
+    private IProviderRuntime DefaultProviderRuntime { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public CommonFixture()
+    {
+        _ = this.Services.GetRequiredService<IOptions<ClusterOptions>>();
+        DefaultProviderRuntime = new ClientProviderRuntime(
+            this.InternalGrainFactory,
+            this.Services,
+            this.Services.GetRequiredService<ClientGrainContext>());
+    }
+
+    /// <summary>
+    /// Returns a correct implementation of the persistence provider according to environment variables.
+    /// </summary>
+    /// <remarks>If the environment invariants have failed to hold upon creation of the storage provider,
+    /// a <em>null</em> value will be provided.</remarks>
+    public async Task<IGrainStorage> GetStorageProvider(bool useOrleansSerializer = false)
+    {
+        IGrainStorageSerializer grainStorageSerializer = useOrleansSerializer ? new OrleansGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<Serializer>())
+                                                                              : new JsonGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<OrleansJsonSerializer>());
+
+        var redisOptions = ConfigurationOptions.Parse(TestDefaultConfiguration.RedisConnectionString);
+        var options = new RedisStorageOptions()
+        {
+            ConnectionString = redisOptions.ToString(),
+            GrainStorageSerializer = grainStorageSerializer
+        };
+
+        var clusterOptions = new ClusterOptions()
+        {
+            ServiceId = Guid.NewGuid().ToString()
+        };
+
+        var storageProvider = new RedisGrainStorage(string.Empty, options, grainStorageSerializer, Options.Create(clusterOptions), DefaultProviderRuntime.ServiceProvider.GetService<ILogger<RedisGrainStorage>>());
+        ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
+        storageProvider.Participate(siloLifeCycle);
+        await siloLifeCycle.OnStart(CancellationToken.None);
+        return storageProvider;
+    }
+}

--- a/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
+++ b/test/Extensions/Tester.Redis/Utility/CommonFixture.cs
@@ -24,7 +24,6 @@ public class CommonFixture : TestEnvironmentFixture
     /// </summary>
     public CommonFixture()
     {
-        TestUtils.CheckForRedis();
         _ = this.Services.GetRequiredService<IOptions<ClusterOptions>>();
         DefaultProviderRuntime = new ClientProviderRuntime(
             this.InternalGrainFactory,
@@ -39,7 +38,7 @@ public class CommonFixture : TestEnvironmentFixture
     /// a <em>null</em> value will be provided.</remarks>
     public async Task<IGrainStorage> GetStorageProvider(bool useOrleansSerializer = false)
     {
-
+        TestUtils.CheckForRedis();
         IGrainStorageSerializer grainStorageSerializer = useOrleansSerializer ? new OrleansGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<Serializer>())
                                                                               : new JsonGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<OrleansJsonSerializer>());
         var options = new RedisStorageOptions()

--- a/test/TestInfrastructure/TestExtensions/Properties/AssemblyInfo.cs
+++ b/test/TestInfrastructure/TestExtensions/Properties/AssemblyInfo.cs
@@ -1,8 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TesterInternal")]
 [assembly: InternalsVisibleTo("NonSilo.Tests")]
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
 [assembly: InternalsVisibleTo("Tester.AdoNet")]
+[assembly: InternalsVisibleTo("Tester.Redis")]
 [assembly: InternalsVisibleTo("AWSUtils.Tests")]
 [assembly: InternalsVisibleTo("GoogleUtils.Tests")]

--- a/test/TesterInternal/Properties/AssemblyInfo.cs
+++ b/test/TesterInternal/Properties/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
 [assembly: InternalsVisibleTo("Tester.AdoNet")]
+[assembly: InternalsVisibleTo("Tester.Redis")]
 [assembly: InternalsVisibleTo("AWSUtils.Tests")]
 [assembly: InternalsVisibleTo("GoogleUtils.Tests")]

--- a/test/TesterInternal/StorageTests/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.StorageTests.Relational
     /// </remarks>
     internal class CommonStorageTests
     {
-        public CommonStorageTests(IGrainStorage storage) => Storage = storage;
+        public CommonStorageTests(IGrainStorage storage) => Storage = storage ?? throw new ArgumentNullException(nameof(storage));
 
         /// <summary>
         /// The storage provider under test.

--- a/test/TesterInternal/StorageTests/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageTests.cs
@@ -187,18 +187,18 @@ namespace UnitTests.StorageTests.Relational
             await Storage.WriteStateAsync(grainTypeName, grainId, grainState);
             var writtenStateVersion = grainState.ETag;
             var recordExitsAfterWriting = grainState.RecordExists;
+            Assert.True(recordExitsAfterWriting);
 
             await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
             var clearedStateVersion = grainState.ETag;
-            var recordExitsAfterClearing = grainState.RecordExists;
-
-            var storedGrainState = new GrainState<T> { State = new T() };
-            await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
-
             Assert.NotEqual(writtenStateVersion, clearedStateVersion);
-            Assert.Equal(storedGrainState.State, Activator.CreateInstance<T>());
-            Assert.True(recordExitsAfterWriting);
+
+            var recordExitsAfterClearing = grainState.RecordExists;
             Assert.False(recordExitsAfterClearing);
+
+            var storedGrainState = new GrainState<T> { State = new T(), ETag = clearedStateVersion };
+            await Storage.WriteStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
+            Assert.Equal(storedGrainState.State, Activator.CreateInstance<T>());
             Assert.True(storedGrainState.RecordExists);
         }
 

--- a/test/TesterInternal/StorageTests/CommonStorageUtilities.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageUtilities.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 
 namespace UnitTests.StorageTests.Relational
@@ -17,8 +17,8 @@ namespace UnitTests.StorageTests.Relational
             Assert.Contains("ServiceId=", exceptionMessage);
             Assert.Contains("ProviderName=", exceptionMessage);
             Assert.Contains("GrainType=", exceptionMessage);
-            Assert.Contains($"GrainId=", exceptionMessage);
-            Assert.Contains($"ETag=", exceptionMessage);
+            Assert.Contains("GrainId=", exceptionMessage);
+            Assert.Contains("ETag=", exceptionMessage);
         }
     }
 }


### PR DESCRIPTION
This adds additional functional tests based on `CommonStorageTests` for the `RedisGrainStorage` provider.
 
@ReubenBond  These tests will currently fail as I have not fixed the issues they highlight in the `RedisGrainStorage` , as I know there are changes to that in PR #8261 and I wanted to avoid conflicts - we will need to rebase one of these PRs onto the other I presume?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8265)