### PR TITLE
[Dependencies] Bump Event Hubs version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageVersion Include="Azure.Core" Version="1.33.0" />
-    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.7.3" />
+    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.9.2" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.14.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.12.0" />
     <!-- 3rd party packages -->


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the reference for `Azure.Messaging.EventHubs` to the latest version.   There have been a number of fixes and enhancements in the 9 months since the previously version was released.  Of particular note, there were two important fixes in the AMQP transport library which could cause corruption in the connection state until the process was restarted.  

No breaking changes were made to the Event Hubs library in this time.

# References and Resources

- [Event Hubs Changelog](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Messaging.EventHubs_5.9.2/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8545)