### PR TITLE
Add static modifier to members when possible, private and internal only (no public API change)

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -481,7 +481,7 @@ namespace Orleans.Clustering.DynamoDB
             }
         }
 
-        private MembershipEntry Parse(SiloInstanceRecord tableEntry)
+        private static MembershipEntry Parse(SiloInstanceRecord tableEntry)
         {
             var parse = new MembershipEntry
             {

--- a/src/AdoNet/Shared/Storage/OracleDatabaseCommandInterceptor.cs
+++ b/src/AdoNet/Shared/Storage/OracleDatabaseCommandInterceptor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Linq.Expressions;
 
@@ -59,7 +59,7 @@ namespace Orleans.Tests.SqlUtils
         /// </summary>
         /// <param name="enumName">String value of a OracleDbType enum value.</param>
         /// <returns>An action which takes a OracleParameter as IDbDataParameter.</returns>
-        private Action<IDbDataParameter> BuildSetOracleDbTypeAction(string enumName)
+        private static Action<IDbDataParameter> BuildSetOracleDbTypeAction(string enumName)
         {
             var type = Type.GetType("Oracle.ManagedDataAccess.Client.OracleParameter, Oracle.ManagedDataAccess");
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -388,7 +388,7 @@ namespace Orleans.AzureUtils
             }
         }
 
-        private string SanitizeQueueName(string queueName)
+        private static string SanitizeQueueName(string queueName)
         {
             var tmp = queueName;
             //Azure queue naming rules : https://docs.microsoft.com/en-us/rest/api/storageservices/Naming-Queues-and-Metadata?redirectedfrom=MSDN
@@ -406,7 +406,7 @@ namespace Orleans.AzureUtils
             return tmp;
         }
 
-        private void ValidateQueueName(string queueName)
+        private static void ValidateQueueName(string queueName)
         {
             // Naming Queues and Metadata: http://msdn.microsoft.com/en-us/library/windowsazure/dd179349.aspx
             if (!(queueName.Length >= 3 && queueName.Length <= 63))

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
@@ -73,13 +73,13 @@ namespace Orleans.Streaming.EventHubs.Testing
             return eventDataList.Count > 0;
         }
 
-        private IEnumerable<int> GenerateEvent(int sequenceNumber)
+        private static IEnumerable<int> GenerateEvent(int sequenceNumber)
         {
             var events = new List<int>();
             events.Add(sequenceNumber);
             return events;
         }
-        
+
         public static Func<StreamId, IStreamDataGenerator<EventData>> CreateFactory(IServiceProvider services)
         {
             return (streamId) => ActivatorUtilities.CreateInstance<SimpleStreamEventDataGenerator>(services, streamId);

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
@@ -147,7 +147,7 @@ namespace Orleans.Configuration
             CreateConnection = createConnection ?? throw new ArgumentNullException(nameof(createConnection));
         }
 
-        private void ValidateValues(string eventHubName, string consumerGroup)
+        private static void ValidateValues(string eventHubName, string consumerGroup)
         {
             if (string.IsNullOrWhiteSpace(eventHubName))
             {

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
@@ -146,7 +146,7 @@ namespace Orleans.Transactions.AzureStorage
             return result;
         }
 
-        private void CheckMaxDataSize(int dataSize, int maxDataSize)
+        private static void CheckMaxDataSize(int dataSize, int maxDataSize)
         {
             if (dataSize > maxDataSize)
             {

--- a/src/Orleans.BroadcastChannel/SubscriberTable/ImplicitChannelSubscriberTable.cs
+++ b/src/Orleans.BroadcastChannel/SubscriberTable/ImplicitChannelSubscriberTable.cs
@@ -181,7 +181,7 @@ namespace Orleans.BroadcastChannel.SubscriberTable
         /// <param name="channelId">The channel ID to use for the grain ID construction.</param>
         /// <param name="channelSubscriber">The GrainBindings for the grain to create</param>
         /// <returns></returns>
-        private IBroadcastChannelConsumerExtension MakeConsumerReference(
+        private static IBroadcastChannelConsumerExtension MakeConsumerReference(
             IGrainFactory grainFactory,
             InternalChannelId channelId,
             BroadcastChannelSubscriber channelSubscriber)

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -460,7 +460,7 @@ namespace Orleans.CodeGenerator
         }
 
         // Returns descriptions of all data members (fields and properties)
-        private IEnumerable<IMemberDescription> GetDataMembers(FieldIdAssignmentHelper fieldIdAssignmentHelper)
+        private static IEnumerable<IMemberDescription> GetDataMembers(FieldIdAssignmentHelper fieldIdAssignmentHelper)
         {
             var members = new Dictionary<(uint, bool), IMemberDescription>();
 

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -110,7 +110,7 @@ internal class FieldIdAssignmentHelper
         return true;
     }
 
-    private (string, uint) GetCanonicalNameAndFieldId(ITypeSymbol typeSymbol, string name)
+    private static (string, uint) GetCanonicalNameAndFieldId(ITypeSymbol typeSymbol, string name)
     {
         name = PropertyUtility.GetCanonicalName(name);
 

--- a/src/Orleans.Core/Async/AsyncSerialExecutor.cs
+++ b/src/Orleans.Core/Async/AsyncSerialExecutor.cs
@@ -124,7 +124,7 @@ namespace Orleans
             return this.executor.AddNext(() => Wrap(func));
         }
 
-        private async Task<bool> Wrap(Func<Task> func)
+        private static async Task<bool> Wrap(Func<Task> func)
         {
             await func();
             return true;

--- a/src/Orleans.Core/Diagnostics/MessagingTrace.cs
+++ b/src/Orleans.Core/Diagnostics/MessagingTrace.cs
@@ -195,7 +195,7 @@ namespace Orleans.Runtime
                 null);
         }
 
-        internal void OnSendRequest(Message message)
+        internal static void OnSendRequest(Message message)
         {
             OrleansInsideRuntimeClientEvent.Log.SendRequest(message);
         }

--- a/src/Orleans.Core/Manifest/GrainBindings.cs
+++ b/src/Orleans.Core/Manifest/GrainBindings.cs
@@ -123,7 +123,7 @@ namespace Orleans.Metadata
             }
         }
 
-        private Cache BuildCache(ClusterManifest clusterManifest)
+        private static Cache BuildCache(ClusterManifest clusterManifest)
         {
             var result = new Dictionary<GrainType, GrainBindings>();
 

--- a/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
+++ b/src/Orleans.Hosting.Kubernetes/ConfigureKubernetesHostingOptions.cs
@@ -94,7 +94,7 @@ namespace Orleans.Hosting.Kubernetes
             }
         }
 
