### PR TITLE
MessagePack codec 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,7 +96,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageVersion Include="Microsoft.Crank.EventSources" Version="0.2.0-alpha.23422.5" />
-    <PackageVersion Include="MessagePack" Version="2.5.124" />
+    <PackageVersion Include="MessagePack" Version="2.5.168" />
     <PackageVersion Include="ZeroFormatter" Version="1.6.4" />
     <PackageVersion Include="Utf8Json" Version="1.3.7" />
     <PackageVersion Include="SpanJson" Version="4.0.1" />

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -236,6 +236,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DashboardToy.AppHost", "pla
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Orleans.Serialization.FSharp.Tests", "test\Orleans.Serialization.FSharp.Tests\Orleans.Serialization.FSharp.Tests.fsproj", "{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Serialization.MessagePack", "src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj", "{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -622,6 +624,10 @@ Global
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -737,6 +743,7 @@ Global
 		{C4DD4F96-3EC6-47C6-97AA-9B14F0F2099B} = {316CDCC7-323F-4264-9FC9-667662BB1F80}
 		{84B44F1D-B7FE-40E3-82F0-730A55AC8613} = {316CDCC7-323F-4264-9FC9-667662BB1F80}
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
+		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
@@ -19,6 +19,9 @@ namespace Orleans.Serialization;
 /// <summary>
 /// A serialization codec which uses <see cref="MessagePackSerializer"/>.
 /// </summary>
+/// <remarks>
+/// MessagePack codec performs slightly worse than default Orleans serializer, if performance is critical for your application, consider using default serialization.
+/// </remarks>
 [Alias(WellKnownAlias)]
 public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
 {
@@ -38,8 +41,9 @@ public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilt
     /// <summary>
     /// Initializes a new instance of the <see cref="MessagePackCodec"/> class.
     /// </summary>
+    /// /// <param name="serializableTypeSelectors">Filters used to indicate which types should be serialized by this codec.</param>
     /// <param name="copyableTypeSelectors">Filters used to indicate which types should be copied by this codec.</param>
-    /// <param name="options">The JSON codec options.</param>
+    /// <param name="options">The MessagePack codec options.</param>
     public MessagePackCodec(
         IEnumerable<ICodecSelector> serializableTypeSelectors,
         IEnumerable<ICopierSelector> copyableTypeSelectors,

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using MessagePack;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.WireProtocol;
+
+namespace Orleans.Serialization;
+
+/// <summary>
+/// A serialization codec which uses <see cref="MessagePackSerializer"/>.
+/// </summary>
+[Alias(WellKnownAlias)]
+public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
+{
+    private static readonly ConcurrentDictionary<Type, bool> SupportedTypes = new();
+
+    private static readonly Type SelfType = typeof(MessagePackCodec);
+
+    private readonly ICodecSelector[] _serializableTypeSelectors;
+    private readonly ICopierSelector[] _copyableTypeSelectors;
+    private readonly MessagePackCodecOptions _options;
+
+    /// <summary>
+    /// The well-known type alias for this codec.
+    /// </summary>
+    public const string WellKnownAlias = "msgpack";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagePackCodec"/> class.
+    /// </summary>
+    /// <param name="copyableTypeSelectors">Filters used to indicate which types should be copied by this codec.</param>
+    /// <param name="options">The JSON codec options.</param>
+    public MessagePackCodec(
+        IEnumerable<ICodecSelector> serializableTypeSelectors,
+        IEnumerable<ICopierSelector> copyableTypeSelectors,
+        IOptions<MessagePackCodecOptions> options)
+    {
+        _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
+        _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
+        _options = options.Value;
+    }
+
+    /// <inheritdoc/>
+    void IFieldCodec.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value)
+    {
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
+        {
+            return;
+        }
+
+        // The schema type when serializing the field is the type of the codec.
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, SelfType, WireType.TagDelimited);
+
+        // Write the type name
+        ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeaderExpected(0, WireType.LengthPrefixed);
+        writer.Session.TypeCodec.WriteLengthPrefixed(ref writer, value.GetType());
+
+        var bufferWriter = new BufferWriterBox<PooledBuffer>(new());
+        try
+        {
+
+            var msgPackWriter = new MessagePackWriter(bufferWriter);
+            MessagePackSerializer.Serialize(expectedType ?? value.GetType(), ref msgPackWriter, value, _options.SerializerOptions);
+            msgPackWriter.Flush();
+
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeaderExpected(1, WireType.LengthPrefixed);
+            writer.WriteVarUInt32((uint)bufferWriter.Value.Length);
+            bufferWriter.Value.CopyTo(ref writer);
+        }
+        finally
+        {
+            bufferWriter.Value.Dispose();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    /// <inheritdoc/>
+    object IFieldCodec.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (field.IsReference)
+        {
+            return ReferenceCodec.ReadReference(ref reader, field.FieldType);
+        }
+
+        field.EnsureWireTypeTagDelimited();
+
+        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+        object result = null;
+        Type type = null;
+        uint fieldId = 0;
+        while (true)
+        {
+            var header = reader.ReadFieldHeader();
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            switch (fieldId)
+            {
+                case 0:
+                    ReferenceCodec.MarkValueField(reader.Session);
+                    type = reader.Session.TypeCodec.ReadLengthPrefixed(ref reader);
+                    break;
+                case 1:
+                    if (type is null)
+                    {
+                        ThrowTypeFieldMissing();
+                    }
+
+                    ReferenceCodec.MarkValueField(reader.Session);
+                    var length = reader.ReadVarUInt32();
+
+                    var bufferWriter = new BufferWriterBox<PooledBuffer>(new());
+                    try
+                    {
+                        reader.ReadBytes(ref bufferWriter, (int)length);
+                        result = MessagePackSerializer.Deserialize(type, bufferWriter.Value.AsReadOnlySequence(), _options.SerializerOptions);
+                    }
+                    finally
+                    {
+                        bufferWriter.Value.Dispose();
+                    }
+
+                    break;
+                default:
+                    reader.ConsumeUnknownField(header);
+                    break;
+            }
+        }
+
+        ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    bool IGeneralizedCodec.IsSupportedType(Type type)
+    {
+        if (type == SelfType)
+        {
+            return true;
+        }
+
+        foreach (var selector in _serializableTypeSelectors)
+        {
+            if (selector.IsSupportedType(type))
+            {
+                return true;
+            }
+        }
+
+        if (_options.IsSerializableType?.Invoke(type) is bool value)
+        {
+            return value;
+        }
+
+        return IsMessagePackContract(type, _options.AllowDataContractAttributes);
+    }
+
+    /// <inheritdoc/>
+    object IDeepCopier.DeepCopy(object input, CopyContext context)
+    {
+        if (context.TryGetCopy(input, out object result))
+        {
+            return result;
+        }
+
+        var bufferWriter = new BufferWriterBox<PooledBuffer>(new());
+        try
+        {
+            var msgPackWriter = new MessagePackWriter(bufferWriter);
+            MessagePackSerializer.Serialize(input.GetType(), ref msgPackWriter, input, _options.SerializerOptions);
+            msgPackWriter.Flush();
+
+            var sequence = bufferWriter.Value.AsReadOnlySequence();
+            result = MessagePackSerializer.Deserialize(input.GetType(), sequence, _options.SerializerOptions);
+        }
+        catch
+        {
+            bufferWriter.Value.Dispose();
+        }
+
+        context.RecordCopy(input, result);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    bool IGeneralizedCopier.IsSupportedType(Type type)
+    {
+        foreach (var selector in _copyableTypeSelectors)
+        {
+            if (selector.IsSupportedType(type))
+            {
+                return true;
+            }
+        }
+
+        if (_options.IsCopyableType?.Invoke(type) is bool value)
+        {
+            return value;
+        }
+
+        return IsMessagePackContract(type, _options.AllowDataContractAttributes);
+    }
+
+    /// <inheritdoc/>
+    bool? ITypeFilter.IsTypeAllowed(Type type) => (((IGeneralizedCopier)this).IsSupportedType(type) || ((IGeneralizedCodec)this).IsSupportedType(type)) ? true : null;
+
+    private static bool IsMessagePackContract(Type type, bool allowDataContractAttribute)
+    {
+        if (SupportedTypes.TryGetValue(type, out bool isMsgPackContract))
+        {
+            return isMsgPackContract;
+        }
+
+        isMsgPackContract = type.GetCustomAttribute<MessagePackObjectAttribute>() is not null;
+
+        if (!isMsgPackContract && allowDataContractAttribute)
+        {
+            isMsgPackContract = type.GetCustomAttribute<DataContractAttribute>() is DataContractAttribute;
+        }
+
+        SupportedTypes.TryAdd(type, isMsgPackContract);
+        return isMsgPackContract;
+    }
+
+    private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
+}

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
@@ -159,6 +159,11 @@ public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilt
             return true;
         }
 
+        if (CommonCodecTypeFilter.IsAbstractOrFrameworkType(type))
+        {
+            return false;
+        }
+
         foreach (var selector in _serializableTypeSelectors)
         {
             if (selector.IsSupportedType(type))
@@ -205,6 +210,11 @@ public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilt
     /// <inheritdoc/>
     bool IGeneralizedCopier.IsSupportedType(Type type)
     {
+        if (CommonCodecTypeFilter.IsAbstractOrFrameworkType(type))
+        {
+            return false;
+        }
+
         foreach (var selector in _copyableTypeSelectors)
         {
             if (selector.IsSupportedType(type))

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodecOptions.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodecOptions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.Serialization;
+using MessagePack;
+
+namespace Orleans.Serialization;
+
+/// <summary>
+/// Options for <see cref="MessagePackCodec"/>.
+/// </summary>
+public class MessagePackCodecOptions
+{
+    /// <summary>
+    /// Gets or sets the <see cref="MessagePackSerializerOptions"/>.
+    /// </summary>
+    public MessagePackSerializerOptions SerializerOptions { get; set; } = MessagePackSerializerOptions.Standard;
+
+    /// <summary>
+    /// Get or sets flag that allows the use of <see cref="DataContractAttribute"/> marked contracts for MessagePackSerializer.
+    /// </summary>
+    public bool AllowDataContractAttributes { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate used to determine if a type is supported by the MessagePack serializer for serialization and deserialization.
+    /// </summary>
+    public Func<Type, bool?> IsSerializableType { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate used to determine if a type is supported by the MessagePack serializer for copying.
+    /// </summary>
+    public Func<Type, bool?> IsCopyableType { get; set; }
+}

--- a/src/Orleans.Serialization.MessagePack/Orleans.Serialization.MessagePack.csproj
+++ b/src/Orleans.Serialization.MessagePack/Orleans.Serialization.MessagePack.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageDescription>MessagePack integration for Orleans.Serialization</PackageDescription>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization.MessagePack/Orleans.Serialization.MessagePack.csproj
+++ b/src/Orleans.Serialization.MessagePack/Orleans.Serialization.MessagePack.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Orleans.Serialization.MessagePack</PackageId>
+    <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
+    <PackageDescription>MessagePack integration for Orleans.Serialization</PackageDescription>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans.Serialization\Orleans.Serialization.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
@@ -1,0 +1,92 @@
+using System;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.Utilities.Internal;
+
+namespace Orleans.Serialization;
+
+/// <summary>
+/// Extension method for <see cref="ISerializerBuilder"/>.
+/// </summary>
+public static class SerializationHostingExtensions
+{
+    private static readonly ServiceDescriptor ServiceDescriptor = new (typeof(MessagePackCodec), typeof(MessagePackCodec));
+
+    /// <summary>
+    /// Adds support for serializing and deserializing values using <see cref="MessagePackSerializer"/>.
+    /// </summary>
+    /// <param name="serializerBuilder">The serializer builder.</param>
+    /// <param name="isSerializable">A delegate used to indicate which types should be serialized by this codec.</param>
+    /// <param name="isCopyable">A delegate used to indicate which types should be copied by this codec.</param>
+    /// <param name="messagePackSerializerOptions">The MessagePack serializer options.</param>
+    public static ISerializerBuilder AddMessagePackSerializer(
+        this ISerializerBuilder serializerBuilder,
+        Func<Type, bool> isSerializable = null,
+        Func<Type, bool> isCopyable = null,
+        MessagePackSerializerOptions messagePackSerializerOptions = null)
+    {
+        return serializerBuilder.AddMessagePackSerializer(
+            isSerializable,
+            isCopyable,
+            optionsBuilder => optionsBuilder.Configure(options =>
+            {
+                if (messagePackSerializerOptions is not null)
+                {
+                    options.SerializerOptions = messagePackSerializerOptions;
+                }
+            })
+        );
+    }
+
+    /// <summary>
+    /// Adds support for serializing and deserializing values using <see cref="MessagePackSerializer"/>.
+    /// </summary>
+    /// <param name="serializerBuilder">The serializer builder.</param>
+    /// <param name="isSerializable">A delegate used to indicate which types should be serialized by this codec.</param>
+    /// <param name="isCopyable">A delegate used to indicate which types should be copied by this codec.</param>
+    /// <param name="configureOptions">A delegate used to configure the options for the MessagePack codec.</param>
+    public static ISerializerBuilder AddMessagePackSerializer(
+        this ISerializerBuilder serializerBuilder,
+        Func<Type, bool> isSerializable,
+        Func<Type, bool> isCopyable,
+        Action<OptionsBuilder<MessagePackCodecOptions>> configureOptions = null)
+    {
+        var services = serializerBuilder.Services;
+        if (configureOptions != null)
+        {
+            configureOptions(services.AddOptions<MessagePackCodecOptions>());
+        }
+
+        if (isSerializable != null)
+        {
+            services.AddSingleton<ICodecSelector>(new DelegateCodecSelector
+            {
+                CodecName = MessagePackCodec.WellKnownAlias,
+                IsSupportedTypeDelegate = isSerializable
+            });
+        }
+
+        if (isCopyable != null)
+        {
+            services.AddSingleton<ICopierSelector>(new DelegateCopierSelector
+            {
+                CopierName = MessagePackCodec.WellKnownAlias,
+                IsSupportedTypeDelegate = isCopyable
+            });
+        }
+
+        if (!services.Contains(ServiceDescriptor))
+        {
+            services.AddSingleton<MessagePackCodec>();
+            services.AddFromExisting<IGeneralizedCodec, MessagePackCodec>();
+            services.AddFromExisting<IGeneralizedCopier, MessagePackCodec>();
+            services.AddFromExisting<ITypeFilter, MessagePackCodec>();
+            serializerBuilder.Configure(options => options.WellKnownTypeAliases[MessagePackCodec.WellKnownAlias] = typeof(MessagePackCodec));
+        }
+
+        return serializerBuilder;
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/MessagePackSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/MessagePackSerializerTests.cs
@@ -1,0 +1,104 @@
+#nullable enable
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+public class MessagePackCodecTests : FieldCodecTester<MyMessagePackClass?, IFieldCodec<MyMessagePackClass?>>
+{
+    public MessagePackCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(ISerializerBuilder builder)
+    {
+        builder.AddMessagePackSerializer();
+    }
+
+    protected override MyMessagePackClass? CreateValue() => new() { IntProperty = 30, StringProperty = "hello", SubClass = new() { Id = Guid.NewGuid() } };
+
+    protected override MyMessagePackClass?[] TestValues => new MyMessagePackClass?[]
+    {
+        null,
+        new() { SubClass = new() { Id = Guid.NewGuid() } },
+        new() { IntProperty = 150, StringProperty = new string('c', 20), SubClass = new() { Id = Guid.NewGuid() } },
+        new() { IntProperty = 150_000, StringProperty = new string('c', 6_000), SubClass = new() { Id = Guid.NewGuid() } },
+    };
+
+    [Fact]
+    public void MessagePackSerializerDeepCopyTyped()
+    {
+        var original = new MyMessagePackClass { IntProperty = 30, StringProperty = "hi", SubClass = new() { Id = Guid.NewGuid() } };
+        var copier = ServiceProvider.GetRequiredService<DeepCopier<MyMessagePackClass>>();
+        var result = copier.Copy(original);
+
+        Assert.Equal(original.IntProperty, result.IntProperty);
+        Assert.Equal(original.StringProperty, result.StringProperty);
+        Assert.Equal(original.SubClass.Id, result.SubClass.Id);
+    }
+
+    [Fact]
+    public void MessagePackSerializerDeepCopyUntyped()
+    {
+        var original = new MyMessagePackClass { IntProperty = 30, StringProperty = "hi", SubClass = new() { Id = Guid.NewGuid() } };
+        var copier = ServiceProvider.GetRequiredService<DeepCopier>();
+        var result = (MyMessagePackClass)copier.Copy((object)original);
+
+        Assert.Equal(original.IntProperty, result.IntProperty);
+        Assert.Equal(original.StringProperty, result.StringProperty);
+        Assert.Equal(original.SubClass.Id, result.SubClass.Id);
+    }
+
+    [Fact]
+    public void MessagePackSerializerRoundTripThroughCodec()
+    {
+        var original = new MyMessagePackClass { IntProperty = 30, StringProperty = "hi", SubClass = new(){ Id = Guid.NewGuid() } };
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.IntProperty, result.IntProperty);
+        Assert.Equal(original.StringProperty, result.StringProperty);
+    }
+
+    [Fact]
+    public void MessagePackSerializerRoundTripThroughUntypedSerializer()
+    {
+        var original = new MyMessagePackClass { IntProperty = 30, StringProperty = "hi", SubClass = new() { Id = Guid.NewGuid() } };
+        var untypedResult = RoundTripThroughUntypedSerializer(original, out _);
+
+        var result = Assert.IsType<MyMessagePackClass>(untypedResult);
+        Assert.Equal(original.IntProperty, result.IntProperty);
+        Assert.Equal(original.StringProperty, result.StringProperty);
+    }
+}
+
+
+[Trait("Category", "BVT")]
+public class MessagePackCodecCopierTests : CopierTester<MyMessagePackClass?, IDeepCopier<MyMessagePackClass?>>
+{
+    public MessagePackCodecCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(ISerializerBuilder builder)
+    {
+        builder.AddMessagePackSerializer();
+    }
+    protected override IDeepCopier<MyMessagePackClass?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyMessagePackClass?>();
+
+    protected override MyMessagePackClass? CreateValue() => new() { IntProperty = 30, StringProperty = "hello", SubClass = new() { Id = Guid.NewGuid() } };
+
+    protected override MyMessagePackClass?[] TestValues => new MyMessagePackClass?[]
+    {
+        null,
+        new() { SubClass = new() { Id = Guid.NewGuid() } },
+        new() { IntProperty = 150, StringProperty = new string('c', 20), SubClass = new() { Id = Guid.NewGuid() } },
+        new() { IntProperty = 150_000, StringProperty = new string('c', 6_000), SubClass = new() { Id = Guid.NewGuid() } },
+    };
+}

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using MessagePack;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Orleans;
@@ -846,7 +847,7 @@ namespace Orleans.Serialization.UnitTests
 
     public class MyFirstForeignLibraryType
     {
-        
+
         public int Num { get; set; }
         public string String { get; set; }
         public DateTimeOffset DateTimeOffset { get; set; }
@@ -917,4 +918,25 @@ namespace Orleans.Serialization.UnitTests
         public MySecondForeignLibraryTypeSurrogate ConvertToSurrogate(in MySecondForeignLibraryType value)
             => new () { Name = value.Name, Value = value.Value, Timestamp = value.Timestamp };
     }
+
+    [MessagePackObject]
+    public sealed record MyMessagePackClass
+    {
+        [Key(0)]
+        public int IntProperty { get; init; }
+
+        [Key(1)]
+        public string StringProperty { get; init; }
+
+        [Key(2)]
+        public MyMessagePackSubClass SubClass { get; init; }
+    }
+
+    [MessagePackObject]
+    public sealed record MyMessagePackSubClass
+    {
+        [Key(0)]
+        public Guid Id { get; init; }
+    }
+
 }

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization\Orleans.Serialization.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.SystemTextJson\Orleans.Serialization.SystemTextJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.NewtonsoftJson\Orleans.Serialization.NewtonsoftJson.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj" />
   </ItemGroup>
 

--- a/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests;
 
+
 [Trait("Category", "BVT")]
 public class ProtobufSerializerTests : FieldCodecTester<MyProtobufClass?, IFieldCodec<MyProtobufClass?>>
 {

--- a/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
@@ -13,7 +13,6 @@ using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests;
 
-
 [Trait("Category", "BVT")]
 public class ProtobufSerializerTests : FieldCodecTester<MyProtobufClass?, IFieldCodec<MyProtobufClass?>>
 {


### PR DESCRIPTION
This PR adds ability to use MessagePack serialization with either MessagePack-specific marked contracts or using DataContract attributes (requires explicit opt-in).

NOTE: quick benchmarking showed that this performs worse than both default Orleans serializer and default MessagePack serializer (since there is more "boilerplate" code required to integrate Orleans <-> MessagePack) so I've put a note in the comments.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8546)