### PR TITLE
ObserverManager: nits

### DIFF
--- a/src/Orleans.Core/Utils/ObserverManager.cs
+++ b/src/Orleans.Core/Utils/ObserverManager.cs
@@ -37,7 +37,7 @@ namespace Orleans.Utilities
     /// <typeparam name="TObserver">
     /// The observer type.
     /// </typeparam>
-    public class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver>
+    public class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> where TIdentity : notnull
     {
         /// <summary>
         /// The observers.
@@ -81,13 +81,7 @@ namespace Orleans.Utilities
         /// <summary>
         /// Gets a copy of the observers.
         /// </summary>
-        public IDictionary<TIdentity, TObserver> Observers
-        {
-            get
-            {
-                return _observers.ToDictionary(_ => _.Key, _ => _.Value.Observer);
-            }
-        }
+        public IDictionary<TIdentity, TObserver> Observers => _observers.ToDictionary(_ => _.Key, _ => _.Value.Observer);
 
         /// <summary>
         /// Removes all observers.
@@ -136,8 +130,11 @@ namespace Orleans.Utilities
         /// </param>
         public void Unsubscribe(TIdentity id)
         {
-            _log.LogDebug("Removed entry for {Id}. {Count} total observers after remove.", id, _observers.Count);
             _observers.Remove(id, out _);
+            if (_log.IsEnabled(LogLevel.Debug))
+            {
+                _log.LogDebug("Removed entry for {Id}. {Count} total observers after remove.", id, _observers.Count);
+            }
         }
 
         /// <summary>
@@ -192,7 +189,7 @@ namespace Orleans.Utilities
                     _observers.Remove(observer, out _);
                     if (_log.IsEnabled(LogLevel.Debug))
                     {
-                        _log.LogDebug("Removing defunct entry for {0}. {1} total observers after remove.", observer, _observers.Count);
+                        _log.LogDebug("Removing defunct entry for {Id}. {Count} total observers after remove.", observer, _observers.Count);
                     }
                 }
             }
@@ -247,7 +244,7 @@ namespace Orleans.Utilities
                     _observers.Remove(observer, out _);
                     if (_log.IsEnabled(LogLevel.Debug))
                     {
-                        _log.LogDebug("Removing defunct entry for {Observer}. {Count} total observers after remove.", observer, _observers.Count);
+                        _log.LogDebug("Removing defunct entry for {Id}. {Count} total observers after remove.", observer, _observers.Count);
                     }
                 }
             }


### PR DESCRIPTION
I made a few adjustments:

- In the `Unsubscribe` method, I added a missing `if` clause with `_log.IsEnabled(LogLevel.Debug)` and moved the log message **after** the `Remove` call to ensure that the `Count` property gets updated correctly. Previously, the message could be misleading because it displayed the count before the removal.
- I addressed the [CA2253](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2253): Named placeholders should not be numeric values.
- I also added a `where TIdentity : notnull` constraint. Although nullable is not enabled, the `Dictionary` uses this constraint, so I applied it for consistency.
- Additionally, I replaced **{Observer}** with **{Id}** in one of the log message, as it aligns with the rest of the code and reflects the actual type of `TIdentity`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8460)