### PR TITLE
Add Analyzer and CodeFix for duplicate method aliases (ORLEANS0011)

### DIFF
--- a/src/Orleans.Analyzers/AliasClashAttributeAnalyzer.cs
+++ b/src/Orleans.Analyzers/AliasClashAttributeAnalyzer.cs
@@ -1,0 +1,131 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Orleans.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public partial class AliasClashAttributeAnalyzer : DiagnosticAnalyzer
+{
+    private readonly record struct AliasBag(string Name, Location Location);
+
+    public const string RuleId = "ORLEANS0011";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+       id: RuleId,
+       category: "Usage",
+       defaultSeverity: DiagnosticSeverity.Error,
+       isEnabledByDefault: true,
+       title: new LocalizableResourceString(nameof(Resources.AliasClashDetectedTitle), Resources.ResourceManager, typeof(Resources)),
+       messageFormat: new LocalizableResourceString(nameof(Resources.AliasClashDetectedMessageFormat), Resources.ResourceManager, typeof(Resources)),
+       description: new LocalizableResourceString(nameof(Resources.AliasClashDetectedDescription), Resources.ResourceManager, typeof(Resources)));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.RegisterSyntaxNodeAction(CheckSyntaxNode, SyntaxKind.InterfaceDeclaration);
+    }
+
+    private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        var interfaceDeclaration = (InterfaceDeclarationSyntax)context.Node;
+        if (!interfaceDeclaration.ExtendsGrainInterface(context.SemanticModel))
+        {
+            return;
+        }
+
+        List<AttributeArgumentBag<string>> bags = new();
+        foreach (var methodDeclaration in interfaceDeclaration.Members.OfType<MethodDeclarationSyntax>())
+        {
+            var attributes = methodDeclaration.AttributeLists.GetAttributeSyntaxes(Constants.AliasAttributeName);
+            foreach (var attribute in attributes)
+            {
+                var bag = attribute.GetArgumentBag<string>(context.SemanticModel);
+                if (bag != default)
+                {
+                    bags.Add(bag);
+                }
+            }
+        }
+
+        var duplicateAliases = bags
+           .GroupBy(alias => alias.Value)
+           .Where(group => group.Count() > 1)
+           .Select(group => group.Key);
+
+        if (!duplicateAliases.Any())
+        {
+            return;
+        }
+
+        foreach (var duplicateAlias in duplicateAliases)
+        {
+            var filteredBags = bags.Where(x => x.Value == duplicateAlias);
+            var duplicateCount = filteredBags.Count();
+
+            if (duplicateCount > 1)
+            {
+                var (prefix, suffix) = ParsePrefixAndNumericSuffix(duplicateAlias);
+
+                filteredBags = filteredBags.Skip(1);
+
+                foreach (var bag in filteredBags)
+                {
+                    string newAlias;
+                    do
+                    {
+                        ++suffix;
+                        newAlias = $"{prefix}{suffix}";
+                    } while (bags.Any(x => x.Value.Equals(newAlias, StringComparison.Ordinal)));
+
+                    var builder = ImmutableDictionary.CreateBuilder<string, string>();
+
+                    builder.Add("AliasName", prefix);
+                    builder.Add("AliasSuffix", suffix.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+                    context.ReportDiagnostic(Diagnostic.Create(
+                       descriptor: Rule,
+                       location: bag.Location,
+                       properties: builder.ToImmutable()));
+
+                    suffix++;
+                }
+            }
+        }
+    }
+
+    private static (string Prefix, ulong Suffix) ParsePrefixAndNumericSuffix(string input)
+    {
+        var suffixLength = GetNumericSuffixLength(input);
+        if (suffixLength == 0)
+        {
+            return (input, 0);
+        }
+
+        return (input.Substring(0, input.Length - suffixLength), ulong.Parse(input.Substring(input.Length - suffixLength)));
+    }
+
+    private static int GetNumericSuffixLength(string input)
+    {
+        var suffixLength = 0;
+        for (var c = input.Length - 1; c > 0; --c)
+        {
+            if (!char.IsDigit(input[c]))
+            {
+                break;
+            }
+
+            ++suffixLength;
+        }
+
+        return suffixLength;
+    }
+}

