### PR TITLE
Move CancellationToken arguments to the end

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -180,7 +180,7 @@ namespace Orleans.Storage
                     command.AddParameter("GrainIdExtensionString", grainId.StringKey);
                     command.AddParameter("ServiceId", serviceId);
                     command.AddParameter("GrainStateVersion", !string.IsNullOrWhiteSpace(grainState.ETag) ? int.Parse(grainState.ETag, CultureInfo.InvariantCulture) : default(int?));
-                }, (selector, resultSetCount, token) => Task.FromResult(selector.GetValue(0).ToString()), CancellationToken.None).ConfigureAwait(false));
+                }, (selector, resultSetCount, token) => Task.FromResult(selector.GetValue(0).ToString()), cancellationToken: CancellationToken.None).ConfigureAwait(false));
                 storageVersion = clearRecord.SingleOrDefault();
             }
             catch(Exception ex)
@@ -272,7 +272,7 @@ namespace Orleans.Storage
                         var result = Tuple.Create(storageState, version?.ToString(CultureInfo.InvariantCulture));
                         return Task.FromResult(result);
                     },
-                    CancellationToken.None, commandBehavior).ConfigureAwait(false)).SingleOrDefault();
+                    commandBehavior, CancellationToken.None).ConfigureAwait(false)).SingleOrDefault();
 
                 T state = readRecords != null ? (T) readRecords.Item1 : default;
                 string etag = readRecords != null ? readRecords.Item2 : null;
@@ -361,7 +361,7 @@ namespace Orleans.Storage
                     command.AddParameter("GrainStateVersion", !string.IsNullOrWhiteSpace(grainState.ETag) ? int.Parse(grainState.ETag, CultureInfo.InvariantCulture) : default(int?));
                     command.AddParameter("PayloadBinary", serialized.ToArray());
                 }, (selector, resultSetCount, token) =>
-                { return Task.FromResult(selector.GetNullableInt32("NewGrainStateVersion").ToString()); }, CancellationToken.None).ConfigureAwait(false);
+                { return Task.FromResult(selector.GetNullableInt32("NewGrainStateVersion").ToString()); }, cancellationToken: CancellationToken.None).ConfigureAwait(false);
                 storageVersion = writeRecord.SingleOrDefault();
             }
             catch(Exception ex)

--- a/src/AdoNet/Shared/Storage/IRelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/IRelationalStorage.cs
@@ -32,8 +32,8 @@ namespace Orleans.Tests.SqlUtils
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. The parameters must be in the same order with same names as defined in the query.</param>
         /// <param name="selector">This function transforms the raw <see cref="IDataRecord"/> results to type <see paramref="TResult"/> the <see cref="int"/> parameter being the resultset number.</param>
-        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <returns>A list of objects as a result of the <see paramref="query"/>.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -58,7 +58,7 @@ namespace Orleans.Tests.SqlUtils
         ///     tp1.DbType = DbType.String;
         ///     tp1.Direction = ParameterDirection.Input;
         ///     command.Parameters.Add(tp1);
-        ///     
+        ///
         ///     //The selector is used to select the results within the result set. In this case there are two homogenous
         ///     //result sets, so there is actually no need to check which result set the selector holds and it could
         ///     //marked with by convention by underscore (_).
@@ -70,19 +70,19 @@ namespace Orleans.Tests.SqlUtils
         ///        {
         ///            TABLE_CATALOG = selector.GetValueOrDefault&lt;string&gt;("TABLE_CATALOG"),
         ///            TABLE_NAME = selector.GetValueOrDefault&lt;string&gt;("TABLE_NAME")
-        ///        }               
-        ///}).ConfigureAwait(continueOnCapturedContext: false);                
-        /// </code>        
+        ///        }
+        ///}).ConfigureAwait(continueOnCapturedContext: false);
+        /// </code>
         /// </example>
