### PR TITLE
Avoid sending cluster manifest to client if client already has the latest version

### DIFF
--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -10,6 +10,9 @@ namespace Orleans.Metadata
     [Serializable, GenerateSerializer, Immutable]
     public sealed class ClusterManifest
     {
+        [NonSerialized]
+        private ImmutableArray<GrainManifest>? _allGrainManifests;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterManifest"/> class.
         /// </summary>
@@ -19,17 +22,12 @@ namespace Orleans.Metadata
         /// <param name="silos">
         /// The silo manifests.
         /// </param>
-        /// <param name="allGrainManifests">
-        /// All grain manifests.
-        /// </param>
         public ClusterManifest(
             MajorMinorVersion version,
-            ImmutableDictionary<SiloAddress, GrainManifest> silos,
-            ImmutableArray<GrainManifest> allGrainManifests)
+            ImmutableDictionary<SiloAddress, GrainManifest> silos)
         {
             this.Version = version;
             this.Silos = silos;
-            this.AllGrainManifests = allGrainManifests;
         }
 
         /// <summary>
@@ -47,7 +45,6 @@ namespace Orleans.Metadata
         /// <summary>
         /// Gets all grain manifests.
         /// </summary>
-        [Id(2)]
-        public ImmutableArray<GrainManifest> AllGrainManifests { get; }
+        public ImmutableArray<GrainManifest> AllGrainManifests => _allGrainManifests ??= Silos.Values.ToImmutableArray();
     }
 }

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -10,9 +10,6 @@ namespace Orleans.Metadata
     [Serializable, GenerateSerializer, Immutable]
     public sealed class ClusterManifest
     {
-        [NonSerialized]
-        private ImmutableArray<GrainManifest>? _allGrainManifests;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterManifest"/> class.
         /// </summary>
@@ -26,8 +23,9 @@ namespace Orleans.Metadata
             MajorMinorVersion version,
             ImmutableDictionary<SiloAddress, GrainManifest> silos)
         {
-            this.Version = version;
-            this.Silos = silos;
+            Version = version;
+            Silos = silos;
+            AllGrainManifests = silos.Values.ToImmutableArray();
         }
 
         /// <summary>
@@ -45,6 +43,7 @@ namespace Orleans.Metadata
         /// <summary>
         /// Gets all grain manifests.
         /// </summary>
-        public ImmutableArray<GrainManifest> AllGrainManifests => _allGrainManifests ??= Silos.Values.ToImmutableArray();
+        [Id(2)]
+        public ImmutableArray<GrainManifest> AllGrainManifests { get; }
     }
 }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -61,6 +61,7 @@ namespace Orleans
             services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
             services.AddLogging();
             services.TryAddSingleton<GrainBindingsResolver>();
+            services.TryAddSingleton<LocalClientDetails>();
             services.TryAddSingleton<OutsideRuntimeClient>();
             services.TryAddSingleton<ClientGrainContext>();
             services.AddFromExisting<IGrainContextAccessor, ClientGrainContext>();

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -28,7 +28,7 @@ namespace Orleans
             }
 
             /// <summary>
-            /// Gets the grain implmentation <see cref="MethodInfo"/>.
+            /// Gets the grain implementation <see cref="MethodInfo"/>.
             /// </summary>
             public MethodInfo ImplementationMethod { get; }
 

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -189,16 +189,18 @@ namespace Orleans.Runtime
         {
             try
             {
+                // First, attempt to call the new API, which provides more information.
                 return await provider.GetClusterManifestUpdate(previousVersion);
             }
             catch (Exception exception)
             {
                 _logger.LogWarning(exception, "Failed to fetch cluster manifest update from {Provider}.", provider);
-            }
 
-            var manifest = await provider.GetClusterManifest();
-            var result = new ClusterManifestUpdate(manifest.Version, manifest.Silos, includesAllActiveServers: true);
-            return result;
+                // If the provider does not support the new API, fall back to the old one.
+                var manifest = await provider.GetClusterManifest();
+                var result = new ClusterManifestUpdate(manifest.Version, manifest.Silos, includesAllActiveServers: true);
+                return result;
+            }
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -117,13 +117,6 @@ namespace Orleans.Runtime
                         }
 
                         var updateResult = await refreshTask;                        