-        private string? ReadNamespaceFromServiceAccount()
+        private static string? ReadNamespaceFromServiceAccount()
         {
             // Read the namespace from the pod's service account.
             var serviceAccountNamespacePath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount", "namespace");

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime
         /// </summary>
         public string? GrainTypeName { get; }
 
-        private TimeSpan GetCollectionAgeLimit(GrainType grainType, Type grainClass, GrainManifest siloManifest, GrainCollectionOptions collectionOptions)
+        private static TimeSpan GetCollectionAgeLimit(GrainType grainType, Type grainClass, GrainManifest siloManifest, GrainCollectionOptions collectionOptions)
         {
             if (siloManifest.Grains.TryGetValue(grainType, out var properties)
                 && properties.Properties.TryGetValue(WellKnownGrainTypeProperties.IdleDeactivationPeriod, out var idleTimeoutString))

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -338,7 +338,7 @@ namespace Orleans.Runtime.Management
         /// <param name="siloAddresses">List of silos to perform the action for</param>
         /// <param name="perSiloAction">The action function to be performed for each silo</param>
         /// <returns>Array containing one Task for each silo the action was performed for</returns>
-        private List<Task> PerformPerSiloAction(SiloAddress[] siloAddresses, Func<SiloAddress, Task> perSiloAction)
+        private static List<Task> PerformPerSiloAction(SiloAddress[] siloAddresses, Func<SiloAddress, Task> perSiloAction)
         {
             var requestsToSilos = new List<Task>();
             foreach (SiloAddress siloAddress in siloAddresses)

--- a/src/Orleans.Runtime/Hosting/SiloHostedService.cs
+++ b/src/Orleans.Runtime/Hosting/SiloHostedService.cs
@@ -36,7 +36,7 @@ namespace Orleans.Hosting
             this.logger.LogInformation("Orleans Silo stopped.");
         }
 
-        private void ValidateSystemConfiguration(IEnumerable<IConfigurationValidator> configurationValidators)
+        private static void ValidateSystemConfiguration(IEnumerable<IConfigurationValidator> configurationValidators)
         {
             foreach (var validator in configurationValidators)
             {

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -287,14 +287,14 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private Task<bool> MembershipExecuteWithRetries(
+        private static Task<bool> MembershipExecuteWithRetries(
             Func<int, Task<bool>> taskFunction,
             TimeSpan timeout)
         {
             return MembershipExecuteWithRetries(taskFunction, timeout, (result, i) => result == false);
         }
 
-        private Task<T> MembershipExecuteWithRetries<T>(
+        private static Task<T> MembershipExecuteWithRetries<T>(
             Func<int, Task<T>> taskFunction,
             TimeSpan timeout,
             Func<T, int, bool> retryValueFilter)
@@ -303,8 +303,8 @@ namespace Orleans.Runtime.MembershipService
                     taskFunction,
                     NUM_CONDITIONAL_WRITE_CONTENTION_ATTEMPTS,
                     NUM_CONDITIONAL_WRITE_ERROR_ATTEMPTS,
-                    retryValueFilter,   // if failed to Update on contention - retry   
-                    (exc, i) => true,            // Retry on errors.          
+                    retryValueFilter,   // if failed to Update on contention - retry
+                    (exc, i) => true,            // Retry on errors.
                     timeout,
                     new ExponentialBackoff(EXP_BACKOFF_CONTENTION_MIN, EXP_BACKOFF_CONTENTION_MAX, EXP_BACKOFF_STEP), // how long to wait between successful retries
                     new ExponentialBackoff(EXP_BACKOFF_ERROR_MIN, EXP_BACKOFF_ERROR_MAX, EXP_BACKOFF_STEP)  // how long to wait between error retries

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -116,13 +116,13 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(T[])}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
     /// <summary>
@@ -266,12 +266,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ReadOnlyMemory<T>)}, {length}, is greater than total length of input.");
     }
 
@@ -428,12 +428,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Memory<T>)}, {length}, is greater than total length of input.");
     }
 
