### PR TITLE
[7.x] Identify F# single case discriminated unions as SumType (#8739)

### DIFF
--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -24,7 +24,16 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            if (!baseType.GetAttributes(compilationAttributeType, out var compilationAttributes) || compilationAttributes.Length == 0)
+            INamedTypeSymbol sumTypeCandidate;
+            if (symbol.GetAttributes(compilationAttributeType, out var compilationAttributes) && compilationAttributes.Length > 0)
+            {
+                sumTypeCandidate = symbol;
+            }
+            else if (baseType.GetAttributes(compilationAttributeType, out compilationAttributes) && compilationAttributes.Length > 0)
+            {
+                sumTypeCandidate = baseType;
+            }
+            else
             {
                 return false;
             }
@@ -52,7 +61,7 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            sumType = baseType;
+            sumType = sumTypeCandidate;
             return true;
         }
 

--- a/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
@@ -1,4 +1,5 @@
 using TestExtensions;
+using UnitTests.FSharpTypes;
 using UnitTests.GrainInterfaces;
 using Xunit;
 
@@ -93,6 +94,74 @@ namespace DefaultCluster.Tests
 
             Assert.IsAssignableFrom<DefaultActivatorValueTypeWithUseActivator>(copy);
             Assert.Equal(4, ((DefaultActivatorValueTypeWithUseActivator)copy).Value);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void Serialization_Roundtrip_FSharp_SingleCaseDiscriminatedUnion()
+        {
+            var du = SingleCaseDU.ofInt(1);
+            var copy = HostedCluster.RoundTripSerializationForTesting(du);
+
+            Assert.IsAssignableFrom<SingleCaseDU>(copy);
+            Assert.Equal(du, copy);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void Serialization_Roundtrip_FSharp_DoubleCaseDiscriminatedUnion()
+        {
+            var case1 = DoubleCaseDU.NewCase1("case 1");
+            var case2 = DoubleCaseDU.NewCase2(2);
+
+            var copyCase1 = HostedCluster.RoundTripSerializationForTesting(case1);
+            var copyCase2 = HostedCluster.RoundTripSerializationForTesting(case2);
+
+            Assert.IsAssignableFrom<DoubleCaseDU>(copyCase1);
+            Assert.IsAssignableFrom<DoubleCaseDU>(copyCase2);
+            Assert.Equal(case1, copyCase1);
+            Assert.Equal(case2, copyCase2);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void Serialization_Roundtrip_FSharp_TripleCaseDiscriminatedUnion()
+        {
+            var case1 = TripleCaseDU.NewCase1("case 1");
+            var case2 = TripleCaseDU.NewCase2(2);
+            var case3 = TripleCaseDU.NewCase3('a');
+
+            var copyCase1 = HostedCluster.RoundTripSerializationForTesting(case1);
+            var copyCase2 = HostedCluster.RoundTripSerializationForTesting(case2);
+            var copyCase3 = HostedCluster.RoundTripSerializationForTesting(case3);
+
+            Assert.IsAssignableFrom<TripleCaseDU>(copyCase1);
+            Assert.IsAssignableFrom<TripleCaseDU>(copyCase2);
+            Assert.IsAssignableFrom<TripleCaseDU>(copyCase3);
+            Assert.Equal(case1, copyCase1);
+            Assert.Equal(case2, copyCase2);
+            Assert.Equal(case3, copyCase3);
+        }
+
+        [Fact(Skip = "DUs with 4 or more cases fail when trying to instanciate Case{1-4}-classes via RuntimeHelpers.GetUninitializedObject when deserializing"),
+         TestCategory("BVT"), TestCategory("Serialization")]
+        public void Serialization_Roundtrip_FSharp_QuadrupleCaseDiscriminatedUnion()
+        {
+            var case1 = QuadrupleCaseDU.NewCase1("case 1");
+            var case2 = QuadrupleCaseDU.NewCase2(2);
+            var case3 = QuadrupleCaseDU.NewCase3('a');
+            var case4 = QuadrupleCaseDU.NewCase4(1);
+
+            var copyCase1 = HostedCluster.RoundTripSerializationForTesting(case1);
+            var copyCase2 = HostedCluster.RoundTripSerializationForTesting(case2);
+            var copyCase3 = HostedCluster.RoundTripSerializationForTesting(case3);
+            var copyCase4 = HostedCluster.RoundTripSerializationForTesting(case4);
+
+            Assert.IsAssignableFrom<QuadrupleCaseDU>(copyCase1);
+            Assert.IsAssignableFrom<QuadrupleCaseDU>(copyCase2);
+            Assert.IsAssignableFrom<QuadrupleCaseDU>(copyCase3);
+            Assert.IsAssignableFrom<QuadrupleCaseDU>(copyCase4);
+            Assert.Equal(case1, copyCase1);
+            Assert.Equal(case2, copyCase2);
+            Assert.Equal(case3, copyCase3);
+            Assert.Equal(case4, copyCase4);
         }
     }
 }

--- a/test/Grains/TestFSharp/Types.fs
+++ b/test/Grains/TestFSharp/Types.fs
@@ -3,10 +3,27 @@ namespace UnitTests.FSharpTypes
 open Orleans
 
 [<Immutable; GenerateSerializer>]
-type SingleCaseDU = 
-    | SingleCaseDU of int 
-    | OtherCase of string
-    static member ofInt i = SingleCaseDU i
+type SingleCaseDU =
+    | Case1 of int
+    static member ofInt i = Case1 i
+
+[<Immutable; GenerateSerializer>]
+type DoubleCaseDU =
+    | Case1 of string
+    | Case2 of int
+
+[<Immutable; GenerateSerializer>]
+type TripleCaseDU =
+    | Case1 of string
+    | Case2 of int
+    | Case3 of char
+
+[<Immutable; GenerateSerializer>]
+type QuadrupleCaseDU =
+    | Case1 of string
+    | Case2 of int
+    | Case3 of char
+    | Case4 of byte
 
 [<Immutable; GenerateSerializer>]
 type Record = {  [<Id(1u)>] A: SingleCaseDU } with


### PR DESCRIPTION
Backport of #8739 to 7.x

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8757)