### PR TITLE
Add support for enabling distributed tracing via configuration switch

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -167,7 +167,7 @@ namespace Orleans
             services.Configure<ClientMessagingOptions>(cfg.GetSection("Messaging"));
             services.Configure<GatewayOptions>(cfg.GetSection("Gateway"));
 
-            if (bool.TryParse(cfg["EnableActivityPropagation"], out var enableDistributedTracing) && enableDistributedTracing)
+            if (bool.TryParse(cfg["EnableDistributedTracing"], out var enableDistributedTracing) && enableDistributedTracing)
             {
                 builder.AddActivityPropagation();
             }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -167,6 +167,11 @@ namespace Orleans
             services.Configure<ClientMessagingOptions>(cfg.GetSection("Messaging"));
             services.Configure<GatewayOptions>(cfg.GetSection("Gateway"));
 
+            if (bool.TryParse(cfg["EnableActivityPropagation"], out var enableDistributedTracing) && enableDistributedTracing)
+            {
+                builder.AddActivityPropagation();
+            }
+
             ApplySubsection(builder, cfg, knownProviderTypes, "Clustering");
             ApplySubsection(builder, cfg, knownProviderTypes, "Reminders");
             ApplyNamedSubsections(builder, cfg, knownProviderTypes, "BroadcastChannel");

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -97,14 +97,12 @@ namespace Orleans.Runtime
             var source = GetActivitySource(context);
             var activity = source.StartActivity(context.Request.GetActivityName(), ActivityKind.Client);
 
-            if (activity is not null)
+            if (activity is null)
             {
-                _propagator.Inject(activity, null, static (carrier, key, value) =>
-                {
-                    RequestContext.Set(key, value);
-                });
+                return context.Invoke();
             }
 
+            _propagator.Inject(activity, null, static (carrier, key, value) => RequestContext.Set(key, value));
             return Process(context, activity);
         }
     }
@@ -170,7 +168,12 @@ namespace Orleans.Runtime
                 activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server);
             }
 
-            activity?.Start();
+            if (activity is null)
+            {
+                return context.Invoke();
+            }
+
+            activity.Start();
             return Process(context, activity);
         }
     }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -421,6 +421,11 @@ namespace Orleans.Hosting
                 services.Configure<EndpointOptions>(o => o.Bind(ep));
             }
 
+            if (bool.TryParse(cfg["EnableActivityPropagation"], out var enableDistributedTracing) && enableDistributedTracing)
+            {
+                builder.AddActivityPropagation();
+            }
+
             ApplySubsection(builder, cfg, knownProviderTypes, "Clustering");
             ApplySubsection(builder, cfg, knownProviderTypes, "Reminders");
             ApplyNamedSubsections(builder, cfg, knownProviderTypes, "BroadcastChannel");

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -421,7 +421,7 @@ namespace Orleans.Hosting
                 services.Configure<EndpointOptions>(o => o.Bind(ep));
             }
 
-            if (bool.TryParse(cfg["EnableActivityPropagation"], out var enableDistributedTracing) && enableDistributedTracing)
+            if (bool.TryParse(cfg["EnableDistributedTracing"], out var enableDistributedTracing) && enableDistributedTracing)
             {
                 builder.AddActivityPropagation();
             }


### PR DESCRIPTION
This is prompted by the Aspire integration, where we want distributed tracing enabled by default during development time

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8829)