### PR TITLE
[WIP] Add `CancellationToken` to most storage interfaces

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -7,6 +7,7 @@ using Orleans.Clustering.AdoNet.Storage;
 using Orleans.Messaging;
 using Orleans.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 
 namespace Orleans.Runtime.Membership
 {
@@ -42,18 +43,22 @@ namespace Orleans.Runtime.Membership
             get { return true; }
         }
 
-        public async Task InitializeGatewayListProvider()
+        public Task InitializeGatewayListProvider() => InitializeGatewayListProvider(CancellationToken.None);
+
+        public Task<IList<Uri>> GetGateways() => GetGateways(CancellationToken.None);
+
+        public async Task InitializeGatewayListProvider(CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.InitializeGatewayListProvider called.");
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(options.Invariant, options.ConnectionString);
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(options.Invariant, options.ConnectionString, cancellationToken);
         }
 
-        public async Task<IList<Uri>> GetGateways()
+        public async Task<IList<Uri>> GetGateways(CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Trace)) logger.LogTrace("AdoNetClusteringTable.GetGateways called.");
             try
             {
-                return await orleansQueries.ActiveGatewaysAsync(this.clusterId);
+                return await orleansQueries.ActiveGatewaysAsync(this.clusterId, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -13,51 +14,59 @@ namespace Orleans.Runtime.ReminderService
         private RelationalOrleansQueries orleansQueries;
 
         public AdoNetReminderTable(
-            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<AdoNetReminderTableOptions> storageOptions)
         {
             this.serviceId = clusterOptions.Value.ServiceId;
             this.options = storageOptions.Value;
         }
 
-        public async Task Init()
+        public Task Init() => Init(CancellationToken.None);
+        public Task<ReminderTableData> ReadRows(GrainId grainId) => ReadRows(grainId, CancellationToken.None);
+        public Task<ReminderTableData> ReadRows(uint begin, uint end) => ReadRows(begin, end, CancellationToken.None);
+        public Task<ReminderEntry> ReadRow(GrainId grainId, string reminderName) => ReadRow(grainId, reminderName, CancellationToken.None); 
+        public Task<string> UpsertRow(ReminderEntry entry) => UpsertRow(entry, CancellationToken.None); 
+        public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag) => RemoveRow(grainId, reminderName, eTag, CancellationToken.None);
+        public Task TestOnlyClearTable() => TestOnlyClearTable(CancellationToken.None);
+
+        public async Task Init(CancellationToken cancellationToken)
         {
-            this.orleansQueries = await RelationalOrleansQueries.CreateInstance(this.options.Invariant, this.options.ConnectionString);
+            this.orleansQueries = await RelationalOrleansQueries.CreateInstance(this.options.Invariant, this.options.ConnectionString, cancellationToken);
         }
 
-        public Task<ReminderTableData> ReadRows(GrainId grainId)
+        public Task<ReminderTableData> ReadRows(GrainId grainId, CancellationToken cancellationToken)
         {
-            return this.orleansQueries.ReadReminderRowsAsync(this.serviceId, grainId);
+            return this.orleansQueries.ReadReminderRowsAsync(this.serviceId, grainId, cancellationToken);
         }
 
-        public Task<ReminderTableData> ReadRows(uint beginHash, uint endHash)
+        public Task<ReminderTableData> ReadRows(uint beginHash, uint endHash, CancellationToken cancellationToken)
         {
-            return this.orleansQueries.ReadReminderRowsAsync(this.serviceId, beginHash, endHash);
+            return this.orleansQueries.ReadReminderRowsAsync(this.serviceId, beginHash, endHash, cancellationToken);
         }
 
-        public Task<ReminderEntry> ReadRow(GrainId grainId, string reminderName)
+        public Task<ReminderEntry> ReadRow(GrainId grainId, string reminderName, CancellationToken cancellationToken)
         {
-            return this.orleansQueries.ReadReminderRowAsync(this.serviceId, grainId, reminderName);
-        }   
-        
-        public Task<string> UpsertRow(ReminderEntry entry)
+            return this.orleansQueries.ReadReminderRowAsync(this.serviceId, grainId, reminderName, cancellationToken);
+        }
+
+        public Task<string> UpsertRow(ReminderEntry entry, CancellationToken cancellationToken)
         {
             if (entry.StartAt.Kind is DateTimeKind.Unspecified)
             {
                 entry.StartAt = new DateTime(entry.StartAt.Ticks, DateTimeKind.Utc);
             }
 
-            return this.orleansQueries.UpsertReminderRowAsync(this.serviceId, entry.GrainId, entry.ReminderName, entry.StartAt, entry.Period);            
+            return this.orleansQueries.UpsertReminderRowAsync(this.serviceId, entry.GrainId, entry.ReminderName, entry.StartAt, entry.Period, cancellationToken);
         }
 
-        public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag)
+        public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag, CancellationToken cancellationToken)
         {
-            return this.orleansQueries.DeleteReminderRowAsync(this.serviceId, grainId, reminderName, eTag);            
+            return this.orleansQueries.DeleteReminderRowAsync(this.serviceId, grainId, reminderName, eTag, cancellationToken);
         }
 
-        public Task TestOnlyClearTable()
+        public Task TestOnlyClearTable(CancellationToken cancellationToken)
         {
-            return this.orleansQueries.DeleteReminderRowsAsync(this.serviceId);
+            return this.orleansQueries.DeleteReminderRowsAsync(this.serviceId, cancellationToken);
         }
     }
 }

--- a/src/AdoNet/Shared/Storage/IRelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/IRelationalStorage.cs
@@ -74,7 +74,7 @@ namespace Orleans.Tests.SqlUtils
         ///}).ConfigureAwait(continueOnCapturedContext: false);
         /// </code>
         /// </example>
-        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a given statement. Especially intended to use with <em>INSERT</em>, <em>UPDATE</em>, <em>DELETE</em> or <em>DDL</em> queries.
@@ -97,7 +97,7 @@ namespace Orleans.Tests.SqlUtils
         /// }).ConfigureAwait(continueOnCapturedContext: false);
         /// </code>
         /// </example>
-        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CommandBehavior commandBehavior = CommandBehavior.Default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The well known invariant name of the underlying database.

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -24,19 +25,24 @@ namespace Orleans.AzureUtils
             this.options = options.Value;
         }
 
-        public async Task InitializeGatewayListProvider()
+        public async Task InitializeGatewayListProvider(CancellationToken cancellationToken)
         {
             this.siloInstanceManager = await OrleansSiloInstanceManager.GetManager(
                 this.clusterId,
                 this.loggerFactory,
-                this.options);
+                this.options,
+                cancellationToken);
         }
+
         // no caching
-        public Task<IList<Uri>> GetGateways()
+        public Task<IList<Uri>> GetGateways(CancellationToken cancellationToken)
         {
             // FindAllGatewayProxyEndpoints already returns a deep copied List<Uri>.
-            return this.siloInstanceManager.FindAllGatewayProxyEndpoints();
+            return this.siloInstanceManager.FindAllGatewayProxyEndpoints(cancellationToken);
         }
+
+        public Task InitializeGatewayListProvider() => InitializeGatewayListProvider(CancellationToken.None);
+        public Task<IList<Uri>> GetGateways() => GetGateways(CancellationToken.None);
 
         public TimeSpan MaxStaleness { get; }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/IBlobContainerFactory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Orleans.Configuration;
@@ -22,6 +24,16 @@ public interface IBlobContainerFactory
     /// </summary>
     /// <param name="client">The connected blob client</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    public Task InitializeAsync(BlobServiceClient client, CancellationToken cancellationToken) => InitializeAsync(client);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    /// <summary>
+    /// Initialize any required dependencies using the provided client and options.
+    /// </summary>
+    /// <param name="client">The connected blob client</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
     public Task InitializeAsync(BlobServiceClient client);
 }
 

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Orleans.Core;
 
 namespace Orleans.Persistence.Cosmos;
