### PR TITLE
CA2016: Forward cancellation token when applicable

### DIFF
--- a/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
+++ b/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
@@ -187,7 +187,7 @@ namespace Orleans.Tests.SqlUtils
             if(cancellationToken.IsCancellationRequested)
             {
                 var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-                tcs.SetCanceled();
+                tcs.SetCanceled(cancellationToken);
                 return tcs.Task;
             }
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -303,7 +303,7 @@ namespace Orleans.Runtime.Messaging
                     }
                     else if (!pendingConnections) break;
 
-                    await Task.Delay(10);
+                    await Task.Delay(10, ct);
                     if (++cycles > 100 && cycles % 500 == 0 && this.ConnectionCount is var remaining and > 0)
                     {
                         this.trace.LogWarning("Waiting for {NumRemaining} connections to terminate", remaining);

--- a/src/Orleans.Core/Networking/ConnectionManagerLifecycleAdapter.cs
+++ b/src/Orleans.Core/Networking/ConnectionManagerLifecycleAdapter.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.Messaging
 
         public async Task OnStop(CancellationToken ct)
         {
-            await Task.Run(() => this.connectionManager.Close(ct));
+            await Task.Run(() => connectionManager.Close(ct), ct);
         }
 
         public void Participate(TLifecycle lifecycle)

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -80,7 +80,7 @@ namespace Orleans.Networking.Shared
             {
                 try
                 {
-                    var acceptSocket = await _listenSocket.AcceptAsync();
+                    var acceptSocket = await _listenSocket.AcceptAsync(cancellationToken);
                     acceptSocket.NoDelay = _options.NoDelay;
 
                     var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -141,7 +141,7 @@ namespace Orleans
 
             // Deliberately avoid capturing the current synchronization context during startup and execute on the default scheduler.
             // This helps to avoid any issues (such as deadlocks) caused by executing with the client's synchronization context/scheduler.
-            await Task.Run(() => this.StartInternal(cancellationToken)).ConfigureAwait(false);
+            await Task.Run(() => this.StartInternal(cancellationToken), cancellationToken).ConfigureAwait(false);
 
             logger.LogInformation((int)ErrorCode.ProxyClient_StartDone, "Started client with address {ActivationAddress} and id {ClientId}", CurrentActivationAddress.ToString(), clientId);
         }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -59,7 +59,7 @@ namespace Orleans.Hosting.Kubernetes
                     watcher[0].Dispose();
                     cancellationRegistration.Dispose();
                 }
-            });
+            }, cancellation);
 
 
             while (await channel.Reader.WaitToReadAsync(cancellation))

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -158,7 +158,7 @@ namespace Orleans.Runtime
                 ct =>
                 {
                     using var _ = new ExecutionContextSuppressor();
-                    _runTask = Task.Run(MonitorWorkingSet);
+                    _runTask = Task.Run(MonitorWorkingSet, ct);
                     return Task.CompletedTask;
                 },
                 async ct =>

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -73,7 +73,7 @@ namespace Orleans.Runtime
                 ServiceLifecycleStage.BecomeActive,
                 ct =>
                 {
-                    _runTask = Task.Run(this.Run);
+                    _runTask = Task.Run(Run, ct);
                     return Task.CompletedTask;
                 },
                 async ct =>

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -190,9 +190,9 @@ namespace Orleans.Runtime.Metadata
             return fetchSuccess;
         }
 
