### PR TITLE
ClientClusterManifestProvider: fix case where gateway returns no update

### DIFF
--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -117,13 +117,13 @@ namespace Orleans.Runtime
                         }
 
                         var updateResult = await refreshTask;
-                        //updateResult may be null.If updateResult is null,wait for the next refresh interval and try again.
                         if (updateResult is null)
                         {
                             // There was no newer cluster manifest, so wait for the next refresh interval and try again.
                             await Task.WhenAny(cancellationTask, Task.Delay(_typeManagementOptions.TypeMapRefreshInterval));
                             continue;
                         }
+
                         gatewayVersion = updateResult.Version;
 
                         // If the manifest does not contain all active servers, merge with the existing manifest until it does.
@@ -183,11 +183,12 @@ namespace Orleans.Runtime
             }
         }
 
-        private async Task<ClusterManifestUpdate> GetClusterManifestUpdate(IClusterManifestSystemTarget provider, MajorMinorVersion previousVersion)
+        private async Task<ClusterManifestUpdate?> GetClusterManifestUpdate(IClusterManifestSystemTarget provider, MajorMinorVersion previousVersion)
         {
             try
             {
                 // First, attempt to call the new API, which provides more information.
+                // This returns null if there is no newer cluster manifest.
                 return await provider.GetClusterManifestUpdate(previousVersion);
             }
             catch (Exception exception)

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -116,7 +116,14 @@ namespace Orleans.Runtime
                             return;
                         }
 
-                        var updateResult = await refreshTask;                        
+                        var updateResult = await refreshTask;
+                        //updateResult may be null.If updateResult is null,wait for the next refresh interval and try again.
+                        if (updateResult is null)
+                        {
+                            // There was no newer cluster manifest, so wait for the next refresh interval and try again.
+                            await Task.WhenAny(cancellationTask, Task.Delay(_typeManagementOptions.TypeMapRefreshInterval));
+                            continue;
+                        }
                         gatewayVersion = updateResult.Version;
 
                         // If the manifest does not contain all active servers, merge with the existing manifest until it does.

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+#nullable enable
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
@@ -20,7 +20,7 @@ namespace Orleans.Runtime
         /// Gets an updated cluster manifest if newer than the provided <paramref name="previousVersion"/>.
         /// </summary>
         /// <returns>The current cluster manifest, or <see langword="null"/> if it is not newer than the provided version.</returns>
-        ValueTask<ClusterManifestUpdate> GetClusterManifestUpdate(MajorMinorVersion previousVersion);
+        ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion);
     }
 
     /// <summary>


### PR DESCRIPTION
There was no newer cluster manifest, so wait for the next refresh interval and try again.
GetClusterManifestUpdate() may be return null  and needs to be processed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8782)