### PR TITLE
Adds support to use `MayInterleave` with `StatelessWorker` grains

### DIFF
--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -103,7 +103,15 @@ namespace Orleans.Runtime
             _ => _shared.GetComponent<TComponent>()
         };
 
-        public void SetComponent<TComponent>(TComponent instance) where TComponent : class => throw new ArgumentException($"Cannot set a component on a {nameof(StatelessWorkerGrainContext)}");
+        public void SetComponent<TComponent>(TComponent instance) where TComponent : class
+        {
+            if (typeof(TComponent) != typeof(GrainCanInterleave))
+            {
+                throw new ArgumentException($"Cannot set a component of type '{instance.GetType().FullName}' on a {nameof(StatelessWorkerGrainContext)}");
+            }
+
+            _shared.SetComponent(instance);
+        }
 
         public TTarget GetTarget<TTarget>() where TTarget : class => throw new NotImplementedException();
 

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -130,5 +130,44 @@ namespace DefaultCluster.Tests.General
 
             // Calls should not have thrown ForwardingFailed exceptions.
         }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorker_DoesNotThrow_IfMarkedWithMayInterleave()
+        {
+            var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
+            var exception = await Record.ExceptionAsync(grain.GoFast);
+
+            Assert.Null(exception);
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorker_ShouldNotInterleaveCalls_IfMayInterleavePredicatedDoesntMatch()
+        {
+            var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
+
+            var delay = TimeSpan.FromSeconds(1);
+            await grain.SetDelay(delay);
+
+            var stopwatch = Stopwatch.StartNew();
+            await Task.WhenAll(grain.GoSlow(), grain.GoSlow(), grain.GoSlow());
+            stopwatch.Stop();
+
+            Assert.InRange(stopwatch.Elapsed.TotalSeconds, 2.85, 3.15); // theoretically it should be 3.0
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorker_ShouldInterleaveCalls_IfMayInterleavePredicatedMatches()
+        {
+            var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
+
+            var delay = TimeSpan.FromSeconds(1);
+            await grain.SetDelay(delay);
+
+            var stopwatch = Stopwatch.StartNew();
+            await Task.WhenAll(grain.GoFast(), grain.GoFast(), grain.GoFast());
+            stopwatch.Stop();
+
+            Assert.InRange(stopwatch.Elapsed.TotalSeconds, 0.85, 1.15); // theoretically it should be 1.0
+        }
     }
 }

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerWithMayInterleaveGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerWithMayInterleaveGrain.cs
@@ -1,0 +1,8 @@
+namespace UnitTests.GrainInterfaces;
+
+public interface IStatelessWorkerWithMayInterleaveGrain : IGrainWithIntegerKey
+{
+    Task SetDelay(TimeSpan delay);
+    Task GoSlow();
+    Task GoFast();
+}

--- a/test/Grains/TestGrains/StatelessWorkerWithMayInterleaveGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerWithMayInterleaveGrain.cs
@@ -1,0 +1,23 @@
+using Orleans.Concurrency;
+using Orleans.Serialization.Invocation;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains;
+
+[StatelessWorker(1)] // '1' to force interleaving, otherwise it just creates a new worker
+[MayInterleave(nameof(MayInterleaveMethod))]
+public class StatelessWorkerWithMayInterleaveGrain : Grain, IStatelessWorkerWithMayInterleaveGrain
+{
+    private TimeSpan _delay = TimeSpan.FromMilliseconds(1);
+
+    public static bool MayInterleaveMethod(IInvokable req) => req.GetMethodName() == nameof(GoFast);
+
+    public Task SetDelay(TimeSpan delay)
+    {
+        _delay = delay;
+        return Task.CompletedTask;
+    }
+
+    public Task GoSlow() => Task.Delay(_delay);
+    public Task GoFast() => Task.Delay(_delay);
+}


### PR DESCRIPTION
Since `MayInterleave` predicate is handled as a *component*, and components are not allowed in SW grain context. Using `MayInterleaveAttribute`, orleans throws an exception as detailed here #9049 - It is understandable to not allow components to be registered with SW's, since they may interplay with the grain's state, and SW use-case is not to dealing with state.

I think the constraint can be relaxed here since the interleaving operation is determined on every message invocation, and the method that determines that is defined as `static` and is purely functional, there should not be any problems AFAIK.

Personally I would go with a custom thread-safe singleton, but I can understand people using `StatelessWorker**(1)**` as a means to have a single worker-per-silo that is inherently thread-safe due to Orleans' scheduler, yet still wanting the interleaving benefits.

Fixes #9049 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9050)