### PR TITLE
[7.x] Use GrainDirectoryCacheFactory to construct a IGrainDirectoryCache (#8844)

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Internal;
@@ -30,12 +31,14 @@ namespace Orleans.Runtime.GrainDirectory
         MembershipVersion ITestAccessor.LastMembershipVersion { get; set; }
 
         public CachedGrainLocator(
+            IServiceProvider serviceProvider,
             GrainDirectoryResolver grainDirectoryResolver,
-            IClusterMembershipService clusterMembershipService)
+            IClusterMembershipService clusterMembershipService,
+            IOptions<GrainDirectoryOptions> grainDirectoryOptions)
         {
             this.grainDirectoryResolver = grainDirectoryResolver;
             this.clusterMembershipService = clusterMembershipService;
-            this.cache = new LRUBasedGrainDirectoryCache(GrainDirectoryOptions.DEFAULT_CACHE_SIZE, GrainDirectoryOptions.DEFAULT_MAXIMUM_CACHE_TTL);
+            this.cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value);
         }
 
         public async ValueTask<GrainAddress> Lookup(GrainId grainId)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -36,6 +36,19 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
+        internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
+        {
+            var grainDirectoryCache = services.GetService<IGrainDirectoryCache>();
+            if (grainDirectoryCache != null)
+            {
+                return grainDirectoryCache;
+            }
+            else
+            {
+                return new LRUBasedGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL);
+            }
+        }
+
         internal static AdaptiveDirectoryCacheMaintainer CreateGrainDirectoryCacheMaintainer(
             LocalGrainDirectory router,
             IGrainDirectoryCache cache,

--- a/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/NonSilo.Tests/Directory/CachedGrainLocatorTests.cs
@@ -1,9 +1,13 @@
+// Ignore Spelling: Locator
+
 using System.Collections.Immutable;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
+using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Metadata;
 using Orleans.Runtime;
@@ -19,7 +23,7 @@ namespace UnitTests.Directory
     {
         private readonly LoggerFactory loggerFactory;
         private readonly SiloLifecycleSubject lifecycle;
-
+        private readonly IOptions<GrainDirectoryOptions> grainDirectoryOptions;
         private readonly IGrainDirectory grainDirectory;
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly MockClusterMembershipService mockMembershipService;
@@ -42,9 +46,12 @@ namespace UnitTests.Directory
                 Array.Empty<IGrainDirectoryResolver>());
             this.mockMembershipService = new MockClusterMembershipService();
 
+            grainDirectoryOptions = Options.Create(new GrainDirectoryOptions());
             this.grainLocator = new CachedGrainLocator(
+                services,
                 this.grainDirectoryResolver, 
-                this.mockMembershipService.Target);
+                this.mockMembershipService.Target,
+                grainDirectoryOptions);
 
             this.grainLocator.Participate(this.lifecycle);
         }


### PR DESCRIPTION
Backport of #8844 to 7.x

---------

Co-authored-by: Mostafa Abdalla <mostafa.abdalla@cm.com>
Co-authored-by: Reuben Bond <203839+ReubenBond@users.noreply.github.com>
(cherry picked from commit ab644bf2da188819c8a3a01fb8c7573b4131a437)