### PR TITLE
Dispose all activations when host is disposed

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -1,11 +1,13 @@
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Orleans.Runtime;
 
-internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>
+internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IGrainContext>>, IAsyncDisposable, IDisposable
 {
     private int _activationsCount;
 
@@ -43,4 +45,47 @@ internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IG
     public IEnumerator<KeyValuePair<GrainId, IGrainContext>> GetEnumerator() => _activations.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        var tasks = new List<Task>();
+        foreach (var (_, value) in _activations)
+        {
+            try
+            {
+                if (value is IAsyncDisposable asyncDisposable)
+                {
+                    tasks.Add(asyncDisposable.DisposeAsync().AsTask());
+                }
+                else if (value is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            catch
+            {
+                // Ignore exceptions during disposal.
+            }
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+    }
+
+    void IDisposable.Dispose()
+    {
+        foreach (var (_, value) in _activations)
+        {
+            try
+            {
+                if (value is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            catch
+            {
+                // Ignore exceptions during disposal.
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #8899

Disposes all activations, including SystemTargets, when the host is disposed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9001)