### PR TITLE
Ensure that `ClusterMembershipOptions.NumVotesForDeathDeclaration` is not greater than `NumProbedSilos` on startup

### DIFF
--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -1,6 +1,8 @@
 using System;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Configuration.Validators;
 
 namespace Orleans.Runtime.Configuration
@@ -24,6 +26,20 @@ namespace Orleans.Runtime.Configuration
             if (clusteringTableProvider == null)
             {
                 throw new OrleansConfigurationException(ClientClusteringValidator.ClusteringNotConfigured);
+            }
+
+            var clusterMembershipOptions = this.serviceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
+            if (clusterMembershipOptions.LivenessEnabled)
+            {
+                if (clusterMembershipOptions.NumVotesForDeathDeclaration > clusterMembershipOptions.NumProbedSilos)
+                {
+                    throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.NumVotesForDeathDeclaration)} ({clusterMembershipOptions.NumVotesForDeathDeclaration}) must be less than or equal to {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.NumProbedSilos)} ({clusterMembershipOptions.NumProbedSilos}).");
+                }
+
+                if (clusterMembershipOptions.NumVotesForDeathDeclaration <= 0)
+                {
+                    throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.NumVotesForDeathDeclaration)} ({clusterMembershipOptions.NumVotesForDeathDeclaration}) must be greater than 0.");
+                }
             }
         }
     }

--- a/test/NonSilo.Tests/SiloBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloBuilderTests.cs
@@ -106,6 +106,33 @@ namespace NonSilo.Tests
         }
 
         /// <summary>
+        /// ClusterMembershipOptions.NumProbedSilos must be greater than ClusterMembershipOptions.NumVotesForDeathDeclaration.
+        /// </summary>
+        [Fact]
+        public async Task SiloBuilder_ClusterMembershipOptionsValidators()
+        {
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => { options.NumVotesForDeathDeclaration = 10; options.NumProbedSilos = 1; });
+                }).RunConsoleAsync();
+            });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => { options.NumVotesForDeathDeclaration = 0; });
+                }).RunConsoleAsync();
+            });
+        }
+
+        /// <summary>
         /// Ensures <see cref="LoadSheddingValidator"/> fails when LoadSheddingLimit greater than 100.
         /// </summary>
         [Fact]


### PR DESCRIPTION
xref #8678
Ensures that:
* `ClusterMembershipOptions.NumVotesForDeathDeclaration` <= `ClusterMembershipOptions.NumProbedSilos`
* `ClusterMembershipOptions.NumVotesForDeathDeclaration` > `0`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8679)