### PR TITLE
Fix assembly name sanitization in code generator

### DIFF
--- a/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/Identifier.cs
@@ -116,8 +116,17 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             }
         }
 
-        private static readonly Regex SanitizeIdentifierRegex = new("[-\\.]", RegexOptions.Compiled);
+        private static readonly Regex SanitizeIdentifierRegex = new("^([0-9]+)|([^0-9a-zA-Z_]+)", RegexOptions.Compiled);
 
-        public static string SanitizeIdentifierName(string input) => SanitizeIdentifierRegex.Replace(input, "");
+        public static string SanitizeIdentifierName(string input) => SanitizeIdentifierRegex.Replace(
+            input,
+            static match => match.Value switch
+            {
+                // Prefix leading digits with an '_' to make them a valid identifier.
+                { Length: > 0 } value when char.IsDigit(value[0]) => $"_{value}",
+
+                // Eliminate all other matches by replacing them with an empty string.
+                _ => ""
+            });
     }
 }


### PR DESCRIPTION
Fixes #7592

Filters out any non-alphanumeric/non-`_` character and prefixes assembly names with a `_` if they start with a digit.
Verified using [@asos-stefanzilik](https://github.com/asos-stefanzilik)'s repo: https://github.com/asos-stefanzilik/BenchmarkOrleansCodeGenIssueRepro

xref #8311 & #7751