@@ -593,12 +593,12 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(ArraySegment<T>)}, {length}, is greater than total length of input.");
     }
 

--- a/src/Orleans.Serialization/Codecs/CollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CollectionCodec.cs
@@ -112,10 +112,10 @@ public sealed class CollectionCodec<T> : IFieldCodec<Collection<T>>
         return result;
     }
 
-    private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+    private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
         $"Declared length of {typeof(Collection<T>)}, {length}, is greater than total length of input.");
 
-    private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+    private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 }
 
 /// <summary>

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -136,17 +136,17 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private Dictionary<TKey, TValue> CreateInstance(int length, IEqualityComparer<TKey> comparer, SerializerSession session, uint placeholderReferenceId)
+        private static Dictionary<TKey, TValue> CreateInstance(int length, IEqualityComparer<TKey> comparer, SerializerSession session, uint placeholderReferenceId)
         {
             var result = new Dictionary<TKey, TValue>(length, comparer);
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
     }
 
     /// <summary>
@@ -312,10 +312,10 @@ namespace Orleans.Serialization.Codecs
             }
         }
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
 
     }
 }

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -115,17 +115,17 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private HashSet<T> CreateInstance(int length, IEqualityComparer<T> comparer, SerializerSession session, uint placeholderReferenceId)
+        private static HashSet<T> CreateInstance(int length, IEqualityComparer<T> comparer, SerializerSession session, uint placeholderReferenceId)
         {
             var result = new HashSet<T>(length, comparer);
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized set is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized set is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -111,10 +111,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -156,7 +156,7 @@ namespace Orleans.Serialization.Codecs
         private void ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {CodecElementType} with declared lengths {string.Join(", ", lengths)}.");
 
-        private void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
+        private static void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/NullableCodec.cs
+++ b/src/Orleans.Serialization/Codecs/NullableCodec.cs
@@ -59,7 +59,7 @@ namespace Orleans.Serialization.Codecs
             return _fieldCodec.ReadValue(ref reader, field);
         }
 
-        private void ThrowInvalidReference(uint reference) => throw new ReferenceNotFoundException(typeof(T?), reference);
+        private static void ThrowInvalidReference(uint reference) => throw new ReferenceNotFoundException(typeof(T?), reference);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -103,7 +103,7 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized queue is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -111,10 +111,10 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
+        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
             $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");
 
-        private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized stack is missing its length field.");
+        private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized stack is missing its length field.");
     }
 
     /// <summary>

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -99,7 +99,7 @@ namespace Orleans.Providers.Streams.Generator
             return segment;
         }
 
-        private StreamPosition GetStreamPosition(GeneratedBatchContainer queueMessage)
+        private static StreamPosition GetStreamPosition(GeneratedBatchContainer queueMessage)
         {
             return new StreamPosition(queueMessage.StreamId, queueMessage.RealToken);
         }

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -88,7 +88,7 @@ namespace Orleans.Providers
             return segment;
         }
 
