### PR TITLE
Improve DeploymentLoadPublisher logic and cleanup

### DIFF
--- a/src/Orleans.Core/Statistics/SiloRuntimeStatistics.cs
+++ b/src/Orleans.Core/Statistics/SiloRuntimeStatistics.cs
@@ -65,7 +65,6 @@ namespace Orleans.Runtime
         [Id(9)]
         public long SentMessages { get; }
 
-
         /// <summary>
         /// The DateTime when this statistics was created.
         /// </summary>

--- a/src/Orleans.Core/SystemTargetInterfaces/IDeploymentLoadPublisher.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDeploymentLoadPublisher.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
+using Orleans.Concurrency;
 
 namespace Orleans.Runtime
 {
     internal interface IDeploymentLoadPublisher : ISystemTarget
     {
+        [OneWay]
         Task UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats);
     }
 }

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -16,22 +16,25 @@ namespace Orleans.Runtime
     /// </summary>
     internal class DeploymentLoadPublisher : SystemTarget, IDeploymentLoadPublisher, ISiloStatusListener
     {
-        private readonly ILocalSiloDetails siloDetails;
-        private readonly ISiloStatusOracle siloStatusOracle;
-        private readonly IInternalGrainFactory grainFactory;
-        private readonly ActivationDirectory activationDirectory;
-        private readonly IActivationWorkingSet activationWorkingSet;
-        private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
-        private readonly IHostEnvironmentStatistics hostEnvironmentStatistics;
-        private readonly IOptions<LoadSheddingOptions> loadSheddingOptions;
+        private readonly ILocalSiloDetails _siloDetails;
+        private readonly ISiloStatusOracle _siloStatusOracle;
+        private readonly IInternalGrainFactory _grainFactory;
+        private readonly ActivationDirectory _activationDirectory;
+        private readonly IActivationWorkingSet _activationWorkingSet;
+        private readonly IAppEnvironmentStatistics _appEnvironmentStatistics;
+        private readonly IHostEnvironmentStatistics _hostEnvironmentStatistics;
+        private readonly IOptions<LoadSheddingOptions> _loadSheddingOptions;
+        private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> _periodicStats;
+        private readonly TimeSpan _statisticsRefreshTime;
+        private readonly List<ISiloStatisticsChangeListener> _siloStatisticsChangeListeners;
+        private readonly ILogger _logger;
 
-        private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> periodicStats;
-        private readonly TimeSpan statisticsRefreshTime;
-        private readonly IList<ISiloStatisticsChangeListener> siloStatisticsChangeListeners;
-        private readonly ILogger logger;
-        private IDisposable publishTimer;
+        private long _lastUpdateDateTimeTicks;
+        private IDisposable _publishTimer;
 
-        public ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> PeriodicStatistics { get { return periodicStats; } }
+        public ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> PeriodicStatistics => _periodicStats;
+
+        public SiloRuntimeStatistics LocalRuntimeStatistics { get; private set; }
 
         public DeploymentLoadPublisher(
             ILocalSiloDetails siloDetails,
@@ -46,155 +49,189 @@ namespace Orleans.Runtime
             IOptions<LoadSheddingOptions> loadSheddingOptions)
             : base(Constants.DeploymentLoadPublisherSystemTargetType, siloDetails.SiloAddress, loggerFactory)
         {
-            this.logger = loggerFactory.CreateLogger<DeploymentLoadPublisher>();
-            this.siloDetails = siloDetails;
-            this.siloStatusOracle = siloStatusOracle;
-            this.grainFactory = grainFactory;
-            this.activationDirectory = activationDirectory;
-            this.activationWorkingSet = activationWorkingSet;
-            this.appEnvironmentStatistics = appEnvironmentStatistics;
-            this.hostEnvironmentStatistics = hostEnvironmentStatistics;
-            this.loadSheddingOptions = loadSheddingOptions;
-            statisticsRefreshTime = options.Value.DeploymentLoadPublisherRefreshTime;
-            periodicStats = new ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>();
-            siloStatisticsChangeListeners = new List<ISiloStatisticsChangeListener>();
+            _logger = loggerFactory.CreateLogger<DeploymentLoadPublisher>();
+            _siloDetails = siloDetails;
+            _siloStatusOracle = siloStatusOracle;
+            _grainFactory = grainFactory;
+            _activationDirectory = activationDirectory;
+            _activationWorkingSet = activationWorkingSet;
+            _appEnvironmentStatistics = appEnvironmentStatistics;
+            _hostEnvironmentStatistics = hostEnvironmentStatistics;
+            _loadSheddingOptions = loadSheddingOptions;
+            _statisticsRefreshTime = options.Value.DeploymentLoadPublisherRefreshTime;
+            _periodicStats = new ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>();
+            _siloStatisticsChangeListeners = new List<ISiloStatisticsChangeListener>();
         }
 
         public async Task Start()
         {
-            logger.LogDebug("Starting DeploymentLoadPublisher");
-            if (statisticsRefreshTime > TimeSpan.Zero)
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Starting DeploymentLoadPublisher");
+            }
+
+            if (_statisticsRefreshTime > TimeSpan.Zero)
             {
                 // Randomize PublishStatistics timer,
                 // but also upon start publish my stats to everyone and take everyone's stats for me to start with something.
-                var randomTimerOffset = RandomTimeSpan.Next(statisticsRefreshTime);
-                this.publishTimer = this.RegisterTimer(PublishStatistics, null, randomTimerOffset, statisticsRefreshTime, "DeploymentLoadPublisher.PublishStatisticsTimer");
+                var randomTimerOffset = RandomTimeSpan.Next(_statisticsRefreshTime);
+                _publishTimer = RegisterTimer(
+                    static state => ((DeploymentLoadPublisher)state).PublishStatistics(),
+                    this,
+                    randomTimerOffset,
+                    _statisticsRefreshTime,
+                    "DeploymentLoadPublisher.PublishStatisticsTimer");
             }
-            await RefreshStatistics();
-            await PublishStatistics(null);
-            logger.LogDebug("Started DeploymentLoadPublisher");
+
+            await RefreshClusterStatistics();
+            await PublishStatistics();
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Started DeploymentLoadPublisher");
+            }
         }
 
