### PR TITLE
Enable TCP keep-alive on all sockets by default

### DIFF
--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -50,6 +50,14 @@ namespace Orleans.Networking.Shared
             };
 
             listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            if (_options.KeepAlive)
+            {
+                listenSocket.EnableKeepAlive(
+                    timeSeconds: _options.KeepAliveTimeSeconds,
+                    intervalSeconds: _options.KeepAliveIntervalSeconds,
+                    retryCount: _options.KeepAliveRetryCount);
+            }
+
             listenSocket.EnableFastPath();
 
             // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
@@ -82,6 +90,13 @@ namespace Orleans.Networking.Shared
                 {
                     var acceptSocket = await _listenSocket.AcceptAsync();
                     acceptSocket.NoDelay = _options.NoDelay;
+                    if (_options.KeepAlive)
+                    {
+                        acceptSocket.EnableKeepAlive(
+                            timeSeconds: _options.KeepAliveTimeSeconds,
+                            intervalSeconds: _options.KeepAliveIntervalSeconds,
+                            retryCount: _options.KeepAliveRetryCount);
+                    }
 
                     var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
 

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionOptions.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionOptions.cs
@@ -9,7 +9,7 @@ namespace Orleans.Networking.Shared
     public class SocketConnectionOptions
     {
         /// <summary>
-        /// Gets or sets the number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
+        /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
@@ -17,9 +17,32 @@ namespace Orleans.Networking.Shared
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
         /// <summary>
-        /// Gets or sets a value indicating whether the Nagle algorithm should be enabled or disabled.
+        /// Whether the Nagle algorithm should be enabled or disabled.
         /// </summary>
         public bool NoDelay { get; set; } = true;
+
+        /// <summary>
+        /// Whether TCP KeepAlive is enabled or disabled.
+        /// </summary>
+        public bool KeepAlive { get; set; } = true;
+
+        /// <summary>
+        /// The number of seconds before the first keep-alive packet is sent on an idle connection.
+        /// </summary>
+        /// <seealso cref="System.Net.Sockets.SocketOptionName.TcpKeepAliveTime"/>
+        public int KeepAliveTimeSeconds { get; set; } = 90;
+
+        /// <summary>
+        /// The number of seconds between keep-alive packets when the remote endpoint is not responding.
+        /// </summary>
+        /// <seealso cref="System.Net.Sockets.SocketOptionName.TcpKeepAliveInterval"/>
+        public int KeepAliveIntervalSeconds { get; set; } = 30;
+
+        /// <summary>
+        /// The number of retry attempts for keep-alive packets before the connection is considered dead.
+        /// </summary>
+        /// <seealso cref="System.Net.Sockets.SocketOptionName.TcpKeepAliveRetryCount"/>
+        public int KeepAliveRetryCount { get; set; } = 10;
 
         /// <summary>
         /// Gets or sets the memory pool factory.

--- a/src/Orleans.Core/Networking/Shared/SocketExtensions.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketExtensions.cs
@@ -9,21 +9,6 @@ namespace Orleans.Networking.Shared
         private const int SIO_LOOPBACK_FAST_PATH = -1744830448;
         private static readonly byte[] Enabled = BitConverter.GetBytes(1);
 
-        private static readonly bool IsSocketKeepAliveRetryCountSupported = CheckIfSocketKeepAliveRetryCountSupported();
-
-        private static bool CheckIfSocketKeepAliveRetryCountSupported()
-        {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return true;
-            }
-
-            // On Windows, RetryCount is only available on Windows 10 version 1703 and later, which is build 15063.
-            // On other platforms, we always return true.
-            var osVersion = Environment.OSVersion.Version;
-            return osVersion.Major > 10 || osVersion.Major == 10 && (osVersion.Minor > 0 || osVersion.Build >= 15063);
-        }
-
         /// <summary>
         /// Enables TCP Loopback Fast Path on a socket.
         /// See https://blogs.technet.microsoft.com/wincat/2012/12/05/fast-tcp-loopback-performance-and-low-latency-with-windows-server-2012-tcp-loopback-fast-path/
@@ -67,11 +52,7 @@ namespace Orleans.Networking.Shared
                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, timeSeconds);
                 socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, intervalSeconds);
-
-                if (IsSocketKeepAliveRetryCountSupported)
-                {
-                    socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, retryCount);
-                }
+                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, retryCount);
             }
             catch
             {


### PR DESCRIPTION
This PR adds support for enabling TCP keep-alive on all sockets and enables it by default with a relatively aggressive 90s idle period before the first keep-alive probe is sent, 30s between retries, and 10 unacknowledged retries before a connection is declared dead.

The value of 90s was chosen because Orleans generally establishes relatively few sockets (under a few hundred per host for a large cluster) and some routers aggressively prune connections after a couple of minutes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8927)