### PR TITLE
Support implementing multiple IConverter<,> in single converter class

### DIFF
--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -571,7 +571,7 @@ namespace Orleans.Serialization.Serializers
                 foreach (var @interface in converterType.GetInterfaces())
                 {
                     if (@interface.IsConstructedGenericType && @interface.GetGenericTypeDefinition() == typeof(IConverter<,>)
-                        && @interface.GenericTypeArguments[0].IsAssignableFrom(fieldType))
+                        && @interface.GenericTypeArguments[0] == fieldType)
                     {
                         converterInterfaceArgs = @interface.GetGenericArguments();
                     }

--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -570,7 +570,8 @@ namespace Orleans.Serialization.Serializers
                 var converterInterfaceArgs = Array.Empty<Type>();
                 foreach (var @interface in converterType.GetInterfaces())
                 {
-                    if (@interface.IsConstructedGenericType && @interface.GetGenericTypeDefinition() == typeof(IConverter<,>))
+                    if (@interface.IsConstructedGenericType && @interface.GetGenericTypeDefinition() == typeof(IConverter<,>)
+                        && @interface.GenericTypeArguments[0].IsAssignableFrom(fieldType))
                     {
                         converterInterfaceArgs = @interface.GetGenericArguments();
                     }

--- a/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
+++ b/src/Orleans.Serialization/Serializers/SurrogateCodec.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
@@ -24,7 +25,7 @@ public sealed class SurrogateCodec<TField, TSurrogate, TConverter>
     private readonly Type _fieldType = typeof(TField);
     private readonly IValueSerializer<TSurrogate> _surrogateSerializer;
     private readonly IDeepCopier<TSurrogate> _surrogateCopier;
-    private readonly IPopulator<TField, TSurrogate> _populator;
+    private readonly IPopulator<TField, TSurrogate>? _populator;
     private readonly TConverter _converter;
 
     /// <summary>

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -115,3 +115,15 @@ public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibr
     protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
 }
+
+
+public class CombinedConverterCopierTests : CopierTester<MyFirstForeignLibraryType, IDeepCopier<MyFirstForeignLibraryType>>
+{
+    public CombinedConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MyFirstForeignLibraryType CreateValue() => new() { Num = 12, String = "hi", DateTimeOffset = DateTimeOffset.Now };
+    protected override bool Equals(MyFirstForeignLibraryType left, MyFirstForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override MyFirstForeignLibraryType[] TestValues => new MyFirstForeignLibraryType[] { null, CreateValue() };
+}

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -124,6 +124,6 @@ public class CombinedConverterCopierTests : CopierTester<MyFirstForeignLibraryTy
     }
 
     protected override MyFirstForeignLibraryType CreateValue() => new() { Num = 12, String = "hi", DateTimeOffset = DateTimeOffset.Now };
-    protected override bool Equals(MyFirstForeignLibraryType left, MyFirstForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
-    protected override MyFirstForeignLibraryType[] TestValues => new MyFirstForeignLibraryType[] { null, CreateValue() };
+    protected override bool Equals(MyFirstForeignLibraryType left, MyFirstForeignLibraryType right) => left.Equals(right);
+    protected override MyFirstForeignLibraryType[] TestValues => new MyFirstForeignLibraryType[] { CreateValue() };
 }

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -850,6 +850,14 @@ namespace Orleans.Serialization.UnitTests
         public int Num { get; set; }
         public string String { get; set; }
         public DateTimeOffset DateTimeOffset { get; set; }
+
+        public override bool Equals(object obj) =>
+            obj is MyFirstForeignLibraryType type
+            && Num == type.Num
+            && string.Equals(String, type.String, StringComparison.Ordinal)
+            && DateTimeOffset.Equals(type.DateTimeOffset);
+
+        public override int GetHashCode() => HashCode.Combine(Num, String, DateTimeOffset);
     }
 
     public class MySecondForeignLibraryType
@@ -857,6 +865,14 @@ namespace Orleans.Serialization.UnitTests
         public string Name { get; set; }
         public float Value { get; set; }
         public DateTimeOffset Timestamp { get; set; }
+
+        public override bool Equals(object obj) =>
+            obj is MySecondForeignLibraryType type
+            && string.Equals(Name, type.Name, StringComparison.Ordinal)
+            && Value == type.Value
+            && Timestamp.Equals(type.Timestamp);
+
+        public override int GetHashCode() => HashCode.Combine(Name, Value, Timestamp);
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -843,4 +843,62 @@ namespace Orleans.Serialization.UnitTests
         [Id(2)] public object UntypedValue;
         [Id(3)] public Type Type2;
     }
+
+    public class MyFirstForeignLibraryType
+    {
+        
+        public int Num { get; set; }
+        public string String { get; set; }
+        public DateTimeOffset DateTimeOffset { get; set; }
+    }
+
+    public class MySecondForeignLibraryType
+    {
+        public string Name { get; set; }
+        public float Value { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+    }
+
+    [GenerateSerializer]
+    public struct MyFirstForeignLibraryTypeSurrogate
+    {
+        [Id(0)]
+        public int Num { get; set; }
+
+        [Id(1)]
+        public string String { get; set; }
+
+        [Id(2)]
+        public DateTimeOffset DateTimeOffset { get; set; }
+    }
+
+
+    [GenerateSerializer]
+    public struct MySecondForeignLibraryTypeSurrogate
+    {
+        [Id(0)]
+        public string Name { get; set; }
+
+        [Id(1)]
+        public float Value { get; set; }
+
+        [Id(2)]
+        public DateTimeOffset Timestamp { get; set; }
+    }
+
+    [RegisterConverter]
+    public sealed class MyCombinedForeignLibraryValueTypeSurrogateConverter :
+        IConverter<MyFirstForeignLibraryType, MyFirstForeignLibraryTypeSurrogate>,
+        IConverter<MySecondForeignLibraryType, MySecondForeignLibraryTypeSurrogate>
+    {
+        public MyFirstForeignLibraryType ConvertFromSurrogate(in MyFirstForeignLibraryTypeSurrogate surrogate)
+            => new () { Num = surrogate.Num, String = surrogate.String, DateTimeOffset = surrogate.DateTimeOffset };
+        public MyFirstForeignLibraryTypeSurrogate ConvertToSurrogate(in MyFirstForeignLibraryType value)
+            => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };
+
+        public MySecondForeignLibraryType ConvertFromSurrogate(in MySecondForeignLibraryTypeSurrogate surrogate)
+            => new() { Name = surrogate.Name, Value = surrogate.Value, Timestamp = surrogate.Timestamp };
+        public MySecondForeignLibraryTypeSurrogate ConvertToSurrogate(in MySecondForeignLibraryType value)
+            => new () { Name = value.Name, Value = value.Value, Timestamp = value.Timestamp };
+    }
 }


### PR DESCRIPTION
Fix and unit test for https://github.com/dotnet/orleans/issues/8879

Only select IConverter<,> interfaces whose types arguments matches the searched type.

Unit test also submitted separately as a fail test in https://github.com/dotnet/orleans/pull/8880
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8881)