### PR TITLE
Cosmos DB: allow customization of retry logic

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -11,16 +11,15 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
 {
     private const string ANY_ETAG = "*";
     private const string KEY_STRING_SEPARATOR = "__";
-    private const string DEFAULT_PARTITION_KEY_PATH = "/PartitionKey";
     private const string GRAINTYPE_PARTITION_KEY_PATH = "/GrainType";
-    private const HttpStatusCode TOO_MANY_REQUESTS = (HttpStatusCode)429;
     private readonly ILogger _logger;
     private readonly CosmosGrainStorageOptions _options;
     private readonly string _name;
     private readonly IServiceProvider _serviceProvider;
     private readonly string _serviceId;
-    private string _partitionKeyPath = DEFAULT_PARTITION_KEY_PATH;
+    private string _partitionKeyPath;
     private readonly IPartitionKeyProvider _partitionKeyProvider;
+    private readonly ICosmosOperationExecutor _executor;
     private CosmosClient _client = default!;
     private Container _container = default!;
 
@@ -39,6 +38,8 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
         _serviceProvider = serviceProvider;
         _serviceId = clusterOptions.Value.ServiceId;
         _partitionKeyProvider = partitionKeyProvider;
+        _executor = options.OperationExecutor;
+        _partitionKeyPath = _options.PartitionKeyPath;
     }
 
     public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
@@ -60,12 +61,12 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
         try
         {
             var pk = new PartitionKey(partitionKey);
-            var entity = await ExecuteWithRetries(static (self, args) =>
+            var entity = await _executor.ExecuteOperation(static args =>
             {
-                var (id, pk) = args;
+                var (self, id, pk) = args;
                 return self._container.ReadItemAsync<GrainStateEntity<T>>(id, pk);
             },
-            (id, pk)).ConfigureAwait(false);
+            (this, id, pk)).ConfigureAwait(false);
 
             if (entity.Resource.State != null)
             {
@@ -136,38 +137,38 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
             var pk = new PartitionKey(partitionKey);
             if (string.IsNullOrWhiteSpace(grainState.ETag))
             {
-                response = await ExecuteWithRetries(
-                    static (self, args) =>
+                response = await _executor.ExecuteOperation(
+                    static args =>
                     {
-                        var (entity, pk) = args;
+                        var (self, entity, pk) = args;
                         return self._container.CreateItemAsync(entity, pk);
                     },
-                    (entity, pk)).ConfigureAwait(false);
+                    (this, entity, pk)).ConfigureAwait(false);
 
                 grainState.ETag = response.Resource.ETag;
             }
             else if (grainState.ETag == ANY_ETAG)
             {
                 var requestOptions = new ItemRequestOptions { IfMatchEtag = grainState.ETag };
-                response = await ExecuteWithRetries(
-                    static (self, args) =>
+                response = await _executor.ExecuteOperation(
+                    static args =>
                     {
-                        var (entity, pk, requestOptions) = args;
+                        var (self, entity, pk, requestOptions) = args;
                         return self._container.UpsertItemAsync(entity, pk, requestOptions);
                     },
-                    (entity, pk, requestOptions)).ConfigureAwait(false);
+                    (this, entity, pk, requestOptions)).ConfigureAwait(false);
                 grainState.ETag = response.Resource.ETag;
             }
             else
             {
                 var requestOptions = new ItemRequestOptions { IfMatchEtag = grainState.ETag };
-                response = await ExecuteWithRetries(
-                    static (self, args) =>
+                response = await _executor.ExecuteOperation(
+                    static args =>
                     {
-                        var (entity, pk, requestOptions) = args;
+                        var (self, entity, pk, requestOptions) = args;
                         return self._container.ReplaceItemAsync(entity, entity.Id, pk, requestOptions);
                     },
-                    (entity, pk, requestOptions)).ConfigureAwait(false);
+                    (this, entity, pk, requestOptions)).ConfigureAwait(false);
                 grainState.ETag = response.Resource.ETag;
             }
 
@@ -211,12 +212,12 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
                 if (string.IsNullOrWhiteSpace(grainState.ETag))
                     return;  //state not written
 
-                await ExecuteWithRetries(static (self, args) =>
+                await _executor.ExecuteOperation(static args =>
                 {
-                    var (id, pk, requestOptions) = args;
+                    var (self, id, pk, requestOptions) = args;
                     return self._container.DeleteItemAsync<GrainStateEntity<T>>(id, pk, requestOptions);
                 },
-                (id, pk, requestOptions));
+                (this, id, pk, requestOptions));
 
                 grainState.ETag = null;
                 grainState.RecordExists = false;
@@ -232,9 +233,9 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
                     PartitionKey = partitionKey
                 };
 
-                var response = await ExecuteWithRetries(static (self, args) =>
+                var response = await _executor.ExecuteOperation(static args =>
                 {
-                    var (grainState, entity, pk, requestOptions) = args;
+                    var (self, grainState, entity, pk, requestOptions) = args;
                     return grainState.ETag switch
                     {
                         null or { Length: 0 } => self._container.CreateItemAsync(entity, pk),
@@ -242,7 +243,7 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
                         _ => self._container.ReplaceItemAsync(entity, entity.Id, pk, requestOptions),
                     };
                 },
-                (grainState, entity, pk, requestOptions)).ConfigureAwait(false);
+                (this, grainState, entity, pk, requestOptions)).ConfigureAwait(false);
 
                 grainState.ETag = response.Resource.ETag;
                 grainState.RecordExists = true;
@@ -343,7 +344,7 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
         var dbResponse = await _client.CreateDatabaseIfNotExistsAsync(_options.DatabaseName, _options.DatabaseThroughput);
         var db = dbResponse.Database;
 
-        var stateContainer = new ContainerProperties(_options.ContainerName, DEFAULT_PARTITION_KEY_PATH);
+        var stateContainer = new ContainerProperties(_options.ContainerName, _options.PartitionKeyPath);
         stateContainer.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
         stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
         stateContainer.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"State\"/*" });
