### PR TITLE
Improve error checking around constructing and parsing generic grain types and clean up tests

### DIFF
--- a/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
+++ b/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
@@ -86,7 +86,7 @@ namespace Orleans
 
             if (GenericGrainType.TryParse(result, out var genericGrainType) && !genericGrainType.IsConstructed)
             {
-                result = genericGrainType.GrainType.GetConstructed(genericInterface.Value);
+                result = genericGrainType.GetConstructed(genericInterface);
             }
 
             return result;
@@ -149,7 +149,7 @@ namespace Orleans
                         }
                         else
                         {
-                            result = genericGrainType.GrainType.GetConstructed(genericInterface.Value);
+                            result = genericGrainType.GetConstructed(genericInterface);
                         }
                     }
                     else

--- a/src/Orleans.Core/IDs/GenericGrainInterfaceType.cs
+++ b/src/Orleans.Core/IDs/GenericGrainInterfaceType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Orleans.Serialization.TypeSystem;
 using Orleans.Utilities;
 
@@ -14,15 +15,21 @@ namespace Orleans.Runtime
         /// Initializes a new instance of the <see cref="GenericGrainInterfaceType"/> struct.
         /// </summary>
         /// <param name="value">The underlying grain interface type.</param>
-        private GenericGrainInterfaceType(GrainInterfaceType value)
+        private GenericGrainInterfaceType(GrainInterfaceType value, int arity)
         {
             Value = value;
+            Arity = arity;
         }
 
         /// <summary>
         /// The underlying <see cref="GrainInterfaceType"/>
         /// </summary>
         public GrainInterfaceType Value { get; }
+
+        /// <summary>
+        /// The arity of the generic type.
+        /// </summary>
+        public int Arity { get; }
 
         /// <summary>
         /// Returns <see langword="true" /> if this instance contains concrete type parameters.
@@ -34,9 +41,16 @@ namespace Orleans.Runtime
         /// </summary>
         public static bool TryParse(GrainInterfaceType grainType, out GenericGrainInterfaceType result)
         {
-            if (!grainType.IsDefault && TypeConverterExtensions.IsGenericType(grainType.Value))
+            if (grainType.IsDefault)
             {
-                result = new GenericGrainInterfaceType(grainType);
+                result = default;
+                return false;
+            }
+
+            var arity = TypeConverterExtensions.GetGenericTypeArity(grainType.Value);
+            if (arity > 0)
+            {
+                result = new GenericGrainInterfaceType(grainType, arity);
                 return true;
             }
 
@@ -50,7 +64,7 @@ namespace Orleans.Runtime
         public GenericGrainInterfaceType GetGenericGrainType()
         {
             var generic = TypeConverterExtensions.GetDeconstructed(Value.Value);
-            return new GenericGrainInterfaceType(new GrainInterfaceType(generic));
+            return new GenericGrainInterfaceType(new GrainInterfaceType(generic), Arity);
         }
 
         /// <summary>
@@ -58,8 +72,13 @@ namespace Orleans.Runtime
         /// </summary>
         public GenericGrainInterfaceType Construct(TypeConverter formatter, params Type[] typeArguments)
         {
+            if (Arity != typeArguments.Length)
+            {
+                ThrowIncorrectArgumentLength(typeArguments);
+            }
+
             var constructed = formatter.GetConstructed(this.Value.Value, typeArguments);
-            return new GenericGrainInterfaceType(new GrainInterfaceType(constructed));
+            return new GenericGrainInterfaceType(new GrainInterfaceType(constructed), Arity);
         }
 
         /// <summary>
@@ -71,5 +90,8 @@ namespace Orleans.Runtime
         /// Returns a UTF8 interpretation of the current instance.
         /// </summary>
         public override string ToString() => Value.ToString();
+
+        [DoesNotReturn]
+        private void ThrowIncorrectArgumentLength(Type[] typeArguments) => throw new ArgumentException($"Incorrect number of type arguments, {typeArguments.Length}, to construct a generic grain type with arity {Arity}.", nameof(typeArguments));
     }
 }

--- a/src/Orleans.Core/Manifest/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainTypeResolver.cs
@@ -95,7 +95,8 @@ namespace Orleans.Metadata
                 && !type.ContainsGenericParameters
                 && !genericGrainType.IsConstructed)
             {
-                grainType = genericGrainType.Construct(_typeConverter, type.GetGenericArguments()).GrainType;
+                var typeArguments = type.GetGenericArguments();
+                grainType = genericGrainType.Construct(_typeConverter, typeArguments).GrainType;
             }
 
             return grainType;

--- a/src/Orleans.Core/Utils/TypeConverterExtensions.cs
+++ b/src/Orleans.Core/Utils/TypeConverterExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers.Text;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Orleans.Runtime;
 using Orleans.Serialization.TypeSystem;
@@ -18,6 +19,36 @@ namespace Orleans.Utilities
         /// Returns true if the provided type string is a generic type.
         /// </summary>
         public static bool IsGenericType(IdSpan type) => type.AsSpan().IndexOf((byte)GenericTypeIndicator) >= 0;
