### PR TITLE
Adds `LinearBackoffClientConnectionRetryFilter` in the default client services

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -86,6 +86,7 @@ namespace Orleans
             services.TryAddFromExisting<IInternalClusterClient, ClusterClient>();
             services.AddFromExisting<IHostedService, ClusterClient>();
             services.AddTransient<IOptions<MessagingOptions>>(static sp => sp.GetRequiredService<IOptions<ClientMessagingOptions>>());
+            services.TryAddSingleton<IClientConnectionRetryFilter, DefaultClientConnectRetryFilter>();
 
             services.AddSingleton<IConfigureOptions<GrainTypeOptions>, DefaultGrainTypeOptionsProvider>();
 

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -86,7 +86,7 @@ namespace Orleans
             services.TryAddFromExisting<IInternalClusterClient, ClusterClient>();
             services.AddFromExisting<IHostedService, ClusterClient>();
             services.AddTransient<IOptions<MessagingOptions>>(static sp => sp.GetRequiredService<IOptions<ClientMessagingOptions>>());
-            services.TryAddSingleton<IClientConnectionRetryFilter, DefaultClientConnectRetryFilter>();
+            services.TryAddSingleton<IClientConnectionRetryFilter, LinearBackoffClientConnectionRetryFilter>();
 
             services.AddSingleton<IConfigureOptions<GrainTypeOptions>, DefaultGrainTypeOptionsProvider>();
 

--- a/src/Orleans.Core/Core/IClientConnectionRetryFilter.cs
+++ b/src/Orleans.Core/Core/IClientConnectionRetryFilter.cs
@@ -19,7 +19,7 @@ namespace Orleans
         Task<bool> ShouldRetryConnectionAttempt(Exception exception, CancellationToken cancellationToken);
     }
 
-    internal sealed class DefaultClientConnectRetryFilter : IClientConnectionRetryFilter
+    internal sealed class LinearBackoffClientConnectionRetryFilter : IClientConnectionRetryFilter
     {
         private int _retryCount = 0;
 

--- a/src/Orleans.Core/Core/IClientConnectionRetryFilter.cs
+++ b/src/Orleans.Core/Core/IClientConnectionRetryFilter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -16,5 +17,31 @@ namespace Orleans
         /// <param name="cancellationToken">The cancellation token used to notify when connection has been aborted externally.</param>
         /// <returns><see langword="true"/> if connection should be re-attempted, <see langword="false"/> if attempts to connect to the cluster should be aborted.</returns>
         Task<bool> ShouldRetryConnectionAttempt(Exception exception, CancellationToken cancellationToken);
+    }
+
+    internal sealed class DefaultClientConnectRetryFilter : IClientConnectionRetryFilter
+    {
+        private int _retryCount = 0;
+
+        private const int MaxRetry = 5;
+        private const int Delay = 1_500;
+
+        public async Task<bool> ShouldRetryConnectionAttempt(
+            Exception exception,
+            CancellationToken cancellationToken)
+        {
+            if (_retryCount >= MaxRetry)
+            {
+                return false;
+            }
+
+            if (!cancellationToken.IsCancellationRequested && exception is SiloUnavailableException)
+            {
+                await Task.Delay(++_retryCount * Delay, cancellationToken);
+                return true;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
close #8716 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8793)