### PR TITLE
Reduce IGrainFactory API surface by moving some methods into extensions

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/GrainFactoryExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Core/GrainFactoryExtensions.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Extension methods for <see cref="IGrainFactory"/>
+    /// </summary>
+    public static class GrainFactoryExtensions
+    {
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey
+        {
+            var grainKey = IdSpan.Create(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidCompoundKey
+        {
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerCompoundKey
+        {
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, string grainPrimaryKey)
+        {
+            var grainKey = IdSpan.Create(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey, keyExtension);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
+        {
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey, keyExtension);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Validates the provided grain key extension.
+        /// </summary>
+        /// <param name="keyExt">The grain key extension.</param>
+        /// <exception cref="ArgumentNullException">The key is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The key is empty or contains only whitespace.</exception>
+        private static void ValidateGrainKeyExtension(string keyExt)
+        {
+            if (!string.IsNullOrWhiteSpace(keyExt)) return;
+
+            if (null == keyExt)
+            {
+                throw new ArgumentNullException(nameof(keyExt)); 
+            }
+            
+            throw new ArgumentException("Key extension is empty or white space.", nameof(keyExt));
+        }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -10,53 +10,6 @@ namespace Orleans
     public interface IGrainFactory
     {
         /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidCompoundKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerCompoundKey;
-
-        /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.
         /// </summary>
         /// <typeparam name="TGrainObserverInterface">
@@ -77,82 +30,6 @@ namespace Orleans
         void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension);
-
-        /// <summary>
         /// Returns a reference to the specified grain which implements the specified interface.
         /// </summary>
         /// <param name="grainId">
@@ -167,17 +44,6 @@ namespace Orleans
         TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable;
 
         /// <summary>
-        /// Returns an untyped reference for the provided grain id.
-        /// </summary>
-        /// <param name="grainId">
-        /// The grain id.
-        /// </param>
-        /// <returns>
-        /// An untyped reference for the provided grain id.
-        /// </returns>
-        IAddressable GetGrain(GrainId grainId);
-
-        /// <summary>
         /// Returns a reference for the provided grain id which implements the specified interface type.
         /// </summary>
         /// <param name="grainId">
@@ -189,6 +55,18 @@ namespace Orleans
         /// <returns>
         /// A reference for the provided grain id which implements the specified interface type.
         /// </returns>
-        IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType);
+        IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType = default);
+
+        /// <summary>
+        /// Gets a grain reference which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
+        /// </summary>
+        /// <remarks>
+        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="interfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
+        /// </remarks>
+        /// <param name="interfaceType">The interface type which the returned grain reference will implement.</param>
+        /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
+        /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
+        /// <returns>A grain reference which implements the provided interface.</returns>
+        IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix);
     }
 }

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -91,26 +91,6 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver => ((IGrainFactory)_runtimeClient.InternalGrainFactory).CreateObjectReference<TGrainObserverInterface>(obj);
 
@@ -133,34 +113,14 @@ namespace Orleans
         TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(grainId);
 
         /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain(grainId);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
-
-        /// <inheritdoc />
         public object Cast(IAddressable grain, Type outputGrainInterfaceType)
             => _runtimeClient.InternalGrainFactory.Cast(grain, outputGrainInterfaceType);
 
         /// <inheritdoc />
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
             => _runtimeClient.InternalGrainFactory.GetGrain(grainId, interfaceType);
+
+        /// <inheritdoc />
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix) => _runtimeClient.InternalGrainFactory.GetGrain(interfaceType, grainKey, grainClassNamePrefix);
     }
 }

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -111,45 +111,11 @@ namespace Orleans.Runtime
             return this.grainFactory.GetGrain<TGrainInterface>(grainId);
         }
 
-        /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId)
-        {
-            return this.grainFactory.GetGrain(grainId);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceId)
         {
             return this.grainFactory.GetGrain(grainId, interfaceId);
         }
+
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix) => grainFactory.GetGrain(interfaceType, grainKey, grainClassNamePrefix);
     }
 }


### PR DESCRIPTION
I am not decided on whether we should merge this yet, but for the sake of argument, we could move some `IGrainFactory` methods into extension methods to reduce the API surface for `IGrainFactory` implementations.

Note that this would be a binary breaking change, so it should wait for at least .NET 8.0 if we decide to do it at all.

xref: https://github.com/dotnet/orleans/issues/8391