### PR TITLE
Update state storage to use IActivator<T> instead of Activator.CreateInstance to handle unserializable types

### DIFF
--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -3,12 +3,14 @@ using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Timers;
 using Orleans.Storage;
+using Orleans.Serialization.Serializers;
 
 namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
         private readonly ILoggerFactory loggerFactory;
+        private readonly IActivatorProvider activatorProvider;
         private readonly IServiceProvider serviceProvider;
         private readonly ITimerRegistry timerRegistry;
         private readonly IGrainFactory grainFactory;
@@ -18,7 +20,8 @@ namespace Orleans.Runtime
             IGrainFactory grainFactory,
             ITimerRegistry timerRegistry,
             IServiceProvider serviceProvider,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IActivatorProvider activatorProvider)
         {
             SiloAddress = localSiloDetails.SiloAddress;
             SiloIdentity = SiloAddress.ToString();
@@ -26,6 +29,7 @@ namespace Orleans.Runtime
             this.timerRegistry = timerRegistry;
             this.serviceProvider = serviceProvider;
             this.loggerFactory = loggerFactory;
+            this.activatorProvider = activatorProvider;
         }
 
         public string SiloIdentity { get; }
@@ -81,7 +85,7 @@ namespace Orleans.Runtime
             if (grainContext is null) throw new ArgumentNullException(nameof(grainContext));
             var grainType = grainContext.GrainInstance?.GetType() ?? throw new ArgumentNullException(nameof(IGrainContext.GrainInstance));
             IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(grainType, ServiceProvider);
-            return new StateStorageBridge<TGrainState>("state", grainContext, grainStorage, this.loggerFactory);
+            return new StateStorageBridge<TGrainState>("state", grainContext, grainStorage, this.loggerFactory, this.activatorProvider);
         }
 
         public static void CheckRuntimeContext(IGrainContext context)

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
+using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Storage;
 
@@ -55,7 +56,7 @@ namespace Orleans.Runtime
 
     internal sealed class PersistentState<TState> : StateStorageBridge<TState>, IPersistentState<TState>, ILifecycleObserver
     {
-        public PersistentState(string stateName, IGrainContext context, IGrainStorage storageProvider) : base(stateName, context, storageProvider, context.ActivationServices.GetRequiredService<ILoggerFactory>())
+        public PersistentState(string stateName, IGrainContext context, IGrainStorage storageProvider) : base(stateName, context, storageProvider, context.ActivationServices.GetRequiredService<ILoggerFactory>(), context.ActivationServices.GetRequiredService<IActivatorProvider>())
         {
             var lifecycle = context.ObservableLifecycle;
             lifecycle.Subscribe(RuntimeTypeNameFormatter.Format(GetType()), GrainLifecycleStage.SetupState, this);

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -5,6 +5,8 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Serializers;
 using Orleans.Storage;
 
 namespace Orleans.Core
@@ -21,6 +23,7 @@ namespace Orleans.Core
         private readonly IGrainContext _grainContext;
         private readonly IGrainStorage _store;
         private readonly ILogger _logger;
+        private readonly IActivator<TState> _activator;
         private GrainState<TState>? _grainState;
 
         /// <inheritdoc/>
@@ -39,7 +42,7 @@ namespace Orleans.Core
             }
         }
 
-        private GrainState<TState> GrainState => _grainState ??= new GrainState<TState>(Activator.CreateInstance<TState>());
+        private GrainState<TState> GrainState => _grainState ??= new GrainState<TState>(_activator.Create());
         internal bool IsStateInitialized => _grainState != null;
 
         /// <inheritdoc/>
@@ -48,17 +51,19 @@ namespace Orleans.Core
         /// <inheritdoc/>
         public bool RecordExists => GrainState.RecordExists;
 
-        public StateStorageBridge(string name, IGrainContext grainContext, IGrainStorage store, ILoggerFactory loggerFactory)
+        public StateStorageBridge(string name, IGrainContext grainContext, IGrainStorage store, ILoggerFactory loggerFactory, IActivatorProvider activatorProvider)
         {
             ArgumentNullException.ThrowIfNull(name);
             ArgumentNullException.ThrowIfNull(grainContext);
             ArgumentNullException.ThrowIfNull(store);
             ArgumentNullException.ThrowIfNull(loggerFactory);
+            ArgumentNullException.ThrowIfNull(activatorProvider);
 
             _logger = loggerFactory.CreateLogger(store.GetType());
             _name = name;
             _grainContext = grainContext;
             _store = store;
+            _activator = activatorProvider.GetActivator<TState>();
         }
 
         /// <inheritdoc />
