### PR TITLE
[Maintenance] Bumping version of some external dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="protobuf-net" Version="3.1.22" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="ZooKeeperNetEx" Version="3.4.12.4" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.6.86" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.6.90" />
     <PackageVersion Include="KubernetesClient" Version="10.0.16" />
     <!-- Test related packages -->
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,7 +59,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="ZooKeeperNetEx" Version="3.4.12.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.86" />
-    <PackageVersion Include="KubernetesClient" Version="9.0.38" />
+    <PackageVersion Include="KubernetesClient" Version="10.0.16" />
     <!-- Test related packages -->
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,7 @@
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="1.0.0-beta13" />
     <PackageVersion Include="Google.Protobuf" Version="3.21.7" />
     <PackageVersion Include="protobuf-net" Version="3.1.22" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="ZooKeeperNetEx" Version="3.4.12.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.90" />
     <PackageVersion Include="KubernetesClient" Version="10.0.16" />


### PR DESCRIPTION
- Bumped KubernetesClient to v10.0.16
- Bumped StackExchange.Redis to 2.6.90
- Bumped Newtonsoft.Json to v13.0.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8272)