### PR TITLE
Fix for Recorded flag not propagated between activities

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,7 @@
 # Orleans Samples
 
-📢 This collection of samples has been moved to the official `dotnet/samples` repository and is part of the Samples browser experience.
+> [!IMPORTANT]
+> 📢 This collection of samples has been moved to the official [`dotnet/samples` repository](https://github.com/dotnet/samples/tree/main/orleans) and is part of the [Samples browser experience](https://learn.microsoft.com/en-us/samples/browse/?expanded=dotnet&products=dotnet-orleans).
 
 - :octocat: [dotnet/samples](https://github.com/dotnet/samples/tree/main/orleans)
 - :eyes: [Samples browser](https://learn.microsoft.com/samples/browse/?expanded=dotnet&products=dotnet-orleans)

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -144,8 +144,16 @@ namespace Orleans.Runtime
             var source = GetActivitySource(context);
             if (!string.IsNullOrEmpty(traceParent))
             {
-                ActivityContext.TryParse(traceParent, traceState, isRemote: true, out ActivityContext parentContext);
-                activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, parentContext);
+                if (ActivityContext.TryParse(traceParent, traceState, isRemote: true, out ActivityContext parentContext))
+                {
+                    // traceParent is a W3CId
+                    activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, parentContext);
+                }
+                else
+                {
+                    // Most likely, traceParent uses ActivityIdFormat.Hierarchical
+                    activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, traceParent);
+                }
 
                 if (activity is not null)
                 {

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -144,7 +144,8 @@ namespace Orleans.Runtime
             var source = GetActivitySource(context);
             if (!string.IsNullOrEmpty(traceParent))
             {
-                activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, traceParent);
+                ActivityContext.TryParse(traceParent, traceState, isRemote: true, out ActivityContext parentContext);
+                activity = source.CreateActivity(context.Request.GetActivityName(), ActivityKind.Server, parentContext);
 
                 if (activity is not null)
                 {


### PR DESCRIPTION
As discussed in #9011, create `ActivityContext` from `traceparent` and set `isRemote: true` to correctly propagate the `Recorded` flag.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9016)