### PR TITLE
feat(streaming): add telemetry tags to stream metrics

### DIFF
--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -11,6 +11,7 @@ using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
+using Orleans.Streaming;
 using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 using Orleans.Streams.Filtering;
 
@@ -483,6 +484,8 @@ namespace Orleans.Streams
             }
 
             var now = _timeProvider.GetUtcNow().UtcDateTime;
+            System.Diagnostics.TagList? tags = null;
+
             // Try to cleanup the pubsub cache at the cadence of 10 times in the configurable StreamInactivityPeriod.
             if ((now - lastTimeCleanedPubSubCache) >= this.options.StreamInactivityPeriod.Divide(StreamInactivityCheckFrequency))
             {
@@ -535,7 +538,11 @@ namespace Orleans.Streams
 
             queueCache?.AddToCache(multiBatch);
             numMessages += multiBatch.Count;
-            _streamInstruments?.PersistentStreamReadMessages.Add(multiBatch.Count);
+            if (_streamInstruments?.PersistentStreamReadMessages.Enabled is true)
+            {
+                tags = StreamInstrumentsTagUtils.InitializeTags(myQueueId, streamProviderName);
+                _streamInstruments.PersistentStreamReadMessages.Add(multiBatch.Count, tags.Value);
+            }
 
             LogTraceGotMessages(multiBatch.Count, new(myQueueId), numMessages);
 
@@ -767,6 +774,7 @@ namespace Orleans.Streams
 
         private async Task RunConsumerCursor(StreamConsumerData consumerData)
         {
+            System.Diagnostics.TagList? tags = null;
             try
             {
                 // double check in case of interleaving
@@ -811,7 +819,13 @@ namespace Orleans.Streams
 
                     try
                     {
-                        _streamInstruments?.PersistentStreamSentMessages.Add(1);
+                        if (_streamInstruments?.PersistentStreamSentMessages.Enabled is true)
+                        {
+                            tags ??= StreamInstrumentsTagUtils.InitializeTags(
+                                consumerData.StreamId, consumerData.SubscriptionId);
+                            _streamInstruments.PersistentStreamSentMessages.Add(1, tags.Value);
+                        }
+
                         if (IsShutdown)
                         {
                             break;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -14,6 +14,7 @@ using Orleans.Runtime.Scheduler;
 using Orleans.Streaming;
 using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 using Orleans.Streams.Filtering;
+using TagList = System.Diagnostics.TagList;
 
 namespace Orleans.Streams
 {
@@ -478,13 +479,13 @@ namespace Orleans.Streams
         /// <returns></returns>
         private async Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver? rcvr, int maxCacheAddCount, CancellationToken cancellationToken)
         {
-            if (rcvr == null || IsShutdown || cancellationToken.IsCancellationRequested)
+            if (rcvr is null || IsShutdown || cancellationToken.IsCancellationRequested)
             {
                 return false;
             }
 
             var now = _timeProvider.GetUtcNow().UtcDateTime;
-            System.Diagnostics.TagList? tags = null;
+            TagList? tags = null;
 
             // Try to cleanup the pubsub cache at the cadence of 10 times in the configurable StreamInactivityPeriod.
             if ((now - lastTimeCleanedPubSubCache) >= this.options.StreamInactivityPeriod.Divide(StreamInactivityCheckFrequency))
@@ -498,7 +499,7 @@ namespace Orleans.Streams
                 return false;
             }
 
-            if (queueCache != null)
+            if (queueCache is not null)
             {
                 if (queueCache.TryPurgeFromCache(out var purgedItems))
                 {
@@ -518,7 +519,7 @@ namespace Orleans.Streams
                 return false;
             }
 
-            if (queueCache != null && queueCache.IsUnderPressure())
+            if (queueCache is not null && queueCache.IsUnderPressure())
             {
                 // Under back pressure. Exit the loop. Will attempt again in the next timer callback.
                 LogInfoStreamCacheUnderPressure();
@@ -548,7 +549,7 @@ namespace Orleans.Streams
 
             foreach (var group in
                 multiBatch
-                .Where(m => m != null)
+                .Where(m => m is not null)
                 .GroupBy(container => container.StreamId))
             {
                 if (IsShutdown || cancellationToken.IsCancellationRequested)
@@ -774,16 +775,16 @@ namespace Orleans.Streams
 
         private async Task RunConsumerCursor(StreamConsumerData consumerData)
         {
-            System.Diagnostics.TagList? tags = null;
+            TagList? tags = null;
             try
             {
                 // double check in case of interleaving
                 if (consumerData.State == StreamConsumerDataState.Active ||
-                    consumerData.Cursor == null) return;
+                    consumerData.Cursor is null) return;
 
                 consumerData.State = StreamConsumerDataState.Active;
                 var deliveredAny = false;
-                while (!IsShutdown && consumerData.Cursor != null)
+                while (!IsShutdown && consumerData.Cursor is not null)
                 {
                     ConsumerBatch nextBatch = default;
                     Exception? exceptionOccured = null;
@@ -831,7 +832,7 @@ namespace Orleans.Streams
                             break;
                         }
 
-                        if (nextBatch.Batch != null)
+                        if (nextBatch.Batch is not null)
                         {
                             var batch = nextBatch.Batch;
                             StreamHandshakeToken? newToken = await AsyncExecutorWithRetries.ExecuteWithRetries(
@@ -841,8 +842,7 @@ namespace Orleans.Streams
                                 (exception, i) => exception is not ClientNotAvailableException && !IsShutdown,
                                 this.options.MaxEventDeliveryTime,
                                 deliveryBackoffProvider);
-
-                            if (newToken != null)
+                            if (newToken is not null)
                             {
                                 consumerData.LastProcessedToken = newToken.Token;
                                 consumerData.LastToken = newToken;
@@ -870,7 +870,7 @@ namespace Orleans.Streams
                             : new StreamEventDeliveryFailureException(consumerData.StreamId);
                     }
                     // if we failed to deliver a batch
-                    if (exceptionOccured != null)
+                    if (exceptionOccured is not null)
                     {
                         var batch = nextBatch.Batch;
                         bool faultedSubscription = await ErrorProtocol(consumerData, exceptionOccured, true, batch, batch?.SequenceToken);

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -822,7 +822,7 @@ namespace Orleans.Streams
                         if (_streamInstruments?.PersistentStreamSentMessages.Enabled is true)
                         {
                             tags ??= StreamInstrumentsTagUtils.InitializeTags(
-                                consumerData.StreamId, consumerData.SubscriptionId);
+                                consumerData.StreamId, consumerData.StreamConsumer.GetGrainId());
                             _streamInstruments.PersistentStreamSentMessages.Add(1, tags.Value);
                         }
 

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -262,12 +262,7 @@ namespace Orleans.Streams
                 if (State.Producers.Count != initialProducerCount)
                 {
                     await WriteStateAsync();
-                    if (_streamInstruments.PubSubConsumersTotal.Enabled)
-                    {
-                        tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, streamConsumer);
-                        _streamInstruments.PubSubConsumersTotal.Add(
-                            -(initialProducerCount - State.Producers.Count), tags.Value);
-                    }
+                    RecordRemovedProducers(producers);
                 }
 
                 if (exception is not null)
@@ -294,6 +289,23 @@ namespace Orleans.Streams
             LogWarningProducerIsDead(producer, producer.Stream);
 
             State.Producers.Remove(producer);
+        }
+
+        private void RecordRemovedProducers(IEnumerable<PubSubPublisherState> producers)
+        {
+            if (!_streamInstruments.PubSubProducersTotal.Enabled)
+            {
+                return;
+            }
+
+            foreach (var producer in producers)
+            {
+                if (!State.Producers.Contains(producer))
+                {
+                    var tags = StreamInstrumentsTagUtils.InitializeTags(producer.Stream, producer.Producer);
+                    _streamInstruments.PubSubProducersTotal.Add(-1, tags);
+                }
+            }
         }
 
         public async Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
@@ -476,13 +488,17 @@ namespace Orleans.Streams
                 LogDebugNotifyProducersOfRemovedConsumer(numProducersBeforeNotify);
 
                 // Notify producers about unregistered consumer.
-                List<Task> tasks = State.Producers
+                var producers = State.Producers.ToList();
+                List<Task> tasks = producers
                     .Select(producerState => ExecuteProducerTask(producerState, p => p.RemoveSubscriber(subscriptionId, streamId)))
                     .ToList();
                 await Task.WhenAll(tasks);
                 //if producers got removed
                 if (State.Producers.Count < numProducersBeforeNotify)
+                {
                     await WriteStateAsync();
+                    RecordRemovedProducers(producers);
+                }
             }
         }
 

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text;

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -45,7 +45,7 @@ namespace Orleans.Streams
             LogDebugTryingToFindStorageProvider(providerName);
 
             var storage = _serviceProvider.GetKeyedService<IGrainStorage>(providerName);
-            if (storage == null)
+            if (storage is null)
             {
                 LogDebugFallbackToStorageProvider(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
 
@@ -204,11 +204,11 @@ namespace Orleans.Streams
                 _streamInstruments.PubSubConsumersAdded.Add(1, tags.Value);
             }
             var pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
-            if (pubSubState != null && pubSubState.IsFaulted)
+            if (pubSubState is not null && pubSubState.IsFaulted)
                 throw new FaultedSubscriptionException(subscriptionId, streamId);
             try
             {
-                if (pubSubState == null)
+                if (pubSubState is null)
                 {
                     pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer);
                     State.Consumers.Add(pubSubState);
@@ -275,7 +275,7 @@ namespace Orleans.Streams
                     }
                 }
 
-                if (exception != null)
+                if (exception is not null)
                 {
                     ExceptionDispatchInfo.Capture(exception).Throw();
                 }

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -12,8 +13,10 @@ using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Serialization.Serializers;
 using Orleans.Storage;
+using Orleans.Streaming;
 using Orleans.Streams.Core;
 using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
+using TagList = System.Diagnostics.TagList;
 
 namespace Orleans.Streams
 {
@@ -46,7 +49,8 @@ namespace Orleans.Streams
             {
                 LogDebugFallbackToStorageProvider(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
 
-                storage = _serviceProvider.GetRequiredKeyedService<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
+                storage = _serviceProvider.GetRequiredKeyedService<IGrainStorage>(
+                    ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
             }
 
             return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage);
@@ -69,8 +73,8 @@ namespace Orleans.Streams
     [GenerateSerializer]
     internal sealed class PubSubGrainState
     {
-        [Id(0)]
-        public HashSet<PubSubPublisherState> Producers { get; set; } = new HashSet<PubSubPublisherState>();
+        [Id(0)] public HashSet<PubSubPublisherState> Producers { get; set; } = new HashSet<PubSubPublisherState>();
+
         [Id(1)]
         public HashSet<PubSubSubscriptionState> Consumers { get; set; } = new HashSet<PubSubSubscriptionState>();
     }
@@ -107,9 +111,16 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId,
+            GrainId streamProducer)
         {
-            _streamInstruments.PubSubProducersAdded.Add(1);
+            TagList? tags = null;
+
+            if (_streamInstruments.PubSubProducersAdded.Enabled)
+            {
+                tags = StreamInstrumentsTagUtils.InitializeTags(streamId, streamProducer);
+                _streamInstruments.PubSubProducersAdded.Add(1, tags.Value);
+            }
 
             try
             {
@@ -118,7 +129,11 @@ namespace Orleans.Streams
                 LogPubSubCounts("RegisterProducer {0}", streamProducer);
                 await WriteStateAsync();
                 StreamingEvents.EmitProducerRegistered(streamId.ProviderName, streamId.StreamId, streamProducer, GrainContext.Address.SiloAddress);
-                _streamInstruments.PubSubProducersTotal.Add(1);
+                if (_streamInstruments.PubSubProducersTotal.Enabled)
+                {
+                    tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, streamProducer);
+                    _streamInstruments.PubSubProducersTotal.Add(1, tags.Value);
+                }
             }
             catch (Exception exc)
             {
@@ -134,7 +149,13 @@ namespace Orleans.Streams
 
         public async Task UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
         {
-            _streamInstruments.PubSubProducersRemoved.Add(1);
+            TagList? tags = null;
+
+            if (_streamInstruments.PubSubProducersRemoved.Enabled)
+            {
+                tags = StreamInstrumentsTagUtils.InitializeTags(streamId, streamProducer);
+                _streamInstruments.PubSubProducersRemoved.Add(1, tags.Value);
+            }
             try
             {
                 int numRemoved = State.Producers.RemoveWhere(s => s.Equals(streamId, streamProducer));
@@ -148,7 +169,11 @@ namespace Orleans.Streams
                     await updateStorageTask;
                     StreamingEvents.EmitProducerUnregistered(streamId.ProviderName, streamId.StreamId, streamProducer, GrainContext.Address.SiloAddress);
                 }
-                _streamInstruments.PubSubProducersTotal.Add(-numRemoved);
+                if (_streamInstruments.PubSubProducersTotal.Enabled)
+                {
+                    tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, streamProducer);
+                    _streamInstruments.PubSubProducersTotal.Add(-numRemoved, tags.Value);
+                }
             }
             catch (Exception exc)
             {
@@ -158,6 +183,7 @@ namespace Orleans.Streams
                 DeactivateOnIdle();
                 throw;
             }
+
             if (State.Producers.Count == 0 && State.Consumers.Count == 0)
             {
                 DeactivateOnIdle(); // No producers or consumers left now, so flag ourselves to expedite Deactivation
@@ -170,7 +196,13 @@ namespace Orleans.Streams
             GrainId streamConsumer,
             string? filterData)
         {
-            _streamInstruments.PubSubConsumersAdded.Add(1);
+            TagList? tags = null;
+
+            if (_streamInstruments.PubSubConsumersAdded.Enabled)
+            {
+                tags = StreamInstrumentsTagUtils.InitializeTags(streamId, streamConsumer);
+                _streamInstruments.PubSubConsumersAdded.Add(1, tags.Value);
+            }
             var pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
             if (pubSubState != null && pubSubState.IsFaulted)
                 throw new FaultedSubscriptionException(subscriptionId, streamId);
@@ -188,7 +220,11 @@ namespace Orleans.Streams
                 LogPubSubCounts("RegisterConsumer {0}", streamConsumer);
                 await WriteStateAsync();
                 StreamingEvents.EmitSubscriptionRegistered(streamId.ProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, GrainContext.Address.SiloAddress);
-                _streamInstruments.PubSubConsumersTotal.Add(1);
+                if (_streamInstruments.PubSubConsumersTotal.Enabled)
+                {
+                    tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, streamConsumer);
+                    _streamInstruments.PubSubConsumersTotal.Add(1, tags.Value);
+                }
             }
             catch (Exception exc)
             {
@@ -213,7 +249,8 @@ namespace Orleans.Streams
             {
                 foreach (PubSubPublisherState producerState in producers)
                 {
-                    tasks.Add(ExecuteProducerTask(producerState, p => p.AddSubscriber(subscriptionId, streamId, streamConsumer, filterData)));
+                    tasks.Add(ExecuteProducerTask(producerState,
+                        p => p.AddSubscriber(subscriptionId, streamId, streamConsumer, filterData)));
                 }
 
                 Exception? exception = null;
@@ -230,7 +267,12 @@ namespace Orleans.Streams
                 if (State.Producers.Count != initialProducerCount)
                 {
                     await WriteStateAsync();
-                    _streamInstruments.PubSubConsumersTotal.Add(-(initialProducerCount - State.Producers.Count));
+                    if (_streamInstruments.PubSubConsumersTotal.Enabled)
+                    {
+                        tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, streamConsumer);
+                        _streamInstruments.PubSubConsumersTotal.Add(
+                            -(initialProducerCount - State.Producers.Count), tags.Value);
+                    }
                 }
 
                 if (exception != null)
@@ -261,7 +303,13 @@ namespace Orleans.Streams
 
         public async Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
-            _streamInstruments.PubSubConsumersRemoved.Add(1);
+            TagList? tags = null;
+
+            if (_streamInstruments.PubSubConsumersRemoved.Enabled)
+            {
+                tags = StreamInstrumentsTagUtils.InitializeTags(streamId, subscriptionId);
+                _streamInstruments.PubSubConsumersRemoved.Add(1, tags.Value);
+            }
 
             try
             {
@@ -281,9 +329,14 @@ namespace Orleans.Streams
                         await WriteStateAsync();
                         StreamingEvents.EmitSubscriptionUnregistered(streamId.ProviderName, streamId.StreamId, subscriptionId.Guid, GrainContext.Address.SiloAddress);
                     }
+
                     await NotifyProducersOfRemovedSubscription(subscriptionId, streamId);
                 }
-                _streamInstruments.PubSubConsumersTotal.Add(-numRemoved);
+                if (_streamInstruments.PubSubConsumersTotal.Enabled)
+                {
+                    tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, subscriptionId);
+                    _streamInstruments.PubSubConsumersTotal.Add(-numRemoved, tags.Value);
+                }
             }
             catch (Exception exc)
             {
@@ -327,8 +380,10 @@ namespace Orleans.Streams
                     numConsumers = State.Consumers.Count;
 
                 string when = args != null && args.Length != 0 ? string.Format(fmt, args) : fmt;
-                _logger.LogDebug("{When}. Now have total of {ProducerCount} producers and {ConsumerCount} consumers. All Consumers = {Consumers}, All Producers = {Producers}",
-                    when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers), Utils.EnumerableToString(State?.Producers));
+                _logger.LogDebug(
+                    "{When}. Now have total of {ProducerCount} producers and {ConsumerCount} consumers. All Consumers = {Consumers}, All Producers = {Producers}",
+                    when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers),
+                    Utils.EnumerableToString(State?.Producers));
             }
         }
 
@@ -388,7 +443,6 @@ namespace Orleans.Streams
                                     c.Consumer)).ToList();
                 return Task.FromResult(subscriptions);
             }
