### PR TITLE
Prevent analyzer exception on aliased attribute names

### DIFF
--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -14,6 +14,7 @@ namespace Orleans.Analyzers
             IdentifierNameSyntax id => id.Identifier.Text,
             QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
 			GenericNameSyntax generic => generic.Identifier.Text,
+            AliasQualifiedNameSyntax aliased => aliased.Name.Identifier.Text,
             _ => throw new NotSupportedException()
         };
 
@@ -71,7 +72,7 @@ namespace Orleans.Analyzers
 
             return null;
         }
-        
+
         public static bool IsAbstract(this MemberDeclarationSyntax member) => member.HasModifier(SyntaxKind.AbstractKeyword);
 
         public static bool IsStatic(this MemberDeclarationSyntax member) => member.HasModifier(SyntaxKind.StaticKeyword);
@@ -81,7 +82,7 @@ namespace Orleans.Analyzers
             foreach (var modifier in member.Modifiers)
             {
                 var kind = modifier.Kind();
-                if (kind == modifierKind) 
+                if (kind == modifierKind)
                 {
                     return true;
                 }

--- a/src/Orleans.Analyzers/SyntaxHelpers.cs
+++ b/src/Orleans.Analyzers/SyntaxHelpers.cs
@@ -9,21 +9,24 @@ namespace Orleans.Analyzers
 {
     internal static class SyntaxHelpers
     {
-        public static string GetTypeName(this AttributeSyntax attributeSyntax) => attributeSyntax.Name switch
+        public static bool TryGetTypeName(this AttributeSyntax attributeSyntax, out string typeName)
         {
-            IdentifierNameSyntax id => id.Identifier.Text,
-            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
-			GenericNameSyntax generic => generic.Identifier.Text,
-            AliasQualifiedNameSyntax aliased => aliased.Name.Identifier.Text,
-            _ => throw new NotSupportedException()
-        };
+            typeName = attributeSyntax.Name switch
+            {
+                IdentifierNameSyntax id => id.Identifier.Text,
+                QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+                GenericNameSyntax generic => generic.Identifier.Text,
+                AliasQualifiedNameSyntax aliased => aliased.Name.Identifier.Text,
+                _ => null
+            };
 
-        public static bool IsAttribute(this AttributeSyntax attributeSyntax, string attributeName)
-        {
-            var name = attributeSyntax.GetTypeName();
-            return string.Equals(name, attributeName, StringComparison.Ordinal)
-                || (name.StartsWith(attributeName, StringComparison.Ordinal) && name.EndsWith(nameof(Attribute), StringComparison.Ordinal) && name.Length == attributeName.Length + nameof(Attribute).Length);
+            return typeName != null;
         }
+
+        public static bool IsAttribute(this AttributeSyntax attributeSyntax, string attributeName) =>
+            attributeSyntax.TryGetTypeName(out var name) &&
+            (string.Equals(name, attributeName, StringComparison.Ordinal)
+             || (name.StartsWith(attributeName, StringComparison.Ordinal) && name.EndsWith(nameof(Attribute), StringComparison.Ordinal) && name.Length == attributeName.Length + nameof(Attribute).Length));
 
         public static bool HasAttribute(this MemberDeclarationSyntax member, string attributeName)
         {

--- a/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
+++ b/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
@@ -41,7 +41,7 @@ public abstract class D { [global::Orleans.Id(0)] public abstract int F { get; s
 """);
 
     [Fact]
-    public Task GenericAttribute()
+    public Task UnrelatedGenericAttribute()
         => VerifyGeneratedDiagnostic("""
 public class GenericAttribute<T> : Attribute { }
 [GenerateSerializer]

--- a/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
+++ b/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.CodeAnalysis;
+using Orleans.Analyzers;
+using Xunit;
+
+namespace Analyzers.Tests;
+
+[TestCategory("BVT"), TestCategory("Analyzer")]
+public class AbstractPropertiesCannotBeSerializedAnalyzerTest : DiagnosticAnalyzerTestBase<AbstractPropertiesCannotBeSerializedAnalyzer>
+{
+    async Task VerifyGeneratedDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, new string[0]);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Single(diagnostics);
+
+        var diagnostic = diagnostics.First();
+        Assert.Equal(AbstractPropertiesCannotBeSerializedAnalyzer.RuleId, diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public Task AliasedAttribute()
+        => VerifyGeneratedDiagnostic("""
+using alias = Orleans;
+[alias::GenerateSerializer]
+public abstract class D { [alias::Id(0)] public abstract int F { get; set; } }
+""");
+
+    [Fact]
+    public Task GloballyQualifiedAttribute()
+        => VerifyGeneratedDiagnostic("""
+[global::Orleans.GenerateSerializer]
+public abstract class D { [global::Orleans.Id(0)] public abstract int F { get; set; } }
+""");
+
+    [Fact]
+    public Task SimpleAttribute()
+        => VerifyGeneratedDiagnostic("""
+[GenerateSerializer] public abstract class D { [Id(0)] public abstract int F { get; set; } }
+""");
+
+    [Fact]
+    public Task GenericAttribute()
+        => VerifyGeneratedDiagnostic("""
+public class GenericAttribute<T> : Attribute { }
+[GenerateSerializer]
+public abstract class D {
+    [GenericAttribute<bool>] [Id(0)] public abstract int F { get; set; }
+}
+""");
+}


### PR DESCRIPTION
This prevents the analyzers which use the `IsAttribute` syntax helper from throwing an exception when an aliased namespace is used. It also adds a few very simple tests to catch regression.

I've also changed the helper to a Try pattern so that an exception is never thrown.

This does mean the analyzer would silently miss some cases if new syntax is introduced, but I think blocking consuming projects from building is probably worse. Happy to undo though.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8355)