### PR TITLE
Make repeatable the execution of SQLServer Ado scripts without errors

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/SQLServer-Clustering-3.7.0.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/SQLServer-Clustering-3.7.0.sql
@@ -1,10 +1,15 @@
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-    'CleanupDefunctSiloEntriesKey','
-    DELETE FROM OrleansMembershipTable
+SELECT
+    'CleanupDefunctSiloEntriesKey',
+    'DELETE FROM OrleansMembershipTable
     WHERE DeploymentId = @DeploymentId
         AND @DeploymentId IS NOT NULL
         AND IAmAliveTime < @IAmAliveTime
         AND Status != 3;
-');
+    '
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'CleanupDefunctSiloEntriesKey'
+);

--- a/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
@@ -146,110 +146,139 @@ WHERE NOT EXISTS
 );
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'UpdateMembershipKey','
-	SET XACT_ABORT, NOCOUNT ON;
-	BEGIN TRANSACTION;
-
-	UPDATE OrleansMembershipVersionTable
-	SET
-		Timestamp = GETUTCDATE(),
-		Version = Version + 1
-	WHERE
-		DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
-		AND Version = @Version AND @Version IS NOT NULL;
-
-	UPDATE OrleansMembershipTable
-	SET
-		Status = @Status,
-		SuspectTimes = @SuspectTimes,
-		IAmAliveTime = @IAmAliveTime
-	WHERE
-		DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
-		AND Address = @Address AND @Address IS NOT NULL
-		AND Port = @Port AND @Port IS NOT NULL
-		AND Generation = @Generation AND @Generation IS NOT NULL
-		AND @@ROWCOUNT > 0;
-
-	SELECT @@ROWCOUNT;
-	COMMIT TRANSACTION;
-');
-
-INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'GatewaysQueryKey','
-	SELECT
-		Address,
-		ProxyPort,
-		Generation
-	FROM
-		OrleansMembershipTable
-	WHERE
-		DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
-		AND Status = @Status AND @Status IS NOT NULL
-		AND ProxyPort > 0;
-');
+SELECT
+	'UpdateMembershipKey',
+	'
+		SET XACT_ABORT, NOCOUNT ON;
+		BEGIN TRANSACTION;
+	
+		UPDATE OrleansMembershipVersionTable
+		SET
+			Timestamp = GETUTCDATE(),
+			Version = Version + 1
+		WHERE
+			DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
+			AND Version = @Version AND @Version IS NOT NULL;
+	
+		UPDATE OrleansMembershipTable
+		SET
+			Status = @Status,
+			SuspectTimes = @SuspectTimes,
+			IAmAliveTime = @IAmAliveTime
+		WHERE
+			DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
+			AND Address = @Address AND @Address IS NOT NULL
+			AND Port = @Port AND @Port IS NOT NULL
+			AND Generation = @Generation AND @Generation IS NOT NULL
+			AND @@ROWCOUNT > 0;
+	
+		SELECT @@ROWCOUNT;
+		COMMIT TRANSACTION;
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+	FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'UpdateMembershipKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
+SELECT
+	'GatewaysQueryKey',
+	'
+		SELECT
+			Address,
+			ProxyPort,
+			Generation
+		FROM
+			OrleansMembershipTable
+		WHERE
+			DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL
+			AND Status = @Status AND @Status IS NOT NULL
+			AND ProxyPort > 0;
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+	FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'GatewaysQueryKey'
+);
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+SELECT
 	'MembershipReadRowKey','