-        private async Task PublishStatistics(object _)
+        private async Task PublishStatistics()
         {
             try
             {
-                if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("PublishStatistics");
-                var members = this.siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
-                var tasks = new List<Task>();
-                var activationCount = this.activationDirectory.Count;
-                var recentlyUsedActivationCount = this.activationWorkingSet.Count;
+                if (_logger.IsEnabled(LogLevel.Trace))
+                {
+                    _logger.LogTrace("PublishStatistics");
+                }
+
+                // Ensure that our timestamp is monotonically increasing.
+                var ticks = _lastUpdateDateTimeTicks = Math.Max(_lastUpdateDateTimeTicks + 1, DateTime.UtcNow.Ticks);
+
                 var myStats = new SiloRuntimeStatistics(
-                    activationCount,
-                    recentlyUsedActivationCount,
-                    this.appEnvironmentStatistics,
-                    this.hostEnvironmentStatistics,
-                    this.loadSheddingOptions,
-                    DateTime.UtcNow);
+                    _activationDirectory.Count,
+                    _activationWorkingSet.Count,
+                    _appEnvironmentStatistics,
+                    _hostEnvironmentStatistics,
+                    _loadSheddingOptions,
+                    new DateTime(ticks, DateTimeKind.Utc));
+
+                // Update statistics locally.
+                LocalRuntimeStatistics = myStats;
+                UpdateRuntimeStatisticsInternal(_siloDetails.SiloAddress, myStats);
+
+                // Inform other cluster members about our refreshed statistics.
+                var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
+                var tasks = new List<Task>(members.Count);
                 foreach (var siloAddress in members)
                 {
+                    // No need to make a grain call to ourselves.
+                    if (siloAddress == _siloDetails.SiloAddress)
+                    {
+                        continue;
+                    }
+
                     try
                     {
-                        tasks.Add(this.grainFactory.GetSystemTarget<IDeploymentLoadPublisher>(
-                            Constants.DeploymentLoadPublisherSystemTargetType, siloAddress)
-                            .UpdateRuntimeStatistics(this.siloDetails.SiloAddress, myStats));
+                        var deploymentLoadPublisher = _grainFactory.GetSystemTarget<IDeploymentLoadPublisher>(Constants.DeploymentLoadPublisherSystemTargetType, siloAddress);
+                        tasks.Add(deploymentLoadPublisher.UpdateRuntimeStatistics(_siloDetails.SiloAddress, myStats));
                     }
                     catch (Exception exception)
                     {
-                        logger.LogWarning(
+                        _logger.LogWarning(
                             (int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_1,
                             exception,
                             "An unexpected exception was thrown by PublishStatistics.UpdateRuntimeStatistics(). Ignored");
                     }
                 }
+
                 await Task.WhenAll(tasks);
             }
             catch (Exception exc)
             {
-                logger.LogWarning(
+                _logger.LogWarning(
                     (int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_2,
                     exc,
                     "An exception was thrown by PublishStatistics.UpdateRuntimeStatistics(). Ignoring");
             }
         }
 
-
         public Task UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("UpdateRuntimeStatistics from {Server}", siloAddress);
-            if (this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
-                return Task.CompletedTask;
-
-            SiloRuntimeStatistics old;
-            // Take only if newer.
-            if (periodicStats.TryGetValue(siloAddress, out old) && old.DateTime > siloStats.DateTime)
-                return Task.CompletedTask;
-
-            periodicStats[siloAddress] = siloStats;
-            NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
+            UpdateRuntimeStatisticsInternal(siloAddress, siloStats);
             return Task.CompletedTask;
         }
 
-        internal async Task<ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>> RefreshStatistics()
+        private void UpdateRuntimeStatisticsInternal(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("RefreshStatistics");
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("UpdateRuntimeStatistics from {Server}", siloAddress);
+            if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+            {
+                return;
+            }
+
+            // Take only if newer.
+            if (_periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime > siloStats.DateTime)
+            {
+                return;
+            }
+
+            _periodicStats[siloAddress] = siloStats;
+            NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
+        }
+
+        internal async Task RefreshClusterStatistics()
+        {
+            if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("RefreshStatistics");
             await this.RunOrQueueTask(() =>
                 {
-                    var tasks = new List<Task>();
-                    var members = this.siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
+                    var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
+                    var tasks = new List<Task>(members.Count);
                     foreach (var siloAddress in members)
                     {
-                        var capture = siloAddress;
-                        Task task = this.grainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, capture)
-                                .GetRuntimeStatistics()
-                                .ContinueWith((Task<SiloRuntimeStatistics> statsTask) =>
-                                    {
-                                        if (statsTask.Status == TaskStatus.RanToCompletion)
-                                        {
-                                            UpdateRuntimeStatistics(capture, statsTask.Result);
-                                        }
-                                        else
-                                        {
-                                            logger.LogWarning(
-                                                (int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_3,
-                                                statsTask.Exception,
-                                                "An unexpected exception was thrown from RefreshStatistics by ISiloControl.GetRuntimeStatistics({SiloAddress}). Will keep using stale statistics.",
-                                                capture);
-                                        }
-                                    });
-                        tasks.Add(task);
-                        task.Ignore();
+                        tasks.Add(RefreshSiloStatistics(siloAddress));
                     }
+
                     return Task.WhenAll(tasks);
                 });
-            return periodicStats;
+        }
+
+        private async Task RefreshSiloStatistics(SiloAddress silo)
+        {
+            try
+            {
+                var statistics = await _grainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo).GetRuntimeStatistics();
+                UpdateRuntimeStatisticsInternal(silo, statistics);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(
+                    (int)ErrorCode.Placement_RuntimeStatisticsUpdateFailure_3,
+                    exception,
+                    "An unexpected exception was thrown from RefreshStatistics by ISiloControl.GetRuntimeStatistics({SiloAddress}). Will keep using stale statistics.",
+                    silo);
+            }
         }
 
         public bool SubscribeToStatisticsChangeEvents(ISiloStatisticsChangeListener observer)
         {
-            lock (siloStatisticsChangeListeners)
+            lock (_siloStatisticsChangeListeners)
             {
-                if (siloStatisticsChangeListeners.Contains(observer)) return false;
+                if (_siloStatisticsChangeListeners.Contains(observer)) return false;
 
-                siloStatisticsChangeListeners.Add(observer);
+                _siloStatisticsChangeListeners.Add(observer);
                 return true;
             }
         }
 
         public bool UnsubscribeStatisticsChangeEvents(ISiloStatisticsChangeListener observer)
         {
-            lock (siloStatisticsChangeListeners)
+            lock (_siloStatisticsChangeListeners)
             {
-                return siloStatisticsChangeListeners.Contains(observer) &&
-                    siloStatisticsChangeListeners.Remove(observer);
+                return _siloStatisticsChangeListeners.Remove(observer);
             }
         }
 
         private void NotifyAllStatisticsChangeEventsSubscribers(SiloAddress silo, SiloRuntimeStatistics stats)
         {
-            lock (siloStatisticsChangeListeners)
+            lock (_siloStatisticsChangeListeners)
             {
-                foreach (var subscriber in siloStatisticsChangeListeners)
+                foreach (var subscriber in _siloStatisticsChangeListeners)
                 {
                     if (stats == null)
                     {
@@ -208,12 +245,11 @@ namespace Orleans.Runtime
             }
         }
 
-
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
             WorkItemGroup.QueueAction(() =>
             {
-                Utils.SafeExecute(() => this.OnSiloStatusChange(updatedSilo, status), this.logger);
+                Utils.SafeExecute(() => OnSiloStatusChange(updatedSilo, status), _logger);
             });
         }
 
@@ -221,9 +257,12 @@ namespace Orleans.Runtime
         {
             if (!status.IsTerminating()) return;
 
-            if (Equals(updatedSilo, this.Silo))
-                this.publishTimer.Dispose();
-            periodicStats.TryRemove(updatedSilo, out _);
+            if (Equals(updatedSilo, Silo))
+            {
+                _publishTimer.Dispose();
+            }
+
+            _periodicStats.TryRemove(updatedSilo, out _);
             NotifyAllStatisticsChangeEventsSubscribers(updatedSilo, null);
         }
     }

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -110,7 +110,7 @@ namespace Orleans.Runtime
         public Task ForceRuntimeStatisticsCollection()
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("ForceRuntimeStatisticsCollection");
-            return this.deploymentLoadPublisher.RefreshStatistics();
+            return this.deploymentLoadPublisher.RefreshClusterStatistics();
         }
 
         public Task<SiloRuntimeStatistics> GetRuntimeStatistics()


### PR DESCRIPTION
* `UpdateRuntimeStatistics` is a notification method and since we use it with `Task.WhenAll`, waiting for its completion before continuing can result in one (eg, dead) silo delaying others from receiving updates: a slow silo will prevent the next round of updates from being collected and sent. Additionally, we do not care if this method fails, so we do not need to track its completion. Therefore, I have marked the method `[OneWay]`.
* Statistics are ignored if they are not the latest, but we are using `DateTime.UtcNow`, so we are susceptible to clock changes. Setting the clock on a host backwards can prevent other hosts from applying updates for some period of time. Therefore, I changed the logic to use a monotonic clock which always proceeds on every cycle, even if the clock has been set backwards.
* Currently we propagate local silo statistics to the local silo using the same mechanism used for remote silos, but this is a waste of a grain call. Instead, this PR applies the local statistics directly and skips sending them via RPC.
* I made some small efficiency (reduced task allocs) and readability/debuggability (use `async`-`await` over `ContinueWith`) changes, plus a more invasive refactoring to rename members to fit the modern C# style.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8472)