### PR TITLE
Fix type parsing of type names with generic array parameter

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Orleans.Serialization.TypeSystem;
 
@@ -134,10 +135,9 @@ public static class RuntimeTypeNameParser
         }
 
         // Parse generic type parameters
-        if (input.TotalGenericArity > 0 && input.TryPeek(out c) && c == ArrayStartIndicator)
+        if (input.TotalGenericArity > 0 && input.TryPeek(out c, out var d) && c == ArrayStartIndicator && d == ArrayStartIndicator)
         {
             input.ConsumeCharacter(ArrayStartIndicator);
-
             var arguments = new TypeSpec[input.TotalGenericArity];
             for (var i = 0; i < input.TotalGenericArity; i++)
             {
@@ -341,6 +341,25 @@ public static class RuntimeTypeNameParser
             return false;
         }
 
+        public bool TryPeek(out char c, out char d)
+        {
+            var result = TryPeek(out c);
+            result &= TryPeek(Index + 1, out d);
+            return result;
+        }
+
+        public bool TryPeek(int index, out char c)
+        {
+            if (index < Input.Length)
+            {
+                c = Input[index];
+                return true;
+            }
+
+            c = default;
+            return false;
+        }
+
         public void Consume(int chars)
         {
             if (Index < Input.Length)
@@ -380,5 +399,29 @@ public static class RuntimeTypeNameParser
         private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
 
         private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
+
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+            var i = 0;
+            foreach (var c in Input)
+            {
+                if (i == Index)
+                {
+                    result.Append("^^^");
+                }
+
+                result.Append(c);
+
+                if (i == Index)
+                {
+                    result.Append("^^^");
+                }
+
+                ++i;
+            }
+
+            return result.ToString();
+        }
     }
 }

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -92,6 +92,35 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(setValue, result);            
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        public async Task GenericGrainTests_SimpleGenericGrainGetGrain_ArrayTypeParameter()
+        {
+            var grain = GetGrain<ISimpleGenericGrain<int[]>>();
+
+            var expected = new[] { 1, 2, 3 };
+            await grain.Set(expected);
+
+            // generic grain implementation does not change the set value:
+            await grain.Transform();
+            
+            var result = await grain.Get();
+            
+            Assert.Equal(expected, result);            
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        public async Task GenericGrainTests_GenericGrainInheritingArray()
+        {
+            var grain = GetGrain<IGenericArrayRegisterGrain<int>>();
+
+            var expected = new[] { 1, 2, 3 };
+            await grain.Set(expected);
+
+            var result = await grain.Get();
+            
+            Assert.Equal(expected, result);            
+        }
+
         /// Can instantiate grains that implement generic interfaces with generic type parameters
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_GenericInterfaceWithGenericParametersGetGrain()

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -231,7 +231,15 @@ namespace UnitTests.GrainInterfaces
     public interface IGenericCastableGrain<T> : IGrainWithGuidKey
     { }
 
+    public interface IGenericRegisterGrain<T> : IGrainWithIntegerKey
+    {
+        Task Set(T value);
+        Task<T> Get();
+    }
 
+    public interface IGenericArrayRegisterGrain<T> : IGenericRegisterGrain<T[]>
+    {
+    }
 
     public interface IGrainSayingHello : IGrainWithGuidKey
     {
@@ -253,8 +261,6 @@ namespace UnitTests.GrainInterfaces
     { }
 
 
-
-
     namespace Generic.EdgeCases
     {
         public interface IBasicGrain : IGrainWithGuidKey
@@ -273,14 +279,11 @@ namespace UnitTests.GrainInterfaces
         public interface IGrainReceivingRepeatedGenArgs<T1, T2> : IBasicGrain
         { }
 
-
         public interface IPartiallySpecifyingInterface<T> : IGrainWithTwoGenArgs<T, int>
         { }
 
-
         public interface IReceivingRepeatedGenArgsAmongstOthers<T1, T2, T3> : IBasicGrain
         { }
-
 
         public interface IReceivingRepeatedGenArgsFromOtherInterface<T1, T2, T3> : IBasicGrain
         { }
@@ -288,11 +291,8 @@ namespace UnitTests.GrainInterfaces
         public interface ISpecifyingGenArgsRepeatedlyToParentInterface<T> : IReceivingRepeatedGenArgsFromOtherInterface<T, T, T>
         { }
 
-
         public interface IReceivingRearrangedGenArgs<T1, T2> : IBasicGrain
         { }
-
-
 
         public interface IReceivingRearrangedGenArgsViaCast<T1, T2> : IBasicGrain
         { }
@@ -300,13 +300,11 @@ namespace UnitTests.GrainInterfaces
         public interface ISpecifyingRearrangedGenArgsToParentInterface<T1, T2> : IReceivingRearrangedGenArgsViaCast<T2, T1>
         { }
 
-
         public interface IArbitraryInterface<T1, T2> : IBasicGrain
         { }
 
         public interface IInterfaceUnrelatedToConcreteGenArgs<T> : IBasicGrain
         { }
-
 
         public interface IInterfaceTakingFurtherSpecializedGenArg<T> : IBasicGrain
         { }

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -768,6 +768,16 @@ namespace UnitTests.Grains
         }
     }
 
+    public class GenericArrayRegisterGrain<T> : Grain, IGenericArrayRegisterGrain<T>
+    {
+        private T[] _value;
+        public Task<T[]> Get() => Task.FromResult(_value);
+        public Task Set(T[] value)
+        {
+            _value = value;
+            return Task.CompletedTask;
+        }
+    }
 
     public class IndepedentlyConcretizedGenericGrain : Grain, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
     {
@@ -903,7 +913,6 @@ namespace UnitTests.Grains
 
         public class GrainSupplyingGenArgSpecializedIntoArray<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<T[]>
         { }
-
 
         public class GrainForCastingBetweenInterfacesOfFurtherSpecializedGenArgs<T>
             : BasicGrain, IAnotherReceivingFurtherSpecializedGenArg<List<T>>, IYetOneMoreReceivingFurtherSpecializedGenArg<T[]>

--- a/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
+++ b/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Reflection;
+using Castle.DynamicProxy.Internal;
 using Orleans.Runtime;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Utilities;
@@ -15,8 +17,10 @@ namespace NonSilo.Tests
     [TestCategory("BVT")]
     public class RuntimeTypeNameFormatterTests
     {
-        private readonly ITestOutputHelper output;
-        private readonly Type[] types = new[]
+        public interface IMyBaseType<T> { }
+        public interface IMyArrayType<T> : IMyBaseType <T[]> { }
+        private readonly ITestOutputHelper _output;
+        private readonly List<Type> _types = new()
             {
                 typeof(NameValueCollection),
                 typeof(int),
@@ -41,7 +45,11 @@ namespace NonSilo.Tests
 
         public RuntimeTypeNameFormatterTests(ITestOutputHelper output)
         {
-            this.output = output;
+            _output = output;
+            _types.Add(typeof(List<>).MakeGenericType(typeof(Inner<int>.Middle).MakeArrayType()));
+            _types.Add(typeof(List<>).MakeGenericType(typeof(Inner<>.Middle).MakeArrayType()));
+            typeof(IMyArrayType<>).MakeGenericType(typeof(Inner<>.Middle)).GetInterfaces().ToList().ForEach(_types.Add);
+            typeof(IMyArrayType<>).GetInterfaces().ToList().ForEach(_types.Add);
         }
 
         /// <summary>
@@ -50,13 +58,16 @@ namespace NonSilo.Tests
         [Fact]
         public void FormattedTypeNamesAreRecoverable()
         {
-            foreach (var type in types)
+            var resolver = new CachedTypeResolver();
+            foreach (var type in _types)
             {
+                if (string.IsNullOrWhiteSpace(type.FullName)) continue;
                 var formatted = RuntimeTypeNameFormatter.Format(type);
-                this.output.WriteLine($"Full Name: {type.FullName}");
-                this.output.WriteLine($"Formatted: {formatted}");
-                var isRecoverable = new CachedTypeResolver().TryResolveType(formatted, out var resolved) && resolved == type;
-                Assert.True(isRecoverable, $"Type.GetType(\"{formatted}\") must be equal to the original type.");
+                _output.WriteLine($"Full Name: {type.FullName}");
+                _output.WriteLine($"Formatted: {formatted}");
+                var isRecoverable = resolver.TryResolveType(formatted, out var resolved) && resolved == type;
+                var resolvedFormatted = resolved is not null ? RuntimeTypeNameFormatter.Format(resolved) : "null";
+                Assert.True(isRecoverable, $"Type.GetType(\"{formatted}\") must be equal to the original type. Got: {resolvedFormatted}");
             }
         }
 
@@ -65,24 +76,26 @@ namespace NonSilo.Tests
         /// </summary>
         [Fact]
         public void ParsedTypeNamesAreIdenticalToFormattedNames()
+
         {
-            foreach (var type in types)
+            foreach (var type in _types)
             {
                 var formatted = RuntimeTypeNameFormatter.Format(type);
                 var parsed = RuntimeTypeNameParser.Parse(formatted);
-                this.output.WriteLine($"Type.FullName: {type.FullName}");
-                this.output.WriteLine($"Formatted    : {formatted}");
-                this.output.WriteLine($"Parsed       : {parsed}");
+                _output.WriteLine($"Type.FullName: {type.FullName}");
+                _output.WriteLine($"Formatted    : {formatted}");
+                _output.WriteLine($"Parsed       : {parsed}");
                 Assert.Equal(formatted, parsed.Format());
 
                 var reparsed = RuntimeTypeNameParser.Parse(parsed.Format());
-                this.output.WriteLine($"Reparsed     : {reparsed}");
+                _output.WriteLine($"Reparsed     : {reparsed}");
                 Assert.Equal(formatted, reparsed.Format());
             }
         } 
         
         public class Inner<T>
         {
+            public class Middle { }
             public class InnerInner<U, V>
             {
                 public class Bottom { }


### PR DESCRIPTION
Fixes #8330

This is a generics corner case which was stumping the type parser when parsing a formatted unconstructed generic type.
For example, this type would not round-trip successfully:
`typeof(List<>).MakeGenericType(typeof(Inner<>.Middle).MakeArrayType())`

Concretely, this behavior was being hit when compiling the grain manifest for a type like `IGenericArrayRegisterGrain<T>`, since the manifest would contain the implemented interfaces, which contains `IGenericRegisterGrain<T[]>` (with no concrete `T`):

``` C#
public interface IGenericRegisterGrain<T> : IGrainWithIntegerKey
{
  Task Set(T value);
  Task<T> Get();
}

public interface IGenericArrayRegisterGrain<T> : IGenericRegisterGrain<T[]>
{
}
```

The fix is to check that we are indeed looking at a formatted generic type, versus an array, by reading ahead for the presence of `[[` (indicating a generic parameter list) rather than just `[` (ambiguous between an array specification or generic parameter list)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8337)