### PR TITLE
Fix: ORLEANS0009 - Skip Static Interface Methods

### DIFF
--- a/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
@@ -43,8 +43,8 @@ namespace Orleans.Analyzers
 
             if (symbol.ContainingType.TypeKind != TypeKind.Interface) return;
 
-            // allow static interface methods to return any type
-            if (symbol.IsStatic)
+            // allow static interface methods to return any type (excluding abstract / virtual)
+            if (symbol.IsStatic && !symbol.IsAbstract && !symbol.IsVirtual)
                 return;
 
             var isIAddressableInterface = false;

--- a/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
@@ -43,6 +43,10 @@ namespace Orleans.Analyzers
 
             if (symbol.ContainingType.TypeKind != TypeKind.Interface) return;
 
+            // allow static interface methods to return any type
+            if (symbol.IsStatic)
+                return;
+
             var isIAddressableInterface = false;
             foreach (var implementedInterface in symbol.ContainingType.AllInterfaces)
             {

--- a/test/Analyzers.Tests/GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest.cs
@@ -66,4 +66,18 @@ public class GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest : DiagnosticAn
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
         Assert.Equal(MessageFormat, diagnostic.GetMessage());
     }
+
+    [Fact]
+    public async Task StaticInterfaceMethodsWithRegularReturnsAreAllowed()
+    {
+        var code = """
+                    public interface I : Orleans.IGrain
+                    {
+                        public static int GetSomeOtherThing(int a) => 0;
+                    }
+                    """;
+
+        var (diagnostics, _) = await this.GetDiagnosticsAsync(code, new string[0]);
+        Assert.Empty(diagnostics);
+    }
 }


### PR DESCRIPTION
Fix for #8377 @ReubenBond 

Included accompanying test that now that passes. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8389)