-
         }
 
         public async Task FaultSubscription(GuidId subscriptionId)
@@ -398,6 +452,7 @@ namespace Orleans.Streams
             {
                 return;
             }
+
             try
             {
                 pubSubState.Fault();
@@ -425,7 +480,8 @@ namespace Orleans.Streams
 
                 // Notify producers about unregistered consumer.
                 List<Task> tasks = State.Producers
-                    .Select(producerState => ExecuteProducerTask(producerState, p => p.RemoveSubscriber(subscriptionId, streamId)))
+                    .Select(producerState =>
+                        ExecuteProducerTask(producerState, p => p.RemoveSubscriber(subscriptionId, streamId)))
                     .ToList();
                 await Task.WhenAll(tasks);
                 //if producers got removed
@@ -440,15 +496,18 @@ namespace Orleans.Streams
         /// <returns></returns>
         private async Task<bool> TryClearState()
         {
-            if (State.Producers.Count == 0 && State.Consumers.Count == 0) // + we already know that numProducers == 0 from previous if-clause
+            if (State.Producers.Count == 0 &&
+                State.Consumers.Count == 0) // + we already know that numProducers == 0 from previous if-clause
             {
                 await ClearStateAsync(); //State contains no producers or consumers, remove it from storage
                 return true;
             }
+
             return false;
         }
 
-        private async Task ExecuteProducerTask(PubSubPublisherState producer, Func<IStreamProducerExtension, Task> producerTask)
+        private async Task ExecuteProducerTask(PubSubPublisherState producer,
+            Func<IStreamProducerExtension, Task> producerTask)
         {
             try
             {

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -49,8 +49,7 @@ namespace Orleans.Streams
             {
                 LogDebugFallbackToStorageProvider(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
 
-                storage = _serviceProvider.GetRequiredKeyedService<IGrainStorage>(
-                    ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
+                storage = _serviceProvider.GetRequiredKeyedService<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
             }
 
             return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage);
@@ -73,8 +72,8 @@ namespace Orleans.Streams
     [GenerateSerializer]
     internal sealed class PubSubGrainState
     {
-        [Id(0)] public HashSet<PubSubPublisherState> Producers { get; set; } = new HashSet<PubSubPublisherState>();
-
+        [Id(0)]
+        public HashSet<PubSubPublisherState> Producers { get; set; } = new HashSet<PubSubPublisherState>();
         [Id(1)]
         public HashSet<PubSubSubscriptionState> Consumers { get; set; } = new HashSet<PubSubSubscriptionState>();
     }
@@ -111,8 +110,7 @@ namespace Orleans.Streams
             return Task.CompletedTask;
         }
 
-        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId,
-            GrainId streamProducer)
+        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
         {
             TagList? tags = null;
 
@@ -183,7 +181,6 @@ namespace Orleans.Streams
                 DeactivateOnIdle();
                 throw;
             }
-
             if (State.Producers.Count == 0 && State.Consumers.Count == 0)
             {
                 DeactivateOnIdle(); // No producers or consumers left now, so flag ourselves to expedite Deactivation
@@ -249,8 +246,7 @@ namespace Orleans.Streams
             {
                 foreach (PubSubPublisherState producerState in producers)
                 {
-                    tasks.Add(ExecuteProducerTask(producerState,
-                        p => p.AddSubscriber(subscriptionId, streamId, streamConsumer, filterData)));
+                    tasks.Add(ExecuteProducerTask(producerState, p => p.AddSubscriber(subscriptionId, streamId, streamConsumer, filterData)));
                 }
 
                 Exception? exception = null;
@@ -332,7 +328,6 @@ namespace Orleans.Streams
                         await WriteStateAsync();
                         StreamingEvents.EmitSubscriptionUnregistered(streamId.ProviderName, streamId.StreamId, subscriptionId.Guid, GrainContext.Address.SiloAddress);
                     }
-
                     await NotifyProducersOfRemovedSubscription(subscriptionId, streamId);
                 }
                 if (_streamInstruments.PubSubConsumersTotal.Enabled)
@@ -385,10 +380,8 @@ namespace Orleans.Streams
                     numConsumers = State.Consumers.Count;
 
                 string when = args != null && args.Length != 0 ? string.Format(fmt, args) : fmt;
-                _logger.LogDebug(
-                    "{When}. Now have total of {ProducerCount} producers and {ConsumerCount} consumers. All Consumers = {Consumers}, All Producers = {Producers}",
-                    when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers),
-                    Utils.EnumerableToString(State?.Producers));
+                _logger.LogDebug("{When}. Now have total of {ProducerCount} producers and {ConsumerCount} consumers. All Consumers = {Consumers}, All Producers = {Producers}",
+                    when, numProducers, numConsumers, Utils.EnumerableToString(State?.Consumers), Utils.EnumerableToString(State?.Producers));
             }
         }
 
