### PR TITLE
Add missing description node to XML docs

### DIFF
--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -55,8 +55,8 @@ public readonly struct EnvironmentStatistics
     /// <remarks>
     /// This value is computed as the lower of two amounts:
     /// <list type="bullet">
-    ///   <item>The amount of memory after which the garbage collector will begin aggressively collecting memory, defined by <see cref="GCMemoryInfo.HighMemoryLoadThresholdBytes"/>.</item>
-    ///   <item>The process' configured memory limit, defined by <see cref="GCMemoryInfo.TotalAvailableMemoryBytes"/>.</item>
+    ///   <item><description>The amount of memory after which the garbage collector will begin aggressively collecting memory, defined by <see cref="GCMemoryInfo.HighMemoryLoadThresholdBytes"/>.</description></item>
+    ///   <item><description>The process' configured memory limit, defined by <see cref="GCMemoryInfo.TotalAvailableMemoryBytes"/>.</description></item>
     /// </list>
     /// Memory limits are common in containerized environments. For more information on configuring memory limits, see <see href="https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#heap-limit"/>
     /// </remarks>

--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -12,8 +12,8 @@ namespace Orleans
     ///
     /// When programming with <b>async</b>, the <b>lock</b> keyword is problematic:
     /// <list type="bullet">
-    ///     <item><b>lock</b> will cause the thread to block while it waits for exclusive access to the critical section of code.</item>
-    ///     <item>The <b>await</b> keyword cannot be used within the scope of a <b>lock</b> construct.</item>
+    ///     <item><description><b>lock</b> will cause the thread to block while it waits for exclusive access to the critical section of code.</description></item>
+    ///     <item><description>The <b>await</b> keyword cannot be used within the scope of a <b>lock</b> construct.</description></item>
     /// </list>
     ///
     /// It is still useful, at times, to provide exclusive access to a critical section of code. AsyncLock provides semantics

--- a/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs
@@ -70,8 +70,8 @@ public sealed class ResourceOptimizedPlacementOptions
     /// <summary>
     /// The specified margin for which: if two silos (one of them being the local to the current pending activation), have a utilization score that should be considered "the same" within this margin.
     /// <list type="bullet">
-    /// <item>When this value is 0, then the policy will always favor the silo with the lower resource utilization, even if that silo is remote to the current pending activation.</item>
-    /// <item>When this value is 100, then the policy will always favor the local silo, regardless of its relative utilization score. This policy essentially becomes equivalent to <see cref="PreferLocalPlacement"/>.</item>
+    /// <item><description>When this value is 0, then the policy will always favor the silo with the lower resource utilization, even if that silo is remote to the current pending activation.</description></item>
+    /// <item><description>When this value is 100, then the policy will always favor the local silo, regardless of its relative utilization score. This policy essentially becomes equivalent to <see cref="PreferLocalPlacement"/>.</description></item>
     /// </list>
     /// </summary>
     /// <remarks><i>

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -41,12 +41,12 @@ namespace Orleans.Runtime.MembershipService
     /// membership algorithm (refutation, for example).
     /// The monitor implements the following heuristics:
     /// <list type="bullet">
-    ///   <item>Check that this silos is marked as active in membership.</item>
-    ///   <item>Check that no other silo suspects this silo.</item>
-    ///   <item>Check for recently received successful ping responses.</item>
-    ///   <item>Check for recently received ping requests.</item>
-    ///   <item>Check that the .NET Thread Pool is able to process work items within one second.</item>
-    ///   <item>Check that local async timers have been firing on-time (within 3 seconds of their due time).</item>
+    ///   <item><description>Check that this silos is marked as active in membership.</description></item>
+    ///   <item><description>Check that no other silo suspects this silo.</description></item>
+    ///   <item><description>Check for recently received successful ping responses.</description></item>
+    ///   <item><description>Check for recently received ping requests.</description></item>
+    ///   <item><description>Check that the .NET Thread Pool is able to process work items within one second.</description></item>
+    ///   <item><description>Check that local async timers have been firing on-time (within 3 seconds of their due time).</description></item>
     /// </list>
     /// </remarks>
     internal class LocalSiloHealthMonitor : ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver, ILocalSiloHealthMonitor
@@ -60,7 +60,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly ClusterMembershipOptions _clusterMembershipOptions;
         private readonly IAsyncTimer _degradationCheckTimer;
         private readonly ThreadPoolMonitor _threadPoolMonitor;
-        private readonly ProbeRequestMonitor _probeRequestMonitor; 
+        private readonly ProbeRequestMonitor _probeRequestMonitor;
         private ValueStopwatch _clusteredDuration;
         private Task? _runTask;
         private bool _isActive;
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.MembershipService
         /// <param name="checkTime">The time which the check is taking place.</param>
         /// <param name="complaints">If not null, will be populated with the current set of detected health issues.</param>
         /// <returns>The local health degradation score, which is a value between 0 (healthy) and <see cref="MaxScore"/> (unhealthy).</returns>
-        public int GetLocalHealthDegradationScore(DateTime checkTime, List<string>? complaints) 
+        public int GetLocalHealthDegradationScore(DateTime checkTime, List<string>? complaints)
         {
             var score = 0;
             score += CheckSuspectingNodes(checkTime, complaints);
@@ -151,7 +151,7 @@ namespace Orleans.Runtime.MembershipService
 
                 complaints?.Add(
                     $".NET Thread Pool is exhibiting delays of {threadPoolDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.");
-            } 
+            }
 
             // Each second of delay contributes to the score.
             return (int)threadPoolDelaySeconds;


### PR DESCRIPTION
Per the guidance at https://learn.microsoft.com/dotnet/csharp/language-reference/xmldoc/recommended-tags#list, a `<description>` node is required for bulleted lists. This PR resolves the list item display issues on Learn API ref pages. For example: 

![image](https://github.com/dotnet/orleans/assets/10702007/bfd0f2db-fa34-4d24-9dc4-54ae6ac78081)

/cc: @mikekistler 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8959)