-        private StreamPosition GetStreamPosition(MemoryMessageData queueMessage)
+        private static StreamPosition GetStreamPosition(MemoryMessageData queueMessage)
         {
             return new StreamPosition(queueMessage.StreamId,
                 new EventSequenceTokenV2(queueMessage.SequenceNumber));

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -722,7 +722,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Add call context for batch delivery call, then clear context immediately, without giving up turn.
         /// </summary>
-        private Task<StreamHandshakeToken> ContextualizedDeliverBatchToConsumer(StreamConsumerData consumerData, IBatchContainer batch)
+        private static Task<StreamHandshakeToken> ContextualizedDeliverBatchToConsumer(StreamConsumerData consumerData, IBatchContainer batch)
         {
             bool isRequestContextSet = batch.ImportRequestContext();
             try

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
@@ -92,7 +92,7 @@ namespace Orleans.Streams
                     return new StreamSubscription(subId, streamId.ProviderName, streamId, grainId);
                 }).ToList();
                 return Task.FromResult(subscriptions);
-            }   
+            }
         }
 
         internal bool IsImplicitSubscriber(GrainId grainId, QualifiedStreamId streamId)

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -121,7 +121,7 @@ namespace Orleans.TestingHost
             }
         }
 
-        private void WriteLog(object value)
+        private static void WriteLog(object value)
         {
             Console.WriteLine(value?.ToString());
         }

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
@@ -59,7 +59,7 @@ namespace Orleans.Transactions.TestKit
             return context => Create(context, genericCreate, args);
         }
 
-        private object Create(IGrainContext context, MethodInfo genericCreate, object[] args)
+        private static object Create(IGrainContext context, MethodInfo genericCreate, object[] args)
         {
             IFaultInjectionTransactionalStateFactory factory = context.ActivationServices.GetRequiredService<IFaultInjectionTransactionalStateFactory>();
             return genericCreate.Invoke(factory, args);

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/GrainFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/GrainFaultTransactionTestRunner.cs
@@ -139,7 +139,7 @@ namespace Orleans.Transactions.TestKit
             });
         }
 
-        private async Task TestAfterDustSettles(Func<Task> what)
+        private static async Task TestAfterDustSettles(Func<Task> what)
         {
             int tries = 2;
             while (tries-- > 0)

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -115,7 +115,7 @@ namespace Orleans.Transactions.TestKit
             await ValidateResults(txGrains, transactionGroups);
         }
 
-        private Task WakeupGrains(List<ITransactionalBitArrayGrain> grains)
+        private static Task WakeupGrains(List<ITransactionalBitArrayGrain> grains)
         {
             var tasks =  new List<Task>();
             foreach (var grain in grains)

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
@@ -147,7 +147,7 @@ namespace Orleans.Transactions.TestKit
                 actual.Should().BeEquivalentTo(expected, assertConfig);
         }
 
-        private PendingTransactionState<TState> MakePendingState(long seqno, TState val, bool tm)
+        private static PendingTransactionState<TState> MakePendingState(long seqno, TState val, bool tm)
         {
             var result = new PendingTransactionState<TState>()
             {
@@ -161,7 +161,7 @@ namespace Orleans.Transactions.TestKit
             return result;
         }
 
-        private ParticipantId MakeParticipantId()
+        private static ParticipantId MakeParticipantId()
         {
             return new ParticipantId(
                                     "tm",
@@ -170,7 +170,7 @@ namespace Orleans.Transactions.TestKit
                                     ParticipantId.Role.Resource | ParticipantId.Role.Manager);
         }
 
-        private Dictionary<Guid, CommitRecord> MakeCommitRecords(int count, int size)
+        private static Dictionary<Guid, CommitRecord> MakeCommitRecords(int count, int size)
         {
             var result = new Dictionary<Guid, CommitRecord>();
             for (int j = 0; j < size; j++)

--- a/src/Orleans.Transactions/Hosting/TransactionCommitterAttributeMapper.cs
+++ b/src/Orleans.Transactions/Hosting/TransactionCommitterAttributeMapper.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using System.Reflection;
@@ -18,7 +18,7 @@ namespace Orleans.Transactions
             return context => Create(context, genericCreate, args);
         }
 
-        private object Create(IGrainContext context, MethodInfo genericCreate, object[] args)
+        private static object Create(IGrainContext context, MethodInfo genericCreate, object[] args)
         {
             ITransactionCommitterFactory factory = context.ActivationServices.GetRequiredService<ITransactionCommitterFactory>();
             return genericCreate.Invoke(factory, args);

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -420,7 +420,7 @@ namespace Orleans.Transactions.State
             }
         }
 