-        private Task StartAsync(CancellationToken _)
+        private Task StartAsync(CancellationToken ct)
         {
-            _runTask = Task.Run(ProcessMembershipUpdates);
+            _runTask = Task.Run(ProcessMembershipUpdates, ct);
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -208,7 +208,7 @@ namespace Orleans.Runtime.MembershipService
 
             Task OnActiveStart(CancellationToken ct)
             {
-                tasks.Add(Task.Run(() => this.ProcessMembershipUpdates()));
+                tasks.Add(Task.Run(ProcessMembershipUpdates, ct));
                 return Task.CompletedTask;
             }
 
@@ -224,7 +224,7 @@ namespace Orleans.Runtime.MembershipService
                 this.monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
 
                 // Allow some minimum time for graceful shutdown.
-                var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
+                var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod, ct), ct.WhenCancelled());
                 await Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
             }
         }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -102,16 +102,16 @@ namespace Orleans.Runtime
         {
             var tasks = new List<Task>(1);
             var cancellation = new CancellationTokenSource();
-            Task OnRuntimeInitializeStart(CancellationToken _)
+            Task OnRuntimeInitializeStart(CancellationToken ct)
             {
-                tasks.Add(Task.Run(() => this.ProcessMembershipUpdates(cancellation.Token)));
+                tasks.Add(Task.Run(() => ProcessMembershipUpdates(cancellation.Token), ct));
                 return Task.CompletedTask;
             }
 
             async Task OnRuntimeInitializeStop(CancellationToken ct)
             {
                 cancellation.Cancel(throwOnFirstException: false);
-                var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
+                var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod, ct), ct.WhenCancelled());
                 await Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
             }
 

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -326,7 +326,7 @@ namespace Orleans.Runtime.MembershipService
 
         public Task OnStart(CancellationToken ct)
         {
-            _runTask = Task.Run(this.Run);
+            _runTask = Task.Run(Run, ct);
             _isActive = true;
             return Task.CompletedTask;
         }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -97,7 +97,7 @@ namespace Orleans.Runtime.MembershipService
 
             Task OnStart(CancellationToken ct)
             {
-                tasks.Add(Task.Run(() => this.CleanupDefunctSilos()));
+                tasks.Add(Task.Run(CleanupDefunctSilos, ct));
                 return Task.CompletedTask;
             }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -874,8 +874,8 @@ namespace Orleans.Runtime.MembershipService
 
             async Task OnRuntimeGrainServicesStart(CancellationToken ct)
             {
-                await Task.Run(() => this.Start());
-                tasks.Add(Task.Run(() => this.PeriodicallyRefreshMembershipTable()));
+                await Task.Run(Start, ct);
+                tasks.Add(Task.Run(PeriodicallyRefreshMembershipTable, ct));
             }
 
             async Task OnRuntimeGrainServicesStop(CancellationToken ct)
@@ -883,7 +883,7 @@ namespace Orleans.Runtime.MembershipService
                 this.membershipUpdateTimer.Dispose();
 
                 // Allow some minimum time for graceful shutdown.
-                var gracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
+                var gracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod, ct), ct.WhenCancelled());
                 await Task.WhenAny(gracePeriod, Task.WhenAll(tasks));
             }
         }

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.MembershipService
 
             Task OnStart(CancellationToken ct)
             {
-                tasks.Add(Task.Run(() => this.ProcessMembershipUpdates()));
+                tasks.Add(Task.Run(ProcessMembershipUpdates, ct));
                 return Task.CompletedTask;
             }
 

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -76,10 +76,10 @@ namespace Orleans.Runtime.Messaging
             if (this.Endpoint is null) return;
 
             lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.RuntimeInitialize - 1, this);
-            lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.Active, _ => Task.Run(Start));
+            lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.Active, ct => Task.Run(Start, ct));
         }
 
-        Task ILifecycleObserver.OnStart(CancellationToken ct) => Task.Run(BindAsync);
-        Task ILifecycleObserver.OnStop(CancellationToken ct) => Task.Run(() => StopAsync(ct));
+        Task ILifecycleObserver.OnStart(CancellationToken ct) => Task.Run(BindAsync, ct);
+        Task ILifecycleObserver.OnStop(CancellationToken ct) => Task.Run(() => StopAsync(ct), ct);
     }
 }

--- a/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionListener.cs
@@ -80,8 +80,8 @@ namespace Orleans.Runtime.Messaging
             await BindAsync();
             // Start accepting connections immediately.
             Start();
-        });
+        }, ct);
 
-        Task ILifecycleObserver.OnStop(CancellationToken ct) => Task.Run(() => StopAsync(ct));
+        Task ILifecycleObserver.OnStop(CancellationToken ct) => Task.Run(() => StopAsync(ct), ct);
     }
 }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -467,15 +467,15 @@ namespace Orleans.Runtime
                 {
                     logger.LogDebug((int)ErrorCode.SiloStopInProgress, "Silo shutdown in progress. Waiting for shutdown to be completed.");
                 }
-                var pause = TimeSpan.FromSeconds(1);                
+                var pause = TimeSpan.FromSeconds(1);
 
                 while (!this.SystemStatus.Equals(SystemStatus.Terminated))
