### PR TITLE
Use AssemblyLoadContext consistently when loading referenced assemblies

### DIFF
--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyHelper.cs
@@ -170,9 +170,19 @@ namespace Orleans.Serialization
                 return Array.Empty<Assembly>();
             }
 
+#if NETCOREAPP3_1_OR_GREATER
+            var assemblyContext = AssemblyLoadContext.GetLoadContext(assembly) ?? AssemblyLoadContext.Default; 
+#endif
+
             return ExpandApplicationParts(
                 new[] { assembly }.Concat(assembly.GetCustomAttributes<ApplicationPartAttribute>()
-                    .Select(name => Assembly.Load(new AssemblyName(name.AssemblyName)))));
+                    .Select(name =>
+#if NETCOREAPP3_1_OR_GREATER
+                        assemblyContext.LoadFromAssemblyName(new AssemblyName(name.AssemblyName))
+#else
+                        Assembly.Load(new AssemblyName(name.AssemblyName))
+#endif
+                    )));
 
             static IEnumerable<Assembly> ExpandApplicationParts(IEnumerable<Assembly> assemblies)
             {
@@ -200,9 +210,18 @@ namespace Orleans.Serialization
                         return;
                     }
 
+#if NETCOREAPP3_1_OR_GREATER
+                    var assemblyContext = AssemblyLoadContext.GetLoadContext(assembly) ?? AssemblyLoadContext.Default; 
+#endif
+
                     foreach (var attribute in attributes)
                     {
-                        var referenced = Assembly.Load(new AssemblyName(attribute.AssemblyName));
+                        var assemblyName = new AssemblyName(attribute.AssemblyName);
+#if NETCOREAPP3_1_OR_GREATER
+                        var referenced = assemblyContext.LoadFromAssemblyName(assemblyName);
+#else
+                        var referenced = Assembly.Load(assemblyName);
+#endif
                         if (assemblies.Add(referenced))
                         {
                             ExpandAssembly(assemblies, referenced);
@@ -211,7 +230,5 @@ namespace Orleans.Serialization
                 }
             }
         }
-
-        private static T GetServiceFromCollection<T>(IServiceCollection services) => (T)services.LastOrDefault(d => d.ServiceType == typeof(T))?.ImplementationInstance;
     }
 }


### PR DESCRIPTION
Fixes #8197

Needs testing, likely manual testing for this one.