### PR TITLE
Fix overread bug in Reader Skip

### DIFF
--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -266,13 +266,13 @@ namespace Orleans.Serialization.Buffers
         private readonly static bool IsReadOnlySequenceInput = typeof(TInput) == typeof(ReadOnlySequenceInput);
         private readonly static bool IsReaderInput = typeof(ReaderInput).IsAssignableFrom(typeof(TInput));
         private readonly static bool IsBufferSliceInput = typeof(TInput) == typeof(BufferSliceReaderInput);
-        
+
         private ReadOnlySpan<byte> _currentSpan;
         private int _bufferPos;
         private int _bufferSize;
         private readonly long _sequenceOffset;
         private TInput _input;
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Reader(TInput input, SerializerSession session, long globalOffset)
         {
@@ -318,7 +318,7 @@ namespace Orleans.Serialization.Buffers
             if (IsSpanInput)
             {
                 _input = default;
-                _currentSpan = input; 
+                _currentSpan = input;
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
                 _sequenceOffset = globalOffset;
@@ -410,11 +410,11 @@ namespace Orleans.Serialization.Buffers
         {
             if (IsReadOnlySequenceInput || IsBufferSliceInput)
             {
-                var previousBuffersSize = Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).PreviousBuffersSize;
                 var end = Position + count;
                 while (Position < end)
                 {
-                    if (Position + _bufferSize >= end)
+                    var previousBuffersSize = Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).PreviousBuffersSize;
+                    if (end - previousBuffersSize <= _bufferSize)
                     {
                         _bufferPos = (int)(end - previousBuffersSize);
                     }
@@ -426,11 +426,11 @@ namespace Orleans.Serialization.Buffers
             }
             else if (IsBufferSliceInput)
             {
-                var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
                 var end = Position + count;
                 while (Position < end)
                 {
-                    if (Position + _bufferSize >= end)
+                    var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
+                    if (end - previousBuffersSize <= _bufferSize)
                     {
                         _bufferPos = (int)(end - previousBuffersSize);
                     }
@@ -517,13 +517,13 @@ namespace Orleans.Serialization.Buffers
             {
                 throw new NotSupportedException($"Type {typeof(TInput)} is not supported");
             }
-            
+
             static void ThrowInvalidPosition(long expectedPosition, long actualPosition)
             {
                 throw new InvalidOperationException($"Expected to arrive at position {expectedPosition} after ForkFrom, but resulting position is {actualPosition}");
             }
         }
-        
+
         /// <summary>
         /// Resumes the reader from the specified position after forked readers are no longer in use.
         /// </summary>

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -408,7 +408,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="count">The number of bytes to skip.</param>
         public void Skip(long count)
         {
-            if (IsReadOnlySequenceInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput)
             {
                 var end = Position + count;
                 while (Position < end)


### PR DESCRIPTION
Fix bug in Reader skip. When the skip count + current position is 1 >than the current buffer size, skip will "overread" the buffer, setting the position to a point > the buffer size.

This causes the next read to advance the buffer and consume the first byte which the skip should have already consumed but didn't.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8709)