### PR TITLE
Fix serialization of types inheriting from `Dictionary<K,V>` which add values in their constructor

### DIFF
--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
@@ -17,7 +19,7 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
     [RegisterSerializer]
-    public sealed class DictionaryCodec<TKey, TValue> : IFieldCodec<Dictionary<TKey, TValue>>
+    public sealed class DictionaryCodec<TKey, TValue> : IFieldCodec<Dictionary<TKey, TValue>> where TKey : notnull
     {
         private readonly Type _keyFieldType = typeof(TKey);
         private readonly Type _valueFieldType = typeof(TValue);
@@ -83,10 +85,10 @@ namespace Orleans.Serialization.Codecs
             field.EnsureWireTypeTagDelimited();
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
-            TKey key = default;
+            TKey? key = default;
             var valueExpected = false;
-            Dictionary<TKey, TValue> result = null;
-            IEqualityComparer<TKey> comparer = null;
+            Dictionary<TKey, TValue>? result = null;
+            IEqualityComparer<TKey>? comparer = null;
             uint fieldId = 0;
             while (true)
             {
@@ -122,7 +124,7 @@ namespace Orleans.Serialization.Codecs
                         }
                         else
                         {
-                            result.Add(key, _valueCodec.ReadValue(ref reader, header));
+                            result!.Add(key!, _valueCodec.ReadValue(ref reader, header));
                             valueExpected = false;
                         }
                         break;
@@ -136,7 +138,7 @@ namespace Orleans.Serialization.Codecs
             return result;
         }
 