-        private bool HasConflict(bool isRead, DateTime priority, Guid transactionId, LockGroup group, out bool resolvable)
+        private static bool HasConflict(bool isRead, DateTime priority, Guid transactionId, LockGroup group, out bool resolvable)
         {
             bool foundResolvableConflicts = false;
 
@@ -451,7 +451,7 @@ namespace Orleans.Transactions.State
             return foundResolvableConflicts;
         }
 
-        private IEnumerable<Guid> Conflicts(Guid transactionId, LockGroup group)
+        private static IEnumerable<Guid> Conflicts(Guid transactionId, LockGroup group)
         {
             foreach (var kvp in group)
             {

--- a/test/Benchmarks/Serialization/Comparison/ClassDeserializeBenchmark.cs
+++ b/test/Benchmarks/Serialization/Comparison/ClassDeserializeBenchmark.cs
@@ -107,7 +107,7 @@ namespace Benchmarks.Comparison
             var instance = Serializer.Deserialize(Input, Session);
             return SumResult(instance);
         }
-        
+
         [Benchmark]
         public int Utf8Json() => SumResult(Utf8JsonNS.JsonSerializer.Deserialize<IntClass>(Utf8JsonInput, Utf8JsonResolver));
 

--- a/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -180,7 +180,7 @@ namespace AWSUtils.Tests.StorageTests
             Assert.Equal(initialState.Grain, convertedState.Grain);  // "Grain"
         }
 
-        private async Task<DynamoDBGrainStorage> InitDynamoDBTableStorageProvider(IProviderRuntime runtime, string storageName)
+        private static async Task<DynamoDBGrainStorage> InitDynamoDBTableStorageProvider(IProviderRuntime runtime, string storageName)
         {
             var options = new DynamoDBStorageOptions();
             options.Service = AWSTestConstants.DynamoDbService;

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -184,7 +184,7 @@ namespace AWSUtils.Tests.Streaming
             }
         }
 
-        private List<object> CreateEvents(int count)
+        private static List<object> CreateEvents(int count)
         {
             return Enumerable.Range(0, count).Select(i =>
             {

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -222,7 +222,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             return itemCount;
         }
 
-        private async Task AddDataIntoCache(EventHubQueueCacheForTesting cache, int count)
+        private static async Task AddDataIntoCache(EventHubQueueCacheForTesting cache, int count)
         {
             await Task.Delay(10);
             List<EventData> messages = Enumerable.Range(0, count)
@@ -231,7 +231,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             cache.Add(messages, DateTime.UtcNow);
         }
 
-        private EventData MakeEventData(long sequenceNumber)
+        private static EventData MakeEventData(long sequenceNumber)
         {
             byte[] ignore = { 12, 23 };
             var now = DateTime.UtcNow;

--- a/test/Extensions/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -117,7 +117,7 @@ namespace ServiceBus.Tests.SlowConsumingTests
             return grains;
         }
 
-        private async Task StopHealthyConsumerGrainComing(List<ISampleStreaming_ConsumerGrain> grains)
+        private static async Task StopHealthyConsumerGrainComing(List<ISampleStreaming_ConsumerGrain> grains)
         {
             List<Task> tasks = new List<Task>();
             foreach (var grain in grains)

--- a/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -113,7 +113,7 @@ namespace ServiceBus.Tests.MonitorTests
             }
         }
 
-        private void AssertCacheMonitorCallCounters(CacheMonitorCounters totalCacheMonitorCallCounters)
+        private static void AssertCacheMonitorCallCounters(CacheMonitorCounters totalCacheMonitorCallCounters)
         {
             var c = totalCacheMonitorCallCounters;
             Assert.True(c.TrackCachePressureMonitorStatusChangeCallCounter > 0,
@@ -124,7 +124,7 @@ namespace ServiceBus.Tests.MonitorTests
             Assert.True(0 == c.TrackMessagePurgedCounter, $"Expected {nameof(c.TrackMessagePurgedCounter)} == 0, got {c.TrackMessagePurgedCounter}");
         }
 
-        private void AssertReceiverMonitorCallCounters(EventHubReceiverMonitorCounters totalReceiverMonitorCallCounters)
+        private static void AssertReceiverMonitorCallCounters(EventHubReceiverMonitorCounters totalReceiverMonitorCallCounters)
         {
             var c = totalReceiverMonitorCallCounters;
             Assert.True(ehPartitionCountPerSilo == c.TrackInitializationCallCounter, $"Expected {nameof(c.TrackInitializationCallCounter)} == {ehPartitionCountPerSilo}, got {c.TrackInitializationCallCounter}");
@@ -133,7 +133,7 @@ namespace ServiceBus.Tests.MonitorTests
             Assert.True(0 == c.TrackShutdownCallCounter, $"Expected {nameof(c.TrackShutdownCallCounter)} == 0, got {c.TrackShutdownCallCounter}");
         }
 
-        private void AssertObjectPoolMonitorCallCounters(ObjectPoolMonitorCounters totalObjectPoolMonitorCallCounters)
+        private static void AssertObjectPoolMonitorCallCounters(ObjectPoolMonitorCounters totalObjectPoolMonitorCallCounters)
         {
             var c = totalObjectPoolMonitorCallCounters;
             Assert.True(c.TrackObjectAllocatedByCacheCallCounter > 0, $"Expected {nameof(c.TrackObjectAllocatedByCacheCallCounter)} > 0, got {c.TrackObjectAllocatedByCacheCallCounter}");

--- a/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -125,7 +125,7 @@ namespace ServiceBus.Tests.StreamingTests
             }
         }
 
-        private async Task<bool> CheckCounters(List<ISampleStreaming_ConsumerGrain> consumers, int totalEventCount, bool assertIsTrue)
+        private static async Task<bool> CheckCounters(List<ISampleStreaming_ConsumerGrain> consumers, int totalEventCount, bool assertIsTrue)
         {
             List<Task<int>> becomeConsumersTasks = consumers
                 .Select((consumer, i) => consumer.GetNumberConsumed())

--- a/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
@@ -133,12 +133,12 @@ public class ReminderTests_Cosmos_Standalone
         };
     }
 
