### PR TITLE
Move `ResourceOptimizedPlacementOptions` to `Orleans.Configuration`

### DIFF
--- a/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 
-namespace Orleans.Runtime.Configuration.Options;
+namespace Orleans.Configuration;
 
 /// <summary>
 /// Settings which regulate the placement of grains across a cluster when using <see cref="ResourceOptimizedPlacement"/>.

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -41,7 +41,6 @@ using Orleans.Serialization.Cloning;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Orleans.Serialization.Internal;
-using Orleans.Runtime.Configuration.Options;
 
 namespace Orleans.Hosting
 {

--- a/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
-using Orleans.Runtime.Configuration.Options;
+using Orleans.Configuration;
 
 namespace Orleans.Runtime.Placement;
 

--- a/test/TesterInternal/General/PlacementOptionsTest.cs
+++ b/test/TesterInternal/General/PlacementOptionsTest.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Options;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration.Options;
+using Orleans.Configuration;
 using TestExtensions;
 using Xunit;
 


### PR DESCRIPTION
Even though all options are in the `Orleans.Runtime.Configuration.Options` folder path, all of the options are under the `Orleans.Configuration` namespace. For consistency reasons this PR moves `ResourceOptimizedPlacementOptions` to this ns.