### PR TITLE
Fix flaky OneWay_Deactivation_CacheInvalidated test

### DIFF
--- a/test/Tester/OneWayDeactivationTests.cs
+++ b/test/Tester/OneWayDeactivationTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Configuration.Internal;
+using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -53,6 +55,7 @@ namespace UnitTests.General
             IOneWayGrain grainToCallFrom;
             while (true)
             {
+                RequestContext.Set(IPlacementDirector.PlacementHintKey, _fixture.HostedCluster.Primary.SiloAddress);
                 grainToCallFrom = _fixture.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
                 var grainHost = await grainToCallFrom.GetSiloAddress();
                 if (grainHost.Equals(_fixture.HostedCluster.Primary.SiloAddress))
@@ -62,6 +65,7 @@ namespace UnitTests.General
             }
 
             // Activate the grain & record its address.
+            RequestContext.Remove(IPlacementDirector.PlacementHintKey);
             var grainToDeactivate = await grainToCallFrom.GetOtherGrain();
             var initialActivationId = await grainToDeactivate.GetActivationId();
             var grainId = grainToDeactivate.GetGrainId();
@@ -75,23 +79,14 @@ namespace UnitTests.General
             Assert.Equal(1, count);
             Assert.NotEqual(initialActivationId, finalActivationId);
 
-            // Test that cache was invalidated, but only if the ActivationAddress has changed.
+            // Test that cache was updated.
             // We don't know what the whole activation address should be, but we do know
-            // that some entry should be successfully removed for the provided grain id.
+            // that some entry should be successfully updated for the provided grain id.
             var newActivationAddress = directoryCache.Operations
                 .OfType<TestDirectoryCache.CacheOperation.AddOrUpdate>()
                 .Last(op => op.Value.GrainId.Equals(grainId))
                 .Value;
-
-            var invalidationOp = directoryCache.Operations
-                .OfType<TestDirectoryCache.CacheOperation.RemoveActivation>()
-                .FirstOrDefault(op => op.Key.Equals(activationAddress) && op.Result);
-
-            if (!newActivationAddress.Equals(activationAddress) && invalidationOp is null)
-            {
-                var ops = string.Join(", ", directoryCache.Operations.Select(op => op.ToString()));
-                Assert.True(invalidationOp is not null, $"Should have processed a cache invalidation for the target activation {activationAddress}. Cache ops: {ops}");
-            }
+            Assert.NotNull(newActivationAddress);
 
             directoryCache.Operations.Clear();
         }


### PR DESCRIPTION
This test is flaky now because of a change in cache invalidation logic, but the current behavior is correct.
What we want to check is that the cache was updated to reflect the grain being re-activated, possibly on a new silo

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8721)