@@ -448,6 +441,7 @@ namespace Orleans.Streams
                                     c.Consumer)).ToList();
                 return Task.FromResult(subscriptions);
             }
+
         }
 
         public async Task FaultSubscription(GuidId subscriptionId)
@@ -457,7 +451,6 @@ namespace Orleans.Streams
             {
                 return;
             }
-
             try
             {
                 pubSubState.Fault();
@@ -485,8 +478,7 @@ namespace Orleans.Streams
 
                 // Notify producers about unregistered consumer.
                 List<Task> tasks = State.Producers
-                    .Select(producerState =>
-                        ExecuteProducerTask(producerState, p => p.RemoveSubscriber(subscriptionId, streamId)))
+                    .Select(producerState => ExecuteProducerTask(producerState, p => p.RemoveSubscriber(subscriptionId, streamId)))
                     .ToList();
                 await Task.WhenAll(tasks);
                 //if producers got removed
@@ -501,18 +493,15 @@ namespace Orleans.Streams
         /// <returns></returns>
         private async Task<bool> TryClearState()
         {
-            if (State.Producers.Count == 0 &&
-                State.Consumers.Count == 0) // + we already know that numProducers == 0 from previous if-clause
+            if (State.Producers.Count == 0 && State.Consumers.Count == 0) // + we already know that numProducers == 0 from previous if-clause
             {
                 await ClearStateAsync(); //State contains no producers or consumers, remove it from storage
                 return true;
             }
-
             return false;
         }
 
-        private async Task ExecuteProducerTask(PubSubPublisherState producer,
-            Func<IStreamProducerExtension, Task> producerTask)
+        private async Task ExecuteProducerTask(PubSubPublisherState producer, Func<IStreamProducerExtension, Task> producerTask)
         {
             try
             {

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -303,11 +303,14 @@ namespace Orleans.Streams
 
         public async Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
+            var consumerState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
             TagList? tags = null;
 
             if (_streamInstruments.PubSubConsumersRemoved.Enabled)
             {
-                tags = StreamInstrumentsTagUtils.InitializeTags(streamId, subscriptionId);
+                tags = consumerState is not null
+                    ? StreamInstrumentsTagUtils.InitializeTags(streamId, consumerState.Consumer)
+                    : StreamInstrumentsTagUtils.InitializeTags(streamId);
                 _streamInstruments.PubSubConsumersRemoved.Add(1, tags.Value);
             }
 
@@ -334,7 +337,9 @@ namespace Orleans.Streams
                 }
                 if (_streamInstruments.PubSubConsumersTotal.Enabled)
                 {
-                    tags ??= StreamInstrumentsTagUtils.InitializeTags(streamId, subscriptionId);
+                    tags ??= consumerState is not null
+                        ? StreamInstrumentsTagUtils.InitializeTags(streamId, consumerState.Consumer)
+                        : StreamInstrumentsTagUtils.InitializeTags(streamId);
                     _streamInstruments.PubSubConsumersTotal.Add(-numRemoved, tags.Value);
                 }
             }

--- a/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
+++ b/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
@@ -5,7 +5,7 @@ using TagList = System.Diagnostics.TagList;
 
 namespace Orleans.Streaming;
 
-internal static class TelemetryUtils
+internal static class StreamInstrumentsTagUtils
 {
     private const string STREAM_KEY = "stream";
     private const string STREAM_NAMESPACE = "namespace";

--- a/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
+++ b/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.CompilerServices;
+using Orleans.Runtime;
+using Orleans.Streams;
+using TagList = System.Diagnostics.TagList;
+
+namespace Orleans.Streaming;
+
+internal static class TelemetryUtils
+{
+    private const string STREAM_KEY = "stream";
+    private const string STREAM_NAMESPACE = "namespace";
+    private const string STREAM_PROVIDER_NAME = "provider";
+    private const string STREAM_PRODUCER = "producer";
+    private const string SUBSCRIPTION_ID = "subscription";
+    private const string QUEUE_ID = "queue";
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TagList InitializeTags(QualifiedStreamId streamId, GrainId streamProducer) =>
+        new()
+        {
+            { STREAM_PROVIDER_NAME, streamId.ProviderName },
+            { STREAM_KEY, streamId.StreamId.GetKeyAsString() },
+            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() },
+            { STREAM_PRODUCER, streamProducer.ToString() }
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TagList InitializeTags(QualifiedStreamId streamId, GuidId subscriptionId) =>
+        new()
+        {
+            { SUBSCRIPTION_ID, subscriptionId.Guid },
+            { STREAM_KEY, streamId.StreamId.GetKeyAsString() },
+            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() }
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static TagList InitializeTags(QueueId queueId, string streamProviderName) =>
+        new()
+        {
+            { QUEUE_ID, queueId.ToStringWithHashCode() },
+            { STREAM_PROVIDER_NAME, streamProviderName }
+        };
+}

--- a/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
+++ b/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
@@ -7,37 +7,34 @@ namespace Orleans.Streaming;
 
 internal static class StreamInstrumentsTagUtils
 {
-    private const string STREAM_KEY = "stream";
     private const string STREAM_NAMESPACE = "namespace";
     private const string STREAM_PROVIDER_NAME = "provider";
-    private const string STREAM_PRODUCER = "producer";
-    private const string SUBSCRIPTION_ID = "subscription";
+    private const string GRAIN_TYPE = "grain_type";
     private const string QUEUE_ID = "queue";
+    private const string UNKNOWN_GRAIN_TYPE = "unknown";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static TagList InitializeTags(QualifiedStreamId streamId, GrainId streamProducer) =>
-        new()
-        {
-            { STREAM_PROVIDER_NAME, streamId.ProviderName },
-            { STREAM_KEY, streamId.StreamId.GetKeyAsString() },
-            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() },
-            { STREAM_PRODUCER, streamProducer.ToString() }
-        };
+    internal static TagList InitializeTags(QualifiedStreamId streamId, GrainId grainId) =>
+        CreateStreamTags(streamId, grainId.Type.ToString() ?? string.Empty);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static TagList InitializeTags(QualifiedStreamId streamId, GuidId subscriptionId) =>
-        new()
-        {
-            { SUBSCRIPTION_ID, subscriptionId.Guid },
-            { STREAM_KEY, streamId.StreamId.GetKeyAsString() },
-            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() }
-        };
+    internal static TagList InitializeTags(QualifiedStreamId streamId) =>
+        CreateStreamTags(streamId, UNKNOWN_GRAIN_TYPE);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static TagList InitializeTags(QueueId queueId, string streamProviderName) =>
+    internal static TagList InitializeTags(QueueId queueId, string streamProviderName) =>
         new()
         {
             { QUEUE_ID, queueId.ToStringWithHashCode() },
             { STREAM_PROVIDER_NAME, streamProviderName }
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TagList CreateStreamTags(QualifiedStreamId streamId, string grainType) =>
+        new()
+        {
+            { STREAM_PROVIDER_NAME, streamId.ProviderName },
+            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() ?? string.Empty },
+            { GRAIN_TYPE, grainType }
         };
 }

