### PR TITLE
Avoid static members in generic types

### DIFF
--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -128,12 +128,12 @@ namespace Orleans.Runtime
             ThrowInvalidCall();
         }
 
-        private static void ThrowInvalidCall()
+        private void ThrowInvalidCall()
         {
             throw new InvalidOperationException($"{typeof(OutgoingCallInvoker<TResult>)}.{nameof(Invoke)}() received an invalid call.");
         }
 
-        private static void ThrowBrokenCallFilterChain(string filterName)
+        private void ThrowBrokenCallFilterChain(string filterName)
         {
             throw new InvalidOperationException($"{typeof(OutgoingCallInvoker<TResult>)}.{nameof(Invoke)}() invoked a broken filter: {filterName}.");
         }

--- a/src/Orleans.Core/Utils/AsyncEnumerable.cs
+++ b/src/Orleans.Core/Utils/AsyncEnumerable.cs
@@ -84,9 +84,9 @@ namespace Orleans.Runtime.Utilities
             }
         }
 
-        private static void ThrowInvalidUpdate() => throw new ArgumentException("The value was not valid");
+        private void ThrowInvalidUpdate() => throw new ArgumentException("The value was not valid");
 
-        private static void ThrowDisposed() => throw new ObjectDisposedException("This instance has been disposed");
+        private void ThrowDisposed() => throw new ObjectDisposedException("This instance has been disposed");
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
@@ -172,7 +172,7 @@ namespace Orleans.Runtime.Utilities
                 get
                 {
                     if (this.IsInitial) ThrowInvalidInstance();
-                    if (this.IsDisposed) ThrowDisposed();
+                    ObjectDisposedException.ThrowIf(IsDisposed, this);
                     if (this.value is T typedValue) return typedValue;
                     return default;
                 }
@@ -185,7 +185,7 @@ namespace Orleans.Runtime.Utilities
 
             public void SetNext(Element next) => this.next.SetResult(next);
 
-            private static T ThrowInvalidInstance() => throw new InvalidOperationException("This instance does not have a value set.");
+            private void ThrowInvalidInstance() => throw new InvalidOperationException("This instance does not have a value set.");
         }
     }
 }

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -220,8 +220,8 @@ namespace Orleans.Serialization
     [RegisterSerializer]
     public class FSharpChoiceCodec<T1, T2> : IFieldCodec<FSharpChoice<T1, T2>>, IDerivedTypeCodec
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -325,9 +325,9 @@ namespace Orleans.Serialization
     [RegisterSerializer]
     public class FSharpChoiceCodec<T1, T2, T3> : IFieldCodec<FSharpChoice<T1, T2, T3>>, IDerivedTypeCodec
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -438,10 +438,10 @@ namespace Orleans.Serialization
     [RegisterSerializer]
     public class FSharpChoiceCodec<T1, T2, T3, T4> : IFieldCodec<FSharpChoice<T1, T2, T3, T4>>, IDerivedTypeCodec
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -561,11 +561,11 @@ namespace Orleans.Serialization
     [RegisterSerializer]
     public class FSharpChoiceCodec<T1, T2, T3, T4, T5> : IFieldCodec<FSharpChoice<T1, T2, T3, T4, T5>>, IDerivedTypeCodec
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -694,12 +694,12 @@ namespace Orleans.Serialization
     [RegisterSerializer]
     public class FSharpChoiceCodec<T1, T2, T3, T4, T5, T6> : IFieldCodec<FSharpChoice<T1, T2, T3, T4, T5, T6>>, IDerivedTypeCodec
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
-        private static readonly Type ElementType6 = typeof(T6);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType6 = typeof(T6);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -116,13 +116,13 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(T[])}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
     /// <summary>
@@ -266,12 +266,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ReadOnlyMemory<T>)}, {length}, is greater than total length of input.");
     }
 
@@ -428,12 +428,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Memory<T>)}, {length}, is greater than total length of input.");
     }
 
@@ -593,12 +593,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ArraySegment<T>)}, {length}, is greater than total length of input.");
     }
 

--- a/src/Orleans.Serialization/Codecs/CollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CollectionCodec.cs
@@ -112,10 +112,10 @@ public sealed class CollectionCodec<T> : IFieldCodec<Collection<T>>
         return result;
     }
 
-    private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+    private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
         $"Declared length of {typeof(Collection<T>)}, {length}, is greater than total length of input.");
 
-    private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+    private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 }
 
 /// <summary>

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -143,10 +143,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
     }
 
     /// <summary>
@@ -312,10 +312,10 @@ namespace Orleans.Serialization.Codecs
             }
         }
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
 
     }
 }

--- a/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
+++ b/src/Orleans.Serialization/Codecs/GeneralizedValueTypeSurrogateCodec.cs
@@ -13,7 +13,7 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="TSurrogate">The surrogate type serialized in place of <typeparamref name="TField"/>.</typeparam>
     public abstract class GeneralizedValueTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField> where TField : struct where TSurrogate : struct
     {
-        private static readonly Type CodecFieldType = typeof(TField);
+        private readonly Type CodecFieldType = typeof(TField);
         private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
 
         /// <summary>

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -121,10 +121,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized set is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized set is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -111,10 +111,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -14,7 +14,7 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="T">The array element type.</typeparam>
     internal sealed class MultiDimensionalArrayCodec<T> : IGeneralizedCodec
     {
-        private static readonly Type DimensionFieldType = typeof(int[]);
+        private readonly Type DimensionFieldType = typeof(int[]);
         private readonly Type CodecElementType = typeof(T);
 
         private readonly IFieldCodec<int[]> _intArrayCodec;
@@ -73,7 +73,7 @@ namespace Orleans.Serialization.Codecs
                         --idx;
                         if (idx < 0)
                         {
-                            _ = ThrowIndexOutOfRangeException(lengths);
+                            ThrowIndexOutOfRangeException(lengths);
                         }
                     }
                 }
