### PR TITLE
Fixes nullability of returned IGrainReminder in GrainReminderExtensions

### DIFF
--- a/src/Orleans.Reminders/GrainReminderExtensions.cs
+++ b/src/Orleans.Reminders/GrainReminderExtensions.cs
@@ -80,7 +80,7 @@ public static class GrainReminderExtensions
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Reminder to return</param>
     /// <returns>Promise for Reminder handle.</returns>
-    public static Task<IGrainReminder> GetReminder(this Grain grain, string reminderName) => GetReminder(grain?.GrainContext, reminderName);
+    public static Task<IGrainReminder?> GetReminder(this Grain grain, string reminderName) => GetReminder(grain?.GrainContext, reminderName);
 
     /// <summary>
     /// Returns a previously registered reminder.
@@ -88,9 +88,9 @@ public static class GrainReminderExtensions
     /// <param name="grain">A grain.</param>
     /// <param name="reminderName">Reminder to return</param>
     /// <returns>Promise for Reminder handle.</returns>
-    public static Task<IGrainReminder> GetReminder(this IGrainBase grain, string reminderName) => GetReminder(grain?.GrainContext, reminderName);
+    public static Task<IGrainReminder?> GetReminder(this IGrainBase grain, string reminderName) => GetReminder(grain?.GrainContext, reminderName);
 
-    private static Task<IGrainReminder> GetReminder(IGrainContext? grainContext, string reminderName)
+    private static Task<IGrainReminder?> GetReminder(IGrainContext? grainContext, string reminderName)
     {
         ArgumentNullException.ThrowIfNull(grainContext, "grain");
         if (string.IsNullOrWhiteSpace(reminderName)) throw new ArgumentNullException(nameof(reminderName));


### PR DESCRIPTION
The returned IGrainReminder was null in orleans 3 and as far as I'm aware the reminder service still returns null when the reminder does not exist. I beleive this is dependent on the underlying storage implementation but I have confirmed null is returned with DynamoDb and Azure storage.