### PR TITLE
Close connection when invalid framing is detected

### DIFF
--- a/src/Orleans.Core/Messaging/InvalidMessageFrameException.cs
+++ b/src/Orleans.Core/Messaging/InvalidMessageFrameException.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Orleans.Runtime.Messaging;
+
+/// <summary>
+/// Indicates that a message frame is invalid, either when sending a messare or receiving a message.
+/// </summary>
+[GenerateSerializer]
+public sealed class InvalidMessageFrameException : OrleansException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMessageFrameException"/> class.
+    /// </summary>
+    public InvalidMessageFrameException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMessageFrameException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InvalidMessageFrameException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMessageFrameException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public InvalidMessageFrameException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    protected InvalidMessageFrameException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/Orleans.Core/Messaging/InvalidMessageFrameException.cs
+++ b/src/Orleans.Core/Messaging/InvalidMessageFrameException.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 namespace Orleans.Runtime.Messaging;
 
 /// <summary>
-/// Indicates that a message frame is invalid, either when sending a messare or receiving a message.
+/// Indicates that a message frame is invalid, either when sending a message or receiving a message.
 /// </summary>
 [GenerateSerializer]
 public sealed class InvalidMessageFrameException : OrleansException

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -189,6 +189,7 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 var bodyLength = bufferWriter.CommittedBytes - headerLength;
+
                 // Before completing, check lengths
                 ThrowIfLengthsInvalid(headerLength, bodyLength);
 
@@ -217,8 +218,8 @@ namespace Orleans.Runtime.Messaging
             if ((uint)bodyLength > (uint)_maxBodyLength) ThrowInvalidBodyLength(bodyLength);
         }
 
-        private void ThrowInvalidHeaderLength(int headerLength) => throw new OrleansException($"Invalid header size: {headerLength} (max configured value is {_maxHeaderLength}, see {nameof(MessagingOptions.MaxMessageHeaderSize)})");
-        private void ThrowInvalidBodyLength(int bodyLength) => throw new OrleansException($"Invalid body size: {bodyLength} (max configured value is {_maxBodyLength}, see {nameof(MessagingOptions.MaxMessageBodySize)})");
+        private void ThrowInvalidHeaderLength(int headerLength) => throw new InvalidMessageFrameException($"Invalid header size: {headerLength} (max configured value is {_maxHeaderLength}, see {nameof(MessagingOptions.MaxMessageHeaderSize)})");
+        private void ThrowInvalidBodyLength(int bodyLength) => throw new InvalidMessageFrameException($"Invalid body size: {bodyLength} (max configured value is {_maxBodyLength}, see {nameof(MessagingOptions.MaxMessageBodySize)})");
 
         private void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Message value, PackedHeaders headers) where TBufferWriter : IBufferWriter<byte>
         {

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -311,8 +311,12 @@ namespace Orleans.Runtime.Messaging
                                     ThreadPool.UnsafeQueueUserWorkItem(handler, preferLocal: true);
                                 }
                             }
-                            catch (Exception exception) when (HandleReceiveMessageFailure(message, exception))
+                            catch (Exception exception)
                             {
+                                if (!HandleReceiveMessageFailure(message, exception))
+                                {
+                                    throw;
+                                }   
                             }
                         } while (requiredBytes == 0);
                     }
@@ -374,8 +378,12 @@ namespace Orleans.Runtime.Messaging
                             message = null;
                         }
                     }
-                    catch (Exception exception) when (HandleSendMessageFailure(message, exception))
+                    catch (Exception exception)
                     {
+                        if (!HandleSendMessageFailure(message, exception))
+                        {
+                            throw;
+                        }
                     }
 
                     var flushResult = await output.FlushAsync();

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -288,7 +288,6 @@ namespace Orleans.Runtime.Messaging
             {
                 var input = this._transport.Input;
                 var requiredBytes = 0;
-                Message message = default;
                 while (true)
                 {
                     var readResult = await input.ReadAsync();
@@ -298,6 +297,7 @@ namespace Orleans.Runtime.Messaging
                     {
                         do
                         {
+                            Message message = default;
                             try
                             {
                                 int headerLength, bodyLength;
@@ -309,7 +309,6 @@ namespace Orleans.Runtime.Messaging
                                     var handler = MessageHandlerPool.Get();
                                     handler.Set(message, this);
                                     ThreadPool.UnsafeQueueUserWorkItem(handler, preferLocal: true);
-                                    message = null;
                                 }
                             }
                             catch (Exception exception) when (this.HandleReceiveMessageFailure(message, exception))

--- a/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/MessageSerializerTests.cs
@@ -65,7 +65,7 @@ namespace UnitTests.Serialization
 
                 var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
                 var writer = pipe.Writer;
-                Assert.Throws<OrleansException>(() => this.messageSerializer.Write(writer, message));
+                Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace UnitTests.Serialization
 
             var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
             var writer = pipe.Writer;
-            Assert.Throws<OrleansException>(() => this.messageSerializer.Write(writer, message));
+            Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
@@ -119,7 +119,7 @@ namespace UnitTests.Serialization
 
             pipe.Reader.TryRead(out var readResult);
             var reader = readResult.Buffer;
-            Assert.Throws<OrleansException>(() => this.messageSerializer.TryRead(ref reader, out var message));
+            Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.TryRead(ref reader, out var message));
         }
 
         private Message RoundTripMessage(Message message)


### PR DESCRIPTION
This fixes an issue which was preventing connections from being closed when invalid framing was encountered.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8692)