### PR TITLE
chore: update dynamodb client options `Service` comment

### DIFF
--- a/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
+++ b/src/AWS/Shared/Storage/DynamoDBClientOptions.cs
@@ -23,7 +23,7 @@ namespace Orleans.Reminders.DynamoDB
         public string SecretKey { get; set; }
 
         /// <summary>
-        /// DynamoDB Service name
+        /// DynamoDB region name, such as "us-west-2"
         /// </summary>
         public string Service { get; set; }
 


### PR DESCRIPTION
Hey, really appreciate the work on this amazing package. I was recently trying to set it up and was quite confused why `Service` is used to denote the AWS region name, and the only reference I could find explaining it was:

https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/dynamodb-storage#configuration

I added the comment for more context and hope it can help to make the configuration options clearer for others!

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8745)