### PR TITLE
Only skip the first message in a consumer if it is a resume token

### DIFF
--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -303,7 +303,10 @@ namespace Orleans.Streams
                         // The handshake token points to an already processed event, we need to advance the cursor to
                         // the next event.
                         consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, requestedHandshakeToken.Token);
-                        consumerData.Cursor.MoveNext(); //
+                        if (!(requestedHandshakeToken is StartToken))
+                        {
+                            consumerData.Cursor.MoveNext(); //
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Should fix #8335

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8488)