### PR TITLE
Remove mention of build.sh from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Please see the [getting started tutorial](https://docs.microsoft.com/dotnet/orle
 On Windows, run the `build.cmd` script to build the NuGet packages locally, then reference the required NuGet packages from `/Artifacts/Release/*`.
 You can run `Test.cmd` to run all BVT tests, and `TestAll.cmd` to also run Functional tests.
 
-On Linux and macOS, run the `build.sh` script or `dotnet build` to build Orleans.
+On Linux and macOS, run `dotnet build` to build Orleans.
 
 ## Official builds
 


### PR DESCRIPTION
build.sh was removed in 6b01cefba but README.md hasn't been updated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8901)