-        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default);
+        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Executes a given statement. Especially intended to use with <em>INSERT</em>, <em>UPDATE</em>, <em>DELETE</em> or <em>DDL</em> queries.
         /// </summary>
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
-        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <returns>Affected rows count.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -94,10 +94,10 @@ namespace Orleans.Tests.SqlUtils
         ///     //There aren't parameters here, but they'd be added like when reading.
         ///     //As the affected rows count is the only thing returned, there isn't
         ///     //facilities to read anything.
-        /// }).ConfigureAwait(continueOnCapturedContext: false);                
+        /// }).ConfigureAwait(continueOnCapturedContext: false);
         /// </code>
         /// </example>
-        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default);
+        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// The well known invariant name of the underlying database.

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -87,12 +87,12 @@ namespace Orleans.Tests.SqlUtils
         {
             if(string.IsNullOrWhiteSpace(invariantName))
             {
-                throw new ArgumentException("The name of invariant must contain characters", "invariantName");
+                throw new ArgumentException("The name of invariant must contain characters", nameof(invariantName));
             }
 
             if(string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentException("Connection string must contain characters", "connectionString");
+                throw new ArgumentException("Connection string must contain characters", nameof(connectionString));
             }
 
             return new RelationalStorage(invariantName, connectionString);
@@ -153,15 +153,15 @@ namespace Orleans.Tests.SqlUtils
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             if(selector == null)
             {
-                throw new ArgumentNullException("selector");
+                throw new ArgumentNullException(nameof(selector));
             }
 
-            return (await ExecuteAsync(query, parameterProvider, selector, ExecuteReaderAsync, commandBehavior, cancellationToken).ConfigureAwait(false)).Item1;
+            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, commandBehavior, cancellationToken).ConfigureAwait(false)).Item1;
         }
 
 
@@ -191,10 +191,10 @@ namespace Orleans.Tests.SqlUtils
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
-            return (await ExecuteAsync(query, parameterProvider, (unit, id, c) => Task.FromResult(unit), ExecuteReaderAsync, commandBehavior, cancellationToken).ConfigureAwait(false)).Item2;
+            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), commandBehavior, cancellationToken).ConfigureAwait(false)).Item2;
         }
 
         /// <summary>
@@ -255,7 +255,7 @@ namespace Orleans.Tests.SqlUtils
         private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteAsync<TResult>(
             string query,
             Action<DbCommand> parameterProvider,
-            Func<DbCommand, Func<IDataRecord, int, CancellationToken, Task<TResult>>, CancellationToken, CommandBehavior, Task<Tuple<IEnumerable<TResult>, int>>> executor,
+            Func<DbCommand, Func<IDataRecord, int, CancellationToken, Task<TResult>>, CommandBehavior, CancellationToken, Task<Tuple<IEnumerable<TResult>, int>>> executor,
             Func<IDataRecord, int, CancellationToken, Task<TResult>> selector,
             CommandBehavior commandBehavior,
             CancellationToken cancellationToken)
