### PR TITLE
Bump Aspire and Azure.Core versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,15 +46,15 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageVersion Include="Azure.Core" Version="1.35.0" />
+    <PackageVersion Include="Azure.Core" Version="1.41.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.9.3" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.16.0" />
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="8.0.1" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="8.0.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="8.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="8.1.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="8.1.0" />
     <!-- 3rd party packages -->
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="1.0.0-beta13" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.300.6" />


### PR DESCRIPTION
Bump Azure.Core to 1.41.0
Update to 8.1 for Aspire
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9099)