-                        if (updateResult is null)
-                        {
-                            // There was no newer cluster manifest, so wait for the next refresh interval and try again.
-                            await Task.WhenAny(cancellationTask, Task.Delay(_typeManagementOptions.TypeMapRefreshInterval));
-                            continue;
-                        }
-
                         gatewayVersion = updateResult.Version;
 
                         // If the manifest does not contain all active servers, merge with the existing manifest until it does.

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -117,15 +117,14 @@ namespace Orleans.Runtime
                             return;
                         }
 
-                        var updateResult = await refreshTask;
-                        updateIncludesAllActiveServers = updateResult.IncludesAllActiveServers;
+                        var updateResult = await refreshTask;                        
                         if (updateResult is null)
                         {
                             // There was no newer cluster manifest, so wait for the next refresh interval and try again.
                             await Task.WhenAny(cancellationTask, Task.Delay(_typeManagementOptions.TypeMapRefreshInterval));
                             continue;
                         }
-
+                        updateIncludesAllActiveServers = updateResult.IncludesAllActiveServers;
                         gatewayVersion = updateResult.Version;
 
                         // If the manifest does not contain all active servers, merge with the existing manifest until it does.

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -238,6 +238,13 @@ namespace Orleans.Runtime.Versions
             foreach (var entry in clusterManifest.Silos)
             {
                 var silo = entry.Key;
+
+                // Since clients are not eligible for placement, we exclude them here.
+                if (silo.IsClient)
+                {
+                    continue;
+                }
+
                 var manifest = entry.Value;
                 foreach (var grainInterface in manifest.Interfaces)
                 {

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime.Versions
         /// <summary>
         /// Gets the local version for a specified grain interface type.
         /// </summary>
-        /// <param name="interfaceType">The grain intrerface type name.</param>
+        /// <param name="interfaceType">The grain interface type name.</param>
         /// <returns>The version of the specified grain interface.</returns>
         public ushort GetLocalVersion(GrainInterfaceType interfaceType)
         {
@@ -151,7 +151,7 @@ namespace Orleans.Runtime.Versions
         /// <param name="grainType">The grain type.</param>
         /// <param name="interfaceType">The grain interface type name.</param>
         /// <param name="versions">The grain interface version.</param>
-        /// <returns>The set of silos which support the specifed grain.</returns>
+        /// <returns>The set of silos which support the specified grain.</returns>
         public (MajorMinorVersion Version, Dictionary<ushort, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort[] versions)
         {
             var result = new Dictionary<ushort, SiloAddress[]>();

--- a/src/Orleans.Core/Manifest/IClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestProvider.cs
@@ -14,6 +14,8 @@ namespace Orleans.Runtime
         /// </summary>
         ClusterManifest Current { get; }
 
+        GetClusterManifestResult GetCurrent(MajorMinorVersion version);
+       
         /// <summary>
         /// Gets the stream of cluster manifest updates.
         /// </summary>

--- a/src/Orleans.Core/Manifest/IClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestProvider.cs
@@ -13,8 +13,6 @@ namespace Orleans.Runtime
         /// Gets the current cluster manifest.
         /// </summary>
         ClusterManifest Current { get; }
-
-        GetClusterManifestResult GetCurrent(MajorMinorVersion version);
        
         /// <summary>
         /// Gets the stream of cluster manifest updates.

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Orleans.Metadata;
 
@@ -12,6 +13,15 @@ namespace Orleans.Runtime
         /// Gets the current cluster manifest.
         /// </summary>
         /// <returns>The current cluster manifest.</returns>
-        ValueTask<ClusterManifest> GetClusterManifest();
+        ValueTask<GetClusterManifestResult> GetClusterManifest(MajorMinorVersion version);
+    }
+
+    [Serializable, GenerateSerializer, Immutable]
+    public class GetClusterManifestResult
+    {
+        [Id(0)]
+        public bool IsVersionChange { get; set; }
+        [Id(1)]
+        public ClusterManifest ClusterManifest { get; set; }
     }
 }

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
 
@@ -15,25 +17,44 @@ namespace Orleans.Runtime
         ValueTask<ClusterManifest> GetClusterManifest();
 
         /// <summary>
-        /// Gets the current cluster manifest if it is newer than the provided <paramref name="version"/>.
+        /// Gets an updated cluster manifest if newer than the provided <paramref name="previousVersion"/>.
         /// </summary>
         /// <returns>The current cluster manifest, or <see langword="null"/> if it is not newer than the provided version.</returns>
-        ValueTask<ClusterManifestUpdate> GetClusterManifestIfNewer(MajorMinorVersion version);
+        ValueTask<ClusterManifestUpdate> GetClusterManifestUpdate(MajorMinorVersion previousVersion);
     }
 
+    /// <summary>
+    /// Represents an update to the cluster manifest.
+    /// </summary>
     [GenerateSerializer, Immutable]
-    public readonly struct ClusterManifestUpdate
+    public class ClusterManifestUpdate
     {
-        public ClusterManifestUpdate(ClusterManifest manifest, bool includesAllActiveServers)
+        public ClusterManifestUpdate(
+            MajorMinorVersion manifestVersion,
+            ImmutableDictionary<SiloAddress, GrainManifest> siloManifests,
+            bool includesAllActiveServers)
         {
-            Manifest = manifest;
+            Version = manifestVersion;
+            SiloManifests = siloManifests;
             IncludesAllActiveServers = includesAllActiveServers;
         }
 
+        /// <summary>
+        /// Gets the version of this instance.
+        /// </summary>
         [Id(0)]
-        public ClusterManifest Manifest { get; }
+        public MajorMinorVersion Version { get; }
 
+        /// <summary>
+        /// Gets the manifests for each silo in the cluster.
+        /// </summary>
         [Id(1)]
+        public ImmutableDictionary<SiloAddress, GrainManifest> SiloManifests { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this update includes all active servers.
+        /// </summary>
+        [Id(2)]
         public bool IncludesAllActiveServers { get; } 
     }
 }

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Orleans.Metadata;
 
@@ -13,15 +12,12 @@ namespace Orleans.Runtime
         /// Gets the current cluster manifest.
         /// </summary>
         /// <returns>The current cluster manifest.</returns>
-        ValueTask<GetClusterManifestResult> GetClusterManifest(MajorMinorVersion version);
-    }
+        ValueTask<ClusterManifest> GetClusterManifest();
 
