### PR TITLE
Remove inaccurate note on observer method return types

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainObserver.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainObserver.cs
@@ -6,7 +6,6 @@ namespace Orleans
     /// A marker interface for grain observers.
     /// Observers are used to receive notifications from grains; that is, they represent the subscriber side of a 
     /// publisher/subscriber interface.
-    /// Note that all observer methods should have a <see langword="void"/> return type, since they do not return a value to the observed grain.
     /// </summary>
     public interface IGrainObserver : IAddressable
     {


### PR DESCRIPTION
Observer interfaces have the same restrictions as grain interfaces

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8344)