### PR TITLE
Throw when deserializing Exceptions by reference, and avoid reference tracking for all Exception-derived types (#8628)

### DIFF
--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -195,7 +195,7 @@ namespace Orleans.CodeGenerator
 
         public bool UseActivator => Type.HasAttribute(_libraryTypes.UseActivatorAttribute) || !IsEmptyConstructable || HasActivatorConstructor;
 
-        public bool TrackReferences => !IsValueType && !Type.HasAttribute(_libraryTypes.SuppressReferenceTrackingAttribute);
+        public bool TrackReferences => !IsValueType && !IsExceptionType && !Type.HasAttribute(_libraryTypes.SuppressReferenceTrackingAttribute);
         public bool OmitDefaultMemberValues => Type.HasAttribute(_libraryTypes.OmitDefaultMemberValuesAttribute);
 
         public List<INamedTypeSymbol> SerializationHooks { get; }

--- a/src/Orleans.Serialization/Exceptions.cs
+++ b/src/Orleans.Serialization/Exceptions.cs
@@ -298,6 +298,48 @@ namespace Orleans.Serialization
     }
 
     /// <summary>
+    /// A reference to a value is not supported here.
+    /// </summary>
+    [Serializable]
+    [GenerateSerializer]
+    public sealed class ReferenceFieldNotSupportedException : SerializerException
+    {
+        /// <summary>
+        /// Gets the type of the target reference.
+        /// </summary>
+        /// <value>The type of the target reference.</value>
+        [Id(0)]
+        public Type TargetReferenceType { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceFieldNotSupportedException"/> class.
+        /// </summary>
+        /// <param name="targetType">Type of the target.</param>
+        public ReferenceFieldNotSupportedException(Type targetType) : base(
+            $"Reference with type {targetType} not allowed here.")
+        {
+            TargetReferenceType = targetType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceFieldNotSupportedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
+        private ReferenceFieldNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            TargetReferenceType = (Type)info.GetValue(nameof(TargetReferenceType), typeof(Type));
+        }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(TargetReferenceType), TargetReferenceType);
+        }
+    }
+
+    /// <summary>
     /// A well-known type was not known.
     /// </summary>
     [Serializable]

--- a/test/Orleans.Serialization.UnitTests/ISerializableTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ISerializableTests.cs
@@ -330,47 +330,6 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal("payload", baseField.Payload);
         }
 
-        [Fact]
-        public void ThrowsOnSerialize_ExceptionReference()
-        {
-            var serializer = _serviceProvider.GetRequiredService<Serializer>();
-
-            // Throw the exception so that stack trace is populated
-            Exception source = Assert.Throws<ExceptionWithGeneratedCodec>((Action)(() =>
-            {
-                throw new ExceptionWithGeneratedCodec();
-            }));
-
-            var exceptionWrapper = new ExceptionWrapper(source);
-
-            var serialized = serializer.SerializeToArray(exceptionWrapper);
-            using var formatterSession = _sessionPool.GetSession();
-            var formatted = BitStreamFormatter.Format(serialized, formatterSession);
-
-            Assert.Throws<ReferenceFieldNotSupportedException>(() => serializer.Deserialize<ExceptionWrapper>(serialized));
-        }
-
-        [GenerateSerializer]
-        public class ExceptionWrapper
-        {
-            [Id(0)]
-            public Exception WrappedExceptionReference1 { get; set; }
-
-            // Forces a reference to the previous serialized value for WrappedExceptionReference1
-            [Id(1)]
-            public Exception WrappedExceptionReference2 { get; set; }
-
-            public ExceptionWrapper(Exception wrappedException)
-            {
-                WrappedExceptionReference1 = wrappedException;
-                WrappedExceptionReference2 = wrappedException;
-            }
-        }
-
-        [GenerateSerializer]
-        public class ExceptionWithGeneratedCodec : Exception
-        {}
-
         [Serializable]
         public class SimpleISerializableObject : ISerializable, IDeserializationCallback
         {

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Runtime.Serialization;
 using System.Text.Json;
 using Newtonsoft.Json;
 using Orleans;
@@ -95,7 +96,7 @@ public class MyValue : IEquatable<MyValue>
     }
 
     public override int GetHashCode() => Value;