-                {                    
+                {
                     if (logger.IsEnabled(LogLevel.Debug))
                     {
                         logger.LogDebug((int)ErrorCode.WaitingForSiloStop, "Silo shutdown still in progress...");
                     }
-                    await Task.Delay(pause).ConfigureAwait(false);
+                    await Task.Delay(pause, cancellationToken).ConfigureAwait(false);
                 }
 
                 await this.SiloTerminated.ConfigureAwait(false);
@@ -488,7 +488,7 @@ namespace Orleans.Runtime
             }
             finally
             {
-                // log final status                
+                // log final status
                 if (gracefully)
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
@@ -575,7 +575,7 @@ namespace Orleans.Runtime
                     }
 
                     // Wait for all queued message sent to OutboundMessageQueue before MessageCenter stop and OutboundMessageQueue stop.
-                    await Task.WhenAny(Task.Delay(waitForMessageToBeQueuedForOutbound), ct.WhenCancelled());
+                    await Task.WhenAny(Task.Delay(waitForMessageToBeQueuedForOutbound, ct), ct.WhenCancelled());
                 }
             }
             catch (Exception exc)
@@ -634,11 +634,11 @@ namespace Orleans.Runtime
 
         private void Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeInitialize, (ct) => Task.Run(() => OnRuntimeInitializeStart(ct)), (ct) => Task.Run(() => OnRuntimeInitializeStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeServices, (ct) => Task.Run(() => OnRuntimeServicesStart(ct)), (ct) => Task.Run(() => OnRuntimeServicesStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeGrainServices, (ct) => Task.Run(() => OnRuntimeGrainServicesStart(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, (ct) => Task.Run(() => OnBecomeActiveStart(ct)), (ct) => Task.Run(() => OnBecomeActiveStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.Active, (ct) => Task.Run(() => OnActiveStart(ct)), (ct) => Task.Run(() => OnActiveStop(ct)));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeInitialize, (ct) => Task.Run(() => OnRuntimeInitializeStart(ct), ct), (ct) => Task.Run(() => OnRuntimeInitializeStop(ct), ct));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeServices, (ct) => Task.Run(() => OnRuntimeServicesStart(ct), ct), (ct) => Task.Run(() => OnRuntimeServicesStop(ct), ct));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeGrainServices, (ct) => Task.Run(() => OnRuntimeGrainServicesStart(ct), ct));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, (ct) => Task.Run(() => OnBecomeActiveStart(ct), ct), (ct) => Task.Run(() => OnBecomeActiveStop(ct), ct));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.Active, (ct) => Task.Run(() => OnActiveStart(ct), ct), (ct) => Task.Run(() => OnActiveStop(ct), ct));
         }
     }
 

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -71,7 +71,7 @@ namespace Orleans.TestingHost
 
             try
             {
-                await Task.Run(() => this.SiloHost.StopAsync(ct));
+                await Task.Run(() => SiloHost.StopAsync(ct), ct);
             }
             catch (Exception exc)
             {

--- a/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
+++ b/src/Orleans.TestingHost/UnixSocketTransport/UnixSocketConnectionListener.cs
@@ -44,7 +44,7 @@ internal class UnixSocketConnectionListener : IConnectionListener
         {
             try
             {
-                var acceptSocket = await _listenSocket.AcceptAsync();
+                var acceptSocket = await _listenSocket.AcceptAsync(cancellationToken);
 
                 var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
 

--- a/src/Orleans.Transactions/State/ActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/ActivationLifetime.cs
@@ -39,7 +39,7 @@ namespace Orleans.Transactions.State
             var maxTime = TimeSpan.FromSeconds(5);
             while (!ct.IsCancellationRequested && pendingDeactivationLocks > 0 && DateTime.UtcNow - startTime < maxTime)
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(10));
+                await Task.Delay(TimeSpan.FromMilliseconds(10), ct);
             }
         }
 

--- a/test/DistributedTests/DistributedTests.Common/MessageChannel/Channels.cs
+++ b/test/DistributedTests/DistributedTests.Common/MessageChannel/Channels.cs
@@ -105,7 +105,7 @@ namespace DistributedTests.Common.MessageChannel
 
                 if (msg != null)
                 {
-                    await queueClient.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
+                    await queueClient.DeleteMessageAsync(msg.MessageId, msg.PopReceipt, ct);
                     return JsonSerializer.Deserialize<T>(msg.MessageText);
                 }
 

