### PR TITLE
Allow custom back-off providers for `PersistentStreamPullingAgent`

### DIFF
--- a/src/Orleans.Streaming/ISiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Streaming/ISiloPersistentStreamConfigurator.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Internal;
+using Orleans.Runtime.Providers;
 using Orleans.Streams;
 
 namespace Orleans.Hosting
@@ -41,6 +43,26 @@ namespace Orleans.Hosting
         /// <param name="configurator">The configuration builder.</param>
         /// <param name="factory">The partition balancer factory.</param>
         public static void ConfigurePartitionBalancing(this ISiloPersistentStreamConfigurator configurator, Func<IServiceProvider, string, IStreamQueueBalancer> factory)
+        {
+            configurator.ConfigureComponent(factory);
+        }
+
+        /// <summary>
+        /// Configures the pulling agents' message delivery backoff provider.
+        /// </summary>
+        /// <param name="configurator">The configuration builder.</param>
+        /// <param name="factory">The message delivery backoff factory.</param>
+        public static void ConfigureBackoffProvider(this ISiloPersistentStreamConfigurator configurator, Func<IServiceProvider, string, IMessageDeliveryBackoffProvider> factory)
+        {
+            configurator.ConfigureComponent(factory);
+        }
+
+        /// <summary>
+        /// Configures the pulling agents' queue reader backoff provider.
+        /// </summary>
+        /// <param name="configurator">The configuration builder.</param>
+        /// <param name="factory">The queue reader backoff factory.</param>
+        public static void ConfigureBackoffProvider(this ISiloPersistentStreamConfigurator configurator, Func<IServiceProvider, string, IQueueReaderBackoffProvider> factory)
         {
             configurator.ConfigureComponent(factory);
         }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -32,6 +32,8 @@ namespace Orleans.Streams
         private int latestRingNotificationSequenceNumber;
         private int latestCommandNumber;
         private readonly IQueueAdapter queueAdapter;
+        private readonly IBackoffProvider _deliveryBackoffProvider;
+        private readonly IBackoffProvider _queueReaderBackoffProvider;
         private readonly IQueueAdapterCache queueAdapterCache;
         private IStreamQueueBalancer queueBalancer;
         private readonly IStreamFilter streamFilter;
@@ -51,7 +53,9 @@ namespace Orleans.Streams
             StreamPullingAgentOptions options,
             ILoggerFactory loggerFactory,
             SiloAddress siloAddress,
-            IQueueAdapter queueAdapter)
+            IQueueAdapter queueAdapter,
+            IBackoffProvider deliveryBackoffProvider,
+            IBackoffProvider queueReaderBackoffProvider)
             : base(managerId, siloAddress, loggerFactory)
         {
             if (string.IsNullOrWhiteSpace(strProviderName))
@@ -80,8 +84,8 @@ namespace Orleans.Streams
             this.streamFilter = streamFilter;
             this.adapterFactory = adapterFactory;
             this.queueAdapter = queueAdapter ?? throw new ArgumentNullException(nameof(queueAdapter));
-
-
+            _deliveryBackoffProvider = deliveryBackoffProvider;
+            _queueReaderBackoffProvider = queueReaderBackoffProvider;
             queueAdapterCache = adapterFactory.GetQueueAdapterCache();
             logger = loggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}");
             logger.LogInformation(
@@ -260,7 +264,7 @@ namespace Orleans.Streams
                         var agentIdNumber = Interlocked.Increment(ref nextAgentId);
                         var agentId = SystemTargetGrainId.Create(Constants.StreamPullingAgentType, this.Silo, $"{streamProviderName}_{agentIdNumber}_{queueId:H}");
                         IStreamFailureHandler deliveryFailureHandler = await adapterFactory.GetDeliveryFailureHandler(queueId);
-                        agent = new PersistentStreamPullingAgent(agentId, streamProviderName, this.loggerFactory, pubSub, streamFilter, queueId, this.options, this.Silo, queueAdapter, queueAdapterCache, deliveryFailureHandler);
+                        agent = new PersistentStreamPullingAgent(agentId, streamProviderName, this.loggerFactory, pubSub, streamFilter, queueId, this.options, this.Silo, queueAdapter, queueAdapterCache, deliveryFailureHandler, _deliveryBackoffProvider, _queueReaderBackoffProvider);
                         this.ActivationServices.GetRequiredService<Catalog>().RegisterSystemTarget(agent);
                         queuesToAgentsMap.Add(queueId, agent);
                         agents.Add(agent);

--- a/src/Orleans.Streaming/Providers/IBackoffProviders.cs
+++ b/src/Orleans.Streaming/Providers/IBackoffProviders.cs
@@ -1,0 +1,14 @@
+using Orleans.Internal;
+using Orleans.Streams;
+
+namespace Orleans.Runtime.Providers;
+
+/// <summary>
+/// Functionality for determining how long the <see cref="IPersistentStreamPullingAgent"/> will wait between successive attempts to deliver a message.
+/// </summary>
+public interface IMessageDeliveryBackoffProvider : IBackoffProvider { }
+
+/// <summary>
+/// Functionality for determining how long the <see cref="IPersistentStreamPullingAgent"/> will wait between successive attempts to read a message from a queue.
+/// </summary>
+public interface IQueueReaderBackoffProvider : IBackoffProvider { }

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -10,9 +10,6 @@ using Orleans.Internal;
 
 namespace Orleans.Runtime.Providers
 {
-    public interface IMessageDeliveryBackoffProvider : IBackoffProvider { }
-    public interface IQueueReaderBackoffProvider : IBackoffProvider { }
-
     internal class SiloStreamProviderRuntime : ISiloSideStreamProviderRuntime
     {
         private readonly IConsistentRingProvider consistentRingProvider;


### PR DESCRIPTION
This PR adds support for custom back-off providers from `PersistentStreamPullingAgent`, mainly for:

1. Message Delivery
2. Queue Reading (to be consistent, but may prove useful for others)

Each provider is keyed to the respective Stream Provider, and allows for different (stream)providers to have different back-off providers.

cc @benjaminpetit 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9035)