-} 
+}
 
 [GenerateSerializer]
 [Immutable]
@@ -148,6 +149,62 @@ public class MyUnsealedImmutableSub : MyMutableBase, IMySub
 {
     [Id(0)]
     public MyValue SubValue { get; set; }
+}
+
+[GenerateSerializer]
+[SuppressReferenceTracking]
+public class MySuppressReferenceTrackingValue : MyValue
+{
+    public MySuppressReferenceTrackingValue(int value) : base(value)
+    {
+    }
+}
+
+[GenerateSerializer]
+public class MyCustomException : Exception
+{
+    public MyCustomException() { }
+    public MyCustomException(string message) : base(message) { }
+    public MyCustomException(string message, Exception inner) : base(message, inner) { }
+    public MyCustomException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+
+    [Id(0)]
+    public int CustomInt;
+}
+
+public class MyCustomForeignException : Exception
+{
+    public MyCustomForeignException(int customInt)
+    {
+        CustomInt = customInt;
+    }
+
+    public MyCustomForeignException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+
+    [Id(0)]
+    public int CustomInt;
+}
+
+[GenerateSerializer]
+public struct MyCustomForeignExceptionSurrogate
+{
+    [Id(0)]
+    public int CustomInt { get; set; }
+
+    public MyCustomForeignExceptionSurrogate(int customInt)
+    {
+        CustomInt = customInt;
+    }
+}
+
+[RegisterConverter]
+public sealed class MyCustomForeignExceptionSurrogateConverter : IConverter<MyCustomForeignException, MyCustomForeignExceptionSurrogate>
+{
+    public MyCustomForeignException ConvertFromSurrogate(in MyCustomForeignExceptionSurrogate surrogate) =>
+        new MyCustomForeignException(surrogate.CustomInt);
+
+    public MyCustomForeignExceptionSurrogate ConvertToSurrogate(in MyCustomForeignException value) =>
+        new MyCustomForeignExceptionSurrogate(value.CustomInt);
 }
 
 [GenerateSerializer]

--- a/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
@@ -145,41 +145,6 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal(customException.CustomInt, ceCopy.CustomInt);
         }
 
-        [Fact]
-        public void ThrowsOnDeserialize_ExceptionReference()
-        {
-            Exception source;
-            try
-            {
-                throw new ExceptionWithGeneratedCodec();
-            }
-            catch (Exception e)
-            {
-                source = e;
-            }
-
-            var exceptionWrapper = new ExceptionWrapper(source);
-
-            Assert.Throws<ReferenceFieldNotSupportedException>(() => RoundTripToExpectedType<ExceptionWrapper, ExceptionWrapper>(exceptionWrapper));
-        }
-
-        [GenerateSerializer]
-        public class ExceptionWrapper
-        {
-            [Id(0)]
-            public Exception WrappedExceptionReference1 { get; set; }
-
-            // Forces a reference to the previous serialized value for WrappedExceptionReference1
-            [Id(1)]
-            public Exception WrappedExceptionReference2 { get; set; }
-
-            public ExceptionWrapper(Exception wrappedException)
-            {
-                WrappedExceptionReference1 = wrappedException;
-                WrappedExceptionReference2 = wrappedException;
-            }
-        }
-
         [GenerateSerializer]
         public class ExceptionWithGeneratedCodec : Exception
         {}