--- a/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
+++ b/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
@@ -1,40 +1,41 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TagList = System.Diagnostics.TagList;
 
+#nullable enable
 namespace Orleans.Streaming;
 
 internal static class StreamInstrumentsTagUtils
 {
-    private const string STREAM_NAMESPACE = "namespace";
-    private const string STREAM_PROVIDER_NAME = "provider";
-    private const string GRAIN_TYPE = "grain_type";
-    private const string QUEUE_ID = "queue";
-    private const string UNKNOWN_GRAIN_TYPE = "unknown";
+    private const string StreamNamespaceTagName = "namespace";
+    private const string StreamProviderNameTagName = "provider";
+    private const string GrainTypeTagName = "grain_type";
+    private const string QueueIdTagName = "queue";
+    private const string UnknownGrainType = "unknown";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TagList InitializeTags(QualifiedStreamId streamId, GrainId grainId) =>
-        CreateStreamTags(streamId, grainId.Type.ToString() ?? string.Empty);
+        CreateStreamTags(streamId, grainId.Type.ToString() ?? UnknownGrainType);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TagList InitializeTags(QualifiedStreamId streamId) =>
-        CreateStreamTags(streamId, UNKNOWN_GRAIN_TYPE);
+        CreateStreamTags(streamId, UnknownGrainType);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TagList InitializeTags(QueueId queueId, string streamProviderName) =>
         new()
         {
-            { QUEUE_ID, queueId.ToStringWithHashCode() },
-            { STREAM_PROVIDER_NAME, streamProviderName }
+            { QueueIdTagName, queueId.ToStringWithHashCode() },
+            { StreamProviderNameTagName, streamProviderName }
         };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static TagList CreateStreamTags(QualifiedStreamId streamId, string grainType) =>
         new()
         {
-            { STREAM_PROVIDER_NAME, streamId.ProviderName },
-            { STREAM_NAMESPACE, streamId.StreamId.GetNamespace() ?? string.Empty },
-            { GRAIN_TYPE, grainType }
+            { StreamProviderNameTagName, streamId.ProviderName },
+            { StreamNamespaceTagName, streamId.StreamId.GetNamespace() ?? string.Empty },
+            { GrainTypeTagName, grainType }
         };
 }