@@ -273,11 +273,11 @@ namespace Orleans.Tests.SqlUtils
                     Task<Tuple<IEnumerable<TResult>, int>> ret;
                     if(isSynchronousAdoNetImplementation)
                     {
-                        ret = Task.Run(() => executor(command, selector, cancellationToken, commandBehavior), cancellationToken);
+                        ret = Task.Run(() => executor(command, selector, commandBehavior, cancellationToken), cancellationToken);
                     }
                     else
                     {
-                        ret = executor(command, selector, cancellationToken, commandBehavior);
+                        ret = executor(command, selector, commandBehavior, cancellationToken);
                     }
 
                     return await ret.ConfigureAwait(continueOnCapturedContext: false);

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -21,7 +21,7 @@ namespace Orleans.Tests.SqlUtils
 {
     /// <summary>
     /// A general purpose class to work with a given relational database and ADO.NET provider.
-    /// </summary>    
+    /// </summary>
     [DebuggerDisplay("InvariantName = {InvariantName}, ConnectionString = {ConnectionString}")]
     internal class RelationalStorage: IRelationalStorage
     {
@@ -103,11 +103,11 @@ namespace Orleans.Tests.SqlUtils
         /// Executes a given statement. Especially intended to use with <em>SELECT</em> statement.
         /// </summary>
         /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">Executes a given statement. Especially intended to use with <em>SELECT</em> statement.</param>        
+        /// <param name="query">Executes a given statement. Especially intended to use with <em>SELECT</em> statement.</param>
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
         /// <param name="selector">This function transforms the raw <see cref="IDataRecord"/> results to type <see paramref="TResult"/> the <see cref="int"/> parameter being the resultset number.</param>
-        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <returns>A list of objects as a result of the <see paramref="query"/>.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -132,7 +132,7 @@ namespace Orleans.Tests.SqlUtils
         ///     tp1.DbType = DbType.String;
         ///     tp1.Direction = ParameterDirection.Input;
         ///     command.Parameters.Add(tp1);
-        ///     
+        ///
         ///     //The selector is used to select the results within the result set. In this case there are two homogenous
         ///     //result sets, so there is actually no need to check which result set the selector holds and it could
         ///     //marked with by convention by underscore (_).
@@ -144,11 +144,11 @@ namespace Orleans.Tests.SqlUtils
         ///        {
         ///            TABLE_CATALOG = selector.GetValueOrDefault&lt;string&gt;("TABLE_CATALOG"),
         ///            TABLE_NAME = selector.GetValueOrDefault&lt;string&gt;("TABLE_NAME")
-        ///        }               
-        ///}).ConfigureAwait(continueOnCapturedContext: false);                
+        ///        }
+        ///}).ConfigureAwait(continueOnCapturedContext: false);
         /// </code>
         /// </example>
-        public async Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
+        public async Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken))
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -161,7 +161,7 @@ namespace Orleans.Tests.SqlUtils
                 throw new ArgumentNullException("selector");
             }
 
-            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, cancellationToken, commandBehavior).ConfigureAwait(false)).Item1;
+            return (await ExecuteAsync(query, parameterProvider, selector, ExecuteReaderAsync, commandBehavior, cancellationToken).ConfigureAwait(false)).Item1;
         }
 
 
@@ -170,8 +170,8 @@ namespace Orleans.Tests.SqlUtils
         /// </summary>
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
-        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
         /// <returns>Affected rows count.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -183,10 +183,10 @@ namespace Orleans.Tests.SqlUtils
         ///     //There aren't parameters here, but they'd be added like when reading.
         ///     //As the affected rows count is the only thing returned, there isn't
         ///     //facilities to read anything.
-        /// }).ConfigureAwait(continueOnCapturedContext: false);                
+        /// }).ConfigureAwait(continueOnCapturedContext: false);
         /// </code>
         /// </example>
-        public async Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
+        public async Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken))
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -194,7 +194,7 @@ namespace Orleans.Tests.SqlUtils
                 throw new ArgumentNullException("query");
             }
 
-            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), cancellationToken, commandBehavior).ConfigureAwait(false)).Item2;
+            return (await ExecuteAsync(query, parameterProvider, (unit, id, c) => Task.FromResult(unit), ExecuteReaderAsync, commandBehavior, cancellationToken).ConfigureAwait(false)).Item2;
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Orleans.Tests.SqlUtils
         }
 
 
-        private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteReaderAsync<TResult>(DbCommand command, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken, CommandBehavior commandBehavior)
+        private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteReaderAsync<TResult>(DbCommand command, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CommandBehavior commandBehavior, CancellationToken cancellationToken)
         {
             using(var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken).ConfigureAwait(continueOnCapturedContext: false))
             {
@@ -250,15 +250,15 @@ namespace Orleans.Tests.SqlUtils
                 }
             }
         }
