### PR TITLE
[CodeGen] Always specify grain extension interface for grain extension calls

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -674,7 +674,7 @@ namespace Orleans.CodeGenerator
             return description;
         }
 
-        internal ProxyMethodDescription GetProxyMethodDescription(INamedTypeSymbol interfaceType, IMethodSymbol method, bool hasCollision)
+        internal ProxyMethodDescription GetProxyMethodDescription(INamedTypeSymbol interfaceType, IMethodSymbol method)
         {
             var originalMethod = method.OriginalDefinition;
             var proxyBaseInfo = GetProxyBase(interfaceType);
@@ -713,7 +713,7 @@ namespace Orleans.CodeGenerator
                 }
             }
 
-            var proxyMethodDescription = ProxyMethodDescription.Create(interfaceDescription, generatedInvokable, method, hasCollision);
+            var proxyMethodDescription = ProxyMethodDescription.Create(interfaceDescription, generatedInvokable, method);
 
             // For backwards compatibility, generate invokers for the specific implementation types as well, where they differ.
             if (Options.GenerateCompatibilityInvokers && !SymbolEqualityComparer.Default.Equals(method.OriginalDefinition.ContainingType, interfaceType))

--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -678,7 +678,14 @@ namespace Orleans.CodeGenerator
         {
             var originalMethod = method.OriginalDefinition;
             var proxyBaseInfo = GetProxyBase(interfaceType);
-            var invokableId = new InvokableMethodId(proxyBaseInfo, originalMethod);
+
+            // For extensions, we want to ensure that the containing type is always the extension.
+            // This ensures that we will always know which 'component' to get in our SetTarget method.
+            // If the type is not an extension, use the original method definition's containing type.
+            // This is the interface where the type was originally defined.
+            var containingType = proxyBaseInfo.IsExtension ? interfaceType : originalMethod.ContainingType;
+
+            var invokableId = new InvokableMethodId(proxyBaseInfo, containingType, originalMethod);
             var interfaceDescription = GetInvokableInterfaceDescription(invokableId.ProxyBase.ProxyBaseType, interfaceType);
 
             // Get or generate an invokable for the original method definition.
@@ -686,7 +693,7 @@ namespace Orleans.CodeGenerator
             {
                 if (!_invokableMethodDescriptions.TryGetValue(invokableId, out var methodDescription))
                 {
-                    methodDescription = _invokableMethodDescriptions[invokableId] = InvokableMethodDescription.Create(invokableId);
+                    methodDescription = _invokableMethodDescriptions[invokableId] = InvokableMethodDescription.Create(invokableId, containingType);
                 }
 
                 generatedInvokable = MetadataModel.GeneratedInvokables[invokableId] = InvokableGenerator.Generate(methodDescription);
@@ -711,7 +718,7 @@ namespace Orleans.CodeGenerator
             // For backwards compatibility, generate invokers for the specific implementation types as well, where they differ.
             if (Options.GenerateCompatibilityInvokers && !SymbolEqualityComparer.Default.Equals(method.OriginalDefinition.ContainingType, interfaceType))
             {
-                var compatInvokableId = new InvokableMethodId(proxyBaseInfo, method);
+                var compatInvokableId = new InvokableMethodId(proxyBaseInfo, interfaceType, method);
                 var compatMethodDescription = InvokableMethodDescription.Create(compatInvokableId, interfaceType);
                 var compatInvokable = InvokableGenerator.Generate(compatMethodDescription);
                 AddMember(compatInvokable.GeneratedNamespace, compatInvokable.ClassDeclarationSyntax);

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -226,8 +226,10 @@ namespace Orleans.CodeGenerator
             INamedTypeSymbol containingInterface,
             string methodId)
         {
-            var proxyBaseComponents = invokableId.ProxyBase.CompositeAliasComponents;
-            var alias = new CompoundTypeAliasComponent[1 + proxyBaseComponents.Length + 2];
+            var proxyBase = invokableId.ProxyBase;
+            var proxyBaseComponents = proxyBase.CompositeAliasComponents;
+            var extensionArgCount = proxyBase.IsExtension ? 1 : 0;
+            var alias = new CompoundTypeAliasComponent[1 + proxyBaseComponents.Length + extensionArgCount + 2];
             alias[0] = new("inv");
             for (var i = 0; i < proxyBaseComponents.Length; i++)
             {
@@ -235,7 +237,15 @@ namespace Orleans.CodeGenerator
             }
 
             alias[1 + proxyBaseComponents.Length] = new(containingInterface);
-            alias[1 + proxyBaseComponents.Length + 1] = new(methodId);
+
+            // For grain extensions, also explicitly include the method's containing type.
+            // This is to distinguish between different extension methods with the same id (eg, alias) but different containing types.
+            if (proxyBase.IsExtension)
+            {
+                alias[1 + proxyBaseComponents.Length + 1] = new(invokableId.Method.ContainingType);
+            }
+
+            alias[1 + proxyBaseComponents.Length + extensionArgCount + 1] = new(methodId);
             return alias;
         }
 

--- a/src/Orleans.CodeGenerator/Model/InvokableMethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableMethodDescription.cs
@@ -14,12 +14,12 @@ namespace Orleans.CodeGenerator
     /// </summary>
     internal sealed class InvokableMethodDescription : IEquatable<InvokableMethodDescription>
     {
-        public static InvokableMethodDescription Create(InvokableMethodId method, INamedTypeSymbol containingType = null) => new(method, containingType);
+        public static InvokableMethodDescription Create(InvokableMethodId method, INamedTypeSymbol containingType) => new(method, containingType);
 
         private InvokableMethodDescription(InvokableMethodId invokableId, INamedTypeSymbol containingType)
         {
             Key = invokableId;
-            ContainingInterface = containingType ?? invokableId.Method.ContainingType;
+            ContainingInterface = containingType;
             GeneratedMethodId = CodeGenerator.CreateHashedMethodId(Method);
             MethodId = CodeGenerator.GetId(Method)?.ToString(CultureInfo.InvariantCulture) ?? CodeGenerator.GetAlias(Method) ?? GeneratedMethodId;
 
@@ -209,6 +209,6 @@ namespace Orleans.CodeGenerator
         public bool Equals(InvokableMethodDescription other) => Key.Equals(other.Key);
         public override bool Equals(object obj) => obj is InvokableMethodDescription imd && Equals(imd);
         public override int GetHashCode() => Key.GetHashCode();
-        public override string ToString() => $"{ProxyBase}/{Method.ContainingType.Name}/{Method.Name}";
+        public override string ToString() => $"{ProxyBase}/{ContainingInterface.Name}/{Method.Name}";
     }
 }

--- a/src/Orleans.CodeGenerator/Model/InvokableMethodId.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableMethodId.cs
@@ -6,30 +6,39 @@ namespace Orleans.CodeGenerator
     /// <summary>
     /// Identifies an invokable method.
     /// </summary>
-    internal readonly struct InvokableMethodId : IEquatable<InvokableMethodId>
+    internal readonly struct InvokableMethodId(InvokableMethodProxyBase proxyBaseInfo, INamedTypeSymbol interfaceType, IMethodSymbol method) : IEquatable<InvokableMethodId>
     {
-        public InvokableMethodId(InvokableMethodProxyBase proxyBaseInfo, IMethodSymbol method)
-        {
-            ProxyBase = proxyBaseInfo;
-            Method = method;
-        }
-
         /// <summary>
         /// Gets the proxy base information for the method (eg, GrainReference, whether it is an extension).
         /// </summary>
-        public InvokableMethodProxyBase ProxyBase { get; }
+        public InvokableMethodProxyBase ProxyBase { get; } = proxyBaseInfo;
 
         /// <summary>
         /// Gets the method symbol.
         /// </summary>
-        public IMethodSymbol Method { get; }
+        public IMethodSymbol Method { get; } = method;
+
+        /// <summary>
+        /// Gets the containing interface symbol.
+        /// </summary>
+        public INamedTypeSymbol InterfaceType { get; } = interfaceType;
 
         public bool Equals(InvokableMethodId other) =>
             ProxyBase.Equals(other.ProxyBase)
-            && SymbolEqualityComparer.Default.Equals(Method, other.Method);
+            && SymbolEqualityComparer.Default.Equals(Method, other.Method)
+            && SymbolEqualityComparer.Default.Equals(InterfaceType, other.InterfaceType);
 
         public override bool Equals(object obj) => obj is InvokableMethodId imd && Equals(imd);
-        public override int GetHashCode() => ProxyBase.GetHashCode() * 17 ^ SymbolEqualityComparer.Default.GetHashCode(Method);
-        public override string ToString() => $"{ProxyBase}/{Method.ContainingType.Name}/{Method.Name}";
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ProxyBase.GetHashCode()
+                    * 17 ^ SymbolEqualityComparer.Default.GetHashCode(Method)
+                    * 17 ^ SymbolEqualityComparer.Default.GetHashCode(InterfaceType);
+            }
+        }
+
+        public override string ToString() => $"{ProxyBase}/{InterfaceType.Name}/{Method.Name}";
     }
 }

--- a/src/Orleans.CodeGenerator/Model/ProxyInterfaceDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ProxyInterfaceDescription.cs
@@ -72,33 +72,19 @@ namespace Orleans.CodeGenerator
 
         public CodeGenerator CodeGenerator { get; }
 
-        private List<ProxyMethodDescription> GetMethods(INamedTypeSymbol symbol)
+        private List<ProxyMethodDescription> GetMethods()
         {
-#pragma warning disable RS1024 // Symbols should be compared for equality
-            var methods = new Dictionary<IMethodSymbol, bool>(MethodSignatureComparer.Default);
-#pragma warning restore RS1024 // Symbols should be compared for equality
-            foreach (var iface in GetAllInterfaces(symbol))
+            var result = new List<ProxyMethodDescription>();
+            foreach (var iface in GetAllInterfaces(InterfaceType))
             {
                 foreach (var method in iface.GetDeclaredInstanceMembers<IMethodSymbol>())
                 {
-                    if (methods.TryGetValue(method, out _))
-                    {
-                        methods[method] = true;
-                        continue;
-                    }
-
-                    methods.Add(method, false);
+                    var methodDescription = CodeGenerator.GetProxyMethodDescription(InterfaceType, method: method);
+                    result.Add(methodDescription);
                 }
             }
 
-            var res = new List<ProxyMethodDescription>();
-            foreach (var pair in methods)
-            {
-                var methodDescription = CodeGenerator.GetProxyMethodDescription(symbol, method: pair.Key, hasCollision: pair.Value);
-                res.Add(methodDescription);
-            }
-
-            return res;
+            return result;
 
             static IEnumerable<INamedTypeSymbol> GetAllInterfaces(INamedTypeSymbol s)
             {
@@ -117,7 +103,7 @@ namespace Orleans.CodeGenerator
 
         public string Name { get; }
         public INamedTypeSymbol InterfaceType { get; }
-        public List<ProxyMethodDescription> Methods => _methods ??= GetMethods(InterfaceType); 
+        public List<ProxyMethodDescription> Methods => _methods ??= GetMethods(); 
         public SemanticModel SemanticModel { get; }
         public string GeneratedNamespace { get; }
         public List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters { get; }

--- a/src/Orleans.CodeGenerator/Model/ProxyMethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ProxyMethodDescription.cs
@@ -79,7 +79,6 @@ namespace Orleans.CodeGenerator
         public ConstructedGeneratedInvokableDescription GeneratedInvokable { get; }
         public ProxyInterfaceDescription ProxyInterface { get; }
 
-        public bool HasCollision { get; }   
         public IMethodSymbol Method { get; }
         public InvokableMethodId InvokableId { get; }
         public List<(string Name, ITypeParameterSymbol Parameter)> TypeParameters { get; }

--- a/src/Orleans.CodeGenerator/Model/ProxyMethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/ProxyMethodDescription.cs
@@ -21,15 +21,14 @@ namespace Orleans.CodeGenerator
         public static ProxyMethodDescription Create(
             ProxyInterfaceDescription proxyInterface,
             GeneratedInvokableDescription generatedInvokable,
-            IMethodSymbol method,
-            bool hasCollision) => new(proxyInterface, generatedInvokable, method, hasCollision);
+            IMethodSymbol method)
+            => new(proxyInterface, generatedInvokable, method);
 
-        private ProxyMethodDescription(ProxyInterfaceDescription proxyInterface, GeneratedInvokableDescription generatedInvokable, IMethodSymbol method, bool hasCollision)
+        private ProxyMethodDescription(ProxyInterfaceDescription proxyInterface, GeneratedInvokableDescription generatedInvokable, IMethodSymbol method)
         {
             _originalInvokable = generatedInvokable;
             Method = method;
             ProxyInterface = proxyInterface;
-            HasCollision = hasCollision;
 
             TypeParameters = new List<(string Name, ITypeParameterSymbol Parameter)>();
             MethodTypeParameters = new List<(string Name, ITypeParameterSymbol Parameter)>();

--- a/src/Orleans.CodeGenerator/ProxyGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxyGenerator.cs
@@ -113,7 +113,7 @@ namespace Orleans.CodeGenerator
                 {
                     declaration = declaration.WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)));
 
-                    // Type parameter constrains are not valid on explicit interface definitions
+                    // Type parameter constraints are not valid on explicit interface definitions
                     var typeParameters = SyntaxFactoryUtility.GetTypeParameterConstraints(methodDescription.MethodTypeParameters);
                     foreach (var (name, constraints) in typeParameters)
                     {

--- a/src/Orleans.CodeGenerator/ProxyGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxyGenerator.cs
@@ -109,26 +109,8 @@ namespace Orleans.CodeGenerator
                     declaration = declaration.WithModifiers(TokenList(Token(SyntaxKind.AsyncKeyword)));
                 }
 
-                if (methodDescription.HasCollision)
-                {
-                    declaration = declaration.WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)));
-
-                    // Type parameter constraints are not valid on explicit interface definitions
-                    var typeParameters = SyntaxFactoryUtility.GetTypeParameterConstraints(methodDescription.MethodTypeParameters);
-                    foreach (var (name, constraints) in typeParameters)
-                    {
-                        if (constraints.Count > 0)
-                        {
-                            declaration = declaration.AddConstraintClauses(
-                                TypeParameterConstraintClause(name).AddConstraints(constraints.ToArray()));
-                        }
-                    }
-                }
-                else
-                {
-                    var explicitInterfaceSpecifier = ExplicitInterfaceSpecifier(methodDescription.Method.ContainingType.ToNameSyntax());
-                    declaration = declaration.WithExplicitInterfaceSpecifier(explicitInterfaceSpecifier);
-                }
+                var explicitInterfaceSpecifier = ExplicitInterfaceSpecifier(methodDescription.Method.ContainingType.ToNameSyntax());
+                declaration = declaration.WithExplicitInterfaceSpecifier(explicitInterfaceSpecifier);
 
                 if (methodDescription.MethodTypeParameters.Count > 0)
                 {

--- a/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainCallContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.Runtime;
@@ -74,12 +75,12 @@ namespace Orleans
         /// <summary>
         /// Gets or sets the result.
         /// </summary>
-        object Result { get; set; }
+        object? Result { get; set; }
        
         /// <summary>
         /// Gets or sets the response.
         /// </summary>
-        Response Response { get; set; }
+        Response? Response { get; set; }
 
         /// <summary>
         /// Invokes the request.
@@ -114,6 +115,6 @@ namespace Orleans
         /// <summary>
         /// Gets the grain context of the sender.
         /// </summary>
-        public IGrainContext SourceContext { get; }
+        public IGrainContext? SourceContext { get; }
     }
 }

--- a/src/Orleans.Core.Abstractions/Placement/ResourceOptimizedPlacement.cs
+++ b/src/Orleans.Core.Abstractions/Placement/ResourceOptimizedPlacement.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime;
 /// Following the <u>power of k-choices</u> algorithm, K silos are picked as potential targets, where K is equal to the square root of the number of silos.
 /// Out of those K silos, the one with the lowest score is chosen for placing the activation. Normalization ensures that each property contributes proportionally
 /// to the overall score. You can adjust the weights based on your specific requirements and priorities for load balancing.
-/// In addition to normalization, an <u>online adaptiv</u> algorithm provides a smoothing effect (filters out high frequency components) and avoids rapid signal
+/// In addition to normalization, an <u>online adaptive</u> algorithm provides a smoothing effect (filters out high frequency components) and avoids rapid signal
 /// drops by transforming it into a polynomial-like decay process. This contributes to avoiding resource saturation on the silos and especially newly joined silos.</para>
 /// <para>Silos which are overloaded by definition of the load shedding mechanism are not considered as candidates for new placements.</para>
 /// <para><i>This placement strategy is configured by adding the <see cref="Placement.ResourceOptimizedPlacementAttribute"/> attribute to a grain.</i></para>

--- a/test/DefaultCluster.Tests/GrainInterfaceHierarchyTests.cs
+++ b/test/DefaultCluster.Tests/GrainInterfaceHierarchyTests.cs
@@ -90,7 +90,6 @@ namespace DefaultCluster.Tests
             Assert.Equal(11, await doSomethingCombinedGrain.GetA());
             Assert.Equal(11, await doSomethingCombinedGrain.GetB());
             Assert.Equal(11, await doSomethingCombinedGrain.GetC());
-
         }
     }
 }

--- a/test/DefaultCluster.Tests/PolymorphicInterfaceTest.cs
+++ b/test/DefaultCluster.Tests/PolymorphicInterfaceTest.cs
@@ -73,6 +73,20 @@ namespace DefaultCluster.Tests.General
             Assert.Equal("B3", await serviceRef.B3Method());
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Cast")]
+        public async Task Polymorphic_InheritedMethodAmbiguity()
+        {
+            // Tests interface inheritance hierarchies which involve duplicate method names, requiring casting to resolve the ambiguity.
+            var grainFullName = typeof(ServiceType).FullName;
+            var serviceRef = this.GrainFactory.GetGrain<IServiceType>(GetRandomGrainId(), grainFullName);
+            var ia = (IA)serviceRef;
+            var ib = (IB)serviceRef;
+            var ic = (IC)serviceRef;
+            Assert.Equal("IA", await ia.CommonMethod());
+            Assert.Equal("IB", await ib.CommonMethod());
+            Assert.Equal("IC", await ic.CommonMethod());
+        }
+
         /// <summary>
         /// This unit test should consolidate all the use cases we are trying to cover with regard to polymorphic grain references
         /// </summary>

--- a/test/Grains/TestGrainInterfaces/UnitTestGrainInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/UnitTestGrainInterfaces.cs
@@ -1,7 +1,8 @@
-﻿namespace UnitTests.GrainInterfaces
+namespace UnitTests.GrainInterfaces
 {
     public interface IA : IGrainWithIntegerKey
     {
+        Task<string> CommonMethod();
         Task<string> A1Method();
         Task<string> A2Method();
         Task<string> A3Method();
@@ -9,6 +10,7 @@
 
     public interface IB : IGrainWithIntegerKey
     {
+        Task<string> CommonMethod();
         Task<string> B1Method();
         Task<string> B2Method();
         Task<string> B3Method();
@@ -16,6 +18,7 @@
 
     public interface IC : IA, IB
     {
+        new Task<string> CommonMethod();
         Task<string> C1Method();
         Task<string> C2Method();
         Task<string> C3Method();

--- a/test/Grains/TestGrains/PolymorphicTestGrain.cs
+++ b/test/Grains/TestGrains/PolymorphicTestGrain.cs
@@ -1,99 +1,29 @@
-﻿using UnitTests.GrainInterfaces;
+using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
     public class PolymorphicTestGrain : Grain, IPolymorphicTestGrain
     {
-        public Task<string> F1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling F1Method");
-            return Task.FromResult("F1");
-        }
-        public Task<string> F2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling F2Method");
-            return Task.FromResult("F2");
-        }
-        public Task<string> F3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling F3Method");
-            return Task.FromResult("F3");
-        }
-        public Task<string> E1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling E1Method");
-            return Task.FromResult("E1");
-        }
-        public Task<string> E2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling E2Method");
-            return Task.FromResult("E2");
-        }
-        public Task<string> E3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling E3Method");
-            return Task.FromResult("E3");
-        }
-        public Task<string> D1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling D1Method");
-            return Task.FromResult("D1");
-        }
-        public Task<string> D2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling D2Method");
-            return Task.FromResult("D2");
-        }
-        public Task<string> D3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling D3Method");
-            return Task.FromResult("D3");
-        }
-        public Task<string> C1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling C1Method");
-            return Task.FromResult("C1");
-        }
-        public Task<string> C2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling C2Method");
-            return Task.FromResult("C2");
-        }
-        public Task<string> C3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling C3Method");
-            return Task.FromResult("C3");
-        }
-        public Task<string> B1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling B1Method");
-            return Task.FromResult("B1");
-        }
-        public Task<string> B2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling B2Method");
-            return Task.FromResult("B2");
-        }
-        public Task<string> B3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling B3Method");
-            return Task.FromResult("B3");
-        }
-        public Task<string> A1Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling A1Method");
-            return Task.FromResult("A1");
-        }
-        public Task<string> A2Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling A2Method");
-            return Task.FromResult("A2");
-        }
-        public Task<string> A3Method()
-        {
-            System.Diagnostics.Trace.WriteLine("Calling A3Method");
-            return Task.FromResult("A3");
-        }
-
+        public Task<string> F1Method() => Task.FromResult("F1");
+        public Task<string> F2Method() => Task.FromResult("F2");
+        public Task<string> F3Method() => Task.FromResult("F3");
+        public Task<string> E1Method() => Task.FromResult("E1");
+        public Task<string> E2Method() => Task.FromResult("E2");
+        public Task<string> E3Method() => Task.FromResult("E3");
+        public Task<string> D1Method() => Task.FromResult("D1");
+        public Task<string> D2Method() => Task.FromResult("D2");
+        public Task<string> D3Method() => Task.FromResult("D3");
+        public Task<string> C1Method() => Task.FromResult("C1");
+        public Task<string> C2Method() => Task.FromResult("C2");
+        public Task<string> C3Method() => Task.FromResult("C3");
+        public Task<string> B1Method() => Task.FromResult("B1");
+        public Task<string> B2Method() => Task.FromResult("B2");
+        public Task<string> B3Method() => Task.FromResult("B3");
+        public Task<string> A1Method() => Task.FromResult("A1");
+        public Task<string> A2Method() => Task.FromResult("A2");
+        public Task<string> A3Method() => Task.FromResult("A3");
+        Task<string> IC.CommonMethod() => Task.FromResult("IC");
+        Task<string> IA.CommonMethod() => Task.FromResult("IA");
+        Task<string> IB.CommonMethod() => Task.FromResult("IB");
     }
 }

--- a/test/Grains/TestGrains/ServiceType.cs
+++ b/test/Grains/TestGrains/ServiceType.cs
@@ -1,4 +1,4 @@
-﻿using UnitTests.GrainInterfaces;
+using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
@@ -96,5 +96,9 @@ namespace UnitTests.Grains
         {
             return Task.FromResult("ServiceTypeMethod3");
         }
+
+        Task<string> IC.CommonMethod() => Task.FromResult("IC");
+        Task<string> IA.CommonMethod() => Task.FromResult("IA");
+        Task<string> IB.CommonMethod() => Task.FromResult("IB");
     }
 }


### PR DESCRIPTION
In #8749, we changed how we generate invokers (essentially, closure classes which represent grain method invocations) so that we only generate one invoker for each original method definition. That was in response to an issue uncovered by one of the analyzers which @ledjon-behluli added: https://discord.com/channels/333727978460676096/922948121619751012/1179628138490232923, where it was previously impossible to add aliases to some types.

Unfortunately, that caused an issue, which @oising hit: for grain extensions, we need to know which extension interface to fetch from the grain so that we can execute the right method against it.

The following code snippet corresponds to the grain extension test interface added in this PR.
Notice that the `target` field is typed based on the original method definition's interface, while `SetTarget` uses the grain extension's interface. That is the desired outcome, ensuring we get the right extension while also calling the correct method overload.

```csharp
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "8.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
[global::Orleans.CompoundTypeAliasAttribute("inv", typeof(global::Orleans.Runtime.GrainReference), "Ext", typeof(global::UnitTests.General.IMyGrainExtension), "9DED4F7A")]
internal sealed class Invokable_IMyGrainExtension_GrainReference_Ext_9DED4F7A : global::Orleans.Runtime.Request
{
    public int arg0;
    global::UnitTests.General.IMyRegularInterface target;
    private static readonly global::System.Reflection.MethodInfo MethodBackingField = OrleansGeneratedCodeHelper.GetMethodInfoOrDefault(typeof(global::UnitTests.General.IMyRegularInterface), "SetExtensionValue", null, new[] { typeof(int) });
    public override int GetArgumentCount() => 1;
    public override string GetMethodName() => "SetExtensionValue";
    public override string GetInterfaceName() => "UnitTests.General.IMyRegularInterface";
    public override string GetActivityName() => "IMyRegularInterface/SetExtensionValue";
    public override global::System.Type GetInterfaceType() => typeof(global::UnitTests.General.IMyRegularInterface);
    public override global::System.Reflection.MethodInfo GetMethod() => MethodBackingField;
    public override void SetTarget(global::Orleans.Serialization.Invocation.ITargetHolder holder) => target = holder.GetComponent<global::UnitTests.General.IMyGrainExtension>();
    public override object GetTarget() => target;
    public override void Dispose()
    {
        arg0 = default;
        target = default;
    }

    public override object GetArgument(int index)
    {
        switch (index)
        {
            case 0:
                return arg0;
            default:
                return OrleansGeneratedCodeHelper.InvokableThrowArgumentOutOfRange(index, 0);
        }
    }

    public override void SetArgument(int index, object value)
    {
        switch (index)
        {
            case 0:
                arg0 = (int)value;
                return;
            default:
                OrleansGeneratedCodeHelper.InvokableThrowArgumentOutOfRange(index, 0);
                return;
        }
    }

    protected override global::System.Threading.Tasks.ValueTask InvokeInner() => target.SetExtensionValue(arg0);
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9009)