### PR TITLE
CachedGrainLocator Unregister Ordering

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             // Cache update
-            this.cache.AddOrUpdate(result, (int) result.MembershipVersion.Value);
+            this.cache.AddOrUpdate(result, (int)result.MembershipVersion.Value);
 
             return result;
         }
@@ -112,9 +112,14 @@ namespace Orleans.Runtime.GrainDirectory
         {
             // Remove from local cache first so we don't return it anymore
             this.cache.Remove(address);
-            
+
             // Remove from grain directory which may take significantly longer
             await GetGrainDirectory(address.GrainId.Type).Unregister(address);
+
+            if (this.cache.LookUp(address.GrainId, out var entry, out _) && entry == address)
+            {
+                this.cache.Remove(address);
+            }
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -116,6 +116,7 @@ namespace Orleans.Runtime.GrainDirectory
             // Remove from grain directory which may take significantly longer
             await GetGrainDirectory(address.GrainId.Type).Unregister(address);
 
+            // There is the potential for a lookup to race with the Unregister and add the bad entry back to the cache.
             if (this.cache.LookUp(address.GrainId, out var entry, out _) && entry == address)
             {
                 this.cache.Remove(address);

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -110,14 +110,11 @@ namespace Orleans.Runtime.GrainDirectory
 
         public async Task Unregister(GrainAddress address, UnregistrationCause cause)
         {
-            try
-            {
-                await GetGrainDirectory(address.GrainId.Type).Unregister(address);
-            }
-            finally
-            {
-                this.cache.Remove(address);
-            }
+            // Remove from local cache first so we don't return it anymore
+            this.cache.Remove(address);
+            
+            // Remove from grain directory which may take significantly longer
+            await GetGrainDirectory(address.GrainId.Type).Unregister(address);
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -377,7 +377,7 @@ namespace UnitTests.Directory
             var expectedAddr = GenerateGrainAddress(expectedSilo);
 
             // Give up control then Run forever
-            this.grainDirectory.When(v => v.Unregister(expectedAddr)).Do(async (t) => { await Task.Yield();  while (true) { } });
+            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) => { await Task.Yield();  while (true) { } });
 
             this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
 
@@ -387,6 +387,90 @@ namespace UnitTests.Directory
             // Unregister and check if cache was cleaned
             _ = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+        }
+
+        [Fact]
+        public async Task UnregisterRacesWithLookupSameId()
+        {
+            var expectedSilo = GenerateSiloAddress();
+
+            // Setup membership service
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            var expectedAddr = GenerateGrainAddress(expectedSilo);
+
+            ManualResetEvent mre = new ManualResetEvent(false);
+
+            // Give up control then Run forever
+            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) =>
+            {
+                await Task.Yield();
+                mre.WaitOne();
+            });
+
+            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
+
+            // Register to populate cache
+            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+
+            // Unregister and check if cache was cleaned
+            Task t = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
+            Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+
+            // Add back to cache simulating a race from lookup
+            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+
+            // Ensure when Unregister finishes if the race occured on the same id that it was removed
+            mre.Set();
+            await t;
+            Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+        }
+
+        [Fact]
+        public async Task UnregisterRacesWithLookupDifferentId()
+        {
+            var expectedSilo = GenerateSiloAddress();
+            var secondSilo = GenerateSiloAddress();
+
+            // Setup membership service
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
+            this.mockMembershipService.UpdateSiloStatus(secondSilo, SiloStatus.Active, "exp");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            var expectedAddr = GenerateGrainAddress(expectedSilo);
+            var secondAddr = GenerateGrainAddress(secondSilo);
+
+            ManualResetEvent mre = new ManualResetEvent(false);
+
+            // Give up control then Run forever
+            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) =>
+            {
+                await Task.Yield();
+                mre.WaitOne();
+            });
+
+            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
+            this.grainDirectory.Register(secondAddr, previousAddress: null).Returns(secondAddr);
+
+            // Register to populate cache
+            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+
+            // Unregister and check if cache was cleaned
+            Task t = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
+            Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+
+            // Add back to cache simulating a race from lookup
+            await this.grainLocator.Register(secondAddr, previousAddress: null);
+            Assert.True(this.grainLocator.TryLookupInCache(secondAddr.GrainId, out _));
+
+            // Ensure when Unregister finishes if the race occured on the same id that it was removed
+            mre.Set();
+            await t;
+            Assert.True(this.grainLocator.TryLookupInCache(secondAddr.GrainId, out _));
         }
 
         private GrainAddress GenerateGrainAddress(SiloAddress siloAddress = null)


### PR DESCRIPTION
When a grain directory experiences high latency it's possible that we hold a bad cached value in memory longer than desired. This can result in silos that retry due to NonExistantActivation exceptions continuing to retry to the same silo that does not own a grain. Instead, if we remove from the local cache first no matter how long the Unregister takes other calls will be able to re-read the grain directory to find the new grain location.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8547)