### PR TITLE
Avoid changing soon-to-be-deprecated RegisterTimer method return type

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -95,7 +95,7 @@ namespace Orleans
         /// <param name="period">Period of subsequent timer ticks.</param>
         /// <returns>Handle for this Timer.</returns>
         /// <seealso cref="IDisposable"/>
-        protected IGrainTimer RegisterTimer(Func<object?, Task> asyncCallback, object? state, TimeSpan dueTime, TimeSpan period)
+        protected IDisposable RegisterTimer(Func<object?, Task> asyncCallback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             if (asyncCallback == null)
                 throw new ArgumentNullException(nameof(asyncCallback));

--- a/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
+++ b/src/Orleans.Core.Abstractions/Timers/ITimerRegistry.cs
@@ -26,7 +26,7 @@ public interface ITimerRegistry
     /// Specify <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable periodic signaling.
     /// </param>
     /// <returns>
-    /// An <see cref="IGrainTimer"/> instance which represents the timer.
+    /// An <see cref="IDisposable"/> instance which represents the timer.
     /// </returns>
-    IGrainTimer RegisterTimer(IGrainContext grainContext, Func<object?, Task> callback, object? state, TimeSpan dueTime, TimeSpan period);
+    IDisposable RegisterTimer(IGrainContext grainContext, Func<object?, Task> callback, object? state, TimeSpan dueTime, TimeSpan period);
 }

--- a/src/Orleans.Runtime/Timers/TimerRegistry.cs
+++ b/src/Orleans.Runtime/Timers/TimerRegistry.cs
@@ -10,7 +10,7 @@ internal class TimerRegistry(ILoggerFactory loggerFactory, TimeProvider timeProv
     private readonly ILogger _timerLogger = loggerFactory.CreateLogger<GrainTimer>();
     private readonly TimeProvider _timeProvider = timeProvider;
 
-    public IGrainTimer RegisterTimer(IGrainContext grainContext, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+    public IDisposable RegisterTimer(IGrainContext grainContext, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
     {
         var timer = new GrainTimer(grainContext, _timerLogger, asyncCallback, state, _timeProvider);
         grainContext?.GetComponent<IGrainTimerRegistry>().OnTimerCreated(timer);

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -158,7 +158,7 @@ namespace UnitTestGrains
         {
             logger.LogInformation("StartTimer Name={Name} Delay={Delay}", name, delay);
             if (timer is not null) throw new InvalidOperationException("Expected timer to be null");
-            this.timer = base.RegisterTimer(TimerTick, name, delay, Constants.INFINITE_TIMESPAN); // One shot timer
+            this.timer = (IGrainTimer)base.RegisterTimer(TimerTick, name, delay, Constants.INFINITE_TIMESPAN); // One shot timer
             this.timerName = name;
 
             return Task.CompletedTask;
@@ -169,7 +169,7 @@ namespace UnitTestGrains
             logger.LogInformation("StartTimer Name={Name} Delay={Delay}", name, delay);
             if (timer is not null) throw new InvalidOperationException("Expected timer to be null");
             var state = Tuple.Create<string, object>(operationType, name);
-            this.timer = base.RegisterTimer(TimerTickAdvanced, state, delay, Constants.INFINITE_TIMESPAN); // One shot timer
+            this.timer = (IGrainTimer)base.RegisterTimer(TimerTickAdvanced, state, delay, Constants.INFINITE_TIMESPAN); // One shot timer
             this.timerName = name;
 
             return Task.CompletedTask;


### PR DESCRIPTION
#8954 changed the public API for RegisterTimer. This broke OrleansTestKit in 8.2.0-preview1. This PR undoes that change. In the future, we will deprecate this API anyway, but this keeps things compatible.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9020)