### PR TITLE
Relax diagnostic analyzers for static members of grain interfaces

### DIFF
--- a/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
@@ -44,8 +44,8 @@ namespace Orleans.Analyzers
 
             if (symbol.ContainingType.TypeKind != TypeKind.Interface) return;
 
-            // allow static interface methods to return any type (excluding abstract / virtual)
-            if (symbol.IsStatic && !symbol.IsAbstract && !symbol.IsVirtual)
+            // allow static interface methods to return any type
+            if (symbol.IsStatic)
                 return;
 
             var isIAddressableInterface = false;

--- a/src/Orleans.Analyzers/GrainInterfacePropertyDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfacePropertyDiagnosticAnalyzer.cs
@@ -35,6 +35,9 @@ namespace Orleans.Analyzers
 
             if (symbol.ContainingType.TypeKind != TypeKind.Interface) return;
 
+            // ignore static members
+            if (symbol.IsStatic) return;
+
             var isIAddressableInterface = false;
             foreach (var implementedInterface in symbol.ContainingType.AllInterfaces)
             {

--- a/src/Orleans.Analyzers/NoRefParamsDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/NoRefParamsDiagnosticAnalyzer.cs
@@ -35,6 +35,9 @@ namespace Orleans.Analyzers
 
             if (symbol.ContainingType.TypeKind != TypeKind.Interface) return;
 
+            // ignore static members
+            if (symbol.IsStatic) return;
+
             var implementedInterfaces = symbol.ContainingType
                                               .AllInterfaces
                                               .Select(interfaceDef => interfaceDef.Name);

--- a/src/Orleans.Serialization/Hosting/SerializerConfigurationAnalyzer.cs
+++ b/src/Orleans.Serialization/Hosting/SerializerConfigurationAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Serialization.Configuration;
+using Orleans.Serialization.Configuration;
 using Orleans.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
@@ -29,7 +29,7 @@ namespace Orleans.Serialization
             var allComplaints = new Dictionary<Type, SerializerConfigurationComplaint>();
             foreach (var @interface in options.Interfaces)
             {
-                foreach (var method in @interface.GetMethods())
+                foreach (var method in @interface.GetMethods(BindingFlags.Instance | BindingFlags.Public))
                 {
                     if (typeof(Task).IsAssignableFrom(method.ReturnType))
                     {

--- a/test/Analyzers.Tests/GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest.cs
@@ -74,6 +74,7 @@ public class GrainInterfaceMethodReturnTypeDiagnosticAnalyzerTest : DiagnosticAn
                     public interface I : Orleans.IGrain
                     {
                         public static int GetSomeOtherThing(int a) => 0;
+                        public static virtual int GetSomeOtherThingVirtual(int a) => 0;
                     }
                     """;
 

--- a/test/Analyzers.Tests/GrainInterfacePropertyDiagnosticAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GrainInterfacePropertyDiagnosticAnalyzerTest.cs
@@ -86,4 +86,34 @@ public class GrainInterfacePropertyDiagnosticAnalyzerTest : DiagnosticAnalyzerTe
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
         Assert.Equal(MessageFormat, diagnostic.GetMessage());
     }
+
+    [Fact]
+    public async Task StaticInterfacePropertiesAllowedInGrainInterface()
+    {
+        var code = """
+                    public interface I : Orleans.IGrain
+                    {
+                        public static int MyProperty => 0;
+                        public static virtual int MyVirtualProperty => 0;
+                    }
+                    """;
+
+        var (diagnostics, _) = await this.GetDiagnosticsAsync(code, new string[0]);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task StaticInterfacePropertiesAllowedInAddressableInterface()
+    {
+        var code = """
+                    public interface I : Orleans.Runtime.IAddressable
+                    {
+                        public static int MyProperty => 0;
+                        public static virtual int MyVirtualProperty => 0;
+                    }
+                    """;
+
+        var (diagnostics, _) = await this.GetDiagnosticsAsync(code, new string[0]);
+        Assert.Empty(diagnostics);
+    }
 }

--- a/test/Analyzers.Tests/NoRefParamsDiagnosticAnalyzerTest.cs
+++ b/test/Analyzers.Tests/NoRefParamsDiagnosticAnalyzerTest.cs
@@ -102,5 +102,18 @@ namespace Analyzers.Tests
 
             Assert.Empty(diagnostics);
         }
+
+        [Fact]
+        public async Task OutAndRefParamsAllowedInStaticGrainInterfaceMethods()
+        {
+            var code = @"public interface I : IGrain
+                        {
+                            public static bool SomeStaticMethod(out int o, ref int v) { o = 0; return false; }
+                            public static virtual bool SomeStaticVirtualMethod(out int o, ref int v) { o = 0; return false; }
+                        }";
+
+            var (diagnostics, _) = await this.GetDiagnosticsAsync(code, new string[0]);
+            Assert.Empty(diagnostics);
+        }
     }
 }

--- a/test/DefaultCluster.Tests/CodeGenTests/IRuntimeCodeGenGrain.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/IRuntimeCodeGenGrain.cs
@@ -342,4 +342,17 @@ namespace Tester.CodeGenTests
             return Task.FromResult(value.Payload.Value);
         }
     }
+
+    public interface IGrainWithStaticMembers : IGrainWithGuidKey
+    {
+        public static int StaticMethodWithNonAsyncReturnType(int a) => 0;
+        public static virtual int StaticVirtualMethodWithNonAsyncReturnType(int a) => 0;
+        public static int StaticProperty => 0;
+        public static virtual int StaticVirtualProperty => 0;
+        public static int StaticMethodWithOutAndVarParams(out int a, ref int b) { a = 0; return 0; }
+        public static virtual int StaticVirtualMethodWithOutAndVarParams(out int a, ref int b) { a = 0; return 0; }
+    }
+
+    public class GrainWithStaticMembers : Grain, IGrainWithStaticMembers
+    { }
 }


### PR DESCRIPTION
Relax diagnostic analyzers for static members of grain interfaces. I.e. never issue `ORLEANS0002`, `ORLEANS0008` and `ORLEANS0009` for static members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8506)