### PR TITLE
Fix support for externally declared records

### DIFF
--- a/Orleans.sln
+++ b/Orleans.sln
@@ -220,6 +220,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tester.Redis", "test\Extens
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Serialization.Protobuf", "src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj", "{A073C0EE-8732-42F9-A22E-D47034E25076}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializerExternalModels", "test\Misc\TestSerializerExternalModels\TestSerializerExternalModels.csproj", "{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cassandra", "Cassandra", "{42C80201-3AC6-4C10-9809-3315A9FDD7A1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Clustering.Cassandra", "src\Cassandra\Orleans.Clustering.Cassandra\Orleans.Clustering.Cassandra.csproj", "{7A1A2ECE-DC4B-4DE7-AEF7-855C50895171}"
@@ -632,6 +634,10 @@ Global
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -748,6 +754,7 @@ Global
 		{84B44F1D-B7FE-40E3-82F0-730A55AC8613} = {316CDCC7-323F-4264-9FC9-667662BB1F80}
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E} = {70BCC54E-1618-4742-A079-07588065E361}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -74,6 +74,18 @@ internal class FieldIdAssignmentHelper
                 {
                     _symbols[member] = (id.Value, false);
                 }
+                else if (PropertyUtility.GetMatchingPrimaryConstructorParameter(prop, _constructorParameters) is { } prm)
+                {
+                    id = CodeGenerator.GetId(_libraryTypes, prop);
+                    if (id.HasValue)
+                    {
+                        _symbols[member] = (id.Value, true);
+                    }
+                    else
+                    {
+                        _symbols[member] = ((uint)_constructorParameters.IndexOf(prm), true);
+                    }
+                }
             }
 
             if (member is IFieldSymbol field)

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -173,7 +173,7 @@ namespace Orleans.CodeGenerator
                     t = t.BaseType;
                 }
 
-                foreach (var ctor in Type.Constructors)
+                foreach (var ctor in Type.Constructors.Where(x => x.IsImplicitlyDeclared))
                 {
                     if (ctor.Parameters.Length != 0)
                     {

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -10,6 +10,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -23,16 +23,17 @@ namespace Orleans.CodeGenerator
                     return;
                 }
 
-                if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_designtimebuild", out var isDesignTimeBuild)
-                    && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-
                 if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_attachdebugger", out var attachDebuggerOption)
                     && string.Equals("true", attachDebuggerOption, StringComparison.OrdinalIgnoreCase))
                 {
                     Debugger.Launch();
+                }
+
+                if (!Debugger.IsAttached &&
+                    context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_designtimebuild", out var isDesignTimeBuild)
+                    && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
                 }
 
                 var options = new CodeGeneratorOptions();

--- a/src/Orleans.CodeGenerator/Properties/launchSettings.json
+++ b/src/Orleans.CodeGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Roslyn": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\test\\Orleans.Serialization.UnitTests\\Orleans.Serialization.UnitTests.csproj"
+    }
+  }
+}

--- a/src/Orleans.CodeGenerator/PropertyUtility.cs
+++ b/src/Orleans.CodeGenerator/PropertyUtility.cs
@@ -18,6 +18,22 @@ namespace Orleans.CodeGenerator
             return GetMatchingProperty(field, field.ContainingType.GetMembers());
         }
 
+        public static bool IsCompilerGenerated(this ISymbol? symbol)
+            => symbol?.GetAttributes().Any(a => a.AttributeClass?.Name == "CompilerGeneratedAttribute") == true;
+
+        public static bool IsCompilerGenerated(this IPropertySymbol? property)
+            => property?.GetMethod.IsCompilerGenerated() == true && property.SetMethod.IsCompilerGenerated();
+
+        public static IParameterSymbol? GetMatchingPrimaryConstructorParameter(IPropertySymbol property, IEnumerable<IParameterSymbol> constructorParameters)
+        {
+            if (!property.IsCompilerGenerated())
+                return null;
+
+            return constructorParameters.FirstOrDefault(p =>
+                string.Equals(p.Name, property.Name, StringComparison.Ordinal) &&
+                SymbolEqualityComparer.Default.Equals(p.Type, property.Type));
+        }
+
         public static IPropertySymbol? GetMatchingProperty(IFieldSymbol field, IEnumerable<ISymbol> memberSymbols)
         {
             var propertyName = PropertyMatchRegex.Match(field.Name);

--- a/test/Misc/TestSerializerExternalModels/Models.cs
+++ b/test/Misc/TestSerializerExternalModels/Models.cs
@@ -3,7 +3,7 @@ using Orleans;
 namespace UnitTests.SerializerExternalModels;
 
 [GenerateSerializer]
-public record struct Person2External(int Age, string Name)
+public record struct Person2ExternalStruct(int Age, string Name)
 {
     [Id(0)]
     public string FavouriteColor { get; set; }
@@ -11,3 +11,15 @@ public record struct Person2External(int Age, string Name)
     [Id(1)]
     public string StarSign { get; set; }
 }
+
+#if NET6_0_OR_GREATER
+[GenerateSerializer]
+public record Person2External(int Age, string Name)
+{
+    [Id(0)]
+    public string FavouriteColor { get; set; }
+
+    [Id(1)]
+    public string StarSign { get; set; }
+}
+#endif

--- a/test/Misc/TestSerializerExternalModels/Models.cs
+++ b/test/Misc/TestSerializerExternalModels/Models.cs
@@ -1,0 +1,13 @@
+using Orleans;
+
+namespace UnitTests.SerializerExternalModels;
+
+[GenerateSerializer]
+public record struct Person2External(int Age, string Name)
+{
+    [Id(0)]
+    public string FavouriteColor { get; set; }
+
+    [Id(1)]
+    public string StarSign { get; set; }
+}

--- a/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
+++ b/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>UnitTests.SerializerExternalModels</RootNamespace>
+    <AssemblyName>SerializerExternalModels</AssemblyName>
+    <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Orleans.Serialization.Abstractions\Orleans.Serialization.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -14,7 +14,10 @@ using System.Linq;
 using UnitTests.SerializerExternalModels;
 using Orleans;
 
+[assembly: GenerateCodeForDeclaringAssembly(typeof(Person2ExternalStruct))]
+#if NET6_0_OR_GREATER
 [assembly: GenerateCodeForDeclaringAssembly(typeof(Person2External))]
+#endif
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -131,6 +134,25 @@ public class GeneratedSerializerTests : IDisposable
     }
 
     [Fact]