@@ -110,7 +115,7 @@ namespace Orleans.Core
                 sw.Stop();
 
                 // Reset the in-memory copy of the state
-                GrainState.State = Activator.CreateInstance<TState>();
+                GrainState.State = _activator.Create();
 
                 // Update counters
                 StorageInstruments.OnStorageDelete(sw.Elapsed);

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -181,8 +181,8 @@ namespace Orleans.Core
         }
 
         private TState CreateInstance()
-            => _activator is null
-                ? Activator.CreateInstance<TState>()
-                : _activator.Create();
+            => _activator is not null
+                ? _activator.Create()
+                : Activator.CreateInstance<TState>();
     }
 }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -5,10 +5,12 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Serialization.Serializers;
 using Orleans.Storage;
 using Orleans.Streams.Core;
 
@@ -55,7 +57,8 @@ namespace Orleans.Streams
                 storage = _serviceProvider.GetRequiredServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
             }
 
-            return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage, _loggerFactory);
+            var activatorProvider = _serviceProvider.GetRequiredService<IActivatorProvider>();
+            return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage, _loggerFactory, activatorProvider);
         }
     }
 

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Runtime;
+using Orleans.Serialization.Serializers;
 using Orleans.Storage;
 using Orleans.Transactions.Abstractions;
 
@@ -17,17 +18,19 @@ namespace Orleans.Transactions
         private readonly IGrainStorage grainStorage;
         private readonly IGrainContext context;
         private readonly ILoggerFactory loggerFactory;
+        private readonly IActivatorProvider activatorProvider;
         private readonly string stateName;
 
         private StateStorageBridge<TransactionalStateRecord<TState>>? stateStorage;
         [MemberNotNull(nameof(stateStorage))]
         private StateStorageBridge<TransactionalStateRecord<TState>> StateStorage => stateStorage ??= GetStateStorage();
 
-        public TransactionalStateStorageProviderWrapper(IGrainStorage grainStorage, string stateName, IGrainContext context, ILoggerFactory loggerFactory)
+        public TransactionalStateStorageProviderWrapper(IGrainStorage grainStorage, string stateName, IGrainContext context, ILoggerFactory loggerFactory, IActivatorProvider activatorProvider)
         {
             this.grainStorage = grainStorage;
             this.context = context;
             this.loggerFactory = loggerFactory;
+            this.activatorProvider = activatorProvider;
             this.stateName = stateName;
         }
 
@@ -101,7 +104,7 @@ namespace Orleans.Transactions
 
         private StateStorageBridge<TransactionalStateRecord<TState>> GetStateStorage()
         {
-            return new(this.stateName, context, grainStorage, loggerFactory);
+            return new(this.stateName, context, grainStorage, loggerFactory, activatorProvider);
         }
     }
 

--- a/test/Grains/TestGrainInterfaces/IPersistenceTestGrains.cs
+++ b/test/Grains/TestGrainInterfaces/IPersistenceTestGrains.cs
@@ -18,7 +18,6 @@ namespace UnitTests.GrainInterfaces
         Task DoDelete();
     }
 
-
     public interface IPersistenceTestGenericGrain<T> : IPersistenceTestGrain // IGrainWithGuidKey
     { }
     //    Task<bool> CheckStateInit();
@@ -37,7 +36,6 @@ namespace UnitTests.GrainInterfaces
         Task<int> DoRead();
         Task DoDelete();
     }
-    
 
     public interface IGrainStorageTestGrain : IGrainWithGuidKey
     {
@@ -226,6 +224,13 @@ namespace UnitTests.GrainInterfaces
             return i == filterValue;
 
         }
+    }
+
+    public interface ISurrogateStateForTypeWithoutPublicConstructorGrain<T> : IGrainWithGuidKey
+        where T : class
+    {
+        Task SetState(T state);
+        Task<T> GetState();
     }
 }
 // ReSharper restore InconsistentNaming

--- a/test/Grains/TestGrainInterfaces/IPersistenceTestGrains.cs
+++ b/test/Grains/TestGrainInterfaces/IPersistenceTestGrains.cs
@@ -232,5 +232,12 @@ namespace UnitTests.GrainInterfaces
         Task SetState(T state);
         Task<T> GetState();
     }
+
+    public interface IRecordTypeWithoutPublicParameterlessConstructorGrain<T> : IGrainWithGuidKey
+        where T : class
+    {
+        Task SetState(T state);
+        Task<T> GetState();
+    }
 }
 // ReSharper restore InconsistentNaming

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -1145,4 +1145,38 @@ namespace UnitTests.Grains
                 Field = value.Field,
             };
     }
