### PR TITLE
ObserverManager: fix Collection was modified

### DIFF
--- a/src/Orleans.Core/Utils/ObserverManager.cs
+++ b/src/Orleans.Core/Utils/ObserverManager.cs
@@ -153,7 +153,7 @@ namespace Orleans.Utilities
         {
             var now = GetDateTime();
             var defunct = default(List<TIdentity>);
-            foreach (var observer in _observers)
+            foreach (var observer in _observers.ToList())
             {
                 if (observer.Value.LastSeen + ExpirationDuration < now)
                 {
@@ -208,7 +208,7 @@ namespace Orleans.Utilities
         {
             var now = GetDateTime();
             var defunct = default(List<TIdentity>);
-            foreach (var observer in _observers)
+            foreach (var observer in _observers.ToList())
             {
                 if (observer.Value.LastSeen + ExpirationDuration < now)
                 {
@@ -257,7 +257,7 @@ namespace Orleans.Utilities
         {
             var now = GetDateTime();
             var defunct = default(List<TIdentity>);
-            foreach (var observer in _observers)
+            foreach (var observer in _observers.ToList())
             {
                 if (observer.Value.LastSeen + ExpirationDuration < now)
                 {


### PR DESCRIPTION
If you add a subscription while `Notify` is in process of enumerating the observers it can lead to exception: `System.InvalidOperationException
Collection was modified; enumeration operation may not execute.`

This can be checked with a simple unit test:
```C#
[Fact]
public async Task CollectionModified()
{
	// Arrange
	var observerManager = new ObserverManager<int, int>(TimeSpan.FromHours(1), NullLogger.Instance);

	var subscriptions = new Dictionary<int, int>();
	for (var i = 0; i < 1000; i++)
	{
		subscriptions.Add(i, i);
	}

	foreach (var subscription in subscriptions)
	{
		observerManager.Subscribe(subscription.Key, subscription.Value);
	}

	bool Predicate(int observer)
	{
		if (observer == 500)
		{
			observerManager.Subscribe(1001, 1001);
		}

		return true;
	}

	Task NotificationAsync(int observer)
	{
		return Task.CompletedTask;
	}

	// Act
	await observerManager.Notify(NotificationAsync, Predicate);
}
```
I did not add this to the current tests, since we don't really have any dedicated `ObserverManager` tests and it's unclear in what namespace to add it.

I'm not fan that we are creating a new list, but this is the simplest way to fix it, I guess.