### PR TITLE
Nullify directory entries of defunct local predecessors during grain activation

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -120,6 +120,22 @@ namespace Orleans.Runtime
             }
         }
 
+        /// <summary>
+        /// Gets previous directory registration for this grain, if known. This is used to update the grain directory to point to the new registration during activation.
+        /// </summary>
+        public GrainAddress PreviousRegistration
+        {
+            get => _extras?.PreviousRegistration;
+            set
+            {
+                lock (this)
+                {
+                    _extras ??= new();
+                    _extras.PreviousRegistration = value;
+                }
+            }
+        }
+
         private Exception DeactivationException => _extras?.DeactivationReason.Exception;
 
         private DeactivationReason DeactivationReason
@@ -895,7 +911,7 @@ namespace Orleans.Runtime
                                 {
                                     // Add this activation to cache invalidation headers.
                                     message.CacheInvalidationHeader ??= new List<GrainAddressCacheUpdate>();
-                                    message.CacheInvalidationHeader.Add(new GrainAddressCacheUpdate(new GrainAddress { GrainId = GrainId, SiloAddress = Address.SiloAddress }, validAddress: null));
+                                    message.CacheInvalidationHeader.Add(new GrainAddressCacheUpdate(Address, validAddress: null));
 
                                     var reason = new DeactivationReason(
                                         DeactivationReasonCode.IncompatibleRequest,
@@ -1082,7 +1098,7 @@ namespace Orleans.Runtime
                     if (context.TryGetValue(GrainAddressMigrationContextKey, out GrainAddress previousRegistration) && previousRegistration is not null)
                     {
                         // Propagate the previous registration, so that the new activation can atomically replace it with its new address.
-                        (_extras ??= new()).PreviousRegistration = previousRegistration;
+                        PreviousRegistration = previousRegistration;
                         if (_shared.Logger.IsEnabled(LogLevel.Debug))
                         {
                             _shared.Logger.LogDebug("Previous activation address was {PreviousRegistration}", previousRegistration);
@@ -1487,42 +1503,66 @@ namespace Orleans.Runtime
             else
             {
                 Exception registrationException;
+                var previousRegistration = PreviousRegistration;
                 try
                 {
-                    var result = await _shared.InternalRuntime.GrainLocator.Register(Address, _extras?.PreviousRegistration);
-                    if (Address.Matches(result))
+                    while (true)
                     {
-                        success = true;
-                    }
-                    else
-                    {
-                        // Set the forwarding address so that messages enqueued on this activation can be forwarded to
-                        // the existing activation.
-                        ForwardingAddress = result?.SiloAddress;
-                        if (ForwardingAddress is { } address)
+                        var result = await _shared.InternalRuntime.GrainLocator.Register(Address, previousRegistration);
+                        if (Address.Matches(result))
                         {
-                            DeactivationReason = new(DeactivationReasonCode.DuplicateActivation, $"This grain is active on another host ({address}).");
+                            success = true;
+                        }
+                        else if (result?.SiloAddress is { } registeredSilo && registeredSilo.Equals(Address.SiloAddress))
+                        {
+                            if (_shared.Logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _shared.Logger.LogDebug(
+                                    "The grain directory has an existing entry pointing to a different activation of this grain on this silo, {PreviousRegistration}."
+                                    + " This may indicate that the previous activation was deactivated but the directory was not successfully updated."
+                                    + " The directory will be updated to point to this activation.",
+                                    previousRegistration);
+                            }
+
+                            // Attempt to register this activation again, using the registration of the previous instance of this grain,
+                            // which is registered to this silo. That activation must be a defunct predecessor of this activation,
+                            // since the catalog only allows one activation of a given grain at a time.
+                            // This could occur if the previous activation failed to unregister itself from the grain directory.
+                            previousRegistration = result;
+                            continue;
+                        }
+                        else
+                        {
+                            // Set the forwarding address so that messages enqueued on this activation can be forwarded to
+                            // the existing activation.
+                            ForwardingAddress = result?.SiloAddress;
+                            if (ForwardingAddress is { } address)
+                            {
+                                DeactivationReason = new(DeactivationReasonCode.DuplicateActivation, $"This grain is active on another host ({address}).");
+                            }
+
+                            success = false;
+                            CatalogInstruments.ActivationConcurrentRegistrationAttempts.Add(1);
+                            if (_shared.Logger.IsEnabled(LogLevel.Debug))
+                            {
+                                // If this was a duplicate, it's not an error, just a race.
+                                // Forward on all of the pending messages, and then forget about this activation.
+                                var primary = _shared.InternalRuntime.LocalGrainDirectory.GetPrimaryForGrain(GrainId);
+                                _shared.Logger.LogDebug(
+                                    (int)ErrorCode.Catalog_DuplicateActivation,
+                                    "Tried to create a duplicate activation {Address}, but we'll use {ForwardingAddress} instead. "
+                                    + "GrainInstance type is {GrainInstanceType}. {PrimaryMessage}"
+                                    + "Full activation address is {Address}. We have {WaitingCount} messages to forward.",
+                                    Address,
+                                    ForwardingAddress,
+                                    GrainInstance?.GetType(),
+                                    primary != null ? "Primary Directory partition for this grain is " + primary + ". " : string.Empty,
+                                    Address.ToFullString(),
+                                    WaitingCount);
+                            }
                         }
 
-                        success = false;
-                        CatalogInstruments.ActivationConcurrentRegistrationAttempts.Add(1);
-                        if (_shared.Logger.IsEnabled(LogLevel.Debug))
-                        {
-                            // If this was a duplicate, it's not an error, just a race.
-                            // Forward on all of the pending messages, and then forget about this activation.
-                            var primary = _shared.InternalRuntime.LocalGrainDirectory.GetPrimaryForGrain(GrainId);
-                            _shared.Logger.LogDebug(
-                                (int)ErrorCode.Catalog_DuplicateActivation,
-                                "Tried to create a duplicate activation {Address}, but we'll use {ForwardingAddress} instead. "
-                                + "GrainInstance type is {GrainInstanceType}. {PrimaryMessage}"
-                                + "Full activation address is {Address}. We have {WaitingCount} messages to forward.",
-                                Address,
-                                ForwardingAddress,
-                                GrainInstance?.GetType(),
-                                primary != null ? "Primary Directory partition for this grain is " + primary + ". " : string.Empty,
-                                Address.ToFullString(),
-                                WaitingCount);
-                        }
+                        break;
                     }
 
                     registrationException = null;

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -121,7 +121,8 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Gets previous directory registration for this grain, if known. This is used to update the grain directory to point to the new registration during activation.
+        /// Gets the previous directory registration for this grain, if known.
+        /// This is used to update the grain directory to point to the new registration during activation.
         /// </summary>
         public GrainAddress PreviousRegistration
         {

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -24,7 +24,6 @@ namespace Orleans.Runtime.Messaging
         private readonly SiloAddress _siloAddress;
         private readonly SiloMessagingOptions messagingOptions;
         private readonly PlacementService placementService;
-        private readonly ActivationDirectory activationDirectory;
         private readonly GrainLocator _grainLocator;
         private readonly ILogger log;
         private readonly Catalog catalog;
@@ -43,7 +42,6 @@ namespace Orleans.Runtime.Messaging
             RuntimeMessagingTrace messagingTrace,
             IOptions<SiloMessagingOptions> messagingOptions,
             PlacementService placementService,
-            ActivationDirectory activationDirectory,
             GrainLocator grainLocator)
         {
             this.catalog = catalog;
@@ -52,7 +50,6 @@ namespace Orleans.Runtime.Messaging
             this.connectionManager = senderManager;
             this.messagingTrace = messagingTrace;
             this.placementService = placementService;
-            this.activationDirectory = activationDirectory;
             _grainLocator = grainLocator;
             this.log = logger;
             this.messageFactory = messageFactory;

--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -49,6 +49,8 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetRuntimeInstanceId();
 
         Task<string> GetActivationId();
+
+        Task<SiloAddress> GetSiloAddress();
     }
 
     public interface IOneWayGrain : IGrainWithGuidKey

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -152,6 +152,7 @@ namespace UnitTests.Grains
         }
     }
 
+    [GrainType("guid-test-grain")]
     internal class GuidTestGrain : Grain, IGuidTestGrain
     {
         private readonly string _id = Guid.NewGuid().ToString();
@@ -200,6 +201,8 @@ namespace UnitTests.Grains
         {
             return Task.FromResult(_id);
         }
+
+        public Task<SiloAddress> GetSiloAddress() => Task.FromResult(ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress);
     }
 
     internal class OneWayGrain : Grain, IOneWayGrain, ISimpleGrainObserver

--- a/test/TesterInternal/GrainLocatorActivationResiliencyTests.cs
+++ b/test/TesterInternal/GrainLocatorActivationResiliencyTests.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Placement;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Tests that grain activation can recover from invalid grain directory entries.
+    /// </summary>
+    public class GrainLocatorActivationResiliencyTests : HostedTestClusterEnsureDefaultStarted
+    {
+        public GrainLocatorActivationResiliencyTests(DefaultClusterFixture fixture) : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests that a grain can be activated even if the grain locator indicates that there is an existing registration for that grain on the same silo.
+        /// </summary>
+        [Fact, TestCategory("BVT")]
+        public async Task ReactivateGrainWithPoisonGrainDirectoryEntry_LocalSilo()
+        {
+            var primarySilo = (InProcessSiloHandle)Fixture.HostedCluster.Primary;
+            var primarySiloAddress = primarySilo.SiloAddress;
+            var grain = GrainFactory.GetGrain<IGuidTestGrain>(Guid.NewGuid());
+
+            // Insert an entry into the grain directory which points to a grain which is not active.
+            // The entry points to the silo which the activation will be created on, but it points to a different activation.
+            // This will cause the first registration attempt to fail, but the activation should recognize that the grain
+            // directory entry is incorrect (points to the current silo, but an activation which must be defunct) and retry
+            // registration, passing the previous registration so that the grain directory entry is updated.
+            var grainLocator = primarySilo.SiloHost.Services.GetRequiredService<GrainLocator>();
+            var badAddress = GrainAddress.GetAddress(primarySiloAddress, grain.GetGrainId(), ActivationId.NewId());
+            await grainLocator.Register(badAddress, previousRegistration: null);
+
+            {
+                // Rig placement to occurs on the primary silo.
+                RequestContext.Set(IPlacementDirector.PlacementHintKey, primarySiloAddress);
+                var silo = await grain.GetSiloAddress();
+                Assert.Equal(primarySiloAddress, silo);
+            }
+        }
+        
+        /// <summary>
+        /// Similar to <see cref="ReactivateGrainWithPoisonGrainDirectoryEntry_LocalSilo"/>, except this test attempts to activate the grain on a different silo
+        /// from the one specified in the grain directory entry, to ensure that the call will be forwarded to the correct silo.
+        /// </summary>
+        [Fact, TestCategory("BVT")]
+        public async Task ReactivateGrainWithPoisonGrainDirectoryEntry_RemoteSilo()
+        {
+            var primarySilo = (InProcessSiloHandle)Fixture.HostedCluster.Primary;
+            var secondarySiloAddress = Fixture.HostedCluster.SecondarySilos.First().SiloAddress;
+            var primarySiloAddress = primarySilo.SiloAddress;
+            var grain = GrainFactory.GetGrain<IGuidTestGrain>(Guid.NewGuid());
+
+            // Insert an entry into the grain directory which points to a grain which is not active.
+            // The entry points to another silo, but that silo also does not host the registered activation.
+            // This will cause the first registration attempt to fail, but the activation will forward messages to the
+            // silo which the registration points to and the subsequent activation will also initially fail registration,
+            // but succeed later.
+            var grainLocator = primarySilo.SiloHost.Services.GetRequiredService<GrainLocator>();
+            var badAddress = GrainAddress.GetAddress(primarySiloAddress, grain.GetGrainId(), ActivationId.NewId());
+            await grainLocator.Register(badAddress, previousRegistration: null);
+
+            {
+                // Rig placement to occurs on the secondary silo, but since there is a directory entry pointing to the primary silo,
+                // the call should be forwarded to the primary silo where the grain will be activated.
+                RequestContext.Set(IPlacementDirector.PlacementHintKey, secondarySiloAddress);
+                var silo = await grain.GetSiloAddress();
+                Assert.Equal(primarySiloAddress, silo);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where activation fails repeatedly during directory registration because the grain directory contains an existing entry for a different activation on the same silo. The fix handles this case by retrying registration, passing the previous address so that the registration will be updated instead of rejected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8704)