### PR TITLE
Add default RedisConnectionString to RedisStorage unit test

### DIFF
--- a/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
+++ b/test/TestInfrastructure/TestExtensions/TestDefaultConfiguration.cs
@@ -71,6 +71,7 @@ namespace TestExtensions
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
+                { nameof(RedisConnectionString), "127.0.0.1:6379" },
                 { nameof(ZooKeeperConnectionString), "127.0.0.1:2181" }
             });
             if (!TryAddJsonFileFromEnvironmentVariable(builder, "ORLEANS_SECRETFILE"))


### PR DESCRIPTION
When conducting unit tests on `RedisStorage`, I found that the absence of `RedisConnectionString` prevents the tests from proceeding. Therefore, it should be added with the default value of `127.0.0.1:6379` to avoid SkipException.T

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8733)