### PR TITLE
[3.x] Fix potential grain timer deadlock during disposal

### DIFF
--- a/src/Orleans.Core/Timers/SafeTimerBase.cs
+++ b/src/Orleans.Core/Timers/SafeTimerBase.cs
@@ -58,6 +58,14 @@ namespace Orleans.Runtime
             timer.Change(due, Constants.INFINITE_TIMESPAN);
         }
 
+        public void Stop()
+        {
+            timerFrequency = Constants.INFINITE_TIMESPAN;
+            dueTime = Constants.INFINITE_TIMESPAN;
+            timerStarted = false;
+            timer.Change(Constants.INFINITE_TIMESPAN, Constants.INFINITE_TIMESPAN);
+        }
+
         private void Init(ILogger logger, Func<object, Task> asynCallback, TimerCallback synCallback, object state, TimeSpan due, TimeSpan period)
         {
             if (synCallback == null && asynCallback == null) throw new ArgumentNullException("synCallback", "Cannot use null for both sync and asyncTask timer callbacks.");

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -222,7 +222,9 @@ namespace Orleans.Runtime
             SetState(ActivationState.Deactivating);
             deactivationStartTime = DateTime.UtcNow;
             if (!IsCurrentlyExecuting)
+            {
                 StopAllTimers();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #7865

To prevent the deadlock, we yield before invoking the timer callback. See [comment](https://github.com/dotnet/orleans/pull/8949#discussion_r1573380779).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8949)