### PR TITLE
Always reset `RuntimeContext` to previous value after use

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RuntimeContext.cs
@@ -23,31 +23,22 @@ namespace Orleans.Runtime
         /// Sets the current grain context.
         /// </summary>
         /// <param name="newContext">The new context.</param>
+        /// <param name="currentContext">The current context at the time of the call.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void SetExecutionContext(IGrainContext newContext)
+        internal static void SetExecutionContext(IGrainContext newContext, out IGrainContext currentContext)
         {
+            currentContext = _threadLocalContext;
             _threadLocalContext = newContext;
         }
 
         /// <summary>
-        /// Sets the current grain context.
+        /// Resets the current grain context to the provided original context.
         /// </summary>
-        /// <param name="newContext">The new context.</param>
-        /// <param name="existingContext">The existing context.</param>
+        /// <param name="originalContext">The original context.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void SetExecutionContext(IGrainContext newContext, out IGrainContext existingContext)
+        internal static void ResetExecutionContext(IGrainContext originalContext)
         {
-            existingContext = _threadLocalContext;
-            _threadLocalContext = newContext;
-        }
-
-        /// <summary>
-        /// Resets the current grain context.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void ResetExecutionContext()
-        {
-            _threadLocalContext = null;
+            _threadLocalContext = originalContext;
         }
     }
 }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
                     _serviceProvider,
                     _sharedComponents);
 
-                RuntimeContext.SetExecutionContext(context, out var existingContext);
+                RuntimeContext.SetExecutionContext(context, out var originalContext);
 
                 try
                 {
@@ -126,7 +126,7 @@ namespace Orleans.Runtime
                 }
                 finally
                 {
-                    RuntimeContext.SetExecutionContext(existingContext);
+                    RuntimeContext.ResetExecutionContext(originalContext);
                 }
 
                 return context;

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -280,7 +280,7 @@ namespace Orleans.Runtime
                     {
                         this.MessagingTrace.OnEnqueueMessageOnActivation(msg, this);
                         var workItem = new RequestWorkItem(this, msg);
-                        this.WorkItemGroup.TaskScheduler.QueueWorkItem(workItem);
+                        this.WorkItemGroup.TaskScheduler.QueueRequestWorkItem(workItem);
                         break;
                     }
 

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -38,7 +38,6 @@ namespace Orleans.Runtime.Scheduler
 
         public void RunTask(Task task)
         {
-            RuntimeContext.SetExecutionContext(workerGroup.GrainContext);
             bool done = TryExecuteTask(task);
             if (!done)
                 logger.LogWarning(

--- a/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
@@ -27,9 +27,9 @@ namespace Orleans.Runtime.Scheduler
 
         public override async void Execute()
         {
+            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
                 RequestContext.Clear();
                 await this.continuation();
                 this.completion.TrySetResult(true);
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Scheduler
             }
             finally
             {
-                RuntimeContext.ResetExecutionContext();
+                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 
@@ -73,9 +73,9 @@ namespace Orleans.Runtime.Scheduler
 
         public override async void Execute()
         {
+            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
                 RequestContext.Clear();
                 var result = await this.continuation();
                 this.completion.TrySetResult(result);
@@ -86,7 +86,7 @@ namespace Orleans.Runtime.Scheduler
             }
             finally
             {
-                RuntimeContext.ResetExecutionContext();
+                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 

--- a/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
@@ -5,28 +5,28 @@ namespace Orleans.Runtime.Scheduler
     internal sealed class RequestWorkItem : WorkItemBase
     {
         private readonly Message request;
-        private readonly SystemTarget target;
+        private readonly SystemTarget _target;
 
         public RequestWorkItem(SystemTarget t, Message m)
         {
-            target = t;
+            _target = t;
             request = m;
         }
 
         public override string Name => $"RequestWorkItem:Id={request.Id}";
 
-        public override IGrainContext GrainContext => this.target;
+        public override IGrainContext GrainContext => _target;
 
         public override void Execute()
         {
+            RuntimeContext.SetExecutionContext(_target, out var originalContext);
             try
             {
-                RuntimeContext.SetExecutionContext(this.target);
-                target.HandleNewRequest(request);
+                _target.HandleNewRequest(request);
             }
             finally
             {
-                RuntimeContext.ResetExecutionContext();
+                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -164,12 +164,12 @@ namespace Orleans.Runtime.Scheduler
 
         // Execute one or more turns for this activation.
         // This method is always called in a single-threaded environment -- that is, no more than one
-        // thread will be in this method at once -- but other asynch threads may still be queueing tasks, etc.
+        // thread will be in this method at once -- but other async threads may still be queueing tasks, etc.
         public void Execute()
         {
+            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
             try
             {
-                RuntimeContext.SetExecutionContext(this.GrainContext);
 
                 // Process multiple items -- drain the applicationMessageQueue (up to max items) for this physical activation
                 int count = 0;
@@ -264,7 +264,7 @@ namespace Orleans.Runtime.Scheduler
                     }
                 }
 
-                RuntimeContext.ResetExecutionContext();
+                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 


### PR DESCRIPTION
Fixes #8854

This PR ensures that we are consistently resetting `RuntimeContext` after every usage. This prevents the access violations from the above issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8864)