### PR TITLE
Add missing configuration validators for Azure Table Storage providers

### DIFF
--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureTableClusteringExtensions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureTableClusteringExtensions.cs
@@ -60,6 +60,7 @@ namespace Orleans.Hosting
                 services =>
                 {
                     configureOptions?.Invoke(services.AddOptions<AzureStorageClusteringOptions>());
+                    services.AddTransient<IConfigurationValidator>(sp => new AzureStorageClusteringOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureStorageClusteringOptions>>().Get(Options.DefaultName), Options.DefaultName));
                     services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>()
                     .ConfigureFormatter<AzureStorageClusteringOptions>();
                 });
@@ -114,6 +115,7 @@ namespace Orleans.Hosting
                 services =>
                 {
                     configureOptions?.Invoke(services.AddOptions<AzureStorageGatewayOptions>());
+                    services.AddTransient<IConfigurationValidator>(sp => new AzureStorageGatewayOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureStorageGatewayOptions>>().Get(Options.DefaultName), Options.DefaultName));
                     services.AddSingleton<IGatewayListProvider, AzureGatewayListProvider>()
                     .ConfigureFormatter<AzureStorageGatewayOptions>();
                 });

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
@@ -1,29 +1,25 @@
-#if ORLEANS_CLUSTERING
-namespace Orleans.Clustering.AzureStorage
-#elif ORLEANS_PERSISTENCE
-namespace Orleans.Persistence.AzureStorage
-#elif ORLEANS_REMINDERS
-namespace Orleans.Reminders.AzureStorage
-#elif ORLEANS_STREAMING
-namespace Orleans.Streaming.AzureStorage
-#elif ORLEANS_EVENTHUBS
-namespace Orleans.Streaming.EventHubs
-#elif TESTER_AZUREUTILS
-namespace Orleans.Tests.AzureUtils
-#elif ORLEANS_TRANSACTIONS
-namespace Orleans.Transactions.AzureStorage
-#elif ORLEANS_DIRECTORY
-namespace Orleans.GrainDirectory.AzureStorage
-#else
-// No default namespace intentionally to cause compile errors if something is not defined
-#endif
+namespace Orleans.Clustering.AzureStorage;
+
+/// <summary>
+/// Specify options used for AzureTableBasedMembership
+/// </summary>
+public class AzureStorageClusteringOptions : AzureStorageOperationOptions
+{
+    public override string TableName { get; set; } = DEFAULT_TABLE_NAME;
+    public const string DEFAULT_TABLE_NAME = "OrleansSiloInstances";
+}
+
+/// <summary>
+/// Configuration validator for <see cref="AzureStorageClusteringOptions"/>.
+/// </summary>
+public class AzureStorageClusteringOptionsValidator : AzureStorageOperationOptionsValidator<AzureStorageClusteringOptions>
 {
     /// <summary>
-    /// Specify options used for AzureTableBasedMembership
+    /// Initializes a new instance of the <see cref="AzureStorageClusteringOptionsValidator"/> class.
     /// </summary>
-    public class AzureStorageClusteringOptions : AzureStorageOperationOptions
+    /// <param name="options">The option to be validated.</param>
+    /// <param name="name">The option name to be validated.</param>
+    public AzureStorageClusteringOptionsValidator(AzureStorageClusteringOptions options, string name) : base(options, name)
     {
-        public override string TableName { get; set; } = DEFAULT_TABLE_NAME;
-        public const string DEFAULT_TABLE_NAME = "OrleansSiloInstances";
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
@@ -1,7 +1,21 @@
-namespace Orleans.Clustering.AzureStorage
+namespace Orleans.Clustering.AzureStorage;
+
+public class AzureStorageGatewayOptions : AzureStorageOperationOptions
 {
-    public class AzureStorageGatewayOptions : AzureStorageOperationOptions
+    public override string TableName { get; set; } = AzureStorageClusteringOptions.DEFAULT_TABLE_NAME;
+}
+
+/// <summary>
+/// Configuration validator for <see cref="AzureStorageGatewayOptions"/>.
+/// </summary>
+public class AzureStorageGatewayOptionsValidator : AzureStorageOperationOptionsValidator<AzureStorageGatewayOptions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureStorageGatewayOptionsValidator"/> class.
+    /// </summary>
+    /// <param name="options">The option to be validated.</param>
+    /// <param name="name">The option name to be validated.</param>
+    public AzureStorageGatewayOptionsValidator(AzureStorageGatewayOptions options, string name) : base(options, name)
     {
-        public override string TableName { get; set; } = AzureStorageClusteringOptions.DEFAULT_TABLE_NAME;
     }
 }

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableGrainDirectoryServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Orleans.Hosting
         {
             configureOptions.Invoke(services.AddOptions<AzureTableGrainDirectoryOptions>(name));
             services
-                .AddTransient<IConfigurationValidator>(sp => new AzureTableGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableGrainDirectoryOptions>>().Get(name)))
+                .AddTransient<IConfigurationValidator>(sp => new AzureTableGrainDirectoryOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableGrainDirectoryOptions>>().Get(name), name))
                 .ConfigureNamedOptionForLogging<AzureTableGrainDirectoryOptions>(name)
                 .AddSingletonNamedService<IGrainDirectory>(name, (sp, name) => ActivatorUtilities.CreateInstance<AzureTableGrainDirectory>(sp, sp.GetOptionsByName<AzureTableGrainDirectoryOptions>(name)))
                 .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainDirectory>(n));

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Options/AzureTableGrainDirectoryOptions.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Options/AzureTableGrainDirectoryOptions.cs
@@ -13,7 +13,7 @@ namespace Orleans.Configuration
 
     public class AzureTableGrainDirectoryOptionsValidator : AzureStorageOperationOptionsValidator<AzureTableGrainDirectoryOptions>
     {
-        public AzureTableGrainDirectoryOptionsValidator(AzureTableGrainDirectoryOptions options) : base(options)
+        public AzureTableGrainDirectoryOptionsValidator(AzureTableGrainDirectoryOptions options, string name) : base(options, name)
         {
         }
     }

