### PR TITLE
Avoid hiding the stack of exceptions thrown from user code

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -540,7 +540,6 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc/>
-        [DebuggerHidden]
         public abstract ValueTask<Response> Invoke();
 
         /// <inheritdoc/>
@@ -586,7 +585,6 @@ namespace Orleans.Runtime
     [SerializerTransparent]
     public abstract class Request : RequestBase 
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -606,7 +604,6 @@ namespace Orleans.Runtime
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(ValueTask resultTask)
         {
             try
@@ -621,7 +618,6 @@ namespace Orleans.Runtime
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract ValueTask InvokeInner();
     }
 
@@ -635,7 +631,6 @@ namespace Orleans.Runtime
     public abstract class Request<TResult> : RequestBase
     {
         /// <inheritdoc/>
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -654,7 +649,6 @@ namespace Orleans.Runtime
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(ValueTask<TResult> resultTask)
         {
             try
@@ -672,7 +666,6 @@ namespace Orleans.Runtime
         /// Invokes the request against the target.
         /// </summary>
         /// <returns>The invocation result.</returns>
-        [DebuggerHidden]
         protected abstract ValueTask<TResult> InvokeInner();
     }
 
@@ -686,7 +679,6 @@ namespace Orleans.Runtime
     public abstract class TaskRequest<TResult> : RequestBase
     {
         /// <inheritdoc/>
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -706,7 +698,6 @@ namespace Orleans.Runtime
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(Task<TResult> resultTask)
         {
             try
@@ -724,7 +715,6 @@ namespace Orleans.Runtime
         /// Invokes the request against the target.
         /// </summary>
         /// <returns>The invocation result.</returns>
-        [DebuggerHidden]
         protected abstract Task<TResult> InvokeInner();
     }
 
@@ -735,7 +725,6 @@ namespace Orleans.Runtime
     public abstract class TaskRequest : RequestBase
     {
         /// <inheritdoc/>
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -756,7 +745,6 @@ namespace Orleans.Runtime
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(Task resultTask)
         {
             try
@@ -774,7 +762,6 @@ namespace Orleans.Runtime
         /// Invokes the request against the target.
         /// </summary>
         /// <returns>The invocation result.</returns>
-        [DebuggerHidden]
         protected abstract Task InvokeInner();
     }
 
@@ -791,7 +778,6 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc/>
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -808,7 +794,6 @@ namespace Orleans.Runtime
         /// <summary>
         /// Invokes the request against the target.
         /// </summary>
-        [DebuggerHidden]
         protected abstract void InvokeInner();
     }
 }

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -39,7 +39,6 @@ namespace Orleans.Runtime
 
         /// <summary>Only to make Reflection happy. Do not use it in your implementation</summary>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Diagnostics.DebuggerHidden]
         protected GrainService() : base()
         {
             throw new Exception("This should not be constructed by client code.");

--- a/test/Orleans.Serialization.UnitTests/Request.cs
+++ b/test/Orleans.Serialization.UnitTests/Request.cs
@@ -28,7 +28,6 @@ namespace Orleans.Serialization.Invocation
     [GenerateSerializer]
     public abstract class UnitTestRequest : UnitTestRequestBase
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -48,7 +47,6 @@ namespace Orleans.Serialization.Invocation
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(ValueTask resultTask)
         {
             try
@@ -63,14 +61,12 @@ namespace Orleans.Serialization.Invocation
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract ValueTask InvokeInner();
     }
 
     [GenerateSerializer]
     public abstract class UnitTestRequest<TResult> : UnitTestRequestBase
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -89,7 +85,6 @@ namespace Orleans.Serialization.Invocation
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(ValueTask<TResult> resultTask)
         {
             try
@@ -104,14 +99,12 @@ namespace Orleans.Serialization.Invocation
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract ValueTask<TResult> InvokeInner();
     }
 
     [GenerateSerializer]
     public abstract class UnitTestTaskRequest<TResult> : UnitTestRequestBase
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -131,7 +124,6 @@ namespace Orleans.Serialization.Invocation
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(Task<TResult> resultTask)
         {
             try
@@ -146,14 +138,12 @@ namespace Orleans.Serialization.Invocation
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract Task<TResult> InvokeInner();
     }
 
     [GenerateSerializer]
     public abstract class UnitTestTaskRequest : UnitTestRequestBase
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -174,7 +164,6 @@ namespace Orleans.Serialization.Invocation
             }
         }
 
-        [DebuggerHidden]
         private static async ValueTask<Response> CompleteInvokeAsync(Task resultTask)
         {
             try
@@ -189,14 +178,12 @@ namespace Orleans.Serialization.Invocation
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract Task InvokeInner();
     }
 
     [GenerateSerializer]
     public abstract class UnitTestVoidRequest : UnitTestRequestBase
     {
-        [DebuggerHidden]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -211,7 +198,6 @@ namespace Orleans.Serialization.Invocation
         }
 
         // Generated
-        [DebuggerHidden]
         protected abstract void InvokeInner();
     }
 }


### PR DESCRIPTION
Currently, we obscure the stack in too many places.

In future (up for grabs!), it would likely be better for us to use:
* [`[DebuggerStepThrough]`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debuggerstepthroughattribute?view=net-7.0), and/or
* [`[DebuggerNonUserCode]`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debuggernonusercodeattribute?view=net-7.0) & [`[DebuggerStepperBoundary]`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debuggerstepperboundaryattribute?view=net-7.0)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8706)