### PR TITLE
test(codegen): add derived from list

### DIFF
--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -547,6 +547,15 @@ public class GeneratedSerializerTests : IDisposable
         Assert.Contains("[#7 VarInt Id: 2 SchemaType: Expected] Value: 2", formattedBitStream); // type reference from Type2 field pointing to the encoded field type of UntypedValue
     }
 
+    [Fact(Skip = "Fix me please")]
+    public void TypeDerivedFromList()
+    {
+        var original = new SerializableClassWithCompiledBase { IntProperty = 30 };
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.IntProperty, result.IntProperty);
+    }
+
     [Fact]
     public void TypeDerivedFromDictionary()
     {


### PR DESCRIPTION
We're migrating from Orleans 3.7.1 to Orleans 8.0.0. 

We have this issue, which a class inherits from a generic list. Currently, the codegen is skipping this and on runtime, it's throwing an error: Could not find a base type serializer. I've added a simple unit test so you have an easy repro of this issue.

![image](https://github.com/dotnet/orleans/assets/1999085/8204ed0d-f8ef-48a6-af12-d65f5d9f3bf0)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8858)