### PR TITLE
Moving RuntimeContext check inside ReminderRegistry

### DIFF
--- a/src/Orleans.Reminders/GrainReminderExtensions.cs
+++ b/src/Orleans.Reminders/GrainReminderExtensions.cs
@@ -117,17 +117,10 @@ public static class GrainReminderExtensions
     }
 
     /// <summary>
-    /// Gets the <see cref="IReminderService"/>.
+    /// Gets the <see cref="IReminderRegistry"/>.
     /// </summary>
     private static IReminderRegistry GetReminderRegistry(IGrainContext grainContext)
     {
-        if (RuntimeContext.Current is null) ThrowInvalidContext();
         return grainContext.ActivationServices.GetRequiredService<IReminderRegistry>();
-    }
-
-    private static void ThrowInvalidContext()
-    {
-        throw new InvalidOperationException("Attempted to access grain from a non-grain context, such as a background thread, which is invalid."
-            + " Ensure that you are only accessing grain functionality from within the context of a grain.");
     }
 }

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -1,17 +1,11 @@
 //#define USE_SQL_SERVER
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
+using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
-using Orleans.Internal;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -126,11 +120,11 @@ namespace UnitTests.TimerTests
             // do some time tests as well
             log.LogInformation("Time tests");
             TimeSpan period = await grain.GetReminderPeriod(DR);
-            await Task.Delay(period.Multiply(2) + LEEWAY); // giving some leeway
+            await Task.Delay((period + LEEWAY).Multiply(2)); // giving some leeway, including leeway in each period to minimize flakiness
             for (int i = 0; i < count; i++)
             {
                 long curr = await grain.GetCounter(DR + "_" + i);
-                Assert.Equal(2,  curr);
+                Assert.Equal(2, curr);
             }
         }
 
@@ -144,7 +138,7 @@ namespace UnitTests.TimerTests
 
             TimeSpan period = await g1.GetReminderPeriod(DR);
 
-            Task<bool>[] tasks = 
+            Task<bool>[] tasks =
             {
                 Task.Run(() => this.PerGrainMultiReminderTestChurn(g1)),
                 Task.Run(() => this.PerGrainMultiReminderTestChurn(g2)),
@@ -169,7 +163,7 @@ namespace UnitTests.TimerTests
 
             // request a reminder that does not exist
             IGrainReminder reminder = await g1.GetReminderObject("blarg");
-           Assert.Null(reminder);
+            Assert.Null(reminder);
         }
 
         internal async Task<bool> PerGrainMultiReminderTestChurn(IReminderTestGrain2 g)
@@ -335,12 +329,12 @@ namespace UnitTests.TimerTests
             await grain.StartReminder(DR);
             await Task.Delay(period.Multiply(failCheckAfter) + LEEWAY); // giving some leeway
             long last = await grain.GetCounter(DR);
-            Assert.Equal(failCheckAfter,   last);  // "{0} CopyGrain {1} Reminder {2}" // Time(), grain.GetPrimaryKey(), DR);
+            Assert.Equal(failCheckAfter, last);  // "{0} CopyGrain {1} Reminder {2}" // Time(), grain.GetPrimaryKey(), DR);
 
             await grain.StopReminder(DR);
             await Task.Delay(period.Multiply(2) + LEEWAY); // giving some leeway
             long curr = await grain.GetCounter(DR);
-            Assert.Equal(last,  curr); // "{0} CopyGrain {1} Reminder {2}", Time(), grain.GetPrimaryKey(), DR);
+            Assert.Equal(last, curr); // "{0} CopyGrain {1} Reminder {2}", Time(), grain.GetPrimaryKey(), DR);
 
             return true;
         }


### PR DESCRIPTION
### Motivation

In unit testing libraries (such as [OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit)) the `RuntimeContext` check for reminder-based grain calls proves very challenging.

Because `RuntimeContext` uses a thread-local mechanism, it becomes non-trivial to ensure the unit test runs on the same thread as the calling code (imagine some IO-bound async behavior happening between the unit test & the Reminder call)

This is related to some of the conversation going on in https://github.com/OrleansContrib/OrleansTestKit/issues/134

Also related to https://github.com/dotnet/orleans/issues/8387 - RuntimeContext hard to test

### Proposed Fix

Move the `RuntimeContext` check into the `ReminderRegistry` so that it sits behind a stubbable testing seam interface instead of residing in an extension method.  This fix should have very similar performance as the prior code.

This change also provides more consistent w/ the Timer Registry implementation, which defers this check to inside the [GrainTimer](https://github.com/dotnet/orleans/blob/4e521dee4f10d1827d7c8676984a952e319312b5/src/Orleans.Runtime/Timers/GrainTimer.cs#L27) code

Alternatives considered:
1. Extending `ReminderOptions` to control if the RuntimeContext check occurs
2. Implementing a singleton `IReminderRegistryResolver` that provides a testing seam to control this logic.

cc @ReubenBond @seniorquico 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8436)