### PR TITLE
Allow `ImplicitStreamSubscriptionAttribute.StreamIdMapper` to be initialized by subclasses

### DIFF
--- a/src/Orleans.Streaming/Core/IStreamIdMapper.cs
+++ b/src/Orleans.Streaming/Core/IStreamIdMapper.cs
@@ -4,12 +4,12 @@ using Orleans.Runtime;
 namespace Orleans.Streams
 {
     /// <summary>
-    /// Common interface for component that map a <see cref="StreamId"/> to a <see cref="GrainId.Key"/>
+    /// Common interface for components that map a <see cref="StreamId"/> to a <see cref="GrainId.Key"/>
     /// </summary>
     public interface IStreamIdMapper
     {
         /// <summary>
-        /// Get the <see cref="GrainId.Key" /> which maps to the provided <see cref="StreamId" />
+        /// Gets the <see cref="GrainId.Key" /> which maps to the provided <see cref="StreamId" />
         /// </summary>
         /// <param name="grainBindings">The grain bindings.</param>
         /// <param name="streamId">The stream identifier.</param>

--- a/src/Orleans.Streaming/Predicates/StreamSubscriptionAttributes.cs
+++ b/src/Orleans.Streaming/Predicates/StreamSubscriptionAttributes.cs
@@ -21,7 +21,10 @@ namespace Orleans
         /// Gets the name of the stream identifier mapper.
         /// </summary>
         /// <value>The name of the stream identifier mapper.</value>
-        public string StreamIdMapper { get; }
+        /// <remarks>
+        /// This value is the name used to resolve the <see cref="IStreamIdMapper"/> registered in the dependency injection container.
+        /// </remarks>
+        public string StreamIdMapper { get; init; }
 
         /// <summary>
         /// Used to subscribe to all stream namespaces.


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8592)