+    public void GeneratedLibExternalRecordStructWithPCtorSerializersRoundTripThroughCodec()
+    {
+        var original = new Person2ExternalStruct(2, "harry")
+        {
+            FavouriteColor = "redborine",
+            StarSign = "Aquaricorn"
+        };
+
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.Age, result.Age);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.FavouriteColor, result.FavouriteColor);
+        Assert.Equal(original.StarSign, result.StarSign);
+    }
+
+#if NET6_0_OR_GREATER
+
+    [Fact]
     public void GeneratedLibExternalRecordWithPCtorSerializersRoundTripThroughCodec()
     {
         var original = new Person2External(2, "harry")
@@ -146,6 +168,8 @@ public class GeneratedSerializerTests : IDisposable
         Assert.Equal(original.FavouriteColor, result.FavouriteColor);
         Assert.Equal(original.StarSign, result.StarSign);
     }
+
+#endif
 
 #if NET6_0_OR_GREATER
     [Fact]

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -11,6 +11,10 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using Xunit;
 using System.Linq;
+using UnitTests.SerializerExternalModels;
+using Orleans;
+
+[assembly: GenerateCodeForDeclaringAssembly(typeof(Person2External))]
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -113,6 +117,23 @@ public class GeneratedSerializerTests : IDisposable
     public void GeneratedRecordWithPCtorSerializersRoundTripThroughCodec()
     {
         var original = new Person2(2, "harry")
+        {
+            FavouriteColor = "redborine",
+            StarSign = "Aquaricorn"
+        };
+
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.Age, result.Age);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.FavouriteColor, result.FavouriteColor);
+        Assert.Equal(original.StarSign, result.StarSign);
+    }
+
+    [Fact]
+    public void GeneratedLibExternalRecordWithPCtorSerializersRoundTripThroughCodec()
+    {
+        var original = new Person2External(2, "harry")
         {
             FavouriteColor = "redborine",
             StarSign = "Aquaricorn"

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -7,6 +7,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <ImplicitUsings>disable</ImplicitUsings>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +30,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.NewtonsoftJson\Orleans.Serialization.NewtonsoftJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj" />
+    <ProjectReference Include="..\Misc\TestSerializerExternalModels\TestSerializerExternalModels.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes improper codec codegen for records declared in referenced projects/assemblies. Roslyn does not guarantee the symbols contain the backing fields for generated properties (see https://github.com/dotnet/roslyn/discussions/72374#discussioncomment-8655916) and it also doesn't even report `record struct` symbols as records at all (see https://github.com/dotnet/roslyn/issues/69326).

This makes for a very inconsistent experience when dealing with types defined in external assemblies that don't use the Orleans SDK themselves.

We implement a heuristics here to determine primary constructors that can be relied upon to detect them consistently:
1. A ctor with non-zero parameters
2. All parameters match by name exactly with corresponding properties
3. All matching properties have getter AND setter annotated with [CompilerGenerated].

In addition, since the backing field isn't available at all in these records, and the corresponding property isn't settable (it's generated as `init set`), we leverage unsafe accessors (see https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafeaccessorattribute?view=net-8.0) instead. The code checks whether the `FieldAccessorDescription` has an initializer syntax or not to determine whether to generate the original code or the new accessor version.

The signature of the accessor matches the delegate that is generated for the regular backing field case, so there is no need to modify other call sites.

Fixes #9092