@@ -16,7 +17,7 @@ public class CosmosGrainStorageOptions : CosmosOptions
     public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
 
     /// <summary>
-    /// Gets or sets a value indicating whether state should be deleted when <see cref="IStorage.ClearStateAsync"/> is called.
+    /// Gets or sets a value indicating whether state should be deleted when <see cref="IStorage.ClearStateAsync(CancellationToken)"/> is called.
     /// </summary>
     public bool DeleteStateOnClear { get; set; }
 

--- a/src/Azure/Orleans.Persistence.Cosmos/IPartitionKeyProvider.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/IPartitionKeyProvider.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Orleans.Persistence.Cosmos;
 
 /// <summary>
@@ -5,6 +7,14 @@ namespace Orleans.Persistence.Cosmos;
 /// </summary>
 public interface IPartitionKeyProvider
 {
+    /// <summary>
+    /// Creates a partition key for the provided grain.
+    /// </summary>
+    /// <param name="grainType">The grain type.</param>
+    /// <param name="grainId">The grain identifier.</param>
+    /// <returns>The partition key.</returns>
+    ValueTask<string> GetPartitionKey(string grainType, GrainId grainId, CancellationToken cancellationToken) => GetPartitionKey(grainType, grainId); 
+
     /// <summary>
     /// Creates a partition key for the provided grain.
     /// </summary>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
@@ -60,7 +61,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// <returns></returns>
         public Task InitAsync()
         {
-            return dataManager.InitTableAsync();
+            return dataManager.InitTableAsync(CancellationToken.None);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
             failureEntity.SetSequenceToken(this.serializer, sequenceToken);
             failureEntity.SetPartitionKey(this.clusterId);
             failureEntity.SetRowkey();
-            await dataManager.CreateTableEntryAsync(failureEntity);
+            await dataManager.CreateTableEntryAsync(failureEntity, CancellationToken.None);
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -7,6 +7,7 @@ using Orleans.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration.Overrides;
+using System.Threading;
 
 namespace Orleans.Streaming.EventHubs
 {
@@ -101,7 +102,7 @@ namespace Orleans.Streaming.EventHubs
 
         private Task Initialize()
         {
-            return dataManager.InitTableAsync();
+            return dataManager.InitTableAsync(CancellationToken.None);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Orleans.Streaming.EventHubs
         /// <returns></returns>
         public async Task<string> Load()
         {
-            var results = await dataManager.ReadSingleTableEntryAsync(entity.PartitionKey, entity.RowKey);
+            var results = await dataManager.ReadSingleTableEntryAsync(entity.PartitionKey, entity.RowKey, CancellationToken.None);
             if (results.Entity != null)
             {
                 entity = results.Entity;
@@ -140,7 +141,7 @@ namespace Orleans.Streaming.EventHubs
 
             entity.Offset = offset;
             throttleSavesUntilUtc = utcNow + persistInterval;
-            inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+            inProgressSave = dataManager.UpsertTableEntryAsync(entity, CancellationToken.None);
             inProgressSave.Ignore();
         }
     }

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -59,7 +59,7 @@ namespace Orleans.Transactions.AzureStorage
             var tableManager = new AzureTableDataManager<TableEntity>(
                 this.options,
                 this.loggerFactory.CreateLogger<AzureTableDataManager<TableEntity>>());
-            await tableManager.InitTableAsync();
+            await tableManager.InitTableAsync(CancellationToken.None);
             this.table = tableManager.Table;
         }
 

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -220,7 +220,7 @@ namespace Orleans
         /// <returns>
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
-        protected virtual Task ClearStateAsync() => _storage!.ClearStateAsync();
+        protected virtual Task ClearStateAsync(CancellationToken cancellationToken = default) => _storage!.ClearStateAsync(cancellationToken);
 
         /// <summary>
         /// Write the current grain state data into the backing store.
@@ -228,7 +228,7 @@ namespace Orleans
         /// <returns>
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
-        protected virtual Task WriteStateAsync() => _storage!.WriteStateAsync();
+        protected virtual Task WriteStateAsync(CancellationToken cancellationToken = default) => _storage!.WriteStateAsync(cancellationToken);
 
         /// <summary>
         /// Reads grain state from backing store, updating <see cref="State"/>.
@@ -239,7 +239,7 @@ namespace Orleans
         /// <returns>
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
-        protected virtual Task ReadStateAsync() => _storage!.ReadStateAsync();
+        protected virtual Task ReadStateAsync(CancellationToken cancellationToken = default) => _storage!.ReadStateAsync(cancellationToken);
 
         private class LifecycleObserver : ILifecycleObserver, IGrainMigrationParticipant
         {

--- a/src/Orleans.Core.Abstractions/Core/IStorage.cs
+++ b/src/Orleans.Core.Abstractions/Core/IStorage.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Core
@@ -19,6 +21,43 @@ namespace Orleans.Core
         /// Gets a value indicating whether the record already exists.
         /// </summary>
         bool RecordExists { get; }
+
+        /// <summary>
+        /// Clears the grain state.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <remarks>
+        /// This will usually mean the state record is deleted from backing store, but the specific behavior is defined by the storage provider instance configured for this grain.
+        /// If the Etag does not match what is present in the backing store, then this operation will fail; Set <see cref="Etag"/> to <see langword="null"/> to indicate "always delete".
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="Task"/> representing the operation.
+        /// </returns>
+        Task ClearStateAsync(CancellationToken cancellationToken) => ClearStateAsync().WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Writes grain state to storage.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <remarks>
+        /// If the Etag does not match what is present in the backing store, then this operation will fail; Set <see cref="Etag"/> to <see langword="null"/> to indicate "always delete".
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="Task"/> representing the operation.
+        /// </returns>
+        Task WriteStateAsync(CancellationToken cancellationToken) => WriteStateAsync().WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Reads grain state from storage.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <remarks>
+        /// Any previous contents of the grain state data will be overwritten.
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="Task"/> representing the operation.
+        /// </returns>
+        Task ReadStateAsync(CancellationToken cancellationToken) => ReadStateAsync().WaitAsync(cancellationToken);
 
         /// <summary>
         /// Clears the grain state.

--- a/src/Orleans.Core/Messaging/IGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/IGatewayListProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Messaging
@@ -9,6 +10,19 @@ namespace Orleans.Messaging
     /// </summary>
     public interface IGatewayListProvider
     {
+        /// <summary>
+        /// Initializes the provider, will be called before all other methods.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task InitializeGatewayListProvider(CancellationToken cancellationToken) => InitializeGatewayListProvider().WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Returns the list of gateways (silos) that can be used by a client to connect to Orleans cluster.
+        /// The Uri is in the form of: "gwy.tcp://IP:port/Generation". See Utils.ToGatewayUri and Utils.ToSiloAddress for more details about Uri format.
+        /// </summary>
+        /// <returns>The list of gateway endpoints.</returns>
+        Task<IList<Uri>> GetGateways(CancellationToken cancellationToken) => GetGateways().WaitAsync(cancellationToken);
+
         /// <summary>
         /// Initializes the provider, will be called before all other methods.
         /// </summary>

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using System.Net;
+using System.Threading;
 
 namespace Orleans.Storage
 {
@@ -15,8 +16,42 @@ namespace Orleans.Storage
         /// <param name="stateName">Name of the state for this grain</param>
         /// <param name="grainId">Grain ID</param>
         /// <param name="grainState">State data object to be populated for this grain.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <typeparam name="T">The grain state type.</typeparam>
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken) => ReadStateAsync(stateName, grainId, grainState).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>Write data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain</param>
+        /// <param name="grainId">Grain ID</param>
+        /// <param name="grainState">State data object to be written for this grain.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Write operation on the specified grain.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken) => WriteStateAsync(stateName, grainId, grainState).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>Delete / Clear data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain</param>
+        /// <param name="grainId">Grain ID</param>
+        /// <param name="grainState">Copy of last-known state data object for this grain.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken) => ClearStateAsync(stateName, grainId, grainState).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>Read data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain</param>
+        /// <param name="grainId">Grain ID</param>
+        /// <param name="grainState">State data object to be populated for this grain.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Read operation on the specified grain.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
 
         /// <summary>Write data function for this storage instance.</summary>
@@ -25,6 +60,7 @@ namespace Orleans.Storage
         /// <param name="grainState">State data object to be written for this grain.</param>
         /// <typeparam name="T">The grain state type.</typeparam>
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
 
         /// <summary>Delete / Clear data function for this storage instance.</summary>
@@ -33,6 +69,7 @@ namespace Orleans.Storage
         /// <param name="grainState">Copy of last-known state data object for this grain.</param>
         /// <typeparam name="T">The grain state type.</typeparam>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
     }
 

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -14,6 +15,91 @@ namespace Orleans
     /// </summary>
     public interface IMembershipTable
     {
+        /// <summary>
+        /// Initializes the membership table, will be called before all other methods
+        /// </summary>
+        /// <param name="tryInitTableVersion">whether an attempt will be made to init the underlying table</param>
+        Task InitializeMembershipTable(bool tryInitTableVersion, CancellationToken cancellationToken) => InitializeMembershipTable(tryInitTableVersion).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Deletes all table entries of the given clusterId
+        /// </summary>
+        Task DeleteMembershipTableEntries(string clusterId, CancellationToken cancellationToken) => DeleteMembershipTableEntries(clusterId).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Delete all dead silo entries older than <paramref name="beforeDate"/>
+        /// </summary>
+        Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate, CancellationToken cancellationToken) => CleanupDefunctSiloEntries(beforeDate).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Atomically reads the Membership Table information about a given silo.
+        /// The returned MembershipTableData includes one MembershipEntry entry for a given silo and the 
+        /// TableVersion for this table. The MembershipEntry and the TableVersion have to be read atomically.
+        /// </summary>
+        /// <param name="key">The address of the silo whose membership information needs to be read.</param>
+        /// <returns>The membership information for a given silo: MembershipTableData consisting one MembershipEntry entry and
+        /// TableVersion, read atomically.</returns>
+        Task<MembershipTableData> ReadRow(SiloAddress key, CancellationToken cancellationToken) => ReadRow(key).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Atomically reads the full content of the Membership Table.
+        /// The returned MembershipTableData includes all MembershipEntry entry for all silos in the table and the 
+        /// TableVersion for this table. The MembershipEntries and the TableVersion have to be read atomically.
+        /// </summary>
+        /// <returns>The membership information for a given table: MembershipTableData consisting multiple MembershipEntry entries and
+        /// TableVersion, all read atomically.</returns>
+        Task<MembershipTableData> ReadAll(CancellationToken cancellationToken) => ReadAll().WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Atomically tries to insert (add) a new MembershipEntry for one silo and also update the TableVersion.
+        /// If operation succeeds, the following changes would be made to the table:
+        /// 1) New MembershipEntry will be added to the table.
+        /// 2) The newly added MembershipEntry will also be added with the new unique automatically generated eTag.
+        /// 3) TableVersion.Version in the table will be updated to the new TableVersion.Version.
+        /// 4) TableVersion etag in the table will be updated to the new unique automatically generated eTag.
+        /// All those changes to the table, insert of a new row and update of the table version and the associated etags, should happen atomically, or fail atomically with no side effects.
+        /// The operation should fail in each of the following conditions:
+        /// 1) A MembershipEntry for a given silo already exist in the table
+        /// 2) Update of the TableVersion failed since the given TableVersion etag (as specified by the TableVersion.VersionEtag property) did not match the TableVersion etag in the table.
+        /// </summary>
+        /// <param name="entry">MembershipEntry to be inserted.</param>
+        /// <param name="tableVersion">The new TableVersion for this table, along with its etag.</param>
+        /// <returns>True if the insert operation succeeded and false otherwise.</returns>
+        Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion, CancellationToken cancellationToken) => InsertRow(entry, tableVersion).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Atomically tries to update the MembershipEntry for one silo and also update the TableVersion.
+        /// If operation succeeds, the following changes would be made to the table:
+        /// 1) The MembershipEntry for this silo will be updated to the new MembershipEntry (the old entry will be fully substituted by the new entry) 
+        /// 2) The eTag for the updated MembershipEntry will also be eTag with the new unique automatically generated eTag.
+        /// 3) TableVersion.Version in the table will be updated to the new TableVersion.Version.
+        /// 4) TableVersion etag in the table will be updated to the new unique automatically generated eTag.
+        /// All those changes to the table, update of a new row and update of the table version and the associated etags, should happen atomically, or fail atomically with no side effects.
+        /// The operation should fail in each of the following conditions:
+        /// 1) A MembershipEntry for a given silo does not exist in the table
+        /// 2) A MembershipEntry for a given silo exist in the table but its etag in the table does not match the provided etag.
+        /// 3) Update of the TableVersion failed since the given TableVersion etag (as specified by the TableVersion.VersionEtag property) did not match the TableVersion etag in the table.
+        /// </summary>
+        /// <param name="entry">MembershipEntry to be updated.</param>
+        /// <param name="etag">The etag  for the given MembershipEntry.</param>
+        /// <param name="tableVersion">The new TableVersion for this table, along with its etag.</param>
+        /// <returns>True if the update operation succeeded and false otherwise.</returns>
+        Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion, CancellationToken cancellationToken) => UpdateRow(entry, etag, tableVersion).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Updates the IAmAlive part (column) of the MembershipEntry for this silo.
+        /// This operation should only update the IAmAlive column and not change other columns.
+        /// This operation is a "dirty write" or "in place update" and is performed without etag validation. 
+        /// With regards to eTags update:
+        /// This operation may automatically update the eTag associated with the given silo row, but it does not have to. It can also leave the etag not changed ("dirty write").
+        /// With regards to TableVersion:
+        /// this operation should not change the TableVersion of the table. It should leave it untouched.
+        /// There is no scenario where this operation could fail due to table semantical reasons. It can only fail due to network problems or table unavailability.
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns>Task representing the successful execution of this operation. </returns>
+        Task UpdateIAmAlive(MembershipEntry entry, CancellationToken cancellationToken) => UpdateIAmAlive(entry).WaitAsync(cancellationToken);
+
         /// <summary>
         /// Initializes the membership table, will be called before all other methods
         /// </summary>

--- a/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/LogStorage/LogViewAdaptor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Storage;
 using Orleans.EventSourcing.Common;
+using System.Threading;
 
 namespace Orleans.EventSourcing.LogStorage
 {
@@ -112,7 +113,7 @@ namespace Orleans.EventSourcing.LogStorage
                     // for manual testing
                     //await Task.Delay(5000);
 
-                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalLog);
+                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalLog, CancellationToken.None);
 
                     Services.Log(LogLevel.Debug, "read success {0}", GlobalLog);
 
@@ -153,7 +154,7 @@ namespace Orleans.EventSourcing.LogStorage
                 // for manual testing
                 //await Task.Delay(5000);
 
-                await globalGrainStorage.WriteStateAsync(grainTypeName, Services.GrainId, GlobalLog);
+                await globalGrainStorage.WriteStateAsync(grainTypeName, Services.GrainId, GlobalLog, CancellationToken.None);
 
                 batchsuccessfullywritten = true;
 
@@ -179,7 +180,7 @@ namespace Orleans.EventSourcing.LogStorage
 
                     try
                     {
-                        await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalLog);
+                        await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalLog, CancellationToken.None);
 
                         Services.Log(LogLevel.Debug, "read success {0}", GlobalLog);
 

