### PR TITLE
Fixes duplicate code-gen for `CompoundTypeAliasTree` with isolated base interface(s)

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -93,14 +93,13 @@ public class CompoundTypeAliasTree
         {
             if (value is not null && existing.Value is { } type && type != value)
             {
-                // When the same grain interface is used across multiple assemblies which dont have cross references,
+                // When the same grain interface is used across multiple assemblies which don't have cross references,
                 // code-gen will generate code for both because it works in isolation, yet at startup they are combined.
 
                 // In this case, if the key is present, and the value is the same as the one being added,
                 // and due to them being logically the same, we can just return the existing CompoundTypeAliasTree.
 
-                // Basically the "fastest" adds it, and the other just consumes it.
-
+                // The first one is allowed to win in this case.
                 return existing;
             }
 

--- a/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
+++ b/src/Orleans.Serialization/TypeSystem/CompoundTypeAliasTree.cs
@@ -93,7 +93,15 @@ public class CompoundTypeAliasTree
         {
             if (value is not null && existing.Value is { } type && type != value)
             {
-                throw new ArgumentException("A key with this value already exists");
+                // When the same grain interface is used across multiple assemblies which dont have cross references,
+                // code-gen will generate code for both because it works in isolation, yet at startup they are combined.
+
+                // In this case, if the key is present, and the value is the same as the one being added,
+                // and due to them being logically the same, we can just return the existing CompoundTypeAliasTree.
+
+                // Basically the "fastest" adds it, and the other just consumes it.
+
+                return existing;
             }
 
             existing.Value = value;


### PR DESCRIPTION
close #8787 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8788)