### PR TITLE
Automate more of the Kubernetes hosting experience

### DIFF
--- a/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
@@ -1,8 +1,14 @@
+#nullable enable
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 
 namespace Orleans.Hosting.Kubernetes
 {
@@ -21,31 +27,60 @@ namespace Orleans.Hosting.Kubernetes
 
         public void Configure(KubernetesHostingOptions options)
         {
-            options.Namespace = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNamespaceEnvironmentVariable);
-            options.PodName = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable);
-            options.PodIP = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodIPEnvironmentVariable);
+            options.Namespace ??= Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNamespaceEnvironmentVariable) ?? ReadNamespaceFromServiceAccount();
+            options.PodName ??= Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable) ?? Environment.MachineName;
+            options.PodIP ??= Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodIPEnvironmentVariable);
         }
 
         public void Configure(ClusterOptions options)
         {
-            options.ServiceId = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ServiceIdEnvironmentVariable);
-            options.ClusterId = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ClusterIdEnvironmentVariable);
+            var serviceIdEnvVar = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ServiceIdEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(serviceIdEnvVar))
+            {
+                options.ServiceId = serviceIdEnvVar;
+            }
+
+            var clusterIdEnvVar = Environment.GetEnvironmentVariable(KubernetesHostingOptions.ClusterIdEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(clusterIdEnvVar))
+            {
+                options.ClusterId = clusterIdEnvVar;
+            }
         }
 
         public void Configure(SiloOptions options)
         {
-            options.SiloName = Environment.GetEnvironmentVariable(KubernetesHostingOptions.PodNameEnvironmentVariable);
+            var hostingOptions = _serviceProvider.GetRequiredService<IOptions<KubernetesHostingOptions>>().Value;
+            if (!string.IsNullOrWhiteSpace(hostingOptions.PodName))
+            {
+                options.SiloName = hostingOptions.PodName;
+            }
         }
 