--- a/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
+++ b/src/Orleans.Streaming/StreamInstrumentsTagUtils.cs
@@ -8,7 +8,6 @@ namespace Orleans.Streaming;
 
 internal static class StreamInstrumentsTagUtils
 {
-    private const string StreamNamespaceTagName = "namespace";
     private const string StreamProviderNameTagName = "provider";
     private const string GrainTypeTagName = "grain_type";
     private const string QueueIdTagName = "queue";
@@ -35,7 +34,6 @@ internal static class StreamInstrumentsTagUtils
         new()
         {
             { StreamProviderNameTagName, streamId.ProviderName },
-            { StreamNamespaceTagName, streamId.StreamId.GetNamespace() ?? string.Empty },
             { GrainTypeTagName, grainType }
         };
 }

--- a/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using Orleans.Runtime;
+using Orleans.Streaming;
+using Orleans.Streams;
+using Xunit;
+using TagList = System.Diagnostics.TagList;
+
+#nullable enable
+namespace UnitTests.OrleansRuntime.Streams
+{
+    public class StreamInstrumentsTagUtilsTests
+    {
+        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public void GrainTagsUseStableLowCardinalityDimensions()
+        {
+            var firstStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
+            var secondStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-2"));
+            var firstGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-1");
+            var secondGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-2");
+
+            var firstTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(firstStreamId, firstGrainId));
+            var secondTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(secondStreamId, secondGrainId));
+
+            Assert.Equal(firstTags.Count, secondTags.Count);
+            foreach (var tag in firstTags)
+            {
+                Assert.True(secondTags.TryGetValue(tag.Key, out var otherValue));
+                Assert.Equal(tag.Value, otherValue);
+            }
+
+            Assert.Equal("ProviderName", firstTags["provider"]);
+            Assert.Equal("Orders", firstTags["namespace"]);
+            Assert.Equal("UnitTests.Streaming.OrderProducerGrain", firstTags["grain_type"]);
+            Assert.DoesNotContain("stream", firstTags.Keys);
+            Assert.DoesNotContain("producer", firstTags.Keys);
+            Assert.DoesNotContain("subscription", firstTags.Keys);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public void StreamOnlyTagsUseUnknownGrainType()
+        {
+            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
+
+            var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(streamId));
+
+            Assert.Equal("ProviderName", tags["provider"]);
+            Assert.Equal("Orders", tags["namespace"]);
+            Assert.Equal("unknown", tags["grain_type"]);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public void QueueTagsIncludeOnlyBoundedDimensions()
+        {
+            var queueId = QueueId.GetQueueId("QueuePrefix", 1, 42);
+
+            var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(queueId, "ProviderName"));
+
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("ProviderName", tags["provider"]);
+            Assert.Equal(queueId.ToStringWithHashCode(), tags["queue"]);
+            Assert.DoesNotContain("grain_type", tags.Keys);
+            Assert.DoesNotContain("namespace", tags.Keys);
+        }
+
+        private static Dictionary<string, object?> ToTagDictionary(TagList tags)
+        {
+            var result = new Dictionary<string, object?>();
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                result[tag.Key] = tag.Value;
+            }
+
+            return result;
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
@@ -6,71 +6,70 @@ using Xunit;
 using TagList = System.Diagnostics.TagList;
 
 #nullable enable
