### PR TITLE
Wait for migrating activations to become active or terminated

### DIFF
--- a/test/DefaultCluster.Tests/Migration/MigrationTests.cs
+++ b/test/DefaultCluster.Tests/Migration/MigrationTests.cs
@@ -62,7 +62,12 @@ namespace DefaultCluster.Tests.General
                 RequestContext.Set(IPlacementDirector.PlacementHintKey, targetHost);
                 await grain.Cast<IGrainManagementExtension>().MigrateOnIdle();
 
-                var newAddress = await grain.GetGrainAddress();
+                GrainAddress newAddress;
+                do
+                {
+                    newAddress = await grain.GetGrainAddress();
+                } while (newAddress.ActivationId == originalAddress.ActivationId);
+
                 var newHost = newAddress.SiloAddress;
                 Assert.Equal(targetHost, newHost);
 
@@ -91,7 +96,12 @@ namespace DefaultCluster.Tests.General
                 RequestContext.Set(IPlacementDirector.PlacementHintKey, targetHost);
                 await grain.Cast<IGrainManagementExtension>().MigrateOnIdle();
 
-                var newAddress = await grain.GetGrainAddress();
+                GrainAddress newAddress;
+                do
+                {
+                    newAddress = await grain.GetGrainAddress();
+                } while (newAddress.ActivationId == originalAddress.ActivationId);
+
                 var newHost = newAddress.SiloAddress;
                 Assert.Equal(targetHost, newHost);
 
@@ -121,7 +131,12 @@ namespace DefaultCluster.Tests.General
                 RequestContext.Set(IPlacementDirector.PlacementHintKey, targetHost);
                 await grain.Cast<IGrainManagementExtension>().MigrateOnIdle();
 
-                var newAddress = await grain.GetGrainAddress();
+                GrainAddress newAddress;
+                do
+                {
+                    newAddress = await grain.GetGrainAddress();
+                } while (newAddress.ActivationId == originalAddress.ActivationId);
+
                 var newHost = newAddress.SiloAddress;
                 Assert.Equal(targetHost, newHost);
 


### PR DESCRIPTION
There is some test flakiness caused by a race in the grain migration process. This PR fixes that race by polling the grains to make sure that they enter an active or terminal state before returning from migration.

The second commit also fixes a test case issue. The issue is that telling a grain to migrate by calling `MigrateOnIdle` does not guarantee that subsequent messages will be enqueued instead of executed on the activation (i.e, migration is async). The fix is to check that we're dealing with a new activation before continuing with the test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8527)