--- a/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
@@ -146,6 +146,45 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void ThrowsOnDeserialize_ExceptionReference()
+        {
+            Exception source;
+            try
+            {
+                throw new ExceptionWithGeneratedCodec();
+            }
+            catch (Exception e)
+            {
+                source = e;
+            }
+
+            var exceptionWrapper = new ExceptionWrapper(source);
+
+            Assert.Throws<ReferenceFieldNotSupportedException>(() => RoundTripToExpectedType<ExceptionWrapper, ExceptionWrapper>(exceptionWrapper));
+        }
+
+        [GenerateSerializer]
+        public class ExceptionWrapper
+        {
+            [Id(0)]
+            public Exception WrappedExceptionReference1 { get; set; }
+
+            // Forces a reference to the previous serialized value for WrappedExceptionReference1
+            [Id(1)]
+            public Exception WrappedExceptionReference2 { get; set; }
+
+            public ExceptionWrapper(Exception wrappedException)
+            {
+                WrappedExceptionReference1 = wrappedException;
+                WrappedExceptionReference2 = wrappedException;
+            }
+        }
+
+        [GenerateSerializer]
+        public class ExceptionWithGeneratedCodec : Exception
+        {}
+
+        [Fact]
         public void GeneratedSerializersRoundTripThroughSerializer_Polymorphic()
         {
             var original = new SomeSubClass

--- a/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PolymorphismTests.cs
@@ -145,10 +145,6 @@ namespace Orleans.Serialization.UnitTests
             Assert.Equal(customException.CustomInt, ceCopy.CustomInt);
         }
 
-        [GenerateSerializer]
-        public class ExceptionWithGeneratedCodec : Exception
-        {}
-
         [Fact]
         public void GeneratedSerializersRoundTripThroughSerializer_Polymorphic()
         {


### PR DESCRIPTION
This adds the two suggestions @ReubenBond makes in [this issue](https://github.com/dotnet/orleans/issues/8628#issuecomment-1714199599).

### Throw an exception when deserializing an Exception-derived type by reference

When we have an `Exception`-derived type that has been serialized as a reference, we should throw an exception when trying to deserialize it with the `ExceptionCodec`, rather than silently returning `null` in it's place.

This scenario could (prior to this PR) come about when an exception is serialized using the code-gen serializer - say you add `[GenerateSerializer]` for your custom exception type, which is valid if you have certain fields you need serialized -, but this is stored in a field of type `Exception`. In that case, the code-gen serializer would by default (absent the `SuppressReferenceTrackingAttribute`) serialize the exception as a reference if it appears more than once. However, on deserialization the `ExceptionCodec` will be used, and will refuse to resolve that reference. This is what made me initially raise https://github.com/dotnet/orleans/issues/8628.

Should that happen, this change just makes it clear in that case why deserialization fails, allowing the user to design around it.

Worth mentioning that I did have a test for this, but the next fix makes it much more difficult to test because it makes it harder to get into this scenario in the first place. I removed the test, as this is simple and exceptional logic, but it depends on how strict you want to be I think. It would be possible, but a pain to test.

### Avoid reference tracking for all Exception-derived types in the first place

We take the behaviour that the `ExceptionCodec` has, which is to not serialize as instances of references when there are multiple references to the same Exception-derived object (reference tracking), and extend this for all Exception types, including those that don't use the `ExceptionCodec` (as described above). This should make less likely for us to get into the scenario above in the first place (that is if the system that serialized the message uses this change, if not then the the above change could still be relevant).

The trickier part here was implementing this to also cover exceptions that are using a surrogate type. I didn't want to make the change for exceptions that have `[GenerateSerializer]`, but not have the same support for exceptions that have a surrogate, because I feel like that discrepancy would be more confusing than just not implementing this at all. To account for that, I also had to modify the `SurrogateCodec`, as it's responsible for reference tracking for surrogates.

I'm not sure how I feel about this change, it feels like it's baking in some knowledge about how the `ExceptionCodec` behaves into the `SurrogateCodec`. If we do want to have this `ExceptionCodec` behaviour for exceptions that aren't serialized by the `ExceptionCodec` however, I think this is necessary. I can completely see the argument though that this change adds too much complexity than it's worth. If you think that, then I'm happy to remove this part and just keep the previous change of throwing above instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8698)