### PR TITLE
Centralize environment statistics filtering

### DIFF
--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -14,6 +14,10 @@ public interface IEnvironmentStatisticsProvider
     EnvironmentStatistics GetEnvironmentStatistics();
 }
 
+// This struct is intentionally 'packed' in order to avoid extra padding.
+// This will be created very frequently, so we reduce stack size and lower the serialization cost.
+// As more fields are added to this, they could be placed in such a manner that it may result in a lot of 'empty' space.
+
 /// <summary>
 /// Contains statistics about the current process and its execution environment.
 /// </summary>

--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -17,7 +17,6 @@ public interface IEnvironmentStatisticsProvider
 // This struct is intentionally 'packed' in order to avoid extra padding.
 // This will be created very frequently, so we reduce stack size and lower the serialization cost.
 // As more fields are added to this, they could be placed in such a manner that it may result in a lot of 'empty' space.
-
 /// <summary>
 /// Contains statistics about the current process and its execution environment.
 /// </summary>

--- a/src/Orleans.Core/Statistics/EnvironmentStatistics.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatistics.cs
@@ -50,7 +50,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
         var availableMemory = systemAvailable + processAvailable;
         var maxAvailableMemory = Math.Min(memoryInfo.TotalAvailableMemoryBytes, memoryInfo.HighMemoryLoadThresholdBytes);
 
-        var filteredCpuUsage = (long)_cpuUsageFilter.Filter((float)cpuUsage);
+        var filteredCpuUsage = _cpuUsageFilter.Filter(cpuUsage);
         var filteredMemoryUsage = (long)_memoryUsageFilter.Filter(memoryUsage);
         var filteredAvailableMemory = (long)_availableMemoryFilter.Filter(availableMemory);
         // no need to filter 'maxAvailableMemory' as it will almost always be a steady value.
@@ -65,7 +65,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
 
     private sealed class EventCounterListener : EventListener
     {
-        public double CpuUsage { get; private set; } = 0d;
+        public float CpuUsage { get; private set; } = 0f;
 
         protected override void OnEventSourceCreated(EventSource source)
         {
@@ -88,7 +88,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
                         && eventPayload.TryGetValue("Mean", out var mean)
                         && mean is double value)
                     {
-                        CpuUsage = value;
+                        CpuUsage = (float)value;
                         break;
                     }
                 }

--- a/src/Orleans.Core/Statistics/EnvironmentStatistics.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatistics.cs
@@ -12,6 +12,9 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
 {
     private const float OneKiloByte = 1024f;
 
+    private long _availableMemoryBytes;
+    private long _maximumAvailableMemoryBytes;
+
     private readonly EventCounterListener _eventCounterListener = new();
 
     [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used for memory-dump debugging.")]
@@ -20,8 +23,9 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
     [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used for memory-dump debugging.")]
     private readonly ObservableCounter<long> _maximumAvailableMemoryCounter;
 
-    private long _availableMemoryBytes;
-    private long _maximumAvailableMemoryBytes;
+    private readonly DualModeKalmanFilter _cpuUsageFilter = new();
+    private readonly DualModeKalmanFilter _memoryUsageFilter = new();
+    private readonly DualModeKalmanFilter _availableMemoryFilter = new();
 
     public EnvironmentStatisticsProvider()
     {
@@ -36,7 +40,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
     {
         var memoryInfo = GC.GetGCMemoryInfo();
 
-        var cpuUsage = (float)_eventCounterListener.CpuUsage;
+        var cpuUsage = _eventCounterListener.CpuUsage;
         var memoryUsage = GC.GetTotalMemory(false) + memoryInfo.FragmentedBytes;
 
         var committedOfLimit = memoryInfo.TotalAvailableMemoryBytes - memoryInfo.TotalCommittedBytes;
@@ -44,13 +48,17 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
         var systemAvailable = Math.Max(0, Math.Min(committedOfLimit, unusedLoad));
         var processAvailable = memoryInfo.TotalCommittedBytes - memoryInfo.HeapSizeBytes;
         var availableMemory = systemAvailable + processAvailable;
+        var maxAvailableMemory = Math.Min(memoryInfo.TotalAvailableMemoryBytes, memoryInfo.HighMemoryLoadThresholdBytes);
 
-        var maximumAvailableMemory = Math.Min(memoryInfo.TotalAvailableMemoryBytes, memoryInfo.HighMemoryLoadThresholdBytes);
+        var filteredCpuUsage = (long)_cpuUsageFilter.Filter((float)cpuUsage);
+        var filteredMemoryUsage = (long)_memoryUsageFilter.Filter(memoryUsage);
+        var filteredAvailableMemory = (long)_availableMemoryFilter.Filter(availableMemory);
+        // no need to filter 'maxAvailableMemory' as it will almost always be a steady value.
 
-        _availableMemoryBytes = availableMemory;
-        _maximumAvailableMemoryBytes = maximumAvailableMemory;
+        _availableMemoryBytes = filteredAvailableMemory;
+        _maximumAvailableMemoryBytes = maxAvailableMemory;
 
-        return new(cpuUsage, memoryUsage, availableMemory, maximumAvailableMemory);
+        return new(filteredCpuUsage, filteredMemoryUsage, filteredAvailableMemory, maxAvailableMemory);
     }
 
     public void Dispose() => _eventCounterListener.Dispose();
@@ -84,6 +92,84 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
                         break;
                     }
                 }
+            }
+        }
+    }
+
+    // See: https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/
+
+    // The rationale behind using a cooperative dual-mode KF, is that we want the input signal to follow a trajectory that
+    // decays with a slower rate than the original one, but also tracks the signal in case of signal increases
+    // (which represent potential of overloading). Both are important, but they are inversely correlated to each other.
+    private sealed class DualModeKalmanFilter
+    {
+        private const float SlowProcessNoiseCovariance = 0f;
+        private const float FastProcessNoiseCovariance = 0.01f;
+
+        private KalmanFilter _slowFilter = new();
+        private KalmanFilter _fastFilter = new();
+
+        private FilterRegime _regime = FilterRegime.Slow;
+
+        private enum FilterRegime
+        {
+            Slow,
+            Fast
+        }
+
+        public float Filter(float measurement)
+        {
+            float slowEstimate = _slowFilter.Filter(measurement, SlowProcessNoiseCovariance);
+            float fastEstimate = _fastFilter.Filter(measurement, FastProcessNoiseCovariance);
+
+            if (measurement > slowEstimate)
+            {
+                if (_regime == FilterRegime.Slow)
+                {
+                    _regime = FilterRegime.Fast;
+                    _fastFilter.SetState(measurement, 0f);
+                    fastEstimate = _fastFilter.Filter(measurement, FastProcessNoiseCovariance);
+                }
+
+                return fastEstimate;
+            }
+            else
+            {
+                if (_regime == FilterRegime.Fast)
+                {
+                    _regime = FilterRegime.Slow;
+                    _slowFilter.SetState(_fastFilter.PriorEstimate, _fastFilter.PriorErrorCovariance);
+                    slowEstimate = _slowFilter.Filter(measurement, SlowProcessNoiseCovariance);
+                }
+
+                return slowEstimate;
+            }
+        }
+
+        private struct KalmanFilter()
+        {
+            public float PriorEstimate { get; private set; } = 0f;
+            public float PriorErrorCovariance { get; private set; } = 1f;
+
+            public void SetState(float estimate, float errorCovariance)
+            {
+                PriorEstimate = estimate;
+                PriorErrorCovariance = errorCovariance;
+            }
+
+            public float Filter(float measurement, float processNoiseCovariance)
+            {
+                float estimate = PriorEstimate;
+                float errorCovariance = PriorErrorCovariance + processNoiseCovariance;
+
+                float gain = errorCovariance / (errorCovariance + 1f);
+                float newEstimate = estimate + gain * (measurement - estimate);
+                float newErrorCovariance = (1f - gain) * errorCovariance;
+
+                PriorEstimate = newEstimate;
+                PriorErrorCovariance = newErrorCovariance;
+
+                return newEstimate;
             }
         }
     }