+    
+
+    public sealed class RecordTypeWithoutPublicParameterlessConstructorGrain : IGrainBase, IRecordTypeWithoutPublicParameterlessConstructorGrain<RecordTypeWithoutPublicParameterlessConstructor>
+    {
+        private readonly IPersistentState<RecordTypeWithoutPublicParameterlessConstructor> _persistence;
+
+        public IGrainContext GrainContext { get; }
+
+        public RecordTypeWithoutPublicParameterlessConstructorGrain(
+            IGrainContext grainContext,
+            [PersistentState("test_state", "OrleansSerializerMemoryStore")] IPersistentState<RecordTypeWithoutPublicParameterlessConstructor> persistence)
+        {
+            GrainContext = grainContext;
+            _persistence = persistence;
+        }
+
+        public async Task SetState(RecordTypeWithoutPublicParameterlessConstructor state)
+        {
+            _persistence.State = state;
+            await _persistence.WriteStateAsync();
+        }
+
+        public async Task<RecordTypeWithoutPublicParameterlessConstructor> GetState()
+        {
+            await _persistence.ReadStateAsync();
+            return _persistence.State;
+        }
+    }
+
+    [GenerateSerializer]
+    public record class RecordTypeWithoutPublicParameterlessConstructor
+    (
+        [property: Id(0)] int Field
+    );
 }

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -1086,4 +1086,63 @@ namespace UnitTests.Grains
             return WriteStateAsync();
         }
     }
+
+    public sealed class SurrogateStateForTypeWithoutPublicConstructorGrain : IGrainBase, ISurrogateStateForTypeWithoutPublicConstructorGrain<ExternalTypeWithoutPublicConstructor>
+    {
+        private readonly IPersistentState<ExternalTypeWithoutPublicConstructor> _persistence;
+
+        public IGrainContext GrainContext { get; }
+
+        public SurrogateStateForTypeWithoutPublicConstructorGrain(
+            IGrainContext grainContext,
+            [PersistentState("test_state", "OrleansSerializerMemoryStore")] IPersistentState<ExternalTypeWithoutPublicConstructor> persistence)
+        {
+            GrainContext = grainContext;
+            _persistence = persistence;
+        }
+
+        public async Task SetState(ExternalTypeWithoutPublicConstructor state)
+        {
+            _persistence.State = state;
+            await _persistence.WriteStateAsync();
+        }
+
+        public async Task<ExternalTypeWithoutPublicConstructor> GetState()
+        {
+            await _persistence.ReadStateAsync();
+            return _persistence.State;
+        }
+    }
+
+    public sealed class ExternalTypeWithoutPublicConstructor
+    {
+        public int Field { get; set; }
+
+        public static ExternalTypeWithoutPublicConstructor Create(int field)
+            => new(field);
+
+        private ExternalTypeWithoutPublicConstructor(int field)
+        {
+            Field = field;
+        }
+    }
+
+    [GenerateSerializer]
+    public struct ExternalTypeWithoutPublicConstructorSurrogate
+    {
+        [Id(0)] public int Field;
+    }
+
+    [RegisterConverter]
+    public sealed class ExternalTypeWithoutPublicConstructorSurrogateConverter : IConverter<ExternalTypeWithoutPublicConstructor, ExternalTypeWithoutPublicConstructorSurrogate>
+    {
+        public ExternalTypeWithoutPublicConstructor ConvertFromSurrogate(in ExternalTypeWithoutPublicConstructorSurrogate surrogate)
+            => ExternalTypeWithoutPublicConstructor.Create(surrogate.Field);
+
+        public ExternalTypeWithoutPublicConstructorSurrogate ConvertToSurrogate(in ExternalTypeWithoutPublicConstructor value)
+            => new()
+            {
+                Field = value.Field,
+            };
+    }
 }

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -1198,6 +1198,19 @@ namespace UnitTests.StorageTests
             Assert.Equal(1, val.Field);
         }
 
