### PR TITLE
Added `HostApplicationBuilder` extensions

### DIFF
--- a/src/Orleans.Core/Hosting/OrleansClientGenericHostExtensions.cs
+++ b/src/Orleans.Core/Hosting/OrleansClientGenericHostExtensions.cs
@@ -32,11 +32,6 @@ namespace Microsoft.Extensions.Hosting
             ArgumentNullException.ThrowIfNull(hostAppBuilder);
             ArgumentNullException.ThrowIfNull(configureDelegate);
 
-            if (hostAppBuilder.Services.Any(s => s.ServiceType.Equals(MarkerType)))
-            {
-                throw GetOrleansSiloAddedException();
-            }
-
             hostAppBuilder.Services.AddOrleansClient(configureDelegate);
 
             return hostAppBuilder;

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
-
+  
 </Project>

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -28,5 +28,5 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Orleans.Runtime/Hosting/OrleansSiloGenericHostExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/OrleansSiloGenericHostExtensions.cs
@@ -39,11 +39,6 @@ namespace Microsoft.Extensions.Hosting
             ArgumentNullException.ThrowIfNull(hostAppBuilder);
             ArgumentNullException.ThrowIfNull(configureDelegate);
 
-            if (hostAppBuilder.Services.Any(service => service.ServiceType.Equals(MarkerType)))
-            {
-                throw GetOrleansClientAddedException();
-            }
-
             hostAppBuilder.Services.AddOrleans(configureDelegate);
 
             return hostAppBuilder;

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Concurrency;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -39,8 +34,8 @@ namespace DefaultCluster.Tests.General
             public async Task InitializeAsync()
             {
                 var (siloPort, gatewayPort) = portAllocator.AllocateConsecutivePortPairs(1);
-                Host = new HostBuilder()
-                    .UseOrleans((ctx, siloBuilder) =>
+                Host = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder()
+                    .UseOrleans(siloBuilder =>
                     {
                         siloBuilder
                             .UseLocalhostClustering(siloPort, gatewayPort)

--- a/test/NonSilo.Tests/ClientBuilderTests.cs
+++ b/test/NonSilo.Tests/ClientBuilderTests.cs
@@ -174,7 +174,7 @@ namespace NonSilo.Tests
             Assert.Throws<ArgumentNullException>(() => hostBuilder.ConfigureServices(null));
 
             var registeredFirst = new int[1];
-            
+
             var one = new MyService { Id = 1 };
             hostBuilder.ConfigureServices(
                 services =>
@@ -196,7 +196,7 @@ namespace NonSilo.Tests
             var client = host.Services.GetRequiredService<IClusterClient>();
             var services = client.ServiceProvider.GetServices<MyService>()?.ToList();
             Assert.NotNull(services);
-            
+
             // Both services should be registered.
             Assert.Equal(2, services.Count);
             Assert.NotNull(services.FirstOrDefault(svc => svc.Id == 1));
@@ -220,6 +220,23 @@ namespace NonSilo.Tests
                         siloBuilder.UseLocalhostClustering();
                     })
                     .UseOrleansClient((ctx, clientBuilder) =>
+                    {
+                        clientBuilder.UseLocalhostClustering();
+                    });
+            });
+        }
+
+        [Fact]
+        public void ClientBuilderWithHotApplicationBuilderThrowsDuringStartupIfSiloBuildersAdded()
+        {
+            Assert.Throws<OrleansConfigurationException>(() =>
+            {
+                _ = Host.CreateApplicationBuilder()
+                    .UseOrleans(siloBuilder =>
+                    {
+                        siloBuilder.UseLocalhostClustering();
+                    })
+                    .UseOrleansClient(clientBuilder =>
                     {
                         clientBuilder.UseLocalhostClustering();
                     });

--- a/test/NonSilo.Tests/SiloBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloBuilderTests.cs
@@ -201,6 +201,23 @@ namespace NonSilo.Tests
             });
         }
 
+        [Fact]
+        public void SiloBuilderWithHotApplicationBuilderThrowsDuringStartupIfClientBuildersAdded()
+        {
+            Assert.Throws<OrleansConfigurationException>(() =>
+            {
+                _ = Host.CreateApplicationBuilder()
+                    .UseOrleansClient(clientBuilder =>
+                    {
+                        clientBuilder.UseLocalhostClustering();
+                    })
+                    .UseOrleans(siloBuilder =>
+                    {
+                        siloBuilder.UseLocalhostClustering();
+                    });
+            });
+        }
+
         private class FakeHostEnvironmentStatistics : IHostEnvironmentStatistics
         {
             public long? TotalPhysicalMemory => 0;


### PR DESCRIPTION
In this PR (related to #8465):

- The _Orleans.Core.csproj_ now depends on `Microsoft.Extensions.Hosting`, instead of just the `Microsoft.Extensions.Hosting.Abstractions`.
- Exposed an `UseOrleans/UseOrleansClient` extension on the `HostApplicationBuilder` API.
- Update the unit tests to use the new extension, see _test/DefaultCluster.Tests/HostedClientTests.cs_.
- Use `ArgumentNullException.ThrowIfNull` in updated _src/Orleans.Runtime/Hosting/GenericHostExtensions.cs_.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8466)