-namespace UnitTests.OrleansRuntime.Streams
+namespace UnitTests.OrleansRuntime.Streams;
+
+public class StreamInstrumentsTagUtilsTests
 {
-    public class StreamInstrumentsTagUtilsTests
+    [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+    public void GrainTagsUseStableLowCardinalityDimensions()
     {
-        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
-        public void GrainTagsUseStableLowCardinalityDimensions()
+        var firstStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
+        var secondStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-2"));
+        var firstGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-1");
+        var secondGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-2");
+
+        var firstTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(firstStreamId, firstGrainId));
+        var secondTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(secondStreamId, secondGrainId));
+
+        Assert.Equal(firstTags.Count, secondTags.Count);
+        foreach (var tag in firstTags)
         {
-            var firstStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
-            var secondStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-2"));
-            var firstGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-1");
-            var secondGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-2");
-
-            var firstTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(firstStreamId, firstGrainId));
-            var secondTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(secondStreamId, secondGrainId));
-
-            Assert.Equal(firstTags.Count, secondTags.Count);
-            foreach (var tag in firstTags)
-            {
-                Assert.True(secondTags.TryGetValue(tag.Key, out var otherValue));
-                Assert.Equal(tag.Value, otherValue);
-            }
-
-            Assert.Equal("ProviderName", firstTags["provider"]);
-            Assert.Equal("Orders", firstTags["namespace"]);
-            Assert.Equal("UnitTests.Streaming.OrderProducerGrain", firstTags["grain_type"]);
-            Assert.DoesNotContain("stream", firstTags.Keys);
-            Assert.DoesNotContain("producer", firstTags.Keys);
-            Assert.DoesNotContain("subscription", firstTags.Keys);
+            Assert.True(secondTags.TryGetValue(tag.Key, out var otherValue));
+            Assert.Equal(tag.Value, otherValue);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
-        public void StreamOnlyTagsUseUnknownGrainType()
+        Assert.Equal("ProviderName", firstTags["provider"]);
+        Assert.Equal("Orders", firstTags["namespace"]);
+        Assert.Equal("UnitTests.Streaming.OrderProducerGrain", firstTags["grain_type"]);
+        Assert.DoesNotContain("stream", firstTags.Keys);
+        Assert.DoesNotContain("producer", firstTags.Keys);
+        Assert.DoesNotContain("subscription", firstTags.Keys);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+    public void StreamOnlyTagsUseUnknownGrainType()
+    {
+        var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
+
+        var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(streamId));
+
+        Assert.Equal("ProviderName", tags["provider"]);
+        Assert.Equal("Orders", tags["namespace"]);
+        Assert.Equal("unknown", tags["grain_type"]);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+    public void QueueTagsIncludeOnlyBoundedDimensions()
+    {
+        var queueId = QueueId.GetQueueId("QueuePrefix", 1, 42);
+
+        var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(queueId, "ProviderName"));
+
+        Assert.Equal(2, tags.Count);
+        Assert.Equal("ProviderName", tags["provider"]);
+        Assert.Equal(queueId.ToStringWithHashCode(), tags["queue"]);
+        Assert.DoesNotContain("grain_type", tags.Keys);
+        Assert.DoesNotContain("namespace", tags.Keys);
+    }
+
+    private static Dictionary<string, object?> ToTagDictionary(TagList tags)
+    {
+        var result = new Dictionary<string, object?>();
+        foreach (KeyValuePair<string, object?> tag in tags)
         {
-            var streamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
-
-            var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(streamId));
-
-            Assert.Equal("ProviderName", tags["provider"]);
-            Assert.Equal("Orders", tags["namespace"]);
-            Assert.Equal("unknown", tags["grain_type"]);
+            result[tag.Key] = tag.Value;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
-        public void QueueTagsIncludeOnlyBoundedDimensions()
-        {
-            var queueId = QueueId.GetQueueId("QueuePrefix", 1, 42);
-
-            var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(queueId, "ProviderName"));
-
-            Assert.Equal(2, tags.Count);
-            Assert.Equal("ProviderName", tags["provider"]);
-            Assert.Equal(queueId.ToStringWithHashCode(), tags["queue"]);
-            Assert.DoesNotContain("grain_type", tags.Keys);
-            Assert.DoesNotContain("namespace", tags.Keys);
-        }
-
-        private static Dictionary<string, object?> ToTagDictionary(TagList tags)
-        {
-            var result = new Dictionary<string, object?>();
-            foreach (KeyValuePair<string, object?> tag in tags)
-            {
-                result[tag.Key] = tag.Value;
-            }
-
-            return result;
-        }
+        return result;
     }
 }

