### PR TITLE
Cosmos DB: perform read for consistency when deleting state which is expected to not exist

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -214,7 +214,7 @@ internal class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLi
                     await ReadStateAsync<T>(grainType, grainId, grainState);
                     if (grainState.RecordExists)
                     {
-                        // State exists but it shouldn't.
+                        // State exists but the current activation has not observed state creation. Therefore, we have inconsistent state and should throw to give the grain a chance to deactivate and recover.
                         throw new CosmosConditionNotSatisfiedException(grainType, grainId, _options.ContainerName, grainState.ETag, "None");
                     }
 


### PR DESCRIPTION
Currently, when `DeleteStateOnClear` is set, deleting state which is expected to not exist (eg, deleting state twice in succession) is a no-op. Instead, for consistency, we should perform a read when state is expected to not exist.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8700)