### PR TITLE
Fix `PooledBuffer` serialization & initialize ActivationMigrationManager on startup

### DIFF
--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -395,6 +395,7 @@ namespace Orleans.Hosting
             services.AddSingleton<MigrationContext.SerializationHooks>();
             services.AddSingleton<ActivationMigrationManager>();
             services.AddFromExisting<IActivationMigrationManager, ActivationMigrationManager>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, ActivationMigrationManager>();
         }
 
         private class AllowOrleansTypes : ITypeNameFilter

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -63,7 +63,6 @@ namespace UnitTests.Serialization
         /// <summary>
         /// Tests that the default (non-fallback) serializer can handle complex classes.
         /// </summary>
-        /// <param name="serializerToUse"></param>
         [Fact, TestCategory("BVT")]
         public void Serialize_ComplexAccessibleClass()
         {


### PR DESCRIPTION
Backport of #8852 to 7.x

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8861)