### PR TITLE
Fix type constraints on `DefaultOptionsFormatter` and `DefaultOptionsFormatterResolver`

### DIFF
--- a/src/Orleans.Core/Configuration/OptionLogger/DefaultOptionsFormatter.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/DefaultOptionsFormatter.cs
@@ -10,7 +10,7 @@ namespace Orleans
     /// Default implementation of <see cref="IOptionFormatter{T}"/>.
     /// </summary>
     /// <typeparam name="T">The options type.</typeparam>
-    internal sealed class DefaultOptionsFormatter<T> : IOptionFormatter<T> where T : class, new()
+    internal sealed class DefaultOptionsFormatter<T> : IOptionFormatter<T> where T : class
     {
         private readonly T _options;
 
@@ -130,7 +130,7 @@ namespace Orleans
         }
     }
 
-    internal class DefaultOptionsFormatterResolver<T> : IOptionFormatterResolver<T> where T: class, new()
+    internal class DefaultOptionsFormatterResolver<T> : IOptionFormatterResolver<T> where T: class
     {
         private readonly IOptionsMonitor<T> _optionsMonitor;
 


### PR DESCRIPTION
The `new()` constraint is not required and can cause a crash during startup

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8384)