-	SELECT
-		v.DeploymentId,
-		m.Address,
-		m.Port,
-		m.Generation,
-		m.SiloName,
-		m.HostName,
-		m.Status,
-		m.ProxyPort,
-		m.SuspectTimes,
-		m.StartTime,
-		m.IAmAliveTime,
-		v.Version
-	FROM
-		OrleansMembershipVersionTable v
-		-- This ensures the version table will returned even if there is no matching membership row.
-		LEFT OUTER JOIN OrleansMembershipTable m ON v.DeploymentId = m.DeploymentId
-		AND Address = @Address AND @Address IS NOT NULL
-		AND Port = @Port AND @Port IS NOT NULL
-		AND Generation = @Generation AND @Generation IS NOT NULL
-	WHERE
-		v.DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
-');
+		SELECT
+			v.DeploymentId,
+			m.Address,
+			m.Port,
+			m.Generation,
+			m.SiloName,
+			m.HostName,
+			m.Status,
+			m.ProxyPort,
+			m.SuspectTimes,
+			m.StartTime,
+			m.IAmAliveTime,
+			v.Version
+		FROM
+			OrleansMembershipVersionTable v
+			-- This ensures the version table will returned even if there is no matching membership row.
+			LEFT OUTER JOIN OrleansMembershipTable m ON v.DeploymentId = m.DeploymentId
+			AND Address = @Address AND @Address IS NOT NULL
+			AND Port = @Port AND @Port IS NOT NULL
+			AND Generation = @Generation AND @Generation IS NOT NULL
+		WHERE
+			v.DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+	FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'MembershipReadRowKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'MembershipReadAllKey','
-	SELECT
-		v.DeploymentId,
-		m.Address,
-		m.Port,
-		m.Generation,
-		m.SiloName,
-		m.HostName,
-		m.Status,
-		m.ProxyPort,
-		m.SuspectTimes,
-		m.StartTime,
-		m.IAmAliveTime,
-		v.Version
-	FROM
-		OrleansMembershipVersionTable v LEFT OUTER JOIN OrleansMembershipTable m
-		ON v.DeploymentId = m.DeploymentId
-	WHERE
-		v.DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
-');
+SELECT
+	'MembershipReadAllKey',
+	'
+		SELECT
+			v.DeploymentId,
+			m.Address,
+			m.Port,
+			m.Generation,
+			m.SiloName,
+			m.HostName,
+			m.Status,
+			m.ProxyPort,
+			m.SuspectTimes,
+			m.StartTime,
+			m.IAmAliveTime,
+			v.Version
+		FROM
+			OrleansMembershipVersionTable v LEFT OUTER JOIN OrleansMembershipTable m
+			ON v.DeploymentId = m.DeploymentId
+		WHERE
+			v.DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+	FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'MembershipReadAllKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'DeleteMembershipTableEntriesKey','
-	DELETE FROM OrleansMembershipTable
-	WHERE DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
-	DELETE FROM OrleansMembershipVersionTable
-	WHERE DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
-');
+SELECT
+	'DeleteMembershipTableEntriesKey',
+	'
+		DELETE FROM OrleansMembershipTable
+		WHERE DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
+		DELETE FROM OrleansMembershipVersionTable
+		WHERE DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+	FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'DeleteMembershipTableEntriesKey'
+);

--- a/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
@@ -206,7 +206,8 @@ WHERE NOT EXISTS
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 SELECT
-	'MembershipReadRowKey','
+	'MembershipReadRowKey',
+    '
 		SELECT
 			v.DeploymentId,
 			m.Address,

--- a/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
@@ -1,4 +1,5 @@
 -- For each deployment, there will be only one (active) membership version table version column which will be updated periodically.
+IF OBJECT_ID(N'[OrleansMembershipVersionTable]', 'U') IS NULL
 CREATE TABLE OrleansMembershipVersionTable
 (
 	DeploymentId NVARCHAR(150) NOT NULL,
@@ -9,6 +10,7 @@ CREATE TABLE OrleansMembershipVersionTable
 );
 
 -- Every silo instance has a row in the membership table.
+IF OBJECT_ID(N'[OrleansMembershipTable]', 'U') IS NULL
 CREATE TABLE OrleansMembershipTable
 (
 	DeploymentId NVARCHAR(150) NOT NULL,

--- a/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
@@ -78,7 +78,10 @@ CREATE TABLE OrleansStorage
     -- rows down to [0, n] relevant ones, n being the number of collided value pairs.
 );
 
-CREATE NONCLUSTERED INDEX IX_OrleansStorage ON OrleansStorage(GrainIdHash, GrainTypeHash);
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'IX_OrleansStorage' AND object_id = OBJECT_ID('OrleansStorage'))
+BEGIN
+	CREATE NONCLUSTERED INDEX IX_OrleansStorage ON OrleansStorage(GrainIdHash, GrainTypeHash);
+END
 
 -- This ensures lock escalation will not lock the whole table, which can potentially be enormous.
 -- See more information at https://www.littlekendra.com/2016/02/04/why-rowlock-hints-can-make-queries-slower-and-blocking-worse-in-sql-server/.

--- a/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql
@@ -193,7 +193,7 @@ SELECT
 WHERE NOT EXISTS 
 ( 
     SELECT 1 
-	FROM OrleansQuery oqt
+    FROM OrleansQuery oqt
     WHERE oqt.[QueryKey] = 'WriteToStorageKey'
 );
 
@@ -225,7 +225,7 @@ SELECT
 WHERE NOT EXISTS 
 ( 
     SELECT 1 
-	FROM OrleansQuery oqt
+    FROM OrleansQuery oqt
     WHERE oqt.[QueryKey] = 'ClearStorageKey'
 );
 
@@ -256,6 +256,6 @@ SELECT
 WHERE NOT EXISTS 
 ( 
     SELECT 1 
-	FROM OrleansQuery oqt
+    FROM OrleansQuery oqt
     WHERE oqt.[QueryKey] = 'ReadFromStorageKey'
 );

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql
@@ -1,4 +1,5 @@
 -- Orleans Reminders table - https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders
+IF OBJECT_ID(N'[OrleansRemindersTable]', 'U') IS NULL
 CREATE TABLE OrleansRemindersTable
 (
 	ServiceId NVARCHAR(150) NOT NULL,
@@ -13,10 +14,9 @@ CREATE TABLE OrleansRemindersTable
 );
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'UpsertReminderRowKey','
-	DECLARE @Version AS INT = 0;
+SELECT
+	'UpsertReminderRowKey',
+	'DECLARE @Version AS INT = 0;
 	SET XACT_ABORT, NOCOUNT ON;
 	BEGIN TRANSACTION;
 	UPDATE OrleansRemindersTable WITH(UPDLOCK, ROWLOCK, HOLDLOCK)
@@ -52,13 +52,18 @@ VALUES
 		@@ROWCOUNT=0;
 	SELECT @Version AS Version;
 	COMMIT TRANSACTION;
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'UpsertReminderRowKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'ReadReminderRowsKey','
-	SELECT
+SELECT
+	'ReadReminderRowsKey',
+	'SELECT
 		GrainId,
 		ReminderName,
 		StartTime,
@@ -68,13 +73,18 @@ VALUES
 	WHERE
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL
 		AND GrainId = @GrainId AND @GrainId IS NOT NULL;
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'ReadReminderRowsKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'ReadReminderRowKey','
-	SELECT
+SELECT
+	'ReadReminderRowKey',
+	'SELECT
 		GrainId,
 		ReminderName,
 		StartTime,
@@ -85,13 +95,18 @@ VALUES
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL
 		AND GrainId = @GrainId AND @GrainId IS NOT NULL
 		AND ReminderName = @ReminderName AND @ReminderName IS NOT NULL;
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'ReadReminderRowKey'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'ReadRangeRows1Key','
-	SELECT
+SELECT
+	'ReadRangeRows1Key',
+	'SELECT
 		GrainId,
 		ReminderName,
 		StartTime,
@@ -102,13 +117,18 @@ VALUES
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL
 		AND GrainHash > @BeginHash AND @BeginHash IS NOT NULL
 		AND GrainHash <= @EndHash AND @EndHash IS NOT NULL;
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'ReadRangeRows1Key'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'ReadRangeRows2Key','
-	SELECT
+SELECT
+	'ReadRangeRows2Key',
+	'SELECT
 		GrainId,
 		ReminderName,
 		StartTime,
@@ -119,26 +139,42 @@ VALUES
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL
 		AND ((GrainHash > @BeginHash AND @BeginHash IS NOT NULL)
 		OR (GrainHash <= @EndHash AND @EndHash IS NOT NULL));
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'ReadRangeRows2Key'
+);
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'DeleteReminderRowKey','
-	DELETE FROM OrleansRemindersTable
+SELECT
+	'DeleteReminderRowKey',
+	'DELETE FROM OrleansRemindersTable
 	WHERE
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL
 		AND GrainId = @GrainId AND @GrainId IS NOT NULL
 		AND ReminderName = @ReminderName AND @ReminderName IS NOT NULL
 		AND Version = @Version AND @Version IS NOT NULL;
 	SELECT @@ROWCOUNT;
-');
+	'
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'DeleteReminderRowKey'
+);    
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
-VALUES
-(
-	'DeleteReminderRowsKey','
-	DELETE FROM OrleansRemindersTable
+SELECT
+	'DeleteReminderRowsKey',
+	'DELETE FROM OrleansRemindersTable
 	WHERE
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL;
-');
+	');
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'DeleteReminderRowsKey'
+);  

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql
@@ -171,7 +171,7 @@ SELECT
 	'DELETE FROM OrleansRemindersTable
 	WHERE
 		ServiceId = @ServiceId AND @ServiceId IS NOT NULL;
-	');
+	'
 WHERE NOT EXISTS 
 ( 
     SELECT 1 

--- a/src/AdoNet/Shared/SQLServer-Main.sql
+++ b/src/AdoNet/Shared/SQLServer-Main.sql
@@ -37,6 +37,7 @@ EXECUTE sp_executesql @snapshotSettings;
 -- This table defines Orleans operational queries. Orleans uses these to manage its operations,
 -- these are the only queries Orleans issues to the database.
 -- These can be redefined (e.g. to provide non-destructive updates) provided the stated interface principles hold.
+IF OBJECT_ID(N'[OrleansQuery]', 'U') IS NULL
 CREATE TABLE OrleansQuery
 (
 	QueryKey VARCHAR(64) NOT NULL,


### PR DESCRIPTION
## Problem:
Multiple execution of .sql scripts during the first startup of software with multiple replicas causes primary key violations and existing table errors.
For example: scripts may be executed via sqlcmd within initcontainer during deployment, if the software has more than one replica they will run multiple times, one per replica.

## Proposed solution:
Add a check that checks whether objects (tables, indexes and queries) already exist before creating them.

## Ref: 
- https://github.com/dotnet/orleans/issues/8676#issuecomment-1778993297

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8799)