### PR TITLE
Incorporate state name into key for Redis grain storage

### DIFF
--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -1,13 +1,9 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
-using Orleans.Serialization.Codecs;
-using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Storage;
 

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -48,7 +48,7 @@ namespace Orleans.Persistence
         /// <summary>
         /// Gets the Redis key for the provided grain type and grain identifier. If not set, the default implementation will be used, which is equivalent to <c>{ServiceId}/state/{grainId}/{grainType}</c>.
         /// </summary>
-        public Func<string, GrainId, RedisKey>? GetRedisKey { get; set; }
+        public Func<string, GrainId, RedisKey>? GetStorageKey { get; set; }
 
         /// <summary>
         /// The default multiplexer creation delegate.
@@ -73,7 +73,7 @@ namespace Orleans.Persistence
             optionsBuilder.Configure((RedisStorageOptions options, IOptions<ClusterOptions> clusterOptions) =>
             {
                 RedisKey keyPrefix = Encoding.UTF8.GetBytes($"{clusterOptions.Value.ServiceId}/state/");
-                options.GetRedisKey = (_, grainId) => keyPrefix.Append(grainId.ToString());
+                options.GetStorageKey = (_, grainId) => keyPrefix.Append(grainId.ToString());
             });
         }
     }

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -1,5 +1,10 @@
+#nullable enable
 using System;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
 using Orleans.Storage;
 using StackExchange.Redis;
 
@@ -21,13 +26,13 @@ namespace Orleans.Persistence
         public int InitStage { get; set; } = ServiceLifecycleStage.ApplicationServices;
 
         /// <inheritdoc/>
-        public IGrainStorageSerializer GrainStorageSerializer { get; set; }
+        public IGrainStorageSerializer? GrainStorageSerializer { get; set; }
 
         /// <summary>
         /// Gets or sets the Redis client configuration.
         /// </summary>
         [RedactRedisConfigurationOptions]
-        public ConfigurationOptions ConfigurationOptions { get; set; }
+        public ConfigurationOptions? ConfigurationOptions { get; set; }
 
         /// <summary>
         /// The delegate used to create a Redis connection multiplexer.
@@ -41,9 +46,36 @@ namespace Orleans.Persistence
         public TimeSpan? EntryExpiry { get; set; } = null;
 
         /// <summary>
+        /// Gets the Redis key for the provided grain type and grain identifier. If not set, the default implementation will be used, which is equivalent to <c>{ServiceId}/state/{grainId}/{grainType}</c>.
+        /// </summary>
+        public Func<string, GrainId, RedisKey>? GetRedisKey { get; set; }
+
+        /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!);
+    }
+
+    /// <summary>
+    /// Extension methods for configuring <see cref="RedisStorageOptions"/>.
+    /// </summary>
+    public static class RedisStorageOptionsExtensions
+    {
+        /// <summary>
+        /// Configures the provided options to use a Redis key format that ignores the grain type, equivalent to <c>{ServiceId}/state/{grainId}</c>.
+        /// </summary>
+        /// <remarks>
+        /// This method is provided as a compatibility utility for users who are migrating from prerelease versions of the Redis storage provider.
+        /// </remarks>
+        /// <param name="optionsBuilder">The options builder.</param>
+        public static void UseGetRedisKeyIgnoringGrainType(this OptionsBuilder<RedisStorageOptions> optionsBuilder)
+        {
+            optionsBuilder.Configure((RedisStorageOptions options, IOptions<ClusterOptions> clusterOptions) =>
+            {
+                RedisKey keyPrefix = Encoding.UTF8.GetBytes($"{clusterOptions.Value.ServiceId}/state/");
+                options.GetRedisKey = (_, grainId) => keyPrefix.Append(grainId.ToString());
+            });
+        }
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -28,7 +28,7 @@ namespace Orleans.Persistence
         private readonly ILogger _logger;
         private readonly RedisStorageOptions _options;
         private readonly IGrainStorageSerializer _grainStorageSerializer;
-
+        private readonly Func<string, GrainId, RedisKey> _getKeyFunc;
         private IConnectionMultiplexer _connection;
         private IDatabase _db;
 
@@ -49,6 +49,7 @@ namespace Orleans.Persistence
             _serviceId = clusterOptions.Value.ServiceId;
             _ttl = options.EntryExpiry is { } ts ? ts.TotalSeconds.ToString(CultureInfo.InvariantCulture) : "-1";
             _keyPrefix = Encoding.UTF8.GetBytes($"{_serviceId}/state/");
+            _getKeyFunc = _options.GetRedisKey ?? GetKey;
         }
 
         /// <inheritdoc />
