### PR TITLE
Small, targeted refactor: Address CA1517 (use nameof)

### DIFF
--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
@@ -25,7 +25,7 @@ namespace OrleansAWSUtils.Streams
 
         public SQSAdapter(Serializer<SQSBatchContainer> serializer, IConsistentRingStreamQueueMapper streamQueueMapper, ILoggerFactory loggerFactory, string dataConnectionString, string serviceId, string providerName)
         {
-            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
+            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
             if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
             this.loggerFactory = loggerFactory;
             this.serializer = serializer;
@@ -44,7 +44,7 @@ namespace OrleansAWSUtils.Streams
         {
             if (token != null)
             {
-                throw new ArgumentException("SQSStream stream provider currently does not support non-null StreamSequenceToken.", "token");
+                throw new ArgumentException("SQSStream stream provider currently does not support non-null StreamSequenceToken.", nameof(token));
             }
             var queueId = streamQueueMapper.GetQueueForStream(streamId);
             SQSStorage queue;

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
@@ -27,8 +27,8 @@ namespace OrleansAWSUtils.Streams
 
         public static IQueueAdapterReceiver Create(Serializer<SQSBatchContainer> serializer, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string serviceId)
         {
-            if (queueId.IsDefault) throw new ArgumentNullException("queueId");
-            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
+            if (queueId.IsDefault) throw new ArgumentNullException(nameof(queueId));
+            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
             if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
 
             var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, serviceId);
@@ -37,8 +37,8 @@ namespace OrleansAWSUtils.Streams
 
         private SQSAdapterReceiver(Serializer<SQSBatchContainer> serializer, ILoggerFactory loggerFactory, QueueId queueId, SQSStorage queue)
         {
-            if (queueId.IsDefault) throw new ArgumentNullException("queueId");
-            if (queue == null) throw new ArgumentNullException("queue");
+            if (queueId.IsDefault) throw new ArgumentNullException(nameof(queueId));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
 
             Id = queueId;
             this.queue = queue;

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSBatchContainer.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSBatchContainer.cs
@@ -54,7 +54,7 @@ namespace OrleansAWSUtils.Streams
 
         private SQSBatchContainer(StreamId streamId, List<object> events, Dictionary<string, object> requestContext)
         {
-            if (events == null) throw new ArgumentNullException("events", "Message contains no events");
+            if (events == null) throw new ArgumentNullException(nameof(events), "Message contains no events");
 
             StreamId = streamId;
             this.events = events;

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -99,12 +99,12 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             if (tableVersion == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.InsertRow aborted due to null check. TableVersion is null ");
-                throw new ArgumentNullException("tableVersion");
+                throw new ArgumentNullException(nameof(tableVersion));
             }
 
             try
@@ -131,12 +131,12 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             if (tableVersion == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateRow aborted due to null check. TableVersion is null");
-                throw new ArgumentNullException("tableVersion");
+                throw new ArgumentNullException(nameof(tableVersion));
             }
 
             try
@@ -158,7 +158,7 @@ namespace Orleans.Runtime.MembershipService
             if (entry == null)
             {
                 if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("AdoNetClusteringTable.UpdateIAmAlive aborted due to null check. MembershipEntry is null.");
-                throw new ArgumentNullException("entry");
+                throw new ArgumentNullException(nameof(entry));
             }
             try
             {

--- a/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
+++ b/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
@@ -62,10 +62,10 @@ namespace Orleans.Tests.SqlUtils
         /// <param name="reader">The reader to use to read from the database.</param>
         /// <param name="ordinal">The column ordinal to read from.</param>
         public OrleansRelationalDownloadStream(DbDataReader reader, int ordinal)
-        {            
+        {
             this.reader = reader;
             this.ordinal = ordinal;
-                        
+
             //This return the total length of the column pointed by the ordinal.
             totalBytes = reader.GetBytes(ordinal, 0, null, 0, 0);
         }
@@ -112,7 +112,7 @@ namespace Orleans.Tests.SqlUtils
 
         /// <summary>
         /// The length of the stream.
-        /// </summary>        
+        /// </summary>
         public override long Length
         {
             get { return totalBytes; }
@@ -128,10 +128,10 @@ namespace Orleans.Tests.SqlUtils
             set { throw new NotSupportedException(); }
         }
 
-        
+
         /// <summary>
         /// Throws <exception cref="NotSupportedException"/>.
-        /// </summary>        
+        /// </summary>
         /// <exception cref="NotSupportedException" />.
         public override void Flush()
         {
@@ -152,7 +152,7 @@ namespace Orleans.Tests.SqlUtils
             ValidateReadParameters(buffer, offset, count);
 
             try
-            {                                                               
+            {
                 int length = Math.Min(count, (int)(totalBytes - position));
                 long bytesRead = 0;
                 if(length > 0)
@@ -176,7 +176,7 @@ namespace Orleans.Tests.SqlUtils
         /// </summary>
         /// <param name="buffer">The buffer to read to.</param>
         /// <param name="offset">The offset to the buffer to stat reading.</param>
-        /// <param name="count">The count of bytes to read to.</param>        
+        /// <param name="count">The count of bytes to read to.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The number of actual bytes read from the stream.</returns>
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -236,7 +236,7 @@ namespace Orleans.Tests.SqlUtils
             }
         }
 
-       
+
         /// <summary>
         /// Throws <exception cref="NotSupportedException"/>.
         /// </summary>
@@ -251,7 +251,7 @@ namespace Orleans.Tests.SqlUtils
 
 
         /// <summary>
-        /// Throws <exception cref="NotSupportedException"/>. 
+        /// Throws <exception cref="NotSupportedException"/>.
         /// </summary>
         /// <returns>Throws <exception cref="NotSupportedException"/>.</returns>
         /// <exception cref="NotSupportedException" />.
@@ -262,7 +262,7 @@ namespace Orleans.Tests.SqlUtils
 
 
         /// <summary>
-        /// Throws <exception cref="NotSupportedException"/>. 
+        /// Throws <exception cref="NotSupportedException"/>.
         /// </summary>
         /// <param name="buffer">The buffer.</param>
         /// <param name="offset">The offset to the buffer.</param>
@@ -290,23 +290,23 @@ namespace Orleans.Tests.SqlUtils
 
         /// <summary>
         /// Checks the parameters passed into a ReadAsync() or Read() are valid.
-        /// </summary>        
+        /// </summary>
         /// <param name="buffer"></param>
         /// <param name="offset"></param>
         /// <param name="count"></param>
         private static void ValidateReadParameters(byte[] buffer, int offset, int count)
-        {            
+        {
             if(buffer == null)
             {
-                throw new ArgumentNullException("buffer");                    
+                throw new ArgumentNullException(nameof(buffer));
             }
             if(offset < 0)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
             if(count < 0)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
             try
             {
@@ -316,7 +316,7 @@ namespace Orleans.Tests.SqlUtils
                 }
             }
             catch(OverflowException)
-            {                
+            {
                 throw new ArgumentException("Invalid offset length");
             }
         }

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -87,12 +87,12 @@ namespace Orleans.Tests.SqlUtils
         {
             if(string.IsNullOrWhiteSpace(invariantName))
             {
-                throw new ArgumentException("The name of invariant must contain characters", "invariantName");
+                throw new ArgumentException("The name of invariant must contain characters", nameof(invariantName));
             }
 
             if(string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentException("Connection string must contain characters", "connectionString");
+                throw new ArgumentException("Connection string must contain characters", nameof(connectionString));
             }
 
             return new RelationalStorage(invariantName, connectionString);
@@ -153,12 +153,12 @@ namespace Orleans.Tests.SqlUtils
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             if(selector == null)
             {
-                throw new ArgumentNullException("selector");
+                throw new ArgumentNullException(nameof(selector));
             }
 
             return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, cancellationToken, commandBehavior).ConfigureAwait(false)).Item1;
@@ -191,7 +191,7 @@ namespace Orleans.Tests.SqlUtils
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), cancellationToken, commandBehavior).ConfigureAwait(false)).Item2;

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -50,12 +50,12 @@ namespace Orleans.Tests.SqlUtils
         {
             if(string.IsNullOrWhiteSpace(tableName))
             {
-                throw new ArgumentException("The name must be a legal SQL table name", "tableName");
+                throw new ArgumentException("The name must be a legal SQL table name", nameof(tableName));
             }
 
             if(parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             var storageConsts = DbConstantsStore.GetDbConstants(storage.InvariantName);

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
@@ -50,7 +50,7 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public AzureQueueBatchContainer(StreamId streamId, List<object> events, Dictionary<string, object> requestContext)
         {
-            if (events == null) throw new ArgumentNullException("events", "Message contains no events");
+            if (events == null) throw new ArgumentNullException(nameof(events), "Message contains no events");
 
             StreamId = streamId;
             this.events = events;

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -96,11 +96,11 @@ namespace Orleans.Providers.Streams.PersistentStreams
         {
             if (subscriptionId == null)
             {
-                throw new ArgumentNullException("subscriptionId");
+                throw new ArgumentNullException(nameof(subscriptionId));
             }
             if (string.IsNullOrWhiteSpace(streamProviderName))
             {
-                throw new ArgumentNullException("streamProviderName");
+                throw new ArgumentNullException(nameof(streamProviderName));
             }
 
             var failureEntity = createEntity();

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -455,11 +455,11 @@ namespace Orleans.GrainDirectory.AzureStorage
             var startTime = DateTime.UtcNow;
             if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace("{Operation} entries: {Data} table {TableName}", operation, Utils.EnumerableToString(collection), TableName);
 
-            if (collection == null) throw new ArgumentNullException("collection");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
 
             if (collection.Count > this.StoragePolicyOptions.MaxBulkUpdateRows)
             {
-                throw new ArgumentOutOfRangeException("collection", collection.Count,
+                throw new ArgumentOutOfRangeException(nameof(collection), collection.Count,
                         "Too many rows for bulk delete - max " + this.StoragePolicyOptions.MaxBulkUpdateRows);
             }
 
@@ -564,10 +564,10 @@ namespace Orleans.GrainDirectory.AzureStorage
         public async Task BulkInsertTableEntries(IReadOnlyCollection<T> collection)
         {
             const string operation = "BulkInsertTableEntries";
-            if (collection == null) throw new ArgumentNullException("collection");
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
             if (collection.Count > this.StoragePolicyOptions.MaxBulkUpdateRows)
             {
-                throw new ArgumentOutOfRangeException("collection", collection.Count,
+                throw new ArgumentOutOfRangeException(nameof(collection), collection.Count,
                         "Too many rows for bulk update - max " + this.StoragePolicyOptions.MaxBulkUpdateRows);
             }
 

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
@@ -133,7 +133,7 @@ namespace Orleans.Runtime
             if (IsKeyExt(GetCategory(typeCodeData)))
             {
                 if (string.IsNullOrWhiteSpace(keyExt))
-                    throw keyExt is null ? new ArgumentNullException("keyExt") : throw new ArgumentException("Extended key is empty or white space.", "keyExt");
+                    throw keyExt is null ? new ArgumentNullException(nameof(keyExt)) : throw new ArgumentException("Extended key is empty or white space.", nameof(keyExt));
             }
             else if (keyExt != null) throw new ArgumentException("Only key extended grains can specify a non-null key extension.");
             return new UniqueKey { TypeCodeData = typeCodeData, KeyExt = keyExt };

--- a/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
@@ -346,10 +346,10 @@ namespace Orleans.Internal
         /// </exception>
         public ExponentialBackoff(TimeSpan minDelay, TimeSpan maxDelay, TimeSpan step)
         {
-            if (minDelay <= TimeSpan.Zero) throw new ArgumentOutOfRangeException("minDelay", minDelay, "ExponentialBackoff min delay must be a positive number.");
-            if (maxDelay <= TimeSpan.Zero) throw new ArgumentOutOfRangeException("maxDelay", maxDelay, "ExponentialBackoff max delay must be a positive number.");
-            if (step <= TimeSpan.Zero) throw new ArgumentOutOfRangeException("step", step, "ExponentialBackoff step must be a positive number.");
-            if (minDelay >= maxDelay) throw new ArgumentOutOfRangeException("minDelay", minDelay, "ExponentialBackoff min delay must be greater than max delay.");
+            if (minDelay <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(minDelay), minDelay, "ExponentialBackoff min delay must be a positive number.");
+            if (maxDelay <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(maxDelay), maxDelay, "ExponentialBackoff max delay must be a positive number.");
+            if (step <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(step), step, "ExponentialBackoff step must be a positive number.");
+            if (minDelay >= maxDelay) throw new ArgumentOutOfRangeException(nameof(minDelay), minDelay, "ExponentialBackoff min delay must be greater than max delay.");
 
             this.minDelay = minDelay;
             this.maxDelay = maxDelay;

--- a/src/Orleans.Core/Async/MultiTaskCompletionSource.cs
+++ b/src/Orleans.Core/Async/MultiTaskCompletionSource.cs
@@ -25,7 +25,7 @@ namespace Orleans
         {
             if (count <= 0)
             {
-                throw new ArgumentOutOfRangeException("count", "count has to be positive.");
+                throw new ArgumentOutOfRangeException(nameof(count), "count has to be positive.");
             }
             tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.count = count;

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -49,7 +49,7 @@ namespace Orleans.Runtime
         public void Start(TimeSpan due, TimeSpan period)
         {
             if (timerStarted) throw new InvalidOperationException(String.Format("Calling start on timer {0} is not allowed, since it was already created in a started mode with specified due.", GetFullName()));
-            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException("period", period, "Cannot use TimeSpan.Zero for timer period");
+            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), period, "Cannot use TimeSpan.Zero for timer period");
 
             long dueTm = (long)dueTime.TotalMilliseconds;
             if (dueTm < -1) throw new ArgumentOutOfRangeException(nameof(dueTime), "The due time must not be less than -1.");
@@ -68,10 +68,10 @@ namespace Orleans.Runtime
 
         private void Init(ILogger logger, Func<object, Task> asynCallback, TimerCallback synCallback, object state, TimeSpan due, TimeSpan period)
         {
-            if (synCallback == null && asynCallback == null) throw new ArgumentNullException("synCallback", "Cannot use null for both sync and asyncTask timer callbacks.");
+            if (synCallback == null && asynCallback == null) throw new ArgumentNullException(nameof(synCallback), "Cannot use null for both sync and asyncTask timer callbacks.");
             int numNonNulls = (asynCallback != null ? 1 : 0) + (synCallback != null ? 1 : 0);
-            if (numNonNulls > 1) throw new ArgumentNullException("synCallback", "Cannot define more than one timer callbacks. Pick one.");
-            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException("period", period, "Cannot use TimeSpan.Zero for timer period");
+            if (numNonNulls > 1) throw new ArgumentNullException(nameof(synCallback), "Cannot define more than one timer callbacks. Pick one.");
+            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), period, "Cannot use TimeSpan.Zero for timer period");
 
             long dueTm = (long)dueTime.TotalMilliseconds;
             if (dueTm < -1) throw new ArgumentOutOfRangeException(nameof(dueTime), "The due time must not be less than -1.");
@@ -192,7 +192,7 @@ namespace Orleans.Runtime
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private bool Change(TimeSpan newDueTime, TimeSpan period)
         {
-            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException("period", period, $"Cannot use TimeSpan.Zero for timer {GetFullName()} period");
+            if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), period, $"Cannot use TimeSpan.Zero for timer {GetFullName()} period");
 
             if (timer == null) return false;
 

--- a/src/Orleans.EventSourcing/JournaledGrain.cs
+++ b/src/Orleans.EventSourcing/JournaledGrain.cs
@@ -45,7 +45,7 @@ namespace Orleans.EventSourcing
         protected virtual void RaiseEvent<TEvent>(TEvent @event) 
             where TEvent : TEventBase
         {
-            if (@event == null) throw new ArgumentNullException("event");
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
 
             LogViewAdaptor.Submit(@event);
         }
@@ -57,7 +57,7 @@ namespace Orleans.EventSourcing
         protected virtual void RaiseEvents<TEvent>(IEnumerable<TEvent> events) 
             where TEvent : TEventBase
         {
-            if (events == null) throw new ArgumentNullException("events");
+            if (events == null) throw new ArgumentNullException(nameof(events));
 
             LogViewAdaptor.SubmitRange((IEnumerable<TEventBase>) events);
         }
@@ -71,7 +71,7 @@ namespace Orleans.EventSourcing
         protected virtual Task<bool> RaiseConditionalEvent<TEvent>(TEvent @event)
             where TEvent : TEventBase
         {
-            if (@event == null) throw new ArgumentNullException("event");
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
 
             return LogViewAdaptor.TryAppend(@event);
         }
@@ -85,7 +85,7 @@ namespace Orleans.EventSourcing
         protected virtual Task<bool> RaiseConditionalEvents<TEvent>(IEnumerable<TEvent> events)
             where TEvent : TEventBase
         {
-            if (events == null) throw new ArgumentNullException("events");
+            if (events == null) throw new ArgumentNullException(nameof(events));
             return LogViewAdaptor.TryAppendRange((IEnumerable<TEventBase>) events);
         }
 

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -728,7 +728,7 @@ namespace Orleans.Runtime.ReminderService
                     throw new ArgumentNullException(nameof(grainId));
 
                 if (string.IsNullOrWhiteSpace(reminderName))
-                    throw new ArgumentException("The reminder name is either null or whitespace.", "reminderName");
+                    throw new ArgumentException("The reminder name is either null or whitespace.", nameof(reminderName));
 
                 this.GrainId = grainId;
                 this.ReminderName = reminderName;

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -359,7 +359,7 @@ namespace Orleans.Runtime
         {
             if (timeout < quantum)
             {
-                throw new ArgumentException(String.Format("timeout must be at least {0}, but it is {1}", quantum, timeout), "timeout");
+                throw new ArgumentException(String.Format("timeout must be at least {0}, but it is {1}", quantum, timeout), nameof(timeout));
             }
 
             return MakeTicketFromDateTime(DateTime.UtcNow + timeout);

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -89,7 +89,7 @@ namespace Orleans.Providers.Streams.Common
             
             var token = other as EventSequenceToken;
             if (token == null)
-                throw new ArgumentOutOfRangeException("other");
+                throw new ArgumentOutOfRangeException(nameof(other));
             
             int difference = SequenceNumber.CompareTo(token.SequenceNumber);
             return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);

--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
@@ -122,7 +122,7 @@ namespace Orleans.Providers.Streams.Common
             {
                 if (index >= writeIndex || index < readIndex)
                 {
-                    throw new ArgumentOutOfRangeException("index");
+                    throw new ArgumentOutOfRangeException(nameof(index));
                 }
                 return cachedMessages[index];
             }
@@ -177,7 +177,7 @@ namespace Orleans.Providers.Streams.Common
                     return i;
                 }
             }
-            throw new ArgumentOutOfRangeException("token");
+            throw new ArgumentOutOfRangeException(nameof(token));
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (start < readIndex)
             {
-                throw new ArgumentOutOfRangeException("start");
+                throw new ArgumentOutOfRangeException(nameof(start));
             }
 
             for (int i = start; i < writeIndex; i++)

--- a/src/Orleans.Streaming/Common/PooledCache/ObjectPool.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ObjectPool.cs
@@ -33,7 +33,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (factoryFunc == null)
             {
-                throw new ArgumentNullException("factoryFunc");
+                throw new ArgumentNullException(nameof(factoryFunc));
             }
 
             this.factoryFunc = factoryFunc;

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -82,8 +82,8 @@ namespace Orleans.Providers.Streams.Common
             TimeSpan? cacheMonitorWriteInterval,
             TimeSpan? purgeMetadataInterval = null)
         {
-            this.cacheDataAdapter = cacheDataAdapter ?? throw new ArgumentNullException("cacheDataAdapter");
-            this.logger = logger ?? throw new ArgumentNullException("logger");
+            this.cacheDataAdapter = cacheDataAdapter ?? throw new ArgumentNullException(nameof(cacheDataAdapter));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.ItemCount = 0;
             pool = new CachedMessagePool(cacheDataAdapter);
             messageBlocks = new LinkedList<CachedMessageBlock>();
@@ -269,13 +269,13 @@ namespace Orleans.Providers.Streams.Common
 
             if (cursorObj == null)
             {
-                throw new ArgumentNullException("cursorObj");
+                throw new ArgumentNullException(nameof(cursorObj));
             }
 
             var cursor = cursorObj as Cursor;
             if (cursor == null)
             {
-                throw new ArgumentOutOfRangeException("cursorObj", "Cursor is bad");
+                throw new ArgumentOutOfRangeException(nameof(cursorObj), "Cursor is bad");
             }
 
             if (cursor.State != CursorStates.Set)

--- a/src/Orleans.Streaming/Extensions/GenericAsyncObserver.cs
+++ b/src/Orleans.Streaming/Extensions/GenericAsyncObserver.cs
@@ -15,9 +15,9 @@ namespace Orleans.Streams
 
         public GenericAsyncObserver(Func<T, StreamSequenceToken, Task> onNextAsync, Func<Exception, Task> onErrorAsync, Func<Task> onCompletedAsync)
         {
-            if (onNextAsync == null) throw new ArgumentNullException("onNextAsync");
-            if (onErrorAsync == null) throw new ArgumentNullException("onErrorAsync");
-            if (onCompletedAsync == null) throw new ArgumentNullException("onCompletedAsync");
+            if (onNextAsync == null) throw new ArgumentNullException(nameof(onNextAsync));
+            if (onErrorAsync == null) throw new ArgumentNullException(nameof(onErrorAsync));
+            if (onCompletedAsync == null) throw new ArgumentNullException(nameof(onCompletedAsync));
 
             this.onNextAsync = onNextAsync;
             this.onErrorAsync = onErrorAsync;

--- a/src/Orleans.Streaming/Extensions/GenericBatchAsyncObserver.cs
+++ b/src/Orleans.Streaming/Extensions/GenericBatchAsyncObserver.cs
@@ -16,9 +16,9 @@ namespace Orleans.Streams
 
         public GenericAsyncBatchObserver(Func<IList<SequentialItem<T>>, Task> onNextAsync, Func<Exception, Task> onErrorAsync, Func<Task> onCompletedAsync)
         {
-            this.onNextAsync = onNextAsync ?? throw new ArgumentNullException("onNextAsync");
-            this.onErrorAsync = onErrorAsync ?? throw new ArgumentNullException("onErrorAsync");
-            this.onCompletedAsync = onCompletedAsync ?? throw new ArgumentNullException("onCompletedAsync");
+            this.onNextAsync = onNextAsync ?? throw new ArgumentNullException(nameof(onNextAsync));
+            this.onErrorAsync = onErrorAsync ?? throw new ArgumentNullException(nameof(onErrorAsync));
+            this.onCompletedAsync = onCompletedAsync ?? throw new ArgumentNullException(nameof(onCompletedAsync));
         }
 
         public Task OnNextAsync(IList<SequentialItem<T>> items)

--- a/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
@@ -171,12 +171,12 @@ namespace Orleans.Providers.Streams.Generator
         {
             if (arg == null)
             {
-                throw new ArgumentNullException("arg");
+                throw new ArgumentNullException(nameof(arg));
             }
             generatorConfig = arg as IStreamGeneratorConfig;
             if (generatorConfig == null)
             {
-                throw new ArgumentOutOfRangeException("arg", "Arg must by of type IStreamGeneratorConfig");
+                throw new ArgumentOutOfRangeException(nameof(arg), "Arg must by of type IStreamGeneratorConfig");
             }
 
             // update generator on receivers

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -79,7 +79,7 @@ namespace Orleans.Streams
             string filterData = null)
         {
             if (token != null && !IsRewindable)
-                throw new ArgumentNullException("token", "Passing a non-null token to a non-rewindable IAsyncObservable.");
+                throw new ArgumentNullException(nameof(token), "Passing a non-null token to a non-rewindable IAsyncObservable.");
             if (observer is GrainReference)
                 throw new ArgumentException("On-behalf subscription via grain references is not supported. Only passing of object references is allowed.", nameof(observer));
             if (batchObserver is GrainReference)
@@ -148,7 +148,7 @@ namespace Orleans.Streams
             StreamSubscriptionHandleImpl<T> oldHandleImpl = CheckHandleValidity(handle);
 
             if (token != null && !IsRewindable)
-                throw new ArgumentNullException("token", "Passing a non-null token to a non-rewindable IAsyncObservable.");
+                throw new ArgumentNullException(nameof(token), "Passing a non-null token to a non-rewindable IAsyncObservable.");
 
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Resume Token={Token}", token);
             await BindExtensionLazy();
@@ -255,14 +255,14 @@ namespace Orleans.Streams
         private StreamSubscriptionHandleImpl<T> CheckHandleValidity(StreamSubscriptionHandle<T> handle)
         {
             if (handle == null)
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
             if (!handle.StreamId.Equals(stream.StreamId))
-                throw new ArgumentException("Handle is not for this stream.", "handle");
+                throw new ArgumentException("Handle is not for this stream.", nameof(handle));
             var handleImpl = handle as StreamSubscriptionHandleImpl<T>;
             if (handleImpl == null)
-                throw new ArgumentException("Handle type not supported.", "handle");
+                throw new ArgumentException("Handle type not supported.", nameof(handle));
             if (!handleImpl.IsValid)
-                throw new ArgumentException("Handle is no longer valid.  It has been used to unsubscribe or resume.", "handle");
+                throw new ArgumentException("Handle is no longer valid.  It has been used to unsubscribe or resume.", nameof(handle));
             return handleImpl;
         }
     }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -57,7 +57,7 @@ namespace Orleans.Streams
             StreamSequenceToken token,
             string filterData)
         {
-            if (null == stream) throw new ArgumentNullException("stream");
+            if (null == stream) throw new ArgumentNullException(nameof(stream));
 
             try
             {

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -57,10 +57,10 @@ namespace Orleans.Streams
             StreamSequenceToken token,
             string filterData)
         {
-            this.subscriptionId = subscriptionId ?? throw new ArgumentNullException("subscriptionId");
+            this.subscriptionId = subscriptionId ?? throw new ArgumentNullException(nameof(subscriptionId));
             this.observer = observer;
             this.batchObserver = batchObserver;
-            this.streamImpl = streamImpl ?? throw new ArgumentNullException("streamImpl");
+            this.streamImpl = streamImpl ?? throw new ArgumentNullException(nameof(streamImpl));
             this.filterData = filterData;
             this.isRewindable = streamImpl.IsRewindable;
             if (IsRewindable)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -56,17 +56,17 @@ namespace Orleans.Streams
         {
             if (string.IsNullOrWhiteSpace(strProviderName))
             {
-                throw new ArgumentNullException("strProviderName");
+                throw new ArgumentNullException(nameof(strProviderName));
             }
 
             if (streamPubSub == null)
             {
-                throw new ArgumentNullException("streamPubSub", "StreamPubSub reference should not be null");
+                throw new ArgumentNullException(nameof(streamPubSub), "StreamPubSub reference should not be null");
             }
 
             if (streamQueueBalancer == null)
             {
-                throw new ArgumentNullException("streamQueueBalancer", "IStreamQueueBalancer streamQueueBalancer reference should not be null");
+                throw new ArgumentNullException(nameof(streamQueueBalancer), "IStreamQueueBalancer streamQueueBalancer reference should not be null");
             }
 
             queuesToAgentsMap = new Dictionary<QueueId, PersistentStreamPullingAgent>();

--- a/src/Orleans.Streaming/PersistentStreams/StreamPosition.cs
+++ b/src/Orleans.Streaming/PersistentStreams/StreamPosition.cs
@@ -19,7 +19,7 @@ namespace Orleans.Streams
         {
             if (sequenceToken == null)
             {
-                throw new ArgumentNullException("sequenceToken");
+                throw new ArgumentNullException(nameof(sequenceToken));
             }
             StreamId = streamId;
             SequenceToken = sequenceToken;

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
@@ -16,7 +16,7 @@ namespace Orleans.Streams
         {
             if (implicitPubSubTable == null)
             {
-                throw new ArgumentNullException("implicitPubSubTable");
+                throw new ArgumentNullException(nameof(implicitPubSubTable));
             }
 
             this.grainFactory = grainFactory;

--- a/src/Orleans.Streaming/PubSub/StreamPubSubImpl.cs
+++ b/src/Orleans.Streaming/PubSub/StreamPubSubImpl.cs
@@ -16,12 +16,12 @@ namespace Orleans.Streams
         {
             if (explicitPubSub == null)
             {
-                throw new ArgumentNullException("explicitPubSub");
+                throw new ArgumentNullException(nameof(explicitPubSub));
             }
 
             if (implicitPubSub == null)
             {
-                throw new ArgumentNullException("implicitPubSub");
+                throw new ArgumentNullException(nameof(implicitPubSub));
             }
 
             this.explicitPubSub = explicitPubSub;

--- a/src/Orleans.Streaming/QueueBalancer/BestFitBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/BestFitBalancer.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Orleans.Streams
 {
     /// <summary>
-    /// Best fit balancer keeps each active bucket responsible for its ideal set of resources, and redistributes 
+    /// Best fit balancer keeps each active bucket responsible for its ideal set of resources, and redistributes
     /// resources from inactive buckets evenly over active buckets.  If there are large numbers of inactive buckets,
     /// this can lead to quite a bit of shuffling of resources from inactive buckets as buckets come back online.
     /// Requirements:
@@ -21,7 +21,7 @@ namespace Orleans.Streams
     ///        these resources from ever being assigned to another bucket unless a bucket becomes inactive.
     ///     2) Build a list of inactive buckets.
     ///     3) For each inactive bucket, add its ideal resource allocation to the list of resources to be reallocated.
-    ///     4) Order the active buckets by the number of resources allocated to each and begin assigning them more resources 
+    ///     4) Order the active buckets by the number of resources allocated to each and begin assigning them more resources
     ///        from the list of resources to be reallocated.
     ///         i) Continue iterating over the active buckets assigning resources until there are no more resources that need
     ///            reallocated.
@@ -46,19 +46,19 @@ namespace Orleans.Streams
         {
             if (buckets == null)
             {
-                throw new ArgumentNullException("buckets");
+                throw new ArgumentNullException(nameof(buckets));
             }
 
             if (resources == null)
             {
-                throw new ArgumentNullException("resources");
+                throw new ArgumentNullException(nameof(resources));
             }
 
             idealDistribution = BuildIdealDistribution(buckets, resources);
         }
 
         /// <summary>
-        /// Gets a distribution for the active buckets. 
+        /// Gets a distribution for the active buckets.
         /// Any active buckets keep their ideal distribution.  Resources from inactive buckets are redistributed evenly
         /// among the active buckets, starting with those with the fewest allocated resources.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Orleans.Streams
         {
             if (activeBuckets == null)
             {
-                throw new ArgumentNullException("activeBuckets");
+                throw new ArgumentNullException(nameof(activeBuckets));
             }
 
             // sanitize active buckets.  Remove duplicates, ensure all buckets are valid
@@ -77,7 +77,7 @@ namespace Orleans.Streams
             {
                 if (!idealDistribution.ContainsKey(bucket))
                 {
-                    throw new ArgumentOutOfRangeException("activeBuckets", String.Format("Active buckets contain a bucket {0} not in the master list.", bucket));
+                    throw new ArgumentOutOfRangeException(nameof(activeBuckets), String.Format("Active buckets contain a bucket {0} not in the master list.", bucket));
                 }
             }
 

--- a/src/Orleans.Streaming/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -59,7 +59,7 @@ namespace Orleans.Streams
         {
             if (queueMapper == null)
             {
-                throw new ArgumentNullException("queueMapper");
+                throw new ArgumentNullException(nameof(queueMapper));
             }
             this.allQueues = queueMapper.GetAllQueues().ToList();
             NotifyAfterStart().Ignore();

--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -85,7 +85,7 @@ namespace Orleans.Streams
             if (base.Cancellation.IsCancellationRequested) throw new InvalidOperationException("Cannot initialize a terminated balancer.");
             if (queueMapper == null)
             {
-                throw new ArgumentNullException("queueMapper");
+                throw new ArgumentNullException(nameof(queueMapper));
             }
             var allQueues = queueMapper.GetAllQueues().ToList();
             this.allQueuesCount = allQueues.Count;

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
@@ -84,12 +84,12 @@ namespace UnitTests.General
         {
             if (string.IsNullOrWhiteSpace(invariantName))
             {
-                throw new ArgumentException("The name of invariant must contain characters", "invariantName");
+                throw new ArgumentException("The name of invariant must contain characters", nameof(invariantName));
             }
 
             if (string.IsNullOrWhiteSpace(testDatabaseName))
             {
-                throw new ArgumentException("database string must contain characters", "testDatabaseName");
+                throw new ArgumentException("database string must contain characters", nameof(testDatabaseName));
             }
 
             Console.WriteLine("Initializing relational databases...");

--- a/test/Extensions/TesterAzureUtils/Utilities/AsyncPipeline.cs
+++ b/test/Extensions/TesterAzureUtils/Utilities/AsyncPipeline.cs
@@ -49,7 +49,7 @@ namespace Tester.AzureUtils.Utilities
         public AsyncPipeline(int capacity)
         {
             if (capacity < 1)
-                throw new ArgumentOutOfRangeException("capacity", "The pipeline size must be larger than 0.");
+                throw new ArgumentOutOfRangeException(nameof(capacity), "The pipeline size must be larger than 0.");
             running = new HashSet<Task>();
             waiting = new LinkedList<Tuple<Task, TaskCompletionSource<bool>>>();
             this.capacity = capacity;
@@ -124,7 +124,7 @@ namespace Tester.AzureUtils.Utilities
         internal void Add(Task task, WhiteBox whiteBox)
         {
             if (null == task)
-                throw new ArgumentNullException("task");
+                throw new ArgumentNullException(nameof(task));
 
             // whitebox testing results-- we initialize pipeSz with an inconsistent copy of Count because it's better than nothing and will reflect that the pipeline size was in a valid state during some portion of this method, even if it isn't at a properly synchronized moment.
             int pipeSz = Count;

--- a/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
+++ b/test/Grains/TestGrains/AdoNet/CustomerGrain.cs
@@ -34,7 +34,7 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
         public async Task AddDevice(IDeviceGrain device)
         {
             if (device == null)
-                throw new ArgumentNullException("device");
+                throw new ArgumentNullException(nameof(device));
 
             if (null == State.Devices)
                 State.Devices = new List<IDeviceGrain>();

--- a/test/Grains/TestGrains/AdoNet/DeviceGrain.cs
+++ b/test/Grains/TestGrains/AdoNet/DeviceGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.SqlUtils.StorageProvider.GrainInterfaces;
@@ -16,7 +16,7 @@ namespace Orleans.SqlUtils.StorageProvider.GrainClasses
         public async Task SetOwner(ICustomerGrain customer)
         {
             if (customer == null)
-                throw new ArgumentNullException("customer");
+                throw new ArgumentNullException(nameof(customer));
 
             State.Owner = customer;
 

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -68,7 +68,7 @@ namespace UnitTests.Grains
             _logger.LogInformation("Consumer.BecomeConsumer");
             if (String.IsNullOrEmpty(providerToUse))
             {
-                throw new ArgumentNullException("providerToUse");
+                throw new ArgumentNullException(nameof(providerToUse));
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             IAsyncStream<int> stream = streamProvider.GetStream<int>(StreamNamespace, streamId);
@@ -96,7 +96,7 @@ namespace UnitTests.Grains
 
         public Task<int> GetNumberConsumed()
         {
-            return Task.FromResult(_numConsumedItems); 
+            return Task.FromResult(_numConsumedItems);
         }
     }
 }

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
         {
             logger.LogInformation("Resume");
             if(handle == null)
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
 
             // new counter for this subscription
             Tuple<Counter,Counter> counters;

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -39,7 +39,7 @@ namespace UnitTests.Grains
             _logger.LogInformation("Producer.BecomeProducer");
             if (String.IsNullOrEmpty(providerToUse))
             {
-                throw new ArgumentNullException("providerToUse");
+                throw new ArgumentNullException(nameof(providerToUse));
             }
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             IAsyncStream<int> stream = streamProvider.GetStream<int>(ConsumerEventCountingGrain.StreamNamespace, streamId);

--- a/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
         {
             if (0 == count)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             burstCount = count;

--- a/test/Grains/TestInternalGrains/InterlockedFlag.cs
+++ b/test/Grains/TestInternalGrains/InterlockedFlag.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 
 namespace UnitTests.TestHelper
@@ -32,7 +32,7 @@ namespace UnitTests.TestHelper
         public void ThrowDisposedIfSet(Type type)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             if (IsSet)
                 throw new ObjectDisposedException(type.Name);
         }

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -127,7 +127,7 @@ namespace UnitTests.Grains
 
         protected void InitStream(StreamId streamId, string providerToUse)
         {
-            if (providerToUse == null) throw new ArgumentNullException("providerToUse", "Can't have null stream provider name");
+            if (providerToUse == null) throw new ArgumentNullException(nameof(providerToUse), "Can't have null stream provider name");
 
             if (State.Stream != null && !State.Stream.StreamId.Equals(streamId))
             {

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -65,7 +65,7 @@ namespace UnitTests.Grains
         public static ConsumerObserver NewObserver(ILogger logger)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new ConsumerObserver(logger);
         }
 
@@ -199,7 +199,7 @@ namespace UnitTests.Grains
         public static ProducerObserver NewObserver(ILogger logger, IGrainFactory grainFactory)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new ProducerObserver(logger, grainFactory);
         }
 
@@ -246,7 +246,7 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             if (0 >= count)
-                throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(count), "The count must be greater than zero.");
             _expectedItemsProduced += count;
             _logger.LogInformation("ProducerObserver.ProduceSequentialSeries: StreamId={StreamId}, num items to produce={Count}.", _streamId, count);
             for (var i = 1; i <= count; ++i)
@@ -258,7 +258,7 @@ namespace UnitTests.Grains
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             if (0 >= count)
-                throw new ArgumentOutOfRangeException("count", "The count must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(count), "The count must be greater than zero.");
             _logger.LogInformation("ProducerObserver.ProduceParallelSeries: streamId={StreamId}, num items to produce={Count}.", _streamId, count);
             _expectedItemsProduced += count;
             var tasks = new Task<bool>[count];
@@ -302,7 +302,7 @@ namespace UnitTests.Grains
         {
             _logger.LogInformation("ProducerObserver.RemoveTimer: streamId={StreamId}.", _streamId);
             if (handle == null)
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
             if (!_timers.Remove(handle))
                 throw new InvalidOperationException("handle not found");
         }
@@ -402,13 +402,13 @@ namespace UnitTests.Grains
             public static TimerState NewTimer(Func<Func<object, Task>, IDisposable> startTimerFunc, Func<string, Task<bool>> produceItemFunc, Action<IDisposable> onDisposeFunc, int count)
             {
                 if (null == startTimerFunc)
-                    throw new ArgumentNullException("startTimerFunc");
+                    throw new ArgumentNullException(nameof(startTimerFunc));
                 if (null == produceItemFunc)
-                    throw new ArgumentNullException("produceItemFunc");
+                    throw new ArgumentNullException(nameof(produceItemFunc));
                 if (null == onDisposeFunc)
-                    throw new ArgumentNullException("onDisposeFunc");
+                    throw new ArgumentNullException(nameof(onDisposeFunc));
                 if (0 >= count)
-                    throw new ArgumentOutOfRangeException("count", count, "argument must be > 0");
+                    throw new ArgumentOutOfRangeException(nameof(count), count, "argument must be > 0");
                 var newOb = new TimerState(produceItemFunc, onDisposeFunc, count);
                 newOb.Handle = startTimerFunc(newOb.OnTickAsync);
                 if (null == newOb.Handle)
@@ -926,7 +926,7 @@ namespace UnitTests.Grains
 
             if (string.IsNullOrWhiteSpace(streamNamespace))
             {
-                throw new ArgumentException("namespace is required (must not be null or whitespace)", "streamNamespace");
+                throw new ArgumentException("namespace is required (must not be null or whitespace)", nameof(streamNamespace));
             }
 
             ConsumerObserver consumerObserver = ConsumerObserver.NewObserver(_logger);

--- a/test/TestInfrastructure/TestExtensions/HierarchicalKeyStore.cs
+++ b/test/TestInfrastructure/TestExtensions/HierarchicalKeyStore.cs
@@ -30,7 +30,7 @@ namespace Orleans.Storage
             {
                 var error = string.Format("Wrong number of keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count);
                 Trace.TraceError(error);
-                throw new ArgumentOutOfRangeException("keys", keys.Count, error);
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count, error);
             }
 
             lock (lockable)
@@ -51,7 +51,7 @@ namespace Orleans.Storage
             {
                 var error = string.Format("Not enough keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count);
                 Trace.TraceError(error);
-                throw new ArgumentOutOfRangeException("keys", keys.Count, error);
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count, error);
             }
 
             lock (lockable)
@@ -64,7 +64,7 @@ namespace Orleans.Storage
         {
             if (keys.Count > numKeyLayers)
             {
-                throw new ArgumentOutOfRangeException("keys", keys.Count,
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count,
                     string.Format("Too many key supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count));
             }
 
@@ -78,7 +78,7 @@ namespace Orleans.Storage
         {
             if (keys.Count > numKeyLayers)
             {
-                throw new ArgumentOutOfRangeException("keys", keys.Count,
+                throw new ArgumentOutOfRangeException(nameof(keys), keys.Count,
                     string.Format("Not enough keys supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count));
             }
 

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -24,7 +24,7 @@ namespace UnitTests.StreamingTests
         {
             if (string.IsNullOrWhiteSpace(streamProviderName))
             {
-                throw new ArgumentNullException("streamProviderName");
+                throw new ArgumentNullException(nameof(streamProviderName));
             }
             this.streamProviderName = streamProviderName;
             this.logger = testCluster.Client.ServiceProvider.GetRequiredService<ILogger<SubscriptionMultiplicityTestRunner>>();

--- a/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
@@ -72,7 +72,7 @@ namespace Tester.TestStreamProviders.Controllable
                 case ControllableTestStreamProviderCommands.AdapterFactoryEcho:
                     return Task.FromResult<object>(Tuple.Create(ControllableTestStreamProviderCommands.AdapterFactoryEcho, arg));
             }
-            throw new ArgumentOutOfRangeException("command");
+            throw new ArgumentOutOfRangeException(nameof(command));
         }
 
         public static ControllableTestAdapterFactory Create(IServiceProvider services, string name)

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -91,7 +91,7 @@ namespace UnitTests.StreamingTests
         public static Streaming_ProducerClientObject NewObserver(ILogger logger, IClusterClient client)
         {
             if (null == logger)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             return new Streaming_ProducerClientObject(logger, client);
         }
 
@@ -181,13 +181,13 @@ namespace UnitTests.StreamingTests
         private static async Task<ConsumerProxy> NewConsumerProxy(Guid streamId, string streamProvider, IStreaming_ConsumerGrain[] targets, ILogger logger, IInternalGrainFactory grainFactory)
         {
             if (targets == null)
-                throw new ArgumentNullException("targets");
+                throw new ArgumentNullException(nameof(targets));
             if (targets.Length == 0)
                 throw new ArgumentException("caller must specify at least one target");
             if (String.IsNullOrWhiteSpace(streamProvider))
-                throw new ArgumentException("Stream provider name is either null or whitespace", "streamProvider");
+                throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
             ConsumerProxy newObj = new ConsumerProxy(targets, logger, grainFactory);
             await newObj.BecomeConsumer(streamId, streamProvider);
@@ -198,7 +198,7 @@ namespace UnitTests.StreamingTests
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainCount), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewConsumerGrainsAsync: multiplexing {GrainCount} consumer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ConsumerGrain>();
@@ -229,7 +229,7 @@ namespace UnitTests.StreamingTests
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainIds), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {GrainCount} consumer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ConsumerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ConsumerGrain>();
@@ -258,7 +258,7 @@ namespace UnitTests.StreamingTests
         public static Task<ConsumerProxy> NewConsumerClientObjectsAsync(Guid streamId, string streamProvider, ILogger logger, IInternalClusterClient client, int consumerCount = 1)
         {
             if (consumerCount < 1)
-                throw new ArgumentOutOfRangeException("consumerCount", "argument must be 1 or greater");
+                throw new ArgumentOutOfRangeException(nameof(consumerCount), "argument must be 1 or greater");
             logger.LogInformation("ConsumerProxy.NewConsumerClientObjectsAsync: multiplexing {ConsumerCount} consumer client objects for stream {StreamId}.", consumerCount, streamId);
             var objs = new IStreaming_ConsumerGrain[consumerCount];
             for (var i = 0; i < consumerCount; ++i)
@@ -269,7 +269,7 @@ namespace UnitTests.StreamingTests
         public static ConsumerProxy NewConsumerGrainAsync_WithoutBecomeConsumer(Guid consumerGrainId, ILogger logger, IInternalGrainFactory grainFactory, string grainClassName = "")
         {
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
             if (string.IsNullOrEmpty(grainClassName)) 
             {
@@ -379,11 +379,11 @@ namespace UnitTests.StreamingTests
         private static async Task<ProducerProxy> NewProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string streamProvider, string streamNamespace, ILogger logger)
         {
             if (targets == null)
-                throw new ArgumentNullException("targets");
+                throw new ArgumentNullException(nameof(targets));
             if (String.IsNullOrWhiteSpace(streamProvider))
-                throw new ArgumentException("Stream provider name is either null or whitespace", "streamProvider");
+                throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
 
             ProducerProxy newObj = new ProducerProxy(targets, streamId, streamProvider, logger);
             await newObj.BecomeProducer(streamId, streamProvider, streamNamespace);
@@ -394,7 +394,7 @@ namespace UnitTests.StreamingTests
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainCount", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainCount), "The grain count must be at least one");
             logger.LogInformation("ProducerProxy.NewProducerGrainsAsync: multiplexing {GrainCount} producer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<Guid, IStreaming_ProducerGrain>();
@@ -425,7 +425,7 @@ namespace UnitTests.StreamingTests
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
-                throw new ArgumentOutOfRangeException("grainIds", "The grain count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(grainIds), "The grain count must be at least one");
             logger.LogInformation("ConsumerProxy.NewProducerConsumerGrainsAsync: multiplexing {GrainCount} producer grains for stream {StreamId}.", grainCount, streamId);
             var grains = new IStreaming_ProducerGrain[grainCount];
             var dedup = new Dictionary<int, IStreaming_ProducerGrain>();
@@ -454,7 +454,7 @@ namespace UnitTests.StreamingTests
         public static Task<ProducerProxy> NewProducerClientObjectsAsync(Guid streamId, string streamProvider,  string streamNamespace, ILogger logger, IClusterClient client, int producersCount = 1)
         {            
             if (producersCount < 1)
-                throw new ArgumentOutOfRangeException("producersCount", "The producer count must be at least one");
+                throw new ArgumentOutOfRangeException(nameof(producersCount), "The producer count must be at least one");
             var producers = new IStreaming_ProducerGrain[producersCount];
             for (var i = 0; i < producersCount; ++i)
                 producers[i] = Streaming_ProducerClientObject.NewObserver(logger, client);


### PR DESCRIPTION
This PR is limited to a single refactor repeated over many times: addressing all instances of CA1517 (use nameof() instead of string constants).

Leaving this PR to only that one refactoring so as to make review substantially simpler.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8516)