-           
+
 
         private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteAsync<TResult>(
             string query,
             Action<DbCommand> parameterProvider,
             Func<DbCommand, Func<IDataRecord, int, CancellationToken, Task<TResult>>, CancellationToken, CommandBehavior, Task<Tuple<IEnumerable<TResult>, int>>> executor,
             Func<IDataRecord, int, CancellationToken, Task<TResult>> selector,
-            CancellationToken cancellationToken,
-            CommandBehavior commandBehavior)
+            CommandBehavior commandBehavior,
+            CancellationToken cancellationToken)
         {
             using (var connection = DbConnectionFactory.CreateConnection(invariantName, connectionString))
             {

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -132,13 +132,13 @@ namespace Orleans.Internal
         /// For making an uncancellable task cancellable, by ignoring its result.
         /// </summary>
         /// <param name="taskToComplete">The task to wait for unless cancelled</param>
-        /// <param name="cancellationToken">A cancellation token for cancelling the wait</param>
         /// <param name="message">Message to set in the exception</param>
+        /// <param name="cancellationToken">A cancellation token for cancelling the wait</param>
         /// <returns></returns>
         internal static async Task WithCancellation(
             this Task taskToComplete,
-            CancellationToken cancellationToken,
-            string message)
+            string message,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -203,7 +203,7 @@ namespace Orleans.Internal
         }
 
         //The rationale for GetAwaiter().GetResult() instead of .Result
-        //is presented at https://github.com/aspnet/Security/issues/59.      
+        //is presented at https://github.com/aspnet/Security/issues/59.
         internal static T GetResult<T>(this Task<T> task)
         {
             return task.GetAwaiter().GetResult();

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -75,12 +75,12 @@ namespace Orleans.Runtime.ReminderService
                     using var timeoutCancellation = new CancellationTokenSource(initTimeout);
                     var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCancellation.Token);
                     await this.QueueTask(Start)
-                        .WithCancellation(ct, $"Starting ReminderService failed due to timeout {initTimeout}");
+                        .WithCancellation($"Starting ReminderService failed due to timeout {initTimeout}", ct);
                 },
                 ct =>
                 {
                     return this.QueueTask(Stop)
-                        .WithCancellation(ct, "Stopping ReminderService failed because the task was cancelled");
+                        .WithCancellation("Stopping ReminderService failed because the task was cancelled", ct);
                 });
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1397,10 +1397,10 @@ namespace Orleans.Runtime
                 try
                 {
                     RequestContextExtensions.Import(requestContextData);
-                    await Lifecycle.OnStart(cancellationToken).WithCancellation(cancellationToken, "Timed out waiting for grain lifecycle to complete activation");
+                    await Lifecycle.OnStart(cancellationToken).WithCancellation("Timed out waiting for grain lifecycle to complete activation", cancellationToken);
                     if (GrainInstance is IGrainBase grainBase)
                     {
-                        await grainBase.OnActivateAsync(cancellationToken).WithCancellation(cancellationToken, $"Timed out waiting for {nameof(IGrainBase.OnActivateAsync)} to complete");
+                        await grainBase.OnActivateAsync(cancellationToken).WithCancellation($"Timed out waiting for {nameof(IGrainBase.OnActivateAsync)} to complete", cancellationToken);
                     }
 
                     lock (this)
@@ -1717,10 +1717,10 @@ namespace Orleans.Runtime
                             RequestContext.Clear(); // Clear any previous RC, so it does not leak into this call by mistake.
                             if (GrainInstance is IGrainBase grainBase)
                             {
-                                await grainBase.OnDeactivateAsync(DeactivationReason, ct).WithCancellation(ct, $"Timed out waiting for {nameof(IGrainBase.OnDeactivateAsync)} to complete");
+                                await grainBase.OnDeactivateAsync(DeactivationReason, ct).WithCancellation($"Timed out waiting for {nameof(IGrainBase.OnDeactivateAsync)} to complete", ct);
                             }
 
-                            await Lifecycle.OnStop(ct).WithCancellation(ct, "Timed out waiting for grain lifecycle to complete deactivation");
+                            await Lifecycle.OnStop(ct).WithCancellation("Timed out waiting for grain lifecycle to complete deactivation", ct);
                         }
 
                         if (_shared.Logger.IsEnabled(LogLevel.Debug))

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -600,14 +600,14 @@ namespace Orleans.Runtime
             {
                 await lifecycleSchedulingSystemTarget
                     .QueueTask(() => this.messageCenter.Gateway.SendStopSendMessages(this.grainFactory))
-                    .WithCancellation(ct, "Sending gateway disconnection requests failed because the task was cancelled");
+                    .WithCancellation("Sending gateway disconnection requests failed because the task was cancelled", ct);
             }
 
             foreach (var grainService in grainServices)
             {
                 await grainService
                     .QueueTask(grainService.Stop)
-                    .WithCancellation(ct, "Stopping GrainService failed because the task was cancelled");
+                    .WithCancellation("Stopping GrainService failed because the task was cancelled", ct);
 
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
@@ -77,7 +77,7 @@ namespace Orleans.Transactions.TestKit
         public void Participate(IGrainLifecycle lifecycle)
         {
             lifecycle.Subscribe<FaultInjectionTransactionalState<TState>>(GrainLifecycleStage.SetupState,
-                (ct) => this.txState.OnSetupState(ct, this.SetupResourceFactory));
+                (ct) => this.txState.OnSetupState(this.SetupResourceFactory, ct));
         }
 
         internal void SetupResourceFactory(IGrainContext context, string stateName, TransactionQueue<TState> queue)

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -190,7 +190,7 @@ namespace Orleans.Transactions
 
         public void Participate(IGrainLifecycle lifecycle)
         {
-            lifecycle.Subscribe<TransactionalState<TState>>(GrainLifecycleStage.SetupState, (ct) => OnSetupState(ct, SetupResourceFactory));
+            lifecycle.Subscribe<TransactionalState<TState>>(GrainLifecycleStage.SetupState, (ct) => OnSetupState(SetupResourceFactory, ct));
         }
 
         private static void SetupResourceFactory(IGrainContext context, string stateName, TransactionQueue<TState> queue)
