### PR TITLE
Add missing query CleanupDefunctSiloEntriesKey to MySQL-Clustering

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/MySQL-Clustering-3.7.0.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/MySQL-Clustering-3.7.0.sql
@@ -7,4 +7,6 @@ VALUES
         AND @DeploymentId IS NOT NULL
         AND IAmAliveTime < @IAmAliveTime
         AND Status !=3;
-');
+')
+ON DUPLICATE KEY UPDATE
+    QueryKey = QueryKey;

--- a/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql
@@ -253,3 +253,14 @@ VALUES
     DELETE FROM OrleansMembershipVersionTable
     WHERE DeploymentId = @DeploymentId AND @DeploymentId IS NOT NULL;
 ');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'CleanupDefunctSiloEntriesKey','
+    DELETE FROM OrleansMembershipTable
+    WHERE DeploymentId = @DeploymentId
+        AND @DeploymentId IS NOT NULL
+        AND IAmAliveTime < @IAmAliveTime
+        AND Status !=3;
+');

--- a/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
@@ -153,7 +153,7 @@ namespace UnitTests.MembershipTests
     public class LivenessTests_MySql : LivenessTestsBase
     {
         public const string TestDatabaseName = "OrleansTest_MySql_Liveness";
-        private const string AdoNetInvariantName = AdoNetInvariants.InvariantNamePostgreSql;
+        private const string AdoNetInvariantName = AdoNetInvariants.InvariantNameMySql;
         public LivenessTests_MySql(ITestOutputHelper output) : base(output)
         {
             EnsurePreconditionsMet();


### PR DESCRIPTION
## Problem:
As written in the issue https://github.com/dotnet/orleans/issues/8676 and [docs](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration), to set up ADO.NET clustering using the MySQL you need to run 2 scripts in sequence:

[main script for MySQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/MySQL-Main.sql)
[clustering script for MySQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql)
However, the clustering script does not include the creation of the CleanupDefunctSiloEntriesKey query required by the ADO.NET implementation (Microsoft.Orleans.Clustering.AdoNet) in both the 7.2.x and the 8.0.x versions of Orleans.

Missing query causes an exception at program startup.

## Proposed solution:
Add the missing query to clustering sql script.

Followed the same pattern as proposed in https://github.com/dotnet/orleans/pull/8811


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8896)