### PR TITLE
Fix incorrect behavior of record codec code generator

### DIFF
--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -314,6 +314,7 @@ namespace Orleans.CodeGenerator
             var instanceParam = "instance".ToIdentifierName();
 
             var body = new List<StatementSyntax>();
+            var writeEndBaseInvocationExpression = ExpressionStatement(InvocationExpression(writerParam.Member("WriteEndBase"), ArgumentList()));
             if (type.HasComplexBaseType)
             {
                 body.Add(
@@ -321,7 +322,7 @@ namespace Orleans.CodeGenerator
                         InvocationExpression(
                             BaseTypeSerializerFieldName.ToIdentifierName().Member(SerializeMethodName),
                             ArgumentList(SeparatedList(new[] { Argument(writerParam).WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)), Argument(instanceParam) })))));
-                body.Add(ExpressionStatement(InvocationExpression(writerParam.Member("WriteEndBase"), ArgumentList())));
+                body.Add(writeEndBaseInvocationExpression);
             }
 
             AddSerializationCallbacks(type, instanceParam, "OnSerializing", body);
@@ -341,7 +342,10 @@ namespace Orleans.CodeGenerator
             if (type.SupportsPrimaryConstructorParameters)
             {
                 AddSerializationMembers(type, serializerFields, members.Where(m => m.IsPrimaryConstructorParameter), libraryTypes, writerParam, instanceParam, previousFieldIdVar, body);
-                body.Add(ExpressionStatement(InvocationExpression(writerParam.Member("WriteEndBase"), ArgumentList())));
+                if (body.LastOrDefault() != writeEndBaseInvocationExpression)
+                {
+                    body.Add(writeEndBaseInvocationExpression);
+                }
             }
 
             AddSerializationMembers(type, serializerFields, members.Where(m => !m.IsPrimaryConstructorParameter), libraryTypes, writerParam, instanceParam, previousFieldIdVar, body);

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -32,6 +32,16 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void GeneratedSerializersRoundTripPolymorphicCollectionThroughCodec()
+        {
+            var original = new TestType2[] { new TestType2.TestType2A("test1"), new TestType2.TestType2B("test2") };
+            var result = RoundTripThroughCodec(original);
+
+            Assert.Equal(original[0].TestString, result[0].TestString);
+            Assert.Equal(original[1].TestString, result[1].TestString);
+        }
+
+        [Fact]
         public void GeneratedSerializersRoundTripThroughCodec()
         {
             var original = new SomeClassWithSerializers { IntField = 2, IntProperty = 30, OtherObject = MyCustomEnum.Two };
@@ -351,7 +361,7 @@ namespace Orleans.Serialization.UnitTests
 
             original.StringProperty = "bananas";
             result = RoundTripThroughCodec(original);
- 
+
             Assert.Equal(default(Guid), result.GuidProperty);
             Assert.Equal(original.GuidProperty, result.GuidProperty);
             Assert.Equal("bananas", result.StringProperty);

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -97,7 +97,7 @@ public class MyValue : IEquatable<MyValue>
     }
 
     public override int GetHashCode() => Value;
-} 
+}
 
 [GenerateSerializer]
 [Immutable]
@@ -378,6 +378,17 @@ namespace Orleans.Serialization.UnitTests
         public int UnmarkedProperty { get; set; }
 
         public override string ToString() => $"{nameof(IntField)}: {IntField}, {nameof(IntProperty)}: {IntProperty}";
+    }
+
+    [GenerateSerializer]
+    [Id(8286)]
+    public abstract record TestType2(string TestString)
+    {
+        [GenerateSerializer]
+        public sealed record TestType2A(string TestString) : TestType2(TestString);
+
+        [GenerateSerializer]
+        public sealed record TestType2B(string TestString) : TestType2(TestString);
     }
 
     [GenerateSerializer]


### PR DESCRIPTION
Hi there!
This fixes https://github.com/dotnet/orleans/issues/8286.

The problem is that if derived record has the same properties as base record e.g.
```
  [GenerateSerializer]
    [Id(8286)]
    public abstract record TestType2(string TestString)
    {
        [GenerateSerializer]
        public sealed record TestType2A(string TestString) : TestType2(TestString);

        [GenerateSerializer]
        public sealed record TestType2B(string TestString) : TestType2(TestString);
    }
```
then the code generator will generate extra call (even if we're not writing any fields).
```
public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, global::OrleansBugRepro.Interfaces.TestType2.TestType2B instance)
    where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
{
    _baseTypeSerializer.Serialize(ref writer, instance);
    writer.WriteEndBase();
    writer.WriteEndBase();  // <-- redundant call
}
```

So I assumed that it only happens with records as it have more things inside than regular class hierarchy (primary constructors, overriden ToString/Equals, etc) and then I tried to do the same thing with class hierarchy:
```
[Immutable, GenerateSerializer, Alias("TestType2")]
public abstract class TestType2
{
    public string? TestString { get; }

    protected TestType2(string? testString)
    {
        TestString = testString;
    }

    [Immutable, GenerateSerializer, Alias("TestType2A")]
    public sealed class TestType2A : TestType2
    {
        public TestType2A(string? testString) : base(testString)
        {
        }
    }

    [Immutable, GenerateSerializer, Alias("TestType2B")]
    public sealed class TestType2B : TestType2
    {
        public TestType2B(string? testString) : base(testString)
        {
        }
    }
}
```
and we're okay with that. The code is generated properly and tests are pass!
```
public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, global::OrleansBugRepro.Interfaces.TestType2.TestType2B instance)
            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
        {
            _baseTypeSerializer.Serialize(ref writer, instance);
            writer.WriteEndBase();
            // <-- no redundant call here
        }
```




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8288)