### PR TITLE
Always read grain state during activation if it has not been rehydrated

### DIFF
--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -1,16 +1,12 @@
 using System;
-using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Timers;
 using Orleans.Storage;
-using Orleans.Serialization.Serializers;
 
 namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
-        private readonly ILoggerFactory loggerFactory;
-        private readonly IActivatorProvider activatorProvider;
         private readonly IServiceProvider serviceProvider;
         private readonly ITimerRegistry timerRegistry;
         private readonly IGrainFactory grainFactory;
@@ -19,17 +15,13 @@ namespace Orleans.Runtime
             ILocalSiloDetails localSiloDetails,
             IGrainFactory grainFactory,
             ITimerRegistry timerRegistry,
-            IServiceProvider serviceProvider,
-            ILoggerFactory loggerFactory,
-            IActivatorProvider activatorProvider)
+            IServiceProvider serviceProvider)
         {
             SiloAddress = localSiloDetails.SiloAddress;
             SiloIdentity = SiloAddress.ToString();
             this.grainFactory = grainFactory;
             this.timerRegistry = timerRegistry;
             this.serviceProvider = serviceProvider;
-            this.loggerFactory = loggerFactory;
-            this.activatorProvider = activatorProvider;
         }
 
         public string SiloIdentity { get; }
@@ -85,7 +77,7 @@ namespace Orleans.Runtime
             if (grainContext is null) throw new ArgumentNullException(nameof(grainContext));
             var grainType = grainContext.GrainInstance?.GetType() ?? throw new ArgumentNullException(nameof(IGrainContext.GrainInstance));
             IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(grainType, ServiceProvider);