-    private string NewClusterId()
+    private static string NewClusterId()
     {
         return string.Format("ReminderTest.{0}", Guid.NewGuid());
     }
 
-    private async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
+    private static async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
     {
         ReminderTableData data = await table.ReadRows(0, 0xffffffff);
         return data.Reminders;

--- a/test/Extensions/TesterAzureUtils/AsyncPipelineTests.cs
+++ b/test/Extensions/TesterAzureUtils/AsyncPipelineTests.cs
@@ -169,14 +169,14 @@ namespace UnitTests.AsyncPrimitivesTests
 
             Assert.True(capacityReached.IsSet, "Pipeline capacity not reached; the delay length probably is too short to be useful.");
             Assert.True(
-                actualSec >= minTimeSec, 
+                actualSec >= minTimeSec,
                 string.Format("The unit test completed too early ({0} sec < {1} sec).", actualSec, minTimeSec));
             Assert.True(
-                actualSec <= maxTimeSec, 
+                actualSec <= maxTimeSec,
                 string.Format("The unit test completed too late ({0} sec > {1} sec).", actualSec, maxTimeSec));
         }
 
-        private void CheckPipelineState(int size, int capacity, InterlockedFlag capacityReached)
+        private static void CheckPipelineState(int size, int capacity, InterlockedFlag capacityReached)
         {
             Assert.True(size >= 0);
             Assert.True(capacity > 0);

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -142,12 +142,12 @@ namespace Tester.AzureUtils.TimerTests
             };
         }
 
-        private string NewClusterId()
+        private static string NewClusterId()
         {
             return string.Format("ReminderTest.{0}", Guid.NewGuid());
         }
 
-        private async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
+        private static async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
         {
             ReminderTableData data = await table.ReadRows(0, 0xffffffff);
             return data.Reminders;

--- a/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -282,7 +282,7 @@ namespace Tester.AzureUtils
             return data;
         }
 
-        private void CheckSiloInstanceTableEntry(SiloInstanceTableEntry referenceEntry, SiloInstanceTableEntry entry)
+        private static void CheckSiloInstanceTableEntry(SiloInstanceTableEntry referenceEntry, SiloInstanceTableEntry entry)
         {
             Assert.Equal(referenceEntry.DeploymentId, entry.DeploymentId);
             Assert.Equal(referenceEntry.Address, entry.Address);

--- a/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
+++ b/test/Grains/BenchmarkGrains/Ping/LoadGrain.cs
@@ -44,7 +44,7 @@ namespace BenchmarkGrains.Ping
             return report;
         }
 
-        private async Task ResolvePending(List<Pending> pendingWork, Report report, bool all = false)
+        private static async Task ResolvePending(List<Pending> pendingWork, Report report, bool all = false)
         {
             try
             {
@@ -71,7 +71,7 @@ namespace BenchmarkGrains.Ping
                 }
             }
         }