--- a/src/Orleans.Analyzers/AliasClashAttributeCodeFix.cs
+++ b/src/Orleans.Analyzers/AliasClashAttributeCodeFix.cs
@@ -1,0 +1,51 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Orleans.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GenerateAliasAttributesCodeFix)), Shared]
+public class AliasClashAttributeCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(AliasClashAttributeAnalyzer.RuleId);
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+        if (root.FindNode(diagnostic.Location.SourceSpan) is not AttributeSyntax attribute)
+        {
+            return;
+        }
+
+        var aliasName = diagnostic.Properties["AliasName"];
+        var aliasSuffix = diagnostic.Properties["AliasSuffix"];
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                Resources.AliasClashDetectedTitle,
+                createChangedDocument: _ =>
+                {
+                    var newAliasName = $"{aliasName}{aliasSuffix}";
+                    var newAttribute = attribute.ReplaceNode(
+                        attribute.ArgumentList.Arguments[0].Expression,
+                        LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(newAliasName)));
+
+                    var newRoot = root.ReplaceNode(attribute, newAttribute);
+                    var newDocument = context.Document.WithSyntaxRoot(newRoot);
+
+                    return Task.FromResult(newDocument);
+                },
+                equivalenceKey: AliasClashAttributeAnalyzer.RuleId),
+            diagnostic);
+    }
+}

--- a/src/Orleans.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Orleans.Analyzers/AnalyzerReleases.Shipped.md
@@ -21,6 +21,9 @@ ORLEANS0007  | Usage   | Error  |
 ORLEANS0008  | Usage   | Error  | Grain interfaces cannot have properties
 ORLEANS0009  | Usage   | Error  | Grain interface methods must return a compatible type
 ORLEANS0010  | Usage   | Info   | Add missing [Alias] attribute
+ORLEANS0011  | Usage   | Error  | The [Alias] attribute must be unique to the declaring type
+ORLEANS0012  | Usage   | Error  | The [Id] attribute must be unique to each members of the declaring type
+ORLEANS0013  | Usage   | Error  | This attribute should not be used on grain implementations
 
 ### Removed Rules
 

--- a/src/Orleans.Analyzers/Constants.cs
+++ b/src/Orleans.Analyzers/Constants.cs
@@ -5,6 +5,7 @@ namespace Orleans.Analyzers
         public const string SystemNamespace = "System";
 
         public const string IAddressibleFullyQualifiedName = "Orleans.Runtime.IAddressable";
+        public const string GrainBaseFullyQualifiedName = "Orleans.Grain";
 
         public const string IdAttributeName = "Id";
         public const string IdAttributeFullyQualifiedName = "global::Orleans.IdAttribute";

