### PR TITLE
Enable enumeration of the keys and entries in RequestContext (#8674)

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -160,6 +160,16 @@ namespace Orleans.Runtime
             }
         }
 
+        /// <summary>
+        /// Gets the collection of keys for the values currently in the request context.
+        /// </summary>
+        public static IEnumerable<string> Keys => CallContextData.Value.Values.Keys;
+
+        /// <summary>
+        /// Gets the collection of entries currently in the request context.
+        /// </summary>
+        public static IEnumerable<KeyValuePair<string, object>> Entries => CallContextData.Value.Values;
+
         internal readonly struct ContextProperties
         {
             public Dictionary<string, object> Values { get; init; }

--- a/test/DefaultCluster.Tests/RequestContextTest.cs
+++ b/test/DefaultCluster.Tests/RequestContextTest.cs
@@ -21,6 +21,8 @@ namespace UnitTDefaultCluster.Tests.General
             var infoFromGrain = await grain.GetRequestContext();
             Assert.NotNull(infoFromGrain);
             Assert.True((int)infoFromGrain == 10);
+
+            Assert.Contains("GrainInfo", RequestContext.Keys);
         }
 
         [Fact(Skip = "Was failing before (just masked as a Pass), needs fixing or removing"), TestCategory("RequestContext"), TestCategory("Functional")]
@@ -33,6 +35,8 @@ namespace UnitTDefaultCluster.Tests.General
             var infoFromGrain = RequestContext.Get("GrainInfo");
             Assert.NotNull(infoFromGrain);
             Assert.True((int)infoFromGrain == 15);
+
+            Assert.Contains("GrainInfo", RequestContext.Keys);
         }
     }
 }


### PR DESCRIPTION
Fixes #8674

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8720)