### PR TITLE
Add default implements for IAsyncObserver and IAsyncBatchObserver 

### DIFF
--- a/src/Orleans.Streaming/Core/IAsyncBatchObserver.cs
+++ b/src/Orleans.Streaming/Core/IAsyncBatchObserver.cs
@@ -74,7 +74,7 @@ namespace Orleans.Streams
         /// </para>
         /// </summary>
         /// <returns>A Task that is completed when the stream-complete operation has been accepted.</returns>
-        Task OnCompletedAsync();
+        Task OnCompletedAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Notifies the consumer that the stream had an error.
@@ -84,6 +84,6 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="ex">An Exception that describes the error that occurred on the stream.</param>
         /// <returns>A Task that is completed when the close has been accepted.</returns>
-        Task OnErrorAsync(Exception ex);
+        Task OnErrorAsync(Exception ex) => throw ex;
     }
 }

--- a/src/Orleans.Streaming/Core/IAsyncObserver.cs
+++ b/src/Orleans.Streaming/Core/IAsyncObserver.cs
@@ -46,7 +46,7 @@ namespace Orleans.Streams
         /// </para>
         /// </summary>
         /// <returns>A Task that is completed when the stream-complete operation has been accepted.</returns>
-        Task OnCompletedAsync();
+        Task OnCompletedAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Notifies the consumer that the stream had an error.
@@ -56,6 +56,6 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="ex">An Exception that describes the error that occurred on the stream.</param>
         /// <returns>A Task that is completed when the close has been accepted.</returns>
-        Task OnErrorAsync(Exception ex);
+        Task OnErrorAsync(Exception ex) => throw ex;
     }
 }


### PR DESCRIPTION
This commit adds default implementations for two methods, OnCompletedAsync and OnErrorAsync, in the IAsyncObserver interface to reduce the occurrence of boilerplate code.