### PR TITLE
Expose Writer<>.Output directly instead of via property

### DIFF
--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -188,7 +188,7 @@ namespace Orleans.Serialization.TestKit
                 var writer = Writer.CreatePooled(buffer, _sessionPool.GetSession());
                 serializer.Serialize(original, ref writer);
                 buffer.Flush();
-                writer.Output.Dispose();
+                writer.Dispose();
 
                 buffer.Position = 0;
                 var reader = Reader.Create(buffer, _sessionPool.GetSession());
@@ -486,7 +486,7 @@ namespace Orleans.Serialization.TestKit
                     buffer.SetLength(buffer.Position);
                     buffer.Position = 0;
                     var result = buffer.ToArray();
-                    writer.Output.Dispose();
+                    writer.Dispose();
                     Assert.Equal(expected, result);
                 }
 

--- a/src/Orleans.Serialization/Buffers/PooledBuffer.cs
+++ b/src/Orleans.Serialization/Buffers/PooledBuffer.cs
@@ -87,11 +87,12 @@ public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
     public void Reset()
     {
         var current = _first;
-        while (current != null && current != _writeHead)
+        while (current != null)
         {
             var previous = current;
             current = previous.Next as SequenceSegment;
             previous.Return();
+            Debug.Assert(current == null || current != _writeHead);
         }
 
         _writeHead?.Return();

--- a/test/Benchmarks/Serialization/MegaGraphBenchmark.cs
+++ b/test/Benchmarks/Serialization/MegaGraphBenchmark.cs
@@ -62,7 +62,7 @@ namespace Benchmarks
             Session.Reset();
             var writer = Writer.CreatePooled(Session);
             Serializer.Serialize(Value, ref writer);
-            writer.Output.Dispose();
+            writer.Dispose();
             return writer.Position;
         }
     }

--- a/test/Orleans.Serialization.UnitTests/PooledBufferTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PooledBufferTests.cs
@@ -61,34 +61,33 @@ namespace Orleans.Serialization.UnitTests
             var writer = Writer.Create(new PooledBuffer(), null);
             writer.Write(randomData);
             writer.Commit();
-            var buffer = writer.Output;
 
-            var slice = buffer.Slice();
+            var slice = writer.Output.Slice();
             var sliceReader = Reader.Create(slice, null);
             var sliceArray = sliceReader.ReadBytes((uint)randomData.Length);
             Assert.Equal(randomData, sliceArray);
 
-            var slice3 = buffer.Slice(100, 1024);
+            var slice3 = writer.Output.Slice(100, 1024);
             var reader3 = Reader.Create(slice3, null);
             var result3 = reader3.ReadBytes((uint)slice3.Length);
             Assert.Equal(randomData.AsSpan(100, 1024).ToArray(), result3);
 
-            var slice2 = buffer.Slice(100);
+            var slice2 = writer.Output.Slice(100);
             var reader2 = Reader.Create(slice2, null);
             var result2 = reader2.ReadBytes((uint)slice2.Length);
             Assert.Equal(randomData.AsSpan(100).ToArray(), result2);
 
-            var slice4 = buffer.Slice(3000, 1500);
+            var slice4 = writer.Output.Slice(3000, 1500);
             var reader4 = Reader.Create(slice4, null);
             var result4 = reader4.ReadBytes((uint)slice4.Length);
             Assert.Equal(randomData.AsSpan(3000, 1500).ToArray(), result4);
 
-            var ros = buffer.AsReadOnlySequence();
+            var ros = writer.Output.AsReadOnlySequence();
             var rosReader = Reader.Create(ros, null);
             var rosArray = rosReader.ReadBytes((uint)randomData.Length);
             Assert.Equal(randomData, rosArray);
 
-            buffer.Dispose();
+            writer.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
#8508 included a defensive measure against a double-free bug which was triggered by improper (but intuitive!) use of `Writer<TBufferWriter>.Output`. The PR comments contain an explanation of the issue.

This PR this effectively reverts the defensive measure taken in #8508, replacing it with a `Debug.Assert`, and exposes `Output` as a mutable field directly, allowing for the intuitive (but incorrect) use which triggered the bug to be correct. It does expose a potential issue: developers would be free to re-assign the output buffer.

That could be an issue, so there is a doc comment warning against direct mutation, but we have no other protection against it. As this saga demonstrated, the issue is present already and possibly more nefarious/hidden.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8509)