### PR TITLE
Fix Benchmark map Reduce 

### DIFF
--- a/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/GrainStorage/IPersistentGrain.cs
@@ -4,9 +4,13 @@ using Orleans;
 
 namespace BenchmarkGrainInterfaces.GrainStorage
 {
+    [GenerateSerializer]
     public class Report
     {
+        [Id(1)]
         public bool Success { get; set; }
+
+        [Id(2)]
         public TimeSpan Elapsed { get; set; }
     }
 

--- a/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
@@ -1,14 +1,22 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans;
 
 namespace BenchmarkGrainInterfaces.Transaction
 {
+    [GenerateSerializer]
     public class Report
     {
+        [Id(1)]
         public int Succeeded { get; set; }
+
+        [Id(2)]
         public int Failed { get; set; }
+
+        [Id(3)]
         public int Throttled { get; set; }
+
+        [Id(4)]
         public TimeSpan Elapsed { get; set; }
     }
 

--- a/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Orleans;
 

--- a/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
+++ b/test/Grains/BenchmarkGrainInterfaces/Transaction/ILoadGrain.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Orleans;
 


### PR DESCRIPTION
Added GenerateSerializer and Id to Report class in IPerstentGrain.cs and ILoadGrain.cs so Benchmark map reduce runs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8332)