### PR TITLE
Fix potential `ArgumentOutOfRangeException` in `LeaseBasedQueueBalancer`

### DIFF
--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -372,7 +372,7 @@ public class LeaseBasedQueueBalancer(
         var results = await _leaseProvider.Renew(_options.LeaseCategory, _myQueues.Select(queue => queue.AcquiredLease).ToArray());
 
         // Update myQueues list with successfully renewed leases.
-        for (var i = 0; i < results.Length; i++)
+        for (var i = results.Length - 1; i >= 0; i--)
         {
             AcquireLeaseResult result = results[i];
             switch (result.StatusCode)


### PR DESCRIPTION
There's a potential for an `ArgumentOutOfRangeException` in the `LeaseBasedQueueBalancer`. This can happen when we remove an element from `_myQueues` while iterating over the results array. When we call `RemoveAt(i)`, we are reducing the size of `_myQueues`, on subsequent iterations of the for loop, `i` will increase, but the length of `_myQueues` has decreased. If we reach a point where `i` is equal to or greater than the new length of `_myQueues`, attempting to access `_myQueues[i]` will throw an `ArgumentOutOfRangeException`. This fix simply loops backwards, this way removing items from `_myQueues` will not affect the indices of the remaining elements that are yet to be processed.