-        
+
         private class Pending
         {
             public IPingGrain Grain { get; set; }

--- a/test/Grains/BenchmarkGrains/Transaction/LoadGrain.cs
+++ b/test/Grains/BenchmarkGrains/Transaction/LoadGrain.cs
@@ -47,7 +47,7 @@ namespace BenchmarkGrains.Transaction
             return report;
         }
 
-        private async Task<List<Task>> ResolvePending(List<Task> pending, Report report, bool all = false)
+        private static async Task<List<Task>> ResolvePending(List<Task> pending, Report report, bool all = false)
         {
             try
             {

--- a/test/NonSilo.Tests/General/RingTests_Standalone.cs
+++ b/test/NonSilo.Tests/General/RingTests_Standalone.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
@@ -95,7 +95,7 @@ namespace UnitTests.General
             VerifyRing(rings);
         }
 
-        private Dictionary<SiloAddress, ConsistentRingProvider> CreateServers(int n)
+        private static Dictionary<SiloAddress, ConsistentRingProvider> CreateServers(int n)
         {
             Dictionary<SiloAddress, ConsistentRingProvider> rings = new Dictionary<SiloAddress, ConsistentRingProvider>();
 
@@ -107,7 +107,7 @@ namespace UnitTests.General
             return rings;
         }
 
-        private Dictionary<SiloAddress, ConsistentRingProvider> Combine(Dictionary<SiloAddress, ConsistentRingProvider> set1, Dictionary<SiloAddress, ConsistentRingProvider> set2)
+        private static Dictionary<SiloAddress, ConsistentRingProvider> Combine(Dictionary<SiloAddress, ConsistentRingProvider> set1, Dictionary<SiloAddress, ConsistentRingProvider> set2)
         {
             // tell set1 about every node in set2
             foreach (ConsistentRingProvider crp in set1.Values)

--- a/test/NonSilo.Tests/OrleansRuntime/Streams/BestFitBalancerTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/Streams/BestFitBalancerTests.cs
@@ -147,7 +147,7 @@ namespace UnitTests.OrleansRuntime.Streams
             }
         }
 
-        private void ValidateBalance(List<int> buckets, List<int> resources, Dictionary<int, List<int>> balancerResults, int idealBalance)
+        private static void ValidateBalance(List<int> buckets, List<int> resources, Dictionary<int, List<int>> balancerResults, int idealBalance)
         {
             var resultBuckets = new List<int>();
             var resultResources = new List<int>();

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -365,13 +365,13 @@ namespace UnitTests.SchedulerTests
             Assert.Null(RequestContext.Get(key));
         }
 
-        private async Task AsyncCheckClearRequestContext(string key)
+        private static async Task AsyncCheckClearRequestContext(string key)
         {
             Assert.Null(RequestContext.Get(key));
             await Task.Delay(TimeSpan.Zero);
         }
 
-        private Task NonAsyncCheckClearRequestContext(string key)
+        private static Task NonAsyncCheckClearRequestContext(string key)
         {
             Assert.Null(RequestContext.Get(key));
             return Task.CompletedTask;

--- a/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
+++ b/test/Orleans.Serialization.UnitTests/InvokableTestInterfaces.cs
@@ -28,7 +28,7 @@ namespace Orleans.Serialization.UnitTests
             CopyContextPool = copyContextPool;
             CodecProvider = codecProvider;
         }
-        
+
         protected TInvokable GetInvokable<TInvokable>() where TInvokable : class, IInvokable, new() => InvokablePool.Get<TInvokable>();
 
         protected ValueTask<T> InvokeAsync<T>(IInvokable body)

--- a/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
@@ -318,7 +318,7 @@ namespace Orleans.Serialization.UnitTests
             _log.WriteLine($"Read references:\n{references}");
         }
 
-        private void GetGeneratedSerializer<T>(out IFieldCodec<T> serializer)
+        private static void GetGeneratedSerializer<T>(out IFieldCodec<T> serializer)
         {
             var services = new ServiceCollection().AddSerializer();
             var serviceProvider = services.BuildServiceProvider();

--- a/test/Tester/EventSourcingTests/AccountGrainTests.cs
+++ b/test/Tester/EventSourcingTests/AccountGrainTests.cs
@@ -16,7 +16,7 @@ namespace Tester.EventSourcingTests
             this.fixture = fixture;
         }
 