-            return new StateStorageBridge<TGrainState>("state", grainContext, grainStorage, this.loggerFactory, this.activatorProvider);
+            return new StateStorageBridge<TGrainState>("state", grainContext, grainStorage);
         }
 
         public static void CheckRuntimeContext(IGrainContext context)

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateStorageFactory.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime
 
     internal sealed class PersistentState<TState> : StateStorageBridge<TState>, IPersistentState<TState>, ILifecycleObserver
     {
-        public PersistentState(string stateName, IGrainContext context, IGrainStorage storageProvider) : base(stateName, context, storageProvider, context.ActivationServices.GetRequiredService<ILoggerFactory>(), context.ActivationServices.GetRequiredService<IActivatorProvider>())
+        public PersistentState(string stateName, IGrainContext context, IGrainStorage storageProvider) : base(stateName, context, storageProvider)
         {
             var lifecycle = context.ObservableLifecycle;
             lifecycle.Subscribe(RuntimeTypeNameFormatter.Format(GetType()), GrainLifecycleStage.SetupState, this);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -41,6 +41,7 @@ using Orleans.Serialization.Cloning;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Orleans.Serialization.Internal;
+using Orleans.Core;
 
 namespace Orleans.Hosting
 {
@@ -346,6 +347,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<IGrainStorageSerializer, JsonGrainStorageSerializer>();
             services.TryAddSingleton<IPersistentStateFactory, PersistentStateFactory>();
             services.TryAddSingleton(typeof(IAttributeToFactoryMapper<PersistentStateAttribute>), typeof(PersistentStateAttributeMapper));
+            services.TryAddSingleton<StateStorageBridgeSharedMap>();
 
             // IAsyncEnumerable support
             services.AddScoped<IAsyncEnumerableGrainExtension, AsyncEnumerableGrainExtension>();

--- a/src/Orleans.Runtime/Hosting/StorageProviderHostExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/StorageProviderHostExtensions.cs
@@ -1,12 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Orleans.Storage;
-using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.GrainDirectory;
 using Orleans.Providers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -27,16 +21,19 @@ namespace Orleans.Runtime.Hosting
             where T : IGrainStorage
         {
             collection.AddKeyedSingleton<IGrainStorage>(name, (sp, key) => implementationFactory(sp, key as string));
+
             // Check if it is the default implementation
             if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
             {
                 collection.TryAddSingleton(sp => sp.GetKeyedService<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             }
+
             // Check if the grain storage implements ILifecycleParticipant<ISiloLifecycle>
             if (typeof(ILifecycleParticipant<ISiloLifecycle>).IsAssignableFrom(typeof(T)))
             {
                 collection.AddSingleton(s => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredKeyedService<IGrainStorage>(name));
             }
+
             return collection;
         }
     }

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -38,10 +38,13 @@ namespace Orleans.Core
 
     internal sealed class StateStorageBridgeShared<TState>(string name, IGrainStorage store, ILogger logger, IActivator<TState> activator)
     {
+        private string? _migrationContextKey;
+
         public readonly string Name = name;
         public readonly IGrainStorage Store = store;
         public readonly ILogger Logger = logger;
         public readonly IActivator<TState> Activator = activator;
+        public string MigrationContextKey => _migrationContextKey ??= $"state.{Name}";
     }
 
     /// <summary>
@@ -162,7 +165,7 @@ namespace Orleans.Core
         {
             try
             {
-                dehydrationContext.TryAddValue($"state.{_shared.Name}", _grainState);
+                dehydrationContext.TryAddValue(_shared.MigrationContextKey, _grainState);
             }
             catch (Exception exception)
             {
@@ -177,7 +180,7 @@ namespace Orleans.Core
         {
             try
             {
-                if (rehydrationContext.TryGetValue<GrainState<TState>>($"state.{_shared.Name}", out var grainState))
+                if (rehydrationContext.TryGetValue<GrainState<TState>>(_shared.MigrationContextKey, out var grainState))
                 {
                     _grainState = grainState;
                     IsStateInitialized = true;

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -1,8 +1,10 @@
 #nullable enable
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Serialization.Activators;
@@ -11,6 +13,37 @@ using Orleans.Storage;
 
 namespace Orleans.Core
 {
+    internal sealed class StateStorageBridgeSharedMap(ILoggerFactory loggerFactory, IActivatorProvider activatorProvider)
+    {
+        private readonly ConcurrentDictionary<(string Name, IGrainStorage Store, Type StateType), object> _instances = new();
+        private readonly ILoggerFactory _loggerFactory = loggerFactory;
+        private readonly IActivatorProvider _activatorProvider = activatorProvider;
+
+        public StateStorageBridgeShared<TState> Get<TState>(string name, IGrainStorage store)
+        {
+            var result = _instances.GetOrAdd((name, store, typeof(TState)), static (key, self) =>
+            {
+                var (name, store, _) = key;
+                return new StateStorageBridgeShared<TState>(
+                    name,
+                    store,
+                    self._loggerFactory.CreateLogger(store.GetType()),
+                    self._activatorProvider.GetActivator<TState>());
+            },
+            this);
+
+            return (StateStorageBridgeShared<TState>)result;
+        }
+    }
+
+    internal sealed class StateStorageBridgeShared<TState>(string name, IGrainStorage store, ILogger logger, IActivator<TState> activator)
+    {
+        public readonly string Name = name;
+        public readonly IGrainStorage Store = store;
+        public readonly ILogger Logger = logger;
+        public readonly IActivator<TState> Activator = activator;
+    }
+
     /// <summary>
     /// Provides functionality for operating on grain state.
     /// Implements the <see cref="IStorage{TState}" />
@@ -19,11 +52,8 @@ namespace Orleans.Core
     /// <seealso cref="IStorage{TState}" />
     public class StateStorageBridge<TState> : IStorage<TState>, IGrainMigrationParticipant
     {
-        private readonly string _name;
         private readonly IGrainContext _grainContext;
-        private readonly IGrainStorage _store;
-        private readonly ILogger _logger;
-        private readonly IActivator<TState> _activator;
+        private readonly StateStorageBridgeShared<TState> _shared;
         private GrainState<TState>? _grainState;
 
         /// <inheritdoc/>
@@ -42,8 +72,8 @@ namespace Orleans.Core
             }
         }
 
-        private GrainState<TState> GrainState => _grainState ??= new GrainState<TState>(_activator.Create());
-        internal bool IsStateInitialized => _grainState != null;
+        private GrainState<TState> GrainState => _grainState ??= new GrainState<TState>(_shared.Activator.Create());
+        internal bool IsStateInitialized { get; private set; }
 
         /// <inheritdoc/>
         public string? Etag { get => GrainState.ETag; set => GrainState.ETag = value; }
@@ -51,19 +81,19 @@ namespace Orleans.Core
         /// <inheritdoc/>
         public bool RecordExists => GrainState.RecordExists;
 
-        public StateStorageBridge(string name, IGrainContext grainContext, IGrainStorage store, ILoggerFactory loggerFactory, IActivatorProvider activatorProvider)
+        [Obsolete("Use StateStorageBridge(string, IGrainContext, IGrainStorage) instead.")]
+        public StateStorageBridge(string name, IGrainContext grainContext, IGrainStorage store, ILoggerFactory loggerFactory, IActivatorProvider activatorProvider) : this(name, grainContext, store)
+        { }
+
+        public StateStorageBridge(string name, IGrainContext grainContext, IGrainStorage store)
         {
             ArgumentNullException.ThrowIfNull(name);
             ArgumentNullException.ThrowIfNull(grainContext);
             ArgumentNullException.ThrowIfNull(store);
-            ArgumentNullException.ThrowIfNull(loggerFactory);
-            ArgumentNullException.ThrowIfNull(activatorProvider);
 
-            _logger = loggerFactory.CreateLogger(store.GetType());
-            _name = name;
             _grainContext = grainContext;
-            _store = store;
-            _activator = activatorProvider.GetActivator<TState>();
+            var sharedInstances = ActivatorUtilities.GetServiceOrCreateInstance<StateStorageBridgeSharedMap>(grainContext.ActivationServices);
+            _shared = sharedInstances.Get<TState>(name, store);
         }
 
         /// <inheritdoc />
@@ -74,7 +104,8 @@ namespace Orleans.Core
                 GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 var sw = ValueStopwatch.StartNew();
-                await _store.ReadStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _shared.Store.ReadStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
+                IsStateInitialized = true;
                 StorageInstruments.OnStorageRead(sw.Elapsed);
             }
             catch (Exception exc)
@@ -92,7 +123,7 @@ namespace Orleans.Core
                 GrainRuntime.CheckRuntimeContext(RuntimeContext.Current);
 
                 var sw = ValueStopwatch.StartNew();
-                await _store.WriteStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _shared.Store.WriteStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
                 StorageInstruments.OnStorageWrite(sw.Elapsed);
             }
             catch (Exception exc)
@@ -111,11 +142,11 @@ namespace Orleans.Core
 
                 var sw = ValueStopwatch.StartNew();
                 // Clear (most likely Delete) state from external storage
-                await _store.ClearStateAsync(_name, _grainContext.GrainId, GrainState);
+                await _shared.Store.ClearStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
                 sw.Stop();
 
                 // Reset the in-memory copy of the state
-                GrainState.State = _activator.Create();
+                GrainState.State = _shared.Activator.Create();
 
                 // Update counters
                 StorageInstruments.OnStorageDelete(sw.Elapsed);
@@ -131,11 +162,11 @@ namespace Orleans.Core
         {
             try
             {
-                dehydrationContext.TryAddValue($"state.{_name}", _grainState);
+                dehydrationContext.TryAddValue($"state.{_shared.Name}", _grainState);
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, "Failed to dehydrate state named {StateName} for grain {GrainId}", _name, _grainContext.GrainId);
+                _shared.Logger.LogError(exception, "Failed to dehydrate state named {StateName} for grain {GrainId}", _shared.Name, _grainContext.GrainId);
 
                 // We must throw here since we do not know that the dehydration context is in a clean state after this.
                 throw;
@@ -146,12 +177,16 @@ namespace Orleans.Core
         {
             try
             {
-                rehydrationContext.TryGetValue($"state.{_name}", out _grainState);
+                if (rehydrationContext.TryGetValue<GrainState<TState>>($"state.{_shared.Name}", out var grainState))
+                {
+                    _grainState = grainState;
+                    IsStateInitialized = true;
+                }
             }
             catch (Exception exception)
             {
                 // It is ok to swallow this exception, since state rehydration is best-effort.
-                _logger.LogError(exception, "Failed to rehydrate state named {StateName} for grain {GrainId}", _name, _grainContext.GrainId);
+                _shared.Logger.LogError(exception, "Failed to rehydrate state named {StateName} for grain {GrainId}", _shared.Name, _grainContext.GrainId);
             }
         }
 
@@ -159,17 +194,17 @@ namespace Orleans.Core
         private void OnError(Exception exception, ErrorCode id, string operation)
         {
             string? errorCode = null;
-            (_store as IRestExceptionDecoder)?.DecodeException(exception, out _, out errorCode, true);
+            (_shared.Store as IRestExceptionDecoder)?.DecodeException(exception, out _, out errorCode, true);
             var errorString = errorCode is { Length: > 0 } ? $" Error: {errorCode}" : null;
 
             var grainId = _grainContext.GrainId;
-            var providerName = _store.GetType().Name;
-            _logger.LogError((int)id, exception, "Error from storage provider {ProviderName}.{StateName} during {Operation} for grain {GrainId}{ErrorCode}", providerName, _name, operation, grainId, errorString);
+            var providerName = _shared.Store.GetType().Name;
+            _shared.Logger.LogError((int)id, exception, "Error from storage provider {ProviderName}.{StateName} during {Operation} for grain {GrainId}{ErrorCode}", providerName, _shared.Name, operation, grainId, errorString);
 
             // If error is not specialization of OrleansException, wrap it
             if (exception is not OrleansException)
             {
-                var errMsg = $"Error from storage provider {providerName}.{_name} during {operation} for grain {grainId}{errorString}{Environment.NewLine} {LogFormatter.PrintException(exception)}";
+                var errMsg = $"Error from storage provider {providerName}.{_shared.Name} during {operation} for grain {grainId}{errorString}{Environment.NewLine} {LogFormatter.PrintException(exception)}";
                 throw new OrleansException(errMsg, exception);
             }
 

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -20,13 +20,11 @@ namespace Orleans.Streams
     internal sealed class PubSubGrainStateStorageFactory
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<PubSubGrainStateStorageFactory> _logger;
 
         public PubSubGrainStateStorageFactory(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
         {
             _serviceProvider = serviceProvider;
-            _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<PubSubGrainStateStorageFactory>();
         }
 
@@ -57,8 +55,7 @@ namespace Orleans.Streams
                 storage = _serviceProvider.GetRequiredKeyedService<IGrainStorage>(ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME);
             }
 
-            var activatorProvider = _serviceProvider.GetRequiredService<IActivatorProvider>();
-            return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage, _loggerFactory, activatorProvider);
+            return new(nameof(PubSubRendezvousGrain), grain.GrainContext, storage);
         }
     }
 

--- a/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
@@ -1,22 +1,23 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 using Orleans.Storage;
-using Orleans.Serialization.Serializers;
 
 namespace Orleans.Transactions
 {
     public class NamedTransactionalStateStorageFactory : INamedTransactionalStateStorageFactory
     {
         private readonly IGrainContextAccessor contextAccessor;
-        private readonly ILoggerFactory loggerFactory;
 
-        public NamedTransactionalStateStorageFactory(IGrainContextAccessor contextAccessor, ILoggerFactory loggerFactory)
+        [Obsolete("Use the NamedTransactionalStateStorageFactory(IGrainContextAccessor contextAccessor) constructor.")]
+        public NamedTransactionalStateStorageFactory(IGrainContextAccessor contextAccessor, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) : this(contextAccessor)
+        {
+        }
+
+        public NamedTransactionalStateStorageFactory(IGrainContextAccessor contextAccessor)
         {
             this.contextAccessor = contextAccessor;
-            this.loggerFactory = loggerFactory;
         }
 
         public ITransactionalStateStorage<TState> Create<TState>(string storageName, string stateName)
@@ -37,8 +38,7 @@ namespace Orleans.Transactions
 
             if (grainStorage != null)
             {
-                IActivatorProvider activatorProvider = currentContext.ActivationServices.GetRequiredService<IActivatorProvider>();
-                return new TransactionalStateStorageProviderWrapper<TState>(grainStorage, stateName, currentContext, this.loggerFactory, activatorProvider);
+                return new TransactionalStateStorageProviderWrapper<TState>(grainStorage, stateName, currentContext);
             }
 
             throw (string.IsNullOrEmpty(storageName))

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Orleans.Core;
 using Orleans.Runtime;
-using Orleans.Serialization.Serializers;
 using Orleans.Storage;
 using Orleans.Transactions.Abstractions;
 
@@ -17,20 +15,16 @@ namespace Orleans.Transactions
     {
         private readonly IGrainStorage grainStorage;
         private readonly IGrainContext context;
-        private readonly ILoggerFactory loggerFactory;
-        private readonly IActivatorProvider activatorProvider;
         private readonly string stateName;
 
         private StateStorageBridge<TransactionalStateRecord<TState>>? stateStorage;
         [MemberNotNull(nameof(stateStorage))]
         private StateStorageBridge<TransactionalStateRecord<TState>> StateStorage => stateStorage ??= GetStateStorage();
 
-        public TransactionalStateStorageProviderWrapper(IGrainStorage grainStorage, string stateName, IGrainContext context, ILoggerFactory loggerFactory, IActivatorProvider activatorProvider)
+        public TransactionalStateStorageProviderWrapper(IGrainStorage grainStorage, string stateName, IGrainContext context)
         {
             this.grainStorage = grainStorage;
             this.context = context;
-            this.loggerFactory = loggerFactory;
-            this.activatorProvider = activatorProvider;
             this.stateName = stateName;
         }
 
@@ -104,7 +98,7 @@ namespace Orleans.Transactions
 
         private StateStorageBridge<TransactionalStateRecord<TState>> GetStateStorage()
         {
-            return new(this.stateName, context, grainStorage, loggerFactory, activatorProvider);
+            return new(this.stateName, context, grainStorage);
         }
     }
 


### PR DESCRIPTION
Fixes #8936

This fixes the issue identified in #8936 where accessing state in the grain's constructor would cause it to not be loaded during activation. Additionally, trying to access `RecordExists` before a successful read has been issued will result in an `InvalidOperationException` being thrown.

This also reduces the number of fields in `StateStorageBridge<T>` by moving fields which can be shared between multiple instances to a shared object.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8944)