### PR TITLE
In GrainDirectoryResolver, replace HasNonDefaultDirectory with IsUsingDhtDirectory

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -453,7 +453,7 @@ namespace Orleans.Runtime
                             var activationData = activation.Value;
                             var placementStrategy = activationData.GetComponent<PlacementStrategy>();
                             var isUsingGrainDirectory = placementStrategy is { IsUsingGrainDirectory: true };
-                            if (!isUsingGrainDirectory || grainDirectoryResolver.HasNonDefaultDirectory(activationData.GrainId.Type)) continue;
+                            if (!isUsingGrainDirectory || !grainDirectoryResolver.IsUsingDhtDirectory(activationData.GrainId.Type)) continue;
                             if (!updatedSilo.Equals(directory.GetPrimaryForGrain(activationData.GrainId))) continue;
 
                             activationsToShutdown.Add(activationData);

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public IGrainDirectory Resolve(GrainType grainType) => this.directoryPerType.GetOrAdd(grainType, this.getGrainDirectoryInternal);
 
-        public bool HasNonDefaultDirectory(GrainType grainType) => !ReferenceEquals(Resolve(grainType), this.DefaultGrainDirectory);
+        public bool IsUsingDhtDirectory(GrainType grainType) => Resolve(grainType) == null;
 
         private IGrainDirectory GetGrainDirectoryPerType(GrainType grainType)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
@@ -37,13 +37,13 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 result = this._clientGrainLocator ??= _servicesProvider.GetRequiredService<ClientGrainLocator>();
             }
-            else if (this.grainDirectoryResolver.HasNonDefaultDirectory(grainType))
+            else if (this.grainDirectoryResolver.IsUsingDhtDirectory(grainType))
             {
-                result = this.cachedGrainLocator;
+                result = this.dhtGrainLocator;
             }
             else
             {
-                result = this.dhtGrainLocator;
+                result = this.cachedGrainLocator;
             }
 
             return result;

--- a/test/NonSilo.Tests/Directory/GrainLocatorResolverTests.cs
+++ b/test/NonSilo.Tests/Directory/GrainLocatorResolverTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using NSubstitute;
+using Orleans.GrainDirectory;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
+using UnitTests.Grains.Directories;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NonSilo.Tests.Directory
+{
+    [TestCategory("BVT"), TestCategory("Directory")]
+    public class GrainLocatorResolverTests
+    {
+        private readonly IGrainDirectory customDirectory;
+        private readonly IHost host;
+        private readonly GrainLocatorResolver target;
+
+        public GrainLocatorResolverTests(ITestOutputHelper output)
+        {
+            this.customDirectory = Substitute.For<IGrainDirectory>();
+
+            var hostBuilder = new HostBuilder();
+            hostBuilder.UseOrleans((ctx, siloBuilder) =>
+            {
+                siloBuilder
+                    .ConfigureServices(svc => svc.AddSingleton(Substitute.For<DhtGrainLocator>(null, null)))
+                    .ConfigureServices(svc => svc.AddSingletonNamedService(CustomDirectoryGrain.DIRECTORY, (sp, nameof) => this.customDirectory))
+                    .ConfigureLogging(builder => builder.AddProvider(new XunitLoggerProvider(output)))
+                    .UseLocalhostClustering();
+            });
+            this.host = hostBuilder.Build();
+
+            this.target = this.host.Services.GetRequiredService<GrainLocatorResolver>();
+        }
+
+        [Fact]
+        public void ReturnsDhtGrainLocatorWhenUsingDhtDirectory()
+        {
+            var grainLocator = this.host.Services.GetRequiredService<DhtGrainLocator>();
+            Assert.Same(grainLocator, target.GetGrainLocator(GrainType.Create(DefaultDirectoryGrain.DIRECTORY)));
+        }
+
+        [Fact]
+        public void ReturnsCachedGrainLocatorWhenUsingCustomDirectory()
+        {
+            var grainLocator = this.host.Services.GetRequiredService<CachedGrainLocator>();
+            Assert.Same(grainLocator, target.GetGrainLocator(GrainType.Create(CustomDirectoryGrain.DIRECTORY)));
+        }
+
+        [Fact]
+        public void ReturnsClientGrainLocatorWhenUsingClient()
+        {
+            var grainLocator = this.host.Services.GetRequiredService<ClientGrainLocator>();
+            Assert.Same(grainLocator, target.GetGrainLocator(ClientGrainId.Create("client").GrainId.Type));
+        }
+    }
+}


### PR DESCRIPTION
Fix #8632

`HasNonDefaultDirectory` was used to check if the directory was the default builtin (DHT) directory but was causing some logic issue when the default directory was overridden during config.

I renamed the method name and changed the logic, so it returns `true` only if the DHT directory is used for the target grain type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8660)