@@ -394,29 +395,6 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
             _logger.LogError(ex, "Error deleting Azure Cosmos DB database");
             WrappedException.CreateAndRethrow(ex);
             throw;
-        }
-    }
-
-    private async Task<TResult> ExecuteWithRetries<TArg1, TResult>(Func<CosmosGrainStorage, TArg1, Task<TResult>> clientFunc, TArg1 arg1)
-    {
-        // From:  https://blogs.msdn.microsoft.com/bigdatasupport/2015/09/02/dealing-with-requestratetoolarge-errors-in-azure-documentdb-and-testing-performance/
-        while (true)
-        {
-            TimeSpan sleepTime;
-            try
-            {
-                return await clientFunc(this, arg1).ConfigureAwait(false);
-            }
-            catch (CosmosException dce) when (dce.StatusCode == TOO_MANY_REQUESTS)
-            {
-                sleepTime = dce.RetryAfter ?? TimeSpan.Zero;
-            }
-            catch (AggregateException ae) when (ae.InnerException is CosmosException dce && dce.StatusCode == TOO_MANY_REQUESTS)
-            {
-                sleepTime = dce.RetryAfter ?? TimeSpan.Zero;
-            }
-
-            await Task.Delay(sleepTime);
         }
     }
 }

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
@@ -9,6 +9,7 @@ public class CosmosGrainStorageOptions : CosmosOptions
 {
     private const string ORLEANS_STORAGE_CONTAINER = "OrleansStorage";
     public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
+    private const string DEFAULT_PARTITION_KEY_PATH = "/PartitionKey";
 
     /// <summary>
     /// Stage of silo lifecycle where storage should be initialized. Storage must be initialized prior to use.
@@ -26,6 +27,8 @@ public class CosmosGrainStorageOptions : CosmosOptions
     /// The default is to not add any property in the State object.
     /// </summary>
     public List<string> StateFieldsToIndex { get; set; } = new();
+
+    public string PartitionKeyPath { get; set; } = DEFAULT_PARTITION_KEY_PATH;
 
     /// <summary>
     /// Initializes a new <see cref="CosmosGrainStorageOptions"/> instance.


### PR DESCRIPTION
Allows customization of the retry logic used by Cosmos DB grain persistence and reminder storage.
Sets `CosmosOptions.ClientOptions` by default.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8693)