### PR TITLE
[3.x] Fix directory/cache validation for defunct silos

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IRemoteGrainDirectory.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IRemoteGrainDirectory.cs
@@ -33,6 +33,7 @@ namespace Orleans.Runtime
         Dictionary<SiloAddress, List<ActivationAddress>> Merge(GrainId grain, IGrainInfo other);
         void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationId activation, SiloAddress silo);
         bool UpdateClusterRegistrationStatus(ActivationId activationId, GrainDirectoryEntryStatus registrationStatus, GrainDirectoryEntryStatus? compareWith = null);
+        Dictionary<ActivationId, IActivationInfo> RemoveWhere<T>(Func<T, IActivationInfo, bool> predicate, T state);
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -28,11 +28,12 @@ namespace Orleans.Runtime.GrainDirectory
             LocalGrainDirectory router,
             IGrainDirectoryCache cache,
             IInternalGrainFactory grainFactory,
+            ISiloStatusOracle siloStatusOracle,
             ILoggerFactory loggerFactory)
         {
             var adaptiveCache = cache as AdaptiveGrainDirectoryCache;
             return adaptiveCache != null
-                ? new AdaptiveDirectoryCacheMaintainer(router, adaptiveCache, grainFactory, loggerFactory)
+                ? new AdaptiveDirectoryCacheMaintainer(router, adaptiveCache, grainFactory, siloStatusOracle, loggerFactory)
                 : null;
         }
     }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -439,6 +439,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             result.Addresses = new List<ActivationAddress>(grainInfoInstancesCount);
+            List<SiloAddress> toRemove = null;
             for (var i = 0; i < grainInfoInstancesCount; i++)
             {
                 var activationInfo = activationInfos[i];
@@ -446,9 +447,27 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     result.Addresses.Add(ActivationAddress.GetAddress(activationInfo.SiloAddress, grain, activationIds[i]));
                 }
+                else
+                {
+                    toRemove ??= new();
+                    toRemove.Add(activationInfo.SiloAddress);
+                }
 
                 activationInfos[i] = null;
                 activationIds[i] = null;
+            }
+
+            if (toRemove is not null)
+            {
+                lock (lockable)
+                {
+                    if (partitionData.TryGetValue(grain, out var grainInfo))
+                    {
+                        foreach (var instance in grainInfo.Instances)
+                        {
+                        }
+                    }
+                }
             }
 
             return result;

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -113,6 +113,7 @@ namespace Orleans.Runtime.GrainDirectory
                     this,
                     this.DirectoryCache,
                     grainFactory,
+                    siloStatusOracle,
                     loggerFactory);
 
             var primarySiloEndPoint = developmentClusterMembershipOptions.Value.PrimarySiloEndpoint;
@@ -576,15 +577,15 @@ namespace Orleans.Runtime.GrainDirectory
                     if (IsValidSilo(address.Silo))
                     {
                         // Caching optimization:
-                        // cache the result of a successfull RegisterActivation call, only if it is not a duplicate activation.
+                        // cache the result of a successful RegisterActivation call, only if it is not a duplicate activation.
                         // this way next local lookup will find this ActivationAddress in the cache and we will save a full lookup!
                         IReadOnlyList<Tuple<SiloAddress, ActivationId>> cached;
                         if (!DirectoryCache.LookUp(address.Grain, out cached))
                         {
                             cached = new List<Tuple<SiloAddress, ActivationId>>(1)
-                        {
-                            Tuple.Create(address.Silo, address.Activation)
-                        };
+                            {
+                                Tuple.Create(address.Silo, address.Activation)
+                            };
                         }
                         else
                         {


### PR DESCRIPTION
There are some cases today where a grain directory/cache entry for a defunct silo can persist in 3.x, causing messages to be sent to silos which have since been evicted from membership and had their tombstone entries cleaned up from membership.

This PR adds some fixes to more eagerly clean up these entries and nullify them where possible.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8498)