--- a/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Storage;
 using Orleans.EventSourcing.Common;
+using System.Threading;
 
 namespace Orleans.EventSourcing.StateStorage
 {
@@ -78,7 +79,7 @@ namespace Orleans.EventSourcing.StateStorage
 
                     var readState = new GrainStateWithMetaDataAndETag<TLogView>();
 
-                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, readState);
+                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, readState, CancellationToken.None);
 
                     GlobalStateCache = readState;
 
@@ -123,7 +124,7 @@ namespace Orleans.EventSourcing.StateStorage
                 // for manual testing
                 //await Task.Delay(5000);
 
-                await globalGrainStorage.WriteStateAsync(grainTypeName, Services.GrainId, nextglobalstate);
+                await globalGrainStorage.WriteStateAsync(grainTypeName, Services.GrainId, nextglobalstate, CancellationToken.None);
 
                 batchsuccessfullywritten = true;
 
@@ -149,7 +150,7 @@ namespace Orleans.EventSourcing.StateStorage
 
                     try
                     {
-                        await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalStateCache);
+                        await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainId, GlobalStateCache, CancellationToken.None);
 
                         Services.Log(LogLevel.Debug, "read success {0}", GlobalStateCache);
 

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -58,22 +58,19 @@ namespace Orleans.Storage
             this.options = options;
         }
 
