### PR TITLE
Protobuf copiers

### DIFF
--- a/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
@@ -1,0 +1,20 @@
+using Google.Protobuf;
+using Orleans.Serialization.Cloning;
+
+namespace Orleans.Serialization;
+
+[RegisterCopier]
+public sealed class ByteStringCopier : IDeepCopier<ByteString>
+{
+    public ByteString DeepCopy(ByteString input, CopyContext context)
+    {
+        if (context.TryGetCopy<ByteString>(input, out var result))
+        {
+            return result;
+        }
+
+        result = ByteString.CopyFrom(input.Span);
+        context.RecordCopy(input, result);
+        return result;
+    }
+}

--- a/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
@@ -3,9 +3,13 @@ using Orleans.Serialization.Cloning;
 
 namespace Orleans.Serialization;
 
+/// <summary>
+/// Copier for <see cref="ByteString"/>.
+/// </summary>
 [RegisterCopier]
 public sealed class ByteStringCopier : IDeepCopier<ByteString>
 {
+    /// <inheritdoc/>
     public ByteString DeepCopy(ByteString input, CopyContext context)
     {
         if (context.TryGetCopy<ByteString>(input, out var result))

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
@@ -1,0 +1,59 @@
+using Google.Protobuf.Collections;
+using Orleans.Serialization.Cloning;
+
+namespace Orleans.Serialization;
+
+/// <summary>
+/// Copier for <see cref="MapFieldCopier{TKey, TValue}"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the t key.</typeparam>
+/// <typeparam name="TValue">The type of the t value.</typeparam>
+[RegisterCopier]
+public sealed class MapFieldCopier<TKey, TValue> : IDeepCopier<MapField<TKey, TValue>>, IBaseCopier<MapField<TKey, TValue>>
+{
+    private readonly IDeepCopier<TKey> _keyCopier;
+    private readonly IDeepCopier<TValue> _valueCopier;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MapFieldCopier{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="keyCopier">The key copier.</param>
+    /// <param name="valueCopier">The value copier.</param>
+    public MapFieldCopier(IDeepCopier<TKey> keyCopier, IDeepCopier<TValue> valueCopier)
+    {
+        _keyCopier = keyCopier;
+        _valueCopier = valueCopier;
+    }
+
+    /// <inheritdoc/>
+    public MapField<TKey, TValue> DeepCopy(MapField<TKey, TValue> input, CopyContext context)
+    {
+        if (context.TryGetCopy<MapField<TKey, TValue>>(input, out var result))
+        {
+            return result;
+        }
+
+        if (input.GetType() != typeof(MapField<TKey, TValue>))
+        {
+            return context.DeepCopy(input);
+        }
+
+        result = new MapField<TKey, TValue>();
+        context.RecordCopy(input, result);
+        foreach (var pair in input)
+        {
+            result[_keyCopier.DeepCopy(pair.Key, context)] = _valueCopier.DeepCopy(pair.Value, context);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void DeepCopy(MapField<TKey, TValue> input, MapField<TKey, TValue> output, CopyContext context)
+    {
+        foreach (var pair in input)
+        {
+            output[_keyCopier.DeepCopy(pair.Key, context)] = _valueCopier.DeepCopy(pair.Value, context);
+        }
+    }
+}

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
@@ -4,7 +4,7 @@ using Orleans.Serialization.Cloning;
 namespace Orleans.Serialization;
 
 /// <summary>
-/// Copier for <see cref="MapFieldCopier{TKey, TValue}"/>.
+/// Copier for <see cref="MapField{TKey, TValue}"/>.
 /// </summary>
 /// <typeparam name="TKey">The type of the t key.</typeparam>
 /// <typeparam name="TValue">The type of the t value.</typeparam>

--- a/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
@@ -1,0 +1,55 @@
+using Google.Protobuf.Collections;
+using Orleans.Serialization.Cloning;
+
+namespace Orleans.Serialization;
+
+/// <summary>
+/// Copier for <see cref="RepeatedField{T}"/>.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+[RegisterCopier]
+public sealed class RepeatedFieldCopier<T> : IDeepCopier<RepeatedField<T>>, IBaseCopier<RepeatedField<T>>
+{
+    private readonly IDeepCopier<T> _copier;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RepeatedFieldCopier{T}"/> class.
+    /// </summary>
+    /// <param name="valueCopier">The value copier.</param>
+    public RepeatedFieldCopier(IDeepCopier<T> valueCopier)
+    {
+        _copier = valueCopier;
+    }
+
+    /// <inheritdoc/>
+    public RepeatedField<T> DeepCopy(RepeatedField<T> input, CopyContext context)
+    {
+        if (context.TryGetCopy<RepeatedField<T>>(input, out var result))
+        {
+            return result;
+        }
+
+        if (input.GetType() != typeof(RepeatedField<T>))
+        {
+            return context.DeepCopy(input);
+        }
+
+        result = new RepeatedField<T> { Capacity = input.Count };
+        context.RecordCopy(input, result);
+        foreach (var item in input)
+        {
+            result.Add(_copier.DeepCopy(item, context));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void DeepCopy(RepeatedField<T> input, RepeatedField<T> output, CopyContext context)
+    {
+        foreach (var item in input)
+        {
+            output.Add(_copier.DeepCopy(item, context));
+        }
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
+using System.Linq;
 using Google.Protobuf;
+using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
@@ -98,6 +100,71 @@ public class ProtobufCodecCopierTests : CopierTester<MyProtobufClass?, IDeepCopi
         new () { SubClass = new MyProtobufClass.Types.SubClass { Id = Guid.NewGuid().ToByteString() } },
         new () { IntProperty = 150, StringProperty = new string('c', 20), SubClass = new MyProtobufClass.Types.SubClass { Id = Guid.NewGuid().ToByteString() } },
         new () { IntProperty = -150_000, StringProperty = new string('c', 6_000), SubClass = new MyProtobufClass.Types.SubClass { Id = Guid.NewGuid().ToByteString() } },
+    };
+}
+
+[Trait("Category", "BVT")]
+public class ProtobufRepeatedFieldCopierTests : CopierTester<RepeatedField<int>, IDeepCopier<RepeatedField<int>>>
+{
+    public ProtobufRepeatedFieldCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override IDeepCopier<RepeatedField<int>> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<RepeatedField<int>>();
+
+    protected override RepeatedField<int> CreateValue()
+    {
+        var result = new RepeatedField<int>();
+        for (var i = 0; i < Random.Next(17) + 5; i++)
+        {
+            result.Add(Random.Next());
+        }
+
+        return result;
+    }
+
+    protected override bool Equals(RepeatedField<int> left, RepeatedField<int> right) => object.ReferenceEquals(left, right) || left.SequenceEqual(right);
+    protected override RepeatedField<int>[] TestValues => new[] { new RepeatedField<int>(), CreateValue(), CreateValue(), CreateValue() };
+}
+
+[Trait("Category", "BVT")]
+public class MapFieldCopierTests : CopierTester<MapField<string, int>, MapFieldCopier<string, int>>
+{
+    public MapFieldCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MapField<string, int> CreateValue()
+    {
+        var result = new MapField<string, int>();
+        for (var i = 0; i < Random.Next(17) + 5; i++)
+        {
+            result[Random.Next().ToString()] = Random.Next();
+        }
+
+        return result;
+    }
+
+    protected override MapField<string, int>[] TestValues => new[] { new MapField<string, int>(), CreateValue(), CreateValue(), CreateValue() };
+    protected override bool Equals(MapField<string, int> left, MapField<string, int> right) => object.ReferenceEquals(left, right) || left.SequenceEqual(right);
+}
+
+[Trait("Category", "BVT")]
+public class ByteStringCopierTests : CopierTester<ByteString, ByteStringCopier>
+{
+    public ByteStringCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override ByteString CreateValue() => Guid.NewGuid().ToByteString();
+
+    protected override bool Equals(ByteString left, ByteString right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
+
+    protected override ByteString[] TestValues => new[]
+    {
+        ByteString.Empty,
+        ByteString.CopyFrom(Enumerable.Range(0, 4097).Select(b => unchecked((byte)b)).ToArray()),
+        CreateValue()
     };
 }
 


### PR DESCRIPTION
There are a few protobuf types that don't extend from `IMessage` so they won't be covered by the general protobuf copier.
One place this can come up is from the transaction system.