@@ -125,7 +125,7 @@ namespace Orleans.Serialization.Codecs
                         {
                             if (result is null || indices is null || lengths is null)
                             {
-                                return ThrowLengthsFieldMissing();
+                                ThrowLengthsFieldMissing();
                             }
 
                             var element = _elementCodec.ReadValue(ref reader, header);
@@ -153,10 +153,10 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public bool IsSupportedType(Type type) => type.IsArray && !type.IsSZArray;
 
-        private static object ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
+        private void ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
 
-        private static T ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
+        private void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/NullableCodec.cs
+++ b/src/Orleans.Serialization/Codecs/NullableCodec.cs
@@ -59,7 +59,7 @@ namespace Orleans.Serialization.Codecs
             return _fieldCodec.ReadValue(ref reader, field);
         }
 
-        private static void ThrowInvalidReference(uint reference) => throw new ReferenceNotFoundException(typeof(T?), reference);
+        private void ThrowInvalidReference(uint reference) => throw new ReferenceNotFoundException(typeof(T?), reference);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -103,7 +103,7 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -111,10 +111,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");
 
-        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized stack is missing its length field.");
+        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized stack is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/TupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TupleCodec.cs
@@ -128,8 +128,8 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2> : IFieldCodec<Tuple<T1, T2>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -260,9 +260,9 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3> : IFieldCodec<Tuple<T1, T2, T3>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -414,10 +414,10 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3, T4> : IFieldCodec<Tuple<T1, T2, T3, T4>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -585,11 +585,11 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3, T4, T5> : IFieldCodec<Tuple<T1, T2, T3, T4, T5>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -776,12 +776,12 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3, T4, T5, T6> : IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
-        private static readonly Type ElementType6 = typeof(T6);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType6 = typeof(T6);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -984,13 +984,13 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3, T4, T5, T6, T7> : IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
-        private static readonly Type ElementType6 = typeof(T6);
-        private static readonly Type ElementType7 = typeof(T7);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType6 = typeof(T6);
+        private readonly Type ElementType7 = typeof(T7);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;
@@ -1210,14 +1210,14 @@ namespace Orleans.Serialization.Codecs
     [RegisterSerializer]
     public sealed class TupleCodec<T1, T2, T3, T4, T5, T6, T7, T8> : IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
-        private static readonly Type ElementType1 = typeof(T1);
-        private static readonly Type ElementType2 = typeof(T2);
-        private static readonly Type ElementType3 = typeof(T3);
-        private static readonly Type ElementType4 = typeof(T4);
-        private static readonly Type ElementType5 = typeof(T5);
-        private static readonly Type ElementType6 = typeof(T6);
-        private static readonly Type ElementType7 = typeof(T7);
-        private static readonly Type ElementType8 = typeof(T8);
+        private readonly Type ElementType1 = typeof(T1);
+        private readonly Type ElementType2 = typeof(T2);
+        private readonly Type ElementType3 = typeof(T3);
+        private readonly Type ElementType4 = typeof(T4);
+        private readonly Type ElementType5 = typeof(T5);
+        private readonly Type ElementType6 = typeof(T6);
+        private readonly Type ElementType7 = typeof(T7);
+        private readonly Type ElementType8 = typeof(T8);
 
         private readonly IFieldCodec<T1> _item1Codec;
         private readonly IFieldCodec<T2> _item2Codec;

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -134,5 +134,5 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
     }
 
     [DoesNotReturn]
-    private static void ThrowNoPopulatorException() => throw new NotSupportedException($"Surrogate type {typeof(TConverter)} does not implement {typeof(IPopulator<TField, TSurrogate>)} and therefore cannot be used in an inheritance hierarchy.");
+    private void ThrowNoPopulatorException() => throw new NotSupportedException($"Surrogate type {typeof(TConverter)} does not implement {typeof(IPopulator<TField, TSurrogate>)} and therefore cannot be used in an inheritance hierarchy.");
 }

--- a/src/Orleans.Serialization/Serializers/ValueSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/ValueSerializer.cs
@@ -13,7 +13,7 @@ namespace Orleans.Serialization.Serializers
     /// <typeparam name="TValueSerializer">The value-type serializer implementation type.</typeparam>
     public sealed class ValueSerializer<TField, TValueSerializer> : IFieldCodec<TField> where TField : struct where TValueSerializer : IValueSerializer<TField>
     {
-        private static readonly Type CodecFieldType = typeof(TField);
+        private readonly Type CodecFieldType = typeof(TField);
         private readonly TValueSerializer _serializer;
 
         /// <summary>


### PR DESCRIPTION
Static members in generic types are expensive, especially fields in singleton classes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8526)