-        public void PostConfigure(string name, EndpointOptions options)
+        public void PostConfigure(string? name, EndpointOptions options)
         {
             // Use PostConfigure to give the developer an opportunity to set SiloPort and GatewayPort using regular
             // Configure methods without needing to worry about ordering with respect to the UseKubernetesHosting call.
             if (options.AdvertisedIPAddress is null)
             {
                 var hostingOptions = _serviceProvider.GetRequiredService<IOptions<KubernetesHostingOptions>>().Value;
-                var podIp = IPAddress.Parse(hostingOptions.PodIP);
-                options.AdvertisedIPAddress = podIp;
+                IPAddress? podIp = null;
+                if (hostingOptions.PodIP is not null)
+                {
+                    podIp = IPAddress.Parse(hostingOptions.PodIP);
+                }
+                else
+                {
+                    var hostAddresses = Dns.GetHostAddresses(hostingOptions.PodName);
+                    if (hostAddresses != null)
+                    {
+                        podIp = IPAddressSelector.PickIPAddress(hostAddresses);
+                    }
+                }
+
+                if (podIp is not null)
+                {
+                    options.AdvertisedIPAddress = podIp;
+                }
             }
 
             if (options.SiloListeningEndpoint is null)
@@ -56,6 +91,112 @@ namespace Orleans.Hosting.Kubernetes
             if (options.GatewayListeningEndpoint is null && options.GatewayPort > 0)
             {
                 options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, options.GatewayPort);
+            }
+        }
+
+        private string? ReadNamespaceFromServiceAccount()
+        {
+            // Read the namespace from the pod's service account.
+            var serviceAccountNamespacePath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount", "namespace");
+            if (File.Exists(serviceAccountNamespacePath))
+            {
+                return File.ReadAllText(serviceAccountNamespacePath).Trim();
+            }
+
+            return null;
+        }
+
+        private static class IPAddressSelector
+        {
+            // IANA private IPv4 addresses
+            private static readonly (IPAddress Address, IPAddress SubnetMask)[] PreferredRanges = new []
+            {
+                (IPAddress.Parse("192.168.0.0"), IPAddress.Parse("255.255.0.0")),
+                (IPAddress.Parse("10.0.0.0"), IPAddress.Parse("255.0.0.0")),
+                (IPAddress.Parse("172.16.0.0"), IPAddress.Parse("255.240.0.0")),
+            };
+
+            public static IPAddress? PickIPAddress(IReadOnlyList<IPAddress> candidates)
+            {
+                IPAddress? chosen = null;
+                foreach (var address in candidates)
+                {
+                    if (chosen is null)
+                    {
+                        chosen = address;
+                    }
+                    else
+                    {
+                        if (CompareIPAddresses(address, chosen))
+                        {
+                            chosen = address;
+                        }
+                    }
+                }
+                return chosen;
+
+                // returns true if lhs is "less" (in some repeatable sense) than rhs
+                static bool CompareIPAddresses(IPAddress lhs, IPAddress rhs)
+                {
+                    var lhsBytes = lhs.GetAddressBytes();
+                    var rhsBytes = rhs.GetAddressBytes();
+
+                    if (lhsBytes.Length != rhsBytes.Length)
+                    {
+                        return lhsBytes.Length < rhsBytes.Length;
+                    }
+
+                    // Prefer IANA private IPv4 address ranges 10.x.x.x, 192.168.x.x, 172.16-31.x.x over other addresses.
+                    if (lhs.AddressFamily is AddressFamily.InterNetwork && rhs.AddressFamily is AddressFamily.InterNetwork)
+                    {
+                        var lhsPref = GetPreferredSubnetRank(lhs);
+                        var rhsPref = GetPreferredSubnetRank(rhs);
+                        if (lhsPref != rhsPref)
+                        {
+                            return lhsPref < rhsPref;
+                        }
+                    }
+
+                    // Compare starting from most significant octet.
+                    // 10.68.20.21 < 10.98.05.04
+                    return lhsBytes.AsSpan().SequenceCompareTo(rhsBytes.AsSpan()) < 0;
+                }
+
+                static int GetPreferredSubnetRank(IPAddress ip)
+                {
+                    var ipBytes = ip.GetAddressBytes();
+                    Span<byte> masked = stackalloc byte[ipBytes.Length];
+                    var i = 0;
+                    foreach (var (Address, SubnetMask) in PreferredRanges)
+                    {
+                        ipBytes.CopyTo(masked);
+                        var subnetMaskBytes = SubnetMask.GetAddressBytes();
+                        if (ipBytes.Length != subnetMaskBytes.Length)
+                        {
+                            continue;
+                        }
+
+                        And(ipBytes, subnetMaskBytes, masked);
+                        if (masked.SequenceEqual(Address.GetAddressBytes()))
+                        {
+                            return i;
+                        }
+
+                        ++i;
+                    }
+
+                    return PreferredRanges.Length;
+                    static void And(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs, Span<byte> result)
+                    {
+                        Debug.Assert(lhs.Length == rhs.Length);
+                        Debug.Assert(lhs.Length == result.Length);
+
+                        for (var i = 0; i < lhs.Length; i++)
+                        {
+                            result[i] = (byte)(lhs[i] & rhs[i]);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptions.cs
@@ -69,6 +69,11 @@ namespace Orleans.Hosting.Kubernetes
         public int MaxAgents { get; set; } = 2;
 
         /// <summary>
+        /// Gets or sets the maximum number of attempts to retry Kubernetes API calls.
+        /// </summary>
+        public int MaxKubernetesApiRetryAttempts { get; set; } = 10;
+
+        /// <summary>
         /// Whether or not to delete pods which correspond to silos which have become defunct since this silo became active.
         /// </summary>
         public bool DeleteDefunctSiloPods { get; set; } = false;

--- a/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptionsValidator.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesHostingOptionsValidator.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.Options;
-using Orleans.Configuration;
-using System;
 using System.Collections.Generic;
 
 namespace Orleans.Hosting.Kubernetes
@@ -10,10 +8,6 @@ namespace Orleans.Hosting.Kubernetes
     /// </summary>
     internal class KubernetesHostingOptionsValidator : IValidateOptions<KubernetesHostingOptions>
     {
-        private readonly IOptions<SiloOptions> _siloOptions;
-
-        public KubernetesHostingOptionsValidator(IOptions<SiloOptions> siloOptions) => _siloOptions = siloOptions;
-
         public ValidateOptionsResult Validate(string name, KubernetesHostingOptions options)
         {
             List<string> failures = default;
@@ -27,12 +21,6 @@ namespace Orleans.Hosting.Kubernetes
             {
                 failures ??= new List<string>();
                 failures.Add($"{nameof(KubernetesHostingOptions)}.{nameof(KubernetesHostingOptions.PodName)} is not set. Set it via the {KubernetesHostingOptions.PodNameEnvironmentVariable} environment variable");
-            }
-
-            if (!string.Equals(_siloOptions.Value.SiloName, options.PodName, StringComparison.Ordinal))
-            {
-                failures ??= new List<string>();
-                failures.Add($"{nameof(SiloOptions)}.{nameof(SiloOptions.SiloName)} is not equal to the current pod name as defined by {nameof(KubernetesHostingOptions)}.{nameof(KubernetesHostingOptions.PodName)}");
             }
 
             if (failures is not null) return ValidateOptionsResult.Fail(failures);

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -448,11 +448,14 @@ namespace Orleans.Runtime
                     }
                 }
 
-                logger.LogInformation(
-                    (int)ErrorCode.Catalog_SiloStatusChangeNotification,
-                    "Catalog is deactivating {Count} activations due to a failure of silo {Silo}, since it is a primary directory partition to these grain ids.",
-                    activationsToShutdown.Count,
-                    updatedSilo.ToStringWithHashCode());
+                if (activationsToShutdown.Count > 0)
+                {
+                    logger.LogInformation(
+                        (int)ErrorCode.Catalog_SiloStatusChangeNotification,
+                        "Catalog is deactivating {Count} activations due to a failure of silo {Silo}, since it is a primary directory partition to these grain ids.",
+                        activationsToShutdown.Count,
+                        updatedSilo.ToStringWithHashCode());
+                }
             }
             finally
             {


### PR DESCRIPTION
This PR simplifies the procedure of using the `Microsoft.Orleans.Hosting.Kubernetes` package by automating more of the process. With this PR, users will no longer need to specify labels or environment variables in their pod specs.

It manages this by:
* Inferring pod name from `Environment.MachineName` if not configured via env vars
* Inferring pod namespace from `/var/run/secrets/kubernetes.io/serviceaccount/namespace` if not configured via env vars
* Updating labels on the pod spec during startup to match the internally configured (eg, default) `ServiceId` & `ClusterId` if they are not configured via labels
* Selecting the most appropriate PodIp based on the IANA private IPv4 address ranges if not configured via env vars

Additionally, it filters out non-`Active` members when performing the on-start purge of unmatched silos. This prevents a race that exists today.

It adds retries to initialization and demotes the Error-level log when Kubernetes drops a watch to Debug (it's not actionable, is common/normal, and is retried indefinitely)

Patching the pod resource (to update labels for discovery) requires the `patch` verb on the pod's role binding. The package will spit out a log line with an example binding if it receives a permissions error trying to list/get/patch pods

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8426)