-    [Serializable, GenerateSerializer, Immutable]
-    public class GetClusterManifestResult
-    {
-        [Id(0)]
-        public bool IsVersionChange { get; set; }
-        [Id(1)]
-        public ClusterManifest ClusterManifest { get; set; }
+        /// <summary>
+        /// Gets the current cluster manifest if it is newer than the provided <paramref name="version"/>.
+        /// </summary>
+        /// <returns>The current cluster manifest, or <see langword="null"/> if it is not newer than the provided version.</returns>
+        ValueTask<ClusterManifest> GetClusterManifestIfNewer(MajorMinorVersion version);
     }
 }

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -18,6 +18,22 @@ namespace Orleans.Runtime
         /// Gets the current cluster manifest if it is newer than the provided <paramref name="version"/>.
         /// </summary>
         /// <returns>The current cluster manifest, or <see langword="null"/> if it is not newer than the provided version.</returns>
-        ValueTask<ClusterManifest> GetClusterManifestIfNewer(MajorMinorVersion version);
+        ValueTask<ClusterManifestUpdate> GetClusterManifestIfNewer(MajorMinorVersion version);
+    }
+
+    [GenerateSerializer, Immutable]
+    public readonly struct ClusterManifestUpdate
+    {
+        public ClusterManifestUpdate(ClusterManifest manifest, bool includesAllActiveServers)
+        {
+            Manifest = manifest;
+            IncludesAllActiveServers = includesAllActiveServers;
+        }
+
+        [Id(0)]
+        public ClusterManifest Manifest { get; }
+
+        [Id(1)]
+        public bool IncludesAllActiveServers { get; } 
     }
 }

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -44,7 +44,7 @@ namespace Orleans.Messaging
         internal static readonly TimeSpan MINIMUM_INTERCONNECT_DELAY = TimeSpan.FromMilliseconds(100);   // wait one tenth of a second between connect attempts
         internal const int CONNECT_RETRY_COUNT = 2;                                                      // Retry twice before giving up on a gateway server
 