+        [Fact, TestCategory("Functional"), TestCategory("Persistence")]
+        public async Task Persistence_RecordTypeWithoutPublicParameterlessConstructor_Read()
+        {
+            IRecordTypeWithoutPublicParameterlessConstructorGrain<RecordTypeWithoutPublicParameterlessConstructor> grain = HostedCluster.GrainFactory
+                .GetGrain<IRecordTypeWithoutPublicParameterlessConstructorGrain<RecordTypeWithoutPublicParameterlessConstructor>>(Guid.NewGuid());
+            RecordTypeWithoutPublicParameterlessConstructor instance = new RecordTypeWithoutPublicParameterlessConstructor(1);
+
+            await grain.SetState(instance);
+            RecordTypeWithoutPublicParameterlessConstructor val = await grain.GetState();
+
+            Assert.Equal(1, val.Field);
+        }
+
         // ---------- Utility functions ----------
         private void SetStoredValue(string providerName, string providerTypeFullName, string grainType, IGrain grain, string fieldName, int newValue)
         {

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -12,6 +12,8 @@ using TesterInternal;
 using TestExtensions;
 using Orleans.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 // ReSharper disable RedundantAssignment
 // ReSharper disable UnusedVariable
@@ -42,6 +44,10 @@ namespace UnitTests.StorageTests
                     hostBuilder.AddTestStorageProvider(MockStorageProviderName2, (sp, name) => ActivatorUtilities.CreateInstance<MockStorageProvider>(sp, name));
                     hostBuilder.AddTestStorageProvider(MockStorageProviderNameLowerCase, (sp, name) => ActivatorUtilities.CreateInstance<MockStorageProvider>(sp, name));
                     hostBuilder.AddTestStorageProvider(ErrorInjectorProviderName, (sp, name) => ActivatorUtilities.CreateInstance<ErrorInjectionStorageProvider>(sp));
+
+                    hostBuilder.Services.AddSingleton<OrleansGrainStorageSerializer>();
+                    hostBuilder.AddMemoryGrainStorage("OrleansSerializerMemoryStore", (OptionsBuilder<MemoryGrainStorageOptions> optionsBuilder) =>
+                        optionsBuilder.Configure<OrleansGrainStorageSerializer>((options, serializer) => options.GrainStorageSerializer = serializer));
                 }
             }
         }
@@ -158,7 +164,7 @@ namespace UnitTests.StorageTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Generics")]
-        public async Task Persistence_Grain_Activate_StoredValue_Generic() 
+        public async Task Persistence_Grain_Activate_StoredValue_Generic()
         {
             const string providerName = MockStorageProviderName1;
             Guid guid = Guid.NewGuid();
@@ -248,7 +254,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
             Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
             SetStoredValue(providerName, typeof(MockStorageProvider).FullName, DefaultGrainStateName, grain, "Field1", 42);
-            
+
             await grain.DoRead();
             providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
             Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
@@ -256,7 +262,7 @@ namespace UnitTests.StorageTests
 
             Assert.Equal(42, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
-        
+
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MemoryStore")]
         public async Task MemoryStore_Read_Write()
         {
@@ -620,7 +626,7 @@ namespace UnitTests.StorageTests
 
             Assert.Equal(expectedVal, val); // Returned value
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
-            
+
             await CheckStorageProviderErrors(grain.DoRead);
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.None);
@@ -749,7 +755,7 @@ namespace UnitTests.StorageTests
         {
             var target = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(Guid.NewGuid());
             var proxy = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorProxyGrain>(Guid.NewGuid());
-            
+
             // Record the original activation ids.
             var targetActivationId = await target.GetActivationId();
             var proxyActivationId = await proxy.GetActivationId();
@@ -1179,6 +1185,19 @@ namespace UnitTests.StorageTests
             Assert.Equal(1, val);
         }
 
+        [Fact, TestCategory("Functional"), TestCategory("Persistence")]
+        public async Task SurrogatePersistence_TypeWithoutPublicConstructor_Read()
+        {
+            ISurrogateStateForTypeWithoutPublicConstructorGrain<ExternalTypeWithoutPublicConstructor> grain = HostedCluster.GrainFactory
+                .GetGrain<ISurrogateStateForTypeWithoutPublicConstructorGrain<ExternalTypeWithoutPublicConstructor>>(Guid.NewGuid());
+            ExternalTypeWithoutPublicConstructor instance = ExternalTypeWithoutPublicConstructor.Create(1);
+
+            await grain.SetState(instance);
+
+            ExternalTypeWithoutPublicConstructor val = await grain.GetState();
+            Assert.Equal(1, val.Field);
+        }
+
         // ---------- Utility functions ----------
         private void SetStoredValue(string providerName, string providerTypeFullName, string grainType, IGrain grain, string fieldName, int newValue)
         {
@@ -1273,7 +1292,7 @@ namespace UnitTests.StorageTests
                     return providerState;
                 }
             }
-            
+
             return providerState;
         }
 

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -1193,8 +1193,8 @@ namespace UnitTests.StorageTests
             ExternalTypeWithoutPublicConstructor instance = ExternalTypeWithoutPublicConstructor.Create(1);
 
             await grain.SetState(instance);
-
             ExternalTypeWithoutPublicConstructor val = await grain.GetState();
+
             Assert.Equal(1, val.Field);
         }
 


### PR DESCRIPTION
Fixes: #8625

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8626)