--- a/src/Orleans.Analyzers/IdClashAttributeAnalyzer.cs
+++ b/src/Orleans.Analyzers/IdClashAttributeAnalyzer.cs
@@ -1,0 +1,88 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Orleans.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class IdClashAttributeAnalyzer : DiagnosticAnalyzer
+{
+    private readonly record struct AliasBag(string Name, Location Location);
+
+    public const string RuleId = "ORLEANS0012";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+       id: RuleId,
+       category: "Usage",
+       defaultSeverity: DiagnosticSeverity.Error,
+       isEnabledByDefault: true,
+       title: new LocalizableResourceString(nameof(Resources.IdClashDetectedTitle), Resources.ResourceManager, typeof(Resources)),
+       messageFormat: new LocalizableResourceString(nameof(Resources.IdClashDetectedMessageFormat), Resources.ResourceManager, typeof(Resources)),
+       description: new LocalizableResourceString(nameof(Resources.IdClashDetectedDescription), Resources.ResourceManager, typeof(Resources)));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.RegisterSyntaxNodeAction(CheckSyntaxNode,
+            SyntaxKind.ClassDeclaration,
+            SyntaxKind.StructDeclaration,
+            SyntaxKind.RecordDeclaration,
+            SyntaxKind.RecordStructDeclaration);
+    }
+
+    private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        var typeDeclaration = context.Node as TypeDeclarationSyntax;
+        if (!typeDeclaration.HasAttribute(Constants.GenerateSerializerAttributeName))
+        {
+            return;
+        }
+
+        List<AttributeArgumentBag<int>> bags = new();
+        foreach (var memberDeclaration in typeDeclaration.Members.OfType<MemberDeclarationSyntax>())
+        {
+            var attributes = memberDeclaration.AttributeLists.GetAttributeSyntaxes(Constants.IdAttributeName);
+            foreach (var attribute in attributes)
+            {
+                var bag = attribute.GetArgumentBag<int>(context.SemanticModel);
+                if (bag != default)
+                {
+                    bags.Add(bag);
+                }
+            }
+        }
+
+        var duplicateIds = bags
+           .GroupBy(id => id.Value)
+           .Where(group => group.Count() > 1)
+           .Select(group => group.Key);
+
+        if (!duplicateIds.Any())
+        {
+            return;
+        }
+
+        foreach (var duplicateId in duplicateIds)
+        {
+            var filteredBags = bags.Where(x => x.Value == duplicateId);
+            var duplicateCount = filteredBags.Count();
+
+            if (duplicateCount > 1)
+            {
+                foreach (var bag in filteredBags)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                       descriptor: Rule,
+                       location: bag.Location));
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Analyzers/IncorrectAttributeUseAnalyzer.cs
+++ b/src/Orleans.Analyzers/IncorrectAttributeUseAnalyzer.cs
@@ -1,0 +1,57 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace Orleans.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class IncorrectAttributeUseAnalyzer : DiagnosticAnalyzer
+{
+    public const string RuleId = "ORLEANS0013";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+       id: RuleId,
+       category: "Usage",
+       defaultSeverity: DiagnosticSeverity.Error,
+       isEnabledByDefault: true,
+       title: new LocalizableResourceString(nameof(Resources.IncorrectAttributeUseTitle), Resources.ResourceManager, typeof(Resources)),
+       messageFormat: new LocalizableResourceString(nameof(Resources.IncorrectAttributeUseMessageFormat), Resources.ResourceManager, typeof(Resources)),
+       description: new LocalizableResourceString(nameof(Resources.IncorrectAttributeUseTitleDescription), Resources.ResourceManager, typeof(Resources)));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.RegisterSyntaxNodeAction(CheckSyntaxNode, SyntaxKind.ClassDeclaration);
+    }
+
+    private void CheckSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ClassDeclarationSyntax) return;
+
+        var classDeclaration = (ClassDeclarationSyntax)context.Node;
+
+        if (!classDeclaration.InheritsGrainClass(context.SemanticModel))
+        {
+            return;
+        }
+
+        TryReportFor(Constants.AliasAttributeName, context, classDeclaration);
+        TryReportFor(Constants.GenerateSerializerAttributeName, context, classDeclaration);
+    }
+
+    private static void TryReportFor(string attributeTypeName, SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDeclaration)
+    {
+        if (classDeclaration.TryGetAttribute(attributeTypeName, out var attribute))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                descriptor: Rule,
+                location: attribute.GetLocation(),
+                messageArgs: new object[] { attributeTypeName }));
+        }
+    }
+}

--- a/src/Orleans.Analyzers/IncorrectAttributeUseCodeFix.cs
+++ b/src/Orleans.Analyzers/IncorrectAttributeUseCodeFix.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using System.Composition;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace Orleans.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(IncorrectAttributeUseCodeFix)), Shared]
+public class IncorrectAttributeUseCodeFix : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(IncorrectAttributeUseAnalyzer.RuleId);
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+
+        if (root.FindNode(diagnostic.Location.SourceSpan) is not AttributeSyntax node)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.IncorrectAttributeUseTitle,
+                createChangedDocument: token =>
+                {
+                    var newRoot = root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepEndOfLine);
+                    return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+
+                },
+                equivalenceKey: IncorrectAttributeUseAnalyzer.RuleId),
+            diagnostic);
+    }
+
+}