+
+        /// <summary>
+        /// Returns the generic arity of the specified grain type.
+        /// </summary>
+        public static int GetGenericTypeArity(IdSpan type)
+        {
+            var typeSpan = type.AsSpan();
+            var startIndex = typeSpan.IndexOf((byte)GenericTypeIndicator) + 1;
+            if (startIndex <= 0 || startIndex >= typeSpan.Length)
+            {
+                return 0;
+            }
+
+            int endIndex;
+            for (endIndex = startIndex; endIndex < typeSpan.Length; endIndex++)
+            {
+                var c = typeSpan[endIndex];
+                if (c is < ((byte)'0') or > ((byte)'9'))
+                {
+                    break;
+                }
+            }
+
+            if (endIndex > startIndex && Utf8Parser.TryParse(typeSpan[startIndex..endIndex], out int arity, out _))
+            {
+                return arity;
+            }
+
+            throw new InvalidOperationException($"Unable to parse arity from type \"{type}\"");
+        }
 
         /// <summary>
         /// Returns true if the provided type string is a constructed generic type.
@@ -65,8 +96,15 @@ namespace Orleans.Utilities
         /// <summary>
         /// Returns the constructed form of the provided generic grain type using the type arguments from the provided constructed interface type.
         /// </summary>
-        public static GrainType GetConstructed(this GrainType grainType, GrainInterfaceType typeArguments)
+        public static GrainType GetConstructed(this GenericGrainType genericGrainType, GenericGrainInterfaceType genericGrainInterfaceType)
         {
+            if (genericGrainType.Arity != genericGrainInterfaceType.Arity)
+            {
+                ThrowGenericArityMismatch(genericGrainType, genericGrainInterfaceType);
+            }
+
+            var grainType = genericGrainType.GrainType;
+            var typeArguments = genericGrainInterfaceType.Value;
             var args = typeArguments.Value.AsSpan();
             var index = args.IndexOf((byte)StartArgument);
             if (index <= 0) return grainType; // if no type arguments are provided, then the current logic expects the unconstructed form (but the grain call is going to fail later anyway...)
@@ -112,5 +150,9 @@ namespace Orleans.Utilities
 
             return result;
         }
+
+        [DoesNotReturn]
+        private static void ThrowGenericArityMismatch(GenericGrainType genericGrainType, GenericGrainInterfaceType genericInterfaceType)
+            => throw new ArgumentException($"Cannot construct generic grain \"{genericGrainType.GrainType}\" using arguments from generic interface \"{genericInterfaceType}\" because the generic arities are not equal: {genericGrainType.Arity} is not equal to {genericInterfaceType.Arity}.");
     }
 }

--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -11,6 +11,7 @@ namespace DefaultCluster.Tests.General
     /// <summary>
     /// Unit tests for grains implementing generic interfaces
     /// </summary>
