### PR TITLE
Adds support to Orleans.Analyzers for generic attributes

### DIFF
--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -13,6 +13,7 @@ namespace Orleans.Analyzers
         {
             IdentifierNameSyntax id => id.Identifier.Text,
             QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+			GenericNameSyntax generic => generic.Identifier.Text,
             _ => throw new NotSupportedException()
         };
 

--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -20,6 +20,9 @@ namespace UnitTests.Grains
         private readonly ILogger<StuckGrain> _log;
         private bool isDeactivatingBlocking = false;
 
+        private static ConcurrentDictionary<GrainId, ManualResetEventSlim> blockingMREMap =
+            new ConcurrentDictionary<GrainId, ManualResetEventSlim>();
+
         public StuckGrain(ILogger<StuckGrain> log)
         {
             _log = log;
@@ -36,6 +39,33 @@ namespace UnitTests.Grains
                 tcss.Remove(key);
                 return true;
             }
+        }
+
+        public static Task WaitForDeactivationStart(GrainId key)
+        {
+            if (!blockingMREMap.TryGetValue(key, out var mre) || mre == null)
+                throw new InvalidOperationException();
+
+
+            return Task.Run(() => mre.Wait(1000));
+        }
+
+        public static void SetDeactivationStarted(GrainId key)
+        {
+            if (!blockingMREMap.TryGetValue(key, out var mre) || mre == null)
+                return;
+
+            mre.Set();
+        }
+
+        public static void BlockCallingTestUntilDeactivation(GrainId key)
+        {
+            if (!blockingMREMap.TryGetValue(key, out var mre) || mre == null)
+                mre = new ManualResetEventSlim(false);
+            else if (mre != null)
+                mre.Reset();
+
+            blockingMREMap[key] = mre;
         }
 
         public static bool IsActivated(Guid key)
@@ -77,6 +107,7 @@ namespace UnitTests.Grains
         public Task BlockingDeactivation()
         {
             isDeactivatingBlocking = true;
+            BlockCallingTestUntilDeactivation(this.GetGrainId());
             DeactivateOnIdle();
             return Task.CompletedTask;
         }
@@ -116,6 +147,7 @@ namespace UnitTests.Grains
         {
             _log.LogInformation(reason.Exception, "Deactivating ReasonCode: {ReasonCode} Description: {ReasonText}", reason.ReasonCode, reason.Description);
 
+            SetDeactivationStarted(this.GetGrainId());
             if (isDeactivatingBlocking) return RunForever();
 
             var key = this.GetPrimaryKey();

--- a/test/TesterInternal/OrleansRuntime/StuckGrainTests.cs
+++ b/test/TesterInternal/OrleansRuntime/StuckGrainTests.cs
@@ -10,6 +10,7 @@ using UnitTests.GrainInterfaces;
 using Xunit;
 using System.Diagnostics;
 using Orleans.Runtime;
+using UnitTests.Grains;
 
 namespace UnitTests.StuckGrainTests
 {
@@ -108,6 +109,8 @@ namespace UnitTests.StuckGrainTests
             var id = Guid.NewGuid();
             var stuckGrain = this.fixture.GrainFactory.GetGrain<IStuckGrain>(id);
             await stuckGrain.BlockingDeactivation();
+
+            await StuckGrain.WaitForDeactivationStart(stuckGrain.GetGrainId());
 
             for (var i = 0; i < 3; i++)
             {


### PR DESCRIPTION
Adds support to Orleans.Analyzers for generic attributes a new feature in C# 11.0.


Currently, if you use a generic attribute in your code, the the orleans analyzers will fail during the analysis phase and throw a "NotSupportedException" when encountering a usage of a generic attribute. This causes a AD0001 analysis error to appear.

A temporary work around for this is to simply use `<NoWarn>AD0001</NoWarn>` on the project. However, this can potentially hide other base level analyzer exception errors and is therefore not a long-term work around.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8352)