### PR TITLE
Use UpDownCounter for grain and system target counts

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/GrainInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/GrainInstruments.cs
@@ -10,7 +10,7 @@ internal static class GrainInstruments
         GrainMetricsListener.Start();
     }
 
-    internal static Counter<int> GrainCounts = Instruments.Meter.CreateCounter<int>(InstrumentNames.GRAIN_COUNTS);
+    internal static UpDownCounter<int> GrainCounts = Instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.GRAIN_COUNTS);
     internal static void IncrementGrainCounts(string grainTypeName)
     {
         GrainCounts.Add(1, new KeyValuePair<string, object>("type", grainTypeName));
@@ -20,7 +20,7 @@ internal static class GrainInstruments
         GrainCounts.Add(-1, new KeyValuePair<string, object>("type", grainTypeName));
     }
 
-    internal static Counter<int> SystemTargetCounts = Instruments.Meter.CreateCounter<int>(InstrumentNames.SYSTEM_TARGET_COUNTS);
+    internal static UpDownCounter<int> SystemTargetCounts = Instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.SYSTEM_TARGET_COUNTS);
     internal static void IncrementSystemTargetCounts(string systemTargetTypeName)
     {
         SystemTargetCounts.Add(1, new KeyValuePair<string, object>("type", systemTargetTypeName));


### PR DESCRIPTION
Fix for #8753

UpDownCounter and Counter have the same implementation but they are interpreted differently by the .Net OTel SDK. UpDownCounter supports reporting negative values and is suitable to keep track of the number of active grains per type. The metric will be exported by the OTel SDK as a cumulative value instead of a delta for Counter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8781)