### PR TITLE
Fix parameter null check in RegexStreamNamespacePredicate

### DIFF
--- a/src/Orleans.Streaming/Predicates/RegexStreamNamespacePredicate.cs
+++ b/src/Orleans.Streaming/Predicates/RegexStreamNamespacePredicate.cs
@@ -23,7 +23,8 @@ namespace Orleans.Streams
         /// <param name="regex">The stream namespace regular expression.</param>
         public RegexStreamNamespacePredicate(string regex)
         {
-            this.regex = new Regex(regex, RegexOptions.Compiled) ?? throw new ArgumentNullException(nameof(regex));
+            ArgumentNullException.ThrowIfNull(regex);
+            this.regex = new Regex(regex, RegexOptions.Compiled);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Previous check was a no-op.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8429)