### PR TITLE
Support custom grain call return types

### DIFF
--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -77,8 +77,16 @@ namespace Orleans.CodeGenerator
                 }
             }
 
+            string returnValueInitializerMethod = null;
+            if (baseClassType.GetAttribute(libraryTypes.ReturnValueProxyAttribute) is { ConstructorArguments: { Length: > 0 } attrArgs })
+            {
+                returnValueInitializerMethod = (string)attrArgs[0].Value;
+            }
+
             while (baseClassType.HasAttribute(libraryTypes.SerializerTransparentAttribute))
+            {
                 baseClassType = baseClassType.BaseType;
+            }
 
             var invokerDescription = new GeneratedInvokerDescription(
                 interfaceDescription,
@@ -89,7 +97,8 @@ namespace Orleans.CodeGenerator
                 serializationHooks,
                 baseClassType,
                 ctorArgs,
-                compoundTypeAliasArgs);
+                compoundTypeAliasArgs,
+                returnValueInitializerMethod);
             return (classDeclaration, invokerDescription);
 
             static Accessibility GetAccessibility(InvokableInterfaceDescription interfaceDescription)

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -45,6 +45,7 @@ namespace Orleans.CodeGenerator
                 DefaultInvokableBaseTypeAttribute = Type("Orleans.DefaultInvokableBaseTypeAttribute"),
                 GenerateCodeForDeclaringAssemblyAttribute = Type("Orleans.GenerateCodeForDeclaringAssemblyAttribute"),
                 InvokableBaseTypeAttribute = Type("Orleans.InvokableBaseTypeAttribute"),
+                ReturnValueProxyAttribute = Type("Orleans.Invocation.ReturnValueProxyAttribute"),
                 RegisterSerializerAttribute = Type("Orleans.RegisterSerializerAttribute"),
                 GeneratedActivatorConstructorAttribute = Type("Orleans.GeneratedActivatorConstructorAttribute"),
                 SerializerTransparentAttribute = Type("Orleans.SerializerTransparentAttribute"),
@@ -297,6 +298,7 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol InvokeMethodNameAttribute { get; private set; }
         public INamedTypeSymbol InvokableCustomInitializerAttribute { get; private set; }
         public INamedTypeSymbol InvokableBaseTypeAttribute { get; private set; }
+        public INamedTypeSymbol ReturnValueProxyAttribute { get; private set; }
         public INamedTypeSymbol DefaultInvokableBaseTypeAttribute { get; private set; }
         public INamedTypeSymbol GenerateCodeForDeclaringAssemblyAttribute { get; private set; }
         public INamedTypeSymbol SerializationCallbacksAttribute { get; private set; }

--- a/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IGeneratedInvokerDescription.cs
@@ -23,7 +23,8 @@ namespace Orleans.CodeGenerator
             List<INamedTypeSymbol> serializationHooks,
             INamedTypeSymbol baseType,
             List<TypeSyntax> constructorArguments,
-            CompoundTypeAliasComponent[] compoundTypeAliasArguments)
+            CompoundTypeAliasComponent[] compoundTypeAliasArguments,
+            string returnValueInitializerMethod)
         {
             InterfaceDescription = interfaceDescription;
             _methodDescription = methodDescription;
@@ -35,6 +36,7 @@ namespace Orleans.CodeGenerator
             SerializationHooks = serializationHooks;
             ActivatorConstructorParameters = constructorArguments;
             CompoundTypeAliasArguments = compoundTypeAliasArguments;
+            ReturnValueInitializerMethod = returnValueInitializerMethod;
         }
 
         public Accessibility Accessibility { get; }
@@ -68,6 +70,7 @@ namespace Orleans.CodeGenerator
         public List<TypeSyntax> ActivatorConstructorParameters { get; }
         public bool HasActivatorConstructor => UseActivator;
         public CompoundTypeAliasComponent[] CompoundTypeAliasArguments {get;}
+        public string ReturnValueInitializerMethod { get; }
 
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => ObjectCreationExpression(TypeSyntax, ArgumentList(), null);
 

--- a/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableInterfaceDescription.cs
@@ -156,11 +156,25 @@ namespace Orleans.CodeGenerator
                         continue;
                     }
 
