### PR TITLE
Activation repartitioner: use `null` for no-op message observer to avoid interface call

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -353,7 +353,7 @@ namespace Orleans.Runtime.Messaging
 
             Exception error = default;
             var serializer = this.shared.ServiceProvider.GetRequiredService<MessageSerializer>();
-            var messageStatisticsSink = this.shared.MessageStatisticsSink;
+            var messageObserver = this.shared.MessageStatisticsSink.GetMessageObserver();
             try
             {
                 var output = this._transport.Output;
@@ -375,7 +375,7 @@ namespace Orleans.Runtime.Messaging
                             inflight.Add(message);
                             var (headerLength, bodyLength) = serializer.Write(output, message);
                             RecordMessageSend(message, headerLength + bodyLength, headerLength);
-                            messageStatisticsSink.RecordMessage(message);
+                            messageObserver?.Invoke(message);
                             message = null;
                         }
                     }

--- a/src/Orleans.Core/Placement/Repartitioning/IMessageStatisticsSink.cs
+++ b/src/Orleans.Core/Placement/Repartitioning/IMessageStatisticsSink.cs
@@ -1,13 +1,15 @@
+#nullable enable
+using System;
 using Orleans.Runtime;
 
 namespace Orleans.Placement.Repartitioning;
 
 internal interface IMessageStatisticsSink
 {
-    void RecordMessage(Message message);
+    Action<Message>? GetMessageObserver();
 }
 
 internal sealed class NoOpMessageStatisticsSink : IMessageStatisticsSink
 {
-    public void RecordMessage(Message message) { }
+    public Action<Message>? GetMessageObserver() => null;
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -138,7 +138,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<MessageCenter>();
             services.TryAddFromExisting<IMessageCenter, MessageCenter>();
             services.TryAddSingleton(FactoryUtility.Create<MessageCenter, Gateway>);
-            services.TryAddSingleton<IConnectedClientCollection>(sp => (IConnectedClientCollection)sp.GetRequiredService<MessageCenter>().Gateway ?? new EmptyConnectedClientCollection());
+            services.TryAddSingleton<IConnectedClientCollection>(sp => sp.GetRequiredService<MessageCenter>().Gateway as IConnectedClientCollection ?? new EmptyConnectedClientCollection());
             services.TryAddSingleton<InternalGrainRuntime>();
             services.TryAddSingleton<InsideRuntimeClient>();
             services.TryAddFromExisting<IRuntimeClient, InsideRuntimeClient>();

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -109,7 +110,9 @@ internal partial class ActivationRepartitioner : IMessageStatisticsSink
         }
     }
 
-    public void RecordMessage(Message message)
+    public Action<Message>? GetMessageObserver() => RecordMessage;
+
+    private void RecordMessage(Message message)
     {
         if (!_enableMessageSampling || message.IsSystemMessage)
         {

--- a/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using Orleans;
 using Orleans.Metadata;
 using System;
 using System.Collections.Concurrent;


### PR DESCRIPTION
This is a minor perf tweak to avoid interface dispatch when the newly-added activation repartitioner is not enabled
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9056)