-        /// <summary> Read state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>
+        /// <inheritdoc/>
         public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             return MakeFixedLatencyCall(() => baseGranStorage.ReadStateAsync(grainType, grainId, grainState));
         }
 
-        /// <summary> Write state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <inheritdoc/>
         public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
            return MakeFixedLatencyCall(() => baseGranStorage.WriteStateAsync(grainType, grainId, grainState));
         }
 
-        /// <summary> Delete / Clear state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>
+        /// <inheritdoc/>
         public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             return MakeFixedLatencyCall(() => baseGranStorage.ClearStateAsync(grainType, grainId, grainState));

--- a/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -17,6 +18,72 @@ namespace Orleans
         /// Initializes this instance.
         /// </summary>
         /// <returns>A Task representing the work performed.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task Init(CancellationToken cancellationToken) => Init().WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Reads the reminder table entries associated with the specified grain.
+        /// </summary>
+        /// <param name="grainId">The grain ID.</param>
+        /// <returns>The reminder table entries associated with the specified grain.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task<ReminderTableData> ReadRows(GrainId grainId, CancellationToken cancellationToken) => ReadRows(grainId).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Return all rows that have their <see cref="GrainId.GetUniformHashCode"/> in the range (start, end]
+        /// </summary>
+        /// <param name="begin">The exclusive lower bound.</param>
+        /// <param name="end">The inclusive upper bound.</param>
+        /// <returns>The reminder table entries which fall within the specified range.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task<ReminderTableData> ReadRows(uint begin, uint end, CancellationToken cancellationToken) => ReadRows(begin, end).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Reads a specifie entry.
+        /// </summary>
+        /// <param name="grainId">The grain ID.</param>
+        /// <param name="reminderName">Name of the reminder.</param>
+        /// <returns>The reminder table entry.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task<ReminderEntry> ReadRow(GrainId grainId, string reminderName, CancellationToken cancellationToken) => ReadRow(grainId, reminderName).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Upserts the specified entry.
+        /// </summary>
+        /// <param name="entry">The entry.</param>
+        /// <returns>The row's new ETag.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task<string> UpsertRow(ReminderEntry entry, CancellationToken cancellationToken) => UpsertRow(entry).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Removes a row from the table.
+        /// </summary>
+        /// <param name="grainId">The grain ID.</param>
+        /// <param name="reminderName">The reminder name.</param>
+        /// /// <param name="eTag">The ETag.</param>
+        /// <returns>true if a row with <paramref name="grainId"/> and <paramref name="reminderName"/> existed and was removed successfully, false otherwise</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag, CancellationToken cancellationToken) => RemoveRow(grainId, reminderName, eTag).WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Clears the table.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        Task TestOnlyClearTable(CancellationToken cancellationToken) => TestOnlyClearTable().WaitAsync(cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        /// <returns>A Task representing the work performed.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task Init();
 
         /// <summary>
@@ -24,6 +91,7 @@ namespace Orleans
         /// </summary>
         /// <param name="grainId">The grain ID.</param>
         /// <returns>The reminder table entries associated with the specified grain.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task<ReminderTableData> ReadRows(GrainId grainId);
 
         /// <summary>
@@ -32,6 +100,7 @@ namespace Orleans
         /// <param name="begin">The exclusive lower bound.</param>
         /// <param name="end">The inclusive upper bound.</param>
         /// <returns>The reminder table entries which fall within the specified range.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task<ReminderTableData> ReadRows(uint begin, uint end);
 
         /// <summary>
@@ -40,6 +109,7 @@ namespace Orleans
         /// <param name="grainId">The grain ID.</param>
         /// <param name="reminderName">Name of the reminder.</param>
         /// <returns>The reminder table entry.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task<ReminderEntry> ReadRow(GrainId grainId, string reminderName);
 
         /// <summary>
@@ -47,6 +117,7 @@ namespace Orleans
         /// </summary>
         /// <param name="entry">The entry.</param>
         /// <returns>The row's new ETag.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task<string> UpsertRow(ReminderEntry entry);
 
         /// <summary>
@@ -56,12 +127,14 @@ namespace Orleans
         /// <param name="reminderName">The reminder name.</param>
         /// /// <param name="eTag">The ETag.</param>
         /// <returns>true if a row with <paramref name="grainId"/> and <paramref name="reminderName"/> existed and was removed successfully, false otherwise</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag);
 
         /// <summary>
         /// Clears the table.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
         Task TestOnlyClearTable();
     }
 

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -75,7 +75,7 @@ namespace Orleans.Runtime
                 return Task.CompletedTask;
             }
 
-            return ReadStateAsync();
+            return ReadStateAsync(cancellationToken);
         }
 
         public Task OnStop(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
@@ -62,14 +63,14 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task ReadStateAsync()
+        public async Task ReadStateAsync(CancellationToken cancellationToken)
         {
             try
             {
                 GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 var sw = ValueStopwatch.StartNew();
-                await _store.ReadStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _store.ReadStateAsync(_name, _grainContext.GrainId, GrainState, cancellationToken);
                 StorageInstruments.OnStorageRead(sw.Elapsed);
             }
             catch (Exception exc)
@@ -80,14 +81,14 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task WriteStateAsync()
+        public async Task WriteStateAsync(CancellationToken cancellationToken)
         {
             try
             {
                 GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 var sw = ValueStopwatch.StartNew();
-                await _store.WriteStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _store.WriteStateAsync(_name, _grainContext.GrainId, GrainState, cancellationToken);
                 StorageInstruments.OnStorageWrite(sw.Elapsed);
             }
             catch (Exception exc)
@@ -98,7 +99,7 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task ClearStateAsync()
+        public async Task ClearStateAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -106,7 +107,7 @@ namespace Orleans.Core
 
                 var sw = ValueStopwatch.StartNew();
                 // Clear (most likely Delete) state from external storage
-                await _store.ClearStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _store.ClearStateAsync(_name, _grainContext.GrainId, GrainState, cancellationToken);
                 sw.Stop();
 
                 // Reset the in-memory copy of the state
@@ -170,5 +171,17 @@ namespace Orleans.Core
 
             ExceptionDispatchInfo.Throw(exception);
         }
+
+        /// <inheritdoc/>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
+        public Task ClearStateAsync() => ClearStateAsync(CancellationToken.None);
+
+        /// <inheritdoc/>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
+        public Task WriteStateAsync() => WriteStateAsync(CancellationToken.None);
+
+        /// <inheritdoc/>
+        [Obsolete($"Use the overload which accepts a {nameof(CancellationToken)}")]
+        public Task ReadStateAsync() => ReadStateAsync(CancellationToken.None);
     }
 }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -498,9 +498,9 @@ namespace Orleans.Streams
             }
         }
 