-        private Dictionary<TKey, TValue> CreateInstance(int length, IEqualityComparer<TKey> comparer, SerializerSession session, uint placeholderReferenceId)
+        private Dictionary<TKey, TValue> CreateInstance(int length, IEqualityComparer<TKey>? comparer, SerializerSession session, uint placeholderReferenceId)
         {
             var result = new Dictionary<TKey, TValue>(length, comparer);
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
@@ -155,10 +157,11 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="TKey">The type of the t key.</typeparam>
     /// <typeparam name="TValue">The type of the t value.</typeparam>
     [RegisterCopier]
-    public sealed class DictionaryCopier<TKey, TValue> : IDeepCopier<Dictionary<TKey, TValue>>, IBaseCopier<Dictionary<TKey, TValue>>
+    public sealed class DictionaryCopier<TKey, TValue> : IDeepCopier<Dictionary<TKey, TValue>>, IBaseCopier<Dictionary<TKey, TValue>> where TKey : notnull
     {
         private readonly IDeepCopier<TKey> _keyCopier;
         private readonly IDeepCopier<TValue> _valueCopier;
+        private readonly ConstructorInfo _baseConstructor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DictionaryCopier{TKey, TValue}"/> class.
@@ -169,6 +172,7 @@ namespace Orleans.Serialization.Codecs
         {
             _keyCopier = keyCopier;
             _valueCopier = valueCopier;
+            _baseConstructor = typeof(Dictionary<TKey, TValue>).GetConstructor([typeof(int), typeof(IEqualityComparer<TKey>)])!;
         }
 
         /// <inheritdoc/>
@@ -197,6 +201,12 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public void DeepCopy(Dictionary<TKey, TValue> input, Dictionary<TKey, TValue> output, CopyContext context)
         {
+            output.Clear();
+            if (input.Comparer is { } comparer)
+            {
+                _baseConstructor.Invoke(output, [input.Count, comparer]);
+            }
+
             foreach (var pair in input)
             {
                 output[_keyCopier.DeepCopy(pair.Key, context)] = _valueCopier.DeepCopy(pair.Value, context);
@@ -210,7 +220,7 @@ namespace Orleans.Serialization.Codecs
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
     [RegisterSerializer]
-    public sealed class DictionaryBaseCodec<TKey, TValue> : IBaseCodec<Dictionary<TKey, TValue>>
+    public sealed class DictionaryBaseCodec<TKey, TValue> : IBaseCodec<Dictionary<TKey, TValue>> where TKey : notnull
     {
         private readonly Type _keyFieldType = typeof(TKey);
         private readonly Type _valueFieldType = typeof(TValue);
@@ -234,7 +244,7 @@ namespace Orleans.Serialization.Codecs
             _keyCodec = OrleansGeneratedCodeHelper.UnwrapService(this, keyCodec);
             _valueCodec = OrleansGeneratedCodeHelper.UnwrapService(this, valueCodec);
             _comparerCodec = OrleansGeneratedCodeHelper.UnwrapService(this, comparerCodec);
-            _baseConstructor = typeof(Dictionary<TKey, TValue>).GetConstructor(new Type[] { typeof(int), typeof(IEqualityComparer<TKey>) });
+            _baseConstructor = typeof(Dictionary<TKey, TValue>).GetConstructor([typeof(int), typeof(IEqualityComparer<TKey>)])!;
         }
 
         void IBaseCodec<Dictionary<TKey, TValue>>.Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Dictionary<TKey, TValue> value)
@@ -259,9 +269,13 @@ namespace Orleans.Serialization.Codecs
 
         void IBaseCodec<Dictionary<TKey, TValue>>.Deserialize<TInput>(ref Reader<TInput> reader, Dictionary<TKey, TValue> value)
         {
-            TKey key = default;
+            // If the dictionary has some values added by the default constructor, clear them.
+            // If those values are in the serialized payload, they will be added below.
+            value.Clear();
+
+            TKey? key = default;
             var valueExpected = false;
-            IEqualityComparer<TKey> comparer = null;
+            IEqualityComparer<TKey>? comparer = null;
             uint fieldId = 0;
             bool hasLengthField = false;
             while (true)
@@ -286,7 +300,8 @@ namespace Orleans.Serialization.Codecs
                         }
 
                         hasLengthField = true;
-                        _baseConstructor.Invoke(value, new object[] { length, comparer });
+                        _baseConstructor.Invoke(value, [length, comparer]);
+
                         break;
                     case 2:
                         if (!hasLengthField)
@@ -301,7 +316,7 @@ namespace Orleans.Serialization.Codecs
                         }
                         else
                         {
-                            value.Add(key, _valueCodec.ReadValue(ref reader, header));
+                            value.Add(key!, _valueCodec.ReadValue(ref reader, header));
                             valueExpected = false;
                         }
                         break;

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -2389,6 +2389,40 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Dictionary<string, int> left, Dictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
+    [GenerateSerializer]
+    public class TypeWithDictionaryBase : Dictionary<string, int>
+    {
+        public TypeWithDictionaryBase() : this(true) { }
+        public TypeWithDictionaryBase(bool addDefaultValue)
+        {
+            if (addDefaultValue)
+            {
+                this["key"] = 1;
+            }
+        }
+
+        [Id(0)]
+        public int OtherProperty { get; set; }
+
+        public override string ToString() => $"[OtherProperty: {OtherProperty}, Values: [{string.Join(", ", this.Select(kvp => $"[{kvp.Key}] = '{kvp.Value}'"))}]]";
+    }
+
+    public class DictionaryBaseCodecTests(ITestOutputHelper output) : FieldCodecTester<TypeWithDictionaryBase, IFieldCodec<TypeWithDictionaryBase>>(output)
+    {
+        protected override TypeWithDictionaryBase[] TestValues => [null, new(), new(addDefaultValue: false), new() { ["foo"] = 15 }, new() { ["foo"] = 15, OtherProperty = 123 }];
+
+        protected override TypeWithDictionaryBase CreateValue() => new() { OtherProperty = Random.Next() };
+        protected override bool Equals(TypeWithDictionaryBase left, TypeWithDictionaryBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
+    }
+
+    public class DictionaryBaseCopierTests(ITestOutputHelper output) : CopierTester<TypeWithDictionaryBase, IDeepCopier<TypeWithDictionaryBase>>(output)
+    {
+        protected override TypeWithDictionaryBase[] TestValues => [null, new(), new(addDefaultValue: false), new() { ["foo"] = 15 }, new() { ["foo"] = 15, OtherProperty = 123 }];
+
+        protected override TypeWithDictionaryBase CreateValue() => new() { OtherProperty = Random.Next() };
+        protected override bool Equals(TypeWithDictionaryBase left, TypeWithDictionaryBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
+    }
+
     public class DictionaryWithComparerCodecTests(ITestOutputHelper output) : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>(output)
     {
         protected override int[] MaxSegmentSizes => [1024];
@@ -2483,7 +2517,7 @@ namespace Orleans.Serialization.UnitTests
 
         protected override Dictionary<string, int>[] TestValues => [null, new Dictionary<string, int>(), CreateValue(), CreateValue(), CreateValue()];
 
-        protected override bool Equals(Dictionary<string, int> left, Dictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
+        protected override bool Equals(Dictionary<string, int> left, Dictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.Comparer?.GetType() == right.Comparer?.GetType();
     }
 
     public class ConcurrentDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCodec<string, int>>(output)


### PR DESCRIPTION
Fixes https://github.com/dotnet/orleans/issues/8989
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/8993)