### PR TITLE
Add accessibility modifiers when absent

### DIFF
--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -26,7 +26,7 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// An explicit map of type CLR viz database type conversions.
         /// </summary>
-        static readonly ReadOnlyDictionary<Type, DbType> typeMap = new ReadOnlyDictionary<Type, DbType>(new Dictionary<Type, DbType>
+        private static readonly ReadOnlyDictionary<Type, DbType> typeMap = new ReadOnlyDictionary<Type, DbType>(new Dictionary<Type, DbType>
         {
             { typeof(object),   DbType.Object },
             { typeof(int),      DbType.Int32 },

--- a/src/Orleans.Core/GrainDirectory/IDhtGrainDirectory.cs
+++ b/src/Orleans.Core/GrainDirectory/IDhtGrainDirectory.cs
@@ -9,11 +9,11 @@ namespace Orleans.GrainDirectory
     /// <summary>
     /// Recursive distributed operations on grain directories.
     /// Each operation may forward the request to a remote owner, increasing the hopCount.
-    /// 
+    ///
     /// The methods here can be called remotely (where extended by IRemoteGrainDirectory) or
     /// locally (where extended by ILocalGrainDirectory)
     /// </summary>
-    interface IDhtGrainDirectory
+    internal interface IDhtGrainDirectory
     {
         /// <summary>
         /// Record a new grain activation by adding it to the directory.
@@ -79,7 +79,7 @@ namespace Orleans.GrainDirectory
         /// </summary>
         [Id(0)]
         public readonly GrainAddress? Address;
-       
+
         /// <summary>
         /// The version of this entry.
         /// </summary>

--- a/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
@@ -13,8 +13,8 @@ namespace Orleans.EventSourcing.LogStorage
     /// A log view adaptor that wraps around a traditional storage adaptor, and uses batching and e-tags
     /// to append entries.
     ///<para>
-    /// The log itself is transient, i.e. not actually saved to storage - only the latest view and some 
-    /// metadata (the log position, and write flags) are stored. 
+    /// The log itself is transient, i.e. not actually saved to storage - only the latest view and some
+    /// metadata (the log position, and write flags) are stored.
     /// </para>
     /// </summary>
     /// <typeparam name="TLogView">Type of log view</typeparam>
@@ -35,15 +35,15 @@ namespace Orleans.EventSourcing.LogStorage
         private const int maxEntriesInNotifications = 200;
 
 
-        readonly IGrainStorage globalGrainStorage;
-        readonly string grainTypeName;   
+        private readonly IGrainStorage globalGrainStorage;
+        private readonly string grainTypeName;
 
         // the object containing the entire log, as retrieved from / sent to storage
-        LogStateWithMetaDataAndETag<TLogEntry> GlobalLog;
+        private LogStateWithMetaDataAndETag<TLogEntry> GlobalLog;
 
         // the confirmed view
-        TLogView ConfirmedViewInternal;
-        int ConfirmedVersionInternal;
+        private TLogView ConfirmedViewInternal;
+        private int ConfirmedVersionInternal;
 
         /// <inheritdoc/>
         protected override TLogView LastConfirmedView()
@@ -251,7 +251,7 @@ namespace Orleans.EventSourcing.LogStorage
         /// </summary>
         [Serializable]
         [GenerateSerializer]
-        protected internal sealed class UpdateNotificationMessage : INotificationMessage 
+        protected internal sealed class UpdateNotificationMessage : INotificationMessage
         {
             /// <inheritdoc/>
             [Id(0)]
@@ -328,10 +328,10 @@ namespace Orleans.EventSourcing.LogStorage
                 var updateNotification = notifications.ElementAt(0).Value;
                 notifications.RemoveAt(0);
 
-                // append all operations in pending 
+                // append all operations in pending
                 foreach (var u in updateNotification.Updates)
                     GlobalLog.StateAndMetaData.Log.Add(u);
-                  
+
                 GlobalLog.StateAndMetaData.FlipBit(updateNotification.Origin);
 
                 GlobalLog.ETag = updateNotification.ETag;
@@ -344,12 +344,12 @@ namespace Orleans.EventSourcing.LogStorage
             Services.Log(LogLevel.Trace, "unprocessed notifications in queue: {0}", notifications.Count);
 
             base.ProcessNotifications();
-         
+
         }
 
 
 #if DEBUG
-        bool operation_in_progress;
+        private bool operation_in_progress;
 #endif
 
         [Conditional("DEBUG")]

--- a/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
@@ -13,8 +13,8 @@ namespace Orleans.EventSourcing.StateStorage
     /// A log view adaptor that wraps around a traditional storage adaptor, and uses batching and e-tags
     /// to append entries.
     ///<para>
-    /// The log itself is transient, i.e. not actually saved to storage - only the latest view and some 
-    /// metadata (the log position, and write flags) are stored. 
+    /// The log itself is transient, i.e. not actually saved to storage - only the latest view and some
+    /// metadata (the log position, and write flags) are stored.
     /// </para>
     /// </summary>
     /// <typeparam name="TLogView">Type of log view</typeparam>
@@ -35,9 +35,9 @@ namespace Orleans.EventSourcing.StateStorage
         private const int maxEntriesInNotifications = 200;
 
 
-        readonly IGrainStorage globalGrainStorage;
-        readonly string grainTypeName;        // stores the confirmed state including metadata
-        GrainStateWithMetaDataAndETag<TLogView> GlobalStateCache;
+        private readonly IGrainStorage globalGrainStorage;
+        private readonly string grainTypeName;        // stores the confirmed state including metadata
+        private GrainStateWithMetaDataAndETag<TLogView> GlobalStateCache;
 
         /// <inheritdoc/>
         protected override TLogView LastConfirmedView()
@@ -221,7 +221,7 @@ namespace Orleans.EventSourcing.StateStorage
         /// </summary>
         [Serializable]
         [GenerateSerializer]
-        protected internal sealed class UpdateNotificationMessage : INotificationMessage 
+        protected internal sealed class UpdateNotificationMessage : INotificationMessage
         {
             /// <inheritdoc/>
             [Id(0)]
@@ -298,7 +298,7 @@ namespace Orleans.EventSourcing.StateStorage
                 var updateNotification = notifications.ElementAt(0).Value;
                 notifications.RemoveAt(0);
 
-                // Apply all operations in pending 
+                // Apply all operations in pending
                 foreach (var u in updateNotification.Updates)
                     try
                     {
@@ -313,7 +313,7 @@ namespace Orleans.EventSourcing.StateStorage
 
                 GlobalStateCache.StateAndMetaData.FlipBit(updateNotification.Origin);
 
-                GlobalStateCache.ETag = updateNotification.ETag;         
+                GlobalStateCache.ETag = updateNotification.ETag;
 
                 Services.Log(LogLevel.Debug, "notification success ({0} updates) {1}", updateNotification.Updates.Count, GlobalStateCache);
             }
@@ -321,12 +321,12 @@ namespace Orleans.EventSourcing.StateStorage
             Services.Log(LogLevel.Trace, "unprocessed notifications in queue: {0}", notifications.Count);
 
             base.ProcessNotifications();
-         
+
         }
 
 
 #if DEBUG
-        bool operation_in_progress;
+        private bool operation_in_progress;
 #endif
 
         [Conditional("DEBUG")]

--- a/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
@@ -190,7 +190,7 @@ namespace Orleans.Providers.Streams.Generator
 
         private class Receiver : IQueueAdapterReceiver
         {
-            const int MaxDelayMs = 20;
+            private const int MaxDelayMs = 20;
             private readonly IQueueAdapterReceiverMonitor receiverMonitor;
             public IStreamGenerator QueueGenerator { private get; set; }
 

--- a/src/Orleans.TestingHost/Utils/AsyncResultHandle.cs
+++ b/src/Orleans.TestingHost/Utils/AsyncResultHandle.cs
@@ -8,8 +8,8 @@ namespace Orleans.TestingHost.Utils
     /// </summary>
     public class AsyncResultHandle
     {
-        bool done = false;
-        bool continueFlag = false;
+        private bool done = false;
+        private bool continueFlag = false;
 
         /// <summary> Reset the current result handle </summary>
         public virtual void Reset()

--- a/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
@@ -17,7 +17,7 @@ namespace Orleans.Transactions.TestKit
     // - can produce errors for fault senarios.
     public class RemoteCommitService : IRemoteCommitService
     {
-        readonly ILogger logger;
+        private readonly ILogger logger;
 
         public RemoteCommitService(ILogger<RemoteCommitService> logger)
         {

--- a/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
+++ b/test/Analyzers.Tests/AbstractPropertiesCannotBeSerializedAnalyzerTest.cs
@@ -7,7 +7,7 @@ namespace Analyzers.Tests;
 [TestCategory("BVT"), TestCategory("Analyzer")]
 public class AbstractPropertiesCannotBeSerializedAnalyzerTest : DiagnosticAnalyzerTestBase<AbstractPropertiesCannotBeSerializedAnalyzer>
 {
-    async Task VerifyGeneratedDiagnostic(string code)
+    private async Task VerifyGeneratedDiagnostic(string code)
     {
         var (diagnostics, _) = await GetDiagnosticsAsync(code, new string[0]);
 

--- a/test/Analyzers.Tests/GenerateGenerateSerializerAttributeAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GenerateGenerateSerializerAttributeAnalyzerTest.cs
@@ -12,7 +12,7 @@ namespace Analyzers.Tests;
 [TestCategory("BVT"), TestCategory("Analyzer")]
 public class GenerateGenerateSerializerAttributeAnalyzerTest : DiagnosticAnalyzerTestBase<GenerateGenerateSerializerAttributeAnalyzer>
 {
-    async Task VerifyGeneratedDiagnostic(string code)
+    private async Task VerifyGeneratedDiagnostic(string code)
     {
         var (diagnostics, _) = await GetDiagnosticsAsync(code, new string[0]);
 

--- a/test/Analyzers.Tests/GenerateSerializationAttributesAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GenerateSerializationAttributesAnalyzerTest.cs
@@ -12,7 +12,7 @@ namespace Analyzers.Tests;
 [TestCategory("BVT"), TestCategory("Analyzer")]
 public class GenerateSerializationAttributesAnalyzerTest : DiagnosticAnalyzerTestBase<GenerateSerializationAttributesAnalyzer>
 {
-    async Task VerifyGeneratedDiagnostic(string code)
+    private async Task VerifyGeneratedDiagnostic(string code)
     {
         var (diagnostics, _) = await GetDiagnosticsAsync(code, new string[0]);
 

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace Benchmarks
 {
-    class Program
+    internal class Program
     {
         private static readonly Dictionary<string, Action<string[]>> _benchmarks = new Dictionary<string, Action<string[]>>
         {

--- a/test/DefaultCluster.Tests/ClientAddressableTests.cs
+++ b/test/DefaultCluster.Tests/ClientAddressableTests.cs
@@ -60,7 +60,7 @@ namespace DefaultCluster.Tests
 
         private class MyProducer : IClientAddressableTestProducer
         {
-            int counter = 0;
+            private int counter = 0;
 
             public Task<int> Poll()
             {

--- a/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
+++ b/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
@@ -14,9 +14,8 @@ namespace DefaultCluster.Tests.General
     public class EchoTaskGrainTests : HostedTestClusterEnsureDefaultStarted
     {
         private readonly TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(10) : TimeSpan.FromSeconds(10);
-
-        const string expectedEcho = "Hello from EchoGrain";
-        const string expectedEchoError = "Error from EchoGrain";
+        private const string expectedEcho = "Hello from EchoGrain";
+        private const string expectedEchoError = "Error from EchoGrain";
         private IEchoTaskGrain grain;
 
         public static readonly TimeSpan Epsilon = TimeSpan.FromSeconds(1);

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -57,7 +57,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("789", stringResult);
         }
 
-        /// Multiple GetGrain requests with the same id return the same concrete grain 
+        /// Multiple GetGrain requests with the same id return the same concrete grain
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceMultiplicity()
         {
@@ -86,10 +86,10 @@ namespace DefaultCluster.Tests.General
 
             // generic grain implementation does not change the set value:
             await grain.Transform();
-            
+
             T result = await grain.Get();
-            
-            Assert.Equal(setValue, result);            
+
+            Assert.Equal(setValue, result);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
@@ -102,10 +102,10 @@ namespace DefaultCluster.Tests.General
 
             // generic grain implementation does not change the set value:
             await grain.Transform();
-            
+
             var result = await grain.Get();
-            
-            Assert.Equal(expected, result);            
+
+            Assert.Equal(expected, result);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
@@ -117,8 +117,8 @@ namespace DefaultCluster.Tests.General
             await grain.Set(expected);
 
             var result = await grain.Get();
-            
-            Assert.Equal(expected, result);            
+
+            Assert.Equal(expected, result);
         }
 
         /// Can instantiate grains that implement generic interfaces with generic type parameters
@@ -154,7 +154,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(1.2f, floatResult);
         }
 
-        /// If both a concrete implementation and a generic implementation of a 
+        /// If both a concrete implementation and a generic implementation of a
         /// generic interface exist, prefer the concrete implementation.
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
@@ -245,7 +245,7 @@ namespace DefaultCluster.Tests.General
             await grainRef1.Set(1);
             await grainRef1.Transform();  // ConcreteGrainWith2GenericInterfaces multiplies the set value by 10:
 
-            // A second reference to a different interface implemented by ConcreteGrainWith2GenericInterfaces 
+            // A second reference to a different interface implemented by ConcreteGrainWith2GenericInterfaces
             // will reference the same grain:
             var grainRef2 = GetGrain<IGenericGrain<int, string>>(grainId);
             // ConcreteGrainWith2GenericInterfaces returns a string representation of the current value multiplied by 10:
@@ -692,7 +692,7 @@ namespace DefaultCluster.Tests.General
             var grain =  this.GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
             _ = await grain.GetState();
         }
-                
+
         [Fact, TestCategory("BVT"), TestCategory("Generics")]
         public async Task Generic_GrainWithTypeConstraints()
         {
@@ -738,7 +738,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
-        public async Task Generic_CastToGenericInterfaceAfterActivation() 
+        public async Task Generic_CastToGenericInterfaceAfterActivation()
         {
             var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
             await grain.DoSomething(); //activates original grain type here
@@ -760,7 +760,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
+
         [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task Generic_CastToDifferentlyConcretizedInterfaceBeforeActivation() {
             var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
@@ -771,7 +771,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
+
         [Fact, TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Generic_CastGenericInterfaceToNonGenericInterfaceBeforeActivation() {
             var grain =  this.GrainFactory.GetGrain<IGenericCastableGrain<string>>(Guid.NewGuid());
@@ -782,7 +782,7 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
+
         /// <summary>
         /// Tests that generic grains can have generic state and that the parameters to the Grain{TState}
         /// class do not have to match the parameters to the grain class itself.
@@ -808,13 +808,13 @@ namespace DefaultCluster.Tests.General
             {
             }
 
-            static async Task<Type[]> GetConcreteGenArgs(IBasicGrain @this) {
+            private static async Task<Type[]> GetConcreteGenArgs(IBasicGrain @this) {
                 var genArgTypeNames = await @this.ConcreteGenArgTypeNames();
 
                 return genArgTypeNames.Select(n => Type.GetType(n))
                                         .ToArray();
             }
-                        
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_PartiallySpecifyingGenericGrainFulfilsInterface() {
@@ -826,7 +826,7 @@ namespace DefaultCluster.Tests.General
                         concreteGenArgs.SequenceEqual(new[] { typeof(int) })
                         );
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_GenericGrainCanReuseOwnGenArgRepeatedly() {
@@ -866,7 +866,7 @@ namespace DefaultCluster.Tests.General
 
                 Assert.Equal("Hello!", response);
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_RepeatedRearrangedGenArgsResolved() {
@@ -881,7 +881,7 @@ namespace DefaultCluster.Tests.General
                         concreteGenArgs.SequenceEqual(new[] { typeof(string), typeof(int) })
                         );
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInTypeResolution() {
@@ -921,7 +921,7 @@ namespace DefaultCluster.Tests.General
 
                 Assert.Equal("Hello!", response);
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_RearrangedGenArgsOfCorrectArityAreResolved() {
@@ -933,7 +933,7 @@ namespace DefaultCluster.Tests.General
                         concreteGenArgs.SequenceEqual(new[] { typeof(long), typeof(int) })
                         );
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable() {
@@ -968,7 +968,7 @@ namespace DefaultCluster.Tests.General
             //Below must be commented out, as supplying multiple fully-specified generic interfaces
             //to a class causes the codegen to fall over, stopping all other tests from working.
 
-            //See new test here of the bit causing the issue - type info conflation:  
+            //See new test here of the bit causing the issue - type info conflation:
             //UnitTests.CodeGeneration.CodeGeneratorTests.CodeGen_EncounteredFullySpecifiedInterfacesAreEncodedDistinctly()
 
 
@@ -983,7 +983,7 @@ namespace DefaultCluster.Tests.General
 
 
             //[Fact, TestCategory("Generics")]
-            //public async Task CastingBetweenFullySpecifiedGenericInterfaces() 
+            //public async Task CastingBetweenFullySpecifiedGenericInterfaces()
             //{
             //    //Is this legitimate? Solely in the realm of virtual grain interfaces - no special knowledge of implementation implicated, only of interface hierarchy
 
@@ -1003,7 +1003,7 @@ namespace DefaultCluster.Tests.General
             //}
 
             //*******************************************************************************************************
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs() {
@@ -1029,7 +1029,7 @@ namespace DefaultCluster.Tests.General
 
                 Assert.Equal("Hello!", response);
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_GenArgsCanBeFurtherSpecialized() {
@@ -1053,7 +1053,7 @@ namespace DefaultCluster.Tests.General
                         concreteGenArgs.SequenceEqual(new[] { typeof(long) })
                         );
             }
-            
+
 
             [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
             public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs() {

--- a/test/DefaultCluster.Tests/LocalErrorGrain.cs
+++ b/test/DefaultCluster.Tests/LocalErrorGrain.cs
@@ -6,8 +6,8 @@ namespace DefaultCluster.Tests
 {
     internal class LocalErrorGrain
     {
-        int m_a = 0;
-        int m_b = 0;
+        private int m_a = 0;
+        private int m_b = 0;
 
         public LocalErrorGrain() { }
 

--- a/test/DefaultCluster.Tests/MultifacetGrainTest.cs
+++ b/test/DefaultCluster.Tests/MultifacetGrainTest.cs
@@ -10,10 +10,11 @@ namespace DefaultCluster.Tests.General
     //using ValueUpdateEventArgs = MultifacetGrainClient.ValueUpdateEventArgs;
     public class MultifacetGrainTest : HostedTestClusterEnsureDefaultStarted
     {
-        IMultifacetWriter writer;
-        IMultifacetReader reader;
+        private IMultifacetWriter writer;
+        private IMultifacetReader reader;
+
         //int eventCounter;
-        const int EXPECTED_NUMBER_OF_EVENTS = 4;
+        private const int EXPECTED_NUMBER_OF_EVENTS = 4;
         private readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
 
         public MultifacetGrainTest(DefaultClusterFixture fixture) : base(fixture)
@@ -25,7 +26,7 @@ namespace DefaultCluster.Tests.General
         {
             writer = this.GrainFactory.GetGrain<IMultifacetWriter>(GetRandomGrainId());
             reader = writer.AsReference<IMultifacetReader>();
-            
+
             int x = 1234;
             bool ok = writer.SetValue(x).Wait(timeout);
             if (!ok) throw new TimeoutException();
@@ -53,7 +54,7 @@ namespace DefaultCluster.Tests.General
             writer.SetValue(5).Wait();
             int v = reader.GetValue().Result;
             Assert.Equal(5, v);
-            
+
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Cast")]

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -80,7 +80,7 @@ namespace DefaultCluster.Tests.General
             this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
-        void ObserverTest_SimpleNotification_Callback(int a, int b, AsyncResultHandle result)
+        private void ObserverTest_SimpleNotification_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
             this.Logger.LogInformation("Invoking ObserverTest_SimpleNotification_Callback for {CallbackCounter} time with a = {A} and b = {B}", this.callbackCounter, a, b);
@@ -145,7 +145,7 @@ namespace DefaultCluster.Tests.General
             this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
-        void ObserverTest_DoubleSubscriptionSameReference_Callback(int a, int b, AsyncResultHandle result)
+        private void ObserverTest_DoubleSubscriptionSameReference_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
             this.Logger.LogInformation("Invoking ObserverTest_DoubleSubscriptionSameReference_Callback for {CallbackCounter} time with a={A} and b={B}", this.callbackCounter, a, b);
@@ -177,7 +177,7 @@ namespace DefaultCluster.Tests.General
             this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
-        void ObserverTest_SubscribeUnsubscribe_Callback(int a, int b, AsyncResultHandle result)
+        private void ObserverTest_SubscribeUnsubscribe_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
             this.Logger.LogInformation("Invoking ObserverTest_SubscribeUnsubscribe_Callback for {CallbackCounter} time with a = {A} and b = {B}", this.callbackCounter, a, b);
@@ -236,7 +236,7 @@ namespace DefaultCluster.Tests.General
             this.GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference2);
         }
 
-        void ObserverTest_DoubleSubscriptionDifferentReferences_Callback(int a, int b, AsyncResultHandle result)
+        private void ObserverTest_DoubleSubscriptionDifferentReferences_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
             this.Logger.LogInformation("Invoking ObserverTest_DoubleSubscriptionDifferentReferences_Callback for {CallbackCounter} time with a = {A} and b = {B}", this.callbackCounter, a, b);
@@ -267,7 +267,7 @@ namespace DefaultCluster.Tests.General
             Assert.False(await result.WaitForFinished(timeout), $"Should timeout waiting {timeout} for SetB");
         }
 
-        void ObserverTest_DeleteObject_Callback(int a, int b, AsyncResultHandle result)
+        private void ObserverTest_DeleteObject_Callback(int a, int b, AsyncResultHandle result)
         {
             callbackCounter++;
             this.Logger.LogInformation("Invoking ObserverTest_DeleteObject_Callback for {CallbackCounter} time with a = {A} and b = {B}", this.callbackCounter, a, b);
@@ -322,8 +322,8 @@ namespace DefaultCluster.Tests.General
 
         internal class SimpleGrainObserver : ISimpleGrainObserver
         {
-            readonly Action<int, int, AsyncResultHandle> action;
-            readonly AsyncResultHandle result;
+            private readonly Action<int, int, AsyncResultHandle> action;
+            private readonly AsyncResultHandle result;
 
             private readonly ILogger logger;
 

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/PostgreSqlStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/PostgreSqlStorageForTesting.cs
@@ -6,7 +6,7 @@ using UnitTests.General;
 
 namespace Tester.RelationalUtilities
 {
-    class PostgreSqlStorageForTesting : RelationalStorageForTesting
+    internal class PostgreSqlStorageForTesting : RelationalStorageForTesting
     {
         protected override string ProviderMoniker => "PostgreSQL";
 

--- a/test/Grains/TestGrains/AsyncSimpleGrain.cs
+++ b/test/Grains/TestGrains/AsyncSimpleGrain.cs
@@ -9,7 +9,7 @@ namespace UnitTests.Grains
     /// </summary>
     public class AsyncSimpleGrain : SimpleGrain, ISimpleGrainWithAsyncMethods
     {
-        TaskCompletionSource<int> resolver;
+        private TaskCompletionSource<int> resolver;
 
         public AsyncSimpleGrain(ILoggerFactory loggerFactory) : base(loggerFactory)
         {

--- a/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
+++ b/test/Grains/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
@@ -5,7 +5,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
+    internal class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
     {
         protected int T { get; set; }
 
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
         }
     }
 
-    class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
+    internal class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
     {
         protected float T { get; set; }
 
@@ -37,7 +37,7 @@ namespace UnitTests.Grains
         }
     }
 
-    class ConcreteGrainWith2GenericInterfaces : Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
+    internal class ConcreteGrainWith2GenericInterfaces : Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
     {
         // IGenericGrain<int, string> methods:
 

--- a/test/Grains/TestGrains/EventSourcing/SeatReservationGrain.cs
+++ b/test/Grains/TestGrains/EventSourcing/SeatReservationGrain.cs
@@ -56,7 +56,7 @@ namespace TestGrains
             Reservations = new Dictionary<int, SeatReservation>();
         }
 
-        void Apply(SeatReservation reservation)
+        private void Apply(SeatReservation reservation)
         {
             // see if this reservation targets an available seat
             // otherwise, treat it as a no-op

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -9,7 +9,7 @@ using TestGrainInterfaces;
 
 namespace TestGrains
 {
-    class GeneratedEventReporterGrain : Grain, IGeneratedEventReporterGrain
+    internal class GeneratedEventReporterGrain : Grain, IGeneratedEventReporterGrain
     {
         private readonly ILogger logger;
 

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -865,8 +865,7 @@ namespace UnitTests.Grains
                                 );
             }
 
-
-            Type GetImmediateSubclass(Type subject) {
+            private Type GetImmediateSubclass(Type subject) {
                 if(subject.BaseType == typeof(BasicGrain)) {
                     return subject;
                 }

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -9,7 +9,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    class ProducerEventCountingGrain : BaseGrain, IProducerEventCountingGrain
+    internal class ProducerEventCountingGrain : BaseGrain, IProducerEventCountingGrain
     {
         private IAsyncObserver<int> _producer;
         private int _numProducedItems;
@@ -59,7 +59,7 @@ namespace UnitTests.Grains
             {
                 throw new ApplicationException("Not yet a producer on a stream.  Must call BecomeProducer first.");
             }
-            
+
             await _producer.OnNextAsync(_numProducedItems + 1);
 
             // update after send in case of error

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -137,7 +137,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
     public class Apple : IFruit
     {
         [Id(0)]
-        readonly int number;
+        private readonly int number;
 
         public Apple(int number)
         {

--- a/test/Grains/TestGrains/ReentrantGrain.cs
+++ b/test/Grains/TestGrains/ReentrantGrain.cs
@@ -109,11 +109,11 @@ namespace UnitTests.Grains
             return arg == "reentrant";
         }
 
-        static object UnwrapImmutable(object item) => item is Immutable<object> ? ((Immutable<object>)item).Value : item;
+        private static object UnwrapImmutable(object item) => item is Immutable<object> ? ((Immutable<object>)item).Value : item;
 
         private IMayInterleavePredicateGrain Self { get; set; }
 
-        // this interleaves only when arg == "reentrant" 
+        // this interleaves only when arg == "reentrant"
         // and test predicate will throw when arg = "err"
         public Task<string> One(string arg)
         {
@@ -151,7 +151,7 @@ namespace UnitTests.Grains
             return GetStream().OnNextAsync(item);
         }
 
-        IAsyncStream<string> GetStream() => 
+        private IAsyncStream<string> GetStream() =>
             this.GetStreamProvider("sms").GetStream<string>("test-stream-interleave", Guid.Empty);
 
         public Task SetSelf(IMayInterleavePredicateGrain self)

--- a/test/Grains/TestInternalGrainInterfaces/ISerializerPresenceTest.cs
+++ b/test/Grains/TestInternalGrainInterfaces/ISerializerPresenceTest.cs
@@ -3,7 +3,7 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    interface ISerializerPresenceTest : IGrainWithGuidKey
+    internal interface ISerializerPresenceTest : IGrainWithGuidKey
     {
         Task<bool> SerializerExistsForType(System.Type param);
 

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -24,8 +24,8 @@ namespace UnitTests.Grains
         private readonly IReminderTable reminderTable;
 
         private readonly IReminderRegistry unvalidatedReminderRegistry;
-        Dictionary<string, ReminderState> allReminders;
-        Dictionary<string, long> sequence;
+        private Dictionary<string, ReminderState> allReminders;
+        private Dictionary<string, long> sequence;
         private TimeSpan period;
 
         private static readonly long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
@@ -239,8 +239,8 @@ namespace UnitTests.Grains
     public class ReminderTestCopyGrain : Grain, IReminderTestCopyGrain, IRemindable
     {
         private readonly IReminderRegistry unvalidatedReminderRegistry;
-        Dictionary<string, IGrainReminder> allReminders;
-        Dictionary<string, long> sequence;
+        private Dictionary<string, IGrainReminder> allReminders;
+        private Dictionary<string, long> sequence;
         private TimeSpan period;
 
         private static readonly long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway

--- a/test/Grains/TestInternalGrains/SerializerPresenceTestGrain.cs
+++ b/test/Grains/TestInternalGrains/SerializerPresenceTestGrain.cs
@@ -7,7 +7,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    class SerializerPresenceTestGrain : Grain, ISerializerPresenceTest
+    internal class SerializerPresenceTestGrain : Grain, ISerializerPresenceTest
     {
         public Task<bool> SerializerExistsForType(Type t)
         {

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -15,12 +15,12 @@ namespace UnitTestGrains
     public class TimerGrain : Grain, ITimerGrain
     {
         private bool deactivating;
-        int counter = 0;
-        Dictionary<string, IDisposable> allTimers;
-        IDisposable defaultTimer;
+        private int counter = 0;
+        private Dictionary<string, IDisposable> allTimers;
+        private IDisposable defaultTimer;
         private static readonly TimeSpan period = TimeSpan.FromMilliseconds(100);
-        readonly string DefaultTimerName = "DEFAULT TIMER";
-        IGrainContext context;
+        private const string DefaultTimerName = "DEFAULT TIMER";
+        private IGrainContext context;
 
         private readonly ILogger logger;
 
@@ -235,7 +235,7 @@ namespace UnitTestGrains
 
         private void CheckRuntimeContext(string what)
         {
-            if (RuntimeContext.Current == null 
+            if (RuntimeContext.Current == null
                 || !RuntimeContext.Current.Equals(context))
             {
                 throw new InvalidOperationException(

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -17,8 +17,9 @@ namespace UnitTests.General
         private readonly TestEnvironmentFixture environment;
         private static Random random => Random.Shared;
 
-        class A { }
-        class B : A { }
+        private class A { }
+
+        private class B : A { }
         
         public IdentifierTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {

--- a/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
+++ b/test/NonSilo.Tests/Serialization/SerializationTests.ImmutableCollections.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Serialization
             this.fixture = fixture;
         }
 
-        void RoundTripCollectionSerializationTest<T>(IEnumerable<T> input)
+        private void RoundTripCollectionSerializationTest<T>(IEnumerable<T> input)
         {
             var output = this.fixture.Serializer.RoundTripSerializationForTesting(input);
             Assert.Equal(input,output);

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -68,12 +68,12 @@ public sealed class MyJsonSerializableAttribute : Attribute
 {
 }
 
-interface IMyBase
+internal interface IMyBase
 {
     MyValue BaseValue { get; set; }
 }
 
-interface IMySub : IMyBase
+internal interface IMySub : IMyBase
 {
     MyValue SubValue { get; set; }
 }

--- a/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Linq;
 using TestGrainInterfaces;
@@ -28,7 +28,7 @@ namespace Tester.EventSourcingTests
         // - confirming at end only, instead of after each update, is fast.
         // - allowing reentrancy, while still confirming after each update, is also fast. 
 
-        private readonly int iterations = 800;
+        private const int iterations = 800;
 
         [Fact, RunThisFirst, TestCategory("EventSourcing")]
         public Task Perf_Warmup()
@@ -94,7 +94,7 @@ namespace Tester.EventSourcingTests
 
     }
 
-    class RunThisFirstAttribute : Attribute
+    internal class RunThisFirstAttribute : Attribute
     {
     }
 

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -10,7 +10,7 @@ using Orleans.Core.Internal;
 
 namespace UnitTests.StreamingTests
 {
-    class DeactivationTestRunner
+    internal class DeactivationTestRunner
     {
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
         private readonly string streamProviderName;

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -97,7 +97,7 @@ namespace Tester.StreamingTests
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(counts.Sum(), lastTry), Timeout);
         }
 
-        Task OnNextAsync(int e, StreamSequenceToken token)
+        private Task OnNextAsync(int e, StreamSequenceToken token)
         {
             Interlocked.Increment(ref this.eventsConsumed);
             return Task.CompletedTask;

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -26,8 +26,8 @@ namespace UnitTests.General
         private readonly TimeSpan failureTimeout = TimeSpan.FromSeconds(30);
         private readonly TimeSpan endWait = TimeSpan.FromMinutes(5);
 
-        enum Fail { First, Random, Last }
-        
+        private enum Fail { First, Random, Last }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             builder.AddSiloBuilderConfigurator<Configurator>();

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -318,8 +318,8 @@ namespace UnitTests.General
     internal class RequestContextGrainObserver : ISimpleGrainObserver
     {
         private readonly ITestOutputHelper output;
-        readonly Action<int, int, object> action;
-        readonly object result;
+        private readonly Action<int, int, object> action;
+        private readonly object result;
 
         public RequestContextGrainObserver(ITestOutputHelper output, Action<int, int, object> action, object result)
         {

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -52,11 +52,11 @@ namespace UnitTests.StorageTests
             }
         }
 
-        const string DefaultGrainStateName = "state";
-        const string MockStorageProviderName1 = "test1";
-        const string MockStorageProviderName2 = "test2";
-        const string MockStorageProviderNameLowerCase = "lowercase";
-        const string ErrorInjectorProviderName = "ErrorInjector";
+        private const string DefaultGrainStateName = "state";
+        private const string MockStorageProviderName1 = "test1";
+        private const string MockStorageProviderName2 = "test2";
+        private const string MockStorageProviderNameLowerCase = "lowercase";
+        private const string ErrorInjectorProviderName = "ErrorInjector";
         private readonly ITestOutputHelper output;
 
         protected TestCluster HostedCluster { get; }
@@ -164,7 +164,7 @@ namespace UnitTests.StorageTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Generics")]
-        public async Task Persistence_Grain_Activate_StoredValue_Generic() 
+        public async Task Persistence_Grain_Activate_StoredValue_Generic()
         {
             const string providerName = MockStorageProviderName1;
             Guid guid = Guid.NewGuid();
@@ -254,7 +254,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
             Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
             SetStoredValue(providerName, typeof(MockStorageProvider).FullName, DefaultGrainStateName, grain, "Field1", 42);
-            
+
             await grain.DoRead();
             providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
             Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
@@ -262,7 +262,7 @@ namespace UnitTests.StorageTests
 
             Assert.Equal(42, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
-        
+
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MemoryStore")]
         public async Task MemoryStore_Read_Write()
         {
@@ -627,7 +627,7 @@ namespace UnitTests.StorageTests
 
             Assert.Equal(expectedVal, val); // Returned value
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
-            
+
             await CheckStorageProviderErrors(grain.DoRead);
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.None);
@@ -756,7 +756,7 @@ namespace UnitTests.StorageTests
         {
             var target = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(Guid.NewGuid());
             var proxy = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorProxyGrain>(Guid.NewGuid());
-            
+
             // Record the original activation ids.
             var targetActivationId = await target.GetActivationId();
             var proxyActivationId = await proxy.GetActivationId();
@@ -1280,11 +1280,11 @@ namespace UnitTests.StorageTests
                     return providerState;
                 }
             }
-            
+
             return providerState;
         }
 
-        class ProviderState
+        private class ProviderState
         {
             public MockStorageProvider.StateForTest ProviderStateForTest { get; set; }
             public PersistenceTestGrainState LastStoredGrainState { get; set; }


### PR DESCRIPTION
This PR ensures that all classes, interfaces, class members, etc. have accessibility modifiers present. This was the result of a tool run by Visual Studio followed by a lot of manual cleanup (for some reason, the tool decided to remove readonly modifiers, which was odd so I added them back).

In one or two cases only, I changed a private readonly to a private const where it made sense to do so as part of that manual cleanup.