### PR TITLE
Brings back support for `StringData` in ATS provider

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -207,7 +207,7 @@ namespace Orleans.Storage
 
             CheckMaxDataSize(binaryData.ToMemory().Length, MAX_DATA_CHUNK_SIZE * MAX_DATA_CHUNKS_COUNT);
 
-            if (options.UseJson)
+            if (options.UseStringFormat)
             {
                 var properties = SplitStringData(binaryData.ToString().AsMemory());
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -40,6 +40,7 @@ namespace Orleans.Storage
 
         private const string BINARY_DATA_PROPERTY_NAME = "Data";
         private const string STRING_DATA_PROPERTY_NAME = "StringData";
+
         private readonly string name;
 
         /// <summary> Default constructor </summary>
@@ -202,23 +203,29 @@ namespace Orleans.Storage
         /// </remarks>
         internal void ConvertToStorageFormat<T>(T grainState, TableEntity entity)
         {
-            int dataSize;
-            IEnumerable<ReadOnlyMemory<byte>> properties;
-            string basePropertyName;
+            var binaryData = storageSerializer.Serialize<T>(grainState);
 
-            // Convert to binary format
-            var data = this.storageSerializer.Serialize<T>(grainState);
-            basePropertyName = BINARY_DATA_PROPERTY_NAME;
+            CheckMaxDataSize(binaryData.ToMemory().Length, MAX_DATA_CHUNK_SIZE * MAX_DATA_CHUNKS_COUNT);
 
-            dataSize = data.ToMemory().Length;
-            properties = SplitBinaryData(data);
-
-            CheckMaxDataSize(dataSize, MAX_DATA_CHUNK_SIZE * MAX_DATA_CHUNKS_COUNT);
-
-            foreach (var keyValuePair in properties.Zip(GetPropertyNames(basePropertyName),
-                (property, name) => new KeyValuePair<string, object>(name, property.ToArray())))
+            if (options.UseJson)
             {
-                entity[keyValuePair.Key] = keyValuePair.Value;
+                var properties = SplitStringData(binaryData.ToString().AsMemory());
+
+                foreach (var keyValuePair in properties.Zip(GetPropertyNames(STRING_DATA_PROPERTY_NAME),
+                (property, name) => new KeyValuePair<string, object>(name, property.ToString())))
+                {
+                    entity[keyValuePair.Key] = keyValuePair.Value;
+                }
+            }
+            else
+            {
+                var properties = SplitBinaryData(binaryData);
+
+                foreach (var keyValuePair in properties.Zip(GetPropertyNames(BINARY_DATA_PROPERTY_NAME),
+                (property, name) => new KeyValuePair<string, object>(name, property.ToArray())))
+                {
+                    entity[keyValuePair.Key] = keyValuePair.Value;
+                }
             }
         }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
@@ -20,9 +20,9 @@ namespace Orleans.Configuration
         public bool DeleteStateOnClear { get; set; } = false;
 
         /// <summary>
-        /// Indicates if grain data should be stored as a json string or in binary format.
+        /// Indicates if grain data should be stored in string or in binary format.
         /// </summary>
-        public bool UseJson { get; set; }
+        public bool UseStringFormat { get; set; }
 
         /// <summary>
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
@@ -20,6 +20,11 @@ namespace Orleans.Configuration
         public bool DeleteStateOnClear { get; set; } = false;
 
         /// <summary>
+        /// Indicates if grain data should be stored as a json string or in binary format.
+        /// </summary>
+        public bool UseJson { get; set; }
+
+        /// <summary>
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
         /// </summary>
         public int InitStage { get; set; } = DEFAULT_INIT_STAGE;

--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -302,6 +302,11 @@ namespace Tester.AzureUtils.Persistence
 
         private async Task<AzureTableGrainStorage> InitAzureTableGrainStorage(bool useJson = false, bool useStringFormat = false, TypeNameHandling? typeNameHandling = null)
         {
+            if (useStringFormat && !useJson)
+            {
+                throw new InvalidOperationException($"Using {nameof(OrleansGrainStorageSerializer)} in conjuction with string data format makes no sense, there for stopping attempt.");
+            }
+
             var options = new AzureTableStorageOptions();
             var jsonOptions = this.providerRuntime.ServiceProvider.GetService<IOptions<OrleansJsonSerializerOptions>>();
             if (typeNameHandling != null)


### PR DESCRIPTION
Currently the Azure Table Storage provider saves the grain state (*encoded JSON*) but in binary format- Regardless if the orleans serializer or one of the two json serializer are used. And while it can be decoded as UTF-8, its cumbersome to do that when someone wants to manually intervene and change the data in ATS. Let alone just a quick way to simply **look** at the data.

This PR brings back `StringData` but with the difference that its does NOT use `Newtonsoft.Json` to serialize the data as it was previously, but instead uses the `GrainStorageSerializer` and converts the `BinaryData` to a string format. This allows the data to follow what ever grain storage serializer is configured by the user i.e.: Newtonsoft.Json` or `System.Text.Json`.

AFAIK this is not a breaking change, as we'll continue to read both formats for backwards compatibility.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8965)