### PR TITLE
Clustering: ensure snapshots are globally uniform

### DIFF
--- a/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
+++ b/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
@@ -15,9 +15,9 @@ namespace Orleans.Runtime
             this.Entries = entries;
         }
 
-        public static MembershipTableSnapshot Create(MembershipEntry localSiloEntry, MembershipTableData table)
+        public static MembershipTableSnapshot Create(MembershipTableData table)
         {
-            if (table is null) throw new ArgumentNullException(nameof(table));
+            ArgumentNullException.ThrowIfNull(table);
 
             var entries = ImmutableDictionary.CreateBuilder<SiloAddress, MembershipEntry>();
             if (table.Members != null)
@@ -29,24 +29,15 @@ namespace Orleans.Runtime
                 }
             }
 
-            if (entries.TryGetValue(localSiloEntry.SiloAddress, out var existing))
-            {
-                entries[localSiloEntry.SiloAddress] = existing.WithStatus(localSiloEntry.Status);
-            }
-            else
-            {
-                entries[localSiloEntry.SiloAddress] = localSiloEntry;
-            }
-
             var version = (table.Version.Version == 0 && table.Version.VersionEtag == "0")
-                ? MembershipVersion.MinValue
-                : new MembershipVersion(table.Version.Version);
+              ? MembershipVersion.MinValue
+              : new MembershipVersion(table.Version.Version);
             return new MembershipTableSnapshot(version, entries.ToImmutable());
         }
 
-        public static MembershipTableSnapshot Create(MembershipEntry localSiloEntry, MembershipTableSnapshot snapshot)
+        public static MembershipTableSnapshot Create(MembershipTableSnapshot snapshot)
         {
-            if (snapshot is null) throw new ArgumentNullException(nameof(snapshot));
+            ArgumentNullException.ThrowIfNull(snapshot);
 
             var entries = ImmutableDictionary.CreateBuilder<SiloAddress, MembershipEntry>();
             if (snapshot.Entries != null)
@@ -56,15 +47,6 @@ namespace Orleans.Runtime
                     var entry = item.Value;
                     entries.Add(entry.SiloAddress, entry);
                 }
-            }
-
-            if (entries.TryGetValue(localSiloEntry.SiloAddress, out var existing))
-            {
-                entries[localSiloEntry.SiloAddress] = existing.WithStatus(localSiloEntry.Status);
-            }
-            else
-            {
-                entries[localSiloEntry.SiloAddress] = localSiloEntry;
             }
 
             return new MembershipTableSnapshot(snapshot.Version, entries.ToImmutable());

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -347,8 +347,21 @@ namespace Orleans
 
         internal MembershipEntry Copy()
         {
-            var copy = (MembershipEntry)MemberwiseClone();
-            copy.SuspectTimes = SuspectTimes is null ? null : new(SuspectTimes);
+            var copy = new MembershipEntry
+            {
+                SiloAddress = SiloAddress,
+                Status = Status,
+                SuspectTimes = SuspectTimes is null ? null : new(SuspectTimes),
+                ProxyPort = ProxyPort,
+                HostName = HostName,
+                SiloName = SiloName,
+                RoleName = RoleName,
+                UpdateZone = UpdateZone,
+                FaultZone = FaultZone,
+                StartTime = StartTime,
+                IAmAliveTime = IAmAliveTime
+            };
+
             return copy;
         }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
 using Orleans.Runtime.Utilities;
+using Orleans.Serialization;
 using Orleans.Serialization.TypeSystem;
 
 namespace Orleans.Runtime.MembershipService
@@ -119,15 +120,8 @@ namespace Orleans.Runtime.MembershipService
                         localSiloEntry.ToFullString());
                     this.KillMyselfLocally($"I should be Dead according to membership table (in RefreshFromSnapshot). Local entry: {(localSiloEntry.ToFullString())}.");
                 }
-
-                snapshot = MembershipTableSnapshot.Create(localSiloEntry.WithStatus(this.CurrentStatus), snapshot);
-            }
-            else
-            {
-                snapshot = MembershipTableSnapshot.Create(this.CreateLocalSiloEntry(this.CurrentStatus), snapshot);
             }
 
-            // If we are behind, let's take directly the snapshot in param
             this.updates.TryPublish(snapshot);
         }
 
@@ -485,10 +479,7 @@ namespace Orleans.Runtime.MembershipService
             if (table is null) throw new ArgumentNullException(nameof(table));
             if (this.log.IsEnabled(LogLevel.Debug)) this.log.LogDebug($"{nameof(ProcessTableUpdate)} (called from {{Caller}}) membership table {{Table}}", caller, table.ToString());
 
-            // Update the current membership snapshot.
-            var (localSiloEntry, _) = this.GetOrCreateLocalSiloEntry(table, this.CurrentStatus);
-            var updated = MembershipTableSnapshot.Create(localSiloEntry, table);
-
+            var updated = MembershipTableSnapshot.Create(table);
             if (this.updates.TryPublish(updated))
             {
                 this.LogMissedIAmAlives(table);


### PR DESCRIPTION
While validating #9103, I uncovered this bug in membership which allows inconsistent membership views between replicas. 
Currently, membership always reflected the silo's local view of its own status (eg `ShuttingDown` vs `Active`) and incorporates that into any membership snapshot it receives. For algorithms relying on consistent membership snapshots, this cannot be allowed. This PR changes the behavior so that each silo sees what every other silo sees for a given membership version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9115)