-        private async Task TestSequence(IAccountGrain account, bool hasLogStored)
+        private static async Task TestSequence(IAccountGrain account, bool hasLogStored)
         {
             Assert.Equal(0u, await account.Balance());
 

--- a/test/Tester/EventSourcingTests/CountersGrainTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainTests.cs
@@ -49,10 +49,10 @@ namespace Tester.EventSourcingTests
         }
 
         private static readonly string[] keys = { "a", "b", "c", "d", "e", "f", "g", "h" };
-        private string RandomKey() { return keys[Random.Shared.Next(keys.Length)]; }
+        private static string RandomKey() { return keys[Random.Shared.Next(keys.Length)]; }
 
 
-        private async Task ConcurrentIncrementsRunner(ICountersGrain grain, int count, bool wait_for_confirmation_on_each)
+        private static async Task ConcurrentIncrementsRunner(ICountersGrain grain, int count, bool wait_for_confirmation_on_each)
         {
             // increment (count) times, on random keys, concurrently
             var tasks = new List<Task>();

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -68,7 +68,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             assemblyGrainsV2 = GetVersionTestDirectory(testDirectory, GrainsV2ProjectName);
         }
 
-        private FileInfo GetVersionTestDirectory(DirectoryInfo testDirectory, string directoryName)
+        private static FileInfo GetVersionTestDirectory(DirectoryInfo testDirectory, string directoryName)
         {
             var projectDirectory = Path.Combine(testDirectory.FullName, VersionsProjectDirectory, directoryName, BinDirectory);
 

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -132,7 +132,7 @@ namespace Tester
             Assert.True(multiStageObserver.Stopped.Values.All(o => o));
         }
 
-        private async Task<Dictionary<TestStages,List<Observer>>> RunLifecycle(Dictionary<TestStages,int> observerCountByStage, TestStages? failOnStart, TestStages? failOnStop)
+        private static async Task<Dictionary<TestStages,List<Observer>>> RunLifecycle(Dictionary<TestStages,int> observerCountByStage, TestStages? failOnStart, TestStages? failOnStop)
         {
             // setup lifecycle observers
             var observersByStage = new Dictionary<TestStages, List<Observer>>();

--- a/test/Tester/LogFomatterTests.cs
+++ b/test/Tester/LogFomatterTests.cs
@@ -385,7 +385,7 @@ namespace Tester
             Assert.Equal(expected.ToString(), actual.ToString());
         }
 
-        private TestLoggerFactory BuildOptionsExpectedResult()
+        private static TestLoggerFactory BuildOptionsExpectedResult()
         {
             var services = new ServiceCollection();
             var testOptions = new TestOptions
@@ -399,7 +399,7 @@ namespace Tester
             return expected;
         }
 
-        private TestLoggerFactory BuildNamedOptionsExpectedResult()
+        private static TestLoggerFactory BuildNamedOptionsExpectedResult()
         {
             var services = new ServiceCollection();
             IOptionFormatter[] formatters = Enumerable

--- a/test/TesterInternal/General/GrainPlacementTests.cs
+++ b/test/TesterInternal/General/GrainPlacementTests.cs
@@ -132,13 +132,13 @@ namespace UnitTests.General
                 yield return grain.GetEndpoint().Result;
         }
 
-        private IEnumerable<string> CollectActivationIds(IPlacementTestGrain grain, int sampleSize)
+        private static IEnumerable<string> CollectActivationIds(IPlacementTestGrain grain, int sampleSize)
         {
             for (var i = 0; i < sampleSize; ++i)
                 yield return grain.GetActivationId().Result;
         }
 
-        private int ActivationCount(IEnumerable<string> ids)
+        private static int ActivationCount(IEnumerable<string> ids)
         {
             return ids.GroupBy(id => id).Count();
         }

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -107,7 +107,7 @@ namespace UnitTests.LivenessTests
                 queueHistogram.Values.Min(list => list.Sum()), queueHistogram.Values.Max(list => list.Sum()));
         }
 
-        private Dictionary<SiloAddress, List<int>> GetQueueHistogram(List<(SiloAddress Key, List<IRingRangeInternal> Value)> siloRanges, int totalNumQueues)
+        private static Dictionary<SiloAddress, List<int>> GetQueueHistogram(List<(SiloAddress Key, List<IRingRangeInternal> Value)> siloRanges, int totalNumQueues)
         {
             var options = new HashRingStreamQueueMapperOptions();
             options.TotalQueueCount = totalNumQueues;


### PR DESCRIPTION
Left unchanged are any modifiers on protected or public members, as well as most internal ones as well.