### PR TITLE
ObserverManager: Guard against `null` in constructor

### DIFF
--- a/src/Orleans.Core/Utils/ObserverManager.cs
+++ b/src/Orleans.Core/Utils/ObserverManager.cs
@@ -59,7 +59,7 @@ namespace Orleans.Utilities
         public ObserverManager(TimeSpan expiration, ILogger log)
         {
             ExpirationDuration = expiration;
-            _log = _log ?? throw new ArgumentNullException(nameof(log));
+            _log = log ?? throw new ArgumentNullException(nameof(log));
             GetDateTime = () => DateTime.UtcNow;
         }
 

--- a/src/Orleans.Core/Utils/ObserverManager.cs
+++ b/src/Orleans.Core/Utils/ObserverManager.cs
@@ -59,7 +59,7 @@ namespace Orleans.Utilities
         public ObserverManager(TimeSpan expiration, ILogger log)
         {
             ExpirationDuration = expiration;
-            _log = _log ?? throw new ArgumentNullException(nameof(_log));
+            _log = _log ?? throw new ArgumentNullException(nameof(log));
             GetDateTime = () => DateTime.UtcNow;
         }
 

--- a/src/Orleans.Core/Utils/ObserverManager.cs
+++ b/src/Orleans.Core/Utils/ObserverManager.cs
@@ -59,7 +59,7 @@ namespace Orleans.Utilities
         public ObserverManager(TimeSpan expiration, ILogger log)
         {
             ExpirationDuration = expiration;
-            _log = log;
+            _log = _log ?? throw new ArgumentNullException(nameof(_log));
             GetDateTime = () => DateTime.UtcNow;
         }
 


### PR DESCRIPTION
When wiring up a sample with `IGrainObservers`, I discovered that when passing null values here results in very bad behavior downstream. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8358)