--- a/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/AzureStorageReminderServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace Orleans.Hosting
             services.AddSingleton<IReminderTable, AzureBasedReminderTable>();
             configureOptions?.Invoke(services.AddOptions<AzureTableReminderStorageOptions>());
             services.ConfigureFormatter<AzureTableReminderStorageOptions>();
+            services.AddTransient<IConfigurationValidator>(sp => new AzureTableReminderStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableReminderStorageOptions>>().Get(Options.DefaultName), Options.DefaultName));
             return services;
         }
 

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureTableReminderStorageOptions.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureTableReminderStorageOptions.cs
@@ -1,22 +1,4 @@
-#if ORLEANS_CLUSTERING
-namespace Orleans.Clustering.AzureStorage
-#elif ORLEANS_PERSISTENCE
-namespace Orleans.Persistence.AzureStorage
-#elif ORLEANS_REMINDERS
 namespace Orleans.Reminders.AzureStorage
-#elif ORLEANS_STREAMING
-namespace Orleans.Streaming.AzureStorage
-#elif ORLEANS_EVENTHUBS
-namespace Orleans.Streaming.EventHubs
-#elif TESTER_AZUREUTILS
-namespace Orleans.Tests.AzureUtils
-#elif ORLEANS_TRANSACTIONS
-namespace Orleans.Transactions.AzureStorage
-#elif ORLEANS_DIRECTORY
-namespace Orleans.GrainDirectory.AzureStorage
-#else
-// No default namespace intentionally to cause compile errors if something is not defined
-#endif
 {
     /// <summary>Options for Azure Table based reminder table.</summary>
     public class AzureTableReminderStorageOptions : AzureStorageOperationOptions
@@ -26,5 +8,20 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// </summary>
         public override string TableName { get; set; } = DEFAULT_TABLE_NAME;
         public const string DEFAULT_TABLE_NAME = "OrleansReminders";
+    }
+
+    /// <summary>
+    /// Configuration validator for <see cref="AzureTableReminderStorageOptions"/>.
+    /// </summary>
+    public class AzureTableReminderStorageOptionsValidator : AzureStorageOperationOptionsValidator<AzureTableReminderStorageOptions>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureTableReminderStorageOptionsValidator"/> class.
+        /// </summary>
+        /// <param name="options">The option to be validated.</param>
+        /// <param name="name">The option name to be validated.</param>
+        public AzureTableReminderStorageOptionsValidator(AzureTableReminderStorageOptions options, string name) : base(options, name)
+        {
+        }
     }
 }

--- a/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionServicecollectionExtensions.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Hosting/AzureTableTransactionServicecollectionExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using Orleans;
 using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.Runtime;
@@ -20,6 +19,7 @@ namespace Orleans.Hosting
             Action<OptionsBuilder<AzureTableTransactionalStateOptions>> configureOptions = null)
         {
             configureOptions?.Invoke(services.AddOptions<AzureTableTransactionalStateOptions>(name));
+            services.AddTransient<IConfigurationValidator>(sp => new AzureTableTransactionalStateOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AzureTableTransactionalStateOptions>>().Get(name), name));
 
             services.TryAddSingleton<ITransactionalStateStorageFactory>(sp => sp.GetServiceByName<ITransactionalStateStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             services.AddSingletonNamedService<ITransactionalStateStorageFactory>(name, AzureTableTransactionalStateStorageFactory.Create);

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateOptions.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateOptions.cs
@@ -15,4 +15,19 @@ namespace Orleans.Configuration
         public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
         public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
     }
+
+    /// <summary>
+    /// Configuration validator for <see cref="AzureTableTransactionalStateOptions"/>.
+    /// </summary>
+    public class AzureTableTransactionalStateOptionsValidator : AzureStorageOperationOptionsValidator<AzureTableTransactionalStateOptions>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureTableTransactionalStateOptionsValidator"/> class.
+        /// </summary>
+        /// <param name="options">The option to be validated.</param>
+        /// <param name="name">The option name to be validated.</param>
+        public AzureTableTransactionalStateOptionsValidator(AzureTableTransactionalStateOptions options, string name) : base(options, name)
+        {
+        }
+    }
 }


### PR DESCRIPTION
These validators surface configuration errors on-startup so that developers do not experience a confusing `NullReferenceException` later on.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8484)