### PR TITLE
Fix for possible false-positive GC delays

### DIFF
--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -6,174 +7,98 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime
 {
+    /// <summary>
+    /// Monitors runtime and component health periodically, reporting complaints.
+    /// </summary>
     internal class Watchdog
     {
-        private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
-        private static readonly TimeSpan stallHeartbeatPeriod = TimeSpan.FromMilliseconds(1000);
-        private readonly TimeSpan healthCheckPeriod;
-        private DateTime lastHeartbeat;
-        private DateTime lastWatchdogCheck;
+        private static readonly TimeSpan PlatformWatchdogHeartbeatPeriod = TimeSpan.FromMilliseconds(1000);
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private readonly TimeSpan _componentHealthCheckPeriod;
+        private readonly List<IHealthCheckParticipant> _participants;
+        private readonly ILogger _logger;
+        private ValueStopwatch _platformWatchdogStopwatch;
+        private ValueStopwatch _componentWatchdogStopwatch;
 
         // GC pause duration since process start.
-        private TimeSpan cumulativeGCPauseDuration;
+        private TimeSpan _cumulativeGCPauseDuration;
 
-        private readonly List<IHealthCheckParticipant> participants;
-        private readonly ILogger logger;
-        private Thread stallThread;
-        private Thread participantsThread;
+        private DateTime _lastComponentHealthCheckTime;
+        private Thread? _platformWatchdogThread;
+        private Thread? _componentWatchdogThread;
 
-        public Watchdog(TimeSpan watchdogPeriod, List<IHealthCheckParticipant> watchables, ILogger<Watchdog> logger)
+        public Watchdog(TimeSpan watchdogPeriod, List<IHealthCheckParticipant> participants, ILogger<Watchdog> logger)
         {
-            this.logger = logger;
-            healthCheckPeriod = watchdogPeriod;
-            participants = watchables;
+            _logger = logger;
+            _componentHealthCheckPeriod = watchdogPeriod;
+            _participants = participants;
         }
 
         public void Start()
         {
-            logger.LogInformation("Starting Silo Watchdog.");
+            _logger.LogInformation("Starting Silo Watchdog.");
 
-            if (stallThread is not null)
+            if (_platformWatchdogThread is not null)
             {
                 throw new InvalidOperationException("Watchdog.Start may not be called more than once");
             }
 
             var now = DateTime.UtcNow;
-            lastHeartbeat = now;
-            cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
+            _platformWatchdogStopwatch = ValueStopwatch.StartNew();
+            _cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
 
-            this.stallThread = new Thread(this.RunStallCheck)
+            _platformWatchdogThread = new Thread(RunPlatformWatchdog)
             {
                 IsBackground = true,
-                Name = "Orleans.Runtime.Watchdog.StallMonitor",
+                Name = "Orleans.Runtime.Watchdog.Platform",
             };
-            this.stallThread.Start();
+            _platformWatchdogThread.Start();
 
-            lastWatchdogCheck = now;
+            _componentWatchdogStopwatch = ValueStopwatch.StartNew();
+            _lastComponentHealthCheckTime = DateTime.UtcNow;
 
-            this.participantsThread = new Thread(this.RunParticipantsCheck)
+            _componentWatchdogThread = new Thread(RunComponentWatchdog)
             {
                 IsBackground = true,
-                Name = "Orleans.Runtime.Watchdog.ParticipantsMonitor",
+                Name = "Orleans.Runtime.Watchdog.Component",
             };
-            this.participantsThread.Start();
+            _componentWatchdogThread.Start();
         }
 
         public void Stop()
         {
-            cancellation.Cancel();
+            _cancellation.Cancel();
         }
 
-        protected void RunStallCheck()
+        protected void RunPlatformWatchdog()
         {
-            while (!this.cancellation.IsCancellationRequested)
+            while (!_cancellation.IsCancellationRequested)
             {
                 try
                 {
-                    StallWatchdogHeartbeatTick();
-                    Thread.Sleep(stallHeartbeatPeriod);
-                }
-                catch (ThreadAbortException)
-                {
-                    // Silo is probably shutting-down, so just ignore and exit
+                    CheckRuntimeHealth();
                 }
                 catch (Exception exc)
                 {
-                    logger.LogError((int)ErrorCode.Watchdog_InternalError, exc, "Watchdog encountered an internal error");
+                    _logger.LogError((int)ErrorCode.Watchdog_InternalError, exc, "Platform watchdog encountered an internal error");
                 }
+
+                _platformWatchdogStopwatch.Restart();
+                _cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
+                Thread.Sleep(PlatformWatchdogHeartbeatPeriod);
             }
         }
 
-        protected void RunParticipantsCheck()
+        private void CheckRuntimeHealth()
         {
-            while (!this.cancellation.IsCancellationRequested)
-            {
-                try
-                {
-                    ParticipantsWatchdogHeartbeatTick();
-                    Thread.Sleep(healthCheckPeriod);
-                }
-                catch (ThreadAbortException)
-                {
-                    // Silo is probably shutting-down, so just ignore and exit
-                }
-                catch (Exception exc)
-                {
-                    logger.LogError((int)ErrorCode.Watchdog_InternalError, exc, "Watchdog encountered an internal error");
-                }
-            }
-        }
-
-        private void StallWatchdogHeartbeatTick()
-        {
-            try
-            {
-                CheckYourOwnHealth(lastHeartbeat, cumulativeGCPauseDuration, logger);
-            }
-            finally
-            {
-                lastHeartbeat = DateTime.UtcNow;
-                cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
-            }
-        }
-
-        private void ParticipantsWatchdogHeartbeatTick()
-        {
-            var timeSinceLastWatchdogCheck = DateTime.UtcNow - lastWatchdogCheck;
-            if (timeSinceLastWatchdogCheck <= healthCheckPeriod)
-            {
-                return;
-            }
-
-            WatchdogInstruments.HealthChecks.Add(1);
-            int numFailedChecks = 0;
-            StringBuilder reasons = null;
-            foreach (IHealthCheckParticipant participant in participants)
-            {
-                try
-                {
-                    bool ok = participant.CheckHealth(lastWatchdogCheck, out var reason);
-                    if (!ok)
-                    {
-                        reasons ??= new StringBuilder();
-                        if (reasons.Length > 0)
-                        {
-                            reasons.Append(' ');
-                        }
-
-                        reasons.Append($"{participant.GetType()} failed health check with reason \"{reason}\".");
-                        numFailedChecks++;
-                    }
-                }
-                catch (Exception exc)
-                {
-                    logger.LogWarning(
-                        (int)ErrorCode.Watchdog_ParticipantThrownException,
-                        exc,
-                        "Health check participant {Participant} has thrown an exception from its CheckHealth method.",
-                        participant.GetType());
-                }
-            }
-
-            if (numFailedChecks > 0)
-            {
-                WatchdogInstruments.FailedHealthChecks.Add(1);
-                logger.LogWarning((int)ErrorCode.Watchdog_HealthCheckFailure, "Watchdog had {FailedChecks} health Check failure(s) out of {ParticipantCount} health Check participants: {Reasons}", numFailedChecks, participants.Count, reasons.ToString());
-            }
-
-            lastWatchdogCheck = DateTime.UtcNow;
-        }
-
-        private static void CheckYourOwnHealth(DateTime lastCheckTime, TimeSpan lastCumulativeGCPauseDuration, ILogger logger)
-        {
-            var timeSinceLastTick = DateTime.UtcNow - lastCheckTime;
-            var pauseDurationSinceLastTick = GC.GetTotalPauseDuration() - lastCumulativeGCPauseDuration;
-            if (timeSinceLastTick > stallHeartbeatPeriod.Multiply(2))
+            var pauseDurationSinceLastTick = GC.GetTotalPauseDuration() - _cumulativeGCPauseDuration;
+            var timeSinceLastTick = _platformWatchdogStopwatch.Elapsed;
+            if (timeSinceLastTick > PlatformWatchdogHeartbeatPeriod.Multiply(2))
             {
                 var gc = new[] { GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2) };
-                logger.LogWarning(
+                _logger.LogWarning(
                     (int)ErrorCode.SiloHeartbeatTimerStalled,
-                    ".NET Runtime Platform stalled for {TimeSinceLastTick}. Total GC Pause duration during that period: {pauseDurationSinceLastTick}. We are now using a total of {TotalMemory}MB memory. gc={GCGen0Count}, {GCGen1Count}, {GCGen2Count}",
+                    ".NET Runtime Platform stalled for {TimeSinceLastTick}. Total GC Pause duration during that period: {pauseDurationSinceLastTick}. We are now using a total of {TotalMemory}MB memory. Collection counts per generation: 0: {GCGen0Count}, 1: {GCGen1Count}, 2: {GCGen2Count}",
                     timeSinceLastTick,
                     pauseDurationSinceLastTick,
                     GC.GetTotalMemory(false) / (1024 * 1024),
@@ -181,6 +106,77 @@ namespace Orleans.Runtime
                     gc[1],
                     gc[2]);
             }
+
+            var timeSinceLastParticipantCheck = _componentWatchdogStopwatch.Elapsed;
+            if (timeSinceLastParticipantCheck > _componentHealthCheckPeriod.Multiply(2))
+            {
+                _logger.LogWarning(
+                    (int)ErrorCode.SiloHeartbeatTimerStalled,
+                    "Participant check thread has not completed for {TimeSinceLastTick}, potentially indicating lock contention or deadlock, CPU starvation, or another execution anomaly.",
+                    timeSinceLastParticipantCheck);
+            }
+        }
+
+        protected void RunComponentWatchdog()
+        {
+            while (!_cancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    CheckComponentHealth();
+                }
+                catch (Exception exc)
+                {
+                    _logger.LogError((int)ErrorCode.Watchdog_InternalError, exc, "Component health check encountered an internal error");
+                }
+
+                _componentWatchdogStopwatch.Restart();
+                Thread.Sleep(_componentHealthCheckPeriod);
+            }
+        }
+
+        private void CheckComponentHealth()
+        {
+            WatchdogInstruments.HealthChecks.Add(1);
+            var numFailedChecks = 0;
+            StringBuilder? complaints = null;
+
+            // Restart the timer before the check to reduce false positives for the stall checker.
+            _componentWatchdogStopwatch.Restart();
+            foreach (var participant in _participants)
+            {
+                try
+                {
+                    var ok = participant.CheckHealth(_lastComponentHealthCheckTime, out var complaint);
+                    if (!ok)
+                    {
+                        complaints ??= new StringBuilder();
+                        if (complaints.Length > 0)
+                        {
+                            complaints.Append(' ');
+                        }
+
+                        complaints.Append($"{participant.GetType()} failed health check with complaint \"{complaint}\".");
+                        ++numFailedChecks;
+                    }
+                }
+                catch (Exception exc)
+                {
+                    _logger.LogWarning(
+                        (int)ErrorCode.Watchdog_ParticipantThrownException,
+                        exc,
+                        "Health check participant {Participant} has thrown an exception from its CheckHealth method.",
+                        participant.GetType());
+                }
+            }
+
+            if (complaints != null)
+            {
+                WatchdogInstruments.FailedHealthChecks.Add(1);
+                _logger.LogWarning((int)ErrorCode.Watchdog_HealthCheckFailure, "{FailedChecks} of {ParticipantCount} components reported issues. Complaints: {Complaints}", numFailedChecks, _participants.Count, complaints);
+            }
+
+            _lastComponentHealthCheckTime = DateTime.UtcNow;
         }
     }
 }

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -36,7 +36,10 @@ namespace Orleans.Runtime
 
         public void Start()
         {
-            _logger.LogInformation("Starting Silo Watchdog.");
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Starting Silo watchdog");
+            }
 
             if (_platformWatchdogThread is not null)
             {


### PR DESCRIPTION
In the application of our organization, we noticed sporadically some `.NET Runtime Platform stalled for...` warnings, even with very small GC object counts, so after a code review we suspect that the additional checks in `WatchdogHeartbeatTick` may be responsible for a false-positive GC delay. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8483)