@@ -202,7 +202,7 @@ namespace Orleans.Transactions
             context.RegisterResourceFactory<ITransactionManager>(stateName, () => new TransactionManager<TState>(queue));
         }
 
-        internal async Task OnSetupState(CancellationToken ct, Action<IGrainContext, string, TransactionQueue<TState>> setupResourceFactory)
+        internal async Task OnSetupState(Action<IGrainContext, string, TransactionQueue<TState>> setupResourceFactory, CancellationToken ct)
         {
             if (ct.IsCancellationRequested) return;
 

--- a/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
@@ -74,7 +74,7 @@ namespace UnitTests.StorageTests.AdoNet
                     p2.Size = dataToInsert.Length;
                     command.Parameters.Add(p2);
 
-                }, cancellationToken, CommandBehavior.SequentialAccess).ConfigureAwait(false);
+                }, CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -91,16 +91,16 @@ namespace UnitTests.StorageTests.AdoNet
             {
                 var streamSelector = (DbDataReader)selector;
                 var id = await streamSelector.GetValueAsync<int>("Id");
-                using(var ms = new MemoryStream())
-                {                    
-                    using(var downloadStream = streamSelector.GetStream(1, sut.Storage))
+                using (var ms = new MemoryStream())
+                {
+                    using (var downloadStream = streamSelector.GetStream(1, sut.Storage))
                     {
                         await downloadStream.CopyToAsync(ms);
 
                         return new StreamingTest { Id = id, StreamData = ms.ToArray() };
                     }
-                }                
-            }, cancellationToken, CommandBehavior.SequentialAccess).ConfigureAwait(false)).Single();
+                }
+            }, CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false)).Single();
         }
 
         protected static Task CancellationTokenTest(RelationalStorageForTesting sut, TimeSpan timeoutLimit)


### PR DESCRIPTION
Hi friends from Orleans,

Taking on one class of IDE warning at a time, this PR moves the CancellationToken argument to the end of the signature for methods not in the public API (internal and private only).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8525)