### PR TITLE
Lift typeof(T) to an instance field where possible

### DIFF
--- a/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ConcurrentDictionaryCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -58,6 +59,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class ConcurrentDictionaryCopier<TKey, TValue> : IDeepCopier<ConcurrentDictionary<TKey, TValue>>, IBaseCopier<ConcurrentDictionary<TKey, TValue>>
     {
+        private readonly Type _fieldType = typeof(ConcurrentDictionary<TKey, TValue>);
         private readonly IDeepCopier<TKey> _keyCopier;
         private readonly IDeepCopier<TValue> _valueCopier;
 
@@ -80,7 +82,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(ConcurrentDictionary<TKey, TValue>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/ConcurrentQueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ConcurrentQueueCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -49,6 +50,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class ConcurrentQueueCopier<T> : IDeepCopier<ConcurrentQueue<T>>, IBaseCopier<ConcurrentQueue<T>>
     {
+        private readonly Type _fieldType = typeof(ConcurrentQueue<T>);
         private readonly IDeepCopier<T> _copier;
 
         /// <summary>
@@ -68,7 +70,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(ConcurrentQueue<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -17,6 +17,7 @@ namespace Orleans.Serialization.Codecs
     public sealed class HashSetCodec<T> : IFieldCodec<HashSet<T>>
     {
         private readonly Type CodecElementType = typeof(T);
+        private readonly Type _comparerType = typeof(IEqualityComparer<T>);
 
         private readonly IFieldCodec<T> _fieldCodec;
         private readonly IFieldCodec<IEqualityComparer<T>> _comparerCodec;
@@ -44,7 +45,7 @@ namespace Orleans.Serialization.Codecs
 
             if (value.Comparer != EqualityComparer<T>.Default)
             {
-                _comparerCodec.WriteField(ref writer, 0, typeof(IEqualityComparer<T>), value.Comparer);
+                _comparerCodec.WriteField(ref writer, 0, _comparerType, value.Comparer);
             }
 
             if (value.Count > 0)
@@ -134,6 +135,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class HashSetCopier<T> : IDeepCopier<HashSet<T>>, IBaseCopier<HashSet<T>>
     {
+        private readonly Type _fieldType = typeof(HashSet<T>);
         private readonly IDeepCopier<T> _copier;
 
         /// <summary>
@@ -153,7 +155,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(HashSet<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -154,7 +154,7 @@ namespace Orleans.Serialization.Codecs
         public bool IsSupportedType(Type type) => type.IsArray && !type.IsSZArray;
 
         private void ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
-            $"Encountered too many elements in array of type {typeof(T)} with declared lengths {string.Join(", ", lengths)}.");
+            $"Encountered too many elements in array of type {CodecElementType} with declared lengths {string.Join(", ", lengths)}.");
 
         private void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -113,6 +113,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class QueueCopier<T> : IDeepCopier<Queue<T>>, IBaseCopier<Queue<T>>
     {
+        private readonly Type _fieldType = typeof(Queue<T>);
         private readonly IDeepCopier<T> _copier;
 
         /// <summary>
@@ -132,7 +133,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(Queue<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/ReadOnlyCollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReadOnlyCollectionCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -49,6 +50,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class ReadOnlyCollectionCopier<T> : IDeepCopier<ReadOnlyCollection<T>>
     {
+        private readonly Type _fieldType = typeof(ReadOnlyCollection<T>);
         private readonly IDeepCopier<T> _elementCopier;
 
         /// <summary>
@@ -68,7 +70,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(ReadOnlyCollection<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/ReadOnlyDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ReadOnlyDictionaryCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -27,6 +28,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class ReadOnlyDictionaryCopier<TKey, TValue> : IDeepCopier<ReadOnlyDictionary<TKey, TValue>>
     {
+        private readonly Type _fieldType = typeof(ReadOnlyDictionary<TKey, TValue>);
         private readonly IDeepCopier<TKey> _keyCopier;
         private readonly IDeepCopier<TValue> _valueCopier;
 
@@ -43,7 +45,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(ReadOnlyDictionary<TKey, TValue>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/SortedDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedDictionaryCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Generic;
 
 namespace Orleans.Serialization.Codecs
@@ -71,6 +72,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class SortedDictionaryCopier<TKey, TValue> : IDeepCopier<SortedDictionary<TKey, TValue>>, IBaseCopier<SortedDictionary<TKey, TValue>>
     {
+        private readonly Type _fieldType = typeof(SortedDictionary<TKey, TValue>);
         private readonly IDeepCopier<TKey> _keyCopier;
         private readonly IDeepCopier<TValue> _valueCopier;
 
@@ -93,7 +95,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(SortedDictionary<TKey, TValue>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/SortedListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedListCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Generic;
 
 namespace Orleans.Serialization.Codecs
@@ -78,6 +79,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class SortedListCopier<TKey, TValue> : IDeepCopier<SortedList<TKey, TValue>>, IBaseCopier<SortedList<TKey, TValue>>
     {
+        private readonly Type _fieldType = typeof(SortedList<TKey, TValue>);
         private readonly IDeepCopier<TKey> _keyCopier;
         private readonly IDeepCopier<TValue> _valueCopier;
 
@@ -100,7 +102,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(SortedList<TKey, TValue>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/SortedSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/SortedSetCodec.cs
@@ -1,5 +1,6 @@
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Serializers;
+using System;
 using System.Collections.Generic;
 
 namespace Orleans.Serialization.Codecs
@@ -59,6 +60,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class SortedSetCopier<T> : IDeepCopier<SortedSet<T>>, IBaseCopier<SortedSet<T>>
     {
+        private readonly Type _fieldType = typeof(SortedSet<T>);
         private readonly IDeepCopier<T> _elementCopier;
 
         /// <summary>
@@ -78,7 +80,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(SortedSet<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -124,6 +124,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class StackCopier<T> : IDeepCopier<Stack<T>>, IBaseCopier<Stack<T>>
     {
+        private readonly Type _fieldType = typeof(Stack<T>);
         private readonly IDeepCopier<T> _copier;
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace Orleans.Serialization.Codecs
                 return result;
             }
 
-            if (input.GetType() != typeof(Stack<T>))
+            if (input.GetType() as object != _fieldType as object)
             {
                 return context.DeepCopy(input);
             }

--- a/src/Orleans.Serialization/Codecs/TupleCodec.cs
+++ b/src/Orleans.Serialization/Codecs/TupleCodec.cs
@@ -88,6 +88,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T> : IDeepCopier<Tuple<T>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T>);
         private readonly IDeepCopier<T> _copier;
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -212,6 +213,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2> : IDeepCopier<Tuple<T1, T2>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
 
@@ -233,7 +235,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -357,6 +359,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3> : IDeepCopier<Tuple<T1, T2, T3>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -385,7 +388,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -522,6 +525,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3, T4> : IDeepCopier<Tuple<T1, T2, T3, T4>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3, T4>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -554,7 +558,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3, T4> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3, T4>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -707,6 +711,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3, T4, T5> : IDeepCopier<Tuple<T1, T2, T3, T4, T5>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3, T4, T5>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -743,7 +748,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3, T4, T5> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -909,6 +914,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3, T4, T5, T6> : IDeepCopier<Tuple<T1, T2, T3, T4, T5, T6>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3, T4, T5, T6>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -949,7 +955,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3, T4, T5, T6> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -1129,6 +1135,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3, T4, T5, T6, T7> : IDeepCopier<Tuple<T1, T2, T3, T4, T5, T6, T7>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3, T4, T5, T6, T7>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -1173,7 +1180,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3, T4, T5, T6, T7> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6, T7>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())
@@ -1365,6 +1372,7 @@ namespace Orleans.Serialization.Codecs
     [RegisterCopier]
     public sealed class TupleCopier<T1, T2, T3, T4, T5, T6, T7, T8> : IDeepCopier<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>>, IOptionalDeepCopier
     {
+        private readonly Type _fieldType = typeof(Tuple<T1, T2, T3, T4, T5, T6, T7, T8>);
         private readonly IDeepCopier<T1> _copier1;
         private readonly IDeepCopier<T2> _copier2;
         private readonly IDeepCopier<T3> _copier3;
@@ -1413,7 +1421,7 @@ namespace Orleans.Serialization.Codecs
             if (context.TryGetCopy(input, out Tuple<T1, T2, T3, T4, T5, T6, T7, T8> existing))
                 return existing;
 
-            if (input.GetType() != typeof(Tuple<T1, T2, T3, T4, T5, T6, T7, T8>))
+            if (input.GetType() as object != _fieldType as object)
                 return context.DeepCopy(input);
 
             if (IsShallowCopyable())

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -292,6 +292,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         /// </summary>
         public abstract class ExceptionCopier<T, B> : IDeepCopier<T>, IBaseCopier<T> where T : B where B : Exception
         {
+            private readonly Type _fieldType = typeof(T);
             private readonly IActivator<T> _activator;
             private readonly IBaseCopier<B> _baseTypeCopier;
 
@@ -306,7 +307,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
                 if (original is null)
                     return null;
 
-                if (original.GetType() != typeof(T))
+                if (original.GetType() as object != _fieldType as object)
                     return context.DeepCopy(original);
 
                 var result = _activator.Create();

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationCallbacksFactory.cs
@@ -36,7 +36,7 @@ namespace Orleans.Serialization
             => GetValueTypeCallbacks<TDelegate>(type, typeof(TOwner));
 
         private SerializationCallbacks<TDelegate> GetValueTypeCallbacks<TDelegate>(Type type, Type owner) where TDelegate : Delegate
-            => (SerializationCallbacks<TDelegate>)_cache.GetOrAdd(type, (t, o) => CreateTypedCallbacks<TDelegate>(t, o), owner);
+            => (SerializationCallbacks<TDelegate>)_cache.GetOrAdd(type, CreateTypedCallbacks<TDelegate>, owner);
 
         [SecurityCritical]
         private static SerializationCallbacks<TDelegate> CreateTypedCallbacks<TDelegate>(Type type, Type owner) where TDelegate : Delegate

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -555,7 +555,7 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
 
             // Do not dispose, since the buffer writer is not owned by the method.
@@ -571,7 +571,7 @@ namespace Orleans.Serialization
         public void Serialize<TBufferWriter>(T value, TBufferWriter destination, SerializerSession session) where TBufferWriter : IBufferWriter<byte>
         {
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
 
             // Do not dispose, since the buffer writer is not owned by the method.
@@ -588,7 +588,7 @@ namespace Orleans.Serialization
             var writer = Writer.CreatePooled(session);
             try
             {
-                _codec.WriteField(ref writer, 0, typeof(T), value);
+                _codec.WriteField(ref writer, 0, _expectedType, value);
                 writer.Commit();
                 return writer.Output.ToArray();
             }
@@ -608,7 +608,7 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -623,7 +623,7 @@ namespace Orleans.Serialization
         public void Serialize(T value, ref Memory<byte> destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -638,7 +638,7 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -653,7 +653,7 @@ namespace Orleans.Serialization
         public void Serialize(T value, ref Span<byte> destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             destination = destination.Slice(0, writer.Position);
         }
@@ -668,7 +668,7 @@ namespace Orleans.Serialization
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             return writer.Position;
         }
@@ -683,7 +683,7 @@ namespace Orleans.Serialization
         public int Serialize(T value, byte[] destination, SerializerSession session)
         {
             var writer = Writer.Create(destination, session);
-            _codec.WriteField(ref writer, 0, typeof(T), value);
+            _codec.WriteField(ref writer, 0, _expectedType, value);
             writer.Commit();
             return writer.Position;
         }
@@ -702,7 +702,7 @@ namespace Orleans.Serialization
                 var buffer = new MemoryStreamBufferWriter(memoryStream);
                 using var session = _sessionPool.GetSession();
                 var writer = Writer.Create(buffer, session);
-                _codec.WriteField(ref writer, 0, typeof(T), value);
+                _codec.WriteField(ref writer, 0, _expectedType, value);
                 writer.Commit();
             }
             else
@@ -711,7 +711,7 @@ namespace Orleans.Serialization
                 var writer = Writer.Create(new PoolingStreamBufferWriter(destination, sizeHint), session);
                 try
                 {
-                    _codec.WriteField(ref writer, 0, typeof(T), value);
+                    _codec.WriteField(ref writer, 0, _expectedType, value);
                     writer.Commit();
                 }
                 finally
@@ -735,7 +735,7 @@ namespace Orleans.Serialization
             {
                 var buffer = new MemoryStreamBufferWriter(memoryStream);
                 var writer = Writer.Create(buffer, session);
-                _codec.WriteField(ref writer, 0, typeof(T), value);
+                _codec.WriteField(ref writer, 0, _expectedType, value);
                 writer.Commit();
             }
             else
@@ -743,7 +743,7 @@ namespace Orleans.Serialization
                 var writer = Writer.Create(new PoolingStreamBufferWriter(destination, sizeHint), session);
                 try
                 {
-                    _codec.WriteField(ref writer, 0, typeof(T), value);
+                    _codec.WriteField(ref writer, 0, _expectedType, value);
                     writer.Commit();
                 }
                 finally

--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -138,10 +138,11 @@ namespace Orleans.Serialization.Serializers
         /// <inheritdoc/>
         public IFieldCodec<TField> TryGetCodec<TField>()
         {
-            if (_typedCodecs.TryGetValue(typeof(TField), out var existing))
+            var fieldType = typeof(TField);
+            if (_typedCodecs.TryGetValue(fieldType, out var existing))
                 return (IFieldCodec<TField>)existing;
 
-            if (TryGetCodec(typeof(TField)) is not { } untypedResult)
+            if (TryGetCodec(fieldType) is not { } untypedResult)
                 return null;
 
             var typedResult = untypedResult switch
@@ -151,7 +152,7 @@ namespace Orleans.Serialization.Serializers
                 _ => new UntypedCodecWrapper<TField>(untypedResult)
             };
 
-            return (IFieldCodec<TField>)_typedCodecs.GetOrAdd(typeof(TField), typedResult);
+            return (IFieldCodec<TField>)_typedCodecs.GetOrAdd(fieldType, typedResult);
         }
 
         /// <inheritdoc/>
@@ -303,10 +304,11 @@ namespace Orleans.Serialization.Serializers
         /// <inheritdoc/>
         public IDeepCopier<T> TryGetDeepCopier<T>()
         {
-            if (_typedCopiers.TryGetValue(typeof(T), out var existing))
+            var type = typeof(T);
+            if (_typedCopiers.TryGetValue(type, out var existing))
                 return (IDeepCopier<T>)existing;
 
-            if (TryGetDeepCopier(typeof(T)) is not { } untypedResult)
+            if (TryGetDeepCopier(type) is not { } untypedResult)
                 return null;
 
             var typedResult = untypedResult switch
@@ -316,7 +318,7 @@ namespace Orleans.Serialization.Serializers
                 _ => new UntypedCopierWrapper<T>(untypedResult)
             };
 
-            return (IDeepCopier<T>)_typedCopiers.GetOrAdd(typeof(T), typedResult);
+            return (IDeepCopier<T>)_typedCopiers.GetOrAdd(type, typedResult);
         }
 
         /// <inheritdoc/>

--- a/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Orleans.Serialization/Serializers/ConcreteTypeSerializer.cs
@@ -33,7 +33,7 @@ namespace Orleans.Serialization.Serializers
         /// <inheritdoc/>
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (value is null || value.GetType() == typeof(TField))
+            if (value is null || value.GetType() as object == CodecFieldType as object)
             {
                 if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
                 {

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -21,7 +21,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
     where TSurrogate : struct
     where TConverter : IConverter<TField, TSurrogate>
 {
-    private readonly Type _fieldType;
+    private readonly Type _fieldType = typeof(TField);
     private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
     private readonly IDeepCopier<TSurrogate> _surrogateCopier;
     private readonly IPopulator<TField, TSurrogate> _populator;
@@ -42,7 +42,6 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
         _surrogateCopier = surrogateCopier;
         _converter = converter;
         _populator = converter as IPopulator<TField, TSurrogate>;
-        _fieldType = typeof(TField);
     }
 
     /// <inheritdoc/>
@@ -91,7 +90,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
             return;
         }
 
-        if (value.GetType() == typeof(TField))
+        if (value.GetType() as object == _fieldType as object)
         {
             writer.WriteStartObject(fieldIdDelta, expectedType, _fieldType);
             var surrogate = _converter.ConvertToSurrogate(in value);


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/orleans/pull/8526#discussion_r1254881749

Instance field access is fast, unlike getting types potentially through lookups from generic type parameters.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8528)