--- a/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
@@ -39,8 +39,6 @@ namespace Orleans.Runtime.Placement
             deploymentLoadPublisher?.SubscribeToStatisticsChangeEvents(this);
         }
 
-        private static bool IsSiloOverloaded(SiloRuntimeStatistics stats) => stats.IsOverloaded || stats.EnvironmentStatistics.CpuUsagePercentage >= 100;
-
         private SiloAddress SelectSiloPowerOfK(SiloAddress[] silos)
         {
             var compatibleSilos = silos.ToSet();
@@ -51,7 +49,7 @@ namespace Orleans.Runtime.Placement
             foreach (var kv in _localCache)
             {
                 totalSilos++;
-                if (IsSiloOverloaded(kv.Value.SiloStats)) continue;
+                if (kv.Value.SiloStats.IsOverloaded) continue;
                 if (!compatibleSilos.Contains(kv.Key)) continue;
 
                 relevantSilos.Add(kv);

--- a/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs
@@ -230,7 +230,7 @@ internal sealed class ResourceOptimizedPlacementDirector : IPlacementDirector, I
             addValueFactory: static (_, statistics) => ResourceStatistics.FromRuntime(statistics),
             updateValueFactory: static (_, _, statistics) => ResourceStatistics.FromRuntime(statistics));
 
-    private readonly record struct NormalizedWeights(float CpuUsageWeight, float MemoryUsageWeight, float AvailableMemoryWeight, float MaxAvailableMemoryWeight);
+    private record NormalizedWeights(float CpuUsageWeight, float MemoryUsageWeight, float AvailableMemoryWeight, float MaxAvailableMemoryWeight);
     private readonly record struct ResourceStatistics(bool IsOverloaded, float CpuUsage, float MemoryUsage, float AvailableMemory, float MaxAvailableMemory)
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
The cooperative dual-mode Kalman filtering is moved from `ResourceOptimizedPlacementDirector` to `EnvironmentStatisticsProvider`, this achieves 3 things:

1. Centralizes the filtering logic of the `EnvironmentStatistics` so when they are published, every receiver already has the filtered data.
2. Allows not only for `ResourceOptimizedPlacementDirector` but also `ActivationCountPlacementDirector` and `OverloadDetector` to make use of the filtered data.
3. Reduces the need to allocate **(N + n)<sup>2</sup>** filters to **N**.
    Where **N** is the number of silos, and **n** is the number of components within a silo, that may decide to use the data.
    For example: `ResourceOptimizedPlacementDirector, ActivationCountPlacementDirector, OverloadDetector`, potentially others 
    in the future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8827)