-        private Task ReadStateAsync() => _storage.ReadStateAsync();
-        private Task WriteStateAsync() => _storage.WriteStateAsync();
-        private Task ClearStateAsync() => _storage.ClearStateAsync();
+        private Task ReadStateAsync() => _storage.ReadStateAsync(CancellationToken.None);
+        private Task WriteStateAsync() => _storage.WriteStateAsync(CancellationToken.None);
+        private Task ClearStateAsync() => _storage.ClearStateAsync(CancellationToken.None);
         void IGrainMigrationParticipant.OnDehydrate(IDehydrationContext dehydrationContext) => _storage.OnDehydrate(dehydrationContext);
         void IGrainMigrationParticipant.OnRehydrate(IRehydrationContext rehydrationContext) => _storage.OnRehydrate(rehydrationContext);
     }

--- a/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -6,6 +6,7 @@ using Orleans.Runtime;
 using Orleans.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Threading;
 
 namespace Orleans.TestingHost
 {
@@ -56,10 +57,19 @@ namespace Orleans.TestingHost
         {
             return Task.Delay(this.options.Latency);
         }
-           
+
+        /// <inheritdoc/>
+        public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState) => ReadStateAsync(grainType, grainId, grainState, CancellationToken.None);
+
+        /// <inheritdoc/>
+        public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState) => WriteStateAsync(grainType, grainId, grainState, CancellationToken.None);
+
+        /// <inheritdoc/>
+        public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState) => ClearStateAsync(grainType, grainId, grainState, CancellationToken.None);
+
         /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
-        public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
@@ -79,12 +89,12 @@ namespace Orleans.TestingHost
                 "ReadState for grain {GrainId} of type {GrainType}",
                 grainId,
                 grainType);
-            await realStorageProvider.ReadStateAsync(grainType, grainId, grainState);
+            await realStorageProvider.ReadStateAsync(grainType, grainId, grainState, cancellationToken);
         }
 
         /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
-        public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
@@ -104,12 +114,12 @@ namespace Orleans.TestingHost
                 "WriteState for grain {GrainId} of type {GrainType}",
                 grainId,
                 grainType);
-            await realStorageProvider.WriteStateAsync(grainType, grainId, grainState);
+            await realStorageProvider.WriteStateAsync(grainType, grainId, grainState, cancellationToken);
         }
 
         /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
-        public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
         {
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
@@ -130,7 +140,7 @@ namespace Orleans.TestingHost
                 "ClearState for grain {GrainId} of type {GrainType}",
                 grainId,
                 grainType);
-            await realStorageProvider.ClearStateAsync(grainType, grainId, grainState);
+            await realStorageProvider.ClearStateAsync(grainType, grainId, grainState, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
@@ -34,7 +35,7 @@ namespace Orleans.Transactions
 
         public async Task<TransactionalStorageLoadResponse<TState>> Load()
         {
-            await this.StateStorage.ReadStateAsync();
+            await this.StateStorage.ReadStateAsync(CancellationToken.None);
             var state = stateStorage.State;
             return new TransactionalStorageLoadResponse<TState>(stateStorage.Etag, state.CommittedState, state.CommittedSequenceId, state.Metadata, state.PendingStates);
         }
@@ -96,7 +97,7 @@ namespace Orleans.Transactions
                 }
             }
 
-            await stateStorage.WriteStateAsync();
+            await stateStorage.WriteStateAsync(CancellationToken.None);
             return stateStorage.Etag!;
         }
 

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/AWSTestConstants.cs
@@ -37,7 +37,8 @@ namespace AWSUtils.Tests.StorageTests
                     },
                     new List<AttributeDefinition> {
                         new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S }
-                    })
+                    },
+                    cancellationToken: CancellationToken.None)
                 .WithTimeout(TimeSpan.FromSeconds(2)).Wait();
                 return true;
             }

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -196,7 +196,7 @@ namespace AWSUtils.Tests.StorageTests
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
 
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Read time = {1}", store.GetType().FullName, readTime);
@@ -220,7 +220,7 @@ namespace AWSUtils.Tests.StorageTests
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.WriteStateAsync(grainTypeName, reference, grainState);
+            await store.WriteStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             TimeSpan writeTime = sw.Elapsed;
             sw.Restart();
@@ -229,7 +229,7 @@ namespace AWSUtils.Tests.StorageTests
             {
                 State = new TestStoreGrainState()
             };
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
             Assert.Equal(grainState.State.A, storedGrainState.State.A);
@@ -252,18 +252,18 @@ namespace AWSUtils.Tests.StorageTests
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.WriteStateAsync(grainTypeName, reference, grainState);
+            await store.WriteStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             TimeSpan writeTime = sw.Elapsed;
             sw.Restart();
 
-            await store.ClearStateAsync(grainTypeName, reference, grainState);
+            await store.ClearStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             var storedGrainState = new GrainState<TestStoreGrainState>
             {
                 State = new TestStoreGrainState()
             };
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
             Assert.NotNull(storedGrainState.State);

--- a/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageStressTests.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/DynamoDBStorageStressTests.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model;
 using Orleans.TestingHost.Utils;
 using System;
 using System.Collections.Generic;
@@ -67,7 +67,7 @@ namespace AWSUtils.Tests.StorageTests
             Stopwatch sw = Stopwatch.StartNew();
 
             var keys = new Dictionary<string, AttributeValue> { { ":PK", new AttributeValue(PartitionKey) } };
-            var data = manager.QueryAsync(UnitTestDynamoDBStorage.INSTANCE_TABLE_NAME, keys, $"PartitionKey = :PK", item => new UnitTestDynamoDBTableData(item)).Result;
+            var data = manager.QueryAsync(UnitTestDynamoDBStorage.INSTANCE_TABLE_NAME, keys, $"PartitionKey = :PK", item => new UnitTestDynamoDBTableData(item), cancellationToken: CancellationToken.None).Result;
 
             sw.Stop();
             int count = data.results.Count();

--- a/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
+++ b/test/Extensions/AWSUtils.Tests/StorageTests/UnitTestDynamoDBStorage.cs
@@ -98,17 +98,19 @@ namespace AWSUtils.Tests.StorageTests
         {
             if (AWSTestConstants.IsDynamoDbAvailable)
             {
-                InitializeTable(INSTANCE_TABLE_NAME,
-                               new List<KeySchemaElement>
-                               {
-                    new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH },
-                    new KeySchemaElement { AttributeName = "RowKey", KeyType = KeyType.RANGE }
-                               },
-                               new List<AttributeDefinition>
-                               {
-                    new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S },
-                    new AttributeDefinition { AttributeName = "RowKey", AttributeType = ScalarAttributeType.S }
-                               }).Wait();
+                InitializeTable(
+                    INSTANCE_TABLE_NAME,
+                    new List<KeySchemaElement>
+                    {
+                        new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH },
+                        new KeySchemaElement { AttributeName = "RowKey", KeyType = KeyType.RANGE }
+                    },
+                    new List<AttributeDefinition>
+                    {
+                        new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S },
+                        new AttributeDefinition { AttributeName = "RowKey", AttributeType = ScalarAttributeType.S }
+                    },
+                    cancellationToken: CancellationToken.None).Wait();
             }
         }
     }

--- a/test/Extensions/ServiceBus.Tests/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
+++ b/test/Extensions/ServiceBus.Tests/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
@@ -32,10 +32,11 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
         public static async Task<int> GetDeliveryFailureCount(string streamProviderName)
         {
             var dataManager = GetDataManager();
-            await dataManager.InitTableAsync();
+            await dataManager.InitTableAsync(CancellationToken.None);
             var deliveryErrors =
                 await dataManager.ReadAllTableEntriesForPartitionAsync(
-                        StreamDeliveryFailureEntity.MakeDefaultPartitionKey(streamProviderName, DeploymentId));
+                        StreamDeliveryFailureEntity.MakeDefaultPartitionKey(streamProviderName, DeploymentId),
+                        CancellationToken.None);
             return deliveryErrors.Count;
         }
 