--- a/src/Orleans.Analyzers/Resources.Designer.cs
+++ b/src/Orleans.Analyzers/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add [Alias] attributes to specify well-known names that can be used to identify types or methods.
+        ///   Looks up a localized string similar to Add [Alias] to specify well-known names that can be used to identify types or methods..
         /// </summary>
         internal static string AddAliasAttributesDescription {
             get {
@@ -88,7 +88,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add missing alias attributes.
+        ///   Looks up a localized string similar to Add missing [Alias].
         /// </summary>
         internal static string AddAliasAttributesTitle {
             get {
@@ -97,7 +97,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add missing alias attributes.
+        ///   Looks up a localized string similar to Add missing [Alias].
         /// </summary>
         internal static string AddAliasMessageFormat {
             get {
@@ -106,7 +106,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add the [GenerateSerializer] attribute to serializable types in your application.
+        ///   Looks up a localized string similar to Add the [GenerateSerializer] attribute to serializable types in your application..
         /// </summary>
         internal static string AddGenerateSerializerAttributeDescription {
             get {
@@ -160,6 +160,33 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The [Alias] attribute must be unique to the declaring type..
+        /// </summary>
+        internal static string AliasClashDetectedDescription {
+            get {
+                return ResourceManager.GetString("AliasClashDetectedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename duplicated [Alias].
+        /// </summary>
+        internal static string AliasClashDetectedMessageFormat {
+            get {
+                return ResourceManager.GetString("AliasClashDetectedMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename duplicated [Alias].
+        /// </summary>
+        internal static string AliasClashDetectedTitle {
+            get {
+                return ResourceManager.GetString("AliasClashDetectedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A single type is not allowed to have multiple constructors annotated with the [OrleansConstructor] attribute.
         /// </summary>
         internal static string AtMostOneOrleansConstructorMessageFormat {
@@ -174,6 +201,60 @@ namespace Orleans.Analyzers {
         internal static string AtMostOneOrleansConstructorTitle {
             get {
                 return ResourceManager.GetString("AtMostOneOrleansConstructorTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The [Id] attribute must be unique to each members of the declaring type..
+        /// </summary>
+        internal static string IdClashDetectedDescription {
+            get {
+                return ResourceManager.GetString("IdClashDetectedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Substitute duplicated [Id] value with the correct unique identity of this member.
+        /// </summary>
+        internal static string IdClashDetectedMessageFormat {
+            get {
+                return ResourceManager.GetString("IdClashDetectedMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Substitute duplicated [Id] value with the correct unique identity of this member.
+        /// </summary>
+        internal static string IdClashDetectedTitle {
+            get {
+                return ResourceManager.GetString("IdClashDetectedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove attribute [{0}].
+        /// </summary>
+        internal static string IncorrectAttributeUseMessageFormat {
+            get {
+                return ResourceManager.GetString("IncorrectAttributeUseMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove attribute.
+        /// </summary>
+        internal static string IncorrectAttributeUseTitle {
+            get {
+                return ResourceManager.GetString("IncorrectAttributeUseTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This attribute should not be used on grain implementations..
+        /// </summary>
+        internal static string IncorrectAttributeUseTitleDescription {
+            get {
+                return ResourceManager.GetString("IncorrectAttributeUseTitleDescription", resourceCulture);
             }
         }
     }

--- a/src/Orleans.Analyzers/Resources.resx
+++ b/src/Orleans.Analyzers/Resources.resx
@@ -148,12 +148,39 @@
     <value>A single type is not allowed to have multiple constructors annotated with the [OrleansConstructor] attribute</value>
   </data>
   <data name="AddAliasAttributesDescription" xml:space="preserve">
-    <value>Add [Alias] attributes to specify well-known names that can be used to identify types or methods.</value>
+    <value>Add [Alias] to specify well-known names that can be used to identify types or methods.</value>
   </data>
   <data name="AddAliasAttributesTitle" xml:space="preserve">
-    <value>Add missing alias attributes</value>
+    <value>Add missing [Alias]</value>
   </data>
   <data name="AddAliasMessageFormat" xml:space="preserve">
-    <value>Add missing alias attributes</value>
+    <value>Add missing [Alias]</value>
+  </data>
+  <data name="AliasClashDetectedDescription" xml:space="preserve">
+    <value>The [Alias] attribute must be unique to the declaring type.</value>
+  </data>
+  <data name="AliasClashDetectedMessageFormat" xml:space="preserve">
+    <value>Rename duplicated [Alias]</value>
+  </data>
+  <data name="AliasClashDetectedTitle" xml:space="preserve">
+    <value>Rename duplicated [Alias]</value>
+  </data>
+  <data name="IdClashDetectedDescription" xml:space="preserve">
+    <value>The [Id] attribute must be unique to each members of the declaring type.</value>
+  </data>
+  <data name="IdClashDetectedMessageFormat" xml:space="preserve">
+    <value>Substitute duplicated [Id] value with the correct unique identity of this member</value>
+  </data>
+  <data name="IdClashDetectedTitle" xml:space="preserve">
+    <value>Substitute duplicated [Id] value with the correct unique identity of this member</value>
+  </data>
+  <data name="IncorrectAttributeUseMessageFormat" xml:space="preserve">
+    <value>Remove attribute [{0}]</value>
+  </data>
+  <data name="IncorrectAttributeUseTitle" xml:space="preserve">
+    <value>Remove attribute</value>
+  </data>
+  <data name="IncorrectAttributeUseTitleDescription" xml:space="preserve">
+    <value>This attribute should not be used on grain implementations.</value>
   </data>
 </root>

--- a/test/Analyzers.Tests/AliasClashAttributeAnalyzerTest.cs
+++ b/test/Analyzers.Tests/AliasClashAttributeAnalyzerTest.cs
@@ -1,0 +1,75 @@
+using Microsoft.CodeAnalysis;
+using Orleans.Analyzers;
+using Xunit;
+
+namespace Analyzers.Tests;
+
+[TestCategory("BVT"), TestCategory("Analyzer")]
+public class AliasClashAttributeAnalyzerTest : DiagnosticAnalyzerTestBase<AliasClashAttributeAnalyzer>
+{
+    private async Task VerifyHasDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+
+        Assert.NotEmpty(diagnostics);
+        var diagnostic = diagnostics.First();
+
+        Assert.Equal(AliasClashAttributeAnalyzer.RuleId, diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    private async Task VerifyHasNoDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+        Assert.Empty(diagnostics);
+    }
+
+    [Theory]
+    [MemberData(nameof(GrainInterfaces))]
+    public Task SameAliasWithinDeclaringType_ShouldTriggerDiagnostic(string grainInterface)
+    {
+        var code = $$"""
+                    public interface I : {{grainInterface}}
+                    {
+                        [Alias("Void")] Task Void(int a);
+                        [Alias("Void")] Task Void(long a);
+                    }
+                    """;
+
+        return VerifyHasDiagnostic(code);
+    }
+
+    [Theory]
+    [MemberData(nameof(GrainInterfaces))]
+    public Task DifferentAliasWithinDeclaringType_ShouldNotTriggerDiagnostic(string grainInterface)
+    {
+        var code = $$"""
+                    public interface I : {{grainInterface}}
+                    {
+                        [Alias("Void")] Task Void(int a);
+                        [Alias("Void1")] Task Void(long a);
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    [Theory]
+    [MemberData(nameof(GrainInterfaces))]
+    public Task SameAliasOutsideDeclaringType_ShouldNotTriggerDiagnostic(string grainInterface)
+    {
+        var code = $$"""
+                    public interface I1 : {{grainInterface}}
+                    {
+                        [Alias("Void")] Task Void(string a);
+                    }
+                    
+                    public interface I2
+                    {
+                        [Alias("Void")] Task Void(string a);
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+}

--- a/test/Analyzers.Tests/DiagnosticAnalyzerTestBase.cs
+++ b/test/Analyzers.Tests/DiagnosticAnalyzerTestBase.cs
@@ -24,6 +24,17 @@ namespace Analyzers.Tests
             "Orleans"
         };
 
+        public static IEnumerable<object[]> GrainInterfaces =>
+            new List<object[]>
+            {
+                new object[] { "Orleans.IGrain" },
+                new object[] { "Orleans.IGrainWithStringKey" },
+                new object[] { "Orleans.IGrainWithGuidKey" },
+                new object[] { "Orleans.IGrainWithGuidCompoundKey" },
+                new object[] { "Orleans.IGrainWithIntegerKey" },
+                new object[] { "Orleans.IGrainWithIntegerCompoundKey" }
+            };
+
         protected virtual DiagnosticAnalyzer CreateDiagnosticAnalyzer() => new TDiagnosticAnalyzer();
 
         protected async Task AssertNoDiagnostics(string source, params string[] extraUsings)

--- a/test/Analyzers.Tests/GenerateAliasAttributesAnalyzerTest.cs
+++ b/test/Analyzers.Tests/GenerateAliasAttributesAnalyzerTest.cs
@@ -79,17 +79,6 @@ public class GenerateAliasAttributesAnalyzerTest : DiagnosticAnalyzerTestBase<Ge
         return VerifyHasNoDiagnostic(code);
     }
 
-    public static IEnumerable<object[]> GrainInterfaces =>
-        new List<object[]>
-        {
-            new object[] { "Orleans.IGrain" },
-            new object[] { "Orleans.IGrainWithStringKey" },
-            new object[] { "Orleans.IGrainWithGuidKey" },
-            new object[] { "Orleans.IGrainWithGuidCompoundKey" },
-            new object[] { "Orleans.IGrainWithIntegerKey" },
-            new object[] { "Orleans.IGrainWithIntegerCompoundKey" }
-        };
-
     #endregion
 
     #region Classes, Structs, Records

--- a/test/Analyzers.Tests/IdClashAttributeAnalyzerTest.cs
+++ b/test/Analyzers.Tests/IdClashAttributeAnalyzerTest.cs
@@ -1,0 +1,138 @@
+using Microsoft.CodeAnalysis;
+using Orleans.Analyzers;
+using Xunit;
+
+namespace Analyzers.Tests;
+
+[TestCategory("BVT"), TestCategory("Analyzer")]
+public class IdClashAttributeAnalyzerTest : DiagnosticAnalyzerTestBase<IdClashAttributeAnalyzer>
+{
+    private async Task VerifyHasDiagnostic(string code, int diagnosticsCount)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Equal(diagnosticsCount, diagnostics.Length);
+
+        var diagnostic = diagnostics.First();
+
+        Assert.Equal(IdClashAttributeAnalyzer.RuleId, diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    private async Task VerifyHasNoDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public Task TypesWithGenerateSerializerAndDuplicatedIds_ShouldTriggerDiagnostic()
+    {
+        var code = """
+                    [GenerateSerializer]
+                    public class C
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(1)] public string P3 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public struct S
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(1)] public string P3 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public record R(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(0)] public string P5 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public record struct RS(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(0)] public string P5 { get; set; }
+                    }
+                    """;
+
+        return VerifyHasDiagnostic(code, 8);
+    }
+
+    [Fact]
+    public Task TypesWithGenerateSerializerAndNoDuplicatedIds_ShouldNoTriggerDiagnostic()
+    {
+        var code = """
+                    [GenerateSerializer]
+                    public class C
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(2)] public string P3 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public struct S
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(2)] public string P3 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public record R(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(1)] public string P5 { get; set; }
+                    }
+
+                    [GenerateSerializer]
+                    public record struct RS(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(1)] public string P5 { get; set; }
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    [Fact]
+    public Task TypesWithoutGenerateSerializerAndDuplicatedIds_ShouldNotTriggerDiagnostic()
+    {
+        var code = """
+                    public class C
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(1)] public string P3 { get; set; }
+                    }
+
+                    public struct S
+                    {
+                        [Id(0)] public string P1 { get; set; }
+                        [Id(1)] public string P2 { get; set; }
+                        [Id(1)] public string P3 { get; set; }
+                    }
+
+                    public record R(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(0)] public string P5 { get; set; }
+                    }
+
+                    public record struct RS(string P1, string P2, string P3)
+                    {
+                        [Id(0)] public string P4 { get; set; }
+                        [Id(0)] public string P5 { get; set; }
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+}

--- a/test/Analyzers.Tests/IncorrectAttributeUseAnalyzerTest.cs
+++ b/test/Analyzers.Tests/IncorrectAttributeUseAnalyzerTest.cs
@@ -1,0 +1,137 @@
+using Microsoft.CodeAnalysis;
+using Orleans.Analyzers;
+using Xunit;
+
+namespace Analyzers.Tests;
+
+[TestCategory("BVT"), TestCategory("Analyzer")]
+public class IncorrectAttributeUseAnalyzerTest : DiagnosticAnalyzerTestBase<IncorrectAttributeUseAnalyzer>
+{
+    private async Task VerifyHasDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+
+        Assert.NotEmpty(diagnostics);
+        var diagnostic = diagnostics.First();
+
+        Assert.Equal(IncorrectAttributeUseAnalyzer.RuleId, diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    private async Task VerifyHasNoDiagnostic(string code)
+    {
+        var (diagnostics, _) = await GetDiagnosticsAsync(code, Array.Empty<string>());
+        Assert.Empty(diagnostics);
+    }
+
+    #region Grain
+
+    [Theory]
+    [MemberData(nameof(Attributes))]
+    public Task ClassInheritingFromGrain_HavingAttributeApplied_ShouldTriggerDiagnostic(string attribute)
+    {
+        var code = $$"""
+                    [{{attribute}}]
+                    public class C : Grain
+                    {
+
+                    }
+                    """;
+
+        return VerifyHasDiagnostic(code);
+    }
+
+    [Theory]
+    [MemberData(nameof(Attributes))]
+    public Task ClassNotInheritingFromGrain_HavingAttributeApplied_ShouldNotTriggerDiagnostic(string attribute)
+    {
+        var code = $$"""
+                    [{{attribute}}]
+                    public class C
+                    {
+
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    [Fact]
+    public Task ClassInheritingFromGrain_NotHavingAttributeApplied_ShouldNotTriggerDiagnostic()
+    {
+        var code = """
+                    public class C : Grain
+                    {
+
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    #endregion
+
+    #region Grain<TGrainState>
+
+    [Theory]
+    [MemberData(nameof(Attributes))]
+    public Task ClassInheritingFromGenericGrain_HavingAttributeApplied_ShouldTriggerDiagnostic(string attribute)
+    {
+        var code = $$"""
+                    [{{attribute}}]
+                    public class C : Grain<S>
+                    {
+
+                    }
+
+                    public class S
+                    {
+                    
+                    }
+                    """;
+
+        return VerifyHasDiagnostic(code);
+    }
+
+    [Theory]
+    [MemberData(nameof(Attributes))]
+    public Task ClassNotInheritingFromGenericGrain_HavingAttributeApplied_ShouldNotTriggerDiagnostic(string attribute)
+    {
+        var code = $$"""
+                    [{{attribute}}]
+                    public class C
+                    {
+
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    [Fact]
+    public Task ClassInheritingFromGenericGrain_NotHavingAttributeApplied_ShouldNotTriggerDiagnostic()
+    {
+        var code = """
+                    public class C : Grain<S>
+                    {
+
+                    }
+
+                    public class S
+                    {
+
+                    }
+                    """;
+
+        return VerifyHasNoDiagnostic(code);
+    }
+
+    #endregion
+
+    public static IEnumerable<object[]> Attributes =>
+        new List<object[]>
+        {
+            new object[] { "Alias(\"alias\")" },
+            new object[] { "GenerateSerializer" }
+        };
+}


### PR DESCRIPTION
cc @ReubenBond 
close #8661 

Analyzer:
![alias-clash-analyzer](https://github.com/dotnet/orleans/assets/46324828/45322c46-ded7-48bf-8aad-845d4e54b706)

Fixer:
![alias-clash-codefix](https://github.com/dotnet/orleans/assets/46324828/40e225c6-f129-4176-b234-a14dc7f3bb53)


Tests:
![alias-clash-tests](https://github.com/dotnet/orleans/assets/46324828/1b2e0d36-183f-4aa8-8502-88d9cf550b96)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8662)