### PR TITLE
Mark Redis providers as stable

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
+++ b/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
@@ -6,7 +6,6 @@
     <Description>Microsoft Orleans Clustering implementation that uses Redis</Description>
     <PackageTags>$(PackageTags) Redis Clustering</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
-    <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 

--- a/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
@@ -6,7 +6,6 @@
     <Description>Microsoft Orleans Grain Directory implementation that uses Redis</Description>
     <PackageTags>$(PackageTags) Redis Grain Directory</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
-    <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 

--- a/src/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.csproj
+++ b/src/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.csproj
@@ -6,7 +6,6 @@
     <Description>Microsoft Orleans Persistence implementation that uses Redis</Description>
     <PackageTags>$(PackageTags) Redis Persistence</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
-    <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 

--- a/src/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.csproj
+++ b/src/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.csproj
@@ -6,7 +6,6 @@
     <Description>Microsoft Orleans Reminders implementation that uses Redis</Description>
     <PackageTags>$(PackageTags) Redis Reminders</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
-    <VersionSuffix Condition="$(VersionSuffix) == ''">beta1</VersionSuffix>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR marks the Redis providers as stable

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8467)