### PR TITLE
Code generator respects scoped usage by language version

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Orleans.CodeGenerator.SyntaxGeneration;
 
 namespace Orleans.CodeGenerator
@@ -178,6 +179,8 @@ namespace Orleans.CodeGenerator
                     Type("System.Collections.Immutable.ImmutableSortedSet`1"),
                     Type("System.Collections.Immutable.ImmutableStack`1"),
                 },
+
+                LanguageVersion = (compilation.SyntaxTrees.FirstOrDefault()?.Options as CSharpParseOptions)?.LanguageVersion
             };
 
             INamedTypeSymbol Type(string metadataName)
@@ -302,6 +305,8 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol FSharpCompilationMappingAttributeOrDefault { get; private set; }
         public INamedTypeSymbol FSharpSourceConstructFlagsOrDefault { get; private set; }
         public INamedTypeSymbol FormatterServices { get; private set; }
+
+        public LanguageVersion? LanguageVersion { get; private set; }
 
         private readonly ConcurrentDictionary<ITypeSymbol, bool> _shallowCopyableTypes = new(SymbolEqualityComparer.Default);
 
@@ -445,5 +450,7 @@ namespace Orleans.CodeGenerator
 
             return null;
         }
+
+        public static bool HasScopedKeyword(this LibraryTypes libraryTypes) => libraryTypes.LanguageVersion is null or >= LanguageVersion.CSharp11;
     }
 }

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -359,7 +359,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(libraryTypes.HasScopedKeyword() ? TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)) : TokenList(Token(SyntaxKind.RefKeyword)));
             }
 
             var res = MethodDeclaration(returnType, SerializeMethodName)
@@ -537,7 +537,7 @@ namespace Orleans.CodeGenerator
 
             if (type.IsValueType)
             {
-                parameters[1] = parameters[1].WithModifiers(TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)));
+                parameters[1] = parameters[1].WithModifiers(libraryTypes.HasScopedKeyword() ? TokenList(Token(SyntaxKind.ScopedKeyword), Token(SyntaxKind.RefKeyword)) : TokenList(Token(SyntaxKind.RefKeyword)));
             }
 
             var res = MethodDeclaration(returnType, DeserializeMethodName)
@@ -717,7 +717,7 @@ namespace Orleans.CodeGenerator
                                     })))),
                                 ReturnStatement()))
                     );
-                    
+
                     // C#: ReferenceCodec.MarkValueField(reader.Session);
                     innerBody.Add(ExpressionStatement(InvocationExpression(IdentifierName("ReferenceCodec").Member("MarkValueField"), ArgumentList(SingletonSeparatedList(Argument(writerParam.Member("Session")))))));
                 }
@@ -1023,7 +1023,7 @@ namespace Orleans.CodeGenerator
             public override bool IsInjected { get; }
         }
 
-        internal sealed class ActivatorFieldDescription : GeneratedFieldDescription 
+        internal sealed class ActivatorFieldDescription : GeneratedFieldDescription
         {
             public ActivatorFieldDescription(TypeSyntax fieldType, string fieldName) : base(fieldType, fieldName)
             {
@@ -1048,7 +1048,7 @@ namespace Orleans.CodeGenerator
             public TypeFieldDescription(TypeSyntax fieldType, string fieldName, TypeSyntax underlyingTypeSyntax, ITypeSymbol underlyingType) : base(fieldType, fieldName)
             {
                 UnderlyingType = underlyingType;
-                UnderlyingTypeSyntax = underlyingTypeSyntax; 
+                UnderlyingTypeSyntax = underlyingTypeSyntax;
             }
 
             public TypeSyntax UnderlyingTypeSyntax { get; }
@@ -1224,22 +1224,22 @@ namespace Orleans.CodeGenerator
             private bool IsProperty => Member.Symbol is IPropertySymbol;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents an accessible field. 
+            /// Gets a value indicating whether or not this member represents an accessible field.
             /// </summary>
             private bool IsGettableField => Field is { } field && _model.IsAccessible(0, field) && !IsObsolete;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents an accessible, mutable field. 
+            /// Gets a value indicating whether or not this member represents an accessible, mutable field.
             /// </summary>
             private bool IsSettableField => Field is { } field && IsGettableField && !field.IsReadOnly;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete getter. 
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete getter.
             /// </summary>
             private bool IsGettableProperty => Property?.GetMethod is { } getMethod && _model.IsAccessible(0, getMethod) && !IsObsolete;
 
             /// <summary>
-            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete setter. 
+            /// Gets a value indicating whether or not this member represents a property with an accessible, non-obsolete setter.
             /// </summary>
             private bool IsSettableProperty => Property?.SetMethod is { } setMethod && _model.IsAccessible(0, setMethod) && !setMethod.IsInitOnly && !IsObsolete;
 
@@ -1247,7 +1247,7 @@ namespace Orleans.CodeGenerator
             /// Gets syntax representing the type of this field.
             /// </summary>
             public TypeSyntax TypeSyntax => Member.Type.TypeKind == TypeKind.Dynamic
-                ? PredefinedType(Token(SyntaxKind.ObjectKeyword)) 
+                ? PredefinedType(Token(SyntaxKind.ObjectKeyword))
                 : _member.GetTypeSyntax(Member.Type);
 
             /// <summary>


### PR DESCRIPTION
The `scoped` keyword was added in C# 11. Prior to this change, attempting to run the code generator on projects < C# 11 would result in errors. Now, the `scoped` keyword is omitted when targeting < C# 11.