@@ -103,7 +104,7 @@ namespace Orleans.Persistence
         /// <inheritdoc />
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
-            var key = GetKey(grainId);
+            var key = _getKeyFunc(grainType, grainId);
 
             try
             {
@@ -159,7 +160,7 @@ namespace Orleans.Persistence
                 end
                 """;
 
-            var key = GetKey(grainId);
+            var key = _getKeyFunc(grainType, grainId);
             RedisValue etag = grainState.ETag ?? "";
             RedisValue newEtag = Guid.NewGuid().ToString("N");
 
@@ -191,7 +192,30 @@ namespace Orleans.Persistence
             }
         }
 
-        private RedisKey GetKey(GrainId grainId) => _keyPrefix.Append(grainId.ToString());
+        private RedisKey GetKey(string grainType, GrainId grainId)
+        {
+            var grainIdTypeBytes = IdSpan.UnsafeGetArray(grainId.Type.Value);
+            var grainIdKeyBytes = IdSpan.UnsafeGetArray(grainId.Key);
+            var grainTypeLength = Encoding.UTF8.GetByteCount(grainType);
+            var suffix = new byte[grainIdTypeBytes.Length + 1 + grainIdKeyBytes.Length + 1 + grainTypeLength];
+            var index = 0;
+
+            grainIdTypeBytes.CopyTo(suffix, 0);
+            index += grainIdTypeBytes.Length;
+
+            suffix[index++] = (byte)'/';
+
+            grainIdKeyBytes.CopyTo(suffix, index);
+            index += grainIdKeyBytes.Length;
+
+            suffix[index++] = (byte)'/';
+
+            var bytesWritten = Encoding.UTF8.GetBytes(grainType, suffix.AsSpan(index));
+            Debug.Assert(bytesWritten == grainTypeLength);
+            Debug.Assert(index + bytesWritten == suffix.Length);
+            
+            return _keyPrefix.Append(suffix);
+        }
 
         /// <inheritdoc />
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
@@ -201,6 +225,7 @@ namespace Orleans.Persistence
                 RedisValue etag = grainState.ETag ?? "";
                 RedisResult response;
                 string newETag;
+                var key = _getKeyFunc(grainType, grainId);
                 if (_options.DeleteStateOnClear)
                 {
                     const string DeleteScript =
@@ -213,7 +238,7 @@ namespace Orleans.Persistence
                           return -1
                         end
                         """;
-                    response = await _db.ScriptEvaluateAsync(DeleteScript, keys: new[] { GetKey(grainId) }, values: new[] { etag }).ConfigureAwait(false);
+                    response = await _db.ScriptEvaluateAsync(DeleteScript, keys: new[] { key }, values: new[] { etag }).ConfigureAwait(false);
                     newETag = null;
                 }
                 else
@@ -229,7 +254,7 @@ namespace Orleans.Persistence
                         end
                         """;
                     newETag = Guid.NewGuid().ToString("N");
-                    response = await _db.ScriptEvaluateAsync(ClearScript, keys: new[] { GetKey(grainId) }, values: new RedisValue[] { etag, newETag }).ConfigureAwait(false);
+                    response = await _db.ScriptEvaluateAsync(ClearScript, keys: new[] { key }, values: new RedisValue[] { etag, newETag }).ConfigureAwait(false);
                 }
 
                 if (response is not null && (int)response == -1)

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -49,7 +49,7 @@ namespace Orleans.Persistence
             _serviceId = clusterOptions.Value.ServiceId;
             _ttl = options.EntryExpiry is { } ts ? ts.TotalSeconds.ToString(CultureInfo.InvariantCulture) : "-1";
             _keyPrefix = Encoding.UTF8.GetBytes($"{_serviceId}/state/");
-            _getKeyFunc = _options.GetRedisKey ?? GetKey;
+            _getKeyFunc = _options.GetStorageKey ?? DefaultGetStorageKey;
         }
 
         /// <inheritdoc />
@@ -192,7 +192,7 @@ namespace Orleans.Persistence
             }
         }
 
-        private RedisKey GetKey(string grainType, GrainId grainId)
+        private RedisKey DefaultGetStorageKey(string grainType, GrainId grainId)
         {
             var grainIdTypeBytes = IdSpan.UnsafeGetArray(grainId.Type.Value);
             var grainIdKeyBytes = IdSpan.UnsafeGetArray(grainId.Key);

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -192,6 +192,9 @@ namespace Orleans.Persistence
             }
         }
 
+        /// <summary>
+        /// Default implementation of <see cref="RedisStorageOptions.GetStorageKey"/> which returns a key equivalent to <c>{ServiceId}/state/{grainId}/{grainType}</c>
+        /// </summary>
         private RedisKey DefaultGetStorageKey(string grainType, GrainId grainId)
         {
             var grainIdTypeBytes = IdSpan.UnsafeGetArray(grainId.Type.Value);
@@ -211,9 +214,9 @@ namespace Orleans.Persistence
             suffix[index++] = (byte)'/';
 
             var bytesWritten = Encoding.UTF8.GetBytes(grainType, suffix.AsSpan(index));
+
             Debug.Assert(bytesWritten == grainTypeLength);
             Debug.Assert(index + bytesWritten == suffix.Length);
-            
             return _keyPrefix.Append(suffix);
         }
 

--- a/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
@@ -150,7 +150,7 @@ namespace Tester.Redis.Persistence
             var grain = fixture.GrainFactory.GetGrain<IGrainStorageGenericGrain<GrainState>>(54321);
             var data = await grain.DoRead();
 
-            var key = $"{ServiceId}/state/{grain.GetGrainId()}";
+            var key = $"{ServiceId}/state/{grain.GetGrainId()}/state";
             await database.HashSetAsync(key, new[] { new HashEntry("etag", "derp") });
 
             await Assert.ThrowsAsync<InconsistentStateException>(() => grain.DoWrite(state));


### PR DESCRIPTION
Fixes #8485

This PR incorporates the state name into the key format for the Redis grain storage provider.
To continue using the key format from the beta versions of storage provider, you will need to configure the delegate used to resolve a key via the `RedisStorageOptions.GetKey` property. A helper method is provided to do so as an extension method on `OptionsBuilder<RedisStorageOptions>`. Here is an example:

``` csharp
siloBuilder
    .AddRedisGrainStorage("MyGrainStorage", (OptionsBuilder<RedisStorageOptions> optionsBuilder) =>
    {
        optionsBuilder.UseGetRedisKeyIgnoringGrainType();
        optionsBuilder.Configure(options =>
        {
            options.ConfigurationOptions = ConfigurationOptions.Parse(connectionString);
        });
    })

```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8487)