-                    if (!SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, l.IInvokable))
+                    var paramType = method.Parameters[0].Type;
+                    if (!SymbolEqualityComparer.Default.Equals(paramType, l.IInvokable))
                     {
-                        complaintMember = member;
-                        complaint = $"incorrect parameter type (found {method.Parameters[0].Type}, expected {l.IInvokable})";
-                        continue;
+                        var implementsIInvokable = false;
+                        foreach (var @interface in paramType.AllInterfaces)
+                        {
+                            if (SymbolEqualityComparer.Default.Equals(@interface, l.IInvokable))
+                            {
+                                implementsIInvokable = true;
+                                break;
+                            }
+                        }
+
+                        if (!implementsIInvokable)
+                        {
+                            complaintMember = member;
+                            complaint = $"incorrect parameter type (found {paramType}, expected {l.IInvokable} or a type which implements {l.IInvokable})";
+                            continue;
+                        }
                     }
 
                     var expectedReturnType = l.ValueTask_1.Construct(method.TypeParameters[0]);
@@ -216,11 +230,25 @@ namespace Orleans.CodeGenerator
                         continue;
                     }
 
-                    if (!SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, l.IInvokable))
+                    var paramType = method.Parameters[0].Type;
+                    if (!SymbolEqualityComparer.Default.Equals(paramType, l.IInvokable))
                     {
-                        complaintMember = member;
-                        complaint = $"incorrect parameter type (found {method.Parameters[0].Type}, expected {l.IInvokable})";
-                        continue;
+                        var implementsIInvokable = false;
+                        foreach (var @interface in paramType.AllInterfaces)
+                        {
+                            if (SymbolEqualityComparer.Default.Equals(@interface, l.IInvokable))
+                            {
+                                implementsIInvokable = true;
+                                break;
+                            }
+                        }
+
+                        if (!implementsIInvokable)
+                        {
+                            complaintMember = member;
+                            complaint = $"incorrect parameter type (found {method.Parameters[0].Type}, expected {l.IInvokable})";
+                            continue;
+                        }
                     }
 
                     if (!SymbolEqualityComparer.Default.Equals(method.ReturnType, l.ValueTask))

--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -452,6 +452,45 @@ namespace Orleans.CodeGenerator.SyntaxGeneration
             }
         }
 