--- a/test/Extensions/Tester.Cosmos/PersistenceProviderTests_Cosmos.cs
+++ b/test/Extensions/Tester.Cosmos/PersistenceProviderTests_Cosmos.cs
@@ -154,7 +154,7 @@ public class PersistenceProviderTests_Cosmos
         Stopwatch sw = new Stopwatch();
         sw.Start();
 
-        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState);
+        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState, CancellationToken.None);
 
         TimeSpan readTime = sw.Elapsed;
         output.WriteLine("{0} - Read time = {1}", store.GetType().FullName, readTime);
@@ -173,7 +173,7 @@ public class PersistenceProviderTests_Cosmos
         Stopwatch sw = new Stopwatch();
         sw.Start();
 
-        await store.WriteStateAsync(grainTypeName, grainId, grainState);
+        await store.WriteStateAsync(grainTypeName, grainId, grainState, CancellationToken.None);
 
         TimeSpan writeTime = sw.Elapsed;
         sw.Restart();
@@ -182,7 +182,7 @@ public class PersistenceProviderTests_Cosmos
         {
             State = new TestStoreGrainState()
         };
-        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState);
+        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState, CancellationToken.None);
         TimeSpan readTime = sw.Elapsed;
         output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
         Assert.Equal(grainState.State.A, storedGrainState.State.A);
@@ -205,18 +205,18 @@ public class PersistenceProviderTests_Cosmos
         Stopwatch sw = new Stopwatch();
         sw.Start();
 
-        await store.WriteStateAsync(grainTypeName, grainId, grainState);
+        await store.WriteStateAsync(grainTypeName, grainId, grainState, CancellationToken.None);
 
         TimeSpan writeTime = sw.Elapsed;
         sw.Restart();
 
-        await store.ClearStateAsync(grainTypeName, grainId, grainState);
+        await store.ClearStateAsync(grainTypeName, grainId, grainState, CancellationToken.None);
 
         var storedGrainState = new GrainState<TestStoreGrainState>
         {
             State = new TestStoreGrainState()
         };
-        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState);
+        await store.ReadStateAsync(grainTypeName, grainId, storedGrainState, CancellationToken.None);
         TimeSpan readTime = sw.Elapsed;
         output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
         Assert.NotNull(storedGrainState.State);

--- a/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
@@ -42,7 +42,7 @@ public class ReminderTests_Cosmos_Standalone
         storageOptions.Value.ConfigureTestDefaults();
 
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        await table.Init();
+        await table.Init(CancellationToken.None);
 
         await TestTableInsertRate(table, 10);
         await TestTableInsertRate(table, 500);
@@ -56,13 +56,13 @@ public class ReminderTests_Cosmos_Standalone
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        await table.Init();
+        await table.Init(CancellationToken.None);
 
         ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
         Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);
 
         ReminderEntry expected = NewReminderEntry();
-        await table.UpsertRow(expected);
+        await table.UpsertRow(expected, CancellationToken.None);
         rows = (await GetAllRows(table)).ToArray();
 
         Assert.Single(rows); // "The reminder table (sid={0}, did={1}) did not contain the correct number of rows (1).", ServiceId, clusterId);
@@ -99,7 +99,7 @@ public class ReminderTests_Cosmos_Standalone
                 int capture = i;
                 Task<bool> promise = Task.Run(async () =>
                 {
-                    await reminderTable.UpsertRow(e);
+                    await reminderTable.UpsertRow(e, CancellationToken.None);
                     _output.WriteLine("Done " + capture);
                     return true;
                 });
@@ -140,7 +140,7 @@ public class ReminderTests_Cosmos_Standalone
 
     private async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
     {
-        ReminderTableData data = await table.ReadRows(0, 0xffffffff);
+        ReminderTableData data = await table.ReadRows(0, 0xffffffff, CancellationToken.None);
         return data.Reminders;
     }
 }

