### PR TITLE
`GenerateAliasAttribtuesAnalyzer` needs to account for file-scoped namespaces

### DIFF
--- a/src/Orleans.Analyzers/GenerateAliasAttributesAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateAliasAttributesAnalyzer.cs
@@ -123,9 +123,9 @@ public class GenerateAliasAttributesAnalyzer : DiagnosticAnalyzer
             {
                 segments.Push(type.Identifier.ToString());
             }
-            else if (node is NamespaceDeclarationSyntax or FileScopedNamespaceDeclarationSyntax)
+            else if (node is BaseNamespaceDeclarationSyntax ns)
             {
-                segments.Push(((BaseNamespaceDeclarationSyntax)node).Name.ToString());
+                segments.Push(ns.Name.ToString());
             }
 
             node = node.Parent;

--- a/src/Orleans.Analyzers/GenerateAliasAttributesAnalyzer.cs
+++ b/src/Orleans.Analyzers/GenerateAliasAttributesAnalyzer.cs
@@ -116,15 +116,16 @@ public class GenerateAliasAttributesAnalyzer : DiagnosticAnalyzer
         SyntaxNode node = typeDeclarationSyntax.Parent;
         StringBuilder sb = new();
         Stack<string> segments = new();
+
         while (node is not null)
         {
             if (node is TypeDeclarationSyntax type)
             {
                 segments.Push(type.Identifier.ToString());
             }
-            else if (node is NamespaceDeclarationSyntax ns)
+            else if (node is NamespaceDeclarationSyntax or FileScopedNamespaceDeclarationSyntax)
             {
-                segments.Push(ns.Name.ToString());
+                segments.Push(((BaseNamespaceDeclarationSyntax)node).Name.ToString());
             }
 
             node = node.Parent;


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8809)