-        internal ClientGrainId ClientId { get; private set; }
+        internal ClientGrainId ClientId => _localClientDetails.ClientId;
         public IRuntimeClient RuntimeClient { get; }
         internal bool Running { get; private set; }
 
@@ -58,17 +58,16 @@ namespace Orleans.Messaging
         // false, then a new gateway is selected using the gateway manager, and a new connection established if necessary.
         private readonly WeakReference<ClientOutboundConnection>[] grainBuckets;
         private readonly ILogger logger;
-        public SiloAddress MyAddress { get; private set; }
+        public SiloAddress MyAddress => _localClientDetails.ClientAddress;
         private int numberOfConnectedGateways = 0;
         private readonly MessageFactory messageFactory;
         private readonly IClusterConnectionStatusListener connectionStatusListener;
         private readonly ConnectionManager connectionManager;
+        private readonly LocalClientDetails _localClientDetails;
 
         public ClientMessageCenter(
             IOptions<ClientMessagingOptions> clientMessagingOptions,
-            IPAddress localAddress,
-            int gen,
-            ClientGrainId clientId,
+            LocalClientDetails localClientDetails,
             IRuntimeClient runtimeClient,
             MessageFactory messageFactory,
             IClusterConnectionStatusListener connectionStatusListener,
@@ -77,8 +76,7 @@ namespace Orleans.Messaging
             GatewayManager gatewayManager)
         {
             this.connectionManager = connectionManager;
-            MyAddress = SiloAddress.New(localAddress, 0, gen);
-            ClientId = clientId;
+            _localClientDetails = localClientDetails;
             this.RuntimeClient = runtimeClient;
             this.messageFactory = messageFactory;
             this.connectionStatusListener = connectionStatusListener;

--- a/src/Orleans.Core/Runtime/LocalClientDetails.cs
+++ b/src/Orleans.Core/Runtime/LocalClientDetails.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans
+{
+    internal class LocalClientDetails
+    {
+        public LocalClientDetails(IOptions<ClientMessagingOptions> clientMessagingOptions)
+        {
+            var options = clientMessagingOptions.Value;
+            var ipAddress = options.LocalAddress ?? ConfigUtilities.GetLocalIPAddress(options.PreferredFamily, options.NetworkInterfaceName);
+
+            // Client generations are negative
+            var generation = -SiloAddress.AllocateNewGeneration();
+            ClientAddress = SiloAddress.New(ipAddress, 0, generation);
+            ClientId = ClientGrainId.Create();
+        }
+
+        public ClientGrainId ClientId { get; }
+        public IPAddress IPAddress => ClientAddress.Endpoint.Address;
+        public SiloAddress ClientAddress { get; }
+    }
+}

--- a/src/Orleans.Core/Utils/StandardExtensions.cs
+++ b/src/Orleans.Core/Utils/StandardExtensions.cs
@@ -8,14 +8,8 @@ namespace Orleans.Internal
     /// </summary>
     internal static class StandardExtensions
     {
-        public static TimeSpan Max(TimeSpan first, TimeSpan second)
-        {
-            return first >= second ? first : second;
-        }
+        public static TimeSpan Max(TimeSpan first, TimeSpan second) => first >= second ? first : second;
 
-        public static TimeSpan Min(TimeSpan first, TimeSpan second)
-        {
-            return first < second ? first : second;
-        }
+        public static TimeSpan Min(TimeSpan first, TimeSpan second) => first < second ? first : second;
     }
 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -35,7 +35,6 @@ namespace Orleans.Runtime
         private SafeTimer callbackTimer;
 
         private GrainLocator grainLocator;
-        private Catalog catalog;
         private MessageCenter messageCenter;
         private List<IIncomingGrainCallFilter> grainCallFilters;
         private readonly DeepCopier _deepCopier;
@@ -95,8 +94,6 @@ namespace Orleans.Runtime
         private SiloAddress MySilo { get; }
 
         public GrainFactory ConcreteGrainFactory { get; }
-
-        private Catalog Catalog => this.catalog ?? (this.catalog = this.ServiceProvider.GetRequiredService<Catalog>());
 
         private GrainLocator GrainLocator
             => this.grainLocator ?? (this.grainLocator = this.ServiceProvider.GetRequiredService<GrainLocator>());

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Metadata;
@@ -19,8 +20,13 @@ namespace Orleans.Runtime
             _clusterManifestProvider = clusterManifestProvider;
         }
 
-        public ValueTask<ClusterManifest> GetClusterManifest() => new ValueTask<ClusterManifest>(_clusterManifestProvider.Current);
+        public ValueTask<GetClusterManifestResult> GetClusterManifest(MajorMinorVersion version)
+        {
+            return new ValueTask<GetClusterManifestResult>(_clusterManifestProvider.GetCurrent(version));
+        } 
 
         public ValueTask<GrainManifest> GetSiloManifest() => new ValueTask<GrainManifest>(_siloManifest);
     }
+
+   
 }

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -20,13 +20,20 @@ namespace Orleans.Runtime
             _clusterManifestProvider = clusterManifestProvider;
         }
 
-        public ValueTask<GetClusterManifestResult> GetClusterManifest(MajorMinorVersion version)
+        public ValueTask<ClusterManifest> GetClusterManifest() => new(_clusterManifestProvider.Current);
+        public ValueTask<ClusterManifest> GetClusterManifestIfNewer(MajorMinorVersion version)
         {
-            return new ValueTask<GetClusterManifestResult>(_clusterManifestProvider.GetCurrent(version));
-        } 
+            var result = _clusterManifestProvider.Current;
+
+            // Only return an updated manifest if it is newer than the provided version.
+            if (result.Version <= version)
+            {
+                return new ValueTask<ClusterManifest>(default(ClusterManifest));
+            }
+
+            return new ValueTask<ClusterManifest>(result);
+        }
 
         public ValueTask<GrainManifest> GetSiloManifest() => new ValueTask<GrainManifest>(_siloManifest);
     }
-
-   
 }

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -1,4 +1,7 @@
-using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Metadata;
@@ -8,32 +11,58 @@ namespace Orleans.Runtime
     internal class ClusterManifestSystemTarget : SystemTarget, IClusterManifestSystemTarget, ISiloManifestSystemTarget
     {
         private readonly GrainManifest _siloManifest;
+        private readonly IClusterMembershipService _clusterMembershipService;
         private readonly IClusterManifestProvider _clusterManifestProvider;
+        private readonly ClusterManifestUpdate _noUpdate = default;
+        private MembershipVersion _activeServersMembershipVersion;
+        private bool _containsAllActiveServers;
 
         public ClusterManifestSystemTarget(
+            IClusterMembershipService clusterMembershipService,
             IClusterManifestProvider clusterManifestProvider,
             ILocalSiloDetails siloDetails,
             ILoggerFactory loggerFactory)
             : base(Constants.ManifestProviderType, siloDetails.SiloAddress, loggerFactory)
         {
             _siloManifest = clusterManifestProvider.LocalGrainManifest;
+            _clusterMembershipService = clusterMembershipService;
             _clusterManifestProvider = clusterManifestProvider;
         }
 
         public ValueTask<ClusterManifest> GetClusterManifest() => new(_clusterManifestProvider.Current);
-        public ValueTask<ClusterManifest> GetClusterManifestIfNewer(MajorMinorVersion version)
+        public ValueTask<ClusterManifestUpdate> GetClusterManifestIfNewer(MajorMinorVersion version)
         {
             var result = _clusterManifestProvider.Current;
 
             // Only return an updated manifest if it is newer than the provided version.
             if (result.Version <= version)
             {
-                return new ValueTask<ClusterManifest>(default(ClusterManifest));
+                return new (_noUpdate);
             }
 
-            return new ValueTask<ClusterManifest>(result);
+            // Maintain a cache of whether the current manifest contains all active servers so that it
+            // does not need to be recomputed each time.
+            var membershipSnapshot = _clusterMembershipService.CurrentSnapshot;
+            if (membershipSnapshot.Version > _activeServersMembershipVersion)
+            {
+                _containsAllActiveServers = true;
+                foreach (var server in membershipSnapshot.Members)
+                {
+                    if (server.Value.Status == SiloStatus.Active)
+                    {
+                        if (!result.Silos.ContainsKey(server.Key))
+                        {
+                            _containsAllActiveServers = false;
+                        }
+                    }
+                }
+
+                _activeServersMembershipVersion = membershipSnapshot.Version;
+            }
+
+            return new (new ClusterManifestUpdate(result, _containsAllActiveServers));
         }
 
-        public ValueTask<GrainManifest> GetSiloManifest() => new ValueTask<GrainManifest>(_siloManifest);
+        public ValueTask<GrainManifest> GetSiloManifest() => new(_siloManifest);
     }
 }

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -39,8 +39,7 @@ namespace Orleans.Runtime.Metadata
             this.LocalGrainManifest = siloManifestProvider.SiloManifest;
             _current = new ClusterManifest(
                 MajorMinorVersion.Zero,
-                ImmutableDictionary.CreateRange(new[] { new KeyValuePair<SiloAddress, GrainManifest>(localSiloDetails.SiloAddress, this.LocalGrainManifest) }),
-                ImmutableArray.Create(this.LocalGrainManifest));
+                ImmutableDictionary.CreateRange(new[] { new KeyValuePair<SiloAddress, GrainManifest>(localSiloDetails.SiloAddress, this.LocalGrainManifest) }));
             _updates = new AsyncEnumerable<ClusterManifest>(
                 initialValue: _current,
                 updateValidator: (previous, proposed) => proposed.Version > previous.Version,
@@ -182,7 +181,7 @@ namespace Orleans.Runtime.Metadata
             var version = new MajorMinorVersion(clusterMembership.Version.Value, existingManifest.Version.Minor + 1);
             if (modified)
             {
-                return _updates.TryPublish(new ClusterManifest(version, builder.ToImmutable(), builder.Values.ToImmutableArray())) && fetchSuccess;
+                return _updates.TryPublish(new ClusterManifest(version, builder.ToImmutable())) && fetchSuccess;
             }
 
             return fetchSuccess;

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -93,31 +93,6 @@ namespace Orleans.Runtime.Metadata
             }
         }
 
-        public GetClusterManifestResult GetCurrent(MajorMinorVersion version)
-        {
-            if (Current == null)
-            {
-                return new GetClusterManifestResult()
-                {
-                    IsVersionChange = true,
-                    ClusterManifest = Current
-                };
-            }
-            if (Current.Version == version)
-            {
-                return new GetClusterManifestResult()
-                {
-                    IsVersionChange = false,
-                    ClusterManifest = new ClusterManifest(MajorMinorVersion.Zero, ImmutableDictionary<SiloAddress, GrainManifest>.Empty, ImmutableArray<GrainManifest>.Empty)
-                };
-            }
-            return new GetClusterManifestResult()
-            {
-                IsVersionChange = true,
-                ClusterManifest = Current
-            };
-        }
-
         private async Task<bool> UpdateManifest(ClusterMembershipSnapshot clusterMembership)
         {
             var existingManifest = _current;

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -93,6 +93,31 @@ namespace Orleans.Runtime.Metadata
             }
         }
 
+        public GetClusterManifestResult GetCurrent(MajorMinorVersion version)
+        {
+            if (Current == null)
+            {
+                return new GetClusterManifestResult()
+                {
+                    IsVersionChange = true,
+                    ClusterManifest = Current
+                };
+            }
+            if (Current.Version == version)
+            {
+                return new GetClusterManifestResult()
+                {
+                    IsVersionChange = false,
+                    ClusterManifest = new ClusterManifest(MajorMinorVersion.Zero, ImmutableDictionary<SiloAddress, GrainManifest>.Empty, ImmutableArray<GrainManifest>.Empty)
+                };
+            }
+            return new GetClusterManifestResult()
+            {
+                IsVersionChange = true,
+                ClusterManifest = Current
+            };
+        }
+
         private async Task<bool> UpdateManifest(ClusterMembershipSnapshot clusterMembership)
         {
             var existingManifest = _current;

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -512,6 +512,31 @@ namespace UnitTests.Directory
                 await Task.Delay(100);
                 yield break;
             }
+
+            public GetClusterManifestResult GetCurrent(MajorMinorVersion version)
+            {
+                if (Current == null)
+                {
+                    return new GetClusterManifestResult()
+                    {
+                        IsVersionChange = true,
+                        ClusterManifest = Current
+                    };
+                }
+                if (Current.Version == version)
+                {
+                    return new GetClusterManifestResult()
+                    {
+                        IsVersionChange = false,
+                        ClusterManifest = new ClusterManifest(MajorMinorVersion.Zero, ImmutableDictionary<SiloAddress, GrainManifest>.Empty, ImmutableArray<GrainManifest>.Empty)
+                    };
+                }
+                return new GetClusterManifestResult()
+                {
+                    IsVersionChange = true,
+                    ClusterManifest = Current
+                };
+            }
         }
     }
 }

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -499,8 +499,7 @@ namespace UnitTests.Directory
         {
             public ClusterManifest Current => new ClusterManifest(
                 MajorMinorVersion.Zero,
-                ImmutableDictionary<SiloAddress, GrainManifest>.Empty,
-                ImmutableArray.Create(new GrainManifest(ImmutableDictionary<GrainType, GrainProperties>.Empty, ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty)));
+                ImmutableDictionary<SiloAddress, GrainManifest>.Empty);
 
             public IAsyncEnumerable<ClusterManifest> Updates => this.GetUpdates();
 

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -512,31 +512,6 @@ namespace UnitTests.Directory
                 await Task.Delay(100);
                 yield break;
             }
-
-            public GetClusterManifestResult GetCurrent(MajorMinorVersion version)
-            {
-                if (Current == null)
-                {
-                    return new GetClusterManifestResult()
-                    {
-                        IsVersionChange = true,
-                        ClusterManifest = Current
-                    };
-                }
-                if (Current.Version == version)
-                {
-                    return new GetClusterManifestResult()
-                    {
-                        IsVersionChange = false,
-                        ClusterManifest = new ClusterManifest(MajorMinorVersion.Zero, ImmutableDictionary<SiloAddress, GrainManifest>.Empty, ImmutableArray<GrainManifest>.Empty)
-                    };
-                }
-                return new GetClusterManifestResult()
-                {
-                    IsVersionChange = true,
-                    ClusterManifest = Current
-                };
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #8722

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8728)