--- a/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/Streams/StreamInstrumentsTagUtilsTests.cs
@@ -14,13 +14,14 @@ public class StreamInstrumentsTagUtilsTests
     public void GrainTagsUseStableLowCardinalityDimensions()
     {
         var firstStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-1"));
-        var secondStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Orders", "user-2"));
+        var secondStreamId = new QualifiedStreamId("ProviderName", StreamId.Create("Payments", "user-2"));
         var firstGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-1");
         var secondGrainId = GrainId.Create("UnitTests.Streaming.OrderProducerGrain", "user-2");
 
         var firstTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(firstStreamId, firstGrainId));
         var secondTags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(secondStreamId, secondGrainId));
 
+        Assert.Equal(2, firstTags.Count);
         Assert.Equal(firstTags.Count, secondTags.Count);
         foreach (var tag in firstTags)
         {
@@ -29,8 +30,8 @@ public class StreamInstrumentsTagUtilsTests
         }
 
         Assert.Equal("ProviderName", firstTags["provider"]);
-        Assert.Equal("Orders", firstTags["namespace"]);
         Assert.Equal("UnitTests.Streaming.OrderProducerGrain", firstTags["grain_type"]);
+        Assert.DoesNotContain("namespace", firstTags.Keys);
         Assert.DoesNotContain("stream", firstTags.Keys);
         Assert.DoesNotContain("producer", firstTags.Keys);
         Assert.DoesNotContain("subscription", firstTags.Keys);
@@ -43,9 +44,10 @@ public class StreamInstrumentsTagUtilsTests
 
         var tags = ToTagDictionary(StreamInstrumentsTagUtils.InitializeTags(streamId));
 
+        Assert.Equal(2, tags.Count);
         Assert.Equal("ProviderName", tags["provider"]);
-        Assert.Equal("Orders", tags["namespace"]);
         Assert.Equal("unknown", tags["grain_type"]);
+        Assert.DoesNotContain("namespace", tags.Keys);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]


### PR DESCRIPTION
This commit introduces telemetry features to several components of the Orleans streaming system. Specifically, a new class, StreamInstrumentsTagUtils, has been created to provide methods for initializing the relevant telemetry tags. This utility is now utilized in numerous places throughout the codebase, including the PubSubRendezvousGrain and PersistentStreamPullingAgent classes, where it facilitates the monitoring of crucial streaming activities. This aids in diagnostics and performance tracking, contributing to ongoing system improvement efforts.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8631)