### PR TITLE
Refactoring for newer C# features

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -16,7 +16,7 @@ namespace Orleans.Clustering.DynamoDB
     internal class DynamoDBGatewayListProvider : IGatewayListProvider
     {
         private DynamoDBStorage storage;
-        private string clusterId;
+        private readonly string clusterId;
         private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString();
         private readonly ILogger logger;
         private readonly DynamoDBGatewayOptions options;

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -17,7 +17,7 @@ namespace Orleans.Clustering.DynamoDB
 {
     internal class DynamoDBMembershipTable : IMembershipTable
     {
-        private static readonly TableVersion NotFoundTableVersion = new TableVersion(0, "0");
+        private static readonly TableVersion NotFoundTableVersion = new(0, "0");
 
         private const string CURRENT_ETAG_ALIAS = ":currentETag";
         private const int MAX_BATCH_SIZE = 25;

--- a/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
@@ -25,7 +25,7 @@ namespace OrleansAWSUtils.Storage
         private const string AccessKeyPropertyName = "AccessKey";
         private const string SecretKeyPropertyName = "SecretKey";
         private const string ServicePropertyName = "Service";
-        private ILogger Logger;
+        private readonly ILogger Logger;
         private string accessKey;
         private string secretKey;
         private string service;

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
@@ -16,7 +16,7 @@ namespace OrleansAWSUtils.Streams
         private readonly Serializer<SQSBatchContainer> serializer;
         protected readonly string DataConnectionString;
         private readonly IConsistentRingStreamQueueMapper streamQueueMapper;
-        protected readonly ConcurrentDictionary<QueueId, SQSStorage> Queues = new ConcurrentDictionary<QueueId, SQSStorage>();
+        protected readonly ConcurrentDictionary<QueueId, SQSStorage> Queues = new();
         private readonly ILoggerFactory loggerFactory;
         public string Name { get; private set; }
         public bool IsRewindable { get { return false; } }
@@ -25,7 +25,7 @@ namespace OrleansAWSUtils.Streams
 
         public SQSAdapter(Serializer<SQSBatchContainer> serializer, IConsistentRingStreamQueueMapper streamQueueMapper, ILoggerFactory loggerFactory, string dataConnectionString, string serviceId, string providerName)
         {
-            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
+            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
             if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
             this.loggerFactory = loggerFactory;
             this.serializer = serializer;
@@ -44,7 +44,7 @@ namespace OrleansAWSUtils.Streams
         {
             if (token != null)
             {
-                throw new ArgumentException("SQSStream stream provider currently does not support non-null StreamSequenceToken.", "token");
+                throw new ArgumentException("SQSStream stream provider currently does not support non-null StreamSequenceToken.", nameof(token));
             }
             var queueId = streamQueueMapper.GetQueueForStream(streamId);
             SQSStorage queue;

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
@@ -20,8 +20,8 @@ namespace OrleansAWSUtils.Streams
         private readonly ClusterOptions clusterOptions;
         private readonly Serializer<SQSBatchContainer> serializer;
         private readonly ILoggerFactory loggerFactory;
-        private HashRingBasedStreamQueueMapper streamQueueMapper;
-        private IQueueAdapterCache adapterCache;
+        private readonly HashRingBasedStreamQueueMapper streamQueueMapper;
+        private readonly IQueueAdapterCache adapterCache;
 
         /// <summary>
         /// Application level failure handler override.

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
@@ -27,8 +27,8 @@ namespace OrleansAWSUtils.Streams
 
         public static IQueueAdapterReceiver Create(Serializer<SQSBatchContainer> serializer, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string serviceId)
         {
-            if (queueId.IsDefault) throw new ArgumentNullException("queueId");
-            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
+            if (queueId.IsDefault) throw new ArgumentNullException(nameof(queueId));
+            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
             if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
 
             var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, serviceId);
@@ -37,8 +37,8 @@ namespace OrleansAWSUtils.Streams
 
         private SQSAdapterReceiver(Serializer<SQSBatchContainer> serializer, ILoggerFactory loggerFactory, QueueId queueId, SQSStorage queue)
         {
-            if (queueId.IsDefault) throw new ArgumentNullException("queueId");
-            if (queue == null) throw new ArgumentNullException("queue");
+            if (queueId.IsDefault) throw new ArgumentNullException(nameof(queueId));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
 
             Id = queueId;
             this.queue = queue;

--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -30,24 +30,24 @@ namespace Orleans.Transactions.DynamoDB
     /// </summary>
     internal class DynamoDBStorage
     {
-        private string accessKey;
-        private string token;
-        private string profileName;
+        private readonly string accessKey;
+        private readonly string token;
+        private readonly string profileName;
         /// <summary> Secret key for this dynamoDB table </summary>
         protected string secretKey;
-        private string service;
+        private readonly string service;
         public const int DefaultReadCapacityUnits = 10;
         public const int DefaultWriteCapacityUnits = 5;
         private readonly ProvisionedThroughput provisionedThroughput;
         private readonly bool createIfNotExists;
         private readonly bool updateIfExists;
         private readonly bool useProvisionedThroughput;
-        private readonly ReadOnlyCollection<TableStatus> updateTableValidTableStatuses = new ReadOnlyCollection<TableStatus>(new List<TableStatus>()
+        private readonly ReadOnlyCollection<TableStatus> updateTableValidTableStatuses = new(new List<TableStatus>()
             {
                 TableStatus.CREATING, TableStatus.UPDATING, TableStatus.ACTIVE
             });
         private AmazonDynamoDBClient ddbClient;
-        private ILogger Logger;
+        private readonly ILogger Logger;
 
         /// <summary>
         /// Create a DynamoDBStorage instance

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -10,9 +10,9 @@ namespace Orleans.Runtime.MembershipService
 {
     public class AdoNetClusteringTable : IMembershipTable
     {
-        private string clusterId;
+        private readonly string clusterId;
         private readonly IServiceProvider serviceProvider;
-        private ILogger logger;
+        private readonly ILogger logger;
         private RelationalOrleansQueries orleansQueries;
         private readonly AdoNetClusteringSiloOptions clusteringTableOptions;
 
@@ -99,12 +99,12 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             if (tableVersion == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. TableVersion is null ");
-                throw new ArgumentNullException("tableVersion");
+                throw new ArgumentNullException(nameof(tableVersion));
             }
 
             try
@@ -131,12 +131,12 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             if (tableVersion == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. TableVersion is null");
-                throw new ArgumentNullException("tableVersion");
+                throw new ArgumentNullException(nameof(tableVersion));
             }
 
             try
@@ -158,7 +158,7 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateIAmAlive aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             try
             {

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime.Membership
     public class AdoNetGatewayListProvider : IGatewayListProvider
     {
         private readonly ILogger logger;
-        private string clusterId;
+        private readonly string clusterId;
         private readonly AdoNetClusteringClientOptions options;
         private RelationalOrleansQueries orleansQueries;
         private readonly IServiceProvider serviceProvider;

--- a/src/AdoNet/Shared/Storage/AdoNetFormatProvider.cs
+++ b/src/AdoNet/Shared/Storage/AdoNetFormatProvider.cs
@@ -18,7 +18,7 @@ namespace Orleans.Tests.SqlUtils
     /// </summary>
     internal class AdoNetFormatProvider: IFormatProvider
     {
-        private readonly AdoNetFormatter formatter = new AdoNetFormatter();
+        private readonly AdoNetFormatter formatter = new();
 
         /// <summary>
         /// Returns an instance of the formatter

--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -21,10 +21,10 @@ namespace Orleans.Tests.SqlUtils
     internal static class DbConnectionFactory
     {
         private static readonly ConcurrentDictionary<string, CachedFactory> factoryCache =
-            new ConcurrentDictionary<string, CachedFactory>();
+            new();
 
         private static readonly Dictionary<string, List<Tuple<string, string>>> providerFactoryTypeMap =
-            new Dictionary<string, List<Tuple<string, string>>>
+            new()
             {
                 { AdoNetInvariants.InvariantNameSqlServer, new List<Tuple<string, string>>{ new Tuple<string, string>("System.Data.SqlClient", "System.Data.SqlClient.SqlClientFactory") } },
                 { AdoNetInvariants.InvariantNameMySql, new List<Tuple<string, string>>{ new Tuple<string, string>("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory") } },

--- a/src/AdoNet/Shared/Storage/DbConstantsStore.cs
+++ b/src/AdoNet/Shared/Storage/DbConstantsStore.cs
@@ -15,7 +15,7 @@ namespace Orleans.Tests.SqlUtils
     internal static class DbConstantsStore
     {
         private static readonly Dictionary<string, DbConstants> invariantNameToConsts =
-            new Dictionary<string, DbConstants>
+            new()
             {
                 {
                     AdoNetInvariants.InvariantNameSqlServer,

--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -26,7 +26,7 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// An explicit map of type CLR viz database type conversions.
         /// </summary>
-        static readonly ReadOnlyDictionary<Type, DbType> typeMap = new ReadOnlyDictionary<Type, DbType>(new Dictionary<Type, DbType>
+        static readonly ReadOnlyDictionary<Type, DbType> typeMap = new(new Dictionary<Type, DbType>
         {
             { typeof(object),   DbType.Object },
             { typeof(int),      DbType.Int32 },

--- a/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
+++ b/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
@@ -290,23 +290,23 @@ namespace Orleans.Tests.SqlUtils
 
         /// <summary>
         /// Checks the parameters passed into a ReadAsync() or Read() are valid.
-        /// </summary>        
+        /// </summary>
         /// <param name="buffer"></param>
         /// <param name="offset"></param>
         /// <param name="count"></param>
         private static void ValidateReadParameters(byte[] buffer, int offset, int count)
-        {            
+        {
             if(buffer == null)
             {
-                throw new ArgumentNullException("buffer");                    
+                throw new ArgumentNullException(nameof(buffer));
             }
             if(offset < 0)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
             if(count < 0)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
             try
             {

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -27,7 +27,7 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// Used to format .NET objects suitable to relational database format.
         /// </summary>
-        private static readonly AdoNetFormatProvider adoNetFormatProvider = new AdoNetFormatProvider();
+        private static readonly AdoNetFormatProvider adoNetFormatProvider = new();
 
         /// <summary>
         /// This is a template to produce query parameters that are indexed.
@@ -50,12 +50,12 @@ namespace Orleans.Tests.SqlUtils
         {
             if(string.IsNullOrWhiteSpace(tableName))
             {
-                throw new ArgumentException("The name must be a legal SQL table name", "tableName");
+                throw new ArgumentException("The name must be a legal SQL table name", nameof(tableName));
             }
 
             if(parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             var storageConsts = DbConstantsStore.GetDbConstants(storage.InvariantName);

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -20,11 +20,11 @@ namespace Orleans.Storage
     /// </summary>
     public class AzureBlobGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private readonly string name;
         private readonly IBlobContainerFactory blobContainerFactory;
         private readonly AzureBlobStorageOptions options;
-        private IGrainStorageSerializer grainStorageSerializer;
+        private readonly IGrainStorageSerializer grainStorageSerializer;
 
         /// <summary> Default constructor </summary>
         public AzureBlobGrainStorage(

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -43,7 +43,7 @@ namespace Orleans.Storage
 
         private const string BINARY_DATA_PROPERTY_NAME = "Data";
         private const string STRING_DATA_PROPERTY_NAME = "StringData";
-        private string name;
+        private readonly string name;
 
         /// <summary> Default constructor </summary>
         public AzureTableGrainStorage(

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -144,10 +144,7 @@ namespace Orleans.Runtime.ReminderService
             return await ReadSingleTableEntryAsync(partitionKey, rowKey);
         }
 
-        private Task<List<(ReminderTableEntry Entity, string ETag)>> FindAllReminderEntries()
-        {
-            return FindReminderEntries(0, 0);
-        }
+        private Task<List<(ReminderTableEntry Entity, string ETag)>> FindAllReminderEntries() => FindReminderEntries(0, 0);
 
         internal async Task<string> UpsertRow(ReminderTableEntry reminderEntry)
         {
@@ -157,9 +154,7 @@ namespace Orleans.Runtime.ReminderService
             }
             catch(Exception exc)
             {
-                HttpStatusCode httpStatusCode;
-                string restStatus;
-                if (AzureTableUtils.EvaluateException(exc, out httpStatusCode, out restStatus))
+                if (AzureTableUtils.EvaluateException(exc, out var httpStatusCode, out var restStatus))
                 {
                     if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("UpsertRow failed with HTTP status code: {HttpStatusCode}, REST status: {RestStatus}", httpStatusCode, restStatus);
                     if (AzureTableUtils.IsContentionError(httpStatusCode)) return null; // false;

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
@@ -16,7 +16,7 @@ namespace Orleans.LeaseProviders
     public class AzureBlobLeaseProvider : ILeaseProvider
     {
         private BlobContainerClient container;
-        private AzureBlobLeaseProviderOptions options;
+        private readonly AzureBlobLeaseProviderOptions options;
         private BlobServiceClient blobClient;
         public AzureBlobLeaseProvider(IOptions<AzureBlobLeaseProviderOptions> options)
             : this(options.Value)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -61,26 +61,17 @@ namespace Orleans.Providers.Streams.AzureQueue
         }
 
         /// <summary>Creates the adapter cache.</summary>
-        public virtual IQueueAdapterCache GetQueueAdapterCache()
-        {
-            return adapterCache;
-        }
+        public virtual IQueueAdapterCache GetQueueAdapterCache() => adapterCache;
 
         /// <summary>Creates the factory stream queue mapper.</summary>
-        public IStreamQueueMapper GetStreamQueueMapper()
-        {
-            return streamQueueMapper;
-        }
+        public IStreamQueueMapper GetStreamQueueMapper() => streamQueueMapper;
 
         /// <summary>
         /// Creates a delivery failure handler for the specified queue.
         /// </summary>
         /// <param name="queueId"></param>
         /// <returns></returns>
-        public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId)
-        {
-            return StreamFailureHandlerFactory(queueId);
-        }
+        public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId) => StreamFailureHandlerFactory(queueId);
 
         public static AzureQueueAdapterFactory Create(IServiceProvider services, string name)
         {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
@@ -101,10 +101,10 @@ namespace Orleans.Streaming.EventHubs.Testing
     {
         //differnt stream in the same partition should use the same sequenceNumberCounter
         private readonly EventDataGeneratorStreamOptions options;
-        private readonly IntCounter sequenceNumberCounter = new IntCounter();
+        private readonly IntCounter sequenceNumberCounter = new();
         private readonly ILogger logger;
-        private Func<StreamId, IStreamDataGenerator<EventData>> generatorFactory;
-        private List<IStreamDataGenerator<EventData>> generators;
+        private readonly Func<StreamId, IStreamDataGenerator<EventData>> generatorFactory;
+        private readonly List<IStreamDataGenerator<EventData>> generators;
 
         /// <summary>
         /// Constructor

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -12,7 +12,7 @@ namespace Orleans.Streaming.EventHubs.Testing
     /// </summary>
     public class EventHubPartitionGeneratorReceiver : IEventHubReceiver
     {
-        private IDataGenerator<EventData> generator;
+        private readonly IDataGenerator<EventData> generator;
         /// <summary>
         /// Constructor
         /// </summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/NoOpCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/NoOpCheckpointer.cs
@@ -6,7 +6,7 @@ namespace Orleans.Streaming.EventHubs.Testing
 {
     public class NoOpCheckpointerFactory : IStreamQueueCheckpointerFactory
     {
-        public static NoOpCheckpointerFactory Instance = new NoOpCheckpointerFactory();
+        public static NoOpCheckpointerFactory Instance = new();
         public Task<IStreamQueueCheckpointer<string>> Create(string partition)
         {
             return Task.FromResult<IStreamQueueCheckpointer<string>>(NoOpCheckpointer.Instance);
@@ -19,7 +19,7 @@ namespace Orleans.Streaming.EventHubs.Testing
     /// </summary>
     public class NoOpCheckpointer : IStreamQueueCheckpointer<string>
     {
-        public static NoOpCheckpointer Instance = new NoOpCheckpointer();
+        public static NoOpCheckpointer Instance = new();
 
         public bool CheckpointExists => true;
         public Task<string> Load()

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AggregatedCachePressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AggregatedCachePressureMonitor.cs
@@ -13,7 +13,7 @@ namespace Orleans.Streaming.EventHubs
     public class AggregatedCachePressureMonitor : List<ICachePressureMonitor>, ICachePressureMonitor
     {
         private bool isUnderPressure;
-        private ILogger logger;
+        private readonly ILogger logger;
         /// <summary>
         /// Cache monitor which is used to report cache related metrics
         /// </summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streaming.EventHubs
         private double cachePressureContributionCount;
         private DateTime nextCheckedTime;
         private bool isUnderPressure;
-        private double flowControlThreshold;
+        private readonly double flowControlThreshold;
 
         /// <summary>
         /// Constructor

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -50,7 +50,7 @@ namespace Orleans.Streaming.EventHubs
 
         private IEventHubReceiver receiver;
 
-        private Func<EventHubPartitionSettings, string, ILogger, IEventHubReceiver> eventHubReceiverFactory;
+        private readonly Func<EventHubPartitionSettings, string, ILogger, IEventHubReceiver> eventHubReceiverFactory;
 
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
@@ -192,7 +192,7 @@ namespace Orleans.Configuration
     public class StreamCheckpointerConfigurationValidator : IConfigurationValidator
     {
         private readonly IServiceProvider services;
-        private string name;
+        private readonly string name;
         public StreamCheckpointerConfigurationValidator(IServiceProvider services, string name)
         {
             this.services = services;

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -455,11 +455,11 @@ namespace Orleans.GrainDirectory.AzureStorage
             var startTime = DateTime.UtcNow;
             if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{Operation} entries: {Data} table {TableName}", operation, Utils.EnumerableToString(collection), TableName);
 
-            if (collection == null) throw new ArgumentNullException("collection");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
 
             if (collection.Count > this.StoragePolicyOptions.MaxBulkUpdateRows)
             {
-                throw new ArgumentOutOfRangeException("collection", collection.Count,
+                throw new ArgumentOutOfRangeException(nameof(collection), collection.Count,
                         "Too many rows for bulk delete - max " + this.StoragePolicyOptions.MaxBulkUpdateRows);
             }
 
@@ -564,10 +564,10 @@ namespace Orleans.GrainDirectory.AzureStorage
         public async Task BulkInsertTableEntries(IReadOnlyCollection<T> collection)
         {
             const string operation = "BulkInsertTableEntries";
-            if (collection == null) throw new ArgumentNullException("collection");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
             if (collection.Count > this.StoragePolicyOptions.MaxBulkUpdateRows)
             {
-                throw new ArgumentOutOfRangeException("collection", collection.Count,
+                throw new ArgumentOutOfRangeException(nameof(collection), collection.Count,
                         "Too many rows for bulk update - max " + this.StoragePolicyOptions.MaxBulkUpdateRows);
             }
 

--- a/src/Orleans.Analyzers/AbstractPropertiesCannotBeSerializedAnalyzer.cs
+++ b/src/Orleans.Analyzers/AbstractPropertiesCannotBeSerializedAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Orleans.Analyzers
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AbstractOrStaticMembersCannotBeSerializedTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AbstractOrStaticMembersCannotBeSerializedMessageFormat), Resources.ResourceManager, typeof(Resources));
 
-        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/AlwaysInterleaveDiagnosticAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Orleans.Analyzers
         public const string MessageFormat = Title;
         public const string Category = "Usage";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/AtMostOneOrleansConstructorAnalyzer.cs
+++ b/src/Orleans.Analyzers/AtMostOneOrleansConstructorAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Orleans.Analyzers
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AtMostOneOrleansConstructorTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AtMostOneOrleansConstructorMessageFormat), Resources.ResourceManager, typeof(Resources));
 
-        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/GenerateGenerateSerializerAttributeAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateGenerateSerializerAttributeAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Orleans.Analyzers
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AddGenerateSerializerAttributeMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AddGenerateSerializerAttributeDescription), Resources.ResourceManager, typeof(Resources));
 
-        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
+        internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateSerializationAttributesAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Orleans.Analyzers
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AddSerializationAttributesMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AddSerializationAttributesDescription), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceMethodReturnTypeDiagnosticAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Orleans.Analyzers
         public const string MessageFormat = $"Grain interfaces methods must return a compatible type, such as Task, Task<T>, ValueTask, ValueTask<T>, or void";
         public const string Category = "Usage";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/GrainInterfacePropertyDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfacePropertyDiagnosticAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Orleans.Analyzers
         public const string MessageFormat = Title;
         public const string Category = "Usage";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Orleans.Analyzers/NoRefParamsDiagnosticAnalyzer.cs
+++ b/src/Orleans.Analyzers/NoRefParamsDiagnosticAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Orleans.Analyzers
         public const string MessageFormat = Title;
         public const string Category = "Usage";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -29,7 +29,7 @@ namespace Orleans.Analyzers
 
         private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MethodDeclarationSyntax syntax)) return;
+            if (context.Node is not MethodDeclarationSyntax syntax) return;
 
             var symbol = context.SemanticModel.GetDeclaredSymbol(syntax, context.CancellationToken);
 

--- a/src/Orleans.BroadcastChannel/BroadcastChannelConsumerExtension.cs
+++ b/src/Orleans.BroadcastChannel/BroadcastChannelConsumerExtension.cs
@@ -15,7 +15,7 @@ namespace Orleans.BroadcastChannel
     {
         private readonly ConcurrentDictionary<InternalChannelId, ICallback> _handlers = new();
         private readonly IOnBroadcastChannelSubscribed _subscriptionObserver;
-        private AsyncLock _lock = new AsyncLock();
+        private readonly AsyncLock _lock = new();
 
         private interface ICallback
         {

--- a/src/Orleans.BroadcastChannel/SubscriberTable/ImplicitChannelSubscriberTable.cs
+++ b/src/Orleans.BroadcastChannel/SubscriberTable/ImplicitChannelSubscriberTable.cs
@@ -12,7 +12,7 @@ namespace Orleans.BroadcastChannel.SubscriberTable
 {
     internal class ImplicitChannelSubscriberTable
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly GrainBindingsResolver _bindings;
         private readonly IChannelNamespacePredicateProvider[] _providers;
         private readonly IServiceProvider _serviceProvider;

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -17,8 +17,8 @@ namespace Orleans.Runtime.Membership
     /// </summary>
     public class ConsulBasedMembershipTable : IMembershipTable
     {
-        private static readonly TableVersion NotFoundTableVersion = new TableVersion(0, "0");
-        private ILogger _logger;
+        private static readonly TableVersion NotFoundTableVersion = new(0, "0");
+        private readonly ILogger _logger;
         private readonly IConsulClient _consulClient;
         private readonly ConsulClusteringOptions clusteringSiloTableOptions;
         private readonly string clusterId;

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -14,8 +14,8 @@ namespace Orleans.Runtime.Membership
     public class ConsulGatewayListProvider : IGatewayListProvider
     {
         private IConsulClient consulClient;
-        private string clusterId;
-        private ILogger logger;
+        private readonly string clusterId;
+        private readonly ILogger logger;
         private readonly ConsulClusteringOptions options;
         private readonly TimeSpan maxStaleness;
         private readonly string kvRootFolder;

--- a/src/Orleans.Clustering.ZooKeeper/MembershipSerializerSettings.cs
+++ b/src/Orleans.Clustering.ZooKeeper/MembershipSerializerSettings.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime.Host
 {
     internal class MembershipSerializerSettings : JsonSerializerSettings
     {
-        public static readonly MembershipSerializerSettings Instance = new MembershipSerializerSettings();
+        public static readonly MembershipSerializerSettings Instance = new();
 
         private MembershipSerializerSettings()
         {

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -36,7 +36,7 @@ namespace Orleans.Runtime.Membership
     /// </remarks>
     public class ZooKeeperBasedMembershipTable : IMembershipTable
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private const int ZOOKEEPER_CONNECTION_TIMEOUT = 2000;
 

--- a/src/Orleans.CodeGenerator.MSBuild/AssemblyResolver.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/AssemblyResolver.cs
@@ -94,10 +94,7 @@ namespace Orleans.CodeGenerator.MSBuild
 
             return null;
 
-            bool NamesMatch(RuntimeLibrary runtime)
-            {
-                return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
-            }
+            bool NamesMatch(RuntimeLibrary runtime) => string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
         }
 
         private Assembly TryLoadAssemblyFromPath(string path)

--- a/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
+++ b/src/Orleans.CodeGenerator.MSBuild/CodeGeneratorCommand.cs
@@ -211,7 +211,7 @@ namespace Orleans.CodeGenerator.MSBuild
             ?? (IEnumerable<MetadataReference>)Array.Empty<MetadataReference>();
 
 
-        private static string GetLanguageName(string projectPath) => (Path.GetExtension(projectPath)) switch
+        private static string GetLanguageName(string projectPath) => Path.GetExtension(projectPath) switch
         {
             ".csproj" => LanguageNames.CSharp,
             string ext when !string.IsNullOrWhiteSpace(ext) => throw new NotSupportedException($"Projects of type {ext} are not supported."),

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -460,7 +460,7 @@ namespace Orleans.CodeGenerator
         }
 
         // Returns descriptions of all data members (fields and properties)
-        private IEnumerable<IMemberDescription> GetDataMembers(FieldIdAssignmentHelper fieldIdAssignmentHelper)
+        private static IEnumerable<IMemberDescription> GetDataMembers(FieldIdAssignmentHelper fieldIdAssignmentHelper)
         {
             var members = new Dictionary<(uint, bool), IMemberDescription>();
 
@@ -557,10 +557,7 @@ namespace Orleans.CodeGenerator
 
         private uint? GetWellKnownTypeId(ISymbol symbol) => GetId(symbol);
 
-        public string GetAlias(ISymbol symbol)
-        {
-            return (string)symbol.GetAttribute(LibraryTypes.AliasAttribute)?.ConstructorArguments.First().Value;
-        }
+        public string GetAlias(ISymbol symbol) => (string)symbol.GetAttribute(LibraryTypes.AliasAttribute)?.ConstructorArguments.First().Value;
 
         private CompoundTypeAliasComponent[] GetCompoundTypeAlias(ISymbol symbol)
         {

--- a/src/Orleans.CodeGenerator/CopierGenerator.cs
+++ b/src/Orleans.CodeGenerator/CopierGenerator.cs
@@ -113,20 +113,22 @@ namespace Orleans.CodeGenerator
         {
             return fieldDescriptions.Select(GetFieldDeclaration).ToArray();
 
-            static MemberDeclarationSyntax GetFieldDeclaration(GeneratedFieldDescription description)
+            static MemberDeclarationSyntax GetFieldDeclaration(GeneratedFieldDescription description) => description switch
             {
-                switch (description)
-                {
-                    case FieldAccessorDescription accessor:
-                        return
-                            FieldDeclaration(VariableDeclaration(accessor.FieldType,
-                                SingletonSeparatedList(VariableDeclarator(accessor.FieldName).WithInitializer(EqualsValueClause(accessor.InitializationSyntax)))))
-                                .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.ReadOnlyKeyword));
-                    default:
-                        return FieldDeclaration(VariableDeclaration(description.FieldType, SingletonSeparatedList(VariableDeclarator(description.FieldName))))
-                            .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.ReadOnlyKeyword));
-                }
-            }
+                FieldAccessorDescription accessor =>
+                    FieldDeclaration(
+                        VariableDeclaration(
+                            accessor.FieldType,
+                            SingletonSeparatedList(
+                                VariableDeclarator(accessor.FieldName).WithInitializer(EqualsValueClause(accessor.InitializationSyntax)))))
+                                            .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.ReadOnlyKeyword)),
+                _ => FieldDeclaration(
+                        VariableDeclaration(
+                            description.FieldType,
+                            SingletonSeparatedList(
+                                VariableDeclarator(description.FieldName))))
+                                            .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.ReadOnlyKeyword)),
+            };
         }
 
         private static ConstructorDeclarationSyntax GenerateConstructor(LibraryTypes libraryTypes, string simpleClassName, List<GeneratedFieldDescription> fieldDescriptions, bool isExceptionType)

--- a/src/Orleans.CodeGenerator/Diagnostics/CanNotGenerateImplicitFieldIdsDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/CanNotGenerateImplicitFieldIdsDiagnostic.cs
@@ -10,7 +10,7 @@ public static class CanNotGenerateImplicitFieldIdsDiagnostic
     public const string MessageFormat = "Could not generate implicit field identifiers for the type {0}: {reason}";
     public const string Category = "Usage";
 
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
     internal static Diagnostic CreateDiagnostic(ISymbol symbol, string reason) => Diagnostic.Create(Rule, symbol.Locations.First(), symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), reason);
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembly_Diagnostic.cs
@@ -9,7 +9,7 @@ public static class GenerateCodeForDeclaringAssemblyAttribute_NoDeclaringAssembl
     public const string MessageFormat = "The type {0} provided as an argument to {1} does not have a declaring assembly";
     public const string Category = "Usage";
 
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
     internal static Diagnostic CreateDiagnostic(AttributeData attribute, ITypeSymbol type) => Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference.SyntaxTree.GetLocation(attribute.ApplicationSyntaxReference.Span), type.ToDisplayString(), attribute.ToString());
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSerializableTypeDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSerializableTypeDiagnostic.cs
@@ -11,7 +11,7 @@ public static class InaccessibleSerializableTypeDiagnostic
     public const string Descsription = "Source generation requires that all types marked as serializable are accessible from generated code. Either make the type public or make it internal and ensure that internals are visible to the generated code.";
     public const string Category = "Usage";
 
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Descsription);
+    private static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Descsription);
 
     internal static Diagnostic CreateDiagnostic(ISymbol symbol) => Diagnostic.Create(Rule, symbol.Locations.First(), symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSetterDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InaccessibleSetterDiagnostic.cs
@@ -10,7 +10,7 @@ public static class InaccessibleSetterDiagnostic
     private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InaccessibleSetterMessageFormat), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InaccessibleSetterDescription), Resources.ResourceManager, typeof(Resources));
 
-    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     public static Diagnostic CreateDiagnostic(Location location, string identifier) => Diagnostic.Create(Rule, location, identifier);
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/IncorrectProxyBaseClassSpecificationDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/IncorrectProxyBaseClassSpecificationDiagnostic.cs
@@ -10,7 +10,7 @@ public static class IncorrectProxyBaseClassSpecificationDiagnostic
     private static readonly LocalizableString MessageFormat = "Proxy base class {0} does not conform to requirements: {1}";
     private static readonly LocalizableString Description = "Proxy base clases must conform. Please report this bug by opening an issue https://github.com/dotnet/orleans/issues/new.";
 
-    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     internal static Diagnostic CreateDiagnostic(INamedTypeSymbol baseClass, Location location, string complaint) => Diagnostic.Create(Rule, location, baseClass.ToDisplayString(), complaint);
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcMethodReturnTypeDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcMethodReturnTypeDiagnostic.cs
@@ -11,7 +11,7 @@ public static class InvalidRpcMethodReturnTypeDiagnostic
     private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.InvalidRpcMethodReturnTypeMessageFormat), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.InvalidRpcMethodReturnTypeDescription), Resources.ResourceManager, typeof(Resources));
 
-    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     public static Diagnostic CreateDiagnostic(Location location, string returnType, string methodIdentifier, string supportedReturnTypeList) => Diagnostic.Create(Rule, location, returnType, methodIdentifier, supportedReturnTypeList);
 

--- a/src/Orleans.CodeGenerator/Diagnostics/RpcInterfacePropertyDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/RpcInterfacePropertyDiagnostic.cs
@@ -10,7 +10,7 @@ public static class RpcInterfacePropertyDiagnostic
     public const string MessageFormat = "The interface {0} contains a property {1}. RPC interfaces must not contain properties.";
     public const string Category = "Usage";
 
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
 
     internal static Diagnostic CreateDiagnostic(INamedTypeSymbol interfaceSymbol, IPropertySymbol property) => Diagnostic.Create(Rule, property.Locations.First(), interfaceSymbol.ToDisplayString(), property.ToDisplayString());
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/UnhandledCodeGenerationExceptionDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/UnhandledCodeGenerationExceptionDiagnostic.cs
@@ -11,7 +11,7 @@ public static class UnhandledCodeGenerationExceptionDiagnostic
     private static readonly LocalizableString MessageFormat = "An unhandled exception occurred while generating source for your project: {0}";
     private static readonly LocalizableString Description = "Please report this bug by opening an issue https://github.com/dotnet/orleans/issues/new.";
 
-    internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    internal static readonly DiagnosticDescriptor Rule = new(RuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
     internal static Diagnostic CreateDiagnostic(Exception exception) => Diagnostic.Create(Rule, location: null, messageArgs: new[] { exception.ToString() });
 }

--- a/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
+++ b/src/Orleans.Connections.Security/Security/DuplexPipeStreamAdapter.cs
@@ -12,7 +12,7 @@ namespace Orleans.Connections.Security
     internal class DuplexPipeStreamAdapter<TStream> : DuplexPipeStream, IDuplexPipe where TStream : Stream
     {
         private bool _disposed;
-        private readonly object _disposeLock = new object();
+        private readonly object _disposeLock = new();
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, Func<Stream, TStream> createStream) :
             this(duplexPipe, new StreamPipeReaderOptions(leaveOpen: true), new StreamPipeWriterOptions(leaveOpen: true), createStream)

--- a/src/Orleans.Connections.Security/Security/OrleansApplicationProtocol.cs
+++ b/src/Orleans.Connections.Security/Security/OrleansApplicationProtocol.cs
@@ -4,6 +4,6 @@ namespace Orleans.Connections.Security
 {
     internal static class OrleansApplicationProtocol
     {
-        public static readonly SslApplicationProtocol Orleans1 = new SslApplicationProtocol("Orleans1");
+        public static readonly SslApplicationProtocol Orleans1 = new("Orleans1");
     }
 }

--- a/src/Orleans.Core.Abstractions/IDs/ClientGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ClientGrainId.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a new <see cref="ClientGrainId"/> instance.
         /// </summary>
-        public static ClientGrainId Create(IdSpan id) => new ClientGrainId(new GrainId(GrainTypePrefix.ClientGrainType, id));
+        public static ClientGrainId Create(IdSpan id) => new(new GrainId(GrainTypePrefix.ClientGrainType, id));
 
         /// <summary>
         /// Converts the provided <see cref="GrainId"/> to a <see cref="ClientGrainId"/>. A return value indicates whether the operation succeeded.

--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -56,12 +56,12 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a new <see cref="GrainType"/> instance.
         /// </summary>
-        public static GrainId Create(GrainType type, string key) => new GrainId(type, IdSpan.Create(key));
+        public static GrainId Create(GrainType type, string key) => new(type, IdSpan.Create(key));
 
         /// <summary>
         /// Creates a new <see cref="GrainType"/> instance.
         /// </summary>
-        public static GrainId Create(GrainType type, IdSpan key) => new GrainId(type, key);
+        public static GrainId Create(GrainType type, IdSpan key) => new(type, key);
 
         /// <summary>
         /// Creates a new <see cref="GrainType"/> instance.

--- a/src/Orleans.Core.Abstractions/IDs/GrainInterfaceType.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainInterfaceType.cs
@@ -38,7 +38,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a <see cref="GrainInterfaceType"/> instance.
         /// </summary>
-        public static GrainInterfaceType Create(string value) => new GrainInterfaceType(value);
+        public static GrainInterfaceType Create(string value) => new(value);
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is GrainInterfaceType id && Equals(id);

--- a/src/Orleans.Core.Abstractions/IDs/GrainType.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainType.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
         /// <returns>
         /// The newly created <see cref="GrainType"/> instance.
         /// </returns>
-        public static GrainType Create(string value) => new GrainType(Encoding.UTF8.GetBytes(value));
+        public static GrainType Create(string value) => new(Encoding.UTF8.GetBytes(value));
 
         /// <summary>
         /// Converts a <see cref="GrainType"/> to a <see cref="IdSpan"/>.
@@ -80,7 +80,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="id">The id span to convert.</param>
         /// <returns>The corresponding <see cref="GrainType"/>.</returns>
-        public static explicit operator GrainType(IdSpan id) => new GrainType(id);
+        public static explicit operator GrainType(IdSpan id) => new(id);
 
         /// <summary>
         /// Gets a value indicating whether this instance is the default value.

--- a/src/Orleans.Core.Abstractions/IDs/GuidId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GuidId.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime
     [GenerateSerializer]
     public sealed class GuidId : IEquatable<GuidId>, IComparable<GuidId>, ISerializable
     {
-        private static readonly Interner<Guid, GuidId> guidIdInternCache = new Interner<Guid, GuidId>(InternerConstants.SIZE_LARGE);
+        private static readonly Interner<Guid, GuidId> guidIdInternCache = new(InternerConstants.SIZE_LARGE);
 
         /// <summary>
         /// The underlying <see cref="Guid"/>.

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
@@ -10,9 +10,9 @@ namespace Orleans.Runtime
     [Serializable, GenerateSerializer, Immutable]
     public sealed class LegacyGrainId : IEquatable<LegacyGrainId>, IComparable<LegacyGrainId>
     {
-        private static readonly Interner<UniqueKey, LegacyGrainId> grainIdInternCache = new Interner<UniqueKey, LegacyGrainId>(InternerConstants.SIZE_LARGE);
-        private static readonly Interner<UniqueKey, byte[]> grainTypeInternCache = new Interner<UniqueKey, byte[]>();
-        private static readonly Interner<UniqueKey, byte[]> grainKeyInternCache = new Interner<UniqueKey, byte[]>();
+        private static readonly Interner<UniqueKey, LegacyGrainId> grainIdInternCache = new(InternerConstants.SIZE_LARGE);
+        private static readonly Interner<UniqueKey, byte[]> grainTypeInternCache = new();
+        private static readonly Interner<UniqueKey, byte[]> grainKeyInternCache = new();
         private static readonly ReadOnlyMemory<byte> ClientPrefixBytes = Encoding.UTF8.GetBytes(GrainTypePrefix.ClientPrefix + ".");
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
@@ -54,7 +54,7 @@ namespace Orleans.Runtime
         private static bool IsKeyExt(Category category)
             => category == Category.KeyExtGrain || category == Category.KeyExtSystemTarget;
 
-        internal static readonly UniqueKey Empty = new UniqueKey();
+        internal static readonly UniqueKey Empty = new();
 
         internal static UniqueKey Parse(ReadOnlySpan<char> input)
         {
@@ -92,9 +92,9 @@ namespace Orleans.Runtime
             return key;
         }
 
-        public static UniqueKey NewKey() => new UniqueKey { Guid = Guid.NewGuid() };
+        public static UniqueKey NewKey() => new() { Guid = Guid.NewGuid() };
 
-        internal static UniqueKey NewKey(Guid guid) => new UniqueKey { Guid = guid };
+        internal static UniqueKey NewKey(Guid guid) => new() { Guid = guid };
 
         internal static UniqueKey NewKey(Guid guid, Category category = Category.None, long typeData = 0, string keyExt = null)
         {
@@ -106,16 +106,20 @@ namespace Orleans.Runtime
         }
 
         internal static UniqueKey NewEmptySystemTargetKey(long typeData)
-            => new UniqueKey { TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
+            => new()
+            { TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
 
         public static UniqueKey NewSystemTargetKey(Guid guid, long typeData)
-            => new UniqueKey { Guid = guid, TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
+            => new()
+            { Guid = guid, TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
 
         public static UniqueKey NewSystemTargetKey(short systemId)
-            => new UniqueKey { N1 = (ulong)systemId, TypeCodeData = GetTypeCodeData(Category.SystemTarget) };
+            => new()
+            { N1 = (ulong)systemId, TypeCodeData = GetTypeCodeData(Category.SystemTarget) };
 
         public static UniqueKey NewGrainServiceKey(short key, long typeData)
-            => new UniqueKey { N1 = (ulong)key, TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
+            => new()
+            { N1 = (ulong)key, TypeCodeData = GetTypeCodeData(Category.SystemTarget, typeData) };
 
         public static UniqueKey NewGrainServiceKey(string key, long typeData)
             => NewKey(GetTypeCodeData(Category.KeyExtSystemTarget, typeData), key);
@@ -133,7 +137,7 @@ namespace Orleans.Runtime
             if (IsKeyExt(GetCategory(typeCodeData)))
             {
                 if (string.IsNullOrWhiteSpace(keyExt))
-                    throw keyExt is null ? new ArgumentNullException("keyExt") : throw new ArgumentException("Extended key is empty or white space.", "keyExt");
+                    throw keyExt is null ? new ArgumentNullException(nameof(keyExt)) : throw new ArgumentException("Extended key is empty or white space.", nameof(keyExt));
             }
             else if (keyExt != null) throw new ArgumentException("Only key extended grains can specify a non-null key extension.");
             return new UniqueKey { TypeCodeData = typeCodeData, KeyExt = keyExt };

--- a/src/Orleans.Core.Abstractions/IDs/ObserverGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ObserverGrainId.cs
@@ -49,7 +49,7 @@ namespace Orleans.Runtime
         /// <returns>
         /// A new <see cref="ObserverGrainId"/> instance for the provided client id.
         /// </returns>
-        public static ObserverGrainId Create(ClientGrainId clientId, IdSpan scopedId) => new ObserverGrainId(ConstructGrainId(clientId, scopedId));
+        public static ObserverGrainId Create(ClientGrainId clientId, IdSpan scopedId) => new(ConstructGrainId(clientId, scopedId));
 
         /// <summary>
         /// Returns <see langword="true"/> if the provided instance represents an observer, <see langword="false"/> if otherwise.

--- a/src/Orleans.Core.Abstractions/IDs/SystemTargetGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SystemTargetGrainId.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
         /// <returns>
         /// A <see cref="SystemTargetGrainId"/>.
         /// </returns>
-        public static SystemTargetGrainId Create(GrainType kind, SiloAddress address) => new SystemTargetGrainId(new GrainId(kind, new IdSpan(address.ToUtf8String())));
+        public static SystemTargetGrainId Create(GrainType kind, SiloAddress address) => new(new GrainId(kind, new IdSpan(address.ToUtf8String())));
 
         /// <summary>
         /// Creates a new <see cref="SystemTargetGrainId"/> instance.
@@ -201,7 +201,7 @@ namespace Orleans.Runtime
         /// </param>
         /// <returns>A grain id for a grain service instance.</returns>
         internal static GrainId CreateGrainServiceGrainId(GrainType grainType, SiloAddress address)
-            => new GrainId(grainType, new IdSpan(address.ToUtf8String()));
+            => new(grainType, new IdSpan(address.ToUtf8String()));
 
         /// <summary>
         /// Creates a system target <see cref="GrainType"/> with the provided name.

--- a/src/Orleans.Core.Abstractions/Logging/LogFormatter.cs
+++ b/src/Orleans.Core.Abstractions/Logging/LogFormatter.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
         public const int MAX_LOG_MESSAGE_SIZE = 20000;
         private const string TIME_FORMAT = "HH:mm:ss.fff 'GMT'"; // Example: 09:50:43.341 GMT
         private const string DATE_FORMAT = "yyyy-MM-dd " + TIME_FORMAT; // Example: 2010-09-02 09:50:43.341 GMT - Variant of UniversalSorta­bleDateTimePat­tern
-        private static readonly ConcurrentDictionary<Type, Func<Exception, string>> exceptionDecoders = new ConcurrentDictionary<Type, Func<Exception, string>>();
+        private static readonly ConcurrentDictionary<Type, Func<Exception, string>> exceptionDecoders = new();
 
         /// <summary>
         /// Utility function to convert a <c>DateTime</c> object into printable data format used by the Logger subsystem.

--- a/src/Orleans.Core.Abstractions/Manifest/MajorMinorVersion.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/MajorMinorVersion.cs
@@ -22,7 +22,7 @@ namespace Orleans.Metadata
         /// <summary>
         /// Gets the zero value.
         /// </summary>
-        public static MajorMinorVersion Zero => new MajorMinorVersion(0, 0);
+        public static MajorMinorVersion Zero => new(0, 0);
 
         /// <summary>
         /// Gets the most significant version component.

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -256,13 +256,13 @@ namespace Orleans.Runtime
         /// The grain reference functionality which is shared by all grain references of a given type.
         /// </summary>
         [NonSerialized]
-        private GrainReferenceShared _shared;
+        private readonly GrainReferenceShared _shared;
 
         /// <summary>
         /// The underlying grain id key.
         /// </summary>
         [NonSerialized]
-        private IdSpan _key;
+        private readonly IdSpan _key;
 
         /// <summary>
         /// Gets the grain reference functionality which is shared by all grain references of a given type.

--- a/src/Orleans.Core.Abstractions/Runtime/MembershipVersion.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/MembershipVersion.cs
@@ -29,7 +29,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets the minimum possible version.
         /// </summary>
-        public static MembershipVersion MinValue => new MembershipVersion(long.MinValue);
+        public static MembershipVersion MinValue => new(long.MinValue);
 
         /// <inheritdoc/>
         public int CompareTo(MembershipVersion other) => this.Value.CompareTo(other.Value);

--- a/src/Orleans.Core/Async/AsyncSerialExecutor.cs
+++ b/src/Orleans.Core/Async/AsyncSerialExecutor.cs
@@ -14,8 +14,8 @@ namespace Orleans
     /// </typeparam>
     public class AsyncSerialExecutor<TResult>
     {
-        private readonly ConcurrentQueue<Tuple<TaskCompletionSource<TResult>, Func<Task<TResult>>>> actions = new ConcurrentQueue<Tuple<TaskCompletionSource<TResult>, Func<Task<TResult>>>>();
-        private readonly InterlockedExchangeLock locker = new InterlockedExchangeLock();
+        private readonly ConcurrentQueue<Tuple<TaskCompletionSource<TResult>, Func<Task<TResult>>>> actions = new();
+        private readonly InterlockedExchangeLock locker = new();
 
         /// <summary>
         /// A lock which relies on <see cref="Interlocked.Exchange(ref long, long)"/>
@@ -110,7 +110,7 @@ namespace Orleans
     /// </summary>
     public class AsyncSerialExecutor
     {
-        private AsyncSerialExecutor<bool> executor = new AsyncSerialExecutor<bool>();
+        private readonly AsyncSerialExecutor<bool> executor = new();
 
         /// <summary>
         /// Submits the next function for execution. It will execute after all previously submitted functions have finished, without interleaving their executions.

--- a/src/Orleans.Core/Async/BatchWorker.cs
+++ b/src/Orleans.Core/Async/BatchWorker.cs
@@ -16,7 +16,7 @@ namespace Orleans
     /// </summary>
     public abstract class BatchWorker
     {
-        private readonly object lockable = new object();
+        private readonly object lockable = new();
 
         private DateTime? scheduledNotify;
 

--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -44,7 +44,7 @@ namespace Orleans.Configuration
     /// </summary>
     public class ClusterOptionsValidator : IConfigurationValidator
     {
-        private ClusterOptions options;
+        private readonly ClusterOptions options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterOptionsValidator"/> class.

--- a/src/Orleans.Core/Configuration/Validators/SerializerConfigurationValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/SerializerConfigurationValidator.cs
@@ -16,9 +16,9 @@ namespace Orleans
     /// </summary>
     public class SerializerConfigurationValidator : IConfigurationValidator
     {
-        private ICodecProvider _codecProvider;
-        private TypeManifestOptions _options;
-        private bool _enabled;
+        private readonly ICodecProvider _codecProvider;
+        private readonly TypeManifestOptions _options;
+        private readonly bool _enabled;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializerConfigurationValidator"/> class.

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -17,7 +17,7 @@ namespace Orleans
         /// <summary>
         /// The cache of typed system target references.
         /// </summary>
-        private readonly Dictionary<(GrainId, Type), ISystemTarget> typedSystemTargetReferenceCache = new Dictionary<(GrainId, Type), ISystemTarget>();
+        private readonly Dictionary<(GrainId, Type), ISystemTarget> typedSystemTargetReferenceCache = new();
 
         private readonly GrainReferenceActivator referenceActivator;
         private readonly GrainInterfaceTypeResolver interfaceTypeResolver;

--- a/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
+++ b/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
@@ -16,8 +16,8 @@ namespace Orleans
     /// </remarks>
     public class GrainInterfaceTypeToGrainTypeResolver
     {
-        private readonly object _lockObj = new object();
-        private readonly ConcurrentDictionary<GrainInterfaceType, GrainType> _genericMapping = new ConcurrentDictionary<GrainInterfaceType, GrainType>();
+        private readonly object _lockObj = new();
+        private readonly ConcurrentDictionary<GrainInterfaceType, GrainType> _genericMapping = new();
         private readonly IClusterManifestProvider _clusterManifestProvider;
         private Cache _cache;
 

--- a/src/Orleans.Core/Diagnostics/EventSourceEvents.cs
+++ b/src/Orleans.Core/Diagnostics/EventSourceEvents.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime
     [EventSource(Name = "Microsoft-Orleans-CallBackData")]
     internal sealed class OrleansCallBackDataEvent : EventSource
     {
-        public static readonly OrleansCallBackDataEvent Log = new OrleansCallBackDataEvent();
+        public static readonly OrleansCallBackDataEvent Log = new();
 
         /// <summary>
         /// Indicates that a request timeout occurred.
@@ -70,7 +70,7 @@ namespace Orleans.Runtime
     [EventSource(Name = "Microsoft-Orleans-OutsideRuntimeClient")]
     internal sealed class OrleansOutsideRuntimeClientEvent : EventSource
     {
-        public static readonly OrleansOutsideRuntimeClientEvent Log = new OrleansOutsideRuntimeClientEvent();
+        public static readonly OrleansOutsideRuntimeClientEvent Log = new();
 
         [NonEvent]
         public void SendRequest(Message message)
@@ -112,7 +112,7 @@ namespace Orleans.Runtime
     [EventSource(Name = "Microsoft-Orleans-Dispatcher")]
     internal sealed class OrleansDispatcherEvent : EventSource
     {
-        public static readonly OrleansDispatcherEvent Log = new OrleansDispatcherEvent();
+        public static readonly OrleansDispatcherEvent Log = new();
 
         [NonEvent]
         public void ReceiveMessage(Message message)
@@ -130,7 +130,7 @@ namespace Orleans.Runtime
     [EventSource(Name = "Microsoft-Orleans-InsideRuntimeClient")]
     internal sealed class OrleansInsideRuntimeClientEvent : EventSource
     {
-        public static readonly OrleansInsideRuntimeClientEvent Log = new OrleansInsideRuntimeClientEvent();
+        public static readonly OrleansInsideRuntimeClientEvent Log = new();
 
         [NonEvent]
         public void SendRequest(Message message)
@@ -172,7 +172,7 @@ namespace Orleans.Runtime
     [EventSource(Name = "Microsoft-Orleans-IncomingMessageAgent")]
     internal sealed class OrleansIncomingMessageAgentEvent : EventSource
     {
-        public static readonly OrleansIncomingMessageAgentEvent Log = new OrleansIncomingMessageAgentEvent();
+        public static readonly OrleansIncomingMessageAgentEvent Log = new();
 
         [NonEvent]
         public void ReceiveMessage(Message message)

--- a/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
+++ b/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
@@ -23,7 +23,7 @@ namespace Orleans.GrainReferences
     /// </summary>
     public sealed class GrainReferenceActivator
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly IServiceProvider _serviceProvider;
         private readonly IGrainReferenceActivatorProvider[] _providers;
         private Dictionary<(GrainType, GrainInterfaceType), IGrainReferenceActivator> _activators = new();

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -19,13 +19,13 @@ namespace Orleans.Runtime
     /// </summary>
     internal class ClientClusterManifestProvider : IClusterManifestProvider, IAsyncDisposable, IDisposable
     {
-        private readonly TaskCompletionSource<bool> _initialized = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ILogger<ClientClusterManifestProvider> _logger;
         private readonly TypeManagementOptions _typeManagementOptions;
         private readonly IServiceProvider _services;
         private readonly GatewayManager _gatewayManager;
         private readonly AsyncEnumerable<ClusterManifest> _updates;
-        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellation = new();
         private ClusterManifest _current;
         private Task _runTask;
 

--- a/src/Orleans.Core/Manifest/GrainBindings.cs
+++ b/src/Orleans.Core/Manifest/GrainBindings.cs
@@ -43,8 +43,8 @@ namespace Orleans.Metadata
     {
         private const string BindingPrefix = WellKnownGrainTypeProperties.BindingPrefix + ".";
         private const char BindingIndexEnd = '.';
-        private readonly object _lockObj = new object();
-        private readonly ConcurrentDictionary<GenericGrainType, GrainType> _genericMapping = new ConcurrentDictionary<GenericGrainType, GrainType>();
+        private readonly object _lockObj = new();
+        private readonly ConcurrentDictionary<GenericGrainType, GrainType> _genericMapping = new();
         private readonly IClusterManifestProvider _clusterManifestProvider;
         private Cache _cache;
 

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -11,9 +11,9 @@ namespace Orleans.Runtime.Versions
     /// </summary>
     internal class GrainVersionManifest
     {
-        private readonly object _lockObj = new object();
-        private readonly ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType> _genericInterfaceMapping = new ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType>();
-        private readonly ConcurrentDictionary<GrainType, GrainType> _genericGrainTypeMapping = new ConcurrentDictionary<GrainType, GrainType>();
+        private readonly object _lockObj = new();
+        private readonly ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType> _genericInterfaceMapping = new();
+        private readonly ConcurrentDictionary<GrainType, GrainType> _genericGrainTypeMapping = new();
         private readonly IClusterManifestProvider _clusterManifestProvider;
         private readonly Dictionary<GrainInterfaceType, ushort> _localVersions;
         private Cache _cache;

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -42,7 +42,7 @@ namespace Orleans.Messaging
     // </summary>
     internal class ClientMessageCenter : IMessageCenter, IDisposable
     {
-        private readonly object grainBucketUpdateLock = new object();
+        private readonly object grainBucketUpdateLock = new();
 
         internal static readonly TimeSpan MINIMUM_INTERCONNECT_DELAY = TimeSpan.FromMilliseconds(100);   // wait one tenth of a second between connect attempts
         internal const int CONNECT_RETRY_COUNT = 2;                                                      // Retry twice before giving up on a gateway server

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -21,9 +21,9 @@ namespace Orleans.Messaging
     /// </summary>
     internal class GatewayManager : IDisposable
     {
-        private readonly object lockable = new object();
-        private readonly Dictionary<SiloAddress, DateTime> knownDead = new Dictionary<SiloAddress, DateTime>();
-        private readonly Dictionary<SiloAddress, DateTime> knownMasked = new Dictionary<SiloAddress, DateTime>();
+        private readonly object lockable = new();
+        private readonly Dictionary<SiloAddress, DateTime> knownDead = new();
+        private readonly Dictionary<SiloAddress, DateTime> knownMasked = new();
         private readonly IGatewayListProvider gatewayListProvider;
         private readonly ILogger logger;
         private readonly ConnectionManager connectionManager;

--- a/src/Orleans.Core/Messaging/PrefixingBufferWriter.cs
+++ b/src/Orleans.Core/Messaging/PrefixingBufferWriter.cs
@@ -215,7 +215,7 @@ namespace Orleans.Runtime.Messaging
         {
             private const int DefaultBufferSize = 4 * 1024;
 
-            private readonly Stack<SequenceSegment> segmentPool = new Stack<SequenceSegment>();
+            private readonly Stack<SequenceSegment> segmentPool = new();
 
             private readonly MemoryPool<byte> memoryPool;
 

--- a/src/Orleans.Core/Networking/ClientConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/ClientConnectionOptions.cs
@@ -8,7 +8,7 @@ namespace Orleans.Configuration
     /// </summary>
     public class ClientConnectionOptions
     {
-        private readonly ConnectionBuilderDelegates delegates = new ConnectionBuilderDelegates();
+        private readonly ConnectionBuilderDelegates delegates = new();
 
         /// <summary>
         /// Adds a connection configuration delegate.

--- a/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
@@ -8,12 +8,12 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class ClientOutboundConnectionFactory : ConnectionFactory
     {
-        internal static readonly object ServicesKey = new object();
+        internal static readonly object ServicesKey = new();
         private readonly ConnectionCommon connectionShared;
         private readonly ClientConnectionOptions clientConnectionOptions;
         private readonly ClusterOptions clusterOptions;
         private readonly ConnectionPreambleHelper connectionPreambleHelper;
-        private readonly object initializationLock = new object();
+        private readonly object initializationLock = new();
         private volatile bool isInitialized;
         private ClientMessageCenter messageCenter;
         private ConnectionManager connectionManager;

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.Messaging
     {
         private static readonly Func<ConnectionContext, Task> OnConnectedDelegate = context => OnConnectedAsync(context);
         private static readonly Action<object> OnConnectionClosedDelegate = state => ((Connection)state).OnTransportConnectionClosed();
-        private static readonly UnboundedChannelOptions OutgoingMessageChannelOptions = new UnboundedChannelOptions
+        private static readonly UnboundedChannelOptions OutgoingMessageChannelOptions = new()
         {
             SingleReader = true,
             SingleWriter = false,
@@ -32,7 +32,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionDelegate middleware;
         private readonly Channel<Message> outgoingMessages;
         private readonly ChannelWriter<Message> outgoingMessageWriter;
-        private readonly List<Message> inflight = new List<Message>(4);
+        private readonly List<Message> inflight = new(4);
         private readonly TaskCompletionSource<int> _transportConnectionClosed = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<int> _initializationTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private IDuplexPipe _transport;
@@ -531,7 +531,7 @@ namespace Orleans.Runtime.Messaging
 
         private sealed class MessageHandlerPoolPolicy : PooledObjectPolicy<MessageHandler>
         {
-            public override MessageHandler Create() => new MessageHandler();
+            public override MessageHandler Create() => new();
 
             public override bool Return(MessageHandler obj)
             {

--- a/src/Orleans.Core/Networking/ConnectionBuilderDelegates.cs
+++ b/src/Orleans.Core/Networking/ConnectionBuilderDelegates.cs
@@ -6,7 +6,7 @@ namespace Orleans.Configuration
 {
     internal class ConnectionBuilderDelegates
     {
-        private readonly List<Action<IConnectionBuilder>> configurationDelegates = new List<Action<IConnectionBuilder>>();
+        private readonly List<Action<IConnectionBuilder>> configurationDelegates = new();
 
         public void Add(Action<IConnectionBuilder> configure)
             => this.configurationDelegates.Add(configure ?? throw new ArgumentNullException(nameof(configure)));

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -22,7 +22,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionFactory connectionFactory;
         private readonly NetworkingTrace trace;
         private readonly CancellationTokenSource shutdownCancellation = new();
-        private readonly object lockObj = new object();
+        private readonly object lockObj = new();
         private readonly TaskCompletionSource<int> closedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public ConnectionManager(
@@ -30,10 +30,9 @@ namespace Orleans.Runtime.Messaging
             ConnectionFactory connectionFactory,
             NetworkingTrace trace)
         {
-            if (trace == null) throw new ArgumentNullException(nameof(trace));
             this.connectionOptions = connectionOptions.Value;
             this.connectionFactory = connectionFactory;
-            this.trace = trace;
+            this.trace = trace ?? throw new ArgumentNullException(nameof(trace));
         }
 
         public int ConnectionCount => connections.Sum(e => e.Value.Connections.Length);

--- a/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
@@ -43,13 +43,13 @@ namespace Orleans.Networking.Shared
         /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the block tracking objects
         /// and add them to this collection. When memory is requested it is taken from here first, and when it is returned it is re-added.
         /// </summary>
-        private readonly ConcurrentQueue<MemoryPoolBlock> _blocks = new ConcurrentQueue<MemoryPoolBlock>();
+        private readonly ConcurrentQueue<MemoryPoolBlock> _blocks = new();
 
         /// <summary>
         /// Thread-safe collection of slabs which have been allocated by this pool. As long as a slab is in this collection and slab.IsActive,
         /// the blocks will be added to _blocks when returned.
         /// </summary>
-        private readonly ConcurrentStack<MemoryPoolSlab> _slabs = new ConcurrentStack<MemoryPoolSlab>();
+        private readonly ConcurrentStack<MemoryPoolSlab> _slabs = new();
 
         /// <summary>
         /// This is part of implementing the IDisposable pattern.
@@ -58,7 +58,7 @@ namespace Orleans.Networking.Shared
 
         private int _totalAllocatedBlocks;
 
-        private readonly object _disposeSync = new object();
+        private readonly object _disposeSync = new();
 
         /// <summary>
         /// This default value passed in to Rent to use the default value for the pool.

--- a/src/Orleans.Core/Networking/Shared/SocketConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnection.cs
@@ -21,13 +21,13 @@ namespace Orleans.Networking.Shared
         private readonly ISocketsTrace _trace;
         private readonly SocketReceiver _receiver;
         private readonly SocketSender _sender;
-        private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _connectionClosedTokenSource = new();
 
-        private readonly object _shutdownLock = new object();
+        private readonly object _shutdownLock = new();
         private volatile bool _socketDisposed;
         private volatile Exception _shutdownReason;
         private Task _processingTask;
-        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _connectionClosed;
 
         internal SocketConnection(Socket socket,

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -10,7 +10,7 @@ namespace Orleans
 {
     internal class ClientGrainContext : IGrainContext, IGrainExtensionBinder, IGrainContextAccessor
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new();
         private readonly ConcurrentDictionary<Type, object> _components = new();
         private readonly OutsideRuntimeClient _runtimeClient;

--- a/src/Orleans.Core/Runtime/Constants.cs
+++ b/src/Orleans.Core/Runtime/Constants.cs
@@ -55,7 +55,7 @@ namespace Orleans.Runtime
 
         public static readonly TimeSpan DEFAULT_CLIENT_DROP_TIMEOUT = TimeSpan.FromMinutes(1);
 
-        private static readonly Dictionary<GrainType, string> singletonSystemTargetNames = new Dictionary<GrainType, string>
+        private static readonly Dictionary<GrainType, string> singletonSystemTargetNames = new()
         {
             {DirectoryServiceType, "DirectoryService"},
             {DirectoryCacheValidatorType, "DirectoryCacheValidator"},

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -13,8 +13,8 @@ namespace Orleans
 {
     internal class InvokableObjectManager : IDisposable
     {
-        private readonly CancellationTokenSource disposed = new CancellationTokenSource();
-        private readonly ConcurrentDictionary<ObserverGrainId, LocalObjectData> localObjects = new ConcurrentDictionary<ObserverGrainId, LocalObjectData>();
+        private readonly CancellationTokenSource disposed = new();
+        private readonly ConcurrentDictionary<ObserverGrainId, LocalObjectData> localObjects = new();
         private readonly IGrainContext rootGrainContext;
         private readonly IRuntimeClient runtimeClient;
         private readonly ILogger logger;

--- a/src/Orleans.Core/Timers/TimerManager.cs
+++ b/src/Orleans.Core/Timers/TimerManager.cs
@@ -40,7 +40,7 @@ namespace Orleans.Timers.Internal
         private sealed class DelayTimer : ITimerCallback, ILinkedListElement<DelayTimer>
         {
             private readonly TaskCompletionSource<bool> completion =
-                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public DelayTimer(DateTime dueTime, CancellationToken cancellationToken)
             {
@@ -82,7 +82,7 @@ namespace Orleans.Timers.Internal
         /// Lock protecting <see cref="allQueues"/>.
         /// </summary>
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly object AllQueuesLock = new object();
+        private static readonly object AllQueuesLock = new();
 
 #pragma warning disable IDE0052 // Remove unread private members
         private static readonly Timer QueueChecker;
@@ -245,7 +245,7 @@ namespace Orleans.Timers.Internal
         /// </summary>
         private sealed class ThreadLocalQueue : ILinkedList<T>
         {
-            public readonly RecursiveInterlockedExchangeLock Lock = new RecursiveInterlockedExchangeLock();
+            public readonly RecursiveInterlockedExchangeLock Lock = new();
 
             /// <summary>
             /// The number of times that this queue has been starved since it was last serviced.

--- a/src/Orleans.Core/Timers/ValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/ValueStopwatch.cs
@@ -82,7 +82,7 @@ namespace Orleans.Runtime
         /// <param name="start">The start timestamp.</param>
         /// <param name="end">The end timestamp.</param>
         /// <returns>A new, stopped <see cref="ValueStopwatch"/> with the provided start and end timestamps.</returns>
-        public static ValueStopwatch FromTimestamp(long start, long end) => new ValueStopwatch(-(end - start));
+        public static ValueStopwatch FromTimestamp(long start, long end) => new(-(end - start));
 
         /// <summary>
         /// Gets the raw counter value for this instance.

--- a/src/Orleans.Core/Utils/AsyncEnumerable.cs
+++ b/src/Orleans.Core/Utils/AsyncEnumerable.cs
@@ -8,8 +8,8 @@ namespace Orleans.Runtime.Utilities
 {
     internal static class AsyncEnumerable
     {
-        internal static readonly object InitialValue = new object();
-        internal static readonly object DisposedValue = new object();
+        internal static readonly object InitialValue = new();
+        internal static readonly object DisposedValue = new();
     }
 
     internal sealed class AsyncEnumerable<T> : IAsyncEnumerable<T>
@@ -21,7 +21,7 @@ namespace Orleans.Runtime.Utilities
             Disposed
         }
 
-        private readonly object updateLock = new object();
+        private readonly object updateLock = new();
         private readonly Func<T, T, bool> updateValidator;
         private Element current;
         
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.Utilities
                 this.next = new TaskCompletionSource<Element>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
-            public static Element CreateInitial() => new Element(
+            public static Element CreateInitial() => new(
                 AsyncEnumerable.InitialValue,
                 new TaskCompletionSource<Element>(TaskCreationOptions.RunContinuationsAsynchronously));
 

--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -202,7 +202,7 @@ namespace Orleans.EventSourcing.Common
 
 
         // the currently submitted, unconfirmed entries. 
-        private readonly List<TSubmissionEntry> pending = new List<TSubmissionEntry>();
+        private readonly List<TSubmissionEntry> pending = new();
 
 
         /// called at beginning of WriteAsync to the current tentative state
@@ -242,7 +242,7 @@ namespace Orleans.EventSourcing.Common
         /// <summary>
         /// Background worker which asynchronously sends operations to the leader
         /// </summary>
-        private BatchWorker worker;
+        private readonly BatchWorker worker;
 
 
 

--- a/src/Orleans.EventSourcing/CustomStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/CustomStorage/LogViewAdaptor.cs
@@ -31,7 +31,7 @@ namespace Orleans.EventSourcing.CustomStorage
             this.primaryCluster = primaryCluster;
         }
 
-        private string primaryCluster;
+        private readonly string primaryCluster;
 
         private TLogView cached;
         private int version;
@@ -280,7 +280,7 @@ namespace Orleans.EventSourcing.CustomStorage
             }
         }
    
-        private SortedList<long, UpdateNotificationMessage> notifications = new SortedList<long,UpdateNotificationMessage>();
+        private readonly SortedList<long, UpdateNotificationMessage> notifications = new();
 
         /// <inheritdoc/>
         protected override void OnNotificationReceived(INotificationMessage payload)

--- a/src/Orleans.EventSourcing/JournaledGrain.cs
+++ b/src/Orleans.EventSourcing/JournaledGrain.cs
@@ -42,10 +42,10 @@ namespace Orleans.EventSourcing
         /// Raises an event.
         /// </summary>
         /// <param name="event">Event to raise.</param>
-        protected virtual void RaiseEvent<TEvent>(TEvent @event) 
+        protected virtual void RaiseEvent<TEvent>(TEvent @event)
             where TEvent : TEventBase
         {
-            if (@event == null) throw new ArgumentNullException("event");
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
 
             LogViewAdaptor.Submit(@event);
         }
@@ -54,16 +54,16 @@ namespace Orleans.EventSourcing
         /// Raise multiple events, as an atomic sequence.
         /// </summary>
         /// <param name="events">Events to raise.</param>
-        protected virtual void RaiseEvents<TEvent>(IEnumerable<TEvent> events) 
+        protected virtual void RaiseEvents<TEvent>(IEnumerable<TEvent> events)
             where TEvent : TEventBase
         {
-            if (events == null) throw new ArgumentNullException("events");
+            if (events == null) throw new ArgumentNullException(nameof(events));
 
             LogViewAdaptor.SubmitRange((IEnumerable<TEventBase>) events);
         }
 
         /// <summary>
-        /// Raise an event conditionally. 
+        /// Raise an event conditionally.
         /// Succeeds only if there are no conflicts, that is, no other events were raised in the meantime.
         /// </summary>
         /// <param name="event">Event to raise.</param>
@@ -71,13 +71,13 @@ namespace Orleans.EventSourcing
         protected virtual Task<bool> RaiseConditionalEvent<TEvent>(TEvent @event)
             where TEvent : TEventBase
         {
-            if (@event == null) throw new ArgumentNullException("event");
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
 
             return LogViewAdaptor.TryAppend(@event);
         }
 
         /// <summary>
-        /// Raise multiple events, as an atomic sequence, conditionally. 
+        /// Raise multiple events, as an atomic sequence, conditionally.
         /// Succeeds only if there are no conflicts, that is, no other events were raised in the meantime.
         /// </summary>
         /// <param name="events">Events to raise</param>
@@ -85,12 +85,12 @@ namespace Orleans.EventSourcing
         protected virtual Task<bool> RaiseConditionalEvents<TEvent>(IEnumerable<TEvent> events)
             where TEvent : TEventBase
         {
-            if (events == null) throw new ArgumentNullException("events");
+            if (events == null) throw new ArgumentNullException(nameof(events));
             return LogViewAdaptor.TryAppendRange((IEnumerable<TEventBase>) events);
         }
 
         /// <summary>
-        /// Gets the current confirmed state. 
+        /// Gets the current confirmed state.
         /// Includes only confirmed events.
         /// </summary>
         protected TGrainState State
@@ -99,7 +99,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Gets the version of the current confirmed state. 
+        /// Gets the version of the current confirmed state.
         /// Equals the total number of confirmed events.
         /// </summary>
         protected int Version
@@ -134,7 +134,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Waits until all previously raised events have been confirmed. 
+        /// Waits until all previously raised events have been confirmed.
         /// <para>await this after raising one or more events, to ensure events are persisted before proceeding, or to guarantee strong consistency (linearizability) even if there are multiple instances of this grain</para>
         /// </summary>
         /// <returns>a task that completes once the events have been confirmed.</returns>
@@ -144,7 +144,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Retrieves the latest state now, and confirms all previously raised events. 
+        /// Retrieves the latest state now, and confirms all previously raised events.
         /// Effectively, this enforces synchronization with the global state.
         /// <para>Await this before reading the state to ensure strong consistency (linearizability) even if there are multiple instances of this grain</para>
         /// </summary>
@@ -173,7 +173,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Retrieves a segment of the confirmed event sequence, possibly from storage. 
+        /// Retrieves a segment of the confirmed event sequence, possibly from storage.
         /// Throws <see cref="NotSupportedException"/> if the events are not available to read.
         /// Whether events are available, and for how long, depends on the providers used and how they are configured.
         /// </summary>
@@ -203,7 +203,7 @@ namespace Orleans.EventSourcing
 
         /// <summary>
         /// Called when a previously reported connection issue has been resolved.
-        /// <para>Override this to monitor the health of the log-consistency protocol. 
+        /// <para>Override this to monitor the health of the log-consistency protocol.
         /// Any exceptions thrown are caught and logged by the <see cref="ILogViewAdaptorFactory"/>.</para>
         /// </summary>
         protected virtual void OnConnectionIssueResolved(ConnectionIssue issue)
@@ -304,7 +304,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Called by adaptor on state change. 
+        /// Called by adaptor on state change.
         /// </summary>
         void ILogViewAdaptorHost<TGrainState, TEventBase>.OnViewChanged(bool tentative, bool confirmed)
         {
@@ -315,7 +315,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// called by adaptor on connection issues. 
+        /// called by adaptor on connection issues.
         /// </summary>
         void IConnectionIssueListener.OnConnectionIssue(ConnectionIssue connectionIssue)
         {
@@ -323,7 +323,7 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// Called by adaptor when a connection issue is resolved. 
+        /// Called by adaptor when a connection issue is resolved.
         /// </summary>
         void IConnectionIssueListener.OnConnectionIssueResolved(ConnectionIssue connectionIssue)
         {

--- a/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
@@ -35,8 +35,8 @@ namespace Orleans.EventSourcing.LogStorage
         private const int maxEntriesInNotifications = 200;
 
 
-        IGrainStorage globalGrainStorage;
-        string grainTypeName;   
+        readonly IGrainStorage globalGrainStorage;
+        readonly string grainTypeName;   
 
         // the object containing the entire log, as retrieved from / sent to storage
         LogStateWithMetaDataAndETag<TLogEntry> GlobalLog;
@@ -300,7 +300,7 @@ namespace Orleans.EventSourcing.LogStorage
                 return base.Merge(earlierMessage, laterMessage); // keep only the version number
         }
 
-        private SortedList<long, UpdateNotificationMessage> notifications = new SortedList<long,UpdateNotificationMessage>();
+        private readonly SortedList<long, UpdateNotificationMessage> notifications = new();
 
         /// <inheritdoc/>
         protected override void OnNotificationReceived(INotificationMessage payload)

--- a/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
@@ -35,8 +35,8 @@ namespace Orleans.EventSourcing.StateStorage
         private const int maxEntriesInNotifications = 200;
 
 
-        IGrainStorage globalGrainStorage;
-        string grainTypeName;        // stores the confirmed state including metadata
+        readonly IGrainStorage globalGrainStorage;
+        readonly string grainTypeName;        // stores the confirmed state including metadata
         GrainStateWithMetaDataAndETag<TLogView> GlobalStateCache;
 
         /// <inheritdoc/>
@@ -270,7 +270,7 @@ namespace Orleans.EventSourcing.StateStorage
                 return base.Merge(earlierMessage, laterMessage); // keep only the version number
         }
 
-        private SortedList<long, UpdateNotificationMessage> notifications = new SortedList<long,UpdateNotificationMessage>();
+        private readonly SortedList<long, UpdateNotificationMessage> notifications = new();
 
         /// <inheritdoc/>
         protected override void OnNotificationReceived(INotificationMessage payload)

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -54,7 +54,7 @@ namespace Orleans.Hosting.Kubernetes
         private readonly ILocalSiloDetails _localSiloDetails;
         private readonly ILogger<KubernetesClusterAgent> _logger;
         private readonly CancellationTokenSource _shutdownToken;
-        private readonly SemaphoreSlim _pauseMonitoringSemaphore = new SemaphoreSlim(0);
+        private readonly SemaphoreSlim _pauseMonitoringSemaphore = new(0);
         private volatile bool _enableMonitoring;
         private Task _runTask;
 

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -44,8 +44,8 @@ namespace Orleans.Storage
     [DebuggerDisplay("MemoryStore:{Name},WithLatency:{latency}")]
     public class MemoryGrainStorageWithLatency :IGrainStorage
     {
-        private MemoryGrainStorage baseGranStorage;
-        private MemoryStorageWithLatencyOptions options;
+        private readonly MemoryGrainStorage baseGranStorage;
+        private readonly MemoryStorageWithLatencyOptions options;
         /// <summary> Default constructor. </summary>
         public MemoryGrainStorageWithLatency(
             string name,

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -728,7 +728,7 @@ namespace Orleans.Runtime.ReminderService
                     throw new ArgumentNullException(nameof(grainId));
 
                 if (string.IsNullOrWhiteSpace(reminderName))
-                    throw new ArgumentException("The reminder name is either null or whitespace.", "reminderName");
+                    throw new ArgumentException("The reminder name is either null or whitespace.", nameof(reminderName));
 
                 this.GrainId = grainId;
                 this.ReminderName = reminderName;

--- a/src/Orleans.Runtime/Activation/GrainContextAccessor.cs
+++ b/src/Orleans.Runtime/Activation/GrainContextAccessor.cs
@@ -2,7 +2,7 @@ namespace Orleans.Runtime
 {
     internal class GrainContextAccessor : IGrainContextAccessor
     {
-        private HostedClient _hostedClient;
+        private readonly HostedClient _hostedClient;
 
         public GrainContextAccessor(HostedClient hostedClient)
         {

--- a/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
+++ b/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
@@ -24,7 +24,7 @@ namespace Orleans.Runtime
     /// </summary>
     public sealed class GrainContextActivator
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly IGrainContextActivatorProvider[] _activatorProviders;
         private readonly IConfigureGrainContextProvider[] _configuratorProviders;
         private readonly GrainPropertiesResolver _resolver;

--- a/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellationSourcesExtension.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Threading.Tasks;
-using Orleans.CodeGeneration;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
-using System.Threading;
 using System.Diagnostics;
 using Orleans.Serialization.Invocation;
 
@@ -15,7 +11,7 @@ namespace Orleans.Runtime
     /// </summary>
     internal class CancellationSourcesExtension : ICancellationSourcesExtension, IDisposable
     {
-        private readonly ConcurrentDictionary<Guid, Entry> _cancellationTokens = new ConcurrentDictionary<Guid, Entry>();
+        private readonly ConcurrentDictionary<Guid, Entry> _cancellationTokens = new();
         private readonly ILogger _logger;
         private readonly IGrainCancellationTokenRuntime _cancellationTokenRuntime;
         private readonly Timer _cleanupTimer;

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -1,14 +1,8 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
-using Orleans.Statistics;
 
 namespace Orleans.Runtime
 {
@@ -24,10 +18,10 @@ namespace Orleans.Runtime
         private DateTime nextTicket;
         private static readonly List<ICollectibleGrainContext> nothing = new(0);
         private readonly ILogger logger;
-        private IAsyncTimer _collectionTimer;
+        private readonly IAsyncTimer _collectionTimer;
         private Task _collectionLoopTask;
-        private int collectionNumber;
-        private int _activationCount;
+        private readonly int collectionNumber;
+        private readonly int _activationCount;
         private readonly IOptions<GrainCollectionOptions> _options;
 
         /// <summary>

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -1,13 +1,11 @@
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
 
 namespace Orleans.Runtime;
 
 internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>
 {
-    private int _activationsCount;
+    private readonly int _activationsCount;
 
     private readonly ConcurrentDictionary<GrainId, IGrainContext> _activations = new();
 

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -1,9 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime.Internal;
@@ -25,7 +20,7 @@ namespace Orleans.Runtime
         private readonly IAsyncTimer _scanPeriodTimer;
         private readonly List<IActivationWorkingSetObserver> _observers;
 
-        private int _activeCount;
+        private readonly int _activeCount;
         private Task _runTask;
 
         public ActivationWorkingSet(

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
         private readonly IServiceProvider _serviceProvider;
         private readonly MessageFactory _messageFactory;
         private readonly IOptionsMonitor<SiloMessagingOptions> _messagingOptions;
-        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, bool>(ReferenceEqualsComparer<ActivationData>.Default);
+        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new(ReferenceEqualsComparer<ActivationData>.Default);
         private bool _enabled = true;
         private Task _runTask;
 

--- a/src/Orleans.Runtime/Configuration/SiloConnectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/SiloConnectionOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.AspNetCore.Connections;
 
 namespace Orleans.Configuration
@@ -10,9 +9,9 @@ namespace Orleans.Configuration
     /// <seealso cref="Orleans.Configuration.SiloConnectionOptions.ISiloConnectionBuilderOptions" />
     public class SiloConnectionOptions : SiloConnectionOptions.ISiloConnectionBuilderOptions
     {
-        private readonly ConnectionBuilderDelegates siloOutboundDelegates = new ConnectionBuilderDelegates();
-        private readonly ConnectionBuilderDelegates siloInboundDelegates = new ConnectionBuilderDelegates();
-        private readonly ConnectionBuilderDelegates gatewayInboundDelegates = new ConnectionBuilderDelegates();
+        private readonly ConnectionBuilderDelegates siloOutboundDelegates = new();
+        private readonly ConnectionBuilderDelegates siloInboundDelegates = new();
+        private readonly ConnectionBuilderDelegates gatewayInboundDelegates = new();
 
         /// <summary>
         /// Configures silo outbound connections.

--- a/src/Orleans.Runtime/Configuration/Validators/CollectionAgeLimitValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/CollectionAgeLimitValidator.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
     internal class GrainCollectionOptionsValidator : IConfigurationValidator
     {
-        private IOptions<GrainCollectionOptions> options;
+        private readonly IOptions<GrainCollectionOptions> options;
 
         public GrainCollectionOptionsValidator(IOptions<GrainCollectionOptions> options)
         {
@@ -29,7 +28,7 @@ namespace Orleans.Configuration
                     $"{nameof(GrainCollectionOptions.CollectionAge)} must be greater than {nameof(GrainCollectionOptions.CollectionQuantum)}, " +
                     $"which is set to {this.options.Value.CollectionQuantum}");
             }
-            foreach(var classSpecificCollectionAge in this.options.Value.ClassSpecificCollectionAge)
+            foreach (var classSpecificCollectionAge in this.options.Value.ClassSpecificCollectionAge)
             {
                 if (classSpecificCollectionAge.Value <= this.options.Value.CollectionQuantum)
                 {

--- a/src/Orleans.Runtime/ConsistentRing/SimpleConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/SimpleConsistentRingProvider.cs
@@ -7,8 +7,8 @@ namespace Orleans.Runtime
     {
         private readonly SiloAddress _localSilo;
         private readonly IClusterMembershipService _clusterMembershipService;
-        private readonly object _lockObj = new object();
-        private VersionedSuccessor _successor = new VersionedSuccessor(MembershipVersion.MinValue, null);
+        private readonly object _lockObj = new();
+        private VersionedSuccessor _successor = new(MembershipVersion.MinValue, null);
 
         public SimpleConsistentRingProvider(ILocalSiloDetails localSiloDetails, IClusterMembershipService clusterMembershipService)
         {

--- a/src/Orleans.Runtime/Core/FatalErrorHandler.cs
+++ b/src/Orleans.Runtime/Core/FatalErrorHandler.cs
@@ -20,10 +20,7 @@ namespace Orleans.Runtime
             this.clusterMembershipOptions = clusterMembershipOptions.Value;
         }
 
-        public bool IsUnexpected(Exception exception)
-        {
-            return !(exception is ThreadAbortException);
-        }
+        public bool IsUnexpected(Exception exception) => exception is not ThreadAbortException;
 
         public void OnFatalException(object sender, string context, Exception exception)
         {

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.GrainReferences;
@@ -18,7 +14,7 @@ namespace Orleans.Runtime
     /// </summary>
     internal sealed class HostedClient : IGrainContext, IGrainExtensionBinder, IDisposable, ILifecycleParticipant<ISiloLifecycle>
     {
-        private readonly object lockObj = new object();
+        private readonly object lockObj = new();
         private readonly Channel<Message> incomingMessages;
         private readonly IGrainReferenceRuntime grainReferenceRuntime;
         private readonly InvokableObjectManager invokableObjects;
@@ -27,7 +23,7 @@ namespace Orleans.Runtime
         private readonly IInternalGrainFactory grainFactory;
         private readonly MessageCenter siloMessageCenter;
         private readonly MessagingTrace messagingTrace;
-        private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new ConcurrentDictionary<Type, (object, IAddressable)>();
+        private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new();
         private readonly ConcurrentDictionary<Type, object> _components = new();
         private readonly IServiceScope _serviceProviderScope;
         private bool disposing;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -38,7 +34,7 @@ namespace Orleans.Runtime
         private Catalog catalog;
         private MessageCenter messageCenter;
         private List<IIncomingGrainCallFilter> grainCallFilters;
-        private DeepCopier _deepCopier;
+        private readonly DeepCopier _deepCopier;
         private readonly InterfaceToImplementationMappingCache interfaceToImplementationMapping;
         private HostedClient hostedClient;
 

--- a/src/Orleans.Runtime/Core/SystemStatus.cs
+++ b/src/Orleans.Runtime/Core/SystemStatus.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Orleans.Runtime
@@ -22,35 +21,35 @@ namespace Orleans.Runtime
 
         /// <summary>Status = Unknown</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Unknown = new SystemStatus(InternalSystemStatus.Unknown);
+        public static readonly SystemStatus Unknown = new(InternalSystemStatus.Unknown);
 
         /// <summary>Status = Creating</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Creating = new SystemStatus(InternalSystemStatus.Creating);
+        public static readonly SystemStatus Creating = new(InternalSystemStatus.Creating);
 
         /// <summary>Status = Created</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Created = new SystemStatus(InternalSystemStatus.Created);
+        public static readonly SystemStatus Created = new(InternalSystemStatus.Created);
 
         /// <summary>Status = Starting</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Starting = new SystemStatus(InternalSystemStatus.Starting);
-        
+        public static readonly SystemStatus Starting = new(InternalSystemStatus.Starting);
+
         /// <summary>Status = Running</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Running = new SystemStatus(InternalSystemStatus.Running);
-        
+        public static readonly SystemStatus Running = new(InternalSystemStatus.Running);
+
         /// <summary>Status = Stopping</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Stopping = new SystemStatus(InternalSystemStatus.Stopping);
-        
+        public static readonly SystemStatus Stopping = new(InternalSystemStatus.Stopping);
+
         /// <summary>Status = ShuttingDown</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus ShuttingDown = new SystemStatus(InternalSystemStatus.ShuttingDown);
+        public static readonly SystemStatus ShuttingDown = new(InternalSystemStatus.ShuttingDown);
 
         /// <summary>Status = Terminated</summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly SystemStatus Terminated = new SystemStatus(InternalSystemStatus.Terminated);
+        public static readonly SystemStatus Terminated = new(InternalSystemStatus.Terminated);
 
         private readonly InternalSystemStatus value;
         private SystemStatus(InternalSystemStatus name) { this.value = name; }

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime
         private readonly SystemTargetGrainId id;
         private GrainReference selfReference;
         private Message running;
-        private Dictionary<Type, object> _components = new Dictionary<Type, object>();
+        private Dictionary<Type, object> _components = new();
 
         /// <summary>Silo address of the system target.</summary>
         public SiloAddress Silo { get; }

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly IGrainDirectoryCache cache;
 
-        private readonly CancellationTokenSource shutdownToken = new CancellationTokenSource();
+        private readonly CancellationTokenSource shutdownToken = new();
         private readonly IClusterMembershipService clusterMembershipService;
 
         private Task listenToClusterChangeTask;

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -37,7 +33,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IClusterMembershipService _clusterMembershipService;
         private readonly SiloMessagingOptions _messagingOptions;
         private readonly CancellationTokenSource _shutdownCancellation = new CancellationTokenSource();
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly GrainId _localHostedClientId;
         private readonly IConnectedClientCollection _connectedClients;
         private Action _schedulePublishUpdate;
@@ -484,7 +480,7 @@ namespace Orleans.Runtime.GrainDirectory
                     {
                         // The target has already seen the latest version for this silo.
                         builder.Remove(silo);
-                    } 
+                    }
                 }
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Scheduler;
 
@@ -24,7 +19,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly ILogger logger;
         private readonly Factory<GrainDirectoryPartition> createPartion;
         private readonly Queue<(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)> pendingOperations = new();
-        private readonly AsyncLock executorLock = new AsyncLock();
+        private readonly AsyncLock executorLock = new();
 
         internal GrainDirectoryHandoffManager(
             LocalGrainDirectory localDirectory,

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -18,7 +18,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly SiloAddress? seed;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IInternalGrainFactory grainFactory;
-        private readonly object writeLock = new object();
+        private readonly object writeLock = new();
         private Action<SiloAddress, SiloStatus>? catalogOnSiloRemoved;
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
 

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
@@ -20,7 +16,7 @@ namespace Orleans.Runtime.Metadata
         private readonly IFatalErrorHandler _fatalErrorHandler;
         private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
         private readonly AsyncEnumerable<ClusterManifest> _updates;
-        private ClusterManifest _current;
+        private readonly ClusterManifest _current;
         private Task _runTask;
 
         public ClusterManifestProvider(

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Internal;
@@ -16,7 +12,7 @@ namespace Orleans.Runtime
         private readonly MembershipTableManager membershipTableManager;
         private readonly ILogger<ClusterMembershipService> log;
         private readonly IFatalErrorHandler fatalErrorHandler;
-        private ClusterMembershipSnapshot snapshot;
+        private readonly ClusterMembershipSnapshot snapshot;
 
         public ClusterMembershipService(
             MembershipTableManager membershipTableManager,

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using System.Text;
 
@@ -62,8 +61,8 @@ namespace Orleans.Runtime
         /// Returns a <see cref="ClusterMembershipUpdate"/> which represents this instance.
         /// </summary>
         /// <returns>A <see cref="ClusterMembershipUpdate"/> which represents this instance.</returns>
-        public ClusterMembershipUpdate AsUpdate() => new ClusterMembershipUpdate(this, this.Members.Values.ToImmutableArray());
-        
+        public ClusterMembershipUpdate AsUpdate() => new(this, this.Members.Values.ToImmutableArray());
+
         /// <summary>
         /// Returns a <see cref="ClusterMembershipUpdate"/> which represents the change in cluster membership from the provided snapshot to this instance.
         /// </summary>

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -348,7 +348,7 @@ namespace Orleans.Runtime.MembershipService
         private class ThreadPoolMonitor
         {
             private static readonly WaitCallback Callback = state => ((ThreadPoolMonitor)state!).Execute();
-            private readonly object _lockObj = new object();
+            private readonly object _lockObj = new();
             private readonly ILogger<ThreadPoolMonitor> _log;
             private bool _scheduled;
             private TimeSpan _lastQueueDelay;

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.MembershipService
     /// </summary>
     internal class MembershipAgent : IHealthCheckParticipant, ILifecycleParticipant<ISiloLifecycle>, IDisposable, MembershipAgent.ITestAccessor
     {
-        private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
+        private readonly CancellationTokenSource cancellation = new();
         private readonly MembershipTableManager tableManager;
         private readonly ILocalSiloDetails localSilo;
         private readonly IFatalErrorHandler fatalErrorHandler;

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -24,7 +20,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly IClusterMembershipService _membershipService;
         private readonly ILocalSiloDetails _localSiloDetails;
         private readonly CancellationTokenSource _stoppingCancellation = new CancellationTokenSource();
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly IAsyncTimer _pingTimer;
         private ValueStopwatch _elapsedSinceLastSuccessfulResponse;
         private Func<SiloHealthMonitor, ProbeResult, Task> _onProbeResult;
@@ -412,10 +408,10 @@ namespace Orleans.Runtime.MembershipService
             }
 
             public static ProbeResult CreateDirect(int failedProbeCount, ProbeResultStatus status)
-                => new ProbeResult(failedProbeCount, status, isDirectProbe: true, 0);
+                => new(failedProbeCount, status, isDirectProbe: true, 0);
 
             public static ProbeResult CreateIndirect(int failedProbeCount, ProbeResultStatus status, IndirectProbeResponse indirectProbeResponse)
-                => new ProbeResult(failedProbeCount, status, isDirectProbe: false, indirectProbeResponse.IntermediaryHealthScore);
+                => new(failedProbeCount, status, isDirectProbe: false, indirectProbeResponse.IntermediaryHealthScore);
 
             public int FailedProbeCount { get; }
 

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using System.Threading;
 using System.Collections.Immutable;
 using Orleans.Internal;
 
@@ -13,7 +9,7 @@ namespace Orleans.Runtime.MembershipService
     /// </summary>
     internal class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
     {
-        private readonly object listenersLock = new object();
+        private readonly object listenersLock = new();
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
         private readonly MembershipTableManager membershipTableManager;
         private readonly ILogger<SiloStatusListenerManager> log;

--- a/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusOracle.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using System.Threading;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -10,8 +8,8 @@ namespace Orleans.Runtime.MembershipService
         private readonly MembershipTableManager membershipTableManager;
         private readonly SiloStatusListenerManager listenerManager;
         private readonly ILogger log;
-        private readonly object cacheUpdateLock = new object();
-        private MembershipTableSnapshot cachedSnapshot;
+        private readonly object cacheUpdateLock = new();
+        private readonly MembershipTableSnapshot cachedSnapshot;
         private Dictionary<SiloAddress, SiloStatus> siloStatusCache = new Dictionary<SiloAddress, SiloStatus>();
         private Dictionary<SiloAddress, SiloStatus> siloStatusCacheOnlyActive = new Dictionary<SiloAddress, SiloStatus>();
 
@@ -30,7 +28,7 @@ namespace Orleans.Runtime.MembershipService
         public SiloStatus CurrentStatus => this.membershipTableManager.CurrentStatus;
         public string SiloName => this.localSiloDetails.Name;
         public SiloAddress SiloAddress => this.localSiloDetails.SiloAddress;
-        
+
         public SiloStatus GetApproximateSiloStatus(SiloAddress silo)
         {
             var status = this.membershipTableManager.MembershipTableSnapshot.GetSiloStatus(silo);
@@ -86,7 +84,7 @@ namespace Orleans.Runtime.MembershipService
             if (silo.Equals(this.SiloAddress)) return false;
 
             var status = this.GetApproximateSiloStatus(silo);
-            
+
             return status == SiloStatus.Dead;
         }
 
@@ -114,6 +112,6 @@ namespace Orleans.Runtime.MembershipService
         public bool SubscribeToSiloStatusEvents(ISiloStatusListener listener) => this.listenerManager.Subscribe(listener);
 
         public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener listener) => this.listenerManager.Unsubscribe(listener);
-    
+
     }
 }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -302,8 +298,8 @@ namespace Orleans.Runtime.Messaging
                 RunContinuationsAsynchronously = true
             };
 
-            private GatewayInboundConnection _connection;
-            private int _dropped;
+            private readonly GatewayInboundConnection _connection;
+            private readonly int _dropped;
             private CoarseStopwatch _disconnectedSince;
 
             internal ClientState(Gateway gateway, ClientGrainId id)

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -1,18 +1,14 @@
-using System;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
-using Orleans.Hosting;
 
 namespace Orleans.Runtime.Messaging
 {
     internal sealed class GatewayConnectionListener : ConnectionListener, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
     {
-        internal static readonly object ServicesKey = new object();
+        internal static readonly object ServicesKey = new();
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly MessageCenter messageCenter;
         private readonly ConnectionCommon connectionShared;

--- a/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
+++ b/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime.Messaging
     /// </summary>
     internal sealed class ProbeRequestMonitor
     {
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private ValueStopwatch _probeRequestStopwatch;
 
         /// <summary>

--- a/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionFactory.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -10,14 +7,14 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class SiloConnectionFactory : ConnectionFactory
     {
-        internal static readonly object ServicesKey = new object();
+        internal static readonly object ServicesKey = new();
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly ConnectionCommon connectionShared;
         private readonly ProbeRequestMonitor probeRequestMonitor;
         private readonly ConnectionPreambleHelper connectionPreambleHelper;
         private readonly IServiceProvider serviceProvider;
         private readonly SiloConnectionOptions siloConnectionOptions;
-        private readonly object initializationLock = new object();
+        private readonly object initializationLock = new();
         private bool isInitialized;
         private ConnectionManager connectionManager;
         private MessageCenter messageCenter;

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -1,17 +1,13 @@
-using System;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
-using Orleans.Hosting;
 
 namespace Orleans.Runtime.Messaging
 {
     internal sealed class SiloConnectionListener : ConnectionListener, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
     {
-        internal static readonly object ServicesKey = new object();
+        internal static readonly object ServicesKey = new();
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly SiloConnectionOptions siloConnectionOptions;
         private readonly MessageCenter messageCenter;

--- a/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
@@ -1,9 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 
@@ -13,7 +8,7 @@ namespace Orleans.Runtime.Placement
     {
         private class CachedLocalStat
         {
-            private int _activationCount;
+            private readonly int _activationCount;
 
             internal CachedLocalStat(SiloRuntimeStatistics siloStats) => SiloStats = siloStats;
 
@@ -21,7 +16,7 @@ namespace Orleans.Runtime.Placement
             public int ActivationCount => _activationCount;
             public void IncrementActivationCount(int delta) => Interlocked.Add(ref _activationCount, delta);
         }
-        
+
         // Track created activations on this silo between statistic intervals.
         private readonly ConcurrentDictionary<SiloAddress, CachedLocalStat> _localCache = new();
         private readonly SiloAddress _localAddress;
@@ -29,7 +24,7 @@ namespace Orleans.Runtime.Placement
 
         public ActivationCountPlacementDirector(
             ILocalSiloDetails localSiloDetails,
-            DeploymentLoadPublisher deploymentLoadPublisher, 
+            DeploymentLoadPublisher deploymentLoadPublisher,
             IOptions<ActivationCountBasedPlacementOptions> options)
         {
             _localAddress = localSiloDetails.SiloAddress;

--- a/src/Orleans.Runtime/Placement/ClientObserverPlacementStrategyResolver.cs
+++ b/src/Orleans.Runtime/Placement/ClientObserverPlacementStrategyResolver.cs
@@ -4,7 +4,7 @@ namespace Orleans.Runtime.Placement
 {
     internal class ClientObserverPlacementStrategyResolver : IPlacementStrategyResolver
     {
-        private readonly ClientObserversPlacement _strategy = new ClientObserversPlacement();
+        private readonly ClientObserversPlacement _strategy = new();
 
         public bool TryResolvePlacementStrategy(GrainType grainType, GrainProperties properties, out PlacementStrategy result)
         {

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime.Scheduler
@@ -14,7 +11,7 @@ namespace Orleans.Runtime.Scheduler
     {
         private readonly ILogger logger;
 
-        private static long idCounter;
+        private static readonly long idCounter;
         private readonly long myId;
         private readonly WorkItemGroup workerGroup;
 #if EXTRA_STATS
@@ -46,7 +43,7 @@ namespace Orleans.Runtime.Scheduler
                     "RunTask: Incomplete base.TryExecuteTask for Task Id={TaskId} with Status={TaskStatus}",
                     task.Id,
                     task.Status);
-            
+
             //  Consider adding ResetExecutionContext() or even better:
             //  Consider getting rid of ResetExecutionContext completely and just making sure we always call SetExecutionContext before TryExecuteTask.
         }
@@ -92,7 +89,7 @@ namespace Orleans.Runtime.Scheduler
             // If the task was previously queued, remove it from the queue
             if (taskWasPreviouslyQueued)
                 canExecuteInline = TryDequeue(task);
-            
+
 
             if (!canExecuteInline)
             {

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.ConsistentRing;
 using Orleans.Runtime.Scheduler;
@@ -15,7 +12,7 @@ namespace Orleans.Runtime
         private readonly string typeName;
         private GrainServiceStatus status;
 
-        private ILogger Logger;
+        private readonly ILogger Logger;
 
         /// <summary>Gets the token for signaling cancellation upon stopping of grain service</summary>
         protected CancellationTokenSource StoppedCancellationTokenSource { get; }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
         private readonly MessageCenter messageCenter;
         private readonly LocalGrainDirectory localGrainDirectory;
         private readonly ILogger logger;
-        private readonly TaskCompletionSource<int> siloTerminatedTask = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<int> siloTerminatedTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly InsideRuntimeClient runtimeClient;
         private SystemTarget fallbackScheduler;
         private readonly ISiloStatusOracle siloStatusOracle;
@@ -40,11 +40,11 @@ namespace Orleans.Runtime
         private readonly TimeSpan initTimeout;
         private readonly TimeSpan stopTimeout = TimeSpan.FromMinutes(1);
         private readonly Catalog catalog;
-        private readonly object lockable = new object();
+        private readonly object lockable = new();
         private readonly GrainFactory grainFactory;
         private readonly ISiloLifecycleSubject siloLifecycle;
         private readonly IMembershipService membershipService;
-        internal List<GrainService> grainServices = new List<GrainService>();
+        internal List<GrainService> grainServices = new();
 
         private readonly ILoggerFactory loggerFactory;
         /// <summary>

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Scheduler;
 
@@ -17,7 +13,7 @@ namespace Orleans.Runtime
         private int totalNumTicks;
         private readonly ILogger logger;
         private volatile Task currentlyExecutingTickTask;
-        private object currentlyExecutingTickTaskLock = new();
+        private readonly object currentlyExecutingTickTaskLock = new();
         private readonly IGrainContext grainContext;
 
         public string Name { get; }

--- a/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/SingleWaiterAutoResetEvent.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace Orleans.Runtime
@@ -23,7 +20,7 @@ namespace Orleans.Runtime
         private const uint ResetMask = ~SignaledFlag & ~WaitingFlag;
 
         private ManualResetValueTaskSourceCore<bool> _waitSource;
-        private volatile uint _status;
+        private readonly uint _status;
 
         public bool RunContinuationsAsynchronously
         {

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Core;
 using Orleans.Serialization.Buffers;
@@ -89,7 +86,7 @@ namespace Orleans.Serialization
     [RegisterCopier]
     public sealed class FSharpOptionCopier<T> : IDeepCopier<FSharpOption<T>>
     {
-        private IDeepCopier<T> _valueCopier;
+        private readonly IDeepCopier<T> _valueCopier;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FSharpOptionCopier{T}"/> class.
@@ -189,7 +186,7 @@ namespace Orleans.Serialization
     [RegisterCopier]
     public sealed class FSharpValueOptionCopier<T> : IDeepCopier<FSharpValueOption<T>>
     {
-        private IDeepCopier<T> _valueCopier;
+        private readonly IDeepCopier<T> _valueCopier;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FSharpValueOptionCopier{T}"/> class.
@@ -290,8 +287,19 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
+
+        /* Unmerged change from project 'Orleans.Serialization.FSharp (netstandard2.1)'
+        Before:
+            }
+
+            [RegisterCopier]
+        After:
+            }
+
+            [RegisterCopier]
+        */
     }
-    
+
     [RegisterCopier]
     public class FSharpChoiceCopier<T1, T2> : IDeepCopier<FSharpChoice<T1, T2>>, IDerivedTypeCopier
     {
@@ -397,8 +405,19 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
+
+        /* Unmerged change from project 'Orleans.Serialization.FSharp (netstandard2.1)'
+        Before:
+            }
+
+            [RegisterCopier]
+        After:
+            }
+
+            [RegisterCopier]
+        */
     }
-    
+
     [RegisterCopier]
     public class FSharpChoiceCopier<T1, T2, T3> : IDeepCopier<FSharpChoice<T1, T2, T3>>, IDerivedTypeCopier
     {
@@ -516,8 +535,19 @@ namespace Orleans.Serialization
             ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
             return result;
         }
+
+        /* Unmerged change from project 'Orleans.Serialization.FSharp (netstandard2.1)'
+        Before:
+            }
+
+            [RegisterCopier]
+        After:
+            }
+
+            [RegisterCopier]
+        */
     }
-    
+
     [RegisterCopier]
     public class FSharpChoiceCopier<T1, T2, T3, T4> : IDeepCopier<FSharpChoice<T1, T2, T3, T4>>, IDerivedTypeCopier
     {
@@ -646,7 +676,7 @@ namespace Orleans.Serialization
             return result;
         }
     }
-    
+
     [RegisterCopier]
     public class FSharpChoiceCopier<T1, T2, T3, T4, T5> : IDeepCopier<FSharpChoice<T1, T2, T3, T4, T5>>, IDerivedTypeCopier
     {
@@ -785,7 +815,7 @@ namespace Orleans.Serialization
             return result;
         }
     }
-    
+
     [RegisterCopier]
     public class FSharpChoiceCopier<T1, T2, T3, T4, T5, T6> : IDeepCopier<FSharpChoice<T1, T2, T3, T4, T5, T6>>, IDerivedTypeCopier
     {
@@ -1115,7 +1145,7 @@ namespace Orleans.Serialization
             return result;
         }
     }
-    
+
     [RegisterCopier]
     public class FSharpResultCopier<T, TError> : IDeepCopier<FSharpResult<T, TError>>, IDerivedTypeCopier
     {

--- a/src/Orleans.Serialization/Buffers/Adaptors/ArrayStreamBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/ArrayStreamBufferWriter.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Buffers;
-using System.IO;
 
 namespace Orleans.Serialization.Buffers.Adaptors
 {
@@ -11,7 +9,7 @@ namespace Orleans.Serialization.Buffers.Adaptors
     {
         public const int DefaultInitialBufferSize = 256;
         private readonly Stream _stream;
-        private byte[] _buffer;
+        private readonly byte[] _buffer;
         private int _index;
 
         /// <summary>

--- a/src/Orleans.Serialization/Buffers/Adaptors/PooledBufferStream.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/PooledBufferStream.cs
@@ -135,7 +135,7 @@ namespace Orleans.Serialization.Buffers.Adaptors
         /// <summary>
         /// Returns a <see cref="ReadOnlySequence{T}"/> previously rented by <see cref="RentReadOnlySequence"/>;
         /// </summary>
-        public void ReturnReadOnlySequence(in ReadOnlySequence<byte> sequence)
+        public static void ReturnReadOnlySequence(in ReadOnlySequence<byte> sequence)
         {
             if (sequence.Start.GetObject() is not BufferSegment segment)
             {

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -19,7 +19,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
     /// </summary>
     public static class OrleansGeneratedCodeHelper
     {
-        private static readonly ThreadLocal<RecursiveServiceResolutionState> ResolutionState = new ThreadLocal<RecursiveServiceResolutionState>(() => new RecursiveServiceResolutionState());
+        private static readonly ThreadLocal<RecursiveServiceResolutionState> ResolutionState = new(() => new RecursiveServiceResolutionState());
 
         private sealed class RecursiveServiceResolutionState
         {

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -107,7 +107,7 @@ namespace Orleans.Serialization
         {
             public ConfigurationContext(IServiceCollection services) => Builder = new SerializerBuilder(services);
 
-            public ServiceDescriptor CreateServiceDescriptor() => new ServiceDescriptor(typeof(ConfigurationContext), this);
+            public ServiceDescriptor CreateServiceDescriptor() => new(typeof(ConfigurationContext), this);
 
             public ISerializerBuilder Builder { get; }
         }

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
@@ -85,16 +85,9 @@ namespace Orleans.Serialization
         [SecurityCritical]
         private static DynamicMethod GetSerializationMethod(Type type, MethodInfo callbackMethod, Type owner)
         {
-            Type[] callbackParameterTypes;
-            if (owner.IsValueType)
-            {
-                callbackParameterTypes = new[] { typeof(object), owner.MakeByRefType(), typeof(StreamingContext) };
-            }
-            else
-            {
-                callbackParameterTypes = new[] { typeof(object), typeof(object), typeof(StreamingContext) };
-            }
-
+            var callbackParameterTypes = owner.IsValueType
+                ? (new[] { typeof(object), owner.MakeByRefType(), typeof(StreamingContext) })
+                : (new[] { typeof(object), typeof(object), typeof(StreamingContext) });
             var method = new DynamicMethod($"{callbackMethod.Name}_Trampoline", null, callbackParameterTypes, type, skipVisibility: true);
             var il = method.GetILGenerator();
 

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -14,7 +14,7 @@ namespace Orleans.Serialization
     /// <summary>
     /// Serializes and deserializes values.
     /// </summary>
-    public sealed class Serializer 
+    public sealed class Serializer
     {
         private readonly SerializerSessionPool _sessionPool;
 
@@ -488,7 +488,7 @@ namespace Orleans.Serialization
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
         public T Deserialize<T>(ArraySegment<byte> source, SerializerSession session) => Deserialize<T>(source.AsSpan(), session);
-        
+
         /// <summary>
         /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
         /// </summary>
@@ -1326,7 +1326,7 @@ namespace Orleans.Serialization
     /// <summary>
     /// Provides methods for serializing and deserializing values which have types which are not statically known.
     /// </summary>
-    public sealed class ObjectSerializer 
+    public sealed class ObjectSerializer
     {
         private readonly SerializerSessionPool _sessionPool;
 
@@ -1720,7 +1720,7 @@ namespace Orleans.Serialization
         /// <param name="type">The expected type of the value.</param>
         /// <returns>The deserialized value.</returns>
         public object Deserialize(ArraySegment<byte> source, SerializerSession session, Type type) => Deserialize(source.AsSpan(), session, type);
-        
+
         /// <summary>
         /// Deserialize a value of type <paramref name="type"/> from <paramref name="source"/>.
         /// </summary>

--- a/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeCodec.cs
@@ -18,8 +18,8 @@ namespace Orleans.Serialization.TypeSystem
     public sealed class TypeCodec
     {
         private const byte Version1 = 1;
-        private readonly ConcurrentDictionary<Type, TypeKey> _typeCache = new ConcurrentDictionary<Type, TypeKey>();
-        private readonly ConcurrentDictionary<int, (TypeKey Key, Type Type)> _typeKeyCache = new ConcurrentDictionary<int, (TypeKey, Type)>();
+        private readonly ConcurrentDictionary<Type, TypeKey> _typeCache = new();
+        private readonly ConcurrentDictionary<int, (TypeKey Key, Type Type)> _typeKeyCache = new();
         private readonly TypeConverter _typeConverter;
         private readonly Func<Type, TypeKey> _getTypeKey;
 

--- a/src/Orleans.Serialization/WireProtocol/Tag.cs
+++ b/src/Orleans.Serialization/WireProtocol/Tag.cs
@@ -56,7 +56,7 @@ namespace Orleans.Serialization.WireProtocol
         /// </summary>
         /// <param name="tag">The tag.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Tag(byte tag) => new Tag(tag);
+        public static implicit operator Tag(byte tag) => new(tag);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Tag"/> to <see cref="System.Byte"/>.

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapter.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapter.cs
@@ -17,7 +17,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         protected readonly string TopicId;
         protected readonly TimeSpan? Deadline;
         private readonly HashRingBasedStreamQueueMapper _streamQueueMapper;
-        protected readonly ConcurrentDictionary<QueueId, PubSubDataManager> Subscriptions = new ConcurrentDictionary<QueueId, PubSubDataManager>();
+        protected readonly ConcurrentDictionary<QueueId, PubSubDataManager> Subscriptions = new();
         protected readonly IPubSubDataAdapter _dataAdapter;
         private readonly ILogger _logger;
         private readonly ILoggerFactory loggerFactory;

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
@@ -19,8 +19,8 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         private readonly ClusterOptions clusterOptions;
         private readonly ILoggerFactory loggerFactory;
         private readonly Func<TDataAdapter> _adaptorFactory;
-        private HashRingBasedStreamQueueMapper _streamQueueMapper;
-        private IQueueAdapterCache _adapterCache;
+        private readonly HashRingBasedStreamQueueMapper _streamQueueMapper;
+        private readonly IQueueAdapterCache _adapterCache;
 
         /// <summary>
         /// Application level failure handler override.

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -24,8 +24,8 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         private Topic _topic;
         private PublisherClient _publisher;
         private SubscriberClient _subscriber;
-        private TimeSpan? _deadline;
-        private ServiceEndpoint _customEndpoint;
+        private readonly TimeSpan? _deadline;
+        private readonly ServiceEndpoint _customEndpoint;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         private readonly ILogger _logger;

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -86,11 +86,10 @@ namespace Orleans.Providers.Streams.Common
         {
             if (other == null)
                 return 1;
-            
-            var token = other as EventSequenceToken;
-            if (token == null)
-                throw new ArgumentOutOfRangeException("other");
-            
+
+            if (other is not EventSequenceToken token)
+                throw new ArgumentOutOfRangeException(nameof(other));
+
             int difference = SequenceNumber.CompareTo(token.SequenceNumber);
             return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);
         }

--- a/src/Orleans.Streaming/Common/Monitors/IBlockPoolMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/IBlockPoolMonitor.cs
@@ -34,8 +34,8 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     public class ObjectPoolMonitorBridge : IObjectPoolMonitor
     {
-        private IBlockPoolMonitor blockPoolMonitor;
-        private int blockSizeInBytes;
+        private readonly IBlockPoolMonitor blockPoolMonitor;
+        private readonly int blockSizeInBytes;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectPoolMonitorBridge"/> class.

--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
@@ -122,7 +122,7 @@ namespace Orleans.Providers.Streams.Common
             {
                 if (index >= writeIndex || index < readIndex)
                 {
-                    throw new ArgumentOutOfRangeException("index");
+                    throw new ArgumentOutOfRangeException(nameof(index));
                 }
                 return cachedMessages[index];
             }
@@ -177,7 +177,7 @@ namespace Orleans.Providers.Streams.Common
                     return i;
                 }
             }
-            throw new ArgumentOutOfRangeException("token");
+            throw new ArgumentOutOfRangeException(nameof(token));
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Orleans.Providers.Streams.Common
 
         /// <summary>
         /// Tries to get the next message from the provided stream, starting at the start index.
-        /// </summary>        
+        /// </summary>
         /// <param name="start">The start index.</param>
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="dataAdapter">The data adapter.</param>
@@ -204,7 +204,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (start < readIndex)
             {
-                throw new ArgumentOutOfRangeException("start");
+                throw new ArgumentOutOfRangeException(nameof(start));
             }
 
             for (int i = start; i < writeIndex; i++)

--- a/src/Orleans.Streaming/Common/PooledCache/ObjectPool.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ObjectPool.cs
@@ -33,7 +33,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (factoryFunc == null)
             {
-                throw new ArgumentNullException("factoryFunc");
+                throw new ArgumentNullException(nameof(factoryFunc));
             }
 
             this.factoryFunc = factoryFunc;

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -34,7 +34,7 @@ namespace Orleans.Providers.Streams.Common
         private readonly PeriodicAction periodicMonitoring;
         private readonly PeriodicAction periodicMetadaPurging;
 
-        private readonly Dictionary<StreamId, (DateTime TimeStamp, StreamSequenceToken Token)> lastPurgedToken = new Dictionary<StreamId, (DateTime TimeStamp, StreamSequenceToken Token)>();
+        private readonly Dictionary<StreamId, (DateTime TimeStamp, StreamSequenceToken Token)> lastPurgedToken = new();
 
         /// <summary>
         /// Gets the cached message most recently added.
@@ -82,8 +82,8 @@ namespace Orleans.Providers.Streams.Common
             TimeSpan? cacheMonitorWriteInterval,
             TimeSpan? purgeMetadataInterval = null)
         {
-            this.cacheDataAdapter = cacheDataAdapter ?? throw new ArgumentNullException("cacheDataAdapter");
-            this.logger = logger ?? throw new ArgumentNullException("logger");
+            this.cacheDataAdapter = cacheDataAdapter ?? throw new ArgumentNullException(nameof(cacheDataAdapter));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.ItemCount = 0;
             pool = new CachedMessagePool(cacheDataAdapter);
             messageBlocks = new LinkedList<CachedMessageBlock>();
@@ -269,13 +269,13 @@ namespace Orleans.Providers.Streams.Common
 
             if (cursorObj == null)
             {
-                throw new ArgumentNullException("cursorObj");
+                throw new ArgumentNullException(nameof(cursorObj));
             }
 
             var cursor = cursorObj as Cursor;
             if (cursor == null)
             {
-                throw new ArgumentOutOfRangeException("cursorObj", "Cursor is bad");
+                throw new ArgumentOutOfRangeException(nameof(cursorObj), "Cursor is bad");
             }
 
             if (cursor.State != CursorStates.Set)

--- a/src/Orleans.Streaming/Extensions/GenericAsyncObserver.cs
+++ b/src/Orleans.Streaming/Extensions/GenericAsyncObserver.cs
@@ -9,9 +9,9 @@ namespace Orleans.Streams
     /// <typeparam name="T">The type of object produced by the observable.</typeparam>
     internal class GenericAsyncObserver<T> : IAsyncObserver<T>
     {
-        private Func<T, StreamSequenceToken, Task> onNextAsync;
-        private Func<Exception, Task> onErrorAsync;
-        private Func<Task> onCompletedAsync;
+        private readonly Func<T, StreamSequenceToken, Task> onNextAsync;
+        private readonly Func<Exception, Task> onErrorAsync;
+        private readonly Func<Task> onCompletedAsync;
 
         public GenericAsyncObserver(Func<T, StreamSequenceToken, Task> onNextAsync, Func<Exception, Task> onErrorAsync, Func<Task> onCompletedAsync)
         {

--- a/src/Orleans.Streaming/Internal/StreamDirectory.cs
+++ b/src/Orleans.Streaming/Internal/StreamDirectory.cs
@@ -12,7 +12,7 @@ namespace Orleans.Streams
     /// </summary>
     internal class StreamDirectory : IAsyncDisposable
     {
-        private readonly ConcurrentDictionary<QualifiedStreamId, object> allStreams = new ConcurrentDictionary<QualifiedStreamId, object>();
+        private readonly ConcurrentDictionary<QualifiedStreamId, object> allStreams = new();
 
         internal IAsyncStream<T> GetOrAddStream<T>(QualifiedStreamId streamId, Func<IAsyncStream<T>> streamCreator)
         {

--- a/src/Orleans.Streaming/Internal/StreamImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamImpl.cs
@@ -30,7 +30,7 @@ namespace Orleans.Streams
         private volatile IInternalAsyncObservable<T>?            consumerInterface;
 
         [NonSerialized]
-        private readonly object initLock = new object();
+        private readonly object initLock = new();
 
         [NonSerialized]
         private IRuntimeClient?                                  runtimeClient;

--- a/src/Orleans.Streaming/MemoryStreams/MemoryMessageBodySerializerFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryMessageBodySerializerFactory.cs
@@ -6,7 +6,7 @@ namespace Orleans.Providers
     internal static class MemoryMessageBodySerializerFactory<TSerializer>
         where TSerializer : class, IMemoryMessageBodySerializer
     {
-        private static readonly Lazy<ObjectFactory> ObjectFactory = new Lazy<ObjectFactory>(
+        private static readonly Lazy<ObjectFactory> ObjectFactory = new(
             () => ActivatorUtilities.CreateFactory(
                 typeof(TSerializer),
                 Type.EmptyTypes));

--- a/src/Orleans.Streaming/MemoryStreams/MemoryStreamQueueGrain.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryStreamQueueGrain.cs
@@ -12,7 +12,7 @@ namespace Orleans.Providers
     /// </summary>
     public class MemoryStreamQueueGrain : Grain, IMemoryStreamQueueGrain, IGrainMigrationParticipant
     {
-        private Queue<MemoryMessageData> _eventQueue = new Queue<MemoryMessageData>();
+        private Queue<MemoryMessageData> _eventQueue = new();
         private long sequenceNumber = DateTime.UtcNow.Ticks;
 
         /// <summary>

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -71,7 +71,7 @@ namespace Orleans.Providers.Streams.Common
         private readonly IStreamProviderRuntime runtime;
         private readonly DeepCopier deepCopier;
         private readonly IRuntimeClient runtimeClient;
-        private readonly ProviderStateManager stateManager = new ProviderStateManager();
+        private readonly ProviderStateManager stateManager = new();
         private IQueueAdapterFactory    adapterFactory;
         private IQueueAdapter           queueAdapter;
         private IPersistentStreamPullingManager pullingAgentManager;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -31,7 +31,7 @@ namespace Orleans.Streams
         private readonly ILoggerFactory loggerFactory;
         private int latestRingNotificationSequenceNumber;
         private int latestCommandNumber;
-        private IQueueAdapter queueAdapter;
+        private readonly IQueueAdapter queueAdapter;
         private readonly IQueueAdapterCache queueAdapterCache;
         private IStreamQueueBalancer queueBalancer;
         private readonly IStreamFilter streamFilter;

--- a/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
@@ -9,9 +9,9 @@ namespace Orleans.Providers
 {
     internal class ClientStreamingProviderRuntime : IStreamProviderRuntime, ILifecycleParticipant<IClusterClientLifecycle>
     {
-        private IStreamPubSub grainBasedPubSub;
-        private IStreamPubSub implicitPubSub;
-        private IStreamPubSub combinedGrainBasedAndImplicitPubSub;
+        private readonly IStreamPubSub grainBasedPubSub;
+        private readonly IStreamPubSub implicitPubSub;
+        private readonly IStreamPubSub combinedGrainBasedAndImplicitPubSub;
         private StreamDirectory streamDirectory;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ImplicitStreamSubscriberTable implicitSubscriberTable;

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.Providers
         private readonly ILocalSiloDetails siloDetails;
         private readonly IGrainContextAccessor grainContextAccessor;
         private readonly ILogger logger;
-        private readonly StreamDirectory hostedClientStreamDirectory = new StreamDirectory();
+        private readonly StreamDirectory hostedClientStreamDirectory = new();
 
         public IGrainFactory GrainFactory => this.runtimeClient.InternalGrainFactory;
         public IServiceProvider ServiceProvider => this.runtimeClient.ServiceProvider;

--- a/src/Orleans.Streaming/PubSub/DefaultStreamNamespacePredicateProvider.cs
+++ b/src/Orleans.Streaming/PubSub/DefaultStreamNamespacePredicateProvider.cs
@@ -78,14 +78,9 @@ namespace Orleans.Streams
             }
 
             var type = Type.GetType(typeName, throwOnError: true);
-            if (string.IsNullOrEmpty(arg))
-            {
-                predicate = (IStreamNamespacePredicate)Activator.CreateInstance(type);
-            }
-            else
-            {
-                predicate = (IStreamNamespacePredicate)Activator.CreateInstance(type, arg);
-            }
+            predicate = string.IsNullOrEmpty(arg)
+                ? (IStreamNamespacePredicate)Activator.CreateInstance(type)
+                : (IStreamNamespacePredicate)Activator.CreateInstance(type, arg);
 
             return true;
         }

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
@@ -12,7 +12,7 @@ namespace Orleans.Streams
 {
     internal class ImplicitStreamSubscriberTable
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
         private readonly GrainBindingsResolver _bindings;
         private readonly IStreamNamespacePredicateProvider[] _providers;
         private readonly IServiceProvider _serviceProvider;

--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -33,9 +33,9 @@ namespace Orleans.Streams
         private readonly LeaseBasedQueueBalancerOptions options;
         private readonly ILeaseProvider leaseProvider;
         private readonly ITimerRegistry timerRegistry;
-        private readonly AsyncSerialExecutor executor = new AsyncSerialExecutor();
+        private readonly AsyncSerialExecutor executor = new();
         private int allQueuesCount;
-        private readonly List<AcquiredQueue> myQueues = new List<AcquiredQueue>();
+        private readonly List<AcquiredQueue> myQueues = new();
         private IDisposable leaseMaintenanceTimer;
         private IDisposable leaseAquisitionTimer;
         private RoundRobinSelector<QueueId> queueSelector;

--- a/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
@@ -14,8 +14,8 @@ namespace Orleans.Hosting
     /// </summary>
     public class PersistentStreamStorageConfigurationValidator : IConfigurationValidator
     {
-        private IServiceProvider services;
-        private string streamProviderName;
+        private readonly IServiceProvider services;
+        private readonly string streamProviderName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PersistentStreamStorageConfigurationValidator"/> class.

--- a/src/Orleans.TestingHost/Logging/FileLogger.cs
+++ b/src/Orleans.TestingHost/Logging/FileLogger.cs
@@ -10,13 +10,13 @@ using Orleans.Runtime;
 namespace Orleans.TestingHost.Logging
 {
     /// <summary>
-    /// The log output which all <see cref="FileLogger"/> share to log messages to 
+    /// The log output which all <see cref="FileLogger"/> share to log messages to
     /// </summary>
     public class FileLoggingOutput : IDisposable
     {
         private static readonly ConcurrentDictionary<FileLoggingOutput, object> Instances = new();
         private readonly TimeSpan flushInterval = Debugger.IsAttached ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(1);
-        private readonly object lockObj = new object();
+        private readonly object lockObj = new();
         private readonly string logFileName;
         private DateTime lastFlush = DateTime.UtcNow;
         private StreamWriter logOutput;
@@ -137,7 +137,7 @@ namespace Orleans.TestingHost.Logging
     public class FileLogger : ILogger
     {
         private readonly FileLoggingOutput output;
-        private string category;
+        private readonly string category;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileLogger"/> class.

--- a/src/Orleans.TestingHost/Logging/FileLoggerProvider.cs
+++ b/src/Orleans.TestingHost/Logging/FileLoggerProvider.cs
@@ -8,7 +8,7 @@ namespace Orleans.TestingHost.Logging
     /// </summary>
     public class FileLoggerProvider : ILoggerProvider
     {
-        private FileLoggingOutput output;
+        private readonly FileLoggingOutput output;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileLoggerProvider"/> class.

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -30,9 +30,9 @@ namespace Orleans.TestingHost
     /// </remarks>
     public class TestCluster : IDisposable, IAsyncDisposable
     {
-        private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
+        private readonly List<SiloHandle> additionalSilos = new();
         private readonly TestClusterOptions options;
-        private readonly StringBuilder log = new StringBuilder();
+        private readonly StringBuilder log = new();
         private readonly InMemoryTransportConnectionHub _transportHub = new();
         private bool _disposed;
         private int startedInstances;

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -15,8 +15,8 @@ namespace Orleans.TestingHost
     /// <summary>Configuration builder for starting a <see cref="TestCluster"/>.</summary>
     public class TestClusterBuilder
     {
-        private readonly List<Action<IConfigurationBuilder>> configureHostConfigActions = new List<Action<IConfigurationBuilder>>();
-        private readonly List<Action> configureBuilderActions = new List<Action>();
+        private readonly List<Action<IConfigurationBuilder>> configureHostConfigActions = new();
+        private readonly List<Action> configureBuilderActions = new();
         private Func<string, IConfiguration, Task<SiloHandle>> _createSiloAsync;
 
         /// <summary>

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -227,16 +227,11 @@ namespace Orleans.TestingHost
                     int initialSilosCount = int.Parse(configuration[nameof(TestClusterOptions.InitialSilosCount)]);
                     bool gatewayPerSilo = bool.Parse(configuration[nameof(TestClusterOptions.GatewayPerSilo)]);
 
-                    if (gatewayPerSilo)
-                    {
-                        options.Gateways = Enumerable.Range(baseGatewayPort, initialSilosCount)
+                    options.Gateways = gatewayPerSilo
+                        ? Enumerable.Range(baseGatewayPort, initialSilosCount)
                             .Select(port => new IPEndPoint(IPAddress.Loopback, port).ToGatewayUri())
-                            .ToList();
-                    }
-                    else
-                    {
-                        options.Gateways = new List<Uri> { new IPEndPoint(IPAddress.Loopback, baseGatewayPort).ToGatewayUri() };
-                    }
+                            .ToList()
+                        : new List<Uri> { new IPEndPoint(IPAddress.Loopback, baseGatewayPort).ToGatewayUri() };
                 };
                 if (configureOptions != null)
                 {

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -210,7 +210,7 @@ namespace Orleans.TestingHost
         /// Converts these options into a dictionary.
         /// </summary>
         /// <returns>The options dictionary.</returns>
-        public Dictionary<string, string> ToDictionary() => new Dictionary<string, string>
+        public Dictionary<string, string> ToDictionary() => new()
         {
             [nameof(SiloPort)] = this.SiloPort.ToString(),
             [nameof(GatewayPort)] = this.GatewayPort.ToString(),

--- a/src/Orleans.TestingHost/TestClusterPortAllocator.cs
+++ b/src/Orleans.TestingHost/TestClusterPortAllocator.cs
@@ -16,8 +16,8 @@ namespace Orleans.TestingHost
     public class TestClusterPortAllocator : ITestClusterPortAllocator
     {
         private bool disposed;
-        private readonly object lockObj = new object();
-        private readonly Dictionary<int, string> allocatedPorts = new Dictionary<int, string>();
+        private readonly object lockObj = new();
+        private readonly Dictionary<int, string> allocatedPorts = new();
 
         /// <inheritdoc />
         public (int, int) AllocateConsecutivePortPairs(int numPorts = 5)
@@ -135,8 +135,8 @@ namespace Orleans.TestingHost
 
         private class MutexManager
         {
-            private readonly Dictionary<string, Mutex> _mutexes = new Dictionary<string, Mutex>();
-            private readonly BlockingCollection<Action> _workItems = new BlockingCollection<Action>();
+            private readonly Dictionary<string, Mutex> _mutexes = new();
+            private readonly BlockingCollection<Action> _workItems = new();
             private readonly Thread _thread;
 
             public static MutexManager Instance { get; } = new MutexManager();

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -31,8 +31,8 @@ namespace Orleans.TestingHost
     public class FaultInjectionGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly IGrainStorage realStorageProvider;
-        private IGrainFactory grainFactory;
-        private ILogger logger;
+        private readonly IGrainFactory grainFactory;
+        private readonly ILogger logger;
         private readonly FaultInjectionGrainStorageOptions options;
 
         /// <summary>

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
@@ -11,12 +11,12 @@ namespace Orleans.TestingHost.UnixSocketTransport;
 
 internal class UnixSocketConnectionListener : IConnectionListener
 {
-    private UnixDomainSocketEndPoint _unixEndpoint;
-    private EndPoint _endpoint;
-    private UnixSocketConnectionOptions _socketConnectionOptions;
-    private SocketsTrace _trace;
-    private SocketSchedulers _schedulers;
-    private MemoryPool<byte> _memoryPool;
+    private readonly UnixDomainSocketEndPoint _unixEndpoint;
+    private readonly EndPoint _endpoint;
+    private readonly UnixSocketConnectionOptions _socketConnectionOptions;
+    private readonly SocketsTrace _trace;
+    private readonly SocketSchedulers _schedulers;
+    private readonly MemoryPool<byte> _memoryPool;
     private Socket _listenSocket;
 
     public UnixSocketConnectionListener(UnixDomainSocketEndPoint unixEndpoint, EndPoint endpoint, UnixSocketConnectionOptions socketConnectionOptions, SocketsTrace trace, SocketSchedulers schedulers)

--- a/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
@@ -23,11 +23,11 @@ namespace Orleans.Transactions.TestKit.Consistency
         private readonly HashSet<string> aborted;
         private readonly Dictionary<string, string> indoubt;
         private bool timeoutsOccurred;
-        private bool tolerateUnknownExceptions;
+        private readonly bool tolerateUnknownExceptions;
         private readonly IGrainFactory grainFactory;
 
-        private readonly Dictionary<string, HashSet<string>> orderEdges = new Dictionary<string, HashSet<string>>();
-        private readonly Dictionary<string, bool> marks = new Dictionary<string, bool>();
+        private readonly Dictionary<string, HashSet<string>> orderEdges = new();
+        private readonly Dictionary<string, bool> marks = new();
 
 
         public ConsistencyTestHarness(

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TestKit
     internal class FaultInjectionTransactionManager<TState> : ITransactionManager
         where TState : class, new()
     {
-        private TransactionManager<TState> tm;
+        private readonly TransactionManager<TState> tm;
         private readonly IGrainRuntime grainRuntime;
         private readonly IGrainContext context;
         private readonly FaultInjectionControl faultInjectionControl;

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
@@ -63,7 +63,7 @@ namespace Orleans.Transactions.TestKit
         private readonly TransactionalState<TState> txState;
         private readonly ILogger logger;
         public FaultInjectionControl FaultInjectionControl { get; set; }
-        private IControlledTransactionFaultInjector faultInjector;
+        private readonly IControlledTransactionFaultInjector faultInjector;
         public string CurrentTransactionId => this.txState.CurrentTransactionId;
         public FaultInjectionTransactionalState(TransactionalState<TState> txState, IControlledTransactionFaultInjector faultInjector, IGrainRuntime grainRuntime, ILogger<FaultInjectionTransactionalState<TState>> logger)
         {

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
@@ -30,7 +30,7 @@ namespace Orleans.Transactions.TestKit
 
     public class FaultInjectionTransactionalStateFactory : IFaultInjectionTransactionalStateFactory
     {
-        private IGrainContextAccessor contextAccessor;
+        private readonly IGrainContextAccessor contextAccessor;
         public FaultInjectionTransactionalStateFactory(IGrainContextAccessor contextAccessor)
         {
             this.contextAccessor = contextAccessor;

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/SimpleAzureStorageExceptionInjector.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/SimpleAzureStorageExceptionInjector.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TestKit
         public bool InjectAfterStore { get; set; }
         private int injectionBeforeStoreCounter = 0;
         private int injectionAfterStoreCounter = 0;
-        private ILogger logger;
+        private readonly ILogger logger;
         public SimpleAzureStorageExceptionInjector(ILogger<SimpleAzureStorageExceptionInjector> logger)
         {
             this.logger = logger;

--- a/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
@@ -17,7 +17,7 @@ namespace Orleans.Transactions.TestKit
     // - can produce errors for fault senarios.
     public class RemoteCommitService : IRemoteCommitService
     {
-        ILogger logger;
+        readonly ILogger logger;
 
         public RemoteCommitService(ILogger<RemoteCommitService> logger)
         {

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
@@ -49,7 +49,7 @@ namespace Orleans.Transactions.TestKit
             response.PendingStates.Should().BeEmpty();
         }
 
-        private static List<PendingTransactionState<TState>> emptyPendingStates = new List<PendingTransactionState<TState>>();
+        private static readonly List<PendingTransactionState<TState>> emptyPendingStates = new();
   
         public virtual async Task StoreWithoutChanges()
         {

--- a/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
@@ -130,14 +130,9 @@ namespace Orleans.Transactions
             // Take sum of write counts
             foreach (KeyValuePair<ParticipantId, AccessCounter> participant in other.Participants)
             {
-                if (!this.Participants.TryGetValue(participant.Key, out var existing))
-                {
-                    this.Participants[participant.Key] = participant.Value;
-                }
-                else
-                {
-                    this.Participants[participant.Key] = existing + participant.Value;
-                }
+                this.Participants[participant.Key] = !this.Participants.TryGetValue(participant.Key, out var existing)
+                    ? participant.Value
+                    : existing + participant.Value;
             }
 
             // take max of timestamp

--- a/src/Orleans.Transactions/State/ActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/ActivationLifetime.cs
@@ -7,7 +7,7 @@ namespace Orleans.Transactions.State
 {
     internal class ActivationLifetime : IActivationLifetime, ILifecycleObserver
     {
-        private readonly CancellationTokenSource onDeactivating = new CancellationTokenSource();
+        private readonly CancellationTokenSource onDeactivating = new();
 
         private int pendingDeactivationLocks;
 

--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -50,10 +50,7 @@ namespace Orleans.Transactions.State
             }
         }
 
-        public bool IsConfirmed(Guid transactionId)
-        {
-            return this.pending.Contains(transactionId);
-        }
+        public bool IsConfirmed(Guid transactionId) => this.pending.Contains(transactionId);
 
         private async Task SendConfirmation(Guid transactionId, DateTime timestamp, List<ParticipantId> participants)
         {

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -15,8 +15,8 @@ namespace Orleans.Transactions.State
     {
         private readonly TransactionalStateOptions options;
         private readonly TransactionQueue<TState> queue;
-        private BatchWorker lockWorker;
-        private BatchWorker storageWorker;
+        private readonly BatchWorker lockWorker;
+        private readonly BatchWorker storageWorker;
         private readonly ILogger logger;
         private readonly IActivationLifetime activationLifetime;
 
@@ -205,15 +205,9 @@ namespace Orleans.Transactions.State
             }
         }
 
-        public void Notify()
-        {
-            this.lockWorker.Notify();
-        }
+        public void Notify() => this.lockWorker.Notify();
 
-        public bool TryGetRecord(Guid transactionId, out TransactionRecord<TState> record)
-        {
-            return this.currentGroup.TryGetValue(transactionId, out record);
-        }
+        public bool TryGetRecord(Guid transactionId, out TransactionRecord<TState> record) => this.currentGroup.TryGetValue(transactionId, out record);
 
         public Task AbortExecutingTransactions(Exception exception)
         {
@@ -558,9 +552,6 @@ namespace Orleans.Transactions.State
             }
         }
 
-        private static int Comparer(TransactionRecord<TState> a, TransactionRecord<TState> b)
-        {
-            return a.Timestamp.CompareTo(b.Timestamp);
-        }
+        private static int Comparer(TransactionRecord<TState> a, TransactionRecord<TState> b) => a.Timestamp.CompareTo(b.Timestamp);
     }
 }

--- a/src/Orleans.Transactions/State/StorageBatch.cs
+++ b/src/Orleans.Transactions/State/StorageBatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,14 +34,14 @@ namespace Orleans.Transactions
         // watermarks for commit, prepare, abort
         private long confirmUpTo;
         private long cancelAbove;
-        private long cancelAboveStart;
+        private readonly long cancelAboveStart;
 
         // prepare records
-        private SortedDictionary<long, PendingTransactionState<TState>> prepares;
+        private readonly SortedDictionary<long, PendingTransactionState<TState>> prepares;
 
         // follow-up actions, to be executed after storing this batch
-        private List<Action> followUpActions;
-        private List<Func<Task<bool>>> storeConditions;
+        private readonly List<Action> followUpActions;
+        private readonly List<Func<Task<bool>>> storeConditions;
         
         // counters for each type of event
         private int total = 0;
@@ -57,10 +57,7 @@ namespace Orleans.Transactions
         public string ETag { get; set; }
 
         public int BatchSize => total;
-        public override string ToString()
-        {
-            return $"batchsize={total} [{read}r {prepare}p {commit}c {confirm}cf {collect}cl {cancel}cc]";
-        }
+        public override string ToString() => $"batchsize={total} [{read}r {prepare}p {commit}c {confirm}cf {collect}cl {cancel}cc]";
 
         public StorageBatch(TransactionalStateMetaData metaData, string etag, long confirmUpTo, long cancelAbove)
         {
@@ -191,15 +188,9 @@ namespace Orleans.Transactions
             MetaData.CommitRecords.Remove(transactionId);
         }
 
-        public void FollowUpAction(Action action)
-        {
-            followUpActions.Add(action);
-        }
+        public void FollowUpAction(Action action) => followUpActions.Add(action);
 
-        public void AddStorePreCondition(Func<Task<bool>> action)
-        {
-            this.storeConditions.Add(action);
-        }
+        public void AddStorePreCondition(Func<Task<bool>> action) => this.storeConditions.Add(action);
 
         public async Task<bool> CheckStorePreConditions()
         {

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -32,7 +32,7 @@ namespace Orleans.Transactions.State
         private int failCounter;
 
         // collection tasks
-        private Dictionary<DateTime, PreparedMessages> unprocessedPreparedMessages;
+        private readonly Dictionary<DateTime, PreparedMessages> unprocessedPreparedMessages;
         private class PreparedMessages
         {
             public PreparedMessages(TransactionalStatus status)

--- a/src/Orleans.Transactions/State/TransactionalStateFactory.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateFactory.cs
@@ -9,7 +9,7 @@ namespace Orleans.Transactions
 {
     public class TransactionalStateFactory : ITransactionalStateFactory
     {
-        private IGrainContextAccessor contextAccessor;
+        private readonly IGrainContextAccessor contextAccessor;
         public TransactionalStateFactory(IGrainContextAccessor contextAccessor)
         {
             this.contextAccessor = contextAccessor;

--- a/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
+++ b/src/Orleans.Transactions/TOC/TocTransactionQueue.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TOC
     internal class TocTransactionQueue<TService> : TransactionQueue<TransactionCommitter<TService>.OperationState>
                 where TService : class
     {
-        private TService service;
+        private readonly TService service;
 
         public TocTransactionQueue(
             TService service,

--- a/src/Orleans.Transactions/TOC/TransactionCommitterFactory.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitterFactory.cs
@@ -7,7 +7,7 @@ namespace Orleans.Transactions
 {
     public class TransactionCommitterFactory : ITransactionCommitterFactory
     {
-        private IGrainContextAccessor contextAccessor;
+        private readonly IGrainContextAccessor contextAccessor;
 
         public TransactionCommitterFactory(IGrainContextAccessor contextAccessor)
         {

--- a/src/Orleans.Transactions/Utilities/CausalClock.cs
+++ b/src/Orleans.Transactions/Utilities/CausalClock.cs
@@ -5,7 +5,7 @@ namespace Orleans.Transactions
 {
     public class CausalClock
     {
-        private readonly object lockable = new object();
+        private readonly object lockable = new();
         private readonly IClock clock;
         private long previous;
 

--- a/src/Redis/Orleans.Clustering.Redis/Storage/JsonSettings.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/JsonSettings.cs
@@ -9,7 +9,7 @@ namespace Orleans.Clustering.Redis
 {
     internal static class JsonSettings
     {
-        public static JsonSerializerSettings JsonSerializerSettings => new JsonSerializerSettings
+        public static JsonSerializerSettings JsonSerializerSettings => new()
         {
             Formatting = Formatting.None,
             TypeNameHandling = TypeNameHandling.None,

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -14,7 +14,7 @@ namespace Orleans.Clustering.Redis
     internal class RedisMembershipTable : IMembershipTable, IDisposable
     {
         private const string TableVersionKey = "Version";
-        private static readonly TableVersion DefaultTableVersion = new TableVersion(0, "0");
+        private static readonly TableVersion DefaultTableVersion = new(0, "0");
         private readonly RedisClusteringOptions _redisOptions;
         private readonly ClusterOptions _clusterOptions;
         private readonly JsonSerializerSettings _jsonSerializerSettings;
@@ -216,7 +216,7 @@ namespace Orleans.Clustering.Redis
             return new TableVersion(version, versionString);
         }
 
-        private static TableVersion Predeccessor(TableVersion tableVersion) => new TableVersion(tableVersion.Version - 1, (tableVersion.Version - 1).ToString(CultureInfo.InvariantCulture));
+        private static TableVersion Predeccessor(TableVersion tableVersion) => new(tableVersion.Version - 1, (tableVersion.Version - 1).ToString(CultureInfo.InvariantCulture));
 
 
         private string Serialize(MembershipEntry value)

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -114,14 +114,9 @@ namespace Orleans.Persistence
                     string eTag = hashEntries.Single(static e => e.Name == "etag").Value;
                     ReadOnlyMemory<byte> data = hashEntries.Single(static e => e.Name == "data").Value;
 
-                    if (data.Length > 0)
-                    {
-                        grainState.State = _grainStorageSerializer.Deserialize<T>(data);
-                    }
-                    else
-                    {
-                        grainState.State = Activator.CreateInstance<T>();
-                    }
+                    grainState.State = data.Length > 0
+                        ? _grainStorageSerializer.Deserialize<T>(data)
+                        : Activator.CreateInstance<T>();
 
                     grainState.ETag = eTag;
                     grainState.RecordExists = true;

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -28,7 +28,7 @@ namespace Orleans.Reminders.Redis
         private IConnectionMultiplexer _muxer;
         private IDatabase _db;
 
-        private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings()
+        private readonly JsonSerializerSettings _jsonSettings = new()
         {
             DateFormatHandling = DateFormatHandling.IsoDateFormat,
             DefaultValueHandling = DefaultValueHandling.Ignore,

--- a/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
+++ b/test/Benchmarks/GrainStorage/GrainStorageBenchmark.cs
@@ -13,9 +13,9 @@ namespace Benchmarks.GrainStorage
     public class GrainStorageBenchmark : IDisposable
     {
         private TestCluster host;
-        private int concurrent;
-        private int payloadSize;
-        private TimeSpan duration;
+        private readonly int concurrent;
+        private readonly int payloadSize;
+        private readonly TimeSpan duration;
 
         public GrainStorageBenchmark(int concurrent, int payloadSize, TimeSpan duration)
         {

--- a/test/Benchmarks/MapReduce/MapReduceBenchmark.cs
+++ b/test/Benchmarks/MapReduce/MapReduceBenchmark.cs
@@ -107,7 +107,7 @@ namespace Benchmarks.MapReduce
             _host?.Dispose();
         }
 
-        private string _text = @"Historically, the world of data and the world of objects" +
+        private readonly string _text = @"Historically, the world of data and the world of objects" +
           @" have not been well integrated. Programmers work in C# or Visual Basic" +
           @" and also in SQL or XQuery. On the one side are concepts such as classes," +
           @" objects, fields, inheritance, and .NET Framework APIs. On the other side" +

--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -12,7 +12,7 @@ namespace Benchmarks.Ping
     public class PingBenchmark : IDisposable
     {
         private readonly ConsoleCancelEventHandler _onCancelEvent;
-        private readonly List<IHost> hosts = new List<IHost>();
+        private readonly List<IHost> hosts = new();
         private readonly IPingGrain grain;
         private readonly IClusterClient client;
         private readonly IHost clientHost;

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -13,7 +13,7 @@ namespace Benchmarks
 {
     class Program
     {
-        private static readonly Dictionary<string, Action<string[]>> _benchmarks = new Dictionary<string, Action<string[]>>
+        private static readonly Dictionary<string, Action<string[]>> _benchmarks = new()
         {
             ["MapReduce"] = _ =>
             {

--- a/test/Benchmarks/Transactions/TransactionBenchmark.cs
+++ b/test/Benchmarks/Transactions/TransactionBenchmark.cs
@@ -18,9 +18,9 @@ namespace Benchmarks.Transactions
     public class TransactionBenchmark : IDisposable
     {
         private TestCluster host;
-        private int runs;
-        private int transactionsPerRun;
-        private int concurrent;
+        private readonly int runs;
+        private readonly int transactionsPerRun;
+        private readonly int concurrent;
 
         public TransactionBenchmark(int runs, int transactionsPerRun, int concurrent)
         {

--- a/test/DefaultCluster.Tests/ClientAddressableTests.cs
+++ b/test/DefaultCluster.Tests/ClientAddressableTests.cs
@@ -13,12 +13,12 @@ namespace DefaultCluster.Tests
     public class ClientAddressableTests : HostedTestClusterEnsureDefaultStarted
     {
         private object anchor;
-        private IRuntimeClient runtimeClient;
+        private readonly IRuntimeClient runtimeClient;
 
         private class MyPseudoGrain : IClientAddressableTestClientObject
         {
             private int counter = 0;
-            private List<int> numbers = new List<int>();
+            private readonly List<int> numbers = new();
 
             public Task<string> OnHappyPath(string message)
             {

--- a/test/DefaultCluster.Tests/CodeGenTests/GeneratorGrainTest.cs
+++ b/test/DefaultCluster.Tests/CodeGenTests/GeneratorGrainTest.cs
@@ -219,7 +219,7 @@ namespace Tester.CodeGenTests
 
         private class ObserverWithGenericMethods : IGrainObserverWithGenericMethods
         {
-            private readonly TaskCompletionSource<object> valueCompletion = new TaskCompletionSource<object>();
+            private readonly TaskCompletionSource<object> valueCompletion = new();
 
             public Task<object> ValueTask => this.valueCompletion.Task;
 

--- a/test/DefaultCluster.Tests/ConcreteStateClassTests.cs
+++ b/test/DefaultCluster.Tests/ConcreteStateClassTests.cs
@@ -11,7 +11,7 @@ namespace DefaultCluster.Tests.General
     /// </summary>
     public class StateClassTests : HostedTestClusterEnsureDefaultStarted
     {
-        private readonly Random rand = new Random();
+        private readonly Random rand = new();
 
         public StateClassTests(DefaultClusterFixture fixture) : base(fixture)
         {

--- a/test/DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/DefaultCluster.Tests/ErrorGrainTest.cs
@@ -220,15 +220,9 @@ namespace DefaultCluster.Tests
 
         private void CreateGR(int n, int type)
         {
-            Guid guid;
-            if (type == 1)
-            {
-                guid = Guid.Parse(string.Format("00000000-0000-0000-0000-{0:X12}", n));
-            }
-            else
-            {
-                guid = Guid.Parse(string.Format("{0:X8}-0000-0000-0000-000000000000", n));
-            }
+            var guid = type == 1
+                ? Guid.Parse(string.Format("00000000-0000-0000-0000-{0:X12}", n))
+                : Guid.Parse(string.Format("{0:X8}-0000-0000-0000-000000000000", n));
             IEchoGrain grain = this.GrainFactory.GetGrain<IEchoGrain>(guid);
             GrainId grainId = ((GrainReference)grain.AsReference<IEchoGrain>()).GrainId;
             output.WriteLine("Guid = {0}, Guid.HashCode = x{1:X8}, GrainId.HashCode = x{2:X8}, GrainId.UniformHashCode = x{3:X8}", guid, guid.GetHashCode(), grainId.GetHashCode(), grainId.GetUniformHashCode());

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -12,7 +12,7 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 {
     public class GrainActivateDeactivateTests : HostedTestClusterEnsureDefaultStarted, IDisposable
     {
-        private IActivateDeactivateWatcherGrain watcher;
+        private readonly IActivateDeactivateWatcherGrain watcher;
 
         public GrainActivateDeactivateTests(DefaultClusterFixture fixture) : base(fixture)
         {

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -23,7 +23,7 @@ namespace DefaultCluster.Tests.General
 
         public class Fixture : IAsyncLifetime
         {
-            private TestClusterPortAllocator portAllocator;
+            private readonly TestClusterPortAllocator portAllocator;
             public IHost Host { get; private set; }
 
             public Fixture()

--- a/test/DefaultCluster.Tests/MultifacetGrainTest.cs
+++ b/test/DefaultCluster.Tests/MultifacetGrainTest.cs
@@ -14,7 +14,7 @@ namespace DefaultCluster.Tests.General
         IMultifacetReader reader;
         //int eventCounter;
         const int EXPECTED_NUMBER_OF_EVENTS = 4;
-        private TimeSpan timeout = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
 
         public MultifacetGrainTest(DefaultClusterFixture fixture) : base(fixture)
         {

--- a/test/DefaultCluster.Tests/OneWayCallTests.cs
+++ b/test/DefaultCluster.Tests/OneWayCallTests.cs
@@ -78,7 +78,7 @@ namespace DefaultCluster.Tests.General
 
         private class SimpleGrainObserver : ISimpleGrainObserver
         {
-            private readonly TaskCompletionSource<int> completion = new TaskCompletionSource<int>();
+            private readonly TaskCompletionSource<int> completion = new();
             public Task ReceivedValue => this.completion.Task;
             public void StateChanged(int a, int b)
             {

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -129,7 +129,7 @@ namespace DefaultCluster.Tests.TimerTests
                 $"Assert: last <= maximalNumTicks. Actual: last = {last}, maximalNumTicks = {maximalNumTicks}");
 
             output.WriteLine(
-                "Total Elapsed time = " + (stopwatch.Elapsed.TotalSeconds) + " sec. Expected Ticks = " + maximalNumTicks +
+                "Total Elapsed time = " + stopwatch.Elapsed.TotalSeconds + " sec. Expected Ticks = " + maximalNumTicks +
                 ". Actual ticks = " + last);
         }
 

--- a/test/DistributedTests/DistributedTests.Grains/ImplicitSubscriberGrain.cs
+++ b/test/DistributedTests/DistributedTests.Grains/ImplicitSubscriberGrain.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Threading.Tasks;
 using DistributedTests.GrainInterfaces;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Streams;
 using Orleans.Streams.Core;
 
@@ -11,7 +8,7 @@ namespace DistributedTests.Grains
     [ImplicitStreamSubscription(StreamingConstants.StreamingNamespace)]
     public class ImplicitSubscriberGrain : Grain, IImplicitSubscriberGrain, IStreamSubscriptionObserver, IAsyncObserver<object>
     {
-        private ILogger _logger;
+        private readonly ILogger _logger;
         private int _requestCounter;
         private int _errorCounter;
 

--- a/test/DistributedTests/DistributedTests.Server/Configurator/EventGeneratorStreamingSilo.cs
+++ b/test/DistributedTests/DistributedTests.Server/Configurator/EventGeneratorStreamingSilo.cs
@@ -94,7 +94,7 @@ namespace DistributedTests.Server.Configurator
     {
         private DateTime _startTime;
         private DateTime _endTime;
-        private readonly List<StreamId> _streamIds = new List<StreamId>();
+        private readonly List<StreamId> _streamIds = new();
         private int _sequenceId = 0;
         private object _payload;
 

--- a/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
@@ -12,7 +12,7 @@ namespace AWSUtils.Tests.StorageTests
 {
     public class AWSTestConstants
     {
-        private static readonly Lazy<bool> _isDynamoDbAvailable = new Lazy<bool>(() =>
+        private static readonly Lazy<bool> _isDynamoDbAvailable = new(() =>
         {
             if (string.IsNullOrEmpty(DynamoDbService))
             {

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -23,7 +23,7 @@ namespace AWSUtils.Tests.StorageTests
     {
         private readonly IProviderRuntime providerRuntime;
         private readonly ITestOutputHelper output;
-        private readonly Dictionary<string, string> providerCfgProps = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> providerCfgProps = new();
         private readonly TestEnvironmentFixture fixture;
 
         public DynamoDBStorageProviderTests(ITestOutputHelper output, TestEnvironmentFixture fixture)

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageStressTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageStressTests.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model;
 using Orleans.TestingHost.Utils;
 using System;
 using System.Collections.Generic;
@@ -16,8 +16,8 @@ namespace AWSUtils.Tests.StorageTests
     public class DynamoDBStorageStressTests : IClassFixture<DynamoDBStorageTestsFixture>
     {
         private readonly ITestOutputHelper output;
-        private string PartitionKey;
-        private UnitTestDynamoDBStorage manager;
+        private readonly string PartitionKey;
+        private readonly UnitTestDynamoDBStorage manager;
 
         public DynamoDBStorageStressTests(DynamoDBStorageTestsFixture fixture, ITestOutputHelper output)
         {
@@ -70,7 +70,7 @@ namespace AWSUtils.Tests.StorageTests
             var data = manager.QueryAsync(UnitTestDynamoDBStorage.INSTANCE_TABLE_NAME, keys, $"PartitionKey = :PK", item => new UnitTestDynamoDBTableData(item)).Result;
 
             sw.Stop();
-            int count = data.results.Count();
+            int count = data.results.Count;
             output.WriteLine("DynamoDBDataManagerStressTests_ReadAll completed. ReadAll {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
 
             //Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageTests.cs
@@ -10,8 +10,8 @@ namespace AWSUtils.Tests.StorageTests.AWSUtils
     [TestCategory("Storage"), TestCategory("AWS"), TestCategory("DynamoDb")]
     public class DynamoDBStorageTests : IClassFixture<DynamoDBStorageTestsFixture>
     {
-        private string PartitionKey;
-        private UnitTestDynamoDBStorage manager;
+        private readonly string PartitionKey;
+        private readonly UnitTestDynamoDBStorage manager;
 
         public DynamoDBStorageTests(DynamoDBStorageTestsFixture fixture)
         {

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -1,18 +1,13 @@
 using AWSUtils.Tests.StorageTests;
-using Orleans.Runtime;
 using Orleans.TestingHost;
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Tester.StreamingTests;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
 using OrleansAWSUtils.Streams;
-using Orleans.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Configuration;
 
 namespace AWSUtils.Tests.Streaming
@@ -21,7 +16,7 @@ namespace AWSUtils.Tests.Streaming
     {
         private const string SQSStreamProviderName = "SQSProvider";
         private const string StreamNamespace = "SQSSubscriptionMultiplicityTestsNamespace";
-        private string StorageConnectionString = AWSTestConstants.SqsConnectionString;
+        private readonly string StorageConnectionString = AWSTestConstants.SqsConnectionString;
 
         private readonly ITestOutputHelper output;
         private ClientStreamTestRunner runner;
@@ -53,7 +48,7 @@ namespace AWSUtils.Tests.Streaming
             public void Configure(ISiloBuilder hostBuilder)
             {
                 hostBuilder
-                    .AddSqsStreams(SQSStreamProviderName, options => 
+                    .AddSqsStreams(SQSStreamProviderName, options =>
                     {
                         options.ConnectionString = AWSTestConstants.SqsConnectionString;
                     })

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -1,15 +1,10 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
 using AWSUtils.Tests.StorageTests;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.TestingHost;
 using OrleansAWSUtils.Streams;
-using Orleans.Hosting;
 using TestExtensions;
 using UnitTests.StreamingTests;
 
@@ -19,7 +14,7 @@ namespace AWSUtils.Tests.Streaming
     {
         private const string SQSStreamProviderName = "SQSProvider";
         private const string StreamNamespace = "SQSSubscriptionMultiplicityTestsNamespace";
-        private string StreamConnectionString = AWSTestConstants.SqsConnectionString;
+        private readonly string StreamConnectionString = AWSTestConstants.SqsConnectionString;
         private SubscriptionMultiplicityTestRunner runner;
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)

--- a/test/Extensions/Consul.Tests/ConsulTestUtils.cs
+++ b/test/Extensions/Consul.Tests/ConsulTestUtils.cs
@@ -10,7 +10,7 @@ namespace Consul.Tests
     public static class ConsulTestUtils
     {
         public static readonly string ConsulConnectionString = TestDefaultConfiguration.ConsulConnectionString;
-        private static readonly Lazy<bool> EnsureConsulLazy = new Lazy<bool>(() => EnsureConsulAsync().Result);
+        private static readonly Lazy<bool> EnsureConsulLazy = new(() => EnsureConsulAsync().Result);
 
         public static void EnsureConsul()
         {

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -24,14 +24,14 @@ namespace ServiceBus.Tests.EvictionStrategyTests
     [TestCategory("EventHub"), TestCategory("Streaming")]
     public class EHPurgeLogicTests
     {
-        private CachePressureInjectionMonitor cachePressureInjectionMonitor;
-        private PurgeDecisionInjectionPredicate purgePredicate;
-        private Serializer serializer;
+        private readonly CachePressureInjectionMonitor cachePressureInjectionMonitor;
+        private readonly PurgeDecisionInjectionPredicate purgePredicate;
+        private readonly Serializer serializer;
         private EventHubAdapterReceiver receiver1;
         private EventHubAdapterReceiver receiver2;
-        private ObjectPool<FixedSizeBuffer> bufferPool;
-        private TimeSpan timeOut = TimeSpan.FromSeconds(30);
-        private EventHubPartitionSettings ehSettings;
+        private readonly ObjectPool<FixedSizeBuffer> bufferPool;
+        private readonly TimeSpan timeOut = TimeSpan.FromSeconds(30);
+        private readonly EventHubPartitionSettings ehSettings;
         private NoOpHostEnvironmentStatistics _hostEnvironmentStatistics;
         private ConcurrentBag<EventHubQueueCacheForTesting> cacheList;
         private List<EHEvictionStrategyForTesting> evictionStrategyList;
@@ -161,7 +161,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             {
                 var purgedBufferList = strategy.InUseBuffers.ToArray<FixedSizeBuffer>();
                 //last one in purgedBufferList should be current buffer, which shouldn't be purged
-                for (int i = 0; i < purgedBufferList.Count() - 1; i++)
+                for (int i = 0; i < purgedBufferList.Length - 1; i++)
                     expectedPurgedBuffers.Add(purgedBufferList[i]);
             });
 

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
@@ -1,8 +1,6 @@
 using Orleans.Providers.Streams.Common;
 using Orleans.Streaming.EventHubs;
 using Orleans.Streams;
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Azure.Messaging.EventHubs;
@@ -13,15 +11,15 @@ namespace ServiceBus.Tests.EvictionStrategyTests
     {
         public EventHubQueueCacheForTesting(IObjectPool<FixedSizeBuffer> bufferPool, IEventHubDataAdapter dataAdapter, IEvictionStrategy evictionStrategy, IStreamQueueCheckpointer<string> checkpointer,
             ILogger logger)
-            :base("test", EventHubAdapterReceiver.MaxMessagesPerRead, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, null, null, null)
-            { }
+            : base("test", EventHubAdapterReceiver.MaxMessagesPerRead, bufferPool, dataAdapter, evictionStrategy, checkpointer, logger, null, null, null)
+        { }
 
         public int ItemCount => this.cache.ItemCount;
     }
     public class EHEvictionStrategyForTesting : ChronologicalEvictionStrategy
     {
         public EHEvictionStrategyForTesting(ILogger logger, ICacheMonitor cacheMonitor = null, TimeSpan? monitorWriteInterval = null, TimePurgePredicate timePurage = null)
-            :base(logger, timePurage, cacheMonitor, monitorWriteInterval)
+            : base(logger, timePurage, cacheMonitor, monitorWriteInterval)
         { }
 
         public Queue<FixedSizeBuffer> InUseBuffers => this.inUseBuffers;
@@ -30,8 +28,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
     public class MockEventHubCacheAdaptor : EventHubDataAdapter
     {
         private long sequenceNumberCounter = 0;
-        private int eventIndex = 1;
-        private string eventHubOffset = "OffSet";
+        private readonly int eventIndex = 1;
+        private readonly string eventHubOffset = "OffSet";
         public MockEventHubCacheAdaptor(Orleans.Serialization.Serializer serializer) : base(serializer)
         { }
 

--- a/test/Extensions/ServiceBus.Tests/Streaming/TimePurgePredicateTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/TimePurgePredicateTests.cs
@@ -1,5 +1,3 @@
-
-using System;
 using Orleans.Providers.Streams.Common;
 using Xunit;
 
@@ -9,8 +7,8 @@ namespace ServiceBus.Tests.StreamingTests
     {
         private static readonly TimeSpan MinTimeInCache = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan MaxRelitiveAgeInCache = TimeSpan.FromMinutes(30);
-        private static readonly TimePurgePredicate TimePurge = new TimePurgePredicate(MinTimeInCache, MaxRelitiveAgeInCache);
-        private static readonly DateTime CacheMaxEnqueTime = new DateTime(2000, 3, 12, 10, 13, 32, DateTimeKind.Utc);
+        private static readonly TimePurgePredicate TimePurge = new(MinTimeInCache, MaxRelitiveAgeInCache);
+        private static readonly DateTime CacheMaxEnqueTime = new(2000, 3, 12, 10, 13, 32, DateTimeKind.Utc);
         private static readonly DateTime NowUtc = DateTime.UtcNow;
 
         /// <summary>

--- a/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
+++ b/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
@@ -20,9 +20,9 @@ namespace ServiceBus.Tests.TestStreamProviders
         private readonly StreamCacheEvictionOptions evictionOptions;
         private readonly StreamStatisticOptions staticticOptions;
         private readonly EventHubOptions ehOptions;
-        private readonly CacheMonitorForTesting cacheMonitorForTesting = new CacheMonitorForTesting();
-        private readonly EventHubReceiverMonitorForTesting eventHubReceiverMonitorForTesting = new EventHubReceiverMonitorForTesting();
-        private readonly BlockPoolMonitorForTesting blockPoolMonitorForTesting = new BlockPoolMonitorForTesting();
+        private readonly CacheMonitorForTesting cacheMonitorForTesting = new();
+        private readonly EventHubReceiverMonitorForTesting eventHubReceiverMonitorForTesting = new();
+        private readonly BlockPoolMonitorForTesting blockPoolMonitorForTesting = new();
 
 
         public EHStreamProviderForMonitorTestsAdapterFactory(
@@ -95,7 +95,7 @@ namespace ServiceBus.Tests.TestStreamProviders
 
         private class CacheFactoryForMonitorTesting : EventHubQueueCacheFactory
         {
-            private CachePressureInjectionMonitor cachePressureInjectionMonitor;
+            private readonly CachePressureInjectionMonitor cachePressureInjectionMonitor;
             public CacheFactoryForMonitorTesting(
                 CachePressureInjectionMonitor cachePressureInjectionMonitor,
                 EventHubStreamCachePressureOptions cacheOptions,

--- a/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/Extensions/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -17,7 +17,7 @@ namespace ServiceBus.Tests.TestStreamProviders
 {
     public class EHStreamProviderWithCreatedCacheListAdapterFactory : EventDataGeneratorAdapterFactory
     {
-        private readonly ConcurrentBag<QueueCacheForTesting> createdCaches = new ConcurrentBag<QueueCacheForTesting>();
+        private readonly ConcurrentBag<QueueCacheForTesting> createdCaches = new();
         private readonly EventHubStreamCachePressureOptions cacheOptions;
         private readonly StreamStatisticOptions staticticOptions;
         private readonly EventHubOptions ehOptions;

--- a/test/Extensions/Tester.Cosmos/PersistenceProviderTests_Cosmos.cs
+++ b/test/Extensions/Tester.Cosmos/PersistenceProviderTests_Cosmos.cs
@@ -18,7 +18,7 @@ namespace Tester.Cosmos.Persistence;
 public class PersistenceProviderTests_Cosmos
 {
     private readonly IProviderRuntime providerRuntime;
-    private readonly Dictionary<string, string> providerCfgProps = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> providerCfgProps = new();
     private readonly ITestOutputHelper output;
     private readonly TestEnvironmentFixture fixture;
     private readonly string _clusterId;

--- a/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
+++ b/test/Extensions/Tester.Redis/Persistence/RedisPersistenceGrainTests.cs
@@ -56,7 +56,7 @@ namespace Tester.Redis.Persistence
             protected override void CheckPreconditionsOrThrow() => TestUtils.CheckForRedis();
         }
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public RedisPersistenceGrainTests(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {
@@ -84,8 +84,8 @@ namespace Tester.Redis.Persistence
 
         // Redis specific tests
 
-        private GrainState state;
-        private IDatabase database;
+        private readonly GrainState state;
+        private readonly IDatabase database;
 
         [SkippableFact]
         public async Task Redis_InitializeWithNoStateTest()

--- a/test/Extensions/Tester.Redis/Utility/TestExtensions.cs
+++ b/test/Extensions/Tester.Redis/Utility/TestExtensions.cs
@@ -30,7 +30,7 @@ namespace Tester.Redis.Utility
 
     public static class SiloAddressUtils
     {
-        private static readonly IPEndPoint localEndpoint = new IPEndPoint(IPAddress.Loopback, 0);
+        private static readonly IPEndPoint localEndpoint = new(IPAddress.Loopback, 0);
 
         public static SiloAddress NewLocalSiloAddress(int gen)
         {

--- a/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_MySql.cs
+++ b/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_MySql.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
@@ -62,7 +59,7 @@ namespace Tester.AdoNet.Persistence
             }
         }
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public PersistenceGrainTests_MySql(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {

--- a/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_Postgres.cs
+++ b/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_Postgres.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
@@ -62,7 +59,7 @@ namespace Tester.AdoNet.Persistence
             }
         }
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public PersistenceGrainTests_Postgres(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {

--- a/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_SqlServer.cs
+++ b/test/Extensions/TesterAdoNet/Persistence/PersistenceGrainTests_SqlServer.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
@@ -61,7 +58,7 @@ namespace Tester.AdoNet.Persistence
             }
         }
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public PersistenceGrainTests_SqlServer(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
@@ -1,19 +1,13 @@
-using System;
-using System.Collections.Generic;
 using System.Data.Common;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Orleans.Tests.SqlUtils;
 using Tester.RelationalUtilities;
-using Xunit.Sdk;
 
 namespace UnitTests.General
 {
     public abstract class RelationalStorageForTesting
     {
         private static readonly Dictionary<string, Func<string, RelationalStorageForTesting>> instanceFactory =
-            new Dictionary<string, Func<string, RelationalStorageForTesting>>
+            new()
             {
                 {AdoNetInvariants.InvariantNameSqlServer, cs => new SqlServerStorageForTesting(cs)},
                 {AdoNetInvariants.InvariantNameMySql, cs => new MySqlStorageForTesting(cs)},

--- a/test/Extensions/TesterAdoNet/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/TesterAdoNet/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -1,10 +1,6 @@
 //#define USE_SQL_SERVER
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.General;
@@ -24,7 +20,7 @@ namespace Tester.AdoNet.Reminders
     public class ReminderTests_AdoNet_SqlServer : ReminderTests_Base, IClassFixture<ReminderTests_AdoNet_SqlServer.Fixture>
     {
         private const string TestDatabaseName = "OrleansTest_SqlServer_Reminders";
-        private static string AdoInvariant = AdoNetInvariants.InvariantNameSqlServer;
+        private static readonly string AdoInvariant = AdoNetInvariants.InvariantNameSqlServer;
         private const string ConnectionStringKey = "ReminderConnectionString";
 
         public class Fixture : BaseTestClusterFixture
@@ -63,7 +59,7 @@ namespace Tester.AdoNet.Reminders
             var controlProxy = fixture.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             controlProxy.EraseReminderTable().WaitWithThrow(TestConstants.InitTimeout);
         }
-        
+
         // Basic tests
 
         [SkippableFact]

--- a/test/Extensions/TesterAzureUtils/AzureTableDataManagerStressTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureTableDataManagerStressTests.cs
@@ -16,8 +16,8 @@ namespace Tester.AzureUtils
     public class AzureTableDataManagerStressTests : AzureStorageBasicTests
     {
         private readonly ITestOutputHelper output;
-        private string PartitionKey;
-        private UnitTestAzureTableDataManager manager;
+        private readonly string PartitionKey;
+        private readonly UnitTestAzureTableDataManager manager;
 
         public AzureTableDataManagerStressTests(ITestOutputHelper output)
         {

--- a/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Net;
-using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables.Models;
 using Orleans.Clustering.AzureStorage;
@@ -12,8 +10,8 @@ namespace Tester.AzureUtils
     [TestCategory("AzureStorage"), TestCategory("Storage")]
     public class AzureTableDataManagerTests : AzureStorageBasicTests
     {
-        private string PartitionKey;
-        private UnitTestAzureTableDataManager manager;
+        private readonly string PartitionKey;
+        private readonly UnitTestAzureTableDataManager manager;
 
         private UnitTestAzureTableData GenerateNewData()
         {

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -1,17 +1,11 @@
 //#define REREAD_STATE_AFTER_WRITE_FAILED
 
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
-using Orleans;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using TestExtensions.Runners;
@@ -35,7 +29,7 @@ namespace Tester.AzureUtils.Persistence
         protected readonly ILogger logger;
         private const int LoopIterations_Grain = 1000;
         private const int BatchSize = 100;
-        private GrainPersistenceTestsRunner basicPersistenceTestsRunner;
+        private readonly GrainPersistenceTestsRunner basicPersistenceTestsRunner;
         private const int MaxReadTime = 200;
         private const int MaxWriteTime = 2000;
         public class SiloBuilderConfigurator : ISiloConfigurator
@@ -163,7 +157,7 @@ namespace Tester.AzureUtils.Persistence
                 grainAzureStore => grainAzureStore.DoRead());
         }
 
-       
+
         protected async Task Persistence_Silo_StorageProvider_Azure(string providerName)
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -1,16 +1,11 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading.Tasks;
 using Azure.Data.Tables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Internal;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -30,7 +25,7 @@ namespace Tester.AzureUtils.Persistence
     public class PersistenceProviderTests_Local
     {
         private readonly IProviderRuntime providerRuntime;
-        private readonly Dictionary<string, string> providerCfgProps = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> providerCfgProps = new();
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture fixture;
 

--- a/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Globalization;
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
@@ -33,7 +30,7 @@ namespace Tester.AzureUtils
             }
         }
 
-        private string clusterId;
+        private readonly string clusterId;
         private int generation;
         private SiloAddress siloAddress;
         private SiloInstanceTableEntry myEntry;
@@ -61,7 +58,7 @@ namespace Tester.AzureUtils
         // Use TestCleanup to run code after each test has run
         public void Dispose()
         {
-            if(manager != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
+            if (manager != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
             {
                 TimeSpan timeout = SiloInstanceTableTestConstants.Timeout;
 
@@ -201,16 +198,16 @@ namespace Tester.AzureUtils
             RegisterSiloInstance();
 
             var gateways = await manager.FindAllGatewayProxyEndpoints();
-            Assert.Equal(0,  gateways.Count);  // "Number of gateways before Silo.Activate"
+            Assert.Equal(0, gateways.Count);  // "Number of gateways before Silo.Activate"
 
             await manager.ActivateSiloInstance(myEntry);
 
             gateways = await manager.FindAllGatewayProxyEndpoints();
-            Assert.Equal(1,  gateways.Count);  // "Number of gateways after Silo.Activate"
+            Assert.Equal(1, gateways.Count);  // "Number of gateways after Silo.Activate"
 
             Uri myGateway = gateways.First();
-            Assert.Equal(myEntry.Address,  myGateway.Host.ToString());  // "Gateway address"
-            Assert.Equal(myEntry.ProxyPort,  myGateway.Port.ToString(CultureInfo.InvariantCulture));  // "Gateway port"
+            Assert.Equal(myEntry.Address, myGateway.Host.ToString());  // "Gateway address"
+            Assert.Equal(myEntry.ProxyPort, myGateway.Port.ToString(CultureInfo.InvariantCulture));  // "Gateway port"
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -232,7 +229,7 @@ namespace Tester.AzureUtils
 
             output.WriteLine("SiloAddress result = {0} From Row Key string = {1}", fromRowKey, MembershipRowKey);
 
-            Assert.Equal(siloAddress,  fromRowKey);
+            Assert.Equal(siloAddress, fromRowKey);
             Assert.Equal(SiloInstanceTableEntry.ConstructRowKey(siloAddress), SiloInstanceTableEntry.ConstructRowKey(fromRowKey));
         }
 
@@ -287,7 +284,7 @@ namespace Tester.AzureUtils
             Assert.Equal(referenceEntry.DeploymentId, entry.DeploymentId);
             Assert.Equal(referenceEntry.Address, entry.Address);
             Assert.Equal(referenceEntry.Port, entry.Port);
-            Assert.Equal(referenceEntry.Generation,  entry.Generation);
+            Assert.Equal(referenceEntry.Generation, entry.Generation);
             Assert.Equal(referenceEntry.HostName, entry.HostName);
             //Assert.Equal(referenceEntry.Status, entry.Status);
             Assert.Equal(referenceEntry.ProxyPort, entry.ProxyPort);

--- a/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -31,7 +31,7 @@ namespace Tester.AzureUtils.Streaming
         private const int NumMessagesPerBatch = 20;
         public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
         private readonly ILoggerFactory loggerFactory;
-        private static List<string> azureQueueNames = AzureQueueUtilities.GenerateQueueNames($"AzureQueueAdapterTests-{Guid.NewGuid()}", 8);
+        private static readonly List<string> azureQueueNames = AzureQueueUtilities.GenerateQueueNames($"AzureQueueAdapterTests-{Guid.NewGuid()}", 8);
 
         public AzureQueueAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {

--- a/test/Extensions/TesterAzureUtils/Utilities/AsyncPipeline.cs
+++ b/test/Extensions/TesterAzureUtils/Utilities/AsyncPipeline.cs
@@ -49,7 +49,7 @@ namespace Tester.AzureUtils.Utilities
         public AsyncPipeline(int capacity)
         {
             if (capacity < 1)
-                throw new ArgumentOutOfRangeException("capacity", "The pipeline size must be larger than 0.");
+                throw new ArgumentOutOfRangeException(nameof(capacity), "The pipeline size must be larger than 0.");
             running = new HashSet<Task>();
             waiting = new LinkedList<Tuple<Task, TaskCompletionSource<bool>>>();
             this.capacity = capacity;
@@ -124,7 +124,7 @@ namespace Tester.AzureUtils.Utilities
         internal void Add(Task task, WhiteBox whiteBox)
         {
             if (null == task)
-                throw new ArgumentNullException("task");
+                throw new ArgumentNullException(nameof(task));
 
             // whitebox testing results-- we initialize pipeSz with an inconsistent copy of Count because it's better than nothing and will reflect that the pipeline size was in a valid state during some portion of this method, even if it isn't at a properly synchronized moment.
             int pipeSz = Count;

--- a/test/Extensions/TesterZooKeeperUtils/ZookeeperTestUtils.cs
+++ b/test/Extensions/TesterZooKeeperUtils/ZookeeperTestUtils.cs
@@ -1,6 +1,4 @@
 using org.apache.zookeeper;
-using System;
-using System.Threading.Tasks;
 using TestExtensions;
 using Xunit;
 
@@ -8,7 +6,7 @@ namespace Tester.ZooKeeperUtils
 {
     public static class ZookeeperTestUtils
     {
-        private static readonly Lazy<bool> EnsureZooKeeperLazy = new Lazy<bool>(() => EnsureZooKeeperAsync().Result);
+        private static readonly Lazy<bool> EnsureZooKeeperLazy = new(() => EnsureZooKeeperAsync().Result);
 
         public static void EnsureZooKeeper()
         {

--- a/test/Grains/BenchmarkGrains/MapReduce/BufferGrain.cs
+++ b/test/Grains/BenchmarkGrains/MapReduce/BufferGrain.cs
@@ -9,7 +9,7 @@ namespace BenchmarkGrains.MapReduce
 {
     public class BufferGrain<T> : DataflowGrain, IBufferGrain<T>
     {
-        private readonly List<T> _items = new List<T>();
+        private readonly List<T> _items = new();
         public Task<GrainDataflowMessageStatus> OfferMessage(T messageValue, bool consumeToAccept)
         {
             throw new NotImplementedException();

--- a/test/Grains/BenchmarkGrains/MapReduce/TransformGrain.cs
+++ b/test/Grains/BenchmarkGrains/MapReduce/TransformGrain.cs
@@ -1,17 +1,12 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using BenchmarkGrainInterfaces.MapReduce;
-using Orleans;
 
 namespace BenchmarkGrains.MapReduce
 {
     public class TransformGrain<TInput, TOutput> : DataflowGrain, ITransformGrain<TInput, TOutput>
     {
         private ITransformProcessor<TInput, TOutput> _processor;
-        private bool _processingStarted ;
+        private bool _processingStarted;
         private bool _proccessingStopped;
 
         private const bool ProcessOnThreadPool = true;
@@ -20,9 +15,9 @@ namespace BenchmarkGrains.MapReduce
         private ITargetGrain<TOutput> _target;
 
         // BlockingCollection has shown worse perf results for this workload types
-        private readonly ConcurrentQueue<TInput> _input = new ConcurrentQueue<TInput>();
+        private readonly ConcurrentQueue<TInput> _input = new();
 
-        private readonly ConcurrentQueue<TOutput> _output = new ConcurrentQueue<TOutput>();
+        private readonly ConcurrentQueue<TOutput> _output = new();
 
         public Task Initialize(ITransformProcessor<TInput, TOutput> processor)
         {

--- a/test/Grains/BenchmarkGrains/Transaction/TransactionGrain.cs
+++ b/test/Grains/BenchmarkGrains/Transaction/TransactionGrain.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Orleans;
 using Orleans.Transactions.Abstractions;
 using BenchmarkGrainInterfaces.Transaction;
 
@@ -16,7 +13,7 @@ namespace BenchmarkGrains.Transaction
 
     public class TransactionGrain : Grain, ITransactionGrain
     {
-        private ITransactionalState<Info> info;
+        private readonly ITransactionalState<Info> info;
 
         public TransactionGrain(
             [TransactionalState("Info")] ITransactionalState<Info> info)

--- a/test/Grains/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -226,7 +222,7 @@ namespace UnitTests.GrainInterfaces
 
         [Id(5)]
         public IEchoGrain SomeGrainReference { get; set; }
-        
+
 #pragma warning disable 618
         public int GetObsoleteInt() => this.ObsoleteInt;
         public void SetObsoleteInt(int value)
@@ -318,7 +314,7 @@ namespace UnitTests.GrainInterfaces
     [Serializable]
     public class ClassWithNestedPrivateClassInListField
     {
-        private readonly List<NestedPrivateClass> coolBeans = new List<NestedPrivateClass>
+        private readonly List<NestedPrivateClass> coolBeans = new()
         {
             new NestedPrivateClass()
         };

--- a/test/Grains/TestGrainInterfaces/SerializerExclusions.cs
+++ b/test/Grains/TestGrainInterfaces/SerializerExclusions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-
 namespace Orleans.UnitTest.GrainInterfaces
 {
     [Serializable]
@@ -8,7 +5,7 @@ namespace Orleans.UnitTest.GrainInterfaces
     public class MyTypeWithAnInternalTypeField
     {
         [Id(0)]
-        private MyInternalDependency _dependency;
+        private readonly MyInternalDependency _dependency;
 
         public MyTypeWithAnInternalTypeField()
         {

--- a/test/Grains/TestGrains/ActivateDeactivateWatcherGrain.cs
+++ b/test/Grains/TestGrains/ActivateDeactivateWatcherGrain.cs
@@ -8,10 +8,10 @@ namespace UnitTests.Grains
 {
     internal class ActivateDeactivateWatcherGrain : IActivateDeactivateWatcherGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
-        private readonly List<string> activationCalls = new List<string>();
-        private readonly List<string> deactivationCalls = new List<string>();
+        private readonly List<string> activationCalls = new();
+        private readonly List<string> deactivationCalls = new();
 
         public ActivateDeactivateWatcherGrain(ILogger<ActivateDeactivateWatcherGrain> logger)
         {

--- a/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
+++ b/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
@@ -10,7 +10,7 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
     [StorageProvider(ProviderName = "SqlStore")]
     public class CustomerGrain : Grain<CustomerState>, ICustomerGrain
     {
-        private readonly Random _random = new Random();
+        private readonly Random _random = new();
 
         public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
@@ -34,7 +34,7 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
         public async Task AddDevice(IDeviceGrain device)
         {
             if (device == null)
-                throw new ArgumentNullException("device");
+                throw new ArgumentNullException(nameof(device));
 
             if (null == State.Devices)
                 State.Devices = new List<IDeviceGrain>();

--- a/test/Grains/TestGrains/AdoNet/DeviceGrain.cs
+++ b/test/Grains/TestGrains/AdoNet/DeviceGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.SqlUtils.StorageProvider.GrainInterfaces;
@@ -16,7 +16,7 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
         public async Task SetOwner(ICustomerGrain customer)
         {
             if (customer == null)
-                throw new ArgumentNullException("customer");
+                throw new ArgumentNullException(nameof(customer));
 
             State.Owner = customer;
 

--- a/test/Grains/TestGrains/ChainedGrain.cs
+++ b/test/Grains/TestGrains/ChainedGrain.cs
@@ -28,7 +28,7 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class ChainedGrain : Grain<ChainedGrainState>, IChainedGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ChainedGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestGrains/ConcurrentGrain.cs
+++ b/test/Grains/TestGrains/ConcurrentGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
 {
     public class ConcurrentGrain : Grain, IConcurrentGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private List<IConcurrentGrain> children;
         private int index;
         private int callNumber;
@@ -63,7 +63,7 @@ namespace UnitTests.Grains
             return Task.FromResult(1);
         }
 
-        private readonly List<int> m_list = new List<int>();
+        private readonly List<int> m_list = new();
 
         public Task<List<int>> ModifyReturnList_Test()
         {
@@ -115,7 +115,7 @@ namespace UnitTests.Grains
     [Reentrant]
     public class ConcurrentReentrantGrain : Grain, IConcurrentReentrantGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private int index;
         private TaskCompletionSource<int> resolver;
 

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
     public class ConsumerEventCountingGrain : Grain, IConsumerEventCountingGrain
     {
         private int _numConsumedItems;
-        private ILogger _logger;
+        private readonly ILogger _logger;
         private IAsyncObservable<int> _consumer;
         private StreamSubscriptionHandle<int> _subscriptionHandle;
         internal const string StreamNamespace = "HaloStreamingNamespace";
@@ -68,7 +68,7 @@ namespace UnitTests.Grains
             _logger.LogInformation("Consumer.BecomeConsumer");
             if (String.IsNullOrEmpty(providerToUse))
             {
-                throw new ArgumentNullException("providerToUse");
+                throw new ArgumentNullException(nameof(providerToUse));
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             IAsyncStream<int> stream = streamProvider.GetStream<int>(StreamNamespace, streamId);
@@ -96,7 +96,7 @@ namespace UnitTests.Grains
 
         public Task<int> GetNumberConsumed()
         {
-            return Task.FromResult(_numConsumedItems); 
+            return Task.FromResult(_numConsumedItems);
         }
     }
 }

--- a/test/Grains/TestGrains/FaultableConsumerGrain.cs
+++ b/test/Grains/TestGrains/FaultableConsumerGrain.cs
@@ -16,7 +16,7 @@ namespace UnitTests.Grains
         private int eventsConsumedCount;
         private int errorsCount;
         private int eventsFailedCount;
-        private ILogger logger;
+        private readonly ILogger logger;
         private StreamSubscriptionHandle<int> consumerHandle;
         private Stopwatch failPeriodTimer;
         private TimeSpan failPeriod;

--- a/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventCollectorGrain.cs
@@ -19,7 +19,7 @@ namespace TestGrains
     {
         public const string StreamNamespace = "Generated";
 
-        private ILogger logger;
+        private readonly ILogger logger;
         private IAsyncStream<GeneratedEvent> stream;
         private int accumulated;
 

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -11,7 +11,7 @@ namespace TestGrains
 {
     class GeneratedEventReporterGrain : Grain, IGeneratedEventReporterGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private Dictionary<Tuple<string, string>, Dictionary<Guid, int>> reports;
 

--- a/test/Grains/TestGrains/GeneratedStreamTestConstants.cs
+++ b/test/Grains/TestGrains/GeneratedStreamTestConstants.cs
@@ -5,7 +5,7 @@ namespace UnitTests.Grains
 {
     public class GeneratedStreamTestConstants
     {
-        public static Guid ReporterId = new Guid("f83247af-c14d-422c-8141-74d7a79717dc");
+        public static Guid ReporterId = new("f83247af-c14d-422c-8141-74d7a79717dc");
         public const string StreamProviderName = "GeneratedStreamProvider";
     }
 }

--- a/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -1,10 +1,5 @@
-
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Placement;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
@@ -19,16 +14,16 @@ namespace TestGrains
     public class ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain : Grain<StreamCheckpoint<int>>, IGeneratedEventCollectorGrain
     {
         public const string StreamNamespace = "NonTransientError_RecoverableStream";
-     
+
         // grain instance state
-        private ILogger logger;
+        private readonly ILogger logger;
         private IAsyncStream<GeneratedEvent> stream;
 
         private class FaultsState
         {
             public bool FaultCleared { get; set; }
         }
-        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new ConcurrentDictionary<Guid, FaultsState>();
+        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new();
         private FaultsState myFaults;
         private FaultsState Faults { get { return myFaults ?? (myFaults = FaultInjectionTracker.GetOrAdd(this.GetPrimaryKey(), key => new FaultsState())); } }
 
@@ -86,7 +81,7 @@ namespace TestGrains
             if (evt.EventType != GeneratedEvent.GeneratedEventType.Report)
             {
                 // every 10 events, checkpoint our grain state
-                if (State.Accumulator%10 != 0) return;
+                if (State.Accumulator % 10 != 0) return;
                 logger.LogInformation(
                     "Checkpointing: StreamGuid: {StreamGuid}, StreamNamespace: {StreamNamespace}, SequenceToken: {SequenceToken}, Accumulator: {Accumulator}",
                     State.StreamGuid,

--- a/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
@@ -1,12 +1,6 @@
-
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Providers;
 using Orleans.Providers.Streams.Generator;
-using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
 using UnitTests.Grains;
@@ -19,9 +13,9 @@ namespace TestGrains
     {
         public const string StreamNamespace = "RecoverableStream";
         public const string StorageProviderName = "AzureStorage";
-        
+
         // grain instance state
-        private ILogger logger;
+        private readonly ILogger logger;
         private IAsyncStream<GeneratedEvent> stream;
 
         public ImplicitSubscription_RecoverableStream_CollectorGrain(ILoggerFactory loggerFactory)

--- a/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -1,16 +1,10 @@
-
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Placement;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
-using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 
 namespace TestGrains
@@ -67,13 +61,13 @@ namespace TestGrains
             }
         }
 
-        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new ConcurrentDictionary<Guid, FaultsState>();
+        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new();
 
         private FaultsState myFaults;
         private FaultsState Faults { get { return myFaults ?? (myFaults = FaultInjectionTracker.GetOrAdd(this.GetPrimaryKey(), key => new FaultsState())); } }
-     
+
         // grain instance state
-        private ILogger logger;
+        private readonly ILogger logger;
         private IAsyncStream<GeneratedEvent> stream;
 
         public ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain(ILoggerFactory loggerFactory)
@@ -133,7 +127,7 @@ namespace TestGrains
                 Faults.onFirstMessageProcessedFault.TryFire(InjectFault);
                 Faults.on33rdMessageFault.TryFire(InjectFault);
                 // every 10 events, checkpoint our grain state
-                if (State.Accumulator%10 != 0) return;
+                if (State.Accumulator % 10 != 0) return;
                 logger.LogInformation(
                     "Checkpointing: StreamGuid: {StreamGuid}, StreamNamespace: {StreamNamespace}, SequenceToken: {SequenceToken}, Accumulator: {Accumulator}.",
                     State.StreamGuid,

--- a/test/Grains/TestGrains/KeyExtensionTestGrain.cs
+++ b/test/Grains/TestGrains/KeyExtensionTestGrain.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
-using Orleans;
-using UnitTests.GrainInterfaces;
+﻿using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
     internal class KeyExtensionTestGrain : Grain, IKeyExtensionTestGrain
     {
-        private Guid uniqueId = Guid.NewGuid();
+        private readonly Guid uniqueId = Guid.NewGuid();
 
         public Task<IKeyExtensionTestGrain> GetGrainReference()
         {

--- a/test/Grains/TestGrains/LivenessTestGrain.cs
+++ b/test/Grains/TestGrains/LivenessTestGrain.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -11,7 +6,7 @@ namespace UnitTests.Grains
     internal class LivenessTestGrain : Grain, ILivenessTestGrain
     {
         private string label;
-        private ILogger logger;
+        private readonly ILogger logger;
         private Guid uniqueId;
 
         public LivenessTestGrain(ILoggerFactory loggerFactory)
@@ -53,7 +48,7 @@ namespace UnitTests.Grains
         {
             logger.LogInformation("StartTimer.");
             base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
-            
+
             return Task.CompletedTask;
         }
 

--- a/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/test/Grains/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.Streams;
 using UnitTests.GrainInterfaces;
 
@@ -14,7 +9,7 @@ namespace UnitTests.Grains
     [ImplicitStreamSubscription("blue")]
     public class MultipleImplicitSubscriptionGrain : Grain, IMultipleImplicitSubscriptionGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private IAsyncStream<int> redStream, blueStream;
         private int redCounter, blueCounter;
 

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using UnitTests.GrainInterfaces;
@@ -13,8 +7,8 @@ namespace UnitTests.Grains
 {
     public class MultipleSubscriptionConsumerGrain : Grain, IMultipleSubscriptionConsumerGrain
     {
-        private readonly Dictionary<StreamSubscriptionHandle<int>, Tuple<Counter,Counter>> consumedMessageCounts;
-        private ILogger logger;
+        private readonly Dictionary<StreamSubscriptionHandle<int>, Tuple<Counter, Counter>> consumedMessageCounts;
+        private readonly ILogger logger;
         private int consumerCount = 0;
 
         public MultipleSubscriptionConsumerGrain(ILoggerFactory loggerFactory)
@@ -64,7 +58,7 @@ namespace UnitTests.Grains
                 e => OnError(e, countCapture, error));
 
             // track counter
-            consumedMessageCounts.Add(handle, Tuple.Create(count,error));
+            consumedMessageCounts.Add(handle, Tuple.Create(count, error));
 
             // return handle
             return handle;
@@ -73,11 +67,11 @@ namespace UnitTests.Grains
         public async Task<StreamSubscriptionHandle<int>> Resume(StreamSubscriptionHandle<int> handle)
         {
             logger.LogInformation("Resume");
-            if(handle == null)
-                throw new ArgumentNullException("handle");
+            if (handle == null)
+                throw new ArgumentNullException(nameof(handle));
 
             // new counter for this subscription
-            Tuple<Counter,Counter> counters;
+            Tuple<Counter, Counter> counters;
             if (!consumedMessageCounts.TryGetValue(handle, out counters))
             {
                 counters = Tuple.Create(new Counter(), new Counter());
@@ -120,7 +114,7 @@ namespace UnitTests.Grains
             return stream.GetAllSubscriptionHandles();
         }
 
-        public Task<Dictionary<StreamSubscriptionHandle<int>, Tuple<int,int>>> GetNumberConsumed()
+        public Task<Dictionary<StreamSubscriptionHandle<int>, Tuple<int, int>>> GetNumberConsumed()
         {
             logger.LogInformation(
                 "ConsumedMessageCounts = {Counts}",
@@ -156,7 +150,7 @@ namespace UnitTests.Grains
 
         private Task OnNext(IList<SequentialItem<int>> items, int countCapture, Counter count)
         {
-            foreach(SequentialItem<int> item in items)
+            foreach (SequentialItem<int> item in items)
             {
                 logger.LogInformation("Got next event {Item} on handle {Handle}", item.Item, countCapture);
                 var contextValue = RequestContext.Get(SampleStreaming_ProducerGrain.RequestContextKey) as string;

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.Streams;
 using UnitTests.GrainInterfaces;
 
@@ -13,7 +8,7 @@ namespace UnitTests.Grains
     {
         private IAsyncObserver<int> _producer;
         private int _numProducedItems;
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
         public ProducerEventCountingGrain(ILoggerFactory loggerFactory)
         {
@@ -39,7 +34,7 @@ namespace UnitTests.Grains
             _logger.LogInformation("Producer.BecomeProducer");
             if (String.IsNullOrEmpty(providerToUse))
             {
-                throw new ArgumentNullException("providerToUse");
+                throw new ArgumentNullException(nameof(providerToUse));
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             IAsyncStream<int> stream = streamProvider.GetStream<int>(ConsumerEventCountingGrain.StreamNamespace, streamId);
@@ -59,7 +54,7 @@ namespace UnitTests.Grains
             {
                 throw new ApplicationException("Not yet a producer on a stream.  Must call BecomeProducer first.");
             }
-            
+
             await _producer.OnNextAsync(_numProducedItems + 1);
 
             // update after send in case of error

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
@@ -1,12 +1,6 @@
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.Streams.Core;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -108,7 +102,7 @@ namespace UnitTests.Grains
     public class CounterObserver<T> : IAsyncObserver<T>, ICounterObserver
     {
         public int NumConsumed { get; private set; }
-        private ILogger logger;
+        private readonly ILogger logger;
         internal CounterObserver(ILogger logger)
         {
             this.NumConsumed = 0;

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -1,12 +1,6 @@
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.Streams;
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains.ProgrammaticSubscribe
@@ -43,7 +37,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
         public Task StartPeriodicProducing(TimeSpan? firePeriod = null)
         {
             logger.LogInformation("StartPeriodicProducing");
-            var period = (firePeriod == null)? defaultFirePeriod : firePeriod;
+            var period = (firePeriod == null) ? defaultFirePeriod : firePeriod;
             producerTimer = base.RegisterTimer(TimerCallback, null, TimeSpan.Zero, period.Value);
             return Task.CompletedTask;
         }
@@ -137,7 +131,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
     public class Apple : IFruit
     {
         [Id(0)]
-        int number;
+        readonly int number;
 
         public Apple(int number)
         {

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -39,7 +39,7 @@ namespace UnitTests.Grains
     {
         private INonReentrantGrain Self { get; set; }
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public NonRentrantGrain(ILoggerFactory loggerFactory)
         {
@@ -185,7 +185,7 @@ namespace UnitTests.Grains
     public class ReentrantSelfManagedGrain1 : Grain, IReentrantSelfManagedGrain
     {
         private long destination;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ReentrantSelfManagedGrain1(ILoggerFactory loggerFactory)
         {
@@ -232,7 +232,7 @@ namespace UnitTests.Grains
     public class NonReentrantSelfManagedGrain1 : Grain, INonReentrantSelfManagedGrain
     {
         private long destination;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public NonReentrantSelfManagedGrain1(ILoggerFactory loggerFactory)
         {
@@ -279,7 +279,7 @@ namespace UnitTests.Grains
     [Reentrant]
     public class FanOutGrain : Grain, IFanOutGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 
         public FanOutGrain(ILoggerFactory loggerFactory)
@@ -399,7 +399,7 @@ namespace UnitTests.Grains
     [Reentrant]
     public class FanOutACGrain : Grain, IFanOutACGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 
         public FanOutACGrain(ILoggerFactory loggerFactory)
@@ -516,7 +516,7 @@ namespace UnitTests.Grains
     [Reentrant]
     public class ReentrantTaskGrain : Grain, IReentrantTaskGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private long otherId;
         private int count;
 
@@ -554,7 +554,7 @@ namespace UnitTests.Grains
 
     public class NonReentrantTaskGrain : Grain, INonReentrantTaskGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private long otherId;
         private int count;
 

--- a/test/Grains/TestGrains/RequestContextTestGrain.cs
+++ b/test/Grains/TestGrains/RequestContextTestGrain.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
@@ -40,7 +36,7 @@ namespace UnitTests.Grains
 
     public class RequestContextTaskGrain : Grain, IRequestContextTaskGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public RequestContextTaskGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestGrains/SimpleDIGrain.cs
+++ b/test/Grains/TestGrains/SimpleDIGrain.cs
@@ -16,7 +16,7 @@ namespace UnitTests.Grains
         private readonly IInjectedScopedService injectedScopedService;
         private readonly IGrainFactory injectedGrainFactory;
         private readonly long grainFactoryId;
-        public static readonly ObjectIDGenerator ObjectIdGenerator = new ObjectIDGenerator();
+        public static readonly ObjectIDGenerator ObjectIdGenerator = new();
         private readonly IGrainContextAccessor grainContextAccessor;
         private IGrainContext originalGrainContext;
 

--- a/test/Grains/TestGrains/SimpleObserverableGrain.cs
+++ b/test/Grains/TestGrains/SimpleObserverableGrain.cs
@@ -10,7 +10,7 @@ namespace UnitTests.Grains
 {
     public class SimpleObserverableGrain : Grain, ISimpleObserverableGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         internal int A { get; set; }
         internal int B { get; set; }
         internal int EventDelay { get; set; }

--- a/test/Grains/TestGrains/SimplePersistentGrain.cs
+++ b/test/Grains/TestGrains/SimplePersistentGrain.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Grains
     /// </summary>
     public class SimplePersistentGrain : Grain<SimplePersistentGrain_State>, ISimplePersistentGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private Guid version;
         
         public SimplePersistentGrain(ILoggerFactory loggerFactory)

--- a/test/Grains/TestGrains/SimpleStreams/SimpleSubscriberGrain.cs
+++ b/test/Grains/TestGrains/SimpleStreams/SimpleSubscriberGrain.cs
@@ -28,8 +28,8 @@ namespace UnitTests.Grains.BroadcastChannel
 
     public abstract class SubscriberGrainBase : Grain, ISubscriberGrain, IOnBroadcastChannelSubscribed
     {
-        private Dictionary<ChannelId, List<int>> _values = new();
-        private Dictionary<ChannelId, List<Exception>> _errors = new();
+        private readonly Dictionary<ChannelId, List<int>> _values = new();
+        private readonly Dictionary<ChannelId, List<Exception>> _errors = new();
         private int _onPublishedCounter = 0;
         private bool _throwsOnReceive = false;
 

--- a/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
+++ b/test/Grains/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains
     /// </summary>
     public class SlowConsumingGrain : Grain, ISlowConsumingGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         public SlowObserver<int> ConsumerObserver { get; private set; }
         public StreamSubscriptionHandle<int> ConsumerHandle { get; set; }
 
@@ -62,8 +62,8 @@ namespace UnitTests.Grains
     public class SlowObserver<T> : IAsyncObserver<T>
     {
         public int NumConsumed { get; private set; }
-        private ILogger logger;
-        private SlowConsumingGrain slowConsumingGrain;
+        private readonly ILogger logger;
+        private readonly SlowConsumingGrain slowConsumingGrain;
         private StreamSequenceToken firstToken;
 
         internal SlowObserver(SlowConsumingGrain grain, ILogger logger)

--- a/test/Grains/TestGrains/StatelessWorkerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerGrain.cs
@@ -18,9 +18,9 @@ namespace UnitTests.Grains
         public const int MaxLocalWorkers = 1;
 
         private Guid activationGuid;
-        private readonly List<Tuple<DateTime, DateTime>> calls = new List<Tuple<DateTime, DateTime>>();
-        private ILogger logger;
-        private static HashSet<Guid> allActivationIds = new HashSet<Guid>();
+        private readonly List<Tuple<DateTime, DateTime>> calls = new();
+        private readonly ILogger logger;
+        private static readonly HashSet<Guid> allActivationIds = new();
 
         public StatelessWorkerGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains
         internal const int MaxLocalWorkers = 1;
         internal const string StreamNamespace = "StatelessWorkerStreamingNamespace";
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public StatelessWorkerStreamConsumerGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestGrains/StatelessWorkerStreamProducerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamProducerGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains
         internal const int MaxLocalWorkers = 1;
         internal const string StreamNamespace = "StatelessWorkerStreamingNamespace";
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public StatelessWorkerStreamProducerGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestGrains/StreamBatchingTestConsumerGrain.cs
+++ b/test/Grains/TestGrains/StreamBatchingTestConsumerGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains.Batching
     [ImplicitStreamSubscription(StreamBatchingTestConst.NonBatchingNameSpace)]
     public class BatchingStreamBatchingTestConsumerGrain : Grain, IStreamBatchingTestConsumerGrain, IStreamSubscriptionObserver
     {
-        private readonly ConsumptionReport report = new ConsumptionReport();
+        private readonly ConsumptionReport report = new();
         
         public Task<ConsumptionReport> GetConsumptionReport() => Task.FromResult(this.report);
 

--- a/test/Grains/TestGrains/StreamingHistoryGrain.cs
+++ b/test/Grains/TestGrains/StreamingHistoryGrain.cs
@@ -10,8 +10,8 @@ namespace UnitTests.Grains
 {
     public class StreamingHistoryGrain : Grain, IStreamingHistoryGrain, IAsyncObserver<int>
     {
-        private List<int> receivedItems = new List<int>();
-        private List<StreamSubscriptionHandle<int>> subscriptionHandles = new List<StreamSubscriptionHandle<int>>();
+        private readonly List<int> receivedItems = new();
+        private readonly List<StreamSubscriptionHandle<int>> subscriptionHandles = new();
 
         public async Task BecomeConsumer(StreamId streamId, string provider, string filterData = null)
         {

--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -13,15 +13,15 @@ namespace UnitTests.Grains
 {
     public class StuckGrain : Grain, IStuckGrain
     {
-        private static ConcurrentDictionary<GrainId, bool> ActivationCalls = new();
-        private static Dictionary<Guid, TaskCompletionSource<bool>> tcss = new Dictionary<Guid, TaskCompletionSource<bool>>();
-        private static Dictionary<Guid, int> counters = new Dictionary<Guid, int>();
-        private static HashSet<Guid> grains = new HashSet<Guid>();
+        private static readonly ConcurrentDictionary<GrainId, bool> ActivationCalls = new();
+        private static readonly Dictionary<Guid, TaskCompletionSource<bool>> tcss = new();
+        private static readonly Dictionary<Guid, int> counters = new();
+        private static readonly HashSet<Guid> grains = new();
         private readonly ILogger<StuckGrain> _log;
         private bool isDeactivatingBlocking = false;
 
-        private static ConcurrentDictionary<GrainId, ManualResetEventSlim> blockingMREMap =
-            new ConcurrentDictionary<GrainId, ManualResetEventSlim>();
+        private static readonly ConcurrentDictionary<GrainId, ManualResetEventSlim> blockingMREMap =
+            new();
 
         public StuckGrain(ILogger<StuckGrain> log)
         {

--- a/test/Grains/TestGrains/VersionAwarePlacementDirector.cs
+++ b/test/Grains/TestGrains/VersionAwarePlacementDirector.cs
@@ -5,7 +5,7 @@ namespace UnitTests.Grains
 {
     public class VersionAwarePlacementDirector : IPlacementDirector
     {
-        private readonly Random random = new Random();
+        private readonly Random random = new();
 
         public Task<SiloAddress> OnAddActivation(PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {

--- a/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
 {
     internal class SimpleActivateDeactivateTestGrain : Grain, ISimpleActivateDeactivateTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private IActivateDeactivateWatcherGrain watcher;
 
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
 
     internal class TailCallActivateDeactivateTestGrain : Grain, ITailCallActivateDeactivateTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private IActivateDeactivateWatcherGrain watcher;
 
@@ -130,7 +130,7 @@ namespace UnitTests.Grains
 
     internal class LongRunningActivateDeactivateTestGrain : Grain, ILongRunningActivateDeactivateTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private IActivateDeactivateWatcherGrain watcher;
 
@@ -215,7 +215,7 @@ namespace UnitTests.Grains
 
     internal class TaskActionActivateDeactivateTestGrain : Grain, ITaskActionActivateDeactivateTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private IActivateDeactivateWatcherGrain watcher;
 
@@ -324,7 +324,7 @@ namespace UnitTests.Grains
 
     public class BadActivateDeactivateTestGrain : Grain, IBadActivateDeactivateTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public BadActivateDeactivateTestGrain(ILoggerFactory loggerFactory)
         {
@@ -382,7 +382,7 @@ namespace UnitTests.Grains
 
     internal class DeactivatingWhileActivatingTestGrain : Grain, IDeactivatingWhileActivatingTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public DeactivatingWhileActivatingTestGrain(ILoggerFactory loggerFactory)
         {
@@ -411,7 +411,7 @@ namespace UnitTests.Grains
 
     internal class CreateGrainReferenceTestGrain : Grain, ICreateGrainReferenceTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         //private IEchoGrain orleansManagedGrain;
         private ITestGrain grain;

--- a/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
         {
             if (0 == count)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             burstCount = count;

--- a/test/Grains/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/Grains/TestInternalGrains/EchoTaskGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class EchoGrain : Grain<EchoTaskGrainState>, IEchoGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public EchoGrain(ILoggerFactory loggerFactory)
         {
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
     {
         private readonly IInternalGrainFactory internalGrainFactory;
         private readonly IGrainContext _grainContext;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public EchoTaskGrain(IInternalGrainFactory internalGrainFactory, ILogger<EchoTaskGrain> logger, IGrainContext grainContext)
         {
@@ -212,7 +212,7 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class BlockingEchoTaskGrain : Grain<EchoTaskGrainState>, IBlockingEchoTaskGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public BlockingEchoTaskGrain(ILoggerFactory loggerFactory)
         {
@@ -305,7 +305,7 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class ReentrantBlockingEchoTaskGrain : Grain<EchoTaskGrainState>, IReentrantBlockingEchoTaskGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ReentrantBlockingEchoTaskGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestInternalGrains/InterlockedFlag.cs
+++ b/test/Grains/TestInternalGrains/InterlockedFlag.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 
 namespace UnitTests.TestHelper
@@ -32,7 +32,7 @@ namespace UnitTests.TestHelper
         public void ThrowDisposedIfSet(Type type)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             if (IsSet)
                 throw new ObjectDisposedException(type.Name);
         }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -703,7 +703,7 @@ namespace UnitTests.Grains
         private IReentrentGrainWithState _other;
         private IGrainContext _context;
         private TaskScheduler _scheduler;
-        private ILogger logger;
+        private readonly ILogger logger;
         private bool executing;
         private Task outstandingWriteStateOperation;
 
@@ -1030,7 +1030,7 @@ namespace UnitTests.Grains
     [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
     internal class InternalGrainWithState : Grain<InternalGrainStateData>, IInternalGrainWithState
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public InternalGrainWithState(ILoggerFactory loggerFactory)
         {
@@ -1064,7 +1064,7 @@ namespace UnitTests.Grains
     [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
     public class StateInheritanceTestGrain : Grain<StateInheritanceTestGrainData>, IStateInheritanceTestGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public StateInheritanceTestGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/Grains/TestInternalGrains/PlacementTestGrain.cs
@@ -204,7 +204,7 @@ namespace UnitTests.Grains
     [PreferLocalPlacement]
     public class LocalContentGrain : Grain, ILocalContentGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
         private object cachedContent;
         internal static ILocalContentGrain InstanceIdForThisSilo;
 
@@ -236,7 +236,7 @@ namespace UnitTests.Grains
 
     public class TestContentGrain : Grain, ITestContentGrain
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public TestContentGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -127,7 +127,7 @@ namespace UnitTests.Grains
 
         protected void InitStream(StreamId streamId, string providerToUse)
         {
-            if (providerToUse == null) throw new ArgumentNullException("providerToUse", "Can't have null stream provider name");
+            if (providerToUse == null) throw new ArgumentNullException(nameof(providerToUse), "Can't have null stream provider name");
 
             if (State.Stream != null && !State.Stream.StreamId.Equals(streamId))
             {

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -61,7 +61,7 @@ namespace UnitTests.Grains
 #endif
     {
         [NonSerialized]
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private readonly IGrainContext _grainContext;
 
@@ -360,7 +360,7 @@ namespace UnitTests.Grains
     public class StreamUnsubscribeTestGrain : Grain<StreamReliabilityTestGrainState>, IStreamUnsubscribeTestGrain
     {
         [NonSerialized]
-        private ILogger logger;
+        private readonly ILogger logger;
 
         private const string StreamNamespace = StreamTestsConstants.StreamReliabilityNamespace;
 

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -65,7 +65,7 @@ namespace UnitTests.Grains
         public static ConsumerObserver NewObserver(ILogger logger)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new ConsumerObserver(logger);
         }
 
@@ -199,7 +199,7 @@ namespace UnitTests.Grains
         public static ProducerObserver NewObserver(ILogger logger, IGrainFactory grainFactory)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new ProducerObserver(logger, grainFactory);
         }
 
@@ -246,7 +246,7 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             if (0 >= count)
-                throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(count), "The count must be greater than zero.");
             _expectedItemsProduced += count;
             _logger.LogInformation("ProducerObserver.ProduceSequentialSeries: StreamId={StreamId}, num items to produce={Count}.", _streamId, count);
             for (var i = 1; i <= count; ++i)
@@ -258,7 +258,7 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             if (0 >= count)
-                throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(count), "The count must be greater than zero.");
             _logger.LogInformation("ProducerObserver.ProduceParallelSeries: streamId={StreamId}, num items to produce={Count}.", _streamId, count);
             _expectedItemsProduced += count;
             var tasks = new Task<bool>[count];
@@ -302,7 +302,7 @@ namespace UnitTests.Grains
         {
             _logger.LogInformation("ProducerObserver.RemoveTimer: streamId={StreamId}.", _streamId);
             if (handle == null)
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
             if (!_timers.Remove(handle))
                 throw new InvalidOperationException("handle not found");
         }
@@ -402,13 +402,13 @@ namespace UnitTests.Grains
             public static TimerState NewTimer(Func<Func<object, Task>, IDisposable> startTimerFunc, Func<string, Task<bool>> produceItemFunc, Action<IDisposable> onDisposeFunc, int count)
             {
                 if (null == startTimerFunc)
-                    throw new ArgumentNullException("startTimerFunc");
+                    throw new ArgumentNullException(nameof(startTimerFunc));
                 if (null == produceItemFunc)
-                    throw new ArgumentNullException("produceItemFunc");
+                    throw new ArgumentNullException(nameof(produceItemFunc));
                 if (null == onDisposeFunc)
-                    throw new ArgumentNullException("onDisposeFunc");
+                    throw new ArgumentNullException(nameof(onDisposeFunc));
                 if (0 >= count)
-                    throw new ArgumentOutOfRangeException("count", count, "argument must be > 0");
+                    throw new ArgumentOutOfRangeException(nameof(count), count, "argument must be > 0");
                 var newOb = new TimerState(produceItemFunc, onDisposeFunc, count);
                 newOb.Handle = startTimerFunc(newOb.OnTickAsync);
                 if (null == newOb.Handle)
@@ -926,7 +926,7 @@ namespace UnitTests.Grains
 
             if (string.IsNullOrWhiteSpace(streamNamespace))
             {
-                throw new ArgumentException("namespace is required (must not be null or whitespace)", "streamNamespace");
+                throw new ArgumentException("namespace is required (must not be null or whitespace)", nameof(streamNamespace));
             }
 
             ConsumerObserver consumerObserver = ConsumerObserver.NewObserver(_logger);

--- a/test/Grains/TestInternalGrains/StressTestGrain.cs
+++ b/test/Grains/TestInternalGrains/StressTestGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Grains
     {
         private string label;
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public StressTestGrain(ILoggerFactory loggerFactory)
         {
@@ -114,7 +114,7 @@ namespace UnitTests.Grains
     internal class ReentrantStressTestGrain : Grain, IReentrantStressTestGrain
     {
         private string label;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ReentrantStressTestGrain(ILoggerFactory loggerFactory)
         {
@@ -271,7 +271,7 @@ namespace UnitTests.Grains
     public class ReentrantLocalStressTestGrain : Grain, IReentrantLocalStressTestGrain
     {
         private string label;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ReentrantLocalStressTestGrain(ILoggerFactory loggerFactory)
         {

--- a/test/Grains/TestInternalGrains/TestExtension.cs
+++ b/test/Grains/TestInternalGrains/TestExtension.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-using Orleans;
-using UnitTests.GrainInterfaces;
+﻿using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
@@ -30,7 +28,7 @@ namespace UnitTests.Grains
 
     public class SimpleExtension : ISimpleExtension
     {
-        private string someString;
+        private readonly string someString;
 
         public SimpleExtension(string someString)
         {
@@ -42,7 +40,7 @@ namespace UnitTests.Grains
             return Task.FromResult(someString);
         }
     }
-    
+
     public class AutoExtension : IAutoExtension
     {
         public Task<string> CheckExtension()

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
 using UnitTests.GrainInterfaces;
@@ -16,7 +10,7 @@ namespace UnitTests.Grains
     {
         private readonly string _id = Guid.NewGuid().ToString();
         private string label;
-        private ILogger logger;
+        private readonly ILogger logger;
         private IDisposable timer;
 
         public TestGrain(ILoggerFactory loggerFactory)
@@ -85,14 +79,14 @@ namespace UnitTests.Grains
 
             var task = Task.Factory.StartNew(() =>
             {
-                bar1 = (string) RequestContext.Get("jarjar");
+                bar1 = (string)RequestContext.Get("jarjar");
                 logger.LogInformation("bar = {Bar}.", bar1);
             });
 
             string bar2 = null;
             var ac = Task.Factory.StartNew(() =>
             {
-                bar2 = (string) RequestContext.Get("jarjar");
+                bar2 = (string)RequestContext.Get("jarjar");
                 logger.LogInformation("bar = {Bar}.", bar2);
             });
 
@@ -163,7 +157,7 @@ namespace UnitTests.Grains
         private readonly string _id = Guid.NewGuid().ToString();
 
         private string label;
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public GuidTestGrain(ILoggerFactory loggerFactory)
         {
@@ -214,7 +208,7 @@ namespace UnitTests.Grains
         private int count;
         private TaskCompletionSource<string> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private IOneWayGrain other;
-        private GrainLocator grainLocator;
+        private readonly GrainLocator grainLocator;
         private int _numSignals;
 
         public OneWayGrain(GrainLocator grainLocator) => this.grainLocator = grainLocator;

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -19,10 +19,10 @@ namespace UnitTestGrains
         Dictionary<string, IDisposable> allTimers;
         IDisposable defaultTimer;
         private static readonly TimeSpan period = TimeSpan.FromMilliseconds(100);
-        string DefaultTimerName = "DEFAULT TIMER";
+        readonly string DefaultTimerName = "DEFAULT TIMER";
         IGrainContext context;
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public TimerGrain(ILoggerFactory loggerFactory)
         {
@@ -58,16 +58,10 @@ namespace UnitTestGrains
                 logger.LogError((int)ErrorCode.Runtime_Error_100146, "Grain not running in the right activation context");
 
             string name = (string)data;
-            IDisposable timer;
-            if (name == DefaultTimerName)
-            {
-                timer = defaultTimer;
-            }
-            else
-            {
-                timer = allTimers[(string)data];
-            }
-            if(timer == null)
+            var timer = name == DefaultTimerName
+                ? defaultTimer
+                : allTimers[(string)data];
+            if (timer == null)
                 logger.LogError((int)ErrorCode.Runtime_Error_100146, "Timer is null");
             if (timer != null && counter > 10000)
             {
@@ -142,7 +136,7 @@ namespace UnitTestGrains
         private IGrainContext context;
         private TaskScheduler activationTaskScheduler;
 
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public TimerCallGrain(ILoggerFactory loggerFactory)
         {

--- a/test/NonSilo.Tests/Async_AsyncExecutorWithRetriesTests.cs
+++ b/test/NonSilo.Tests/Async_AsyncExecutorWithRetriesTests.cs
@@ -26,7 +26,7 @@ namespace NonSilo.Tests
         public void Async_AsyncExecutorWithRetriesTest_1()
         {
             int counter = 0;
-            Func<int, Task<int>> myFunc = ((int funcCounter) =>
+            Func<int, Task<int>> myFunc = (int funcCounter) =>
             {
                 // ReSharper disable AccessToModifiedClosure
                 Assert.Equal(counter, funcCounter);
@@ -37,11 +37,11 @@ namespace NonSilo.Tests
                 else
                     throw new ArgumentException("Wrong arg!");
                 // ReSharper restore AccessToModifiedClosure
-            });
-            Func<Exception, int, bool> errorFilter = ((Exception exc, int i) =>
+            };
+            Func<Exception, int, bool> errorFilter = (Exception exc, int i) =>
             {
                 return true;
-            });
+            };
 
             Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(myFunc, 10, 10, null, errorFilter);
             int value = promise.Result;
@@ -98,19 +98,19 @@ namespace NonSilo.Tests
         {
             int counter = 0;
             int lastIteration = 0;
-            Func<int, Task<int>> myFunc = ((int funcCounter) =>
+            Task<int> myFunc(int funcCounter)
             {
                 lastIteration = funcCounter;
                 Assert.Equal(counter, funcCounter);
                 this.output.WriteLine("Running for {0} time.", counter);
                 return Task.FromResult(++counter);
-            });
-            Func<Exception, int, bool> errorFilter = ((Exception exc, int i) =>
+            }
+            bool errorFilter(Exception exc, int i)
             {
                 Assert.Equal(lastIteration, i);
                 Assert.True(false, "Should not be called");
                 return true;
-            });
+            }
 
             int maxRetries = 5;
             Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -391,7 +391,7 @@ namespace UnitTests.Directory
 
         private class NoOpClusterManifestProvider : IClusterManifestProvider
         {
-            public ClusterManifest Current => new ClusterManifest(
+            public ClusterManifest Current => new(
                 MajorMinorVersion.Zero,
                 ImmutableDictionary<SiloAddress, GrainManifest>.Empty,
                 ImmutableArray.Create(new GrainManifest(ImmutableDictionary<GrainType, GrainProperties>.Empty, ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty)));

--- a/test/NonSilo.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/NonSilo.Tests/Directory/ClientDirectoryTests.cs
@@ -36,7 +36,7 @@ namespace NonSilo.Tests.Directory
         private readonly ClientDirectory _directory;
         private readonly ClientDirectory.TestAccessor _testAccessor;
         private readonly IConnectedClientCollection _connectedClientCollection;
-        private readonly ConcurrentDictionary<SiloAddress, IRemoteClientDirectory> _remoteDirectories = new ConcurrentDictionary<SiloAddress, IRemoteClientDirectory>();
+        private readonly ConcurrentDictionary<SiloAddress, IRemoteClientDirectory> _remoteDirectories = new();
         private long _expectedConnectedClientsVersion;
 
         public ClientDirectoryTests()

--- a/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
+++ b/test/NonSilo.Tests/Directory/MockClusterMembershipService.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Runtime.Utilities;
 
@@ -11,7 +7,7 @@ namespace UnitTests.Directory
     internal class MockClusterMembershipService : IClusterMembershipService
     {
         private long version = 0;
-        private Dictionary<SiloAddress, (SiloStatus Status, string Name)> statuses;
+        private readonly Dictionary<SiloAddress, (SiloStatus Status, string Name)> statuses;
         private ClusterMembershipSnapshot snapshot;
         private readonly AsyncEnumerable<ClusterMembershipSnapshot> updates;
 
@@ -50,7 +46,7 @@ namespace UnitTests.Directory
             return new ClusterMembershipSnapshot(dictBuilder.ToImmutable(), new MembershipVersion(version));
         }
 
-        public ValueTask Refresh(MembershipVersion minimumVersion = default) => new ValueTask();
+        public ValueTask Refresh(MembershipVersion minimumVersion = default) => new();
 
         public Task<bool> TryKill(SiloAddress siloAddress) => throw new NotImplementedException();
     }

--- a/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
@@ -1,21 +1,16 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
 using Xunit;
 using Tester;
-using Orleans.Internal;
 
 namespace UnitTests.General
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RequestContextTests_Local : IDisposable
     {
-        private readonly Dictionary<string, object> headers = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> headers = new();
 
 
         private readonly TestEnvironmentFixture fixture;

--- a/test/NonSilo.Tests/General/RingTests_Standalone.cs
+++ b/test/NonSilo.Tests/General/RingTests_Standalone.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
 using Orleans.Runtime.ConsistentRing;
@@ -71,8 +69,8 @@ namespace UnitTests.General
 
         private void TestChurn(int[] indexesFails, int[] indexesJoins)
         {
-            Dictionary<SiloAddress, ConsistentRingProvider> rings, holder = new Dictionary<SiloAddress, ConsistentRingProvider>();
-            List<SiloAddress> sortedServers, fail = new List<SiloAddress>();
+            Dictionary<SiloAddress, ConsistentRingProvider> rings, holder = new();
+            List<SiloAddress> sortedServers, fail = new();
 
             rings = CreateServers(count);
 
@@ -208,12 +206,14 @@ namespace UnitTests.General
     internal class RangeBreakable
     {
         private List<SingleRange> ranges { get; set; }
-        internal int NumRanges { get { return ranges.Count(); } }
+        internal int NumRanges => ranges.Count;
 
         public RangeBreakable()
         {
-            ranges = new List<SingleRange>(1);
-            ranges.Add(RangeFactory.CreateFullRange() as SingleRange);
+            ranges = new List<SingleRange>(1)
+            {
+                RangeFactory.CreateFullRange() as SingleRange
+            };
         }
 
         public bool Remove(IRingRange range)

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -363,7 +363,7 @@ namespace NonSilo.Tests.Membership
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new MembershipEntry { SiloAddress = address, Status = status };
+        private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new() { SiloAddress = address, Status = status };
 
         private static async Task UntilEqual<T>(T expected, Func<T> getActual)
         {

--- a/test/NonSilo.Tests/Membership/InMemoryMembershipTable.cs
+++ b/test/NonSilo.Tests/Membership/InMemoryMembershipTable.cs
@@ -1,10 +1,6 @@
-using System.Threading.Tasks;
 using Orleans.Runtime;
-using System;
 using Orleans;
-using System.Linq;
 using System.Collections.Immutable;
-using System.Collections.Generic;
 
 namespace NonSilo.Tests.Membership
 {
@@ -13,10 +9,10 @@ namespace NonSilo.Tests.Membership
     /// </summary>
     public class InMemoryMembershipTable : IMembershipTable
     {
-        private readonly object tableLock = new object();
-        private readonly List<(string, object)> calls = new List<(string, object)>();
+        private readonly object tableLock = new();
+        private readonly List<(string, object)> calls = new();
         private ImmutableList<(MembershipEntry, string)> entries = ImmutableList<(MembershipEntry, string)>.Empty;
-        private TableVersion version = new TableVersion(0, "0");
+        private TableVersion version = new(0, "0");
 
         public InMemoryMembershipTable() { }
 

--- a/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
+++ b/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
@@ -1,9 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
@@ -350,7 +345,7 @@ namespace NonSilo.Tests.Membership
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new MembershipEntry { SiloAddress = address, Status = status, StartTime = DateTime.UtcNow, IAmAliveTime = DateTime.UtcNow };
+        private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new() { SiloAddress = address, Status = status, StartTime = DateTime.UtcNow, IAmAliveTime = DateTime.UtcNow };
 
         private static async Task Until(Func<bool> condition)
         {

--- a/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/SiloHealthMonitorTests.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
@@ -34,7 +29,7 @@ namespace NonSilo.Tests.Membership
         private readonly ILocalSiloHealthMonitor _localSiloHealthMonitor;
         private readonly IRemoteSiloProber _prober;
         private readonly IClusterMembershipService _membershipService;
-        private ClusterMembershipOptions _clusterMembershipOptions;
+        private readonly ClusterMembershipOptions _clusterMembershipOptions;
         private readonly IOptionsMonitor<ClusterMembershipOptions> _optionsMonitor;
         private readonly Channel<ProbeResult> _probeResults;
         private readonly SiloHealthMonitor _monitor;
@@ -280,13 +275,13 @@ namespace NonSilo.Tests.Membership
         }
 
         private static ClusterMembershipSnapshot Snapshot(long version, params ClusterMember[] members)
-            => new ClusterMembershipSnapshot(
+            => new(
                 ImmutableDictionary.CreateRange(
                     members.Select(m => new KeyValuePair<SiloAddress, ClusterMember>(m.SiloAddress, m))),
                 new MembershipVersion(version));
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static ClusterMember Member(SiloAddress address, SiloStatus status) => new ClusterMember(address, status, address.ToString());
+        private static ClusterMember Member(SiloAddress address, SiloStatus status) => new(address, status, address.ToString());
     }
 }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Internal;
@@ -19,7 +16,7 @@ namespace UnitTests.SchedulerTests
 {
     public class OrleansTaskSchedulerAdvancedTests_Set2 : IDisposable
     {
-        private static readonly object Lockable = new object();
+        private static readonly object Lockable = new();
         private static readonly int WaitFactor = Debugger.IsAttached ? 100 : 1;
         private readonly ITestOutputHelper output;
         private readonly UnitTestSchedulingContext context;
@@ -33,7 +30,7 @@ namespace UnitTests.SchedulerTests
             this.context = new UnitTestSchedulingContext();
             this.performanceMetrics = new TestHooksHostEnvironmentStatistics();
         }
-        
+
         public void Dispose()
         {
             this.loggerFactory.Dispose();
@@ -629,7 +626,7 @@ namespace UnitTests.SchedulerTests
                 }
 
                 bool ok = resultHandles[i].Task.Result;
-                
+
                 try
                 {
                     // since resultHandle being complete doesn't directly imply that the final chain was completed (there's a chance for a race condition), give a small chance for it to complete.
@@ -702,7 +699,7 @@ namespace UnitTests.SchedulerTests
             {
                 this.output.WriteLine("#0 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                     SynchronizationContext.Current, TaskScheduler.Current);
-                
+
                 Task t1 = grain.Test1();
 
                 Action wrappedDoneAction = () => { wrappedDone.SetResult(true); };
@@ -723,7 +720,7 @@ namespace UnitTests.SchedulerTests
             });
             wrapper.Start(scheduler);
             await wrapper;
-            
+
             var timeoutLimit = TimeSpan.FromSeconds(1);
             try
             {

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Runtime.Scheduler;
@@ -9,9 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Orleans.TestingHost.Utils;
 using Orleans.Internal;
-using System.Collections.Generic;
 using Orleans;
-using Orleans.Core;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -57,12 +52,12 @@ namespace UnitTests.SchedulerTests
         void IGrainContext.Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
         void IGrainContext.Migrate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken) => throw new NotImplementedException();
     }
-    
+
     [TestCategory("BVT"), TestCategory("Scheduler")]
     public class OrleansTaskSchedulerBasicTests : IDisposable
     {
         private readonly ITestOutputHelper output;
-        private static readonly object Lockable = new object();
+        private static readonly object Lockable = new();
         private readonly UnitTestSchedulingContext rootContext;
         private readonly ILoggerFactory loggerFactory;
         public OrleansTaskSchedulerBasicTests(ITestOutputHelper output)
@@ -73,7 +68,7 @@ namespace UnitTests.SchedulerTests
             this.rootContext = new UnitTestSchedulingContext();
             rootContext.Scheduler = SchedulingHelper.CreateWorkItemGroupForTesting(this.rootContext, this.loggerFactory);
         }
-        
+
         public void Dispose()
         {
             SynchronizationContext.SetSynchronizationContext(null);
@@ -234,7 +229,7 @@ namespace UnitTests.SchedulerTests
             Assert.False(t1.IsFaulted, "Task-1 faulted: " + t1.Exception);
             Assert.True(result1.Task.Result, "Task-1 completed");
         }
-                
+
         [Fact]
         public async Task Sched_Task_SubTaskExecutionSequencing()
         {
@@ -245,7 +240,7 @@ namespace UnitTests.SchedulerTests
 
             int n = 0;
             TaskCompletionSource<int> finished = new TaskCompletionSource<int>();
-            var numCompleted = new[] {0};
+            var numCompleted = new[] { 0 };
             Action closure = () =>
             {
                 LogContext("ClosureWorkItem-task " + Task.CurrentId);
@@ -291,7 +286,7 @@ namespace UnitTests.SchedulerTests
             Assert.True(n != 0, "Work items did not get executed");
             Assert.Equal(10, n);  // "Work items executed concurrently"
         }
-        
+
         [Fact]
         public void Sched_AC_RequestContext_StartNew_ContinueWith()
         {

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -418,7 +418,7 @@ namespace UnitTests.Serialization
 
         private class BanningTypeResolver : TypeResolver
         {
-            private readonly CachedTypeResolver _resolver = new CachedTypeResolver();
+            private readonly CachedTypeResolver _resolver = new();
             private readonly HashSet<Type> _blockedTypes;
 
             public BanningTypeResolver(params Type[] blockedTypes)

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -1448,7 +1448,7 @@ namespace Orleans.Serialization.UnitTests
         {
         }
 
-        protected override Int128 CreateValue() => new Int128(unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
+        protected override Int128 CreateValue() => new(unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
         protected override Int128[] TestValues => new Int128[]
         {
@@ -2158,7 +2158,7 @@ namespace Orleans.Serialization.UnitTests
     {
         protected override int[] MaxSegmentSizes => new[] { 1024 };
         private int _nextComparer;
-        private IEqualityComparer<string>[] _comparers = new IEqualityComparer<string>[]
+        private readonly IEqualityComparer<string>[] _comparers = new IEqualityComparer<string>[]
         {
             new CaseInsensitiveEqualityComparer(),
 #if NETCOREAPP3_1_OR_GREATER
@@ -2439,15 +2439,9 @@ namespace Orleans.Serialization.UnitTests
 
         protected override IPAddress CreateValue()
         {
-            byte[] bytes;
-            if (Random.Next(1) == 0)
-            {
-                bytes = new byte[4];
-            }
-            else
-            {
-                bytes = new byte[16];
-            }
+            var bytes = Random.Next(1) == 0
+                ? (new byte[4])
+                : (new byte[16]);
             Random.NextBytes(bytes);
             return new IPAddress(bytes);
         }
@@ -2463,15 +2457,9 @@ namespace Orleans.Serialization.UnitTests
 
         protected override IPAddress CreateValue()
         {
-            byte[] bytes;
-            if (Random.Next(1) == 0)
-            {
-                bytes = new byte[4];
-            }
-            else
-            {
-                bytes = new byte[16];
-            }
+            var bytes = Random.Next(1) == 0
+                ? (new byte[4])
+                : (new byte[16]);
             Random.NextBytes(bytes);
             return new IPAddress(bytes);
         }
@@ -2600,7 +2588,7 @@ namespace Orleans.Serialization.UnitTests
         }
 
         protected override int[] MaxSegmentSizes => new[] { 128 };
-        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
+        protected override Uri CreateValue() => new($"http://www.{Guid.NewGuid()}.com/");
 
         protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
 
@@ -2613,7 +2601,7 @@ namespace Orleans.Serialization.UnitTests
         {
         }
 
-        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
+        protected override Uri CreateValue() => new($"http://www.{Guid.NewGuid()}.com/");
 
         protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
 

--- a/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/JsonSerializerTests.cs
@@ -1,11 +1,6 @@
 #nullable enable
 using System;
-using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
@@ -28,7 +23,7 @@ namespace Orleans.Serialization.UnitTests
             builder.AddJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
         }
 
-        protected override MyJsonClass? CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello", Id = new(Guid.NewGuid()) };
+        protected override MyJsonClass? CreateValue() => new() { IntProperty = 30, SubTypeProperty = "hello", Id = new(Guid.NewGuid()) };
 
         protected override MyJsonClass?[] TestValues => new MyJsonClass?[]
         {
@@ -96,7 +91,7 @@ namespace Orleans.Serialization.UnitTests
         protected override IDeepCopier<MyJsonClass?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyJsonClass?>();
 
 
-        protected override MyJsonClass? CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello", Id = new(Guid.NewGuid()) };
+        protected override MyJsonClass? CreateValue() => new() { IntProperty = 30, SubTypeProperty = "hello", Id = new(Guid.NewGuid()) };
 
         protected override MyJsonClass?[] TestValues => new MyJsonClass?[]
         {

--- a/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
@@ -21,7 +21,7 @@ namespace Orleans.Serialization.UnitTests
             builder.AddNewtonsoftJsonSerializer(isSupported: type => type.GetCustomAttribute<MyJsonSerializableAttribute>(inherit: false) is not null);
         }
 
-        protected override MyJsonClass CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
+        protected override MyJsonClass CreateValue() => new() { IntProperty = 30, SubTypeProperty = "hello" };
 
         protected override int[] MaxSegmentSizes => new[] { 840 };
 
@@ -91,7 +91,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override IDeepCopier<MyJsonClass> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyJsonClass>();
 
-        protected override MyJsonClass CreateValue() => new MyJsonClass { IntProperty = 30, SubTypeProperty = "hello" };
+        protected override MyJsonClass CreateValue() => new() { IntProperty = 30, SubTypeProperty = "hello" };
 
         protected override MyJsonClass[] TestValues => new MyJsonClass[]
         {

--- a/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
@@ -92,7 +92,7 @@ public class ProtobufCodecCopierTests : CopierTester<MyProtobufClass?, IDeepCopi
     }
     protected override IDeepCopier<MyProtobufClass?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyProtobufClass?>();
 
-    protected override MyProtobufClass? CreateValue() => new MyProtobufClass { IntProperty = 30, StringProperty = "hello", SubClass = new MyProtobufClass.Types.SubClass { Id = Guid.NewGuid().ToByteString() } };
+    protected override MyProtobufClass? CreateValue() => new() { IntProperty = 30, StringProperty = "hello", SubClass = new MyProtobufClass.Types.SubClass { Id = Guid.NewGuid().ToByteString() } };
 
     protected override MyProtobufClass?[] TestValues => new MyProtobufClass?[]
     {

--- a/test/TestInfrastructure/TestExtensions/HierarchicalKeyStore.cs
+++ b/test/TestInfrastructure/TestExtensions/HierarchicalKeyStore.cs
@@ -17,7 +17,7 @@ namespace Orleans.Storage
         [NonSerialized]
         private readonly Dictionary<string, Dictionary<string, object>> dataTable = new();
         private readonly int numKeyLayers;
-        private readonly object lockable = new object();
+        private readonly object lockable = new();
 
         public HierarchicalKeyStore(int keyLayers)
         {
@@ -30,7 +30,7 @@ namespace Orleans.Storage
             {
                 var error = string.Format("Wrong number of keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count);
                 Trace.TraceError(error);
-                throw new ArgumentOutOfRangeException("keys", keys.Count, error);
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count, error);
             }
 
             lock (lockable)
@@ -51,7 +51,7 @@ namespace Orleans.Storage
             {
                 var error = string.Format("Not enough keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count);
                 Trace.TraceError(error);
-                throw new ArgumentOutOfRangeException("keys", keys.Count, error);
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count, error);
             }
 
             lock (lockable)
@@ -64,7 +64,7 @@ namespace Orleans.Storage
         {
             if (keys.Count > numKeyLayers)
             {
-                throw new ArgumentOutOfRangeException("keys", keys.Count,
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count,
                     string.Format("Too many key supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count));
             }
 
@@ -78,7 +78,7 @@ namespace Orleans.Storage
         {
             if (keys.Count > numKeyLayers)
             {
-                throw new ArgumentOutOfRangeException("keys", keys.Count,
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count,
                     string.Format("Not enough keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count));
             }
 

--- a/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
+++ b/test/TestInfrastructure/TestExtensions/MockStorageProvider.cs
@@ -71,14 +71,16 @@ namespace UnitTests.StorageTests
 
         private static int _instanceNum;
         private readonly int _id;
-
-        private int initCount, closeCount, readCount, writeCount, deleteCount;
-
+        private readonly int initCount;
+        private int closeCount;
+        private int readCount;
+        private int writeCount;
+        private int deleteCount;
         private readonly int numKeys;
         private readonly DeepCopier copier;
-        private ILocalDataStore StateStore;
+        private readonly ILocalDataStore StateStore;
         private const string stateStoreKey = "State";
-        private ILogger logger;
+        private readonly ILogger logger;
         public string LastId { get; private set; }
         public object LastState { get; private set; }
 

--- a/test/TestInfrastructure/TestExtensions/SiloAddressUtils.cs
+++ b/test/TestInfrastructure/TestExtensions/SiloAddressUtils.cs
@@ -5,7 +5,7 @@ namespace TestExtensions
 {
     public static class SiloAddressUtils
     {
-        private static readonly IPEndPoint localEndpoint = new IPEndPoint(IPAddress.Loopback, 0);
+        private static readonly IPEndPoint localEndpoint = new(IPAddress.Loopback, 0);
 
         public static SiloAddress NewLocalSiloAddress(int gen)
         {

--- a/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
+++ b/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
@@ -10,7 +7,7 @@ namespace TestExtensions
 {
     public class TestDefaultConfiguration
     {
-        private static readonly object LockObject = new object();
+        private static readonly object LockObject = new();
         private static IConfiguration defaultConfiguration;
 
         static TestDefaultConfiguration()
@@ -37,9 +34,9 @@ namespace TestExtensions
 
         public static string CosmosDBAccountEndpoint => defaultConfiguration[nameof(CosmosDBAccountEndpoint)];
         public static string CosmosDBAccountKey => defaultConfiguration[nameof(CosmosDBAccountKey)];
-        public static Uri TableEndpoint => new Uri(defaultConfiguration[nameof(TableEndpoint)]);
-        public static Uri DataBlobUri => new Uri(defaultConfiguration[nameof(DataBlobUri)]);
-        public static Uri DataQueueUri => new Uri(defaultConfiguration[nameof(DataQueueUri)]);
+        public static Uri TableEndpoint => new(defaultConfiguration[nameof(TableEndpoint)]);
+        public static Uri DataBlobUri => new(defaultConfiguration[nameof(DataBlobUri)]);
+        public static Uri DataQueueUri => new(defaultConfiguration[nameof(DataQueueUri)]);
         public static string DataConnectionString => defaultConfiguration[nameof(DataConnectionString)];
         public static string EventHubConnectionString => defaultConfiguration[nameof(EventHubConnectionString)];
         public static string EventHubFullyQualifiedNamespace => defaultConfiguration[nameof(EventHubFullyQualifiedNamespace)];

--- a/test/Tester/ClientConnectionTests/StallConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/StallConnectionTests.cs
@@ -1,15 +1,11 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
-using System;
 using System.Diagnostics;
 using System.Net.Sockets;
-using System.Threading.Tasks;
 using TestExtensions;
 using Xunit;
 
@@ -17,7 +13,7 @@ namespace Tester.ClientConnectionTests
 {
     public class StallConnectionTests : TestClusterPerTest
     {
-        private static TimeSpan Timeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {

--- a/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
@@ -28,7 +28,7 @@ namespace Tester.EventSourcingTests
         // - confirming at end only, instead of after each update, is fast.
         // - allowing reentrancy, while still confirming after each update, is also fast. 
 
-        private int iterations = 800;
+        private readonly int iterations = 800;
 
         [Fact, RunThisFirst, TestCategory("EventSourcing")]
         public Task Perf_Warmup()
@@ -100,7 +100,7 @@ namespace Tester.EventSourcingTests
 
     public class SimplePriorityOrderer : ITestCaseOrderer
     {
-        private string attrname = typeof(RunThisFirstAttribute).AssemblyQualifiedName;
+        private readonly string attrname = typeof(RunThisFirstAttribute).AssemblyQualifiedName;
 
         private bool HasRunThisFirstAttribute(ITestCase testcase)
         {

--- a/test/Tester/EventSourcingTests/CountersGrainTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainTests.cs
@@ -48,7 +48,7 @@ namespace Tester.EventSourcingTests
             await ConcurrentIncrementsRunner(grain, 50, false);
         }
 
-        private static string[] keys = { "a", "b", "c", "d", "e", "f", "g", "h" };
+        private static readonly string[] keys = { "a", "b", "c", "d", "e", "f", "g", "h" };
         private string RandomKey() { return keys[Random.Shared.Next(keys.Length)]; }
 
 

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests.General
         private readonly ITestOutputHelper output;
         private readonly Fixture fixture;
         private readonly IMessageSerializationGrain exceptionGrain;
-        private readonly MessageSerializationClientObject clientObject = new MessageSerializationClientObject();
+        private readonly MessageSerializationClientObject clientObject = new();
         private readonly IMessageSerializationClientObject clientObjectRef;
 
         public ExceptionPropagationTests(ITestOutputHelper output, Fixture fixture)

--- a/test/Tester/GrainServiceTests/TestGrainService.cs
+++ b/test/Tester/GrainServiceTests/TestGrainService.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Orleans;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Services;
 using UnitTests.GrainInterfaces;
@@ -50,7 +46,7 @@ namespace Tester
 
     public class TestGrainService : GrainService, ITestGrainService
     {
-        private TestGrainServiceOptions config;
+        private readonly TestGrainServiceOptions config;
 
         public TestGrainService(GrainId id, Silo silo, ILoggerFactory loggerFactory, IOptions<TestGrainServiceOptions> options) : base(id, silo, loggerFactory)
         {

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
@@ -39,7 +32,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         private readonly FileInfo assemblyGrainsV1;
         private readonly FileInfo assemblyGrainsV2;
 
-        private readonly List<SiloHandle> deployedSilos = new List<SiloHandle>();
+        private readonly List<SiloHandle> deployedSilos = new();
         private int siloIdx = 0;
         private TestClusterBuilder builder;
         private TestCluster cluster;

--- a/test/Tester/LogFomatterTests.cs
+++ b/test/Tester/LogFomatterTests.cs
@@ -443,7 +443,7 @@ namespace Tester
         {
             public string Name { get; private set; }
 
-            private TestOptions options;
+            private readonly TestOptions options;
             public TestOptionsFormatter2(IOptions<TestOptions> options)
             {
                 this.options = options.Value;
@@ -486,7 +486,7 @@ namespace Tester
         {
             public string Name { get; private set; }
 
-            private TestOptions options;
+            private readonly TestOptions options;
             public TestOptionsFormatter(IOptions<TestOptions> options)
             {
                 this.options = options.Value;
@@ -525,7 +525,7 @@ namespace Tester
 
         private class TestLoggerFactory : ILoggerFactory
         {
-            private readonly ConcurrentDictionary<string, Logger> loggers = new ConcurrentDictionary<string, Logger>();
+            private readonly ConcurrentDictionary<string, Logger> loggers = new();
 
             public void AddProvider(ILoggerProvider provider)
             {
@@ -548,7 +548,7 @@ namespace Tester
 
             private class Logger : ILogger
             {
-                private readonly List<string> entries = new List<string>();
+                private readonly List<string> entries = new();
 
                 public IDisposable BeginScope<TState>(TState state)
                 {

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Orleans;
 using Orleans.Streams;
 using Orleans.Internal;
 using UnitTests.GrainInterfaces;
@@ -14,7 +11,7 @@ namespace UnitTests.StreamingTests
     {
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
         private readonly string streamProviderName;
-        private IClusterClient client;
+        private readonly IClusterClient client;
 
         private class Counter
         {

--- a/test/Tester/StreamingTests/Filtering/StreamFilteringTestsBase.cs
+++ b/test/Tester/StreamingTests/Filtering/StreamFilteringTestsBase.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams.Filtering;
 using TestExtensions;
@@ -13,7 +10,7 @@ namespace Tester.StreamingTests.Filtering
 {
     public class CustomStreamFilter : IStreamFilter
     {
-        private ILogger<CustomStreamFilter> logger;
+        private readonly ILogger<CustomStreamFilter> logger;
 
         public CustomStreamFilter(ILogger<CustomStreamFilter> logger)
         {

--- a/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
@@ -1,13 +1,7 @@
-
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
@@ -50,7 +44,7 @@ namespace Tester.StreamingTests
         private readonly ITestOutputHelper output = null;
         private readonly ClientStreamTestRunner runner;
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public MemoryStreamProviderBatchedClientTests(Fixture fixture)
         {

--- a/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -1,13 +1,7 @@
-
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
@@ -31,14 +25,14 @@ namespace Tester.StreamingTests
             private class MyClientBuilderConfigurator : IClientBuilderConfigurator
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder
-                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b => b
                     .ConfigurePartitioning(partitionCount));
             }
 
             private class MySiloBuilderConfigurator : ISiloConfigurator
             {
-                public void Configure(ISiloBuilder hostBuilder)=> hostBuilder.AddMemoryGrainStorage("PubSubStore")
-                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                public void Configure(ISiloBuilder hostBuilder) => hostBuilder.AddMemoryGrainStorage("PubSubStore")
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b => b
                     .ConfigurePartitioning(partitionCount))
                     .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(5));
             }
@@ -47,7 +41,7 @@ namespace Tester.StreamingTests
         private readonly ITestOutputHelper output = null;
         private readonly ClientStreamTestRunner runner;
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public MemoryStreamProviderClientTests(Fixture fixture)
         {

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -1,20 +1,15 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
-using System.Linq;
-using System.Collections.Generic;
 
 namespace Tester.StreamingTests
 {
     public class PluggableQueueBalancerTestBase : OrleansTestingBase
     {
         private readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
-        private static Type QueueBalancerType = typeof(LeaseBasedQueueBalancerForTest);
+        private static readonly Type QueueBalancerType = typeof(LeaseBasedQueueBalancerForTest);
 
         public virtual async Task ShouldUseInjectedQueueBalancerAndBalanceCorrectly(BaseTestClusterFixture fixture, string streamProviderName, int siloCount, int totalQueueCount)
         {
@@ -33,8 +28,8 @@ namespace Tester.StreamingTests
 
         private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry)
         {
-            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap();
-            if(lastTry)
+            Dictionary<string, int> responsibilityMap = await leaseManager.GetResponsibilityMap();
+            if (lastTry)
             {
                 //there should be one StreamQueueBalancer per silo
                 Assert.Equal(responsibilityMap.Count, siloCount);

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
@@ -1,10 +1,5 @@
-using Orleans;
 using Orleans.Runtime;
 using Orleans.TestingHost;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Streams.Core;
@@ -16,7 +11,7 @@ using UnitTests.Grains.ProgrammaticSubscribe;
 
 namespace Tester.StreamingTests
 {
-    public abstract class ProgrammaticSubcribeTestsRunner 
+    public abstract class ProgrammaticSubcribeTestsRunner
     {
         private readonly BaseTestClusterFixture fixture;
         public const string StreamProviderName = "StreamProvider1";
@@ -32,7 +27,7 @@ namespace Tester.StreamingTests
             var subGrain = this.fixture.HostedCluster.GrainFactory.GetGrain<ISubscribeGrain>(Guid.NewGuid());
             Assert.True(await subGrain.CanGetSubscriptionManager(StreamProviderName));
         }
-        
+
         [SkippableFact]
         public async Task Programmatic_Subscribe_CanUseNullNamespace()
         {
@@ -61,11 +56,11 @@ namespace Tester.StreamingTests
             int numProduced = 0;
             await TestingUtils.WaitUntilAsync(lastTry => ProducerHasProducedSinceLastCheck(numProduced, producer, lastTry), _timeout);
             await producer.StopPeriodicProducing();
-            
+
             var tasks = new List<Task>();
             foreach (var consumer in consumers)
             {
-                tasks.Add(TestingUtils.WaitUntilAsync(lastTry => CheckCounters(new List<ITypedProducerGrain> { producer }, 
+                tasks.Add(TestingUtils.WaitUntilAsync(lastTry => CheckCounters(new List<ITypedProducerGrain> { producer },
                     consumer, lastTry, this.fixture.Logger), _timeout));
             }
             await Task.WhenAll(tasks);
@@ -76,7 +71,7 @@ namespace Tester.StreamingTests
             await Task.WhenAll(tasks);
         }
 
-        [SkippableFact(Skip= "https://github.com/dotnet/orleans/issues/5635")]
+        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/5635")]
         public async Task StreamingTests_Consumer_Producer_UnSubscribe()
         {
             var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
@@ -108,7 +103,7 @@ namespace Tester.StreamingTests
 
             //assert normal consumer consumed equal to produced
             await TestingUtils.WaitUntilAsync(
-            lastTry =>CheckCounters(new List<ITypedProducerGrain> { producer }, consumerNormal, lastTry, this.fixture.Logger), _timeout);
+            lastTry => CheckCounters(new List<ITypedProducerGrain> { producer }, consumerNormal, lastTry, this.fixture.Logger), _timeout);
 
             //asert unsubscribed consumer consumed less than produced
             numProduced = await producer.GetNumberProduced();
@@ -133,7 +128,7 @@ namespace Tester.StreamingTests
             var subscriptionIds = subscriptions.Select(sub => sub.SubscriptionId).ToSet();
             Assert.True(expectedSubscriptionIds.SetEquals(subscriptionIds));
 
-             //remove one subscription
+            //remove one subscription
             await subscriptionManager.RemoveSubscription(streamId, expectedSubscriptions[0].SubscriptionId);
             expectedSubscriptions = expectedSubscriptions.GetRange(1, 1);
             subscriptions = await subscriptionManager.GetSubscriptions(streamId);
@@ -165,12 +160,12 @@ namespace Tester.StreamingTests
 
             //get subscription count now, should be all removed/unsubscribed 
             var subscriptions = await subscriptionManager.GetSubscriptions(streamId);
-            Assert.True( subscriptions.Count<Orleans.Streams.Core.StreamSubscription>()== 0);
+            Assert.True(subscriptions.Count<Orleans.Streams.Core.StreamSubscription>() == 0);
             // clean up tests
         }
 
 
-        [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5650")]
+        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/5650")]
         public async Task StreamingTests_Consumer_Producer_SubscribeToTwoStream_MessageWithPolymorphism()
         {
             var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
@@ -260,7 +255,7 @@ namespace Tester.StreamingTests
 
         //test utilities and statics
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
-       
+
         public static async Task<bool> ProducerHasProducedSinceLastCheck(int numProducedLastTime, ITypedProducerGrain producer, bool assertIsTrue)
         {
             var numProduced = await producer.GetNumberProduced();
@@ -297,9 +292,9 @@ namespace Tester.StreamingTests
 
     public class SubscriptionManager
     {
-        private IGrainFactory grainFactory;
-        private IServiceProvider serviceProvider;
-        private IStreamSubscriptionManager subManager;
+        private readonly IGrainFactory grainFactory;
+        private readonly IServiceProvider serviceProvider;
+        private readonly IStreamSubscriptionManager subManager;
         public SubscriptionManager(TestCluster cluster)
         {
             this.grainFactory = cluster.GrainFactory;

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -16,7 +13,7 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         //test utilities and statics
         public static string StreamProviderName = "StreamProvider1";
         public static string StreamProviderName2 = "StreamProvider2";
-        private BaseTestClusterFixture fixture;
+        private readonly BaseTestClusterFixture fixture;
         public SubscriptionObserverWithImplicitSubscribingTestRunner(BaseTestClusterFixture fixture)
         {
             this.fixture = fixture;
@@ -44,8 +41,8 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
 
             var implicitConsumer =
                 this.fixture.HostedCluster.GrainFactory.GetGrain<IImplicitSubscribeGrain>(streamId.Guid);
-             await TestingUtils.WaitUntilAsync(lastTry => ProgrammaticSubcribeTestsRunner.CheckCounters(new List<ITypedProducerGrain> { producer },
-                    implicitConsumer, lastTry, this.fixture.Logger), _timeout);
+            await TestingUtils.WaitUntilAsync(lastTry => ProgrammaticSubcribeTestsRunner.CheckCounters(new List<ITypedProducerGrain> { producer },
+                   implicitConsumer, lastTry, this.fixture.Logger), _timeout);
 
             //clean up test
             await implicitConsumer.StopConsuming();
@@ -100,7 +97,7 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
             await TestingUtils.WaitUntilAsync(lastTry => ProgrammaticSubcribeTestsRunner.ProducerHasProducedSinceLastCheck(numProduced, producer2, lastTry), _timeout);
             await producer.StopPeriodicProducing();
             await producer2.StopPeriodicProducing();
-            
+
             var implicitConsumer =
                 this.fixture.HostedCluster.GrainFactory.GetGrain<IImplicitSubscribeGrain>(streamId.Guid);
             await TestingUtils.WaitUntilAsync(lastTry => ProgrammaticSubcribeTestsRunner.CheckCounters(new List<ITypedProducerGrain> { producer, producer2 },

--- a/test/Tester/StreamingTests/StreamBatchingTestRunner.cs
+++ b/test/Tester/StreamingTests/StreamBatchingTestRunner.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Orleans;
 using Orleans.Streams;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
@@ -15,7 +11,7 @@ namespace UnitTests.StreamingTests
     {
         protected readonly BaseTestClusterFixture fixture;
         protected readonly ITestOutputHelper output;
-        private TimeSpan Timeout = TimeSpan.FromSeconds(30);
+        private readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
         protected StreamBatchingTestRunner(BaseTestClusterFixture fixture, ITestOutputHelper output)
         {
@@ -23,7 +19,7 @@ namespace UnitTests.StreamingTests
             this.output = output;
         }
 
-        [SkippableFact(Skip="https://github.com/dotnet/orleans/issues/5649"), TestCategory("Functional"), TestCategory("Streaming")]
+        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/5649"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SingleSendBatchConsume()
         {
             const int ExpectedConsumed = 30;
@@ -31,7 +27,7 @@ namespace UnitTests.StreamingTests
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
             IAsyncStream<string> stream = provider.GetStream<string>(StreamBatchingTestConst.BatchingNameSpace, streamGuid);
-            for(int i = 0; i< ExpectedConsumed; i++)
+            for (int i = 0; i < ExpectedConsumed; i++)
             {
                 await stream.OnNextAsync(i.ToString());
             }

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -27,7 +23,7 @@ namespace UnitTests.StreamingTests
             public const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
             public const string StreamNamespace = GeneratedEventCollectorGrain.StreamNamespace;
 
-            public readonly static SimpleGeneratorOptions GeneratorConfig = new SimpleGeneratorOptions
+            public readonly static SimpleGeneratorOptions GeneratorConfig = new()
             {
                 StreamNamespace = StreamNamespace,
                 EventsInStream = 100

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -24,7 +24,7 @@ namespace UnitTests.StreamingTests
         {
             if (string.IsNullOrWhiteSpace(streamProviderName))
             {
-                throw new ArgumentNullException("streamProviderName");
+                throw new ArgumentNullException(nameof(streamProviderName));
             }
             this.streamProviderName = streamProviderName;
             this.logger = testCluster.Client.ServiceProvider.GetRequiredService<ILogger<SubscriptionMultiplicityTestRunner>>();

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -1,15 +1,6 @@
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Hosting;
 using Orleans.Providers;
-using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -38,7 +29,7 @@ namespace Tester.StreamingTests
             private class MyClientBuilderConfigurator : IClientBuilderConfigurator
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b => b
                     .ConfigurePartitioning(partitionCount));
             }
 
@@ -46,12 +37,12 @@ namespace Tester.StreamingTests
             {
                 public void Configure(ISiloBuilder hostBuilder) => hostBuilder
                     .AddMemoryGrainStorage("PubSubStore")
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b => b
                     .ConfigurePartitioning(partitionCount));
             }
         }
 
-        private Fixture fixture;
+        private readonly Fixture fixture;
 
         public SystemTargetRouteTests(Fixture fixture)
         {
@@ -71,7 +62,7 @@ namespace Tester.StreamingTests
                 .ToList();
 
             // subscribe to all streams
-            foreach(Guid streamId in streamIds)
+            foreach (Guid streamId in streamIds)
             {
                 IStreamProvider streamProvider = this.fixture.Client.GetStreamProvider(Fixture.StreamProviderName);
                 IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamId);

--- a/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
@@ -72,7 +72,7 @@ namespace Tester.TestStreamProviders.Controllable
                 case ControllableTestStreamProviderCommands.AdapterFactoryEcho:
                     return Task.FromResult<object>(Tuple.Create(ControllableTestStreamProviderCommands.AdapterFactoryEcho, arg));
             }
-            throw new ArgumentOutOfRangeException("command");
+            throw new ArgumentOutOfRangeException(nameof(command));
         }
 
         public static ControllableTestAdapterFactory Create(IServiceProvider services, string name)

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
-using Orleans;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Microsoft.Extensions.Logging;
@@ -24,7 +21,7 @@ namespace UnitTests.StorageTests
     [GenerateSerializer]
     public struct ErrorInjectionBehavior
     {
-        public static readonly ErrorInjectionBehavior None = new ErrorInjectionBehavior { ErrorInjectionPoint = ErrorInjectionPoint.None };
+        public static readonly ErrorInjectionBehavior None = new() { ErrorInjectionPoint = ErrorInjectionPoint.None };
 
         [Id(0)]
         public Type ExceptionType { get; set; }
@@ -73,7 +70,7 @@ namespace UnitTests.StorageTests
 
     public class ErrorInjectionStorageProvider : MockStorageProvider, IControllable
     {
-        private ILogger logger;
+        private readonly ILogger logger;
 
         public ErrorInjectionStorageProvider(
             ILogger<ErrorInjectionStorageProvider> logger,
@@ -89,7 +86,7 @@ namespace UnitTests.StorageTests
             IManagementGrain mgmtGrain = grainFactory.GetGrain<IManagementGrain>(0);
             await mgmtGrain.SendControlCommandToProvider(
                 typeof(ErrorInjectionStorageProvider).FullName,
-                providerName, 
+                providerName,
                 (int)Commands.SetErrorInjection,
                 errorInjectionBehavior);
         }
@@ -103,7 +100,7 @@ namespace UnitTests.StorageTests
             ErrorInjection = errorInject;
             logger.LogInformation("Set ErrorInjection to {ErrorInjection}", ErrorInjection);
         }
-        
+
         public async override Task Close()
         {
             logger.LogInformation("Close ErrorInjection={ErrorInjection}", ErrorInjection);
@@ -121,7 +118,7 @@ namespace UnitTests.StorageTests
 
         public async override Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
-            logger.LogInformation( "ReadStateAsync for {GrainType} {GrainId} ErrorInjection={ErrorInjection}", grainType, grainId, ErrorInjection);
+            logger.LogInformation("ReadStateAsync for {GrainType} {GrainId} ErrorInjection={ErrorInjection}", grainType, grainId, ErrorInjection);
             try
             {
                 ThrowIfMatches(ErrorInjectionPoint.BeforeRead);
@@ -172,7 +169,7 @@ namespace UnitTests.StorageTests
         /// <param name="command">A serial number of the command.</param>
         /// <param name="arg">An opaque command argument</param>
         public override Task<object> ExecuteCommand(int command, object arg)
-        { 
+        {
             switch ((Commands)command)
             {
                 case Commands.SetErrorInjection:

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
@@ -18,7 +13,7 @@ namespace UnitTests.General
     [TestCategory("Elasticity"), TestCategory("Placement")]
     public class ElasticPlacementTests : TestClusterPerTest
     {
-        private readonly List<IActivationCountBasedPlacementTestGrain> grains = new List<IActivationCountBasedPlacementTestGrain>();
+        private readonly List<IActivationCountBasedPlacementTestGrain> grains = new();
         private const int leavy = 300;
         private const int perSilo = 1000;
 
@@ -155,7 +150,7 @@ namespace UnitTests.General
         /// <summary>
         /// Do not place activation in case all silos are above 110 CPU utilization or have overloaded flag set.
         /// </summary>
-        [SkippableFact(Skip= "https://github.com/dotnet/orleans/issues/4008"), TestCategory("Functional")]
+        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/4008"), TestCategory("Functional")]
         public async Task ElasticityTest_AllSilosOverloaded()
         {
             var taintedGrainPrimary = await GetGrainAtSilo(this.HostedCluster.Primary.SiloAddress);

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -1,14 +1,5 @@
-using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.CodeGeneration;
-using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using Tester;
@@ -23,7 +14,7 @@ namespace UnitTests.General
     {
         private readonly ITestOutputHelper output;
         private readonly Fixture fixture;
-        private OutsideRuntimeClient runtimeClient;
+        private readonly OutsideRuntimeClient runtimeClient;
 
         public class Fixture : BaseTestClusterFixture
         {
@@ -42,7 +33,7 @@ namespace UnitTests.General
             RequestContextTestUtils.ClearActivityId();
             RequestContext.Clear();
         }
-        
+
         public void Dispose()
         {
             RequestContextTestUtils.ClearActivityId();
@@ -57,7 +48,7 @@ namespace UnitTests.General
 
             RequestContextTestUtils.SetActivityId(activityId);
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
+            Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
         }
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
@@ -72,19 +63,19 @@ namespace UnitTests.General
 
             RequestContext.Set(key, val);
             var result = await grain.TraceIdEcho();
-            Assert.Equal(val,  result);  // "Immediate RequestContext echo was not correct"
+            Assert.Equal(val, result);  // "Immediate RequestContext echo was not correct"
 
             RequestContext.Set(key, val2);
             result = await grain.TraceIdDoubleEcho();
-            Assert.Equal(val2,  result);  // "Transitive RequestContext echo was not correct"
+            Assert.Equal(val2, result);  // "Transitive RequestContext echo was not correct"
 
             RequestContext.Set(key, val);
             result = await grain.TraceIdDelayedEcho1();
-            Assert.Equal(val,  result); // "Delayed (StartNew) RequestContext echo was not correct");
+            Assert.Equal(val, result); // "Delayed (StartNew) RequestContext echo was not correct");
 
             RequestContext.Set(key, val2);
             result = await grain.TraceIdDelayedEcho2();
-            Assert.Equal(val2,  result); // "Delayed (ContinueWith) RequestContext echo was not correct");
+            Assert.Equal(val2, result); // "Delayed (ContinueWith) RequestContext echo was not correct");
         }
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
@@ -99,23 +90,23 @@ namespace UnitTests.General
 
             RequestContext.Set(key, val);
             var result = await grain.TraceIdEcho();
-            Assert.Equal(val,  result);  // "Immediate RequestContext echo was not correct"
+            Assert.Equal(val, result);  // "Immediate RequestContext echo was not correct"
 
             RequestContext.Set(key, val2);
             result = await grain.TraceIdDoubleEcho();
-            Assert.Equal(val2,  result);  // "Transitive RequestContext echo was not correct"
+            Assert.Equal(val2, result);  // "Transitive RequestContext echo was not correct"
 
             RequestContext.Set(key, val);
             result = await grain.TraceIdDelayedEcho1();
-            Assert.Equal(val,  result); // "Delayed (StartNew) RequestContext echo was not correct");
+            Assert.Equal(val, result); // "Delayed (StartNew) RequestContext echo was not correct");
 
             RequestContext.Set(key, val2);
             result = await grain.TraceIdDelayedEcho2();
-            Assert.Equal(val2,  result); // "Delayed (ContinueWith) RequestContext echo was not correct");
+            Assert.Equal(val2, result); // "Delayed (ContinueWith) RequestContext echo was not correct");
 
             RequestContext.Set(key, val);
             result = await grain.TraceIdDelayedEchoAwait();
-            Assert.Equal(val,  result); // "Delayed (Await) RequestContext echo was not correct");
+            Assert.Equal(val, result); // "Delayed (Await) RequestContext echo was not correct");
 
             // Expected behaviour is this won't work, because Task.Run by design does not use Orleans task scheduler
             //RequestContext.Set(key, val2);
@@ -129,8 +120,8 @@ namespace UnitTests.General
             var grain = this.fixture.GrainFactory.GetGrain<IRequestContextTaskGrain>(1);
             Tuple<string, string> requestContext = await grain.TestRequestContext();
             this.fixture.Logger.LogInformation("Request Context is: {RequestContext}", requestContext);
-            Assert.Equal("binks",  requestContext.Item1);  // "Item1=" + requestContext.Item1
-            Assert.Equal("binks",  requestContext.Item2);  // "Item2=" + requestContext.Item2
+            Assert.Equal("binks", requestContext.Item1);  // "Item1=" + requestContext.Item1
+            Assert.Equal("binks", requestContext.Item2);  // "Item2=" + requestContext.Item2
         }
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
@@ -144,17 +135,17 @@ namespace UnitTests.General
 
             RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, activityId);
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
+            Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
             RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, nullActivityId);
             result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+            Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
             RequestContext.Set(RequestContext.CALL_CHAIN_REENTRANCY_HEADER, activityId2);
             result = await grain.E2EActivityId();
-            Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
+            Assert.Equal(activityId2, result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
         }
 
@@ -178,14 +169,14 @@ namespace UnitTests.General
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
-                Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+                Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             }
             RequestContext.Clear();
 
             Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
-            Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
+            Assert.Equal(activityId2, result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
         }
 
@@ -201,7 +192,7 @@ namespace UnitTests.General
             Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             RequestContext.ReentrancyId = activityId;
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
+            Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
             RequestContext.ReentrancyId = nullActivityId;
@@ -209,14 +200,14 @@ namespace UnitTests.General
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
-                Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+                Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             }
             RequestContext.Clear();
 
             Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
-            Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
+            Assert.Equal(activityId2, result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
         }
 
@@ -230,14 +221,14 @@ namespace UnitTests.General
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "E2E ActivityId should not exist"
+            Assert.Equal(nullActivityId, result);  // "E2E ActivityId should not exist"
 
             result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+            Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
             result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "E2E ActivityId 2 should not exist"
+            Assert.Equal(nullActivityId, result);  // "E2E ActivityId 2 should not exist"
             Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));  // "No ActivityId context should be set"
 
             for (int i = 0; i < Environment.ProcessorCount; i++)
@@ -246,7 +237,7 @@ namespace UnitTests.General
 
                 result = await grain.E2EActivityId();
 
-                Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+                Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
 
                 RequestContext.Clear();
             }
@@ -260,26 +251,26 @@ namespace UnitTests.General
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
             Guid result = grain.E2EActivityId().Result;
-            Assert.Equal(nullActivityId,  result);  // "E2E ActivityId should not exist"
+            Assert.Equal(nullActivityId, result);  // "E2E ActivityId should not exist"
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+            Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
 
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
-                Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+                Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             }
             RequestContext.Clear();
             RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
+            Assert.Null(RequestContext.Get(RequestContext.CALL_CHAIN_REENTRANCY_HEADER));
             result = await grain.E2EActivityId();
-            Assert.Equal(nullActivityId,  result);  // "Null ActivityId propagated E2E incorrectly"
+            Assert.Equal(nullActivityId, result);  // "Null ActivityId propagated E2E incorrectly"
             RequestContext.Clear();
         }
 
@@ -293,7 +284,7 @@ namespace UnitTests.General
 
             RequestContext.ReentrancyId = activityId;
             Guid result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly"
+            Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly"
             RequestContext.Clear();
 
             using (RequestContext.SuppressCallChainReentrancy())
@@ -305,12 +296,12 @@ namespace UnitTests.General
 
             RequestContext.ReentrancyId = activityId2;
             result = await grain.E2EActivityId();
-            Assert.Equal(activityId2,  result);  // "E2E ActivityId #2 should have been propagated"
+            Assert.Equal(activityId2, result);  // "E2E ActivityId #2 should have been propagated"
             RequestContext.Clear();
 
             RequestContext.ReentrancyId = activityId;
             result = await grain.E2EActivityId();
-            Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly after #2"
+            Assert.Equal(activityId, result);  // "E2E ActivityId #1 not propagated correctly after #2"
             RequestContext.Clear();
         }
     }
@@ -384,7 +375,7 @@ namespace UnitTests.General
     {
         private readonly ITestOutputHelper output;
 
-        private AsyncLocal<int> threadId = new AsyncLocal<int>();
+        private readonly AsyncLocal<int> threadId = new();
 
         public Halo_CallContextTests(ITestOutputHelper output)
         {

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using TestExtensions;
@@ -17,7 +13,7 @@ namespace Tests.GeoClusterTests
     public class BasicLogTestGrainTests : IClassFixture<BasicLogTestGrainTests.Fixture>
     {
         private readonly Fixture fixture;
-        private Random random;
+        private readonly Random random;
 
         public class Fixture : BaseAzureTestClusterFixture
         {
@@ -45,11 +41,11 @@ namespace Tests.GeoClusterTests
                         {
                             options.ConfigureTableServiceClient(TestDefaultConfiguration.DataConnectionString);
                         }))
-                        .AddMemoryGrainStorage("MemoryStore"); 
+                        .AddMemoryGrainStorage("MemoryStore");
                 }
             }
         }
-        
+
         public BasicLogTestGrainTests(Fixture fixture)
         {
             this.fixture = fixture;

--- a/test/TesterInternal/GrainDirectoryPartitionTests.cs
+++ b/test/TesterInternal/GrainDirectoryPartitionTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -17,8 +12,8 @@ public class GrainDirectoryPartitionTests
 {
     private readonly GrainDirectoryPartition _target;
     private readonly MockSiloStatusOracle _siloStatusOracle;
-    private static readonly SiloAddress LocalSiloAddress =  SiloAddress.FromParsableString("127.0.0.1:11111@123");
-    private static readonly SiloAddress OtherSiloAddress =  SiloAddress.FromParsableString("127.0.0.2:11111@456");
+    private static readonly SiloAddress LocalSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
+    private static readonly SiloAddress OtherSiloAddress = SiloAddress.FromParsableString("127.0.0.2:11111@456");
 
     public GrainDirectoryPartitionTests()
     {
@@ -58,7 +53,7 @@ public class GrainDirectoryPartitionTests
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
 
         // Insert invalid entry, pointing to dead silo
-       Assert.Throws<OrleansException>(() => _target.AddSingleActivation(grainAddress, previousAddress: null));
+        Assert.Throws<OrleansException>(() => _target.AddSingleActivation(grainAddress, previousAddress: null));
     }
 
     [Fact]
@@ -143,7 +138,7 @@ public class GrainDirectoryPartitionTests
 
     private class MockSiloStatusOracle : ISiloStatusOracle
     {
-        private Dictionary<SiloAddress, SiloStatus> _content = new();
+        private readonly Dictionary<SiloAddress, SiloStatus> _content = new();
 
         public MockSiloStatusOracle(SiloAddress siloAddress = null)
         {

--- a/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
@@ -19,7 +14,7 @@ namespace UnitTests.MembershipTests
     {
         internal class Observer : ISimpleGrainObserver
         {
-            private readonly SemaphoreSlim semaphore = new SemaphoreSlim(0);
+            private readonly SemaphoreSlim semaphore = new(0);
             private int lastA;
             private int lastB;
 

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost.Utils;
@@ -24,7 +20,7 @@ namespace UnitTests.StreamingTests
         private ConsumerProxy consumer;
         private const int Many = 3;
         private const int ItemCount = 10;
-        private ILogger logger;
+        private readonly ILogger logger;
         private readonly string streamProviderName;
         private readonly int testNumber;
         private readonly bool runFullTest;
@@ -445,7 +441,7 @@ namespace UnitTests.StreamingTests
                 await producer.ProduceParallelSeries(ItemCount);
                 await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout);
                 await CheckCounters(producer, consumer);
-           
+
                 await producer.ProducePeriodicSeries(ItemCount);
                 await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout);
                 await CheckCounters(producer, consumer);
@@ -463,7 +459,7 @@ namespace UnitTests.StreamingTests
         private async Task<bool> CheckCounters(ProducerProxy producer, ConsumerProxy consumer, bool assertAreEqual = true)
         {
             var consumerCount = await consumer.ConsumerCount;
-            Assert.NotEqual(0,  consumerCount);  // "no consumers were detected."
+            Assert.NotEqual(0, consumerCount);  // "no consumers were detected."
             _ = await producer.ProducerCount;
             var numProduced = await producer.ExpectedItemsProduced;
             var expectConsumed = numProduced * consumerCount;
@@ -476,7 +472,7 @@ namespace UnitTests.StreamingTests
                 numConsumed);
             if (assertAreEqual)
             {
-                Assert.Equal(expectConsumed,  numConsumed); // String.Format("expectConsumed = {0}, numConsumed = {1}", expectConsumed, numConsumed));
+                Assert.Equal(expectConsumed, numConsumed); // String.Format("expectConsumed = {0}, numConsumed = {1}", expectConsumed, numConsumed));
                 return true;
             }
             else
@@ -524,15 +520,15 @@ namespace UnitTests.StreamingTests
             }
             var expectActivationCount = 0;
             logger.LogInformation(
-                "Test {TestNumber} CheckGrainsDeactivated: {Type}ActivationCount = {ActivationCount}, Expected{Type}ActivationCount = {ExpectActivationCount}", 
-                testNumber, 
-                str, 
-                activationCount, 
+                "Test {TestNumber} CheckGrainsDeactivated: {Type}ActivationCount = {ActivationCount}, Expected{Type}ActivationCount = {ExpectActivationCount}",
+                testNumber,
+                str,
+                activationCount,
                 str,
                 expectActivationCount);
             if (assertAreEqual)
             {
-                Assert.Equal(expectActivationCount,  activationCount); // String.Format("Expected{0}ActivationCount = {1}, {0}ActivationCount = {2}", str, expectActivationCount, activationCount));
+                Assert.Equal(expectActivationCount, activationCount); // String.Format("Expected{0}ActivationCount = {1}, {0}ActivationCount = {2}", str, expectActivationCount, activationCount));
             }
             return expectActivationCount == activationCount;
         }

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -91,7 +91,7 @@ namespace UnitTests.StreamingTests
         public static Streaming_ProducerClientObject NewObserver(ILogger logger, IClusterClient client)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new Streaming_ProducerClientObject(logger, client);
         }
 
@@ -181,13 +181,13 @@ namespace UnitTests.StreamingTests
         private static async Task<ConsumerProxy> NewConsumerProxy(Guid streamId, string streamProvider, IStreaming_ConsumerGrain[] targets, ILogger logger, IInternalGrainFactory grainFactory)
         {
             if (targets == null)
-                throw new ArgumentNullException("targets");
+                throw new ArgumentNullException(nameof(targets));
             if (targets.Length == 0)
                 throw new ArgumentException("caller must specify at least one target");
             if (String.IsNullOrWhiteSpace(streamProvider))
-                throw new ArgumentException("Stream provider name is either null or whitespace", "streamProvider");
+                throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
             ConsumerProxy newObj = new ConsumerProxy(targets, logger, grainFactory);
             await newObj.BecomeConsumer(streamId, streamProvider);
@@ -198,7 +198,7 @@ namespace UnitTests.StreamingTests
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainCount), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewConsumerGrainsAsync: multiplexing {GrainCount} consumer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ConsumerGrain>();
@@ -229,7 +229,7 @@ namespace UnitTests.StreamingTests
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainIds), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {GrainCount} consumer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ConsumerGrain>();
@@ -258,7 +258,7 @@ namespace UnitTests.StreamingTests
         public static Task<ConsumerProxy> NewConsumerClientObjectsAsync(Guid streamId, string streamProvider, ILogger logger, IInternalClusterClient client, int consumerCount = 1)
         {
             if (consumerCount < 1)
-                throw new ArgumentOutOfRangeException("consumerCount", "argument must be 1 or greater");
+                throw new ArgumentOutOfRangeException(nameof(consumerCount), "argument must be 1 or greater");
             logger.LogInformation("ConsumerProxy.NewConsumerClientObjectsAsync: multiplexing {ConsumerCount} consumer client objects for stream {StreamId}.", consumerCount, streamId);
             var objs = new IStreaming_ConsumerGrain[consumerCount];
             for (var i = 0; i < consumerCount; ++i)
@@ -269,9 +269,9 @@ namespace UnitTests.StreamingTests
         public static ConsumerProxy NewConsumerGrainAsync_WithoutBecomeConsumer(Guid consumerGrainId, ILogger logger, IInternalGrainFactory grainFactory, string grainClassName = "")
         {
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
-            if (string.IsNullOrEmpty(grainClassName)) 
+            if (string.IsNullOrEmpty(grainClassName))
             {
                 grainClassName = typeof(Streaming_ConsumerGrain).FullName;
             }
@@ -379,11 +379,11 @@ namespace UnitTests.StreamingTests
         private static async Task<ProducerProxy> NewProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string streamProvider, string streamNamespace, ILogger logger)
         {
             if (targets == null)
-                throw new ArgumentNullException("targets");
+                throw new ArgumentNullException(nameof(targets));
             if (String.IsNullOrWhiteSpace(streamProvider))
-                throw new ArgumentException("Stream provider name is either null or whitespace", "streamProvider");
+                throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
             ProducerProxy newObj = new ProducerProxy(targets, streamId, streamProvider, logger);
             await newObj.BecomeProducer(streamId, streamProvider, streamNamespace);
@@ -394,7 +394,7 @@ namespace UnitTests.StreamingTests
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainCount), "The grain count must be at least one");
             logger.LogInformation("ProducerProxy.NewProducerGrainsAsync: multiplexing {GrainCount} producer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ProducerGrain>();
@@ -425,7 +425,7 @@ namespace UnitTests.StreamingTests
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainIds), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {GrainCount} producer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ProducerGrain>();
@@ -446,15 +446,15 @@ namespace UnitTests.StreamingTests
                             grains[i] = grainFactory.GetGrain<IStreaming_ProducerConsumerGrain>(grainIds[i], grainFullName);
                         }
                         dedup[grainIds[i]] = grains[i];
-                    }                    
+                    }
                 }
             return NewProducerProxy(grains, streamId, streamProvider, null, logger);
         }
 
         public static Task<ProducerProxy> NewProducerClientObjectsAsync(Guid streamId, string streamProvider,  string streamNamespace, ILogger logger, IClusterClient client, int producersCount = 1)
-        {            
+        {
             if (producersCount < 1)
-                throw new ArgumentOutOfRangeException("producersCount", "The producer count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(producersCount), "The producer count must be at least one");
             var producers = new IStreaming_ProducerGrain[producersCount];
             for (var i = 0; i < producersCount; ++i)
                 producers[i] = Streaming_ProducerClientObject.NewObserver(logger, client);

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
@@ -1,6 +1,4 @@
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
-using Orleans.Hosting;
 using Orleans.TestingHost;
 using Orleans.Transactions.TestKit;
 using Orleans.Transactions.TestKit.xUnit;
@@ -15,7 +13,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
     public class TransactionRecoveryTests : TestClusterPerTest
     {
         private TransactionRecoveryTestsRunnerxUnit testRunner;
-        private ITestOutputHelper helper;
+        private readonly ITestOutputHelper helper;
 
         public TransactionRecoveryTests(ITestOutputHelper helper)
         {

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionOverloadDetectorTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionOverloadDetectorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Xunit.Abstractions;
 using Xunit;
@@ -10,7 +9,7 @@ namespace Orleans.Transactions.Tests
     [TestCategory("BVT"), TestCategory("Transactions")]
     public class TransactionOverloadDetectorTests
     {
-        private ITestOutputHelper output;
+        private readonly ITestOutputHelper output;
 
         public TransactionOverloadDetectorTests(ITestOutputHelper output)
         {


### PR DESCRIPTION
This PR does a number of small refactorings to favor more recent C# features, especially:
- The simpler new() syntax instead of new T()
- Adding readonly modifiers where possible
- Using nameof(member) instead of "member"

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8514)