### PR TITLE
Clean up WorkItemGroup and ActivationTaskScheduler logic

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
@@ -223,8 +223,9 @@ namespace Orleans.Runtime
         /// <summary>
         /// Schedules a work item for execution by this instance.
         /// </summary>
-        /// <param name="workItem">The work item.</param>
-        void QueueWorkItem(IThreadPoolWorkItem workItem);
+        /// <param name="action">The work item.</param>
+        /// <param name="state">The state passed when invoking the item.</param>
+        void QueueAction(Action<object> action, object state);
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -2050,22 +2050,13 @@ namespace Orleans.Runtime
             }
         }
 
-        private class MigrateWorkItem : IWorkItem
+        private class MigrateWorkItem(ActivationData activation, Dictionary<string, object> requestContext, CancellationToken cancellationToken) : WorkItemBase
         {
-            private readonly ActivationData _activation;
-            private readonly Dictionary<string, object> _requestContext;
-            private readonly CancellationToken _cancellationToken;
+            public override string Name => "Migrate";
 
-            public MigrateWorkItem(ActivationData activation, Dictionary<string, object> requestContext, CancellationToken cancellationToken)
-            {
-                _activation = activation;
-                _requestContext = requestContext;
-                _cancellationToken = cancellationToken;
-            }
+            public override IGrainContext GrainContext => activation;
 
-            public string Name => "Migrate";
-            public IGrainContext GrainContext => _activation;
-            public void Execute() => _activation.StartMigratingAsync(_requestContext, _cancellationToken).Ignore();
+            public override void Execute() => activation.StartMigratingAsync(requestContext, cancellationToken).Ignore();
         }
     }
 }

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime
 {
     /// <summary>
     /// Base class for various system services, such as grain directory, reminder service, etc.
-    /// Made public for GrainSerive to inherit from it.
+    /// Made public for GrainService to inherit from it.
     /// Can be turned to internal after a refactoring that would remove the inheritance relation.
     /// </summary>
     public abstract class SystemTarget : ISystemTarget, ISystemTargetBase, IGrainContext, IGrainExtensionBinder, ISpanFormattable, IDisposable

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -280,7 +280,7 @@ namespace Orleans.Runtime
                     {
                         this.MessagingTrace.OnEnqueueMessageOnActivation(msg, this);
                         var workItem = new RequestWorkItem(this, msg);
-                        this.WorkItemGroup.TaskScheduler.QueueRequestWorkItem(workItem);
+                        this.WorkItemGroup.QueueWorkItem(workItem);
                         break;
                     }
 

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,7 @@ namespace Orleans.Runtime.Scheduler
     /// A single-concurrency, in-order task scheduler for per-activation work scheduling.
     /// </summary>
     [DebuggerDisplay("ActivationTaskScheduler-{myId} RunQueue={workerGroup.WorkItemCount}")]
-    internal class ActivationTaskScheduler : TaskScheduler
+    internal sealed class ActivationTaskScheduler : TaskScheduler
     {
         private readonly ILogger logger;
 
@@ -36,18 +37,26 @@ namespace Orleans.Runtime.Scheduler
         /// <returns>An enumerable of the tasks currently scheduled.</returns>
         protected override IEnumerable<Task> GetScheduledTasks() => this.workerGroup.GetScheduledTasks();
 
-        public void RunTask(Task task)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void RunTaskFromWorkItemGroup(Task task)
         {
             bool done = TryExecuteTask(task);
             if (!done)
-                logger.LogWarning(
-                    (int)ErrorCode.SchedulerTaskExecuteIncomplete4,
-                    "RunTask: Incomplete base.TryExecuteTask for Task Id={TaskId} with Status={TaskStatus}",
-                    task.Id,
-                    task.Status);
-            
-            //  Consider adding ResetExecutionContext() or even better:
-            //  Consider getting rid of ResetExecutionContext completely and just making sure we always call SetExecutionContext before TryExecuteTask.
+            {
+#if DEBUG
+                LogTryExecuteTaskNotDone(task);
+#endif
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void LogTryExecuteTaskNotDone(Task task)
+        {
+            logger.LogWarning(
+                (int)ErrorCode.SchedulerTaskExecuteIncomplete4,
+                "RunTask: Incomplete base.TryExecuteTask for Task Id={TaskId} with Status={TaskStatus}",
+                task.Id,
+                task.Status);
         }
 
         /// <summary>Queues a task to the scheduler.</summary>
@@ -70,8 +79,7 @@ namespace Orleans.Runtime.Scheduler
         /// <param name="taskWasPreviouslyQueued">A Boolean denoting whether or not task has previously been queued. If this parameter is True, then the task may have been previously queued (scheduled); if False, then the task is known not to have been queued, and this call is being made in order to execute the task inline without queuing it.</param>
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
-            var currentContext = RuntimeContext.Current;
-            bool canExecuteInline = currentContext != null && object.Equals(currentContext, workerGroup.GrainContext);
+            var canExecuteInline = !taskWasPreviouslyQueued && Equals(RuntimeContext.Current, workerGroup.GrainContext);
 
 #if DEBUG
             if (logger.IsEnabled(LogLevel.Trace))
@@ -86,13 +94,6 @@ namespace Orleans.Runtime.Scheduler
                     workerGroup.ExternalWorkItemCount);
             }
 #endif
-            if (!canExecuteInline) return false;
-
-            // If the task was previously queued, remove it from the queue
-            if (taskWasPreviouslyQueued)
-                canExecuteInline = TryDequeue(task);
-            
-
             if (!canExecuteInline)
             {
 #if DEBUG
@@ -116,11 +117,9 @@ namespace Orleans.Runtime.Scheduler
             bool done = TryExecuteTask(task);
             if (!done)
             {
-                logger.LogWarning(
-                    (int)ErrorCode.SchedulerTaskExecuteIncomplete3,
-                    "TryExecuteTaskInline: Incomplete base.TryExecuteTask for Task Id={TaskId} with Status={TaskStatus}",
-                    task.Id,
-                    task.Status);
+#if DEBUG
+                LogTryExecuteTaskNotDone(task);
+#endif
             }
 #if DEBUG
             if (logger.IsEnabled(LogLevel.Trace))

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
@@ -27,7 +27,6 @@ namespace Orleans.Runtime.Scheduler
 
         public override async void Execute()
         {
-            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
             try
             {
                 RequestContext.Clear();
@@ -37,10 +36,6 @@ namespace Orleans.Runtime.Scheduler
             catch (Exception exception)
             {
                 this.completion.TrySetException(exception);
-            }
-            finally
-            {
-                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 
@@ -73,7 +68,6 @@ namespace Orleans.Runtime.Scheduler
 
         public override async void Execute()
         {
-            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
             try
             {
                 RequestContext.Clear();
@@ -83,10 +77,6 @@ namespace Orleans.Runtime.Scheduler
             catch (Exception exception)
             {
                 this.completion.TrySetException(exception);
-            }
-            finally
-            {
-                RuntimeContext.ResetExecutionContext(originalContext);
             }
         }
 

--- a/src/Orleans.Runtime/Scheduler/IWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/IWorkItem.cs
@@ -1,12 +1,12 @@
 using System;
-using System.Threading;
 
 namespace Orleans.Runtime.Scheduler
 {
-    internal interface IWorkItem : IThreadPoolWorkItem
+    internal interface IWorkItem
     {
         string Name { get; }
         IGrainContext GrainContext { get; }
+        void Execute();
 
         internal static readonly Action<object> ExecuteWorkItem = state => ((IWorkItem)state).Execute();
     }

--- a/src/Orleans.Runtime/Scheduler/IWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/IWorkItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 
 namespace Orleans.Runtime.Scheduler
@@ -6,5 +7,7 @@ namespace Orleans.Runtime.Scheduler
     {
         string Name { get; }
         IGrainContext GrainContext { get; }
+
+        internal static readonly Action<object> ExecuteWorkItem = state => ((IWorkItem)state).Execute();
     }
 }

--- a/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/RequestWorkItem.cs
@@ -17,18 +17,7 @@ namespace Orleans.Runtime.Scheduler
 
         public override IGrainContext GrainContext => _target;
 
-        public override void Execute()
-        {
-            RuntimeContext.SetExecutionContext(_target, out var originalContext);
-            try
-            {
-                _target.HandleNewRequest(request);
-            }
-            finally
-            {
-                RuntimeContext.ResetExecutionContext(originalContext);
-            }
-        }
+        public override void Execute() => _target.HandleNewRequest(request);
 
         public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
         {

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -174,9 +174,8 @@ namespace Orleans.Runtime.Scheduler
             {
 
                 // Process multiple items -- drain the queue (up to max items) for this activation
-                var loopStart = Environment.TickCount64;
-                var taskStart = loopStart;
-                var taskEnd = taskStart;
+                long loopStart, taskStart, taskEnd;
+                loopStart = taskStart = taskEnd = Environment.TickCount64;
                 do
                 {
                     Task task;
@@ -203,11 +202,6 @@ namespace Orleans.Runtime.Scheduler
                     try
                     {
                         TaskScheduler.RunTaskFromWorkItemGroup(task);
-                    }
-                    catch (Exception ex)
-                    {
-                        LogTaskRunError(task, ex);
-                        throw;
                     }
                     finally
                     {

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -14,7 +14,7 @@ using Orleans.Internal;
 namespace Orleans.Runtime.Scheduler
 {
     [DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
-    internal sealed class WorkItemGroup : IWorkItem, IWorkItemScheduler
+    internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
     {
         private enum WorkGroupStatus
         {

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -14,7 +14,7 @@ using Orleans.Internal;
 namespace Orleans.Runtime.Scheduler
 {
     [DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
-    internal class WorkItemGroup : IWorkItem, IWorkItemScheduler
+    internal sealed class WorkItemGroup : IWorkItem, IWorkItemScheduler
     {
         private enum WorkGroupStatus
         {
@@ -204,7 +204,7 @@ namespace Orleans.Runtime.Scheduler
 
                     try
                     {
-                        TaskScheduler.RunTask(task);
+                        TaskScheduler.RunTaskFromWorkItemGroup(task);
                     }
                     catch (Exception ex)
                     {
@@ -307,7 +307,7 @@ namespace Orleans.Runtime.Scheduler
         }
 
         public void QueueAction(Action action) => TaskScheduler.QueueAction(action);
+        public void QueueAction(Action<object> action, object state) => TaskScheduler.QueueAction(action, state);
         public void QueueTask(Task task) => task.Start(TaskScheduler);
-        public void QueueWorkItem(IThreadPoolWorkItem workItem) => TaskScheduler.QueueThreadPoolWorkItem(workItem);
     }
 }

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -11,326 +11,299 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
 
-namespace Orleans.Runtime.Scheduler
+namespace Orleans.Runtime.Scheduler;
+
+[DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
+internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
 {
-    [DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
-    internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
+    private enum WorkGroupStatus
     {
-        private enum WorkGroupStatus
-        {
-            Waiting = 0,
-            Runnable = 1,
-            Running = 2
-        }
+        Waiting = 0,
+        Runnable = 1,
+        Running = 2
+    }
 
-        private readonly ILogger log;
-        private WorkGroupStatus state;
-        private readonly object lockable;
-        private readonly Queue<Task> workItems;
+    private readonly ILogger _log;
+    private readonly object _lockObj = new();
+    private readonly Queue<Task> _workItems = new();
+    private readonly SchedulingOptions _schedulingOptions;
 
-        private long totalItemsEnqueued;
-        private long totalItemsProcessed;
-        private long _lastLongQueueWarningTimestamp;
+    private long _totalItemsEnqueued;
+    private long _totalItemsProcessed;
+    private long _lastLongQueueWarningTimestamp;
 
-        private Task currentTask;
-        private long currentTaskStarted;
+    private WorkGroupStatus _state;
+    private Task _currentTask;
+    private long _currentTaskStarted;
 
-        private readonly SchedulingOptions schedulingOptions;
+    internal ActivationTaskScheduler TaskScheduler { get; }
 
-        internal ActivationTaskScheduler TaskScheduler { get; }
+    public IGrainContext GrainContext { get; set; }
 
-        public IGrainContext GrainContext { get; set; }
+    internal int ExternalWorkItemCount
+    {
+        get { lock (_lockObj) { return _workItems.Count; } }
+    }
 
-        internal bool IsSystemGroup => this.GrainContext is ISystemTargetBase;
+    public WorkItemGroup(
+        IGrainContext grainContext,
+        ILogger<WorkItemGroup> logger,
+        ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
+        IOptions<SchedulingOptions> schedulingOptions)
+    {
+        GrainContext = grainContext;
+        _schedulingOptions = schedulingOptions.Value;
+        _state = WorkGroupStatus.Waiting;
+        _log = logger;
+        TaskScheduler = new ActivationTaskScheduler(this, activationTaskSchedulerLogger);
+    }
 
-        public string Name => GrainContext?.ToString() ?? "Unknown";
-
-        internal int ExternalWorkItemCount
-        {
-            get { lock (lockable) { return workItems.Count; } }
-        }
-
-        private Task CurrentTask
-        {
-            get => currentTask;
-            set => currentTask = value;
-        }
-
-        public WorkItemGroup(
-            IGrainContext grainContext,
-            ILogger<WorkItemGroup> logger,
-            ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
-            IOptions<SchedulingOptions> schedulingOptions)
-        {
-            GrainContext = grainContext;
-            this.schedulingOptions = schedulingOptions.Value;
-            state = WorkGroupStatus.Waiting;
-            workItems = new Queue<Task>();
-            lockable = new object();
-            totalItemsEnqueued = 0;
-            totalItemsProcessed = 0;
-            TaskScheduler = new ActivationTaskScheduler(this, activationTaskSchedulerLogger);
-            log = logger;
-        }
-
-        /// <summary>
-        /// Adds a task to this activation.
-        /// If we're adding it to the run list and we used to be waiting, now we're runnable.
-        /// </summary>
-        /// <param name="task">The work item to add.</param>
-        public void EnqueueTask(Task task)
-        {
+    /// <summary>
+    /// Adds a task to this activation.
+    /// If we're adding it to the run list and we used to be waiting, now we're runnable.
+    /// </summary>
+    /// <param name="task">The work item to add.</param>
+    public void EnqueueTask(Task task)
+    {
 #if DEBUG
-            if (log.IsEnabled(LogLevel.Trace))
+        if (_log.IsEnabled(LogLevel.Trace))
+        {
+            _log.LogTrace(
+                "EnqueueWorkItem {Task} into {GrainContext} when TaskScheduler.Current={TaskScheduler}",
+                task,
+                GrainContext,
+                System.Threading.Tasks.TaskScheduler.Current);
+        }
+#endif
+
+        lock (_lockObj)
+        {
+            long thisSequenceNumber = _totalItemsEnqueued++;
+            int count = _workItems.Count;
+
+            _workItems.Enqueue(task);
+            int maxPendingItemsLimit = _schedulingOptions.MaxPendingWorkItemsSoftLimit;
+            if (maxPendingItemsLimit > 0 && count > maxPendingItemsLimit)
             {
-                this.log.LogTrace(
-                    "EnqueueWorkItem {Task} into {GrainContext} when TaskScheduler.Current={TaskScheduler}",
+                var now = Environment.TickCount64;
+                if (now > _lastLongQueueWarningTimestamp + 10_000)
+                {
+                    LogTooManyTasksInQueue(count, maxPendingItemsLimit);
+                }
+
+                _lastLongQueueWarningTimestamp = now;
+            }
+
+            if (_state != WorkGroupStatus.Waiting)
+            {
+                return;
+            }
+
+            _state = WorkGroupStatus.Runnable;
+#if DEBUG
+            if (_log.IsEnabled(LogLevel.Trace))
+            {
+                _log.LogTrace(
+                    "Add to RunQueue {Task}, #{SequenceNumber}, onto {GrainContext}",
                     task,
-                    this.GrainContext,
-                    System.Threading.Tasks.TaskScheduler.Current);
+                    thisSequenceNumber,
+                    GrainContext);
             }
 #endif
-
-            lock (lockable)
-            {
-                long thisSequenceNumber = totalItemsEnqueued++;
-                int count = workItems.Count;
-
-                workItems.Enqueue(task);
-                int maxPendingItemsLimit = schedulingOptions.MaxPendingWorkItemsSoftLimit;
-                if (maxPendingItemsLimit > 0 && count > maxPendingItemsLimit)
-                {
-                    var now = Environment.TickCount64;
-                    if (now > _lastLongQueueWarningTimestamp + 10_000)
-                    {
-                        LogTooManyTasksInQueue(count, maxPendingItemsLimit);
-                    }
-
-                    _lastLongQueueWarningTimestamp = now;
-                }
-                if (state != WorkGroupStatus.Waiting) return;
-
-                state = WorkGroupStatus.Runnable;
-#if DEBUG
-                if (log.IsEnabled(LogLevel.Trace))
-                {
-                    log.LogTrace(
-                        "Add to RunQueue {Task}, #{SequenceNumber}, onto {GrainContext}",
-                        task,
-                        thisSequenceNumber,
-                        GrainContext);
-                }
-#endif
-                ScheduleExecution(this);
-            }
+            ScheduleExecution(this);
         }
+    }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogTooManyTasksInQueue(int count, int maxPendingItemsLimit)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void LogTooManyTasksInQueue(int count, int maxPendingItemsLimit)
+    {
+        _log.LogWarning(
+            (int)ErrorCode.SchedulerTooManyPendingItems,
+            "{PendingWorkItemCount} pending work items for group {WorkGroupName}, exceeding the warning threshold of {WarningThreshold}",
+            count,
+            GrainContext?.ToString() ?? "Unknown",
+            maxPendingItemsLimit);
+    }
+
+    /// <summary>
+    /// For debugger purposes only.
+    /// </summary>
+    internal IEnumerable<Task> GetScheduledTasks()
+    {
+        foreach (var task in _workItems)
         {
-            log.LogWarning(
-                (int)ErrorCode.SchedulerTooManyPendingItems,
-                "{PendingWorkItemCount} pending work items for group {WorkGroupName}, exceeding the warning threshold of {WarningThreshold}",
-                count,
-                this.Name,
-                maxPendingItemsLimit);
+            yield return task;
         }
+    }
 
-        /// <summary>
-        /// For debugger purposes only.
-        /// </summary>
-        internal IEnumerable<Task> GetScheduledTasks()
+    // Execute one or more turns for this activation.
+    // This method is always called in a single-threaded environment -- that is, no more than one
+    // thread will be in this method at once -- but other async threads may still be queueing tasks, etc.
+    public void Execute()
+    {
+        RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
+        var turnWarningDurationMs = (long)Math.Ceiling(_schedulingOptions.TurnWarningLengthThreshold.TotalMilliseconds);
+        var activationSchedulingQuantumMs = (long)_schedulingOptions.ActivationSchedulingQuantum.TotalMilliseconds;
+        try
         {
-            foreach (var task in this.workItems)
+
+            // Process multiple items -- drain the queue (up to max items) for this activation
+            long loopStart, taskStart, taskEnd;
+            loopStart = taskStart = taskEnd = Environment.TickCount64;
+            do
             {
-                yield return task;
-            }
-        }
-
-        private static object DumpAsyncState(object o)
-        {
-            if (o is Delegate action)
-                return action.Target is null ? action.Method.DeclaringType + "." + action.Method.Name
-                    : action.Method.DeclaringType.Name + "." + action.Method.Name + ": " + DumpAsyncState(action.Target);
-
-            if (o?.GetType() is { Name: "ContinuationWrapper" } wrapper
-                && (wrapper.GetField("_continuation", BindingFlags.Instance | BindingFlags.NonPublic)
-                    ?? wrapper.GetField("m_continuation", BindingFlags.Instance | BindingFlags.NonPublic)
-                    )?.GetValue(o) is Action continuation)
-                return DumpAsyncState(continuation);
-
-            return o;
-        }
-
-        // Execute one or more turns for this activation.
-        // This method is always called in a single-threaded environment -- that is, no more than one
-        // thread will be in this method at once -- but other async threads may still be queueing tasks, etc.
-        public void Execute()
-        {
-            RuntimeContext.SetExecutionContext(GrainContext, out var originalContext);
-            var turnWarningDurationMs = (long)Math.Ceiling(schedulingOptions.TurnWarningLengthThreshold.TotalMilliseconds);
-            var activationSchedulingQuantumMs = (long)schedulingOptions.ActivationSchedulingQuantum.TotalMilliseconds;
-            try
-            {
-
-                // Process multiple items -- drain the queue (up to max items) for this activation
-                long loopStart, taskStart, taskEnd;
-                loopStart = taskStart = taskEnd = Environment.TickCount64;
-                do
+                Task task;
+                lock (_lockObj)
                 {
-                    Task task;
-                    lock (lockable)
-                    {
-                        state = WorkGroupStatus.Running;
+                    _state = WorkGroupStatus.Running;
 
-                        // Get the first Work Item on the list
-                        if (workItems.Count > 0)
-                        {
-                            CurrentTask = task = workItems.Dequeue();
-                            currentTaskStarted = taskStart;
-                        }
-                        else
-                        {
-                            // If the list is empty, then we're done
-                            break;
-                        }
-                    }
-
-#if DEBUG
-                    LogTaskStart(task);
-#endif
-                    try
+                    // Get the first Work Item on the list
+                    if (_workItems.Count > 0)
                     {
-                        TaskScheduler.RunTaskFromWorkItemGroup(task);
-                    }
-                    finally
-                    {
-                        totalItemsProcessed++;
-                        taskEnd = Environment.TickCount64;
-                        var taskDurationMs = taskEnd - taskStart;
-                        taskStart = taskEnd;
-                        if (taskDurationMs > turnWarningDurationMs)
-                        {
-                            SchedulerInstruments.LongRunningTurnsCounter.Add(1);
-                            LogLongRunningTurn(task, taskDurationMs);
-                        }
-
-                        CurrentTask = null;
-                    }
-                }
-                while (activationSchedulingQuantumMs <= 0 || taskEnd - loopStart < activationSchedulingQuantumMs);
-            }
-            catch (Exception ex)
-            {
-                LogTaskLoopError(ex);
-            }
-            finally
-            {
-                // Now we're not Running anymore.
-                // If we left work items on our run list, we're Runnable, and need to go back on the silo run queue;
-                // If our run list is empty, then we're waiting.
-                lock (lockable)
-                {
-                    if (workItems.Count > 0)
-                    {
-                        state = WorkGroupStatus.Runnable;
-                        ScheduleExecution(this);
+                        _currentTask = task = _workItems.Dequeue();
+                        _currentTaskStarted = taskStart;
                     }
                     else
                     {
-                        state = WorkGroupStatus.Waiting;
+                        // If the list is empty, then we're done
+                        break;
                     }
                 }
 
-                RuntimeContext.ResetExecutionContext(originalContext);
+#if DEBUG
+                LogTaskStart(task);
+#endif
+                try
+                {
+                    TaskScheduler.RunTaskFromWorkItemGroup(task);
+                }
+                finally
+                {
+                    _totalItemsProcessed++;
+                    taskEnd = Environment.TickCount64;
+                    var taskDurationMs = taskEnd - taskStart;
+                    taskStart = taskEnd;
+                    if (taskDurationMs > turnWarningDurationMs)
+                    {
+                        SchedulerInstruments.LongRunningTurnsCounter.Add(1);
+                        LogLongRunningTurn(task, taskDurationMs);
+                    }
+
+                    _currentTask = null;
+                }
             }
+            while (activationSchedulingQuantumMs <= 0 || taskEnd - loopStart < activationSchedulingQuantumMs);
         }
+        catch (Exception ex)
+        {
+            LogTaskLoopError(ex);
+        }
+        finally
+        {
+            // Now we're not Running anymore.
+            // If we left work items on our run list, we're Runnable, and need to go back on the silo run queue;
+            // If our run list is empty, then we're waiting.
+            lock (_lockObj)
+            {
+                if (_workItems.Count > 0)
+                {
+                    _state = WorkGroupStatus.Runnable;
+                    ScheduleExecution(this);
+                }
+                else
+                {
+                    _state = WorkGroupStatus.Waiting;
+                }
+            }
+
+            RuntimeContext.ResetExecutionContext(originalContext);
+        }
+    }
 
 #if DEBUG
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogTaskStart(Task task)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void LogTaskStart(Task task)
+    {
+        if (_log.IsEnabled(LogLevel.Trace))
         {
-            if (log.IsEnabled(LogLevel.Trace))
-            {
-                log.LogTrace(
-                "About to execute task {Task} in GrainContext={GrainContext}",
-                OrleansTaskExtentions.ToString(task),
-                this.GrainContext);
-            }
+            _log.LogTrace(
+            "About to execute task {Task} in GrainContext={GrainContext}",
+            OrleansTaskExtentions.ToString(task),
+            GrainContext);
         }
+    }
 #endif
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogTaskLoopError(Exception ex)
-        {
-            this.log.LogError(
-                (int)ErrorCode.Runtime_Error_100032,
-                ex,
-                "Worker thread {Thread} caught an exception thrown from IWorkItem.Execute",
-                Thread.CurrentThread.ManagedThreadId);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogTaskRunError(Task task, Exception ex)
-        {
-            this.log.LogError(
-                (int)ErrorCode.SchedulerExceptionFromExecute,
-                ex,
-                "Worker thread caught an exception thrown from Execute by task {Task}",
-                OrleansTaskExtentions.ToString(task));
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogLongRunningTurn(Task task, long taskDurationMs)
-        {
-            var taskDuration = TimeSpan.FromMilliseconds(taskDurationMs);
-            this.log.LogWarning(
-                (int)ErrorCode.SchedulerTurnTooLong3,
-                "Task {Task} in WorkGroup {GrainContext} took elapsed time {Duration} for execution, which is longer than {TurnWarningLengthThreshold}. Running on thread {Thread}",
-                OrleansTaskExtentions.ToString(task),
-                this.GrainContext.ToString(),
-                taskDuration.ToString("g"),
-                schedulingOptions.TurnWarningLengthThreshold,
-                Thread.CurrentThread.ManagedThreadId.ToString());
-        }
-
-        public override string ToString() => $"{(IsSystemGroup ? "System*" : "")}WorkItemGroup:Name={Name},WorkGroupStatus={state}";
-
-        public string DumpStatus()
-        {
-            lock (lockable)
-            {
-                var sb = new StringBuilder();
-                sb.Append(this);
-                sb.AppendFormat(". Currently QueuedWorkItems={0}; Total Enqueued={1}; Total processed={2}; ",
-                    workItems.Count, totalItemsEnqueued, totalItemsProcessed);
-                if (CurrentTask is Task task)
-                {
-                    sb.AppendFormat(" Executing Task Id={0} Status={1} for {2}.",
-                        task.Id, task.Status, TimeSpan.FromMilliseconds(Environment.TickCount64 - currentTaskStarted));
-                }
-
-                sb.AppendFormat("TaskRunner={0}; ", TaskScheduler);
-                if (GrainContext != null)
-                {
-                    var detailedStatus = this.GrainContext switch
-                    {
-                        ActivationData activationData => activationData.ToDetailedString(includeExtraDetails: true),
-                        SystemTarget systemTarget => systemTarget.ToDetailedString(),
-                        object obj => obj.ToString(),
-                        _ => "None"
-                    };
-                    sb.AppendFormat("Detailed context=<{0}>", detailedStatus);
-                }
-                return sb.ToString();
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ScheduleExecution(WorkItemGroup workItem) => ThreadPool.UnsafeQueueUserWorkItem(workItem, preferLocal: true);
-
-        public void QueueAction(Action action) => TaskScheduler.QueueAction(action);
-        public void QueueAction(Action<object> action, object state) => TaskScheduler.QueueAction(action, state);
-        public void QueueTask(Task task) => task.Start(TaskScheduler);
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void LogTaskLoopError(Exception ex)
+    {
+        _log.LogError(
+            (int)ErrorCode.Runtime_Error_100032,
+            ex,
+            "Worker thread {Thread} caught an exception thrown from IWorkItem.Execute",
+            Thread.CurrentThread.ManagedThreadId);
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void LogTaskRunError(Task task, Exception ex)
+    {
+        _log.LogError(
+            (int)ErrorCode.SchedulerExceptionFromExecute,
+            ex,
+            "Worker thread caught an exception thrown from Execute by task {Task}",
+            OrleansTaskExtentions.ToString(task));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void LogLongRunningTurn(Task task, long taskDurationMs)
+    {
+        var taskDuration = TimeSpan.FromMilliseconds(taskDurationMs);
+        _log.LogWarning(
+            (int)ErrorCode.SchedulerTurnTooLong3,
+            "Task {Task} in WorkGroup {GrainContext} took elapsed time {Duration} for execution, which is longer than {TurnWarningLengthThreshold}. Running on thread {Thread}",
+            OrleansTaskExtentions.ToString(task),
+            GrainContext.ToString(),
+            taskDuration.ToString("g"),
+            _schedulingOptions.TurnWarningLengthThreshold,
+            Thread.CurrentThread.ManagedThreadId.ToString());
+    }
+
+    public override string ToString() => $"{(GrainContext is SystemTarget ? "System*" : "")}WorkItemGroup:Name={GrainContext?.ToString() ?? "Unknown"},WorkGroupStatus={_state}";
+
+    public string DumpStatus()
+    {
+        lock (_lockObj)
+        {
+            var sb = new StringBuilder();
+            sb.Append(this);
+            sb.AppendFormat(". Currently QueuedWorkItems={0}; Total Enqueued={1}; Total processed={2}; ",
+                _workItems.Count, _totalItemsEnqueued, _totalItemsProcessed);
+            if (_currentTask is Task task)
+            {
+                sb.AppendFormat(" Executing Task Id={0} Status={1} for {2}.",
+                    task.Id, task.Status, TimeSpan.FromMilliseconds(Environment.TickCount64 - _currentTaskStarted));
+            }
+
+            sb.AppendFormat("TaskRunner={0}; ", TaskScheduler);
+            if (GrainContext != null)
+            {
+                var detailedStatus = GrainContext switch
+                {
+                    ActivationData activationData => activationData.ToDetailedString(includeExtraDetails: true),
+                    SystemTarget systemTarget => systemTarget.ToDetailedString(),
+                    object obj => obj.ToString(),
+                    _ => "None"
+                };
+                sb.AppendFormat("Detailed context=<{0}>", detailedStatus);
+            }
+            return sb.ToString();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ScheduleExecution(WorkItemGroup workItem) => ThreadPool.UnsafeQueueUserWorkItem(workItem, preferLocal: true);
+
+    public void QueueAction(Action action) => TaskScheduler.QueueAction(action);
+    public void QueueAction(Action<object> action, object state) => TaskScheduler.QueueAction(action, state);
+    public void QueueTask(Task task) => task.Start(TaskScheduler);
 }

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -17,7 +17,7 @@ namespace Orleans.Runtime.Scheduler;
 [DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
 internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
 {
-    private enum WorkGroupStatus
+    private enum WorkGroupStatus : byte
     {
         Waiting = 0,
         Runnable = 1,

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -1,7 +1,8 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -33,7 +34,7 @@ internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
     private long _lastLongQueueWarningTimestamp;
 
     private WorkGroupStatus _state;
-    private Task _currentTask;
+    private Task? _currentTask;
     private long _currentTaskStarted;
 
     internal ActivationTaskScheduler TaskScheduler { get; }


### PR DESCRIPTION
Follow-up to #8864 to clean up some of the scheduling logic:

* Reduce the places where `RuntimeContext` is set to 2:
  1. In Catalog when constructing a grain instance
  2. In WorkItemGroup when executing tasks on an activation
* Remove unnecessary logs and logic
* Use `Environment.TickCount64` to measure task run durations instead of `Stopwatch.GetTimestamp()` for performance, also reduce calls to once or twice per task, versus multiple more.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/orleans/pull/8865)