### PR TITLE
Fix streaming config validator registration

### DIFF
--- a/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Streaming/SiloPersistentStreamConfigurator.cs
@@ -73,7 +73,7 @@ namespace Orleans.Hosting
             this.ConfigureComponent((s,n) => s.GetRequiredKeyedService<IStreamProvider>(n) as IControllable);
             this.ConfigureDelegate(services => services.AddSingleton(sp => PersistentStreamProvider.ParticipateIn<ISiloLifecycle>(sp, this.Name)));
             this.ConfigureComponent(adapterFactory);
-            this.ConfigureComponent(PersistentStreamStorageConfigurationValidator.Create);
+            this.ConfigureDelegate(services => services.AddSingleton(sp => PersistentStreamStorageConfigurationValidator.Create(sp, this.Name)));
         }
     }
 }


### PR DESCRIPTION
Since the migration to Keyed-DI, the Streaming options validator was not called.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8876)