+        public static bool IsAssignableFrom(this INamedTypeSymbol symbol, INamedTypeSymbol type)
+        {
+            if (symbol.TypeKind == TypeKind.Interface)
+            {
+                return IsInterfaceAssignableFromInternal(symbol, type);
+            }
+
+            return IsBaseAssignableFromInternal(symbol, type);
+        }
+
+        private static bool IsBaseAssignableFromInternal(this INamedTypeSymbol symbol, INamedTypeSymbol? type)
+        {
+            if (type is null) return false;
+            if (SymbolEqualityComparer.Default.Equals(symbol, type))
+            {
+                return true;
+            }
+
+            return IsBaseAssignableFromInternal(symbol, type.BaseType);
+        }
+
+        private static bool IsInterfaceAssignableFromInternal(this INamedTypeSymbol iface, INamedTypeSymbol type)
+        {
+            if (SymbolEqualityComparer.Default.Equals(iface, type))
+            {
+                return true;
+            }
+
+            foreach (var typeInterface in type.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(iface, typeInterface))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static IEnumerable<INamedTypeSymbol> GetDeclaredTypes(this IAssemblySymbol reference)
         {
             foreach (var module in reference.Modules)

--- a/src/Orleans.Core.Abstractions/Concurrency/GrainAttributeConcurrency.cs
+++ b/src/Orleans.Core.Abstractions/Concurrency/GrainAttributeConcurrency.cs
@@ -14,7 +14,7 @@ namespace Orleans.Concurrency
     /// that may significantly improve the performance of your application.
     /// </para>
     /// </summary>
-    [InvokableCustomInitializer(nameof(RequestBase.AddInvokeMethodOptions), InvokeMethodOptions.ReadOnly)]
+    [InvokableCustomInitializer(nameof(IRequest.AddInvokeMethodOptions), InvokeMethodOptions.ReadOnly)]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class ReadOnlyAttribute : Attribute
     {
@@ -88,7 +88,7 @@ namespace Orleans.Concurrency
     /// Note that this attribute is applied to method declaration in the grain interface,
     /// and not to the method in the implementation class itself.
     /// </remarks>
-    [InvokableCustomInitializer(nameof(RequestBase.AddInvokeMethodOptions), InvokeMethodOptions.AlwaysInterleave)]
+    [InvokableCustomInitializer(nameof(IRequest.AddInvokeMethodOptions), InvokeMethodOptions.AlwaysInterleave)]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class AlwaysInterleaveAttribute : Attribute
     {
@@ -132,7 +132,7 @@ namespace Orleans.Concurrency
     /// <summary>
     /// Indicates that a method on a grain interface is one-way and that no response message will be sent to the caller.
     /// </summary>
-    [InvokableCustomInitializer(nameof(RequestBase.AddInvokeMethodOptions), InvokeMethodOptions.OneWay)]
+    [InvokableCustomInitializer(nameof(IRequest.AddInvokeMethodOptions), InvokeMethodOptions.OneWay)]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class OneWayAttribute : Attribute
     {

--- a/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
+++ b/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
@@ -8,7 +8,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <RootNamespace>Orleans</RootNamespace>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -419,6 +419,15 @@ namespace Orleans.Runtime
         {
             return this.Runtime.InvokeMethodAsync(this, methodDescription, methodDescription.Options);
         }
+
+        /// <summary>
+        /// Invokes the provided method.
+        /// </summary>
+        /// <param name="methodDescription">The method description.</param>
+        protected void Invoke(IRequest methodDescription)
+        {
+            this.Runtime.InvokeMethod(this, methodDescription, methodDescription.Options);
+        }
     }
 
     public interface IRequest : IInvokable

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -430,6 +430,9 @@ namespace Orleans.Runtime
         }
     }
 
+    /// <summary>
+    /// Represents a request to invoke a method on a grain.
+    /// </summary>
     public interface IRequest : IInvokable
     {
         /// <summary>

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainReferenceRuntime.cs
@@ -31,6 +31,14 @@ namespace Orleans.Runtime
         ValueTask InvokeMethodAsync(GrainReference reference, IInvokable request, InvokeMethodOptions options);
 
         /// <summary>
+        /// Invokes the specified void-returning method on the provided grain interface without waiting for a response.
+        /// </summary>
+        /// <param name="reference">The grain reference.</param>
+        /// <param name="request">The method description.</param>
+        /// <param name="options">The invocation options.</param>
+        void InvokeMethod(GrainReference reference, IInvokable request, InvokeMethodOptions options);
+
+        /// <summary>
         /// Converts the provided <paramref name="grain"/> to the provided <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="grain">The grain.</param>

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -183,7 +183,7 @@ namespace Orleans.Runtime.Messaging
                 if (bodyCodec is not null)
                 {
                     innerWriter = Writer.Create(new MessageBufferWriter(bufferWriter), _serializationSession);
-                    if (rawCodec != null) rawCodec.WriteRaw(ref innerWriter, message.BodyObject);
+                    if (rawCodec != null) rawCodec.WriteRaw(ref innerWriter, message.BodyObject!);
                     else bodyCodec.WriteField(ref innerWriter, 0, null, message.BodyObject);
                     innerWriter.Commit();
                 }

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Orleans</RootNamespace>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Orleans</RootNamespace>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Orleans.Core.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 
 namespace Orleans
@@ -11,7 +11,8 @@ namespace Orleans
     internal class ClientGrainContext : IGrainContext, IGrainExtensionBinder, IGrainContextAccessor
     {
         private readonly object _lockObj = new object();
-        private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new ConcurrentDictionary<Type, (object, IAddressable)>();
+        private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new();
+        private readonly ConcurrentDictionary<Type, object> _components = new();
         private readonly OutsideRuntimeClient _runtimeClient;
         private GrainReference _grainReference;
 
@@ -47,6 +48,23 @@ namespace Orleans
         public TComponent GetComponent<TComponent>() where TComponent : class
         {
             if (this is TComponent component) return component;
+            if (_components.TryGetValue(typeof(TComponent), out var result))
+            {
+                return (TComponent)result;
+            }
+            else if (typeof(TComponent) == typeof(PlacementStrategy))
+            {
+                return (TComponent)(object)ClientObserversPlacement.Instance;
+            }
+
+            lock (_lockObj)
+            {
+                if (ActivationServices.GetService<TComponent>() is { } activatedComponent)
+                {
+                    return (TComponent)_components.GetOrAdd(typeof(TComponent), activatedComponent);
+                }
+            }
+
             return default;
         }
 
@@ -58,7 +76,21 @@ namespace Orleans
 
         public void SetComponent<TComponent>(TComponent instance) where TComponent : class
         {
-            throw new NotSupportedException($"Cannot set components on shared client instance. Extension contract: {typeof(TComponent)}. Component: {instance} (Type: {instance?.GetType()})");
+            if (this is TComponent)
+            {
+                throw new ArgumentException("Cannot override a component which is implemented by the client context");
+            }
+
+            lock (_lockObj)
+            {
+                if (instance == null)
+                {
+                    _components.Remove(typeof(TComponent), out _);
+                    return;
+                }
+
+                _components[typeof(TComponent)] = instance;
+            }
         }
 
         public (TExtension, TExtensionInterface) GetOrSetExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -215,6 +215,11 @@ namespace Orleans.Runtime
             {
                 result = (TComponent)resultObj;
             }
+            else if (ActivationServices.GetService<TComponent>() is { } component)
+            {
+                SetComponent(component);
+                result = component;
+            }
             else
             {
                 result = _shared.GetComponent<TComponent>();

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.GrainReferences;
 using Orleans.Internal;
@@ -27,6 +28,8 @@ namespace Orleans.Runtime
         private readonly MessageCenter siloMessageCenter;
         private readonly MessagingTrace messagingTrace;
         private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new ConcurrentDictionary<Type, (object, IAddressable)>();
+        private readonly ConcurrentDictionary<Type, object> _components = new();
+        private readonly IServiceScope _serviceProviderScope;
         private bool disposing;
         private Task messagePump;
 
@@ -64,6 +67,7 @@ namespace Orleans.Runtime
             this.ClientId = CreateHostedClientGrainId(siloDetails.SiloAddress);
             this.Address = Gateway.GetClientActivationAddress(this.ClientId.GrainId, siloDetails.SiloAddress);
             this.GrainReference = referenceActivator.CreateReference(this.ClientId.GrainId, default);
+            _serviceProviderScope = runtimeClient.ServiceProvider.CreateScope();
         }
 
         public static ClientGrainId CreateHostedClientGrainId(SiloAddress siloAddress) => ClientGrainId.Create($"hosted-{siloAddress.ToParsableString()}");
@@ -81,7 +85,7 @@ namespace Orleans.Runtime
 
         public GrainAddress Address { get; }
 
-        public IServiceProvider ActivationServices => this.runtimeClient.ServiceProvider;
+        public IServiceProvider ActivationServices => _serviceProviderScope.ServiceProvider;
 
         public IGrainLifecycle ObservableLifecycle => throw new NotImplementedException();
 
@@ -114,7 +118,7 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public void DeleteObjectReference(IAddressable obj)
         {
-            if (!(obj is GrainReference reference))
+            if (obj is not GrainReference reference)
             {
                 throw new ArgumentException("Argument reference is not a grain reference.");
             }
@@ -133,12 +137,43 @@ namespace Orleans.Runtime
         public TComponent GetComponent<TComponent>() where TComponent : class
         {
             if (this is TComponent component) return component;
+            if (_components.TryGetValue(typeof(TComponent), out var result))
+            {
+                return (TComponent)result;
+            }
+            else if (typeof(TComponent) == typeof(PlacementStrategy))
+            {
+                return (TComponent)(object)ClientObserversPlacement.Instance;
+            }
+
+            lock (lockObj)
+            {
+                if (ActivationServices.GetService<TComponent>() is { } activatedComponent)
+                {
+                    return (TComponent)_components.GetOrAdd(typeof(TComponent), activatedComponent);
+                }
+            }
+
             return default;
         }
 
         public void SetComponent<TComponent>(TComponent instance) where TComponent : class
         {
-            throw new NotSupportedException($"Cannot set components on shared client instance. Extension contract: {typeof(TComponent)}. Component: {instance} (Type: {instance?.GetType()})");
+            if (this is TComponent)
+            {
+                throw new ArgumentException("Cannot override a component which is implemented by the client context");
+            }
+
+            lock (lockObj)
+            {
+                if (instance == null)
+                {
+                    _components.Remove(typeof(TComponent), out _);
+                    return;
+                }
+
+                _components[typeof(TComponent)] = instance;
+            }
         }
 
         /// <inheritdoc />
@@ -180,6 +215,7 @@ namespace Orleans.Runtime
         {
             if (this.disposing) return;
             this.disposing = true;
+            _serviceProviderScope.Dispose();
             Utils.SafeExecute(() => this.siloMessageCenter.SetHostedClient(null));
             Utils.SafeExecute(() => this.incomingMessages.Writer.TryComplete());
             Utils.SafeExecute(() => this.messagePump?.GetAwaiter().GetResult());

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -149,23 +149,17 @@ namespace Orleans.Runtime
                 sharedData = this.sharedCallbackData;
             }
 
-            var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
-            if (context is null && !oneWay)
-            {
-                this.logger.LogWarning(
-                    (int)ErrorCode.IGC_SendRequest_NullContext,
-                    "Null context {Message}: {StackTrace}",
-                    message,
-                    Utils.GetStackTrace());
-            }
-
             if (message.IsExpirableMessage(this.messagingOptions.DropExpiredMessages))
             {
                 message.TimeToLive = sharedData.ResponseTimeout;
             }
 
+            var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             if (!oneWay)
             {
+                Debug.Assert(context is not null);
+
+                // Register a callback for the request.
                 var callbackData = new CallbackData(sharedData, context, message);
                 callbacks.TryAdd((message.SendingGrain, message.Id), callbackData);
             }

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -560,13 +560,9 @@ namespace Orleans
 namespace Orleans.Invocation
 {
     /// <summary>
-    /// Applied to invokable base types to indicate that instances of this type should be returned directly from generated proxy methods rather than being passed to
-    /// the proxy invoke method.
+    /// Applied to invokable base types (see TaskRequest) to indicate that instances of derived types should be returned directly from generated proxy methods rather than being passed to
+    /// the runtime for invocation. This is used to support calling patterns other than request-response, such as streaming.
     /// </summary>
-    /// <remarks>
-    /// This is used for types which should not be submitted to the remote target immediately, such as durable tasks, possibly async enumerables, and other types
-    /// which do not follow the typical request-response pattern.
-    /// </remarks>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ReturnValueProxyAttribute : Attribute
     {
@@ -575,6 +571,9 @@ namespace Orleans.Invocation
             InitializerMethodName = initializerMethodName;
         }
 
+        /// <summary>
+        /// The name of the method to 
+        /// </summary>
         public string InitializerMethodName { get; }
     }
 }

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -536,7 +536,7 @@ namespace Orleans
         TValue ConvertFromSurrogate(in TSurrogate surrogate);
 
         /// <summary>
-        /// Converts a value to the valuetype.
+        /// Converts a value to the value type.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The surrogate.</returns>
@@ -554,5 +554,27 @@ namespace Orleans
         /// <param name="surrogate">The surrogate.</param>
         /// <param name="value">The value.</param>
         void Populate(in TSurrogate surrogate, TValue value);
+    }
+}
+
+namespace Orleans.Invocation
+{
+    /// <summary>
+    /// Applied to invokable base types to indicate that instances of this type should be returned directly from generated proxy methods rather than being passed to
+    /// the proxy invoke method.
+    /// </summary>
+    /// <remarks>
+    /// This is used for types which should not be submitted to the remote target immediately, such as durable tasks, possibly async enumerables, and other types
+    /// which do not follow the typical request-response pattern.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ReturnValueProxyAttribute : Attribute
+    {
+        public ReturnValueProxyAttribute(string initializerMethodName)
+        {
+            InitializerMethodName = initializerMethodName;
+        }
+
+        public string InitializerMethodName { get; }
     }
 }

--- a/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/Grains/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grains/TestGrains/TestGrains.csproj
+++ b/test/Grains/TestGrains/TestGrains.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(MinTestTargetFramework)</TargetFramework>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <NoWarn>$(NoWarn);1591;1591;618</NoWarn>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR adds support for extending the set of supported grain return types.

This allows us to support calling patterns beyond request-response. For example, `IAsyncEnumerable<T>`.
A subsequent PR will add initial support for returning `IAsyncEnumerable<T>` from grains, based on this functionality.

To use this, a developer would start by annotating a request base type with `[ReturnValueProxy(initializerMethodName)]`. Doing so prevents the code generator from relying on .NET's `AsyncMethodBuilder` to create the instances of the return type and instead allows the value returned from the method with the name specified by `initializerMethodName` to provide that value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8415)