--- a/test/Extensions/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/Extensions/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.MembershipTests
                 Invariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new AdoNetClusteringTable(this.Services, this._clusterOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(this._clusterOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/Extensions/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/Extensions/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -32,19 +32,19 @@ namespace UnitTests.MembershipTests
             var options = new AdoNetClusteringSiloOptions()
             {
                 Invariant = GetAdoInvariant(),
-                ConnectionString = this.connectionString,
+                ConnectionString = connectionString,
             };
-            return new AdoNetClusteringTable(this.Services, this._clusterOptions, Options.Create(options), this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(_clusterOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
             var options = new AdoNetClusteringClientOptions()
             {
-                ConnectionString = this.connectionString,
+                ConnectionString = connectionString,
                 Invariant = GetAdoInvariant()
             };
-            return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.Services, Options.Create(options), this._gatewayOptions, this._clusterOptions);
+            return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), Services, Options.Create(options), _gatewayOptions, _clusterOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/Extensions/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/Extensions/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.MembershipTests
                 Invariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new AdoNetClusteringTable(this.Services, this._clusterOptions, Options.Create(options),  this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(this._clusterOptions, Options.Create(options),  this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/Extensions/TesterAzureUtils/AzureTableDataManagerStressTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureTableDataManagerStressTests.cs
@@ -65,7 +65,7 @@ namespace Tester.AzureUtils
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            var data = manager.ReadAllTableEntriesForPartitionAsync(PartitionKey)
+            var data = manager.ReadAllTableEntriesForPartitionAsync(PartitionKey, CancellationToken.None)
                 .WaitForResultWithThrow(new AzureStoragePolicyOptions().CreationTimeout).Select(tuple => tuple.Entity);
 
             sw.Stop();
@@ -86,7 +86,7 @@ namespace Tester.AzureUtils
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            var data = manager.ReadAllTableEntriesAsync()
+            var data = manager.ReadAllTableEntriesAsync(CancellationToken.None)
                 .WaitForResultWithThrow(new AzureStoragePolicyOptions().CreationTimeout).Select(tuple => tuple.Entity);
 
             sw.Stop();
@@ -96,7 +96,7 @@ namespace Tester.AzureUtils
             Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
 
             sw = Stopwatch.StartNew();
-            manager.ClearTableAsync().WaitWithThrow(new AzureStoragePolicyOptions().CreationTimeout);
+            manager.ClearTableAsync(CancellationToken.None).WaitWithThrow(new AzureStoragePolicyOptions().CreationTimeout);
             sw.Stop();
             output.WriteLine("AzureTable_ReadAllTableEntities clear. Cleared table of {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
         }
@@ -116,7 +116,7 @@ namespace Tester.AzureUtils
                 dataObject.PartitionKey = partitionKey;
                 dataObject.RowKey = rowKey;
                 dataObject.StringData = rowKey;
-                var promise = manager.UpsertTableEntryAsync(dataObject);
+                var promise = manager.UpsertTableEntryAsync(dataObject, CancellationToken.None);
                 promises.Add(promise);
                 if ((i % batchSize) == 0 && i > 0)
                 {

--- a/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureTableDataManagerTests.cs
@@ -32,12 +32,12 @@ namespace Tester.AzureUtils
         public async Task AzureTableDataManager_CreateTableEntryAsync()
         {
             var data = GenerateNewData();
-            await manager.CreateTableEntryAsync(data);
+            await manager.CreateTableEntryAsync(data, CancellationToken.None);
             try
             {
                 var data2 = data.Clone();
                 data2.StringData = "NewData";
-                await manager.CreateTableEntryAsync(data2);
+                await manager.CreateTableEntryAsync(data2, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -49,7 +49,7 @@ namespace Tester.AzureUtils
                 Assert.Equal(HttpStatusCode.Conflict, httpStatusCode);
                 Assert.Equal("EntityAlreadyExists", restStatus);
             }
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
         }
 
@@ -57,14 +57,14 @@ namespace Tester.AzureUtils
         public async Task AzureTableDataManager_UpsertTableEntryAsync()
         {
             var data = GenerateNewData();
-            await manager.UpsertTableEntryAsync(data);
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            await manager.UpsertTableEntryAsync(data, CancellationToken.None);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
 
             var data2 = data.Clone();
             data2.StringData = "NewData";
-            await manager.UpsertTableEntryAsync(data2);
-            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey);
+            await manager.UpsertTableEntryAsync(data2, CancellationToken.None);
+            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey, CancellationToken.None);
             Assert.Equal(data2.StringData, tuple.Entity.StringData);
         }
 
@@ -75,7 +75,7 @@ namespace Tester.AzureUtils
             var data = GenerateNewData();
             try
             {
-                await manager.UpdateTableEntryAsync(data, AzureTableUtils.ANY_ETAG);
+                await manager.UpdateTableEntryAsync(data, AzureTableUtils.ANY_ETAG, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -88,25 +88,25 @@ namespace Tester.AzureUtils
                 Assert.Equal(TableErrorCode.ResourceNotFound.ToString(), restStatus);
             }
 
-            await manager.UpsertTableEntryAsync(data);
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            await manager.UpsertTableEntryAsync(data, CancellationToken.None);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
 
             var data2 = data.Clone();
             data2.StringData = "NewData";
-            string eTag1 = await manager.UpdateTableEntryAsync(data2, AzureTableUtils.ANY_ETAG);
-            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey);
+            string eTag1 = await manager.UpdateTableEntryAsync(data2, AzureTableUtils.ANY_ETAG, CancellationToken.None);
+            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey, CancellationToken.None);
             Assert.Equal(data2.StringData, tuple.Entity.StringData);
 
             var data3 = data.Clone();
             data3.StringData = "EvenNewerData";
-            _ = await manager.UpdateTableEntryAsync(data3, eTag1);
-            tuple = await manager.ReadSingleTableEntryAsync(data3.PartitionKey, data3.RowKey);
+            _ = await manager.UpdateTableEntryAsync(data3, eTag1, CancellationToken.None);
+            tuple = await manager.ReadSingleTableEntryAsync(data3.PartitionKey, data3.RowKey, CancellationToken.None);
             Assert.Equal(data3.StringData, tuple.Entity.StringData);
 
             try
             {
-                string eTag3 = await manager.UpdateTableEntryAsync(data3.Clone(), eTag1);
+                string eTag3 = await manager.UpdateTableEntryAsync(data3.Clone(), eTag1, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -126,7 +126,7 @@ namespace Tester.AzureUtils
             var data = GenerateNewData();
             try
             {
-                await manager.DeleteTableEntryAsync(data, AzureTableUtils.ANY_ETAG);
+                await manager.DeleteTableEntryAsync(data, AzureTableUtils.ANY_ETAG, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -137,12 +137,12 @@ namespace Tester.AzureUtils
                 Assert.Equal(HttpStatusCode.NotFound, httpStatusCode);
             }
 
-            string eTag1 = await manager.UpsertTableEntryAsync(data);
-            await manager.DeleteTableEntryAsync(data, eTag1);
+            string eTag1 = await manager.UpsertTableEntryAsync(data, CancellationToken.None);
+            await manager.DeleteTableEntryAsync(data, eTag1, CancellationToken.None);
 
             try
             {
-                await manager.DeleteTableEntryAsync(data, eTag1);
+                await manager.DeleteTableEntryAsync(data, eTag1, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -153,7 +153,7 @@ namespace Tester.AzureUtils
                 Assert.Equal(HttpStatusCode.NotFound, httpStatusCode);
             }
 
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Null(tuple.Entity);
         }
 
@@ -164,7 +164,7 @@ namespace Tester.AzureUtils
             var data = GenerateNewData();
             try
             {
-                await manager.MergeTableEntryAsync(data, AzureTableUtils.ANY_ETAG);
+                await manager.MergeTableEntryAsync(data, AzureTableUtils.ANY_ETAG, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -177,14 +177,14 @@ namespace Tester.AzureUtils
                 Assert.Equal(TableErrorCode.ResourceNotFound.ToString(), restStatus);
             }
 
-            string eTag1 = await manager.UpsertTableEntryAsync(data);
+            string eTag1 = await manager.UpsertTableEntryAsync(data, CancellationToken.None);
             var data2 = data.Clone();
             data2.StringData = "NewData";
-            await manager.MergeTableEntryAsync(data2, eTag1);
+            await manager.MergeTableEntryAsync(data2, eTag1, CancellationToken.None);
 
             try
             {
-                await manager.MergeTableEntryAsync(data, eTag1);
+                await manager.MergeTableEntryAsync(data, eTag1, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -197,7 +197,7 @@ namespace Tester.AzureUtils
                 Assert.True(restStatus == TableErrorCode.UpdateConditionNotSatisfied.ToString());
             }
 
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Equal("NewData", tuple.Entity.StringData);
         }
 
@@ -205,7 +205,7 @@ namespace Tester.AzureUtils
         public async Task AzureTableDataManager_ReadSingleTableEntryAsync()
         {
             var data = GenerateNewData();
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey, CancellationToken.None);
             Assert.Null(tuple.Entity);
         }
 
@@ -218,7 +218,7 @@ namespace Tester.AzureUtils
             var data2 = GenerateNewData();
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, AzureTableUtils.ANY_ETAG);
+                await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, AzureTableUtils.ANY_ETAG, CancellationToken.None);
             }
             catch (RequestFailedException exc)
             {
@@ -230,11 +230,11 @@ namespace Tester.AzureUtils
                 Assert.Equal(TableErrorCode.ResourceNotFound.ToString(), restStatus);
             }
 
-            string etag = await manager.CreateTableEntryAsync(data2.Clone());
-            var tuple = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag);
+            string etag = await manager.CreateTableEntryAsync(data2.Clone(), CancellationToken.None);
+            var tuple = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag, CancellationToken.None);
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), tuple.Item2);
+                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), tuple.Item2, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -249,7 +249,7 @@ namespace Tester.AzureUtils
 
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), AzureTableUtils.ANY_ETAG);
+                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), AzureTableUtils.ANY_ETAG, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -272,7 +272,7 @@ namespace Tester.AzureUtils
             var data2 = GenerateNewData();
             try
             {
-                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, AzureTableUtils.ANY_ETAG, data2, AzureTableUtils.ANY_ETAG);
+                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, AzureTableUtils.ANY_ETAG, data2, AzureTableUtils.ANY_ETAG, CancellationToken.None);
                 Assert.True(false, "Update should have failed since the data has not been created yet");
             }
             catch (RequestFailedException exc)
@@ -285,13 +285,13 @@ namespace Tester.AzureUtils
                 Assert.Equal(TableErrorCode.ResourceNotFound.ToString(), restStatus);
             }
 
