### PR TITLE
Improve versatility of `PooledArrayBufferWriter` and rename to `PooledBuffer`

### DIFF
--- a/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
@@ -131,7 +131,7 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            var innerWriter = Writer.Create(new PooledArrayBufferWriter(), null);
+            var innerWriter = Writer.Create(new PooledBuffer(), null);
             innerWriter.WriteInt32(value.GetConsistentHashCode());
             WriteSiloAddressInner(ref innerWriter, value);
             innerWriter.Commit();

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -65,7 +65,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value.GetType());
 
         // Write the serialized payload
-        // Note that the Utf8JsonWriter and PooledArrayBufferWriter could be pooled as long as they're correctly
+        // Note that the Utf8JsonWriter and PooledBuffer could be pooled as long as they're correctly
         // reset at the end of each use.
         var bufferWriter = new BufferWriterBox<PooledArrayBufferWriter>(new PooledArrayBufferWriter());
         try

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -67,7 +67,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         // Write the serialized payload
         // Note that the Utf8JsonWriter and PooledBuffer could be pooled as long as they're correctly
         // reset at the end of each use.
-        var bufferWriter = new BufferWriterBox<PooledArrayBufferWriter>(new PooledArrayBufferWriter());
+        var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
             var jsonWriter = new Utf8JsonWriter(bufferWriter);
@@ -126,7 +126,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
                     var length = reader.ReadVarUInt32();
 
                     // To possibly improve efficiency, this could be converted to read a ReadOnlySequence<byte> instead of a byte array.
-                    var tempBuffer = new PooledArrayBufferWriter();
+                    var tempBuffer = new PooledBuffer();
                     try
                     {
                         reader.ReadBytes(ref tempBuffer, (int)length);
@@ -181,7 +181,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
             return result;
 
 
-        var bufferWriter = new BufferWriterBox<PooledArrayBufferWriter>(new PooledArrayBufferWriter());
+        var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
             var jsonWriter = new Utf8JsonWriter(bufferWriter);

--- a/src/Orleans.Serialization.TestKit/BufferTestHelper.cs
+++ b/src/Orleans.Serialization.TestKit/BufferTestHelper.cs
@@ -20,6 +20,7 @@ namespace Orleans.Serialization.TestKit
             }
 
             result.Add(ActivatorUtilities.CreateInstance<StructBufferWriterTester>(serviceProvider));
+            result.Add(ActivatorUtilities.CreateInstance<PooledBufferWriterTester>(serviceProvider));
             return result.ToArray();
         }
 
@@ -89,6 +90,34 @@ namespace Orleans.Serialization.TestKit
             }
 
             public override string ToString() => $"{nameof(TestBufferWriterStruct)}";
+        }
+
+        private struct PooledOutputBuffer : IBufferWriter<byte>, IOutputBuffer, IDisposable
+        {
+            private PooledArrayBufferWriter _buffer;
+
+            public PooledOutputBuffer()
+            {
+                _buffer = new();
+            }
+
+            public void Advance(int count) => _buffer.Advance(count);
+            public void Dispose() => _buffer.Dispose();
+            public Memory<byte> GetMemory(int sizeHint = 0) => _buffer.GetMemory(sizeHint);
+            public ReadOnlySequence<byte> GetReadOnlySequence(int maxSegmentSize) => _buffer.AsReadOnlySequence();
+            public Span<byte> GetSpan(int sizeHint = 0) => _buffer.GetSpan(sizeHint);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private class PooledBufferWriterTester : BufferTester<PooledOutputBuffer>
+        {
+            public PooledBufferWriterTester(IServiceProvider serviceProvider) : base(serviceProvider)
+            {
+            }
+
+            protected override PooledOutputBuffer CreateBufferWriter() => new();
+
+            public override string ToString() => $"{nameof(PooledBufferWriterTester)}";
         }
     }
 }