+    [TestCategory("BVT"), TestCategory("Generics")]
     public class GenericGrainTests : HostedTestClusterEnsureDefaultStarted
     {
         private static int grainId = 0;
@@ -21,17 +22,17 @@ namespace DefaultCluster.Tests.General
 
         public TGrainInterface GetGrain<TGrainInterface>(long i) where TGrainInterface : IGrainWithIntegerKey
         {
-            return  this.GrainFactory.GetGrain<TGrainInterface>(i);
+            return this.GrainFactory.GetGrain<TGrainInterface>(i);
         }
 
         public TGrainInterface GetGrain<TGrainInterface>() where TGrainInterface : IGrainWithIntegerKey
         {
-            return  this.GrainFactory.GetGrain<TGrainInterface>(GetRandomGrainId());
+            return this.GrainFactory.GetGrain<TGrainInterface>(GetRandomGrainId());
         }
 
         /// Can instantiate multiple concrete grain types that implement
         /// different specializations of the same generic interface
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
         {
             var grainOfIntFloat1 = GetGrain<IGenericGrain<int, float>>();
@@ -52,7 +53,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -67,7 +68,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Can instantiate generic grain specializations
-        [Theory, TestCategory("BVT"), TestCategory("Generics")]
+        [Theory]
         [InlineData(1.2f)]
         [InlineData(3.4f)]
         [InlineData("5.6")]
@@ -80,13 +81,13 @@ namespace DefaultCluster.Tests.General
 
             // generic grain implementation does not change the set value:
             await grain.Transform();
-            
+
             T result = await grain.Get();
-            
-            Assert.Equal(setValue, result);            
+
+            Assert.Equal(setValue, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_SimpleGenericGrainGetGrain_ArrayTypeParameter()
         {
             var grain = GetGrain<ISimpleGenericGrain<int[]>>();
@@ -96,13 +97,13 @@ namespace DefaultCluster.Tests.General
 
             // generic grain implementation does not change the set value:
             await grain.Transform();
-            
+
             var result = await grain.Get();
-            
-            Assert.Equal(expected, result);            
+
+            Assert.Equal(expected, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_GenericGrainInheritingArray()
         {
             var grain = GetGrain<IGenericArrayRegisterGrain<int>>();
@@ -111,12 +112,12 @@ namespace DefaultCluster.Tests.General
             await grain.Set(expected);
 
             var result = await grain.Get();
-            
-            Assert.Equal(expected, result);            
+
+            Assert.Equal(expected, result);
         }
 
         /// Can instantiate grains that implement generic interfaces with generic type parameters
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_GenericInterfaceWithGenericParametersGetGrain()
         {
 
@@ -133,7 +134,7 @@ namespace DefaultCluster.Tests.General
 
 
         /// Multiple GetGrain requests with the same id return the same generic grain specialization
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_SimpleGenericGrainMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -150,7 +151,7 @@ namespace DefaultCluster.Tests.General
 
         /// If both a concrete implementation and a generic implementation of a 
         /// generic interface exist, prefer the concrete implementation.
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
         {
             var grainOfDouble1 = GetGrain<ISimpleGenericGrain<double>>();
@@ -171,7 +172,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -189,7 +190,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Can instantiate concrete grains that implement multiple generic interfaces
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesGetGrain()
         {
             var grain1 = GetGrain<ISimpleGenericGrain<int>>();
@@ -210,7 +211,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id and interface return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity1()
         {
             var grainId = GetRandomGrainId();
@@ -230,7 +231,7 @@ namespace DefaultCluster.Tests.General
         }
 
         /// Multiple GetGrain requests with the same id and different interfaces return the same concrete grain implementation
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity2()
         {
             var grainId = GetRandomGrainId();
@@ -248,7 +249,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("100", floatResult);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainTests_UseGenericFactoryInsideGrain()
         {
             var grainId = GetRandomGrainId();
@@ -259,21 +260,21 @@ namespace DefaultCluster.Tests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrain_GetGrain()
         {
-            var grain =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var grain = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
             await grain.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrainControlFlow()
         {
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
 
-            var grain =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var grain = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
 
             await grain.SetA(a);
 
@@ -283,14 +284,14 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, stringPromise.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public void Generic_SimpleGrainControlFlow_Blocking()
         {
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
 
-            var grain =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var grain = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
 
             // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
             grain.SetA(a).Wait();
@@ -301,14 +302,14 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, stringPromise.Result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrainDataFlow()
         {
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
 
-            var grain =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var grain = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
 
             var setAPromise = grain.SetA(a);
             var setBPromise = grain.SetB(b);
@@ -318,34 +319,34 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, x);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrain2_GetGrain()
         {
-            var g1 =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
-            var g2 =  this.GrainFactory.GetGrain<ISimpleGenericGrainU<int>>(grainId++);
-            var g3 =  this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, int>>(grainId++);
+            var g1 = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var g2 = this.GrainFactory.GetGrain<ISimpleGenericGrainU<int>>(grainId++);
+            var g3 = this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, int>>(grainId++);
             await g1.GetA();
             await g2.GetA();
             await g3.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrainGenericParameterWithMultipleArguments_GetGrain()
         {
-            var g1 =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<Dictionary<int, int>>>(GetRandomGrainId());
+            var g1 = this.GrainFactory.GetGrain<ISimpleGenericGrain1<Dictionary<int, int>>>(GetRandomGrainId());
             await g1.GetA();
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrainControlFlow2_GetAB()
         {
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
 
-            var g1 =  this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
-            var g2 =  this.GrainFactory.GetGrain<ISimpleGenericGrainU<int>>(grainId++);
-            var g3 =  this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, int>>(grainId++);
+            var g1 = this.GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+            var g2 = this.GrainFactory.GetGrain<ISimpleGenericGrainU<int>>(grainId++);
+            var g3 = this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, int>>(grainId++);
 
             string r1 = await g1.GetAxB(a, b);
             string r2 = await g2.GetAxB(a, b);
@@ -355,31 +356,31 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expected, r3);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_SimpleGrainControlFlow3()
         {
-            ISimpleGenericGrain2<int, float> g =  this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, float>>(grainId++);
+            ISimpleGenericGrain2<int, float> g = this.GrainFactory.GetGrain<ISimpleGenericGrain2<int, float>>(grainId++);
             await g.SetA(3);
             await g.SetB(1.25f);
             Assert.Equal("3x1.25", await g.GetAxB());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_BasicGrainControlFlow()
         {
-            IBasicGenericGrain<int, float> g =  this.GrainFactory.GetGrain<IBasicGenericGrain<int, float>>(0);
+            IBasicGenericGrain<int, float> g = this.GrainFactory.GetGrain<IBasicGenericGrain<int, float>>(0);
             await g.SetA(3);
             await g.SetB(1.25f);
             Assert.Equal("3x1.25", await g.GetAxB());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GrainWithListFields()
         {
             string a = Random.Shared.Next(100).ToString(CultureInfo.InvariantCulture);
             string b = Random.Shared.Next(100).ToString(CultureInfo.InvariantCulture);
 
-            var g1 =  this.GrainFactory.GetGrain<IGrainWithListFields>(grainId++);
+            var g1 = this.GrainFactory.GetGrain<IGrainWithListFields>(grainId++);
 
             var p1 = g1.AddItem(a);
             var p2 = g1.AddItem(b);
@@ -392,14 +393,14 @@ namespace DefaultCluster.Tests.General
                 string.Format("Result: r[0]={0}, r[1]={1}", r1[0], r1[1]));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_GrainWithListFields()
         {
             int a = Random.Shared.Next(100);
             int b = Random.Shared.Next(100);
 
 
-            var g1 =  this.GrainFactory.GetGrain<IGenericGrainWithListFields<int>>(grainId++);
+            var g1 = this.GrainFactory.GetGrain<IGenericGrainWithListFields<int>>(grainId++);
 
             var p1 = g1.AddItem(a);
             var p2 = g1.AddItem(b);
@@ -412,20 +413,20 @@ namespace DefaultCluster.Tests.General
                 string.Format("Result: r[0]={0}, r[1]={1}", r1[0], r1[1]));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_GrainWithNoProperties_ControlFlow()
         {
             int a = Random.Shared.Next(100);
             int b = Random.Shared.Next(100);
             string expected = a + "x" + b;
 
-            var g1 =  this.GrainFactory.GetGrain<IGenericGrainWithNoProperties<int>>(grainId++);
+            var g1 = this.GrainFactory.GetGrain<IGenericGrainWithNoProperties<int>>(grainId++);
 
             string r1 = await g1.GetAxB(a, b);
             Assert.Equal(expected, r1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GrainWithNoProperties_ControlFlow()
         {
             int a = Random.Shared.Next(100);
@@ -433,29 +434,29 @@ namespace DefaultCluster.Tests.General
             string expected = a + "x" + b;
 
             long grainId = GetRandomGrainId();
-            var g1 =  this.GrainFactory.GetGrain<IGrainWithNoProperties>(grainId);
+            var g1 = this.GrainFactory.GetGrain<IGrainWithNoProperties>(grainId);
 
             string r1 = await g1.GetAxB(a, b);
             Assert.Equal(expected, r1);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_ReaderWriterGrain1()
         {
             int a = Random.Shared.Next(100);
-            var g =  this.GrainFactory.GetGrain<IGenericReaderWriterGrain1<int>>(grainId++);
+            var g = this.GrainFactory.GetGrain<IGenericReaderWriterGrain1<int>>(grainId++);
             await g.SetValue(a);
             var res = await g.GetValue();
             Assert.Equal(a, res);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_ReaderWriterGrain2()
         {
             int a = Random.Shared.Next(100);
             string b = "bbbbb";
 
-            var g =  this.GrainFactory.GetGrain<IGenericReaderWriterGrain2<int, string>>(grainId++);
+            var g = this.GrainFactory.GetGrain<IGenericReaderWriterGrain2<int, string>>(grainId++);
             await g.SetValue1(a);
             await g.SetValue2(b);
             var r1 = await g.GetValue1();
@@ -464,14 +465,14 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(b, r2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_ReaderWriterGrain3()
         {
             int a = Random.Shared.Next(100);
             string b = "bbbbb";
             double c = 3.145;
 
-            var g =  this.GrainFactory.GetGrain<IGenericReaderWriterGrain3<int, string, double>>(grainId++);
+            var g = this.GrainFactory.GetGrain<IGenericReaderWriterGrain3<int, string, double>>(grainId++);
             await g.SetValue1(a);
             await g.SetValue2(b);
             await g.SetValue3(c);
@@ -483,12 +484,12 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(c, r3);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Non_Primitive_Type_Argument()
         {
-            IEchoHubGrain<Guid, string> g1 =  this.GrainFactory.GetGrain<IEchoHubGrain<Guid, string>>(1);
-            IEchoHubGrain<Guid, int> g2 =  this.GrainFactory.GetGrain<IEchoHubGrain<Guid, int>>(1);
-            IEchoHubGrain<Guid, byte[]> g3 =  this.GrainFactory.GetGrain<IEchoHubGrain<Guid, byte[]>>(1);
+            IEchoHubGrain<Guid, string> g1 = this.GrainFactory.GetGrain<IEchoHubGrain<Guid, string>>(1);
+            IEchoHubGrain<Guid, int> g2 = this.GrainFactory.GetGrain<IEchoHubGrain<Guid, int>>(1);
+            IEchoHubGrain<Guid, byte[]> g3 = this.GrainFactory.GetGrain<IEchoHubGrain<Guid, byte[]>>(1);
 
             Assert.NotEqual((GrainReference)g1, (GrainReference)g2);
             Assert.NotEqual((GrainReference)g1, (GrainReference)g3);
@@ -503,40 +504,40 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(3m, await g3.GetX());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_1()
         {
             const string msg1 = "Hello from EchoGenericChainGrain-1";
 
-            IEchoGenericChainGrain<string> g1 =  this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
+            IEchoGenericChainGrain<string> g1 = this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
 
             string received = await g1.Echo(msg1);
             Assert.Equal(msg1, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_2()
         {
             const string msg2 = "Hello from EchoGenericChainGrain-2";
 
-            IEchoGenericChainGrain<string> g2 =  this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
+            IEchoGenericChainGrain<string> g2 = this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
 
             string received = await g2.Echo2(msg2);
             Assert.Equal(msg2, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_3()
         {
             const string msg3 = "Hello from EchoGenericChainGrain-3";
 
-            IEchoGenericChainGrain<string> g3 =  this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
+            IEchoGenericChainGrain<string> g3 = this.GrainFactory.GetGrain<IEchoGenericChainGrain<string>>(GetRandomGrainId());
 
             string received = await g3.Echo3(msg3);
             Assert.Equal(msg3, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_4()
         {
             const string msg4 = "Hello from EchoGenericChainGrain-4";
@@ -547,7 +548,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg4, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_5()
         {
             const string msg5 = "Hello from EchoGenericChainGrain-5";
@@ -558,7 +559,7 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(msg5, received);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_Echo_Chain_6()
         {
             const string msg6 = "Hello from EchoGenericChainGrain-6";
@@ -570,108 +571,84 @@ namespace DefaultCluster.Tests.General
         }
 
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_1Argument_GenericCallOnly()
         {
-            var grain =  this.GrainFactory.GetGrain<IGeneric1Argument<string>>(Guid.NewGuid(), "UnitTests.Grains.Generic1ArgumentGrain");
+            var grain = this.GrainFactory.GetGrain<IGeneric1Argument<string>>(Guid.NewGuid(), "UnitTests.Grains.Generic1ArgumentGrain");
             var s1 = Guid.NewGuid().ToString();
             var s2 = await grain.Ping(s1);
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
-        public async Task Generic_1Argument_NonGenericCallFirst()
+        [Fact]
+        public void Generic_1Argument_NonGenericCallFirst()
         {
-
-            var id = Guid.NewGuid();
-            var nonGenericFacet =  this.GrainFactory.GetGrain<INonGenericBase>(id, "UnitTests.Grains.Generic1ArgumentGrain");
-            await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                try
-                {
-                    await nonGenericFacet.Ping();
-                }
-                catch (AggregateException exc)
-                {
-                    throw exc.GetBaseException();
-                }
-            });
+            Assert.Throws<ArgumentException>(() => this.GrainFactory.GetGrain<INonGenericBase>(Guid.NewGuid(), "UnitTests.Grains.Generic1ArgumentGrain"));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task Generic_1Argument_GenericCallFirst()
         {
             var id = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<IGeneric1Argument<string>>(id, "UnitTests.Grains.Generic1ArgumentGrain");
+            var grain = this.GrainFactory.GetGrain<IGeneric1Argument<string>>(id, "UnitTests.Grains.Generic1ArgumentGrain");
             var s1 = Guid.NewGuid().ToString();
             var s2 = await grain.Ping(s1);
             Assert.Equal(s1, s2);
-            var nonGenericFacet =  this.GrainFactory.GetGrain<INonGenericBase>(id, "UnitTests.Grains.Generic1ArgumentGrain");
-            await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                try
-                {
-                    await nonGenericFacet.Ping();
-                }
-                catch (AggregateException exc)
-                {
-                    throw exc.GetBaseException();
-                }
-            });
+            Assert.Throws<ArgumentException>(() => this.GrainFactory.GetGrain<INonGenericBase>(id, "UnitTests.Grains.Generic1ArgumentGrain"));
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task DifferentTypeArgsProduceIndependentActivations()
         {
-            var grain1 =  this.GrainFactory.GetGrain<IDbGrain<int>>(0);
+            var grain1 = this.GrainFactory.GetGrain<IDbGrain<int>>(0);
             await grain1.SetValue(123);
 
-            var grain2 =  this.GrainFactory.GetGrain<IDbGrain<string>>(0);
+            var grain2 = this.GrainFactory.GetGrain<IDbGrain<string>>(0);
             var v = await grain2.GetValue();
             Assert.Null(v);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("Echo")]
         public async Task Generic_PingSelf()
         {
             var id = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
+            var grain = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
             var s1 = Guid.NewGuid().ToString();
             var s2 = await grain.PingSelf(s1);
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("Echo")]
         public async Task Generic_PingOther()
         {
             var id = Guid.NewGuid();
             var targetId = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
-            var target =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
+            var grain = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
+            var target = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
             var s1 = Guid.NewGuid().ToString();
             var s2 = await grain.PingOther(target, s1);
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Echo")]
+        [Fact, TestCategory("Echo")]
         public async Task Generic_PingSelfThroughOther()
         {
             var id = Guid.NewGuid();
             var targetId = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
-            var target =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
+            var grain = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
+            var target = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
             var s1 = Guid.NewGuid().ToString();
             var s2 = await grain.PingSelfThroughOther(target, s1);
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("ActivateDeactivate")]
+        [Fact, TestCategory("ActivateDeactivate")]
         public async Task Generic_ScheduleDelayedPingAndDeactivate()
         {
             var id = Guid.NewGuid();
             var targetId = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
-            var target =  this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
+            var grain = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(id);
+            var target = this.GrainFactory.GetGrain<IGenericPingSelf<string>>(targetId);
             var s1 = Guid.NewGuid().ToString();
             await grain.ScheduleDelayedPingToSelfAndDeactivate(target, s1, TimeSpan.FromSeconds(5));
             await Task.Delay(TimeSpan.FromSeconds(6));
@@ -679,19 +656,19 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(s1, s2);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Generics"), TestCategory("Serialization")]
+        [Fact, TestCategory("Serialization")]
         public async Task SerializationTests_Generic_CircularReferenceTest()
         {
             var grainId = Guid.NewGuid();
-            var grain =  this.GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
+            var grain = this.GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
             _ = await grain.GetState();
         }
-                
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+
+        [Fact]
         public async Task Generic_GrainWithTypeConstraints()
         {
             var grainId = Guid.NewGuid().ToString();
-            var grain =  this.GrainFactory.GetGrain<IGenericGrainWithConstraints<List<int>, int, string>>(grainId);
+            var grain = this.GrainFactory.GetGrain<IGenericGrainWithConstraints<List<int>, int, string>>(grainId);
             var result = await grain.GetCount();
             Assert.Equal(0, result);
             await grain.Add(42);
@@ -715,7 +692,7 @@ namespace DefaultCluster.Tests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Persistence")]
+        [Fact, TestCategory("Persistence")]
         public async Task Generic_GrainWithValueTypeState()
         {
             Guid id = Guid.NewGuid();
@@ -731,10 +708,10 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(expectedValue, await grain.GetStateData());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
-        public async Task Generic_CastToGenericInterfaceAfterActivation() 
+        [Fact, TestCategory("Cast")]
+        public async Task Generic_CastToGenericInterfaceAfterActivation()
         {
-            var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+            var grain = this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
             await grain.DoSomething(); //activates original grain type here
 
             var castRef = grain.AsReference<ISomeGenericGrain<string>>();
@@ -744,9 +721,10 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("Hello!", result);
         }
 
-        [Fact(Skip= "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
-        public async Task Generic_CastToDifferentlyConcretizedGenericInterfaceBeforeActivation() {
-            var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+        [Fact, TestCategory("Cast")]
+        public async Task Generic_CastToDifferentlyConcretizedGenericInterfaceBeforeActivation()
+        {
+            var grain = this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
 
             var castRef = grain.AsReference<IIndependentlyConcretizedGenericGrain<string>>();
 
@@ -754,10 +732,11 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
-        [Fact, TestCategory("BVT"), TestCategory("Cast")]
-        public async Task Generic_CastToDifferentlyConcretizedInterfaceBeforeActivation() {
-            var grain =  this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+
+        [Fact, TestCategory("Cast")]
+        public async Task Generic_CastToDifferentlyConcretizedInterfaceBeforeActivation()
+        {
+            var grain = this.GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
 
             var castRef = grain.AsReference<IIndependentlyConcretizedGrain>();
 
@@ -765,10 +744,11 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
-        [Fact, TestCategory("BVT"), TestCategory("Cast"), TestCategory("Generics")]
-        public async Task Generic_CastGenericInterfaceToNonGenericInterfaceBeforeActivation() {
-            var grain =  this.GrainFactory.GetGrain<IGenericCastableGrain<string>>(Guid.NewGuid());
+
+        [Fact, TestCategory("Cast")]
+        public async Task Generic_CastGenericInterfaceToNonGenericInterfaceBeforeActivation()
+        {
+            var grain = this.GrainFactory.GetGrain<IGenericCastableGrain<string>>(Guid.NewGuid());
 
             var castRef = grain.AsReference<INonGenericCastGrain>();
 
@@ -776,13 +756,13 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal("Hello!", result);
         }
-        
+
         /// <summary>
         /// Tests that generic grains can have generic state and that the parameters to the Grain{TState}
         /// class do not have to match the parameters to the grain class itself.
         /// </summary>
         /// <returns></returns>
-        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        [Fact]
         public async Task GenericGrainStateParameterMismatchTest()
         {
             var grain = this.GrainFactory.GetGrain<IGenericGrainWithGenericState<int, List<Guid>, string>>(Guid.NewGuid());
@@ -794,288 +774,198 @@ namespace DefaultCluster.Tests.General
     namespace Generic.EdgeCases
     {
         using UnitTests.GrainInterfaces.Generic.EdgeCases;
+        using UnitTests.Grains.Generic.EdgeCases;
 
-
+        [TestCategory("BVT"), TestCategory("Generics")]
         public class GenericEdgeCaseTests : HostedTestClusterEnsureDefaultStarted
         {
             public GenericEdgeCaseTests(DefaultClusterFixture fixture) : base(fixture)
             {
             }
 
-            private static async Task<Type[]> GetConcreteGenArgs(IBasicGrain @this) {
+            private static async Task<Type[]> GetConcreteGenArgs(IBasicGrain @this)
+            {
                 var genArgTypeNames = await @this.ConcreteGenArgTypeNames();
-
-                return genArgTypeNames.Select(n => Type.GetType(n))
-                                        .ToArray();
+                return genArgTypeNames.Select(Type.GetType).ToArray();
             }
-                        
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_PartiallySpecifyingGenericGrainFulfilsInterface() {
-                var grain =  this.GrainFactory.GetGrain<IGrainWithTwoGenArgs<string, int>>(Guid.NewGuid());
-
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_PartiallySpecifyingGenericGrainFulfilsInterface()
+            {
+                var grain = this.GrainFactory.GetGrain<IGrainWithTwoGenArgs<string, int>>(Guid.NewGuid());
                 var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(int) })
-                        );
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(int) }));
             }
-            
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_GenericGrainCanReuseOwnGenArgRepeatedly() {
-                //resolves correctly but can't be activated: too many gen args supplied for concrete class
-
-                var grain =  this.GrainFactory.GetGrain<IGrainReceivingRepeatedGenArgs<int, int>>(Guid.NewGuid());
-
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_GenericGrainCanReuseOwnGenArgRepeatedly()
+            {
+                // Resolves correctly but can't be activated: too many gen args supplied for concrete class
+                var grain = this.GrainFactory.GetGrain<IGrainReceivingRepeatedGenArgs<int, int>>(Guid.NewGuid());
                 var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(int) })
-                        );
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(int) }));
             }
 
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable() {
-                var grain =  this.GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable()
+            {
+                var grain = this.GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
                 await grain.Hello();
-
                 var castRef = grain.AsReference<IGrainWithTwoGenArgs<string, int>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
 
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable_Activating() {
-                var grain =  this.GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable_Activating()
+            {
+                var grain = this.GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
                 var castRef = grain.AsReference<IGrainWithTwoGenArgs<string, int>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
-            
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RepeatedRearrangedGenArgsResolved() {
-                //again resolves to the correct generic type definition, but fails on activation as too many args
-                //gen args aren't being properly inferred from matched concrete type
 
-                var grain =  this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsAmongstOthers<int, string, int>>(Guid.NewGuid());
-
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_RepeatedRearrangedGenArgsResolved()
+            {
+                // Again resolves to the correct generic type definition, but fails on activation as too many args
+                // gen args aren't being properly inferred from matched concrete type
+                var grain = this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsAmongstOthers<int, string, int>>(Guid.NewGuid());
                 var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(string), typeof(int) })
-                        );
-            }
-            
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInTypeResolution() {
-                var grain =  this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
-
-                var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(Enumerable.Empty<Type>())
-                        );
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(string), typeof(int) }));
             }
 
+            [Fact]
+            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInTypeResolution()
+            {
+                var grain = this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
+                var concreteGenArgs = await GetConcreteGenArgs(grain);
+                Assert.True(concreteGenArgs.SequenceEqual(Enumerable.Empty<Type>()));
+            }
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting() {
-                var grain =  this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting()
+            {
+                var grain = this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
                 await grain.Hello();
-
                 var castRef = grain.AsReference<ISpecifyingGenArgsRepeatedlyToParentInterface<bool>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
 
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting_Activating() {
-                //Only errors on invocation: wrong arity again
-
-                var grain =  this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting_Activating()
+            {
+                var grain = this.GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
                 var castRef = grain.AsReference<ISpecifyingGenArgsRepeatedlyToParentInterface<bool>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
-            
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RearrangedGenArgsOfCorrectArityAreResolved() {
-                var grain =  this.GrainFactory.GetGrain<IReceivingRearrangedGenArgs<int, long>>(Guid.NewGuid());
-
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_RearrangedGenArgsOfCorrectArityAreResolved()
+            {
+                var grain = this.GrainFactory.GetGrain<IReceivingRearrangedGenArgs<int, long>>(Guid.NewGuid());
                 var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(long), typeof(int) })
-                        );
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(long), typeof(int) }));
             }
-            
 
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable() {
-                var grain =  this.GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable()
+            {
+                var grain = this.GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
                 await grain.Hello();
-
                 var castRef = grain.AsReference<IReceivingRearrangedGenArgsViaCast<long, int>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
 
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable_Activating() {
-                var grain =  this.GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable_Activating()
+            {
+                var grain = this.GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
                 var castRef = grain.AsReference<IReceivingRearrangedGenArgsViaCast<long, int>>();
-
                 var response = await castRef.Hello();
-
                 Assert.Equal("Hello!", response);
             }
 
+            public interface IFullySpecifiedGenericInterface<T> : IBasicGrain
+            { }
 
+            public interface IDerivedFromMultipleSpecializationsOfSameInterface : IFullySpecifiedGenericInterface<int>, IFullySpecifiedGenericInterface<long>
+            { }
 
-            //**************************************************************************************************************
-            //**************************************************************************************************************
+            public class GrainFulfillingMultipleSpecializationsOfSameInterfaceViaIntermediate : BasicGrain, IDerivedFromMultipleSpecializationsOfSameInterface
+            { }
 
-            //Below must be commented out, as supplying multiple fully-specified generic interfaces
-            //to a class causes the codegen to fall over, stopping all other tests from working.
-
-            //See new test here of the bit causing the issue - type info conflation:  
-            //UnitTests.CodeGeneration.CodeGeneratorTests.CodeGen_EncounteredFullySpecifiedInterfacesAreEncodedDistinctly()
-
-
-            //public interface IFullySpecifiedGenericInterface<T> : IBasicGrain
-            //{ }
-
-            //public interface IDerivedFromMultipleSpecializationsOfSameInterface : IFullySpecifiedGenericInterface<int>, IFullySpecifiedGenericInterface<long>
-            //{ }
-
-            //public class GrainFulfillingMultipleSpecializationsOfSameInterfaceViaIntermediate : BasicGrain, IDerivedFromMultipleSpecializationsOfSameInterface
-            //{ }
-
-
-            //[Fact, TestCategory("Generics")]
-            //public async Task CastingBetweenFullySpecifiedGenericInterfaces() 
-            //{
-            //    //Is this legitimate? Solely in the realm of virtual grain interfaces - no special knowledge of implementation implicated, only of interface hierarchy
-
-            //    //codegen falling over: duplicate key when both specializations are matched to same concrete type
-
-            //    var grain =  this.GrainFactory.GetGrain<IDerivedFromMultipleSpecializationsOfSameInterface>(Guid.NewGuid());
-
-            //    await grain.Hello();
-
-            //    var castRef = grain.AsReference<IFullySpecifiedGenericInterface<int>>();
-
-            //    await castRef.Hello();
-
-            //    var castRef2 = castRef.AsReference<IFullySpecifiedGenericInterface<long>>();
-
-            //    await castRef2.Hello();
-            //}
-
-            //*******************************************************************************************************
-            
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs() {
-                var grain =  this.GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task CastingBetweenFullySpecifiedGenericInterfaces()
+            {
+                var grain = this.GrainFactory.GetGrain<IDerivedFromMultipleSpecializationsOfSameInterface>(Guid.NewGuid());
                 await grain.Hello();
-
-                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
-
-                var response = await grain.Hello();
-
-                Assert.Equal("Hello!", response);
+                var castRef = grain.AsReference<IFullySpecifiedGenericInterface<int>>();
+                await castRef.Hello();
+                var castRef2 = castRef.AsReference<IFullySpecifiedGenericInterface<long>>();
+                await castRef2.Hello();
             }
 
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating() {
-                var grain =  this.GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
-
-                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
-
-                var response = await grain.Hello();
-
-                Assert.Equal("Hello!", response);
-            }
-            
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_GenArgsCanBeFurtherSpecialized() {
-                var grain =  this.GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
-
-                var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(int) })
-                        );
-            }
-
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_GenArgsCanBeFurtherSpecializedIntoArrays() {
-                var grain =  this.GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<long[]>>(Guid.NewGuid());
-
-                var concreteGenArgs = await GetConcreteGenArgs(grain);
-
-                Assert.True(
-                        concreteGenArgs.SequenceEqual(new[] { typeof(long) })
-                        );
-            }
-            
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs() {
-                var grain =  this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
-
+            [Fact]
+            public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs()
+            {
+                var grain = this.GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
                 await grain.Hello();
+                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+                var response = await grain.Hello();
+                Assert.Equal("Hello!", response);
+            }
+
+
+            [Fact]
+            public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating()
+            {
+                var grain = this.GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
+                _ = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+                var response = await grain.Hello();
+                Assert.Equal("Hello!", response);
+            }
+
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_GenArgsCanBeFurtherSpecialized()
+            {
+                var grain = this.GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
+                var concreteGenArgs = await GetConcreteGenArgs(grain);
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(int) }));
+            }
+
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_GenArgsCanBeFurtherSpecializedIntoArrays()
+            {
+                var grain = this.GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<long[]>>(Guid.NewGuid());
+                var concreteGenArgs = await GetConcreteGenArgs(grain);
+                Assert.True(concreteGenArgs.SequenceEqual(new[] { typeof(long) }));
+            }
+
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs()
+            {
+                var grain = this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
+                await grain.Hello();
+                _ = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
+                var response = await grain.Hello();
+                Assert.Equal("Hello!", response);
+            }
+
+            [Fact(Skip = "Currently unsupported")]
+            public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating()
+            {
+                var grain = this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
                 _ = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
 
                 var response = await grain.Hello();
 
                 Assert.Equal("Hello!", response);
             }
-
-
-            [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-            public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating() {
-                var grain =  this.GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
-                _ = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
-
-                var response = await grain.Hello();
-
-                Assert.Equal("Hello!", response);
-            }
-
         }
-
-
     }
-
-
 }

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -742,7 +742,6 @@ namespace UnitTests.Grains
         }
     }
 
-
     public class NonGenericCastableGrain : Grain, INonGenericCastableGrain, ISomeGenericGrain<string>, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
     {
         public Task DoSomething() {
@@ -753,7 +752,6 @@ namespace UnitTests.Grains
             return Task.FromResult("Hello!");
         }
     }
-
 
     public class GenericCastableGrain<T> : Grain, IGenericCastableGrain<T>, INonGenericCastGrain
     {
@@ -773,18 +771,15 @@ namespace UnitTests.Grains
         }
     }
 
-    public class IndepedentlyConcretizedGenericGrain : Grain, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
+    public class IndependentlyConcretizedGenericGrain : Grain, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
     {
-        public Task<string> Hello() {
-            return Task.FromResult("I have been independently concretized!");
-        }
+        public Task<string> Hello() => Task.FromResult("I have been independently concretized!");
     }
 
     public interface IReducer<TState, TAction>
     {
         Task<TState> Handle(TState prevState, TAction act);
     }
-
 
     [Serializable]
     [GenerateSerializer]
@@ -842,25 +837,23 @@ namespace UnitTests.Grains
         using System.Linq;
         using UnitTests.GrainInterfaces.Generic.EdgeCases;
 
-
         public abstract class BasicGrain : Grain
         {
-            public Task<string> Hello() {
+            public Task<string> Hello()
+            {
                 return Task.FromResult("Hello!");
             }
 
-            public Task<string[]> ConcreteGenArgTypeNames() {
+            public Task<string[]> ConcreteGenArgTypeNames()
+            {
                 var grainType = GetImmediateSubclass(this.GetType());
-
-                return Task.FromResult(
-                                grainType.GetGenericArguments()
-                                            .Select(t => t.FullName)
-                                            .ToArray()
-                                );
+                return Task.FromResult(grainType.GetGenericArguments().Select(t => t.FullName).ToArray());
             }
 
-            private Type GetImmediateSubclass(Type subject) {
-                if(subject.BaseType == typeof(BasicGrain)) {
+            private Type GetImmediateSubclass(Type subject)
+            {
+                if(subject.BaseType == typeof(BasicGrain))
+                {
                     return subject;
                 }
 
@@ -868,19 +861,14 @@ namespace UnitTests.Grains
             }
         }
 
-
-
         public class PartiallySpecifyingGrain<T> : BasicGrain, IGrainWithTwoGenArgs<string, T>
         { }
-
 
         public class GrainWithPartiallySpecifyingInterface<T> : BasicGrain, IPartiallySpecifyingInterface<T>
         { }
 
-
         public class GrainSpecifyingSameGenArgTwice<T> : BasicGrain, IGrainReceivingRepeatedGenArgs<T, T>
         { }
-
 
         public class SpecifyingRepeatedGenArgsAmongstOthers<T1, T2> : BasicGrain, IReceivingRepeatedGenArgsAmongstOthers<T2, T1, T2>
         { }
@@ -888,18 +876,14 @@ namespace UnitTests.Grains
         public class GrainForTestingCastingBetweenInterfacesWithReusedGenArgs : BasicGrain, ISpecifyingGenArgsRepeatedlyToParentInterface<bool>
         { }
 
-
         public class SpecifyingSameGenArgsButRearranged<T1, T2> : BasicGrain, IReceivingRearrangedGenArgs<T2, T1>
         { }
-
 
         public class GrainForTestingCastingWithRearrangedGenArgs<T1, T2> : BasicGrain, ISpecifyingRearrangedGenArgsToParentInterface<T1, T2>
         { }
 
-
         public class GrainWithGenArgsUnrelatedToFullySpecifiedGenericInterface<T1, T2> : BasicGrain, IArbitraryInterface<T1, T2>, IInterfaceUnrelatedToConcreteGenArgs<float>
         { }
-
 
         public class GrainSupplyingFurtherSpecializedGenArg<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<List<T>>
         { }
@@ -910,8 +894,5 @@ namespace UnitTests.Grains
         public class GrainForCastingBetweenInterfacesOfFurtherSpecializedGenArgs<T>
             : BasicGrain, IAnotherReceivingFurtherSpecializedGenArg<List<T>>, IYetOneMoreReceivingFurtherSpecializedGenArg<T[]>
         { }
-
-
     }
-
 }


### PR DESCRIPTION
Throws earlier when trying to construct a generic type using types from another generic type with different arity.
Enables previously skipped "generic corner case" tests for scenarios which are now supported.
General cleanup of the relevant test code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8705)