--- a/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
+++ b/test/Extensions/TesterAdoNet/StorageTests/RelationalStoreTests.cs
@@ -90,16 +90,16 @@ namespace UnitTests.StorageTests.AdoNet
             }, async (selector, resultSetCount, canellationToken) =>
             {
                 var streamSelector = (DbDataReader)selector;
-                var id = await streamSelector.GetValueAsync<int>("Id");
+                var id = await streamSelector.GetValueAsync<int>("Id", cancellationToken: canellationToken);
                 using(var ms = new MemoryStream())
-                {                    
+                {
                     using(var downloadStream = streamSelector.GetStream(1, sut.Storage))
                     {
-                        await downloadStream.CopyToAsync(ms);
+                        await downloadStream.CopyToAsync(ms, canellationToken);
 
                         return new StreamingTest { Id = id, StreamData = ms.ToArray() };
                     }
-                }                
+                }
             }, cancellationToken, CommandBehavior.SequentialAccess).ConfigureAwait(false)).Single();
         }
 

--- a/test/Grains/TestGrains/CatalogTestGrain.cs
+++ b/test/Grains/TestGrains/CatalogTestGrain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +11,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            return Task.Delay(TimeSpan.FromMilliseconds(50));
+            return Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
         }
 
         public Task Initialize()

--- a/test/Grains/TestGrains/LogTestGrainVariations.cs
+++ b/test/Grains/TestGrains/LogTestGrainVariations.cs
@@ -89,7 +89,7 @@ namespace TestGrains
             await Task.Run(async () =>
             {
                 await Task.Delay(10);
-            });
+            }, cancellationToken);
         }
 
 

--- a/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/Grains/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -92,7 +92,7 @@ namespace UnitTests.Grains
                     Assert.False(t.IsFaulted, "RecordActivateCall failed");
                     Assert.True(doingActivate, "Doing Activate");
                     doingActivate = false;
-                });
+                }, cancellationToken);
         }
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
@@ -107,7 +107,7 @@ namespace UnitTests.Grains
                     Assert.False(t.IsFaulted, "RecordDeactivateCall failed");
                     Assert.True(doingDeactivate, "Doing Deactivate");
                     doingDeactivate = false;
-                });
+                }, cancellationToken);
         }
 
         public Task<string> DoSomething()
@@ -285,7 +285,7 @@ namespace UnitTests.Grains
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            Task.Factory.StartNew(() => logger.LogInformation("OnDeactivateAsync"));
+            Task.Factory.StartNew(() => logger.LogInformation("OnDeactivateAsync"), cancellationToken);
 
             Assert.False(doingActivate, "Not doing Activate");
             Assert.False(doingDeactivate, "Not doing Deactivate");
@@ -299,7 +299,7 @@ namespace UnitTests.Grains
                     Assert.True(doingDeactivate, "Doing Deactivate");
                     Thread.Sleep(TimeSpan.FromSeconds(1));
                     doingDeactivate = false;
-                })
+                }, cancellationToken)
                 .ContinueWith((Task t) => logger.LogInformation("Finished-OnDeactivateAsync"),
                     TaskContinuationOptions.ExecuteSynchronously);
         }

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -144,7 +144,7 @@ namespace UnitTests.Grains
 
         public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            await Task.Delay(TimeSpan.FromSeconds(3));
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
 
             if (this.GetPrimaryKeyLong() == -2)
                 throw new ArgumentException("Primary key cannot be -2 for this test case");

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -394,7 +394,7 @@ namespace NonSilo.Tests.Membership
             while (!stopped.IsCompleted)
             {
                 while (this.timerCalls.TryDequeue(out var call)) call.Completion.TrySetResult(false);
-                await Task.Delay(15);
+                await Task.Delay(15, cancellation);
             }
 
             await stopped;

--- a/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
+++ b/test/NonSilo.Tests/Membership/MembershipAgentTests.cs
@@ -366,7 +366,7 @@ namespace NonSilo.Tests.Membership
             while (!stopped.IsCompleted)
             {
                 foreach (var pair in this.timerCalls) while (pair.Value.TryDequeue(out var call)) call.Completion.TrySetResult(false);
-                await Task.Delay(15);
+                await Task.Delay(15, cancellation);
             }
 
             await stopped;

--- a/test/TesterInternal/StorageTests/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageTests.cs
@@ -164,7 +164,7 @@ namespace UnitTests.StorageTests.Relational
                     {
                         await Store_WriteRead(grainTypeName, grainData.GrainId, grainData.GrainState);
                         return 0;
-                    });
+                    }, ct);
 
                     var versionAfter = grainData.GrainState.ETag;
                     Assert.NotEqual(versionBefore, versionAfter);


### PR DESCRIPTION
This PR addresses all instances of CA2016: passing cancellation token when possible. There are no method signature changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8530)