-            string etag = await manager.CreateTableEntryAsync(data2.Clone());
-            var tuple1 = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag);
-            _ = await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
+            string etag = await manager.CreateTableEntryAsync(data2.Clone(), CancellationToken.None);
+            var tuple1 = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag, CancellationToken.None);
+            _ = await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2, CancellationToken.None);
 
             try
             {
-                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
+                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2, CancellationToken.None);
                 Assert.True(false, "Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -310,7 +310,7 @@ namespace Tester.AzureUtils.Persistence
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
 
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Read time = {1}", store.GetType().FullName, readTime);
@@ -334,7 +334,7 @@ namespace Tester.AzureUtils.Persistence
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.WriteStateAsync(grainTypeName, reference, grainState);
+            await store.WriteStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             TimeSpan writeTime = sw.Elapsed;
             sw.Restart();
@@ -343,7 +343,7 @@ namespace Tester.AzureUtils.Persistence
             {
                 State = new TestStoreGrainState()
             };
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
             Assert.Equal(grainState.State.A, storedGrainState.State.A);
@@ -366,18 +366,18 @@ namespace Tester.AzureUtils.Persistence
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            await store.WriteStateAsync(grainTypeName, reference, grainState);
+            await store.WriteStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             TimeSpan writeTime = sw.Elapsed;
             sw.Restart();
 
-            await store.ClearStateAsync(grainTypeName, reference, grainState);
+            await store.ClearStateAsync(grainTypeName, reference, grainState, CancellationToken.None);
 
             var storedGrainState = new GrainState<TestStoreGrainState>
             {
                 State = new TestStoreGrainState()
             };
-            await store.ReadStateAsync(grainTypeName, reference, storedGrainState);
+            await store.ReadStateAsync(grainTypeName, reference, storedGrainState, CancellationToken.None);
             TimeSpan readTime = sw.Elapsed;
             this.output.WriteLine("{0} - Write time = {1} Read time = {2}", store.GetType().FullName, writeTime, readTime);
             Assert.NotNull(storedGrainState.State);

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -51,7 +51,7 @@ namespace Tester.AzureUtils.TimerTests
             storageOptions.Value.ConfigureTestDefaults();
 
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.Init();
+            await table.Init(CancellationToken.None);
 
             await TestTableInsertRate(table, 10);
             await TestTableInsertRate(table, 500);
@@ -65,13 +65,13 @@ namespace Tester.AzureUtils.TimerTests
             var storageOptions = Options.Create(new AzureTableReminderStorageOptions());
             storageOptions.Value.ConfigureTestDefaults();
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.Init();
+            await table.Init(CancellationToken.None);
 
             ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
             Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);
 
             ReminderEntry expected = NewReminderEntry();
-            await table.UpsertRow(expected);
+            await table.UpsertRow(expected, CancellationToken.None);
             rows = (await GetAllRows(table)).ToArray();
 
             Assert.Single(rows); // "The reminder table (sid={0}, did={1}) did not contain the correct number of rows (1).", ServiceId, clusterId);
@@ -108,7 +108,7 @@ namespace Tester.AzureUtils.TimerTests
                     int capture = i;
                     Task<bool> promise = Task.Run(async () =>
                     {
-                        await reminderTable.UpsertRow(e);
+                        await reminderTable.UpsertRow(e, CancellationToken.None);
                         this.output.WriteLine("Done " + capture);
                         return true;
                     });
@@ -149,7 +149,7 @@ namespace Tester.AzureUtils.TimerTests
 
         private async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
         {
-            ReminderTableData data = await table.ReadRows(0, 0xffffffff);
+            ReminderTableData data = await table.ReadRows(0, 0xffffffff, CancellationToken.None);
             return data.Reminders;
         }
     }

--- a/test/Extensions/TesterAzureUtils/Streaming/TestAzureTableStorageStreamFailureHandler.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/TestAzureTableStorageStreamFailureHandler.cs
@@ -19,18 +19,19 @@ namespace Tester.AzureUtils.Streaming
         public static async Task<int> GetDeliveryFailureCount(string streamProviderName)
         {
             var dataManager = GetDataManager();
-            await dataManager.InitTableAsync();
+            await dataManager.InitTableAsync(CancellationToken.None);
             var deliveryErrors =
                 await dataManager.ReadAllTableEntriesForPartitionAsync(
-                        StreamDeliveryFailureEntity.MakeDefaultPartitionKey(streamProviderName, DeploymentId));
+                        StreamDeliveryFailureEntity.MakeDefaultPartitionKey(streamProviderName, DeploymentId),
+                        CancellationToken.None);
             return deliveryErrors.Count;
         }
 
         public static async Task DeleteAll()
         {
             var dataManager = GetDataManager();
-            await dataManager.InitTableAsync();
-            await dataManager.DeleteTableAsync();
+            await dataManager.InitTableAsync(CancellationToken.None);
+            await dataManager.DeleteTableAsync(CancellationToken.None);
         }
 
         private static AzureTableDataManager<TableEntity> GetDataManager()

--- a/test/Extensions/TesterAzureUtils/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/TesterAzureUtils/UnitTestAzureTableDataManager.cs
@@ -59,7 +59,7 @@ namespace Tester.AzureUtils
             : base(new AzureStorageOperationOptions { TableName = INSTANCE_TABLE_NAME }.ConfigureTestDefaults(),
                   NullLoggerFactory.Instance.CreateLogger<UnitTestAzureTableDataManager>())
         {
-            InitTableAsync().WithTimeout(new AzureStoragePolicyOptions().CreationTimeout).Wait();
+            InitTableAsync(CancellationToken.None).WithTimeout(new AzureStoragePolicyOptions().CreationTimeout).Wait();
         }
     }
 }

--- a/test/TesterInternal/StorageTests/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageTests.cs
@@ -63,9 +63,9 @@ namespace UnitTests.StorageTests.Relational
             var grainTypeName = GrainTypeGenerator.GetGrainType<Guid>();
             var grainReference = this.GetTestReferenceAndState(0, null);
             var grainState = grainReference.GrainState;
-            await Storage.WriteStateAsync(grainTypeName, grainReference.GrainId, grainState).ConfigureAwait(false);
+            await Storage.WriteStateAsync(grainTypeName, grainReference.GrainId, grainState, CancellationToken.None).ConfigureAwait(false);
             var storedGrainState = new GrainState<TestState1> { State = new TestState1() };
-            await Storage.ReadStateAsync(grainTypeName, grainReference.GrainId, storedGrainState).ConfigureAwait(false);
+            await Storage.ReadStateAsync(grainTypeName, grainReference.GrainId, storedGrainState, CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(grainState.ETag, storedGrainState.ETag);
             Assert.Equal(grainState.State, storedGrainState.State);
@@ -184,12 +184,12 @@ namespace UnitTests.StorageTests.Relational
         {
             //A legal situation for clearing has to be arranged by writing a state to the storage before
             //clearing it. Writing and clearing both change the ETag, so they should differ.
-            await Storage.WriteStateAsync(grainTypeName, grainId, grainState);
+            await Storage.WriteStateAsync(grainTypeName, grainId, grainState, CancellationToken.None);
             var writtenStateVersion = grainState.ETag;
             var recordExitsAfterWriting = grainState.RecordExists;
             Assert.True(recordExitsAfterWriting);
 
-            await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+            await Storage.ClearStateAsync(grainTypeName, grainId, grainState, CancellationToken.None).ConfigureAwait(false);
             var clearedStateVersion = grainState.ETag;
             Assert.NotEqual(writtenStateVersion, clearedStateVersion);
 
@@ -197,7 +197,7 @@ namespace UnitTests.StorageTests.Relational
             Assert.False(recordExitsAfterClearing);
 
             var storedGrainState = new GrainState<T> { State = new T(), ETag = clearedStateVersion };
-            await Storage.WriteStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
+            await Storage.WriteStateAsync(grainTypeName, grainId, storedGrainState, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(storedGrainState.State, Activator.CreateInstance<T>());
             Assert.True(storedGrainState.RecordExists);
         }
@@ -212,9 +212,9 @@ namespace UnitTests.StorageTests.Relational
         /// <returns></returns>
         internal async Task Store_WriteRead<T>(string grainTypeName, GrainId grainId, GrainState<T> grainState) where T : new()
         {
-            await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+            await Storage.WriteStateAsync(grainTypeName, grainId, grainState, CancellationToken.None).ConfigureAwait(false);
             var storedGrainState = new GrainState<T> { State = new T() };
-            await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
+            await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState, CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(grainState.ETag, storedGrainState.ETag);
             Assert.Equal(grainState.State, storedGrainState.State);


### PR DESCRIPTION
This PR adds overloads of methods on storage-backed interfaces (`IGatewayListProvider`, `IGrainStorage`, `IReminderTable`, `IMembershipTable`) to include a `CancellationToken` parameter.

Consequently, I've plumbed the `CancellationToken` through wherever applicable.