--- a/src/Orleans.Serialization.TestKit/BufferTestHelper.cs
+++ b/src/Orleans.Serialization.TestKit/BufferTestHelper.cs
@@ -94,7 +94,7 @@ namespace Orleans.Serialization.TestKit
 
         private struct PooledOutputBuffer : IBufferWriter<byte>, IOutputBuffer, IDisposable
         {
-            private PooledArrayBufferWriter _buffer;
+            private PooledBuffer _buffer;
 
             public PooledOutputBuffer()
             {

--- a/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.NetworkInformation;
 
 namespace Orleans.Serialization.Buffers.Adaptors;
-using static Orleans.Serialization.Buffers.PooledArrayBufferWriter;
+using static Orleans.Serialization.Buffers.PooledBuffer;
 
 public struct BufferSliceReaderInput
 {
@@ -20,7 +20,7 @@ public struct BufferSliceReaderInput
         _segment = InitialSegmentSentinel;
     }
 
-    internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+    internal readonly PooledBuffer Buffer => _slice._buffer;
     internal readonly int Position => _position;
     internal readonly int Offset => _slice._offset;
     internal readonly int Length => _slice._length;

--- a/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Net.NetworkInformation;
-
-namespace Orleans.Serialization.Buffers.Adaptors;
 using static Orleans.Serialization.Buffers.PooledBuffer;
 
+namespace Orleans.Serialization.Buffers.Adaptors;
+
+/// <summary>
+/// Input type for <see cref="Reader{TInput}"/> to support <see cref="BufferSlice"/> buffers.
+/// </summary>
 public struct BufferSliceReaderInput
 {
     private static readonly SequenceSegment InitialSegmentSentinel = new();
@@ -14,6 +16,10 @@ public struct BufferSliceReaderInput
     private SequenceSegment _segment;
     private int _position;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferSliceReaderInput"/> type.
+    /// </summary>
+    /// <param name="slice">The underlying buffer.</param>
     public BufferSliceReaderInput(in BufferSlice slice)
     {
         _slice = slice;
@@ -26,13 +32,13 @@ public struct BufferSliceReaderInput
     internal readonly int Length => _slice._length;
     internal long PreviousBuffersSize;
 
-    public BufferSliceReaderInput ForkFrom(int position)
+    internal BufferSliceReaderInput ForkFrom(int position)
     {
         var sliced = _slice.Slice(position);
         return new BufferSliceReaderInput(in sliced);
     }
 
-    public ReadOnlySpan<byte> GetNext()
+    internal ReadOnlySpan<byte> GetNext()
     {
         if (ReferenceEquals(_segment, InitialSegmentSentinel))
         {
@@ -70,7 +76,7 @@ public struct BufferSliceReaderInput
             if (segmentLength == 0)
             {
                 ThrowInsufficientData();
-                return ReadOnlySpan<byte>.Empty;
+                return default;
             }
 
             var result = segment.Slice(segmentOffset, segmentLength);
@@ -86,7 +92,7 @@ public struct BufferSliceReaderInput
             if (finalLength == 0)
             {
                 ThrowInsufficientData();
-                return ReadOnlySpan<byte>.Empty;
+                return default;
             }
 
             var result = head.Array.AsSpan(finalOffset, finalLength);
@@ -97,7 +103,7 @@ public struct BufferSliceReaderInput
         }
 
         ThrowInsufficientData();
-        return ReadOnlySpan<byte>.Empty;
+        return default;
     }
 
     [DoesNotReturn]

--- a/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.NetworkInformation;
+
+namespace Orleans.Serialization.Buffers.Adaptors;
+using static Orleans.Serialization.Buffers.PooledArrayBufferWriter;
+
+public struct BufferSliceReaderInput
+{
+    private static readonly SequenceSegment InitialSegmentSentinel = new();
+    private static readonly SequenceSegment FinalSegmentSentinel = new();
+    private readonly BufferSlice _slice;
+    private SequenceSegment _segment;
+    private int _position;
+
+    public BufferSliceReaderInput(in BufferSlice slice)
+    {
+        _slice = slice;
+        _segment = InitialSegmentSentinel;
+    }
+
+    internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+    internal readonly int Position => _position;
+    internal readonly int Offset => _slice._offset;
+    internal readonly int Length => _slice._length;
+    internal long PreviousBuffersSize;
+
+    public BufferSliceReaderInput ForkFrom(int position)
+    {
+        var sliced = _slice.Slice(position);
+        return new BufferSliceReaderInput(in sliced);
+    }
+
+    public ReadOnlySpan<byte> GetNext()
+    {
+        if (ReferenceEquals(_segment, InitialSegmentSentinel))
+        {
+            _segment = _slice._buffer._first;
+        }
+
+        var endPosition = Offset + Length;
+        while (_segment != null && _segment != FinalSegmentSentinel)
+        {
+            var segment = _segment.CommittedMemory.Span;
+
+            // Find the starting segment and the offset to copy from.
+            int segmentOffset;
+            if (_position < Offset)
+            {
+                if (_position + segment.Length <= Offset)
+                {
+                    // Start is in a subsequent segment
+                    _position += segment.Length;
+                    _segment = _segment.Next as SequenceSegment;
+                    continue;
+                }
+                else
+                {
+                    // Start is in this segment
+                    segmentOffset = Offset;
+                }
+            }
+            else
+            {
+                segmentOffset = 0;
+            }
+
+            var segmentLength = Math.Min(segment.Length - segmentOffset, endPosition - (_position + segmentOffset));
+            if (segmentLength == 0)
+            {
+                ThrowInsufficientData();
+                return ReadOnlySpan<byte>.Empty;
+            }
+
+            var result = segment.Slice(segmentOffset, segmentLength);
+            _position += segmentOffset + segmentLength;
+            _segment = _segment.Next as SequenceSegment;
+            return result;
+        }
+
+        if (_segment != FinalSegmentSentinel && Buffer._currentPosition > 0 && Buffer._writeHead is { } head && _position < endPosition)
+        {
+            var finalOffset = Math.Max(Offset - _position, 0);
+            var finalLength = Math.Min(Buffer._currentPosition, endPosition - (_position + finalOffset));
+            if (finalLength == 0)
+            {
+                ThrowInsufficientData();
+                return ReadOnlySpan<byte>.Empty;
+            }
+
+            var result = head.Array.AsSpan(finalOffset, finalLength);
+            _position += finalLength;
+            Debug.Assert(_position == endPosition);
+            _segment = FinalSegmentSentinel;
+            return result;
+        }
+
+        ThrowInsufficientData();
+        return ReadOnlySpan<byte>.Empty;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
+}

--- a/src/Orleans.Serialization/Buffers/Adaptors/BufferWriterExtensions.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/BufferWriterExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Serialization.Buffers.Adaptors;
+
+internal static class BufferWriterExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Write<TBufferWriter>(this ref TBufferWriter writer, ReadOnlySequence<byte> input) where TBufferWriter : struct, IBufferWriter<byte>
+    {
+        foreach (var segment in input)
+        {
+            writer.Write(segment.Span);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Write<TBufferWriter>(ref this TBufferWriter writer, ReadOnlySpan<byte> value) where TBufferWriter : struct, IBufferWriter<byte>
+    {
+        var destination = writer.GetSpan();
+
+        // Fast path, try copying to the available memory directly
+        if (value.Length <= destination.Length)
+        {
+            value.CopyTo(destination);
+            writer.Advance(value.Length);
+        }
+        else
+        {
+            WriteMultiSegment(ref writer, value, destination);
+        }
+    }
+
+    private static void WriteMultiSegment<TBufferWriter>(ref TBufferWriter writer, in ReadOnlySpan<byte> source, Span<byte> destination) where TBufferWriter : struct, IBufferWriter<byte>
+    {
+        var input = source;
+        while (true)
+        {
+            var writeSize = Math.Min(destination.Length, input.Length);
+            input.Slice(0, writeSize).CopyTo(destination);
+            writer.Advance(writeSize);
+            input = input.Slice(writeSize);
+            if (input.Length > 0)
+            {
+                destination = writer.GetSpan();
+
+                continue;
+            }
+
+            return;
+        }
+    }
+}

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -5,20 +5,25 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if NET6_0_OR_GREATER
+using System.Numerics;
+#else
+using Orleans.Serialization.Utilities;
+#endif
 
-namespace Orleans.Serialization.Buffers.Adaptors;
+namespace Orleans.Serialization.Buffers;
 
 /// <summary>
 /// A <see cref="IBufferWriter{T}"/> implementation implemented using pooled arrays which is specialized for creating <see cref="ReadOnlySequence{T}"/> instances.
 /// </summary>
 [StructLayout(LayoutKind.Auto)]
-public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
+public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
 {
-    private SequenceSegment _first;
-    private SequenceSegment _last;
-    private SequenceSegment _current;
-    private long _totalLength;
-    private int _currentPosition;
+    internal SequenceSegment _first;
+    internal SequenceSegment _last;
+    internal SequenceSegment _writeHead;
+    internal int _totalLength;
+    internal int _currentPosition;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PooledArrayBufferWriter"/> struct.
@@ -26,13 +31,13 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     public PooledArrayBufferWriter()
     {
         _first = _last = null;
-        _current = null;
+        _writeHead = null;
         _totalLength = 0;
         _currentPosition = 0;
     }
 
     /// <summary>Gets the total length which has been written.</summary>
-    public readonly long Length => _totalLength + _currentPosition;
+    public readonly int Length => _totalLength + _currentPosition;
 
     /// <summary>
     /// Returns the data which has been written as an array.
@@ -51,9 +56,9 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
             current = current.Next as SequenceSegment;
         }
 
-        if (_current is not null && _currentPosition > 0)
+        if (_writeHead is not null && _currentPosition > 0)
         {
-            _current.Array.AsSpan(0, _currentPosition).CopyTo(resultSpan);
+            _writeHead.Array.AsSpan(0, _currentPosition).CopyTo(resultSpan);
         }
 
         return result;
@@ -63,7 +68,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Advance(int bytes)
     {
-        if (_current is null || _currentPosition > _current.Array.Length)
+        if (_writeHead is null || _currentPosition > _writeHead.Array.Length)
         {
             ThrowInvalidOperation();
         }
@@ -71,11 +76,14 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         _currentPosition += bytes;
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void ThrowInvalidOperation() => throw new InvalidOperationException("Attempted to advance past the end of a buffer.");
     }
 
-    /// <inheritdoc/>
-    public void Dispose()
+    /// <summary>
+    /// Resets this instance, returning all memory.
+    /// </summary>
+    public void Reset()
     {
         var current = _first;
         while (current != null)
@@ -85,36 +93,57 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
             previous.Return();
         }
 
-        _current?.Return();
+        _writeHead?.Return();
 
-        _first = _last = null;
-        _current = null;
-        _currentPosition = 0;
-        _totalLength = 0;
+        _first = _last = _writeHead = null;
+        _currentPosition = _totalLength = 0;
     }
+
+    /// <inheritdoc/>
+    public void Dispose() => Reset();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Memory<byte> GetMemory(int sizeHint = 0)
     {
-        if (_current is null || sizeHint >= _current.Array.Length - _currentPosition)
+        if (_writeHead is null || sizeHint >= _writeHead.Array.Length - _currentPosition)
         {
             return GetMemorySlow(sizeHint);
         }
 
-        return _current.AsMemory(_currentPosition);
+        return _writeHead.AsMemory(_currentPosition);
     }
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<byte> GetSpan(int sizeHint)
+    public Span<byte> GetSpan(int sizeHint = 0)
     {
-        if (_current is null || sizeHint >= _current.Array.Length - _currentPosition)
+        if (_writeHead is null || sizeHint >= _writeHead.Array.Length - _currentPosition)
         {
             return GetSpanSlow(sizeHint);
         }
 
-        return _current.Array.AsSpan(_currentPosition);
+        return _writeHead.Array.AsSpan(_currentPosition);
+    }
+
+    /// <summary>Copies the contents of this writer to a span.</summary>
+    public readonly void CopyTo(Span<byte> output)
+    {
+        var current = _first;
+        while (output.Length > 0 && current != null)
+        {
+            var segment = current.CommittedMemory.Span;
+            var slice = segment[..Math.Min(segment.Length, output.Length)];
+            slice.CopyTo(output);
+            output = output[slice.Length..];
+            current = current.Next as SequenceSegment;
+        }
+
+        if (output.Length > 0 && _currentPosition > 0 && _writeHead is not null)
+        {
+            var span = _writeHead.Array.AsSpan(0, Math.Min(output.Length, _currentPosition));
+            span.CopyTo(output);
+        }
     }
 
     /// <summary>Copies the contents of this writer to another writer.</summary>
@@ -128,9 +157,68 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
             current = current.Next as SequenceSegment;
         }
 
-        if (_currentPosition > 0 && _current is not null)
+        if (_currentPosition > 0 && _writeHead is not null)
         {
-            writer.Write(_current.Array.AsSpan(0, _currentPosition));
+            writer.Write(_writeHead.Array.AsSpan(0, _currentPosition));
+        }
+    }
+
+    /// <summary>Copies the contents of this writer to another writer.</summary>
+    public readonly void CopyTo<TBufferWriter>(ref TBufferWriter writer) where TBufferWriter : IBufferWriter<byte>
+    {
+        var current = _first;
+        while (current != null)
+        {
+            var span = current.CommittedMemory.Span;
+            writer.Write(span);
+            current = current.Next as SequenceSegment;
+        }
+
+        if (_currentPosition > 0 && _writeHead is not null)
+        {
+            Write(ref writer, _writeHead.Array.AsSpan(0, _currentPosition));
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Write<TBufferWriter>(ref TBufferWriter writer, ReadOnlySpan<byte> value) where TBufferWriter : IBufferWriter<byte>
+    {
+        Span<byte> destination = writer.GetSpan();
+
+        // Fast path, try copying to the available memory directly
+        if (value.Length <= destination.Length)
+        {
+            value.CopyTo(destination);
+            writer.Advance(value.Length);
+        }
+        else
+        {
+            WriteMultiSegment(ref writer, value, destination);
+        }
+    }
+
+    private static void WriteMultiSegment<TBufferWriter>(ref TBufferWriter writer, in ReadOnlySpan<byte> source, Span<byte> destination) where TBufferWriter : IBufferWriter<byte>
+    {
+        ReadOnlySpan<byte> input = source;
+        while (true)
+        {
+            int writeSize = Math.Min(destination.Length, input.Length);
+            input.Slice(0, writeSize).CopyTo(destination);
+            writer.Advance(writeSize);
+            input = input.Slice(writeSize);
+            if (input.Length > 0)
+            {
+                destination = writer.GetSpan();
+
+                if (destination.IsEmpty)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(writer));
+                }
+
+                continue;
+            }
+
+            return;
         }
     }
 
@@ -147,10 +235,91 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         Commit();
         if (_first == _last)
         {
-            return new ReadOnlySequence<byte>(_first.CommittedMemory);
+            return new ReadOnlySequence<byte>(_first!.CommittedMemory);
         }
 
-        return new ReadOnlySequence<byte>(_first, 0, _last, _last.CommittedMemory.Length);
+        return new ReadOnlySequence<byte>(_first!, 0, _last!, _last!.CommittedMemory.Length);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="BufferSlice"/> covering this entire buffer.
+    /// </summary>
+    /// <remarks>
+    /// The lifetime of the returned <see cref="BufferSlice"/> must be shorter than the lifetime of this instance.
+    /// </remarks>
+    /// <returns>A <see cref="BufferSlice"/> covering this entire buffer.</returns>
+    public BufferSlice Slice() => new(this, 0, Length);
+
+    /// <summary>
+    /// Returns a slice of this buffer, beginning at the specified offset.
+    /// </summary>
+    /// <remarks>
+    /// The lifetime of the returned <see cref="BufferSlice"/> must be shorter than the lifetime of this instance.
+    /// </remarks>
+    /// <returns>A slice representing a subset of this instance, beginning at the specified offset.</returns>
+    public BufferSlice Slice(int offset) => new(this, offset, Length - offset);
+
+    /// <summary>
+    /// Returns a slice of this buffer, beginning at the specified offset and having the specified length.
+    /// </summary>
+    /// <remarks>
+    /// The lifetime of the returned <see cref="BufferSlice"/> must be shorter than the lifetime of this instance.
+    /// </remarks>
+    /// <returns>A slice representing a subset of this instance, beginning at the specified offset.</returns>
+    public BufferSlice Slice(int offset, int length) => new(this, offset, length);
+
+    /// <summary>
+    /// Writes the provided sequence to this buffer.
+    /// </summary>
+    /// <param name="input">The data to write.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write(ReadOnlySequence<byte> input)
+    {
+        foreach (var segment in input)
+        {
+            Write(segment.Span);
+        }
+    }
+
+    /// <summary>
+    /// Writes the provided value to this buffer.
+    /// </summary>
+    /// <param name="value">The data to write.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write(ReadOnlySpan<byte> value)
+    {
+        var destination = GetSpan();
+
+        // Fast path, try copying to the available memory directly
+        if (value.Length <= destination.Length)
+        {
+            value.CopyTo(destination);
+            Advance(value.Length);
+        }
+        else
+        {
+            WriteMultiSegment(value, destination);
+        }
+    }
+
+    private void WriteMultiSegment(in ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        var input = source;
+        while (true)
+        {
+            var writeSize = Math.Min(destination.Length, input.Length);
+            input.Slice(0, writeSize).CopyTo(destination);
+            Advance(writeSize);
+            input = input.Slice(writeSize);
+            if (input.Length > 0)
+            {
+                destination = GetSpan();
+
+                continue;
+            }
+
+            return;
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -162,69 +331,519 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     private SequenceSegment Grow(int sizeHint)
     {
         Commit();
-        var newBuffer = SequenceSegment.Rent(sizeHint);
-        return _current = newBuffer;
+        var newBuffer = SequenceSegmentPool.Shared.Rent(sizeHint);
+        return _writeHead = newBuffer;
     }
 
     private void Commit()
     {
-        if (_currentPosition == 0 || _current is null)
+        if (_currentPosition == 0 || _writeHead is null)
         {
             return;
         }
 
-        _current.Commit(_totalLength, _currentPosition);
+        _writeHead.Commit(_totalLength, _currentPosition);
         _totalLength += _currentPosition;
         if (_first is null)
         {
-            _first = _current;
-            _last = _current;
+            _first = _writeHead;
+            _last = _writeHead;
         }
         else
         {
-            _last.SetNext(_current);
-            _last = _current;
+
+            Debug.Assert(_last is not null);
+            _last.SetNext(_writeHead);
+            _last = _writeHead;
         }
 
-        _current = null;
+        _writeHead = null;
         _currentPosition = 0;
     }
 
-    private sealed class SequenceSegment : ReadOnlySequenceSegment<byte>
+    /// <summary>
+    /// Returns an enumerable sequence of <see cref="Memory{T}"/> values which represent the data which has been written to this buffer.
+    /// </summary>
+    /// <returns>An enumerable sequence of <see cref="Memory{T}"/> values.</returns>
+    public BufferSlice.MemorySequence AsMemorySequence() => Slice().AsMemorySequence();
+
+    /// <summary>
+    /// Returns an enumerable sequence of <see cref="Span{T}"/> values which represent the data which has been written to this buffer.
+    /// </summary>
+    /// <returns>An enumerable sequence of <see cref="Span{T}"/> values.</returns>
+    public BufferSlice.SpanSequence AsSpanSequence() => Slice().AsSpanSequence();
+
+    /// <summary>
+    /// Represents a slice of a <see cref="PooledArrayBufferWriter"/>.
+    /// </summary>
+    public readonly struct BufferSlice
     {
-        private const int MinimumBlockSize = 4096;
-        private static readonly ConcurrentBag<SequenceSegment> Blocks = new();
+        internal readonly PooledArrayBufferWriter _buffer;
+        internal readonly int _offset;
+        internal readonly int _length;
 
-        public static SequenceSegment Rent(int size = -1) => size <= MinimumBlockSize && Blocks.TryTake(out var block) ? block : new(size);
-
-        private SequenceSegment(int length)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferSlice"/> type.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The offet into the buffer at which this slice begins.</param>
+        /// <param name="length">The length of this slice.</param>
+        public BufferSlice(in PooledArrayBufferWriter buffer, int offset, int length)
         {
-            if (length <= MinimumBlockSize)
+            _buffer = buffer;
+            _offset = offset;
+            _length = length;
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="PooledArrayBufferWriter"/>.
+        /// </summary>
+        public readonly PooledArrayBufferWriter Buffer => _buffer;
+
+        /// <summary>
+        /// Gets the offset into the underlying buffer at which this slice begins.
+        /// </summary>
+        public readonly int Offset => _offset;
+
+        /// <summary>
+        /// Gets the length of this slice.
+        /// </summary>
+        public readonly int Length => _length;
+
+        /// <summary>
+        /// Forms a slice out of this instance, beginning at the specified offset into this slice.
+        /// </summary>
+        /// <param name="offset">The offet into this slice where the newly formed slice will begin.</param>
+        /// <returns>A slice instance.</returns>
+        public readonly BufferSlice Slice(int offset) => new(in _buffer, _offset + offset, _length - offset);
+
+        /// <summary>
+        /// Forms a slice out of this instance, beginning at the specified offset into this slice and having the specified length.
+        /// </summary>
+        /// <param name="offset">The offet into this slice where the newly formed slice will begin.</param>
+        /// <param name="length">The lenght of the new slice.</param>
+        /// <returns>A slice instance.</returns>
+        public readonly BufferSlice Slice(int offset, int length) => new(in _buffer, _offset + offset, length);
+
+        /// <summary>Copies the contents of this writer to a span.</summary>
+        public readonly int CopyTo(Span<byte> output)
+        {
+            var copied = 0;
+            foreach (var span in this)
             {
-#if NET6_0_OR_GREATER
-                var pinnedArray = GC.AllocateUninitializedArray<byte>(MinimumBlockSize, pinned: true);
-#else
-                // Note: Not actually pinned in this case since it just a potential fragmentation optimization
-                var pinnedArray = new byte[MinimumBlockSize];
-#endif
-                Array = pinnedArray;
+                var slice = span[..Math.Min(span.Length, output.Length)];
+                slice.CopyTo(output);
+                output = output[slice.Length..];
+                copied += slice.Length;
+            }
+
+            return copied;
+        }
+
+        /// <summary>Copies the contents of this writer to a pooled buffer.</summary>
+        public readonly void CopyTo(ref PooledArrayBufferWriter output)
+        {
+            foreach (var span in this)
+            {
+                output.Write(span);
+            }
+        }
+
+        /// <summary>Copies the contents of this writer to a buffer writer.</summary>
+        public readonly void CopyTo<TBufferWriter>(ref TBufferWriter output) where TBufferWriter : struct, IBufferWriter<byte>
+        {
+            foreach (var span in this)
+            {
+                output.Write(span);
+            }
+        }
+
+        /// <summary>
+        /// Returns the data which has been written as an array.
+        /// </summary>
+        /// <returns>The data which has been written.</returns>
+        public readonly byte[] ToArray()
+        {
+            var result = new byte[_length];
+            CopyTo(result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns an enumerable sequence of <see cref="Memory{T}"/> values which represent the data which has been written to this buffer.
+        /// </summary>
+        /// <returns>An enumerable sequence of <see cref="Memory{T}"/> values.</returns>
+        public readonly MemorySequence AsMemorySequence() => new(this);
+
+        /// <summary>
+        /// Returns an enumerable sequence of <see cref="Span{T}"/> values which represent the data which has been written to this buffer.
+        /// </summary>
+        /// <returns>An enumerable sequence of <see cref="Span{T}"/> values.</returns>
+        public readonly SpanSequence AsSpanSequence() => new(this);
+
+        /// <summary>
+        /// Returns an enumerator which can be used to enumerate the data referenced by this instance.
+        /// </summary>
+        /// <returns>An enumerator for the data contained in this instance.</returns>
+        public readonly SpanEnumerator GetEnumerator() => new(this);
+
+        /// <summary>
+        /// Represents a sequence of <see cref="Memory{T}"/> values from a <see cref="BufferSlice"/>.
+        /// </summary>
+        public readonly ref struct MemorySequence
+        {
+            private readonly BufferSlice _slice;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="MemorySequence"/> type.
+            /// </summary>
+            /// <param name="slice">The slice.</param>
+            public MemorySequence(BufferSlice slice) => _slice = slice;
+
+            /// <summary>
+            /// Returns an enumerator for the underlying buffers.
+            /// </summary>
+            /// <returns>An enumerator.</returns>
+            public MemoryEnumerator GetEnumerator() => new(_slice);
+        }
+
+        /// <summary>
+        /// Represents a sequence of <see cref="Span{T}"/> values from a <see cref="BufferSlice"/>.
+        /// </summary>
+        public readonly ref struct SpanSequence
+        {
+            private readonly BufferSlice _slice;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SpanSequence"/> type.
+            /// </summary>
+            /// <param name="slice">The slice.</param>
+            public SpanSequence(BufferSlice slice) => _slice = slice;
+
+            /// <summary>
+            /// Returns an enumerator for the underlying buffers.
+            /// </summary>
+            /// <returns>An enumerator.</returns>
+            public SpanEnumerator GetEnumerator() => new(_slice);
+        }
+
+        /// <summary>
+        /// Enumerates over spans of bytes in a <see cref="BufferSlice"/>.
+        /// </summary>
+        public ref struct SpanEnumerator
+        {
+            private static readonly SequenceSegment InitialSegmentSentinel = new();
+            private static readonly SequenceSegment FinalSegmentSentinel = new();
+            private readonly BufferSlice _slice;
+            private int _position;
+            private SequenceSegment _segment;
+
+            /// <summary>
+            /// Intializes a new instance of the <see cref="SpanEnumerator"/> type.
+            /// </summary>
+            /// <param name="slice">The slice to enumerate.</param>
+            public SpanEnumerator(BufferSlice slice)
+            {
+                _slice = slice;
+                _segment = InitialSegmentSentinel;
+                Current = Span<byte>.Empty;
+            }
+
+            internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+            internal readonly int Offset => _slice._offset;
+            internal readonly int Length => _slice._length;
+
+            /// <summary>
+            /// Gets the element in the collection at the current position of the enumerator.
+            /// </summary>
+            public ReadOnlySpan<byte> Current { get; private set; }
+
+            /// <summary>
+            /// Advances the enumerator to the next element of the collection.
+            /// </summary>
+            /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
+            public bool MoveNext()
+            {
+                if (ReferenceEquals(_segment, InitialSegmentSentinel))
+                {
+                    _segment = _slice._buffer._first;
+                }
+
+                var endPosition = Offset + Length;
+                while (_segment != null && _segment != FinalSegmentSentinel)
+                {
+                    var segment = _segment.CommittedMemory.Span;
+
+                    // Find the starting segment and the offset to copy from.
+                    int segmentOffset;
+                    if (_position < Offset)
+                    {
+                        if (_position + segment.Length <= Offset)
+                        {
+                            // Start is in a subsequent segment
+                            _position += segment.Length;
+                            _segment = _segment.Next as SequenceSegment;
+                            continue;
+                        }
+                        else
+                        {
+                            // Start is in this segment
+                            segmentOffset = Offset;
+                        }
+                    }
+                    else
+                    {
+                        segmentOffset = 0;
+                    }
+
+                    var segmentLength = Math.Min(segment.Length - segmentOffset, endPosition - (_position + segmentOffset));
+                    if (segmentLength == 0)
+                    {
+                        Current = Span<byte>.Empty;
+                        _segment = FinalSegmentSentinel;
+                        return false;
+                    }
+
+                    Current = segment.Slice(segmentOffset, segmentLength);
+                    _position += segmentOffset + segmentLength;
+                    _segment = _segment.Next as SequenceSegment;
+                    return true;
+                }
+
+                if (_segment != FinalSegmentSentinel && Buffer._currentPosition > 0 && Buffer._writeHead is { } head && _position < endPosition)
+                {
+                    var finalOffset = Math.Max(Offset - _position, 0);
+                    var finalLength = Math.Min(Buffer._currentPosition, endPosition - (_position + finalOffset));
+                    if (finalLength == 0)
+                    {
+                        Current = Span<byte>.Empty;
+                        _segment = FinalSegmentSentinel;
+                        return false;
+                    }
+
+                    Current = head.Array.AsSpan(finalOffset, finalLength);
+                    _position += finalLength;
+                    Debug.Assert(_position == endPosition);
+                    _segment = FinalSegmentSentinel;
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Enumerates over sequences of bytes in a <see cref="BufferSlice"/>.
+        /// </summary>
+        public ref struct MemoryEnumerator
+        {
+            private static readonly SequenceSegment InitialSegmentSentinel = new();
+            private static readonly SequenceSegment FinalSegmentSentinel = new();
+            private readonly BufferSlice _slice;
+            private int _position;
+            private SequenceSegment _segment;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="MemoryEnumerator"/> type.
+            /// </summary>
+            /// <param name="slice">The slice to enumerate.</param>
+            public MemoryEnumerator(BufferSlice slice)
+            {
+                _slice = slice;
+                _segment = InitialSegmentSentinel;
+                Current = Memory<byte>.Empty;
+            }
+
+            internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+            internal readonly int Offset => _slice._offset;
+            internal readonly int Length => _slice._length;
+
+            /// <summary>
+            /// Gets the element in the collection at the current position of the enumerator.
+            /// </summary>
+            public ReadOnlyMemory<byte> Current { get; private set; }
+
+            /// <summary>
+            /// Advances the enumerator to the next element of the collection.
+            /// </summary>
+            /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
+            public bool MoveNext()
+            {
+                if (ReferenceEquals(_segment, InitialSegmentSentinel))
+                {
+                    _segment = _slice._buffer._first;
+                }
+
+                var endPosition = Offset + Length;
+                while (_segment != null && _segment != FinalSegmentSentinel)
+                {
+                    var segment = _segment.CommittedMemory;
+
+                    // Find the starting segment and the offset to copy from.
+                    int segmentOffset;
+                    if (_position < Offset)
+                    {
+                        if (_position + segment.Length <= Offset)
+                        {
+                            // Start is in a subsequent segment
+                            _position += segment.Length;
+                            _segment = _segment.Next as SequenceSegment;
+                            continue;
+                        }
+                        else
+                        {
+                            // Start is in this segment
+                            segmentOffset = Offset;
+                        }
+                    }
+                    else
+                    {
+                        segmentOffset = 0;
+                    }
+
+                    var segmentLength = Math.Min(segment.Length - segmentOffset, endPosition - (_position + segmentOffset));
+                    if (segmentLength == 0)
+                    {
+                        Current = Memory<byte>.Empty;
+                        return false;
+                    }
+
+                    Current = segment.Slice(segmentOffset, segmentLength);
+                    _position += segmentOffset + segmentLength;
+                    _segment = _segment.Next as SequenceSegment;
+                    return true;
+                }
+
+                if (_segment != FinalSegmentSentinel && Buffer._currentPosition > 0 && Buffer._writeHead is { } head && _position < endPosition)
+                {
+                    var finalOffset = Math.Max(Offset - _position, 0);
+                    var finalLength = Math.Min(Buffer._currentPosition, endPosition - (_position + finalOffset));
+                    if (finalLength == 0)
+                    {
+                        Current = Memory<byte>.Empty;
+                        return false;
+                    }
+
+                    Current = head.Array.AsMemory(finalOffset, finalLength);
+                    _position += finalLength;
+                    Debug.Assert(_position == endPosition);
+                    _segment = FinalSegmentSentinel;
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+
+    private sealed class SequenceSegmentPool
+    {
+        public static SequenceSegmentPool Shared { get; } = new();
+        public const int MinimumBlockSize = 4 * 1024;
+        private readonly ConcurrentQueue<SequenceSegment> _blocks = new();
+        private readonly ConcurrentQueue<SequenceSegment> _largeBlocks = new();
+
+        private SequenceSegmentPool() { }
+
+        public SequenceSegment Rent(int size = -1)
+        {
+            SequenceSegment block;
+            if (size <= MinimumBlockSize)
+            {
+                if (!_blocks.TryDequeue(out block))
+                {
+                    block = new SequenceSegment(size);
+                }
+            }
+            else if (_largeBlocks.TryDequeue(out block))
+            {
+                block.ResizeLargeSegment(size);
+                return block;
+            }
+
+            return block ?? new SequenceSegment(size);
+        }
+
+        internal void Return(SequenceSegment block)
+        {
+            Debug.Assert(block.IsValid);
+            if (block.IsMinimumSize)
+            {
+                _blocks.Enqueue(block);
             }
             else
             {
+                _largeBlocks.Enqueue(block);
+            }
+        }
+    }
+
+    internal sealed class SequenceSegment : ReadOnlySequenceSegment<byte>
+    {
+        internal SequenceSegment()
+        {
+            Array = System.Array.Empty<byte>();
+        }
+
+        internal SequenceSegment(int length)
+        {
+            InitializeArray(length);
+        }
+
+        public void ResizeLargeSegment(int length)
+        {
+            Debug.Assert(length > SequenceSegmentPool.MinimumBlockSize);
+            InitializeArray(length);
+        }
+
+#if NET6_0_OR_GREATER
+        [MemberNotNull(nameof(Array))]
+#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void InitializeArray(int length)
+        {
+            if (length <= SequenceSegmentPool.MinimumBlockSize)
+            {
+                Debug.Assert(Array is null);
+#if NET6_0_OR_GREATER
+                var array = GC.AllocateUninitializedArray<byte>(SequenceSegmentPool.MinimumBlockSize, pinned: true);
+#else
+                var array = new byte[SequenceSegmentPool.MinimumBlockSize];
+#endif
+                Array = array;
+            }
+            else
+            {
+                // Round up to a power of two.
+                length = (int)BitOperations.RoundUpToPowerOf2((uint)length);
+
+                if (Array is not null)
+                {
+                    // The segment has an appropriate size already.
+                    if (Array.Length == length)
+                    {
+                        return;
+                    }
+
+                    // The segment is being resized.
+                    ArrayPool<byte>.Shared.Return(Array);
+                }
+
                 Array = ArrayPool<byte>.Shared.Rent(length);
             }
         }
 
         public byte[] Array { get; private set; }
 
-        public ReadOnlyMemory<byte> CommittedMemory => base.Memory;
+        public ReadOnlyMemory<byte> CommittedMemory => Memory;
 
-        private bool IsStandardSize => Array.Length == MinimumBlockSize;
+        public bool IsValid => Array is { Length: > 0 };
+        public bool IsMinimumSize => Array.Length == SequenceSegmentPool.MinimumBlockSize;
 
         public Memory<byte> AsMemory(int offset)
         {
 #if NET6_0_OR_GREATER
-            if (IsStandardSize)
+            if (IsMinimumSize)
             {
                 return MemoryMarshal.CreateFromPinnedArray(Array, offset, Array.Length - offset);
             }
@@ -236,7 +855,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         public Memory<byte> AsMemory(int offset, int length)
         {
 #if NET6_0_OR_GREATER
-            if (IsStandardSize)
+            if (IsMinimumSize)
             {
                 return MemoryMarshal.CreateFromPinnedArray(Array, offset, length);
             }
@@ -248,7 +867,7 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         public void Commit(long runningIndex, int length)
         {
             RunningIndex = runningIndex;
-            base.Memory = AsMemory(0, length);
+            Memory = AsMemory(0, length);
         }
 
         public void SetNext(SequenceSegment next) => Next = next;
@@ -257,17 +876,9 @@ public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         {
             RunningIndex = default;
             Next = default;
-            base.Memory = default;
+            Memory = default;
 
-            if (IsStandardSize)
-            {
-                Blocks.Add(this);
-            }
-            else
-            {
-                ArrayPool<byte>.Shared.Return(Array);
-                Array = null;
-            }
+            SequenceSegmentPool.Shared.Return(this);
         }
     }
 }

--- a/src/Orleans.Serialization/Buffers/PooledBuffer.cs
+++ b/src/Orleans.Serialization/Buffers/PooledBuffer.cs
@@ -17,7 +17,7 @@ namespace Orleans.Serialization.Buffers;
 /// A <see cref="IBufferWriter{T}"/> implementation implemented using pooled arrays which is specialized for creating <see cref="ReadOnlySequence{T}"/> instances.
 /// </summary>
 [StructLayout(LayoutKind.Auto)]
-public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
+public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
 {
     internal SequenceSegment _first;
     internal SequenceSegment _last;
@@ -26,9 +26,9 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     internal int _currentPosition;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PooledArrayBufferWriter"/> struct.
+    /// Initializes a new instance of the <see cref="PooledBuffer"/> struct.
     /// </summary>
-    public PooledArrayBufferWriter()
+    public PooledBuffer()
     {
         _first = _last = null;
         _writeHead = null;
@@ -374,11 +374,11 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
     public BufferSlice.SpanSequence AsSpanSequence() => Slice().AsSpanSequence();
 
     /// <summary>
-    /// Represents a slice of a <see cref="PooledArrayBufferWriter"/>.
+    /// Represents a slice of a <see cref="PooledBuffer"/>.
     /// </summary>
     public readonly struct BufferSlice
     {
-        internal readonly PooledArrayBufferWriter _buffer;
+        internal readonly PooledBuffer _buffer;
         internal readonly int _offset;
         internal readonly int _length;
 
@@ -388,7 +388,7 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         /// <param name="buffer">The buffer.</param>
         /// <param name="offset">The offet into the buffer at which this slice begins.</param>
         /// <param name="length">The length of this slice.</param>
-        public BufferSlice(in PooledArrayBufferWriter buffer, int offset, int length)
+        public BufferSlice(in PooledBuffer buffer, int offset, int length)
         {
             _buffer = buffer;
             _offset = offset;
@@ -396,9 +396,9 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         }
 
         /// <summary>
-        /// Gets the underlying <see cref="PooledArrayBufferWriter"/>.
+        /// Gets the underlying <see cref="PooledBuffer"/>.
         /// </summary>
-        public readonly PooledArrayBufferWriter Buffer => _buffer;
+        public readonly PooledBuffer Buffer => _buffer;
 
         /// <summary>
         /// Gets the offset into the underlying buffer at which this slice begins.
@@ -441,7 +441,7 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
         }
 
         /// <summary>Copies the contents of this writer to a pooled buffer.</summary>
-        public readonly void CopyTo(ref PooledArrayBufferWriter output)
+        public readonly void CopyTo(ref PooledBuffer output)
         {
             foreach (var span in this)
             {
@@ -549,7 +549,7 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
                 Current = Span<byte>.Empty;
             }
 
-            internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+            internal readonly PooledBuffer Buffer => _slice._buffer;
             internal readonly int Offset => _slice._offset;
             internal readonly int Length => _slice._length;
 
@@ -654,7 +654,7 @@ public partial struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
                 Current = Memory<byte>.Empty;
             }
 
-            internal readonly PooledArrayBufferWriter Buffer => _slice._buffer;
+            internal readonly PooledBuffer Buffer => _slice._buffer;
             internal readonly int Offset => _slice._offset;
             internal readonly int Length => _slice._length;
 

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Numerics;
 #endif
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Orleans.Serialization.Buffers.Adaptors;
 using Orleans.Serialization.Session;
+using static Orleans.Serialization.Buffers.PooledArrayBufferWriter;
 #if !NETCOREAPP3_1_OR_GREATER
 using Orleans.Serialization.Utilities;
 #endif
@@ -175,6 +178,33 @@ namespace Orleans.Serialization.Buffers
         /// <summary>
         /// Creates a reader for the provided input stream.
         /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Reader<BufferSliceReaderInput> Create(PooledArrayBufferWriter input, SerializerSession session) => Create(input.Slice(), session);
+
+        /// <summary>
+        /// Creates a reader for the provided input stream.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Reader<BufferSliceReaderInput> Create(BufferSlice input, SerializerSession session) => Create(new BufferSliceReaderInput(in input), session);
+
+        /// <summary>
+        /// Creates a reader for the provided input stream.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Reader<BufferSliceReaderInput> Create(BufferSliceReaderInput input, SerializerSession session) => new Reader<BufferSliceReaderInput>(input, session, 0);
+
+        /// <summary>
+        /// Creates a reader for the provided input stream.
+        /// </summary>
         /// <param name="stream">The stream.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
@@ -188,7 +218,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<ReadOnlySequence<byte>> Create(ReadOnlySequence<byte> sequence, SerializerSession session) => new Reader<ReadOnlySequence<byte>>(sequence, session, 0);
+        public static Reader<ReadOnlySequenceInput> Create(ReadOnlySequence<byte> sequence, SerializerSession session) => new Reader<ReadOnlySequenceInput>(new ReadOnlySequenceInput { Sequence = sequence }, session, 0);
 
         /// <summary>
         /// Creates a reader for the provided input data.
@@ -226,20 +256,29 @@ namespace Orleans.Serialization.Buffers
     }
 
     /// <summary>
+    /// Input type for <see cref="Reader{TInput}"/> to support <see cref="ReadOnlySequence{Byte}"/> buffers.
+    /// </summary>
+    public struct ReadOnlySequenceInput
+    {
+        internal ReadOnlySequence<byte> Sequence;
+        internal SequencePosition NextSequencePosition;
+        internal long PreviousBuffersSize;
+    }
+
+    /// <summary>
     /// Provides functionality for parsing data from binary input.
     /// </summary>
     /// <typeparam name="TInput">The underlying buffer reader type.</typeparam>
     public ref struct Reader<TInput>
     {
         private readonly static bool IsSpanInput = typeof(TInput) == typeof(SpanReaderInput);
-        private readonly static bool IsReadOnlySequenceInput = typeof(TInput) == typeof(ReadOnlySequence<byte>);
+        private readonly static bool IsReadOnlySequenceInput = typeof(TInput) == typeof(ReadOnlySequenceInput);
         private readonly static bool IsReaderInput = typeof(ReaderInput).IsAssignableFrom(typeof(TInput));
+        private readonly static bool IsBufferSliceInput = typeof(BufferSliceReaderInput).IsAssignableFrom(typeof(TInput));
         
         private ReadOnlySpan<byte> _currentSpan;
-        private SequencePosition _nextSequencePosition;
         private int _bufferPos;
         private int _bufferSize;
-        private long _previousBuffersSize;
         private readonly long _sequenceOffset;
         private TInput _input;
         
@@ -248,23 +287,30 @@ namespace Orleans.Serialization.Buffers
         {
             if (IsReadOnlySequenceInput)
             {
-                ref var sequence = ref Unsafe.As<TInput, ReadOnlySequence<byte>>(ref input);
+                ref var typedInput = ref Unsafe.As<TInput, ReadOnlySequenceInput>(ref input);
+                var sequence = typedInput.Sequence;
+                typedInput.NextSequencePosition = sequence.Start;
                 _input = input;
-                _nextSequencePosition = sequence.Start;
                 _currentSpan = sequence.First.Span;
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
-                _previousBuffersSize = 0;
+                _sequenceOffset = globalOffset;
+            }
+            else if (IsBufferSliceInput)
+            {
+                _input = input;
+                ref var slice = ref Unsafe.As<TInput, BufferSliceReaderInput>(ref _input);
+                _currentSpan = slice.GetNext();
+                _bufferPos = 0;
+                _bufferSize = _currentSpan.Length;
                 _sequenceOffset = globalOffset;
             }
             else if (IsReaderInput)
             {
                 _input = input;
-                _nextSequencePosition = default;
                 _currentSpan = default;
                 _bufferPos = 0;
                 _bufferSize = default;
-                _previousBuffersSize = 0;
                 _sequenceOffset = globalOffset;
             }
             else
@@ -281,11 +327,9 @@ namespace Orleans.Serialization.Buffers
             if (IsSpanInput)
             {
                 _input = default;
-                _nextSequencePosition = default;
                 _currentSpan = input; 
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
-                _previousBuffersSize = 0;
                 _sequenceOffset = globalOffset;
             }
             else
@@ -313,7 +357,13 @@ namespace Orleans.Serialization.Buffers
             {
                 if (IsReadOnlySequenceInput)
                 {
-                    return _sequenceOffset + _previousBuffersSize + _bufferPos;
+                    var previousBuffersSize = Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).PreviousBuffersSize;
+                    return _sequenceOffset + previousBuffersSize + _bufferPos;
+                }
+                else if (IsBufferSliceInput)
+                {
+                    var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
+                    return _sequenceOffset + previousBuffersSize + _bufferPos;
                 }
                 else if (IsSpanInput)
                 {
@@ -340,7 +390,11 @@ namespace Orleans.Serialization.Buffers
             {
                 if (IsReadOnlySequenceInput)
                 {
-                    return Unsafe.As<TInput, ReadOnlySequence<byte>>(ref _input).Length;
+                    return Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).Sequence.Length;
+                }
+                else if (IsBufferSliceInput)
+                {
+                    return Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).Length;
                 }
                 else if (IsSpanInput)
                 {
@@ -363,14 +417,31 @@ namespace Orleans.Serialization.Buffers
         /// <param name="count">The number of bytes to skip.</param>
         public void Skip(long count)
         {
-            if (IsReadOnlySequenceInput)
+            if (IsReadOnlySequenceInput || IsBufferSliceInput)
             {
+                var previousBuffersSize = Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).PreviousBuffersSize;
                 var end = Position + count;
                 while (Position < end)
                 {
                     if (Position + _bufferSize >= end)
                     {
-                        _bufferPos = (int)(end - _previousBuffersSize);
+                        _bufferPos = (int)(end - previousBuffersSize);
+                    }
+                    else
+                    {
+                        MoveNext();
+                    }
+                }
+            }
+            else if (IsBufferSliceInput)
+            {
+                var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
+                var end = Position + count;
+                while (Position < end)
+                {
+                    if (Position + _bufferSize >= end)
+                    {
+                        _bufferPos = (int)(end - previousBuffersSize);
                     }
                     else
                     {
@@ -409,9 +480,24 @@ namespace Orleans.Serialization.Buffers
         {
             if (IsReadOnlySequenceInput)
             {
-                ref var sequence = ref Unsafe.As<TInput, ReadOnlySequence<byte>>(ref _input);
-                var slicedSequence = sequence.Slice(position - _sequenceOffset);
-                forked = new Reader<TInput>(Unsafe.As<ReadOnlySequence<byte>, TInput>(ref slicedSequence), Session, position);
+                ref var typedInput = ref Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input);
+                var slicedSequence = typedInput.Sequence.Slice(position - _sequenceOffset);
+                var newInput = new ReadOnlySequenceInput
+                {
+                    Sequence = slicedSequence
+                };
+                forked = new Reader<TInput>(Unsafe.As<ReadOnlySequenceInput, TInput>(ref newInput), Session, position);
+
+                if (forked.Position != position)
+                {
+                    ThrowInvalidPosition(position, forked.Position);
+                }
+            }
+            else if (IsBufferSliceInput)
+            {
+                ref var input = ref Unsafe.As<TInput, BufferSliceReaderInput>(ref _input);
+                var newInput = input.ForkFrom(checked((int)position));
+                forked = new Reader<TInput>(Unsafe.As<BufferSliceReaderInput, TInput>(ref newInput), Session, position);
 
                 if (forked.Position != position)
                 {
@@ -459,6 +545,10 @@ namespace Orleans.Serialization.Buffers
             {
                 // Nothing is required.
             }
+            else if (IsBufferSliceInput)
+            {
+                // Nothing is required.
+            }
             else if (IsSpanInput)
             {
                 // Nothing is required.
@@ -489,22 +579,30 @@ namespace Orleans.Serialization.Buffers
         {
             if (IsReadOnlySequenceInput)
             {
-                ref var sequence = ref Unsafe.As<TInput, ReadOnlySequence<byte>>(ref _input);
-                _previousBuffersSize += _bufferSize;
+                ref var typedInput = ref Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input);
+                typedInput.PreviousBuffersSize += _bufferSize;
 
                 // If this is the first call to MoveNext then nextSequencePosition is invalid and must be moved to the second position.
-                if (_nextSequencePosition.Equals(sequence.Start))
+                if (typedInput.NextSequencePosition.Equals(typedInput.Sequence.Start))
                 {
-                    _ = sequence.TryGet(ref _nextSequencePosition, out _);
+                    _ = typedInput.Sequence.TryGet(ref typedInput.NextSequencePosition, out _);
                 }
 
-                if (!sequence.TryGet(ref _nextSequencePosition, out var memory))
+                if (!typedInput.Sequence.TryGet(ref typedInput.NextSequencePosition, out var memory))
                 {
                     _currentSpan = memory.Span;
                     ThrowInsufficientData();
                 }
 
                 _currentSpan = memory.Span;
+                _bufferPos = 0;
+                _bufferSize = _currentSpan.Length;
+            }
+            else if (IsBufferSliceInput)
+            {
+                ref var slice = ref Unsafe.As<TInput, BufferSliceReaderInput>(ref _input);
+                slice.PreviousBuffersSize += _bufferSize;
+                _currentSpan = slice.GetNext();
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
             }
@@ -525,7 +623,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte ReadByte()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 var pos = _bufferPos;
                 if ((uint)pos < (uint)_currentSpan.Length)
@@ -567,7 +665,7 @@ namespace Orleans.Serialization.Buffers
         /// <returns>The <see cref="uint"/> which was read.</returns>
         public uint ReadUInt32()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 const int width = 4;
                 if (_bufferPos + width > _bufferSize)
@@ -611,7 +709,7 @@ namespace Orleans.Serialization.Buffers
         /// <returns>The <see cref="ulong"/> which was read.</returns>
         public ulong ReadUInt64()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 const int width = 8;
                 if (_bufferPos + width > _bufferSize)
@@ -648,6 +746,7 @@ namespace Orleans.Serialization.Buffers
             }
         }
 
+        [DoesNotReturn]
         private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
 
         /// <summary>
@@ -688,7 +787,7 @@ namespace Orleans.Serialization.Buffers
             }
 
             var bytes = new byte[count];
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 var destination = new Span<byte>(bytes);
                 ReadBytes(destination);
@@ -707,7 +806,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="destination">The destination.</param>
         public void ReadBytes(scoped Span<byte> destination)
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 if (_bufferPos + destination.Length <= _bufferSize)
                 {
@@ -755,7 +854,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryReadBytes(int length, out ReadOnlySpan<byte> bytes)
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 if (_bufferPos + length <= _bufferSize)
                 {
@@ -788,7 +887,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe uint ReadVarUInt32()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 var pos = _bufferPos;
 
@@ -846,7 +945,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong ReadVarUInt64()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
             {
                 var pos = _bufferPos;
 

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -176,7 +176,7 @@ namespace Orleans.Serialization.Buffers
     public static class Reader
     {
         /// <summary>
-        /// Creates a reader for the provided input stream.
+        /// Creates a reader for the provided buffer.
         /// </summary>
         /// <param name="input">The input.</param>
         /// <param name="session">The session.</param>
@@ -185,22 +185,13 @@ namespace Orleans.Serialization.Buffers
         public static Reader<BufferSliceReaderInput> Create(PooledBuffer input, SerializerSession session) => Create(input.Slice(), session);
 
         /// <summary>
-        /// Creates a reader for the provided input stream.
+        /// Creates a reader for the provided buffer.
         /// </summary>
         /// <param name="input">The input.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<BufferSliceReaderInput> Create(BufferSlice input, SerializerSession session) => Create(new BufferSliceReaderInput(in input), session);
-
-        /// <summary>
-        /// Creates a reader for the provided input stream.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="session">The session.</param>
-        /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<BufferSliceReaderInput> Create(BufferSliceReaderInput input, SerializerSession session) => new Reader<BufferSliceReaderInput>(input, session, 0);
+        public static Reader<BufferSliceReaderInput> Create(BufferSlice input, SerializerSession session) => new(new BufferSliceReaderInput(in input), session, 0);
 
         /// <summary>
         /// Creates a reader for the provided input stream.
@@ -209,43 +200,43 @@ namespace Orleans.Serialization.Buffers
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<ReaderInput> Create(Stream stream, SerializerSession session) => new Reader<ReaderInput>(new StreamReaderInput(stream, ArrayPool<byte>.Shared), session, 0);
+        public static Reader<ReaderInput> Create(Stream stream, SerializerSession session) => new(new StreamReaderInput(stream, ArrayPool<byte>.Shared), session, 0);
 
         /// <summary>
-        /// Creates a reader for the provided input data.
+        /// Creates a reader for the provided buffer.
         /// </summary>
-        /// <param name="sequence">The input data.</param>
+        /// <param name="sequence">The buffer.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<ReadOnlySequenceInput> Create(ReadOnlySequence<byte> sequence, SerializerSession session) => new Reader<ReadOnlySequenceInput>(new ReadOnlySequenceInput { Sequence = sequence }, session, 0);
+        public static Reader<ReadOnlySequenceInput> Create(ReadOnlySequence<byte> sequence, SerializerSession session) => new(new ReadOnlySequenceInput { Sequence = sequence }, session, 0);
 
         /// <summary>
-        /// Creates a reader for the provided input data.
+        /// Creates a reader for the provided buffer.
         /// </summary>
-        /// <param name="buffer">The input data.</param>
+        /// <param name="buffer">The buffer.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<SpanReaderInput> Create(ReadOnlySpan<byte> buffer, SerializerSession session) => new Reader<SpanReaderInput>(buffer, session, 0);
+        public static Reader<SpanReaderInput> Create(ReadOnlySpan<byte> buffer, SerializerSession session) => new(buffer, session, 0);
 
         /// <summary>
-        /// Creates a reader for the provided input data.
+        /// Creates a reader for the provided buffer.
         /// </summary>
-        /// <param name="buffer">The input data.</param>
+        /// <param name="buffer">The buffer.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<SpanReaderInput> Create(byte[] buffer, SerializerSession session) => new Reader<SpanReaderInput>(buffer, session, 0);
+        public static Reader<SpanReaderInput> Create(byte[] buffer, SerializerSession session) => new(buffer, session, 0);
 
         /// <summary>
-        /// Creates a reader for the provided input data.
+        /// Creates a reader for the provided buffer.
         /// </summary>
-        /// <param name="buffer">The input data.</param>
+        /// <param name="buffer">The buffer.</param>
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<SpanReaderInput> Create(ReadOnlyMemory<byte> buffer, SerializerSession session) => new Reader<SpanReaderInput>(buffer.Span, session, 0);
+        public static Reader<SpanReaderInput> Create(ReadOnlyMemory<byte> buffer, SerializerSession session) => new(buffer.Span, session, 0);
     }
 
     /// <summary>
@@ -274,7 +265,7 @@ namespace Orleans.Serialization.Buffers
         private readonly static bool IsSpanInput = typeof(TInput) == typeof(SpanReaderInput);
         private readonly static bool IsReadOnlySequenceInput = typeof(TInput) == typeof(ReadOnlySequenceInput);
         private readonly static bool IsReaderInput = typeof(ReaderInput).IsAssignableFrom(typeof(TInput));
-        private readonly static bool IsBufferSliceInput = typeof(BufferSliceReaderInput).IsAssignableFrom(typeof(TInput));
+        private readonly static bool IsBufferSliceInput = typeof(TInput) == typeof(BufferSliceReaderInput);
         
         private ReadOnlySpan<byte> _currentSpan;
         private int _bufferPos;

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Orleans.Serialization.Buffers.Adaptors;
 using Orleans.Serialization.Session;
-using static Orleans.Serialization.Buffers.PooledArrayBufferWriter;
+using static Orleans.Serialization.Buffers.PooledBuffer;
 #if !NETCOREAPP3_1_OR_GREATER
 using Orleans.Serialization.Utilities;
 #endif
@@ -182,7 +182,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Reader<BufferSliceReaderInput> Create(PooledArrayBufferWriter input, SerializerSession session) => Create(input.Slice(), session);
+        public static Reader<BufferSliceReaderInput> Create(PooledBuffer input, SerializerSession session) => Create(input.Slice(), session);
 
         /// <summary>
         /// Creates a reader for the provided input stream.

--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -92,7 +92,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Writer{TBufferWriter}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Writer<PooledArrayBufferWriter> CreatePooled(SerializerSession session) => new(new PooledArrayBufferWriter(), session);
+        public static Writer<PooledBuffer> CreatePooled(SerializerSession session) => new(new PooledBuffer(), session);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Utilities/BitOperations.cs
+++ b/src/Orleans.Serialization/Utilities/BitOperations.cs
@@ -129,6 +129,25 @@ namespace Orleans.Serialization.Utilities
 
             return TrailingZeroCount(lo);
         }
+
+        /// <summary>Round the given integral value up to a power of 2.</summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint RoundUpToPowerOf2(uint value)
+        {
+            // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --value;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+        }
     }
 #endif
 }

--- a/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
+++ b/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
@@ -1,4 +1,5 @@
 using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.WireProtocol;
@@ -25,6 +26,18 @@ namespace Orleans.Serialization.Utilities
             var res = new StringBuilder();
             Format(ref reader, res);
             return res.ToString();
+        }
+
+        /// <summary>
+        /// Formats the specified array.
+        /// </summary>
+        /// <param name="slice">The array.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>The formatted input.</returns>
+        public static string Format(PooledArrayBufferWriter.BufferSlice slice, SerializerSession session)
+        {
+            var reader = Reader.Create(slice, session);
+            return Format(ref reader);
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
+++ b/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
@@ -34,7 +34,7 @@ namespace Orleans.Serialization.Utilities
         /// <param name="slice">The array.</param>
         /// <param name="session">The session.</param>
         /// <returns>The formatted input.</returns>
-        public static string Format(PooledArrayBufferWriter.BufferSlice slice, SerializerSession session)
+        public static string Format(PooledBuffer.BufferSlice slice, SerializerSession session)
         {
             var reader = Reader.Create(slice, session);
             return Format(ref reader);

--- a/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
@@ -1,4 +1,4 @@
-﻿using CsCheck;
+using CsCheck;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Buffers.Adaptors;
 using Orleans.Serialization.Session;
@@ -175,14 +175,14 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [Trait("Category", "BVT")]
-    public sealed class ReaderWriterSegmentWriterTest : ReaderWriterTestBase<TestMultiSegmentBufferWriter, TestMultiSegmentBufferWriter, ReadOnlySequence<byte>>
+    public sealed class ReaderWriterSegmentWriterTest : ReaderWriterTestBase<TestMultiSegmentBufferWriter, TestMultiSegmentBufferWriter, ReadOnlySequenceInput>
     {
         public ReaderWriterSegmentWriterTest(ITestOutputHelper output) : base(output)
         {
         }
 
         protected override TestMultiSegmentBufferWriter CreateBuffer() => new(maxAllocationSize: 10);
-        protected override Reader<ReadOnlySequence<byte>> CreateReader(TestMultiSegmentBufferWriter buffer, SerializerSession session) => Reader.Create(buffer.GetReadOnlySequence(maxSegmentSize: 8), session);
+        protected override Reader<ReadOnlySequenceInput> CreateReader(TestMultiSegmentBufferWriter buffer, SerializerSession session) => Reader.Create(buffer.GetReadOnlySequence(maxSegmentSize: 8), session);
         protected override Writer<TestMultiSegmentBufferWriter> CreateWriter(TestMultiSegmentBufferWriter buffer, SerializerSession session) => Writer.Create(buffer, session);
         protected override TestMultiSegmentBufferWriter GetBuffer(TestMultiSegmentBufferWriter originalBuffer, TestMultiSegmentBufferWriter output) => output;
         protected override void DisposeBuffer(TestMultiSegmentBufferWriter buffer, TestMultiSegmentBufferWriter output)


### PR DESCRIPTION
* Improve versatility of `PooledArrayBufferWriter` so that it can be cheaply sliced, enumerated, and used as an input to `Reader<TInput>` (for deserialization).
* Reduce size of Reader when not using `ReadOnlySequence<byte>` or `BufferSlice` as input

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8307)