### PR TITLE
Deduplicate generated type manifest providers added via DI

### DIFF
--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -20,7 +20,7 @@ namespace Orleans.CodeGenerator
                 Compilation = compilation,
                 ApplicationPartAttribute = Type("Orleans.ApplicationPartAttribute"),
                 Action_2 = Type("System.Action`2"),
-                ITypeManifestProvider = Type("Orleans.Serialization.Configuration.ITypeManifestProvider"),
+                TypeManifestProviderBase = Type("Orleans.Serialization.Configuration.TypeManifestProviderBase"),
                 Field = Type("Orleans.Serialization.WireProtocol.Field"),
                 FieldCodec_1 = Type("Orleans.Serialization.Codecs.IFieldCodec`1"),
                 AbstractTypeSerializer = Type("Orleans.Serialization.Serializers.AbstractTypeSerializer`1"),
@@ -203,7 +203,7 @@ namespace Orleans.CodeGenerator
         }
 
         public INamedTypeSymbol Action_2 { get; private set; }
-        public INamedTypeSymbol ITypeManifestProvider { get; private set; }
+        public INamedTypeSymbol TypeManifestProviderBase { get; private set; }
         public INamedTypeSymbol Field { get; private set; }
         public INamedTypeSymbol DeepCopier_1 { get; private set; }
         public INamedTypeSymbol ShallowCopier { get; private set; }

--- a/src/Orleans.CodeGenerator/MetadataGenerator.cs
+++ b/src/Orleans.CodeGenerator/MetadataGenerator.cs
@@ -104,13 +104,13 @@ namespace Orleans.CodeGenerator
             AddCompoundTypeAliases(metadataModel, configParam, body);
 
             var configType = libraryTypes.TypeManifestOptions;
-            var configureMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Configure")
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+            var configureMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "ConfigureInner")
+                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword))
                 .AddParameterListParameters(
                     Parameter(configParam.Identifier).WithType(configType.ToTypeSyntax()))
                 .AddBodyStatements(body.ToArray());
 
-            var interfaceType = libraryTypes.ITypeManifestProvider;
+            var interfaceType = libraryTypes.TypeManifestProviderBase;
             return ClassDeclaration("Metadata_" + SyntaxGeneration.Identifier.SanitizeIdentifierName(compilation.AssemblyName))
                 .AddBaseListTypes(SimpleBaseType(interfaceType.ToTypeSyntax()))
                 .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.SealedKeyword))

--- a/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
+++ b/src/Orleans.Serialization/Configuration/DefaultTypeManifestProvider.cs
@@ -1,12 +1,19 @@
 using System;
 using System.Net;
+using Microsoft.Extensions.Options;
 using Orleans.Serialization.Invocation;
 
 namespace Orleans.Serialization.Configuration
 {
-    internal class DefaultTypeManifestProvider : ITypeManifestProvider
+    internal class DefaultTypeManifestProvider : TypeManifestProviderBase, IPostConfigureOptions<TypeManifestOptions>
     {
-        public void Configure(TypeManifestOptions typeManifest)
+        public void PostConfigure(string name, TypeManifestOptions options)
+        {
+            // Clean up the options bookkeeping.
+            options.TypeManifestProviders.Clear();
+        }
+
+        protected override void ConfigureInner(TypeManifestOptions typeManifest)
         {
             var wellKnownTypes = typeManifest.WellKnownTypeIds;
             wellKnownTypes[0] = typeof(void); // Represents the type of null

--- a/src/Orleans.Serialization/Configuration/ITypeManifestProvider.cs
+++ b/src/Orleans.Serialization/Configuration/ITypeManifestProvider.cs
@@ -8,4 +8,30 @@ namespace Orleans.Serialization.Configuration
     public interface ITypeManifestProvider : IConfigureOptions<TypeManifestOptions>
     {
     }
+
+    /// <summary>
+    /// Base class for generated type manifest providers.
+    /// </summary>
+    public abstract class TypeManifestProviderBase : ITypeManifestProvider
+    {
+        /// <inheritdoc/>
+        void IConfigureOptions<TypeManifestOptions>.Configure(TypeManifestOptions options)
+        {
+            if (options.TypeManifestProviders.Add(Key))
+            {
+                ConfigureInner(options);
+            }
+        }
+
+        /// <summary>
+        /// Gets the unique identifier for this type manifest provider.
+        /// </summary>
+        public virtual object Key => GetType();
+
+        /// <summary>
+        /// Configures the provided type manifest options.
+        /// </summary>
+        /// <param name="options">The type manifest options.</param>
+        protected abstract void ConfigureInner(TypeManifestOptions options);
+    }
 }

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -86,5 +86,10 @@ namespace Orleans.Serialization.Configuration
         /// Default: <see langword="false"/>.
         /// </summary>
         public bool AllowAllTypes { get; set; }
+
+        /// <summary>
+        /// Gets the set of type manifest providers which have configured this instance.
+        /// </summary>
+        internal HashSet<object> TypeManifestProviders { get; } = new();
     }
 }

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ namespace Orleans.Serialization
                 services.Add(context.CreateServiceDescriptor());
                 services.AddOptions();
                 services.AddSingleton<IConfigureOptions<TypeManifestOptions>, DefaultTypeManifestProvider>();
+                services.AddSingleton<IPostConfigureOptions<TypeManifestOptions>, DefaultTypeManifestProvider>();
                 services.AddSingleton<TypeResolver, CachedTypeResolver>();
                 services.AddSingleton<TypeConverter>();
                 services.TryAddSingleton<CodecProvider>();

--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -91,7 +91,7 @@ public class CompoundTypeAliasTree
 
         if (_children.TryGetValue(key, out var existing))
         {
-            if (value is not null && existing.Value is not null)
+            if (value is not null && existing.Value is { } type && type != value)
             {
                 throw new ArgumentException("A key with this value already exists");
             }


### PR DESCRIPTION
It is possible for users to get into a situation where they add assemblies to serializer/Orleans configuration multiple times accidentally. This PR deduplicates the effects of generated type manifest providers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8489)