### PR TITLE
Improve accuracy and stability of `ActivationWorkingSet`

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -657,9 +657,10 @@ namespace Orleans.Runtime
 
         bool IActivationWorkingSetMember.IsCandidateForRemoval(bool wouldRemove)
         {
+            const int IdlenessLowerBound = 10_000;
             lock (this)
             {
-                var inactive = IsInactive;
+                var inactive = IsInactive && _idleDuration.ElapsedMilliseconds > IdlenessLowerBound;
 
                 // This instance will remain in the working set if it is either not pending removal or if it is currently active.
                 _isInWorkingSet = !wouldRemove || !inactive;


### PR DESCRIPTION
The current logic in `ActivationWorkingSet` will remove a grain from the working set if it is visited twice consecutively and was idle both times. This does not account for cases where the grain was busy between those visits. The improved logic in this PR uses the idle duration to cover the period and reduce the chance of a would-be active grain being evicted from the working set.

I also increased the scan interval, since 100ms is needlessly aggressive for what is essentially a rolling window.