### PR TITLE
Ensure reminder table is initialized before access

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -81,8 +81,9 @@ namespace Orleans.Runtime.ReminderService
                 ServiceLifecycleStage.Active,
                 async ct =>
                 {
-                    using var timeoutCancellation = new CancellationTokenSource(this.reminderOptions.InitializationTimeout);
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCancellation.Token);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    cts.CancelAfter(this.reminderOptions.InitializationTimeout);
+
                     await this.QueueTask(Start)
                         .WithCancellation($"Starting ReminderService failed because the task was canceled.", cts.Token);
                 },
@@ -95,8 +96,8 @@ namespace Orleans.Runtime.ReminderService
         /// <returns></returns>
         private async Task Initialize(CancellationToken cancellationToken)
         {
-            using var timeoutCancellation = new CancellationTokenSource(this.reminderOptions.InitializationTimeout);
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellation.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(this.reminderOptions.InitializationTimeout);
 
             // Confirm that it can access the underlying store, as after this the ReminderService will load in the background, without the opportunity to prevent the Silo from starting
             await reminderTable.StartAsync(cts.Token);

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -26,7 +26,6 @@ namespace Orleans.Runtime.ReminderService
         private readonly Dictionary<ReminderIdentity, LocalReminderData> localReminders = new();
         private readonly IReminderTable reminderTable;
         private readonly TaskCompletionSource<bool> startedTask;
-        private readonly TimeSpan initTimeout;
         private readonly IAsyncTimerFactory asyncTimerFactory;
         private readonly IAsyncTimer listRefreshTimer; // timer that refreshes our list of reminders to reflect global reminder table
         private readonly GrainReferenceActivator _referenceActivator;
@@ -54,7 +53,6 @@ namespace Orleans.Runtime.ReminderService
             _referenceActivator = referenceActivator;
             _grainInterfaceType = interfaceTypeResolver.GetGrainInterfaceType(typeof(IRemindable));
             this.reminderOptions = reminderOptions.Value;
-            this.initTimeout = this.reminderOptions.InitializationTimeout;
             this.reminderTable = reminderTable;
             this.asyncTimerFactory = asyncTimerFactory;
             ReminderInstruments.RegisterActiveRemindersObserve(() => localReminders.Count);
@@ -68,36 +66,45 @@ namespace Orleans.Runtime.ReminderService
         {
             observer.Subscribe(
                 nameof(LocalReminderService),
+                ServiceLifecycleStage.BecomeActive,
+                async ct =>
+                {
+                    await this.QueueTask(() => Initialize(ct));
+                },
+                async ct =>
+                {
+                    await this.QueueTask(Stop)
+                        .WithCancellation("Stopping ReminderService failed because the task was cancelled.", ct);
+                });
+            observer.Subscribe(
+                nameof(LocalReminderService),
                 ServiceLifecycleStage.Active,
                 async ct =>
                 {
-                    using var timeoutCancellation = new CancellationTokenSource(initTimeout);
-                    var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCancellation.Token);
+                    using var timeoutCancellation = new CancellationTokenSource(this.reminderOptions.InitializationTimeout);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCancellation.Token);
                     await this.QueueTask(Start)
-                        .WithCancellation($"Starting ReminderService failed due to timeout {initTimeout}", ct);
+                        .WithCancellation($"Starting ReminderService failed because the task was canceled.", cts.Token);
                 },
-                ct =>
-                {
-                    return this.QueueTask(Stop)
-                        .WithCancellation("Stopping ReminderService failed because the task was cancelled", ct);
-                });
+                ct => Task.CompletedTask);
         }
 
         /// <summary>
         /// Attempt to retrieve reminders, that are my responsibility, from the global reminder table when starting this silo (reminder service instance)
         /// </summary>
         /// <returns></returns>
-        public override async Task Start()
+        private async Task Initialize(CancellationToken cancellationToken)
         {
-            // confirm that it can access the underlying store, as after this the ReminderService will load in the background, without the opportunity to prevent the Silo from starting
-            await reminderTable.Init().WithTimeout(initTimeout, $"ReminderTable Initialization failed due to timeout {initTimeout}");
+            using var timeoutCancellation = new CancellationTokenSource(this.reminderOptions.InitializationTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellation.Token);
 
-            _ = base.Start();
+            // Confirm that it can access the underlying store, as after this the ReminderService will load in the background, without the opportunity to prevent the Silo from starting
+            await reminderTable.StartAsync(cts.Token);
         }
 
         public async override Task Stop()
         {
-            _ = base.Stop();
+            await base.Stop();
 
             if (listRefreshTimer != null)
             {
@@ -113,7 +120,9 @@ namespace Orleans.Runtime.ReminderService
                 r.StopReminder();
             }
 
-            // for a graceful shutdown, also handover reminder responsibilities to new owner, and update the ReminderTable
+            await reminderTable.StopAsync();
+
+            // For a graceful shutdown, also handover reminder responsibilities to new owner, and update the ReminderTable
             // currently, this is taken care of by periodically reading the reminder table
         }
 

--- a/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -16,8 +17,18 @@ namespace Orleans
         /// <summary>
         /// Initializes this instance.
         /// </summary>
-        /// <returns>A Task representing the work performed.</returns>
-        Task Init();
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task StartAsync(CancellationToken cancellationToken = default)
+#pragma warning disable CS0618 // Type or member is obsolete
+            => Init();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        [Obsolete("Implement and use StartAsync instead")]
+        Task Init() => Task.CompletedTask;
 
         /// <summary>
         /// Reads the reminder table entries associated with the specified grain.
@@ -63,6 +74,13 @@ namespace Orleans
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
         Task TestOnlyClearTable();
+
+        /// <summary>
+        /// Stops the reminder table.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Tester.Cosmos/ReminderTests_Cosmos_Standalone.cs
@@ -42,7 +42,8 @@ public class ReminderTests_Cosmos_Standalone
         storageOptions.Value.ConfigureTestDefaults();
 
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        await table.Init();
+        using var cancellation = new CancellationTokenSource(new ReminderOptions().InitializationTimeout);
+        await table.StartAsync(cancellation.Token);
 
         await TestTableInsertRate(table, 10);
         await TestTableInsertRate(table, 500);
@@ -56,7 +57,8 @@ public class ReminderTests_Cosmos_Standalone
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        await table.Init();
+        using var cancellation = new CancellationTokenSource(new ReminderOptions().InitializationTimeout);
+        await table.StartAsync(cancellation.Token);
 
         ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
         Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);

--- a/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -45,7 +45,7 @@ namespace Tester.AzureUtils.TimerTests
             storageOptions.Value.ConfigureTestDefaults();
 
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.Init();
+            await table.StartAsync();
 
             await TestTableInsertRate(table, 10);
             await TestTableInsertRate(table, 500);
@@ -59,7 +59,7 @@ namespace Tester.AzureUtils.TimerTests
             var storageOptions = Options.Create(new AzureTableReminderStorageOptions());
             storageOptions.Value.ConfigureTestDefaults();
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.Init();
+            await table.StartAsync();
 
             ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
             Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.TestingHost.Utils;
-using Orleans.Internal;
 
 namespace UnitTests.RemindersTest
 {
@@ -42,7 +41,8 @@ namespace UnitTests.RemindersTest
 
         public virtual async Task InitializeAsync()
         {
-            await this.remindersTable.Init().WithTimeout(TimeSpan.FromMinutes(1));
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await this.remindersTable.StartAsync(cancellation.Token);
         }
 
         public virtual async Task DisposeAsync()


### PR DESCRIPTION
It is possible that the `IReminderTable` implementation might be accessed before it has been successfully initialized. This PR ensures that is not the case for `LocalReminderService` by initializing the table before starting the `LocalReminderService` and before grains are allowed to start.

While doing so, I also implemented support for `CancellationToken` in `IReminderTable` for startup/shutdown, obsoleting the existing `Init()` method and replacing it with `StartAsync(CancellationToken)`, adding a new `StopAsync(CancellationToken)`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8982)