### PR TITLE
Address all IDE0049. Use language keywords instead

### DIFF
--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -37,7 +37,7 @@ namespace Orleans.Tests.SqlUtils
 
         private static CachedFactory GetFactory(string invariantName)
         {
-            if (String.IsNullOrWhiteSpace(invariantName))
+            if (string.IsNullOrWhiteSpace(invariantName))
             {
                 throw new ArgumentNullException(nameof(invariantName));
             }
@@ -99,12 +99,12 @@ namespace Orleans.Tests.SqlUtils
 
         public static DbConnection CreateConnection(string invariantName, string connectionString)
         {
-            if (String.IsNullOrWhiteSpace(invariantName))
+            if (string.IsNullOrWhiteSpace(invariantName))
             {
                 throw new ArgumentNullException(nameof(invariantName));
             }
 
-            if (String.IsNullOrWhiteSpace(connectionString))
+            if (string.IsNullOrWhiteSpace(connectionString))
             {
                 throw new ArgumentNullException(nameof(connectionString));
             }

--- a/src/AdoNet/Shared/Storage/OracleDatabaseCommandInterceptor.cs
+++ b/src/AdoNet/Shared/Storage/OracleDatabaseCommandInterceptor.cs
@@ -116,7 +116,7 @@ namespace Orleans.Tests.SqlUtils
                 //we map these to DbType.Int32
                 if (commandParameter.DbType == DbType.Boolean)
                 {
-                    commandParameter.Value = commandParameter.ToString() == Boolean.TrueString ? 1 : 0;
+                    commandParameter.Value = commandParameter.ToString() == bool.TrueString ? 1 : 0;
                     commandParameter.DbType = DbType.Int32;
                 }
             }

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -274,7 +274,7 @@ namespace Orleans.Runtime.MembershipService
             }
 
             if (suspectingSilos.Count != suspectingTimes.Count)
-                throw new OrleansException(String.Format("SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
+                throw new OrleansException(string.Format("SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
 
             for (int i = 0; i < suspectingSilos.Count; i++)
                 parse.AddSuspector(suspectingSilos[i], suspectingTimes[i]);
@@ -326,8 +326,8 @@ namespace Orleans.Runtime.MembershipService
             }
             else
             {
-                tableEntry.SuspectingSilos = String.Empty;
-                tableEntry.SuspectingTimes = String.Empty;
+                tableEntry.SuspectingSilos = string.Empty;
+                tableEntry.SuspectingTimes = string.Empty;
             }
             tableEntry.PartitionKey = deploymentId;
             tableEntry.RowKey = SiloInstanceTableEntry.ConstructRowKey(memEntry.SiloAddress);

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -138,7 +138,7 @@ namespace Orleans.AzureUtils
             SiloInstanceTableEntry[] entries = queryResults.Select(entry => entry.Item1).ToArray();
 
             var sb = new StringBuilder();
-            sb.Append(String.Format("Deployment {0}. Silos: ", DeploymentId));
+            sb.Append(string.Format("Deployment {0}. Silos: ", DeploymentId));
 
             // Loop through the results, displaying information about the entity
             Array.Sort(entries,
@@ -148,11 +148,11 @@ namespace Orleans.AzureUtils
                     if (e2 == null) return (e1 == null) ? 0 : 1;
                     if (e1.SiloName == null) return (e2.SiloName == null) ? 0 : -1;
                     if (e2.SiloName == null) return (e1.SiloName == null) ? 0 : 1;
-                    return String.CompareOrdinal(e1.SiloName, e2.SiloName);
+                    return string.CompareOrdinal(e1.SiloName, e2.SiloName);
                 });
             foreach (SiloInstanceTableEntry entry in entries)
             {
-                sb.AppendLine(String.Format("[IP {0}:{1}:{2}, {3}, Instance={4}, Status={5}]", entry.Address, entry.Port, entry.Generation,
+                sb.AppendLine(string.Format("[IP {0}:{1}:{2}, {3}, Instance={4}, Status={5}]", entry.Address, entry.Port, entry.Generation,
                     entry.HostName, entry.SiloName, entry.Status));
             }
             return sb.ToString();

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -367,7 +367,7 @@ namespace Orleans.AzureUtils
 
         private void ReportErrorAndRethrow(Exception exc, string operation, AzureQueueErrorCode errorCode)
         {
-            var errMsg = String.Format(
+            var errMsg = string.Format(
                 "Error doing {0} for Azure storage queue {1} " + Environment.NewLine
                 + "Exception = {2}", operation, QueueName, exc);
             logger.LogError((int)errorCode, exc, "{Message}", errMsg);
@@ -412,37 +412,37 @@ namespace Orleans.AzureUtils
             if (!(queueName.Length >= 3 && queueName.Length <= 63))
             {
                 // A queue name must be from 3 through 63 characters long.
-                throw new ArgumentException(String.Format("A queue name must be from 3 through 63 characters long, while your queueName length is {0}, queueName is {1}.", queueName.Length, queueName), queueName);
+                throw new ArgumentException(string.Format("A queue name must be from 3 through 63 characters long, while your queueName length is {0}, queueName is {1}.", queueName.Length, queueName), queueName);
             }
 
-            if (!Char.IsLetterOrDigit(queueName.First()))
+            if (!char.IsLetterOrDigit(queueName.First()))
             {
                 // A queue name must start with a letter or number
-                throw new ArgumentException(String.Format("A queue name must start with a letter or number, while your queueName is {0}.", queueName), queueName);
+                throw new ArgumentException(string.Format("A queue name must start with a letter or number, while your queueName is {0}.", queueName), queueName);
             }
 
-            if (!Char.IsLetterOrDigit(queueName.Last()))
+            if (!char.IsLetterOrDigit(queueName.Last()))
             {
                 // The first and last letters in the queue name must be alphanumeric. The dash (-) character cannot be the first or last character.
-                throw new ArgumentException(String.Format("The last letter in the queue name must be alphanumeric, while your queueName is {0}.", queueName), queueName);
+                throw new ArgumentException(string.Format("The last letter in the queue name must be alphanumeric, while your queueName is {0}.", queueName), queueName);
             }
 
-            if (!queueName.All(c => Char.IsLetterOrDigit(c) || c.Equals('-')))
+            if (!queueName.All(c => char.IsLetterOrDigit(c) || c.Equals('-')))
             {
                 // A queue name can only contain letters, numbers, and the dash (-) character.
-                throw new ArgumentException(String.Format("A queue name can only contain letters, numbers, and the dash (-) character, while your queueName is {0}.", queueName), queueName);
+                throw new ArgumentException(string.Format("A queue name can only contain letters, numbers, and the dash (-) character, while your queueName is {0}.", queueName), queueName);
             }
 
             if (queueName.Contains("--"))
             {
                 // Consecutive dash characters are not permitted in the queue name.
-                throw new ArgumentException(String.Format("Consecutive dash characters are not permitted in the queue name, while your queueName is {0}.", queueName), queueName);
+                throw new ArgumentException(string.Format("Consecutive dash characters are not permitted in the queue name, while your queueName is {0}.", queueName), queueName);
             }
 
-            if (queueName.Where(Char.IsLetter).Any(c => !Char.IsLower(c)))
+            if (queueName.Where(char.IsLetter).Any(c => !char.IsLower(c)))
             {
                 // All letters in a queue name must be lowercase.
-                throw new ArgumentException(String.Format("All letters in a queue name must be lowercase, while your queueName is {0}.", queueName), queueName);
+                throw new ArgumentException(string.Format("All letters in a queue name must be lowercase, while your queueName is {0}.", queueName), queueName);
             }
         }
     }

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -149,7 +149,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 || httpStatusCode == HttpStatusCode.ServiceUnavailable  /* 503 */
                 || httpStatusCode == HttpStatusCode.GatewayTimeout      /* 504 */
                 || (httpStatusCode == HttpStatusCode.InternalServerError /* 500 */
-                    && !String.IsNullOrEmpty(restStatusCode)
+                    && !string.IsNullOrEmpty(restStatusCode)
                     && TableErrorCode.OperationTimedOut.ToString().Equals(restStatusCode, StringComparison.OrdinalIgnoreCase))
             );
         }
@@ -248,7 +248,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                             exc,
                             "DataNotFound reading Azure storage table {TableName}:{Retry} HTTP status code={StatusCode} REST status code={RESTStatusCode}",
                             tableName,
-                            iteration == 0 ? String.Empty : (" Repeat=" + iteration),
+                            iteration == 0 ? string.Empty : (" Repeat=" + iteration),
                             httpStatusCode,
                             restStatus);
 

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/LegacyGrainId.cs
@@ -329,7 +329,7 @@ namespace Orleans.Runtime
                     fullString = "???/" + idString;
                     break;
             }
-            return detailed ? String.Format("{0}-0x{1, 8:X8}", fullString, GetUniformHashCode()) : fullString;
+            return detailed ? string.Format("{0}-0x{1, 8:X8}", fullString, GetUniformHashCode()) : fullString;
         }
 
         public static bool IsLegacyGrainType(Type type)

--- a/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
+++ b/src/Orleans.Core.Abstractions/IDs/Legacy/UniqueKey.cs
@@ -26,11 +26,11 @@ namespace Orleans.Runtime
         }
 
         [Id(0)]
-        public UInt64 N0 { get; private set; }
+        public ulong N0 { get; private set; }
         [Id(1)]
-        public UInt64 N1 { get; private set; }
+        public ulong N1 { get; private set; }
         [Id(2)]
-        public UInt64 TypeCodeData { get; private set; }
+        public ulong TypeCodeData { get; private set; }
         [Id(3)]
         public string KeyExt { get; private set; }
 
@@ -332,7 +332,7 @@ namespace Orleans.Runtime
             return keyString;
         }
 
-        internal static Category GetCategory(UInt64 typeCodeData)
+        internal static Category GetCategory(ulong typeCodeData)
         {
             return (Category)((typeCodeData >> 56) & 0xFF);
         }

--- a/src/Orleans.Core/Configuration/ConfigUtilities.cs
+++ b/src/Orleans.Core/Configuration/ConfigUtilities.cs
@@ -223,7 +223,7 @@ namespace Orleans.Runtime.Configuration
                 "SecretKey=", "SessionToken=",              // DynamoDb
             };
             var mark = "<--SNIP-->";
-            if (String.IsNullOrEmpty(connectionString)) return "null";
+            if (string.IsNullOrEmpty(connectionString)) return "null";
             //if connection string format doesn't contain any secretKey, then return just <--SNIP-->
             if (!secretKeys.Any(key => connectionString.Contains(key))) return mark;
 

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -158,7 +158,7 @@ namespace Orleans.Storage
         /// <inheritdoc/>
         public override string ToString()
         {
-            return String.Format("InconsistentStateException: {0} Expected Etag={1} Received Etag={2} {3}",
+            return string.Format("InconsistentStateException: {0} Expected Etag={1} Received Etag={2} {3}",
                 Message, StoredEtag, CurrentEtag, InnerException);
         }
 

--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -48,7 +48,7 @@ namespace Orleans.Runtime
 
         public void Start(TimeSpan due, TimeSpan period)
         {
-            if (timerStarted) throw new InvalidOperationException(String.Format("Calling start on timer {0} is not allowed, since it was already created in a started mode with specified due.", GetFullName()));
+            if (timerStarted) throw new InvalidOperationException(string.Format("Calling start on timer {0} is not allowed, since it was already created in a started mode with specified due.", GetFullName()));
             if (period == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), period, "Cannot use TimeSpan.Zero for timer period");
 
             long dueTm = (long)dueTime.TotalMilliseconds;
@@ -146,7 +146,7 @@ namespace Orleans.Runtime
         public bool CheckTimerFreeze(DateTime lastCheckTime, Func<string> callerName)
         {
             return CheckTimerDelay(previousTickTime, totalNumTicks,
-                        dueTime, timerFrequency, logger, () => String.Format("{0}.{1}", GetFullName(), callerName()), ErrorCode.Timer_SafeTimerIsNotTicking, true);
+                        dueTime, timerFrequency, logger, () => string.Format("{0}.{1}", GetFullName(), callerName()), ErrorCode.Timer_SafeTimerIsNotTicking, true);
         }
 
         public static bool CheckTimerDelay(DateTime previousTickTime, int totalNumTicks, 

--- a/src/Orleans.EventSourcing/LogConsistency/ILogConsistencyDiagnostics.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/ILogConsistencyDiagnostics.cs
@@ -27,7 +27,7 @@ namespace Orleans.EventSourcing
         /// <summary>
         /// A map from event names to event counts
         /// </summary>
-        public Dictionary<String, long> EventCounters;
+        public Dictionary<string, long> EventCounters;
         /// <summary>
         /// A list of all measured stabilization latencies
         /// </summary>

--- a/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
@@ -125,9 +125,9 @@ namespace Orleans
         public IList<ReminderEntry> Reminders { get; private set; }
 
         /// <summary>
-        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString() => $"[{Reminders.Count} reminders: {Utils.EnumerableToString(Reminders)}.";
     }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -359,7 +359,7 @@ namespace Orleans.Runtime
         {
             if (timeout < quantum)
             {
-                throw new ArgumentException(String.Format("timeout must be at least {0}, but it is {1}", quantum, timeout), nameof(timeout));
+                throw new ArgumentException(string.Format("timeout must be at least {0}, but it is {1}", quantum, timeout), nameof(timeout));
             }
 
             return MakeTicketFromDateTime(DateTime.UtcNow + timeout);

--- a/src/Orleans.Runtime/Core/SystemStatus.cs
+++ b/src/Orleans.Runtime/Core/SystemStatus.cs
@@ -55,11 +55,11 @@ namespace Orleans.Runtime
         private readonly InternalSystemStatus value;
         private SystemStatus(InternalSystemStatus name) { this.value = name; }
 
-        /// <see cref="Object.ToString"/>
+        /// <see cref="object.ToString"/>
         public override string ToString() { return this.value.ToString(); }
-        /// <see cref="Object.GetHashCode"/>
+        /// <see cref="object.GetHashCode"/>
         public override int GetHashCode() { return this.value.GetHashCode(); }
-        /// <see cref="Object.Equals(Object)"/>
+        /// <see cref="object.Equals(object)"/>
         public override bool Equals(object obj) { var ss = obj as SystemStatus; return ss != null && this.Equals(ss); }
         /// <see cref="IEquatable{T}.Equals(T)"/>
         public bool Equals(SystemStatus other) { return (other != null) && this.value.Equals(other.value); }

--- a/src/Orleans.Runtime/Services/GrainServicesSiloBuilderExtensions.cs
+++ b/src/Orleans.Runtime/Services/GrainServicesSiloBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Orleans.Hosting
             var grainServiceInterfaceType = serviceType.GetInterfaces().FirstOrDefault(x => x.GetInterfaces().Contains(typeof(IGrainService)));
             if (grainServiceInterfaceType is null)
             {
-                throw new InvalidOperationException(String.Format($"Cannot find an interface on {serviceType.FullName} which implements IGrainService"));
+                throw new InvalidOperationException(string.Format($"Cannot find an interface on {serviceType.FullName} which implements IGrainService"));
             }
 
             var typeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grainServiceInterfaceType);

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -256,7 +256,7 @@ namespace Orleans.Runtime
             lock (lockable)
             {
                 if (!this.SystemStatus.Equals(SystemStatus.Created))
-                    throw new InvalidOperationException(String.Format("Calling Silo.Start() on a silo which is not in the Created state. This silo is in the {0} state.", this.SystemStatus));
+                    throw new InvalidOperationException(string.Format("Calling Silo.Start() on a silo which is not in the Created state. This silo is in the {0} state.", this.SystemStatus));
 
                 this.SystemStatus = SystemStatus.Starting;
             }

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime
         public void Start()
         {
             if (TimerAlreadyStopped)
-                throw new ObjectDisposedException(String.Format("The timer {0} was already disposed.", GetFullName()));
+                throw new ObjectDisposedException(string.Format("The timer {0} was already disposed.", GetFullName()));
 
             timer.Start(dueTime, timerFrequency);
         }

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -265,7 +265,7 @@ namespace Orleans.Streams
 
         public override string ToString()
         {
-            return String.Format("StreamSubscriptionHandleImpl:Stream={0},HandleId={1}", IsValid ? streamImpl.InternalStreamId.ToString() : "null", HandleId);
+            return string.Format("StreamSubscriptionHandleImpl:Stream={0},HandleId={1}", IsValid ? streamImpl.InternalStreamId.ToString() : "null", HandleId);
         }
     }
 }

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -77,7 +77,7 @@ namespace Orleans.Providers
                 // if this fails with clean block, then requested size is too big
                 if (!currentBuffer.TryGetSegment(size, out segment))
                 {
-                    string errmsg = String.Format(CultureInfo.InvariantCulture,
+                    string errmsg = string.Format(CultureInfo.InvariantCulture,
                         "Message size is too big. MessageSize: {0}", size);
                     throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                 }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -89,7 +89,7 @@ namespace Orleans.Providers.Streams.Common
             DeepCopier deepCopier,
             ILogger<PersistentStreamProvider> logger)
         {
-            if (String.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
             if (runtime == null) throw new ArgumentNullException(nameof(runtime));
             this.pubsubOptions = pubsubOptions ?? throw new ArgumentNullException(nameof(pubsubOptions));
             this.Name = name;

--- a/src/Orleans.Streaming/QueueAdapters/QueueCacheMissException.cs
+++ b/src/Orleans.Streaming/QueueAdapters/QueueCacheMissException.cs
@@ -68,7 +68,7 @@ namespace Orleans.Streams
         /// <param name="low">The earliest available sequence token.</param>
         /// <param name="high">The latest available sequence token.</param>
         public QueueCacheMissException(string requested, string low, string high)
-            : this(String.Format(CultureInfo.InvariantCulture, MESSAGE_FORMAT, requested, low, high))
+            : this(string.Format(CultureInfo.InvariantCulture, MESSAGE_FORMAT, requested, low, high))
         {
             Requested = requested;
             Low = low;

--- a/src/Orleans.Streaming/QueueBalancer/BestFitBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/BestFitBalancer.cs
@@ -77,7 +77,7 @@ namespace Orleans.Streams
             {
                 if (!idealDistribution.ContainsKey(bucket))
                 {
-                    throw new ArgumentOutOfRangeException(nameof(activeBuckets), String.Format("Active buckets contain a bucket {0} not in the master list.", bucket));
+                    throw new ArgumentOutOfRangeException(nameof(activeBuckets), string.Format("Active buckets contain a bucket {0} not in the master list.", bucket));
                 }
             }
 

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -119,7 +119,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_ULong_MaxValue()
         {
-            ulong key1AsUlong = UInt64.MaxValue; // == -1L
+            ulong key1AsUlong = ulong.MaxValue; // == -1L
             long key1 = (long)key1AsUlong;
 
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(key1);
@@ -140,7 +140,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_ULong_MinValue()
         {
-            ulong key1AsUlong = UInt64.MinValue; // == zero
+            ulong key1AsUlong = ulong.MinValue; // == zero
             long key1 = (long)key1AsUlong;
 
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(key1);
@@ -162,7 +162,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_Long_MaxValue()
         {
-            long key1 = Int32.MaxValue;
+            long key1 = int.MaxValue;
             ulong key1AsUlong = (ulong)key1;
 
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(key1);
@@ -183,7 +183,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("ActivateDeactivate"), TestCategory("GetGrain")]
         public void BasicActivation_Long_MinValue()
         {
-            long key1 = Int64.MinValue;
+            long key1 = long.MinValue;
             ulong key1AsUlong = (ulong)key1;
 
             ITestGrain g1 = this.GrainFactory.GetGrain<ITestGrain>(key1);

--- a/test/DefaultCluster.Tests/LocalErrorGrain.cs
+++ b/test/DefaultCluster.Tests/LocalErrorGrain.cs
@@ -23,12 +23,12 @@ namespace DefaultCluster.Tests
             return Task.CompletedTask;
         }
 
-        public Task<Int32> GetAxB()
+        public Task<int> GetAxB()
         {
             return Task.FromResult(m_a * m_b);
         }
 
-        public async Task<Int32> GetAxBError()
+        public async Task<int> GetAxBError()
         {
             await Task.CompletedTask;
             throw new Exception("GetAxBError-Exception");

--- a/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -200,7 +200,7 @@ namespace AWSUtils.Tests.Streaming
         {
             const string DeploymentIdFormat = "cluster-{0}";
             string now = DateTime.UtcNow.ToString("yyyy-MM-dd-hh-mm-ss-ffff");
-            return String.Format(DeploymentIdFormat, now);
+            return string.Format(DeploymentIdFormat, now);
         }
     }
 }

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/RelationalStorageForTesting.cs
@@ -117,7 +117,7 @@ namespace UnitTests.General
 
             Console.WriteLine("Creating database tables...");
 
-            var setupScript = String.Empty;
+            var setupScript = string.Empty;
 
             // Concatenate scripts
             foreach (var fileName in testStorage.SetupSqlScriptFileNames)

--- a/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -156,7 +156,7 @@ namespace Tester.AzureUtils
 
         private static string PrintQueueMessage(QueueMessage message)
         {
-            return String.Format("QueueMessage: Id = {0}, NextVisibleTime = {1}, DequeueCount = {2}, PopReceipt = {3}, Content = {4}",
+            return string.Format("QueueMessage: Id = {0}, NextVisibleTime = {1}, DequeueCount = {2}, PopReceipt = {3}, Content = {4}",
                     message.MessageId,
                     message.NextVisibleOn.HasValue ? LogFormatter.PrintDate(message.NextVisibleOn.Value.DateTime) : "",
                     message.DequeueCount,
@@ -166,7 +166,7 @@ namespace Tester.AzureUtils
 
         private static string PrintQueueMessage(PeekedMessage message)
         {
-            return String.Format("QueueMessage: Id = {0}, DequeueCount = {1}, Content = {2}",
+            return string.Format("QueueMessage: Id = {0}, DequeueCount = {1}, Content = {2}",
                     message.MessageId,
                     message.DequeueCount,
                     message.MessageText);

--- a/test/Grains/TestGrainInterfaces/EventSourcing/IAccountGrain.cs
+++ b/test/Grains/TestGrainInterfaces/EventSourcing/IAccountGrain.cs
@@ -34,7 +34,7 @@ namespace TestGrainInterfaces
 
         /// <summary> A description for this transaction  </summary>
         [Id(1)]
-        public String Description { get; set; }
+        public string Description { get; set; }
 
         /// <summary> time on which the request entered the system  </summary>
         [Id(2)]

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -66,7 +66,7 @@ namespace UnitTests.Grains
         public async Task BecomeConsumer(Guid streamId, string providerToUse)
         {
             _logger.LogInformation("Consumer.BecomeConsumer");
-            if (String.IsNullOrEmpty(providerToUse))
+            if (string.IsNullOrEmpty(providerToUse))
             {
                 throw new ArgumentNullException(nameof(providerToUse));
             }

--- a/test/Grains/TestGrains/DeadlockGrain.cs
+++ b/test/Grains/TestGrains/DeadlockGrain.cs
@@ -43,7 +43,7 @@ namespace UnitTests.Grains
     {
         private readonly ILogger logger;
         public DeadlockNonReentrantGrain(ILoggerFactory loggerFactory) => this.logger = loggerFactory.CreateLogger(this.Id);
-        private string Id { get { return String.Format("DeadlockNonReentrantGrain {0}", base.IdentityString); } }
+        private string Id { get { return string.Format("DeadlockNonReentrantGrain {0}", base.IdentityString); } }
 
         public async Task CallNext_1(List<(long GrainId, bool Blocking)> callChain, int currCallIndex)
         {

--- a/test/Grains/TestGrains/GeneratorTestDerivedDerivedGrain.cs
+++ b/test/Grains/TestGrains/GeneratorTestDerivedDerivedGrain.cs
@@ -10,7 +10,7 @@ namespace UnitTests.Grains
         {
             string strAll = string.Empty;
             foreach(string str in strArray)
-                strAll = String.Concat(strAll, str);
+                strAll = string.Concat(strAll, str);
 
             return Task.FromResult(strAll);
         }

--- a/test/Grains/TestGrains/GeneratorTestDerivedGrain2.cs
+++ b/test/Grains/TestGrains/GeneratorTestDerivedGrain2.cs
@@ -8,7 +8,7 @@ namespace UnitTests.Grains
     {
         public Task<string> StringConcat(string str1, string str2, string str3)
         {
-            return Task.FromResult((String.Concat(str1, str2, str3)));
+            return Task.FromResult((string.Concat(str1, str2, str3)));
         }
     }
 }

--- a/test/Grains/TestGrains/GeneratorTestGrain.cs
+++ b/test/Grains/TestGrains/GeneratorTestGrain.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Grains
 
         public Task<bool> StringIsNullOrEmpty()
         {
-            return Task.FromResult(String.IsNullOrEmpty(myGrainString));
+            return Task.FromResult(string.IsNullOrEmpty(myGrainString));
         }
 
         public Task<MemberVariables> GetMemberVariables()

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -805,7 +805,7 @@ namespace UnitTests.Grains
         public Task<string> Handle(string prevState, Reducer1Action act) => Task.FromResult(prevState + act);
     }
 
-    public class Reducer2 : IReducer<Int32, Reducer2Action>
+    public class Reducer2 : IReducer<int, Reducer2Action>
     {
         public Task<int> Handle(int prevState, Reducer2Action act) => Task.FromResult(prevState + act.ToString().Length);
     }

--- a/test/Grains/TestGrains/LogTestGrain.cs
+++ b/test/Grains/TestGrains/LogTestGrain.cs
@@ -23,7 +23,7 @@ namespace TestGrains
         [Orleans.Id(1)]
         public int B;
         [Orleans.Id(2)]
-        public Dictionary<String, int> Reservations;
+        public Dictionary<string, int> Reservations;
 
         public MyGrainState()
         {

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -37,7 +37,7 @@ namespace UnitTests.Grains
         public Task BecomeProducer(Guid streamId, string providerToUse)
         {
             _logger.LogInformation("Producer.BecomeProducer");
-            if (String.IsNullOrEmpty(providerToUse))
+            if (string.IsNullOrEmpty(providerToUse))
             {
                 throw new ArgumentNullException(nameof(providerToUse));
             }

--- a/test/Grains/TestGrains/SimpleGenericGrain.cs
+++ b/test/Grains/TestGrains/SimpleGenericGrain.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Grains
             // Compare reference to this grain created by the client 
             var thisReference = GrainFactory.GetGrain<ISimpleGenericGrain<TType>>(this.GetPrimaryKeyLong());
             if (!thisReference.Equals(clientReference))
-                throw new Exception(String.Format("Case_3: 2 grain references are different, while should have been the same: gr1={0}, gr2={1}", thisReference, clientReference));
+                throw new Exception(string.Format("Case_3: 2 grain references are different, while should have been the same: gr1={0}, gr2={1}", thisReference, clientReference));
 
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
         public static string CaptureRuntimeEnvironment()
         {
             var callStack = Utils.GetStackTrace(1); // Don't include this method in stack trace
-            return String.Format(
+            return string.Format(
                 "   TaskScheduler={0}" + Environment.NewLine
                 + "   RuntimeContext={1}" + Environment.NewLine
                 + "   WorkerPoolThread={2}" + Environment.NewLine

--- a/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -371,7 +371,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            logger.LogInformation(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
+            logger.LogInformation(string.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -32,7 +32,7 @@ namespace UnitTests.Grains
 
         public override string ToString()
         {
-            return String.Format("{0}", Data);
+            return string.Format("{0}", Data);
         }
     }
 
@@ -250,7 +250,7 @@ namespace UnitTests.Grains
             _expectedItemsProduced += count;
             _logger.LogInformation("ProducerObserver.ProduceSequentialSeries: StreamId={StreamId}, num items to produce={Count}.", _streamId, count);
             for (var i = 1; i <= count; ++i)
-                await ProduceItem(String.Format("sequential#{0}", i));
+                await ProduceItem(string.Format("sequential#{0}", i));
         }
 
         public Task ProduceParallelSeries(int count)
@@ -430,7 +430,7 @@ namespace UnitTests.Grains
                 if (_started && !_disposedFlag.IsSet)
                 {
                     --_counter;
-                    bool shouldContinue = await _produceItemFunc(String.Format("periodic#{0}", _counter));
+                    bool shouldContinue = await _produceItemFunc(string.Format("periodic#{0}", _counter));
                     if (!shouldContinue || 0 == _counter)
                         Dispose();
                 }

--- a/test/TestInfrastructure/TestExtensions/TestUtils.cs
+++ b/test/TestInfrastructure/TestExtensions/TestUtils.cs
@@ -100,7 +100,7 @@ namespace Tester
             if (baseline > TimeSpan.Zero)
             {
                 double delta = (duration - baseline).TotalMilliseconds / baseline.TotalMilliseconds;
-                timeDeltaStr = String.Format("-- Change = {0}%", 100.0 * delta);
+                timeDeltaStr = string.Format("-- Change = {0}%", 100.0 * delta);
             }
             Console.WriteLine("Time for {0} loops doing {1} = {2} {3} Memory used={4}", numIterations, what, duration, timeDeltaStr, memUsed);
             return duration;

--- a/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
@@ -28,7 +28,7 @@ namespace Tester.ClientConnectionTests
             {
                 s.Connect(gwEndpoint);
 
-                Int32 invalidSize = 99999;
+                int invalidSize = 99999;
                 s.Send(BitConverter.GetBytes(invalidSize));
 
                 bool socketClosed = s.Poll(100000, SelectMode.SelectRead) && s.Available == 0;

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -54,7 +54,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var testDirectory = new DirectoryInfo(GetType().Assembly.Location);
 
-            while (String.Compare(testDirectory.Name, CommonParentDirectory, StringComparison.OrdinalIgnoreCase) != 0 || testDirectory.Parent == null)
+            while (string.Compare(testDirectory.Name, CommonParentDirectory, StringComparison.OrdinalIgnoreCase) != 0 || testDirectory.Parent == null)
             {
                 testDirectory = testDirectory.Parent;
             }

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -223,7 +223,7 @@ namespace UnitTests.General
                 if (responsibleSilo.Equals(s))
                     return randomKey;
             }
-            throw new Exception(String.Format("Could not pick a key that silo {0} will be responsible for. Primary.Ring = \n{1}",
+            throw new Exception(string.Format("Could not pick a key that silo {0} will be responsible for. Primary.Ring = \n{1}",
                 responsibleSilo, testHooks.GetConsistentRingProviderDiagnosticInfo().Result));
         }
 

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -213,7 +213,7 @@ namespace UnitTests.General
         private static void AssertIsInRange(int actual, double expected, int leavy)
         {
             Assert.True(expected - leavy <= actual && actual <= expected + leavy,
-                String.Format("Expecting a value in the range between {0} and {1}, but instead got {2} outside the range.",
+                string.Format("Expecting a value in the range between {0} and {1}, but instead got {2} outside the range.",
                     expected - leavy, expected + leavy, actual));
         }
 

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -92,7 +92,7 @@ namespace UnitTests.LivenessTests
 
             Dictionary<SiloAddress, List<int>> queueHistogram = GetQueueHistogram(allAgentRanges, (int)NUM_QUEUES);
             string str = Utils.EnumerableToString(sortedSiloRanges,
-                tuple => String.Format("Silo {0} -> Range {1:0.000}%, {2} queues: {3}", 
+                tuple => string.Format("Silo {0} -> Range {1:0.000}%, {2} queues: {3}", 
                     tuple.Item1,
                     tuple.Item2.RangePercentage(),
                     queueHistogram[tuple.Item1].Sum(),

--- a/test/TesterInternal/OrleansRuntime/Streams/FixedSizeBufferTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/FixedSizeBufferTests.cs
@@ -60,11 +60,11 @@ namespace UnitTests.OrleansRuntime.Streams
             ArraySegment<byte> segment;
             for (int i = 0; i < TestBlockSize; i++)
             {
-                Assert.True(buffer.TryGetSegment(1, out segment), String.Format("Should be able to get {0}th segement of size 1.", i + 1));
+                Assert.True(buffer.TryGetSegment(1, out segment), string.Format("Should be able to get {0}th segement of size 1.", i + 1));
                 Assert.Equal(i, segment.Offset);
                 Assert.Single(segment);
             }
-            Assert.False(buffer.TryGetSegment(1, out segment), String.Format("Should be able to get {0}th segement of size 1.", TestBlockSize + 1));
+            Assert.False(buffer.TryGetSegment(1, out segment), string.Format("Should be able to get {0}th segement of size 1.", TestBlockSize + 1));
             Assert.Null(segment.Array);
             Assert.Equal(0, segment.Offset);
 #pragma warning disable xUnit2013 // Do not use equality check to check for collection size.

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -125,7 +125,7 @@ namespace UnitTests.OrleansRuntime.Streams
                     // if this fails with clean block, then requested size is too big
                     if (!currentBuffer.TryGetSegment(size, out segment))
                     {
-                        string errmsg = String.Format(CultureInfo.InvariantCulture,
+                        string errmsg = string.Format(CultureInfo.InvariantCulture,
                             "Message size is too big. MessageSize: {0}", size);
                         throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                     }

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -184,7 +184,7 @@ namespace UnitTests.StreamingTests
                 throw new ArgumentNullException(nameof(targets));
             if (targets.Length == 0)
                 throw new ArgumentException("caller must specify at least one target");
-            if (String.IsNullOrWhiteSpace(streamProvider))
+            if (string.IsNullOrWhiteSpace(streamProvider))
                 throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
@@ -380,7 +380,7 @@ namespace UnitTests.StreamingTests
         {
             if (targets == null)
                 throw new ArgumentNullException(nameof(targets));
-            if (String.IsNullOrWhiteSpace(streamProvider))
+            if (string.IsNullOrWhiteSpace(streamProvider))
                 throw new ArgumentException("Stream provider name is either null or whitespace", nameof(streamProvider));
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));

--- a/test/TesterInternal/StreamingTests/StreamTestUtils.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestUtils.cs
@@ -81,7 +81,7 @@ namespace UnitTests.StreamingTests
         {
             // expected == -1 means don't care / don't assert check value.
             string prefix = expected == -1 ? "Not-checked" : actual == expected ? "True" : "FALSE";
-            string fmtMsg = String.Format("--> {0}: ", prefix) + String.Format(msg, args);
+            string fmtMsg = string.Format("--> {0}: ", prefix) + string.Format(msg, args);
             output.WriteLine(fmtMsg);
             if (expected != -1)
             {


### PR DESCRIPTION
Use language keywords instead of framework type names for type references.

Supersedes part of https://github.com/dotnet/orleans/pull/8471

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8613)