### PR TITLE
Fix table storage Reminders and GrainDirectory providers registration

### DIFF
--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableStorageGrainDirectoryProviderBuilder.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableStorageGrainDirectoryProviderBuilder.cs
@@ -8,7 +8,7 @@ using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
 
-[assembly: RegisterProvider("AzureTableStorage", "Clustering", "Silo", typeof(AzureTableStorageGrainDirectoryProviderBuilder))]
+[assembly: RegisterProvider("AzureTableStorage", "GrainDirectory", "Silo", typeof(AzureTableStorageGrainDirectoryProviderBuilder))]
 
 namespace Orleans.Hosting;
 

--- a/src/Azure/Orleans.Reminders.AzureStorage/AzureTableStorageRemindersProviderBuilder.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/AzureTableStorageRemindersProviderBuilder.cs
@@ -10,11 +10,11 @@ using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Reminders.AzureStorage;
 
-[assembly: RegisterProvider("AzureTableStorage", "GrainStorage", "Silo", typeof(AzureTableStorageGrainStorageProviderBuilder))]
+[assembly: RegisterProvider("AzureTableStorage", "Reminders", "Silo", typeof(AzureTableStorageRemindersProviderBuilder))]
 
 namespace Orleans.Hosting;
 
-internal sealed class AzureTableStorageGrainStorageProviderBuilder : IProviderBuilder<ISiloBuilder>
+internal sealed class AzureTableStorageRemindersProviderBuilder : IProviderBuilder<ISiloBuilder>
 {
     public void Configure(ISiloBuilder builder, string name, IConfigurationSection configurationSection)
     {


### PR DESCRIPTION
It seems Reminders and GrainDirectory providers for AzureTableStorage are improperly registered.
It should fix this issue that i've been able to reproduce https://github.com/dotnet/aspire/issues/4010 . It's currently impossible to use Table Storage for both reminders and grain state with Aspire. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9045)