### PR TITLE
Prevent PlacementWorker.ProcessLoop from running on foreign schedulers

### DIFF
--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -215,7 +215,7 @@ namespace Orleans.Runtime.Placement
         private class PlacementWorker
         {
             private readonly Dictionary<GrainId, GrainPlacementWorkItem> _inProgress = new();
-            private readonly SingleWaiterAutoResetEvent _workSignal = new();
+            private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = true };
             private readonly ILogger _logger;
 #pragma warning disable IDE0052 // Remove unread private members. Justification: retained for debugging purposes
             private readonly Task _processLoopTask;


### PR DESCRIPTION
With the current configuration, it's possible for `PlacementService.PlacementWorker.ProcessLoop()` to resume execution on an unintended scheduler, which can have unintended consequences. This PR fixes that. I noticed this as test flakiness when certain tests were run in conjunction with each other.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8760)