### PR TITLE
Migrate from `FormatterServices` to `RuntimeHelpers` in preparation for .NET 8

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -39,7 +39,7 @@ namespace Orleans.CodeGenerator
                 AliasAttribute = Type("Orleans.AliasAttribute"),
                 IInvokable = Type("Orleans.Serialization.Invocation.IInvokable"),
                 InvokeMethodNameAttribute = Type("Orleans.InvokeMethodNameAttribute"),
-                FormatterServices = Type("System.Runtime.Serialization.FormatterServices"),
+                RuntimeHelpers = Type("System.Runtime.CompilerServices.RuntimeHelpers"),
                 InvokableCustomInitializerAttribute = Type("Orleans.InvokableCustomInitializerAttribute"),
                 DefaultInvokableBaseTypeAttribute = Type("Orleans.DefaultInvokableBaseTypeAttribute"),
                 GenerateCodeForDeclaringAssemblyAttribute = Type("Orleans.GenerateCodeForDeclaringAssemblyAttribute"),
@@ -301,7 +301,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol SerializerTransparentAttribute { get; private set; }
         public INamedTypeSymbol FSharpCompilationMappingAttributeOrDefault { get; private set; }
         public INamedTypeSymbol FSharpSourceConstructFlagsOrDefault { get; private set; }
-        public INamedTypeSymbol FormatterServices { get; private set; }
+        public INamedTypeSymbol RuntimeHelpers { get; private set; }
 
         private readonly ConcurrentDictionary<ITypeSymbol, bool> _shallowCopyableTypes = new(SymbolEqualityComparer.Default);
 

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -226,7 +226,7 @@ namespace Orleans.CodeGenerator
             {
                 return CastExpression(
                     TypeSyntax,
-                    InvocationExpression(libraryTypes.FormatterServices.ToTypeSyntax().Member("GetUninitializedObject"))
+                    InvocationExpression(libraryTypes.RuntimeHelpers.ToTypeSyntax().Member("GetUninitializedObject"))
                         .AddArgumentListArguments(
                             Argument(TypeOfExpression(TypeSyntax))));
             }

--- a/src/Orleans.Serialization/Activators/DefaultActivator.cs
+++ b/src/Orleans.Serialization/Activators/DefaultActivator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Orleans.Serialization.Activators
 {
@@ -24,6 +23,6 @@ namespace Orleans.Serialization.Activators
             return (Func<T>)method.CreateDelegate(typeof(Func<T>));
         }
 
-        public T Create() => _constructor is { } ctor ? ctor() : Unsafe.As<T>(FormatterServices.GetUninitializedObject(_type));
+        public T Create() => _constructor is { } ctor ? ctor() : Unsafe.As<T>(RuntimeHelpers.GetUninitializedObject(_type));
     }
 }

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -6,6 +6,7 @@ using Orleans.Serialization.WireProtocol;
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Security;
 
@@ -124,7 +125,7 @@ namespace Orleans.Serialization
             var callbacks = _serializationCallbacks.GetReferenceTypeCallbacks(type);
 
             var info = new SerializationInfo(type, _formatterConverter);
-            var result = FormatterServices.GetUninitializedObject(type);
+            var result = RuntimeHelpers.GetUninitializedObject(type);
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             callbacks.OnDeserializing?.Invoke(result, _streamingContext);
 

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using Microsoft.Extensions.Options;
@@ -378,7 +379,7 @@ namespace Orleans.Serialization
                     }
                     else
                     {
-                        result = (Exception)FormatterServices.GetUninitializedObject(type);
+                        result = (Exception)RuntimeHelpers.GetUninitializedObject(type);
                     }
                 }
                 catch (Exception constructorException)


### PR DESCRIPTION
See: https://github.com/dotnet/designs/pull/293

Move from `FormatterServices.GetUninitializedObject` to `RuntimeHelpers.GetUninitializedObject`. The former is implemented by the latter anyway.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8362)