### PR TITLE
Allow GrainTimers to dispose themselves from their own callback

### DIFF
--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -146,6 +146,12 @@ internal abstract class GrainTimer : IGrainTimer
         // Schedule the next tick.
         try
         {
+            if (_cts.IsCancellationRequested)
+            {
+                // The instance has been disposed. No further ticks should be fired.
+                return;
+            }
+
             if (!_changed)
             {
                 // If the timer was not modified during the tick, schedule the next tick based on the period.
@@ -160,8 +166,10 @@ internal abstract class GrainTimer : IGrainTimer
         catch (ObjectDisposedException)
         {
         }
-
-        _firing = false;
+        finally
+        {
+            _firing = false;
+        }
     }
 
     private Response OnCallbackException(Exception exc)

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -198,6 +198,17 @@ namespace DefaultCluster.Tests.TimerTests
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
+        public async Task GrainTimer_DisposeFromCallback()
+        {
+            // Schedule a timer which disposes itself from its own callback.
+            var grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
+            await grain.RunSelfDisposingTimer();
+
+            var pocoGrain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
+            await pocoGrain.RunSelfDisposingTimer();
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
         public async Task NonReentrantGrainTimer_Test()
         {
             const string testName = "NonReentrantGrainTimer_Test";

--- a/test/Grains/TestGrainInterfaces/ITimerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITimerGrain.cs
@@ -26,6 +26,7 @@ namespace UnitTests.GrainInterfaces
         Task RestartTimer(string name, TimeSpan dueTime);
         Task RestartTimer(string name, TimeSpan dueTime, TimeSpan period);
         Task StopTimer(string name);
+        Task RunSelfDisposingTimer();
     }
 
     public interface IPocoTimerCallGrain : ITimerCallGrain


### PR DESCRIPTION
Fixes #8582
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9065)