### PR TITLE
Fix wire break for IRemoteGrainDirectory API

### DIFF
--- a/src/Orleans.Core/GrainDirectory/IDhtGrainDirectory.cs
+++ b/src/Orleans.Core/GrainDirectory/IDhtGrainDirectory.cs
@@ -20,6 +20,15 @@ namespace Orleans.GrainDirectory
         /// <para>This method must be called from a scheduler thread.</para>
         /// </summary>
         /// <param name="address">The address of the new activation.</param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>The registered address and the version associated with this directory mapping.</returns>
+        Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount = 0);
+
+        /// <summary>
+        /// Record a new grain activation by adding it to the directory.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address">The address of the new activation.</param>
         /// <param name="currentRegistration">The existing registration, which may be null.</param>
         /// <param name="hopCount">Counts recursion depth across silos</param>
         /// <returns>The registered address and the version associated with this directory mapping.</returns>

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
                 }
             }
 
-            if (collectionOptions.ClassSpecificCollectionAge.TryGetValue(grainClass.FullName, out var specified))
+            if (collectionOptions.ClassSpecificCollectionAge.TryGetValue(grainClass.FullName!, out var specified))
             {
                 return specified;
             }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -410,6 +410,7 @@ namespace Orleans.Runtime.GrainDirectory
             return owner;
         }
 
+        public Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount) => RegisterAsync(address, previousAddress: null, hopCount: hopCount);
 
         public async Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, int hopCount)
         {

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -105,5 +105,7 @@ namespace Orleans.Runtime.GrainDirectory
             router.HandoffManager.AcceptExistingRegistrations(singleActivations);
             return Task.CompletedTask;
         }
+
+        public Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount = 0) => router.RegisterAsync(address, hopCount);
     }
 }

--- a/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
+++ b/test/NonSilo.Tests/Directory/MockLocalGrainDirectory.cs
@@ -91,6 +91,11 @@ namespace UnitTests.Directory
             throw new NotImplementedException();
         }
 
+        public Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount = 0)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress previousAddress, int hopCount = 0)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Changing the signature of `RegisterAsync` was a breaking change, so this PR adds the original signature back as an overload.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8593)