### PR TITLE
Allow deactivation to be triggered during activation, clean up deactivation flow

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -257,12 +257,12 @@ namespace Orleans
         ActivationFailed,
 
         /// <summary>
-        /// This activation is affected by an internal failure.
+        /// This activation is affected by an internal failure in the distributed grain directory.
         /// </summary>
         /// <remarks>
         /// This could be caused by the failure of a process hosting this activation's grain directory partition, for example.
         /// </remarks>
-        InternalFailure,
+        DirectoryFailure,
 
         /// <summary>
         /// This activation is idle.

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,9 @@ namespace Orleans.Internal
     /// </summary>
     internal static class OrleansTaskExtentions
     {
+        public static ConfiguredTaskAwaitable SuppressThrowing(this ValueTask task) => task.AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+        public static ConfiguredTaskAwaitable SuppressThrowing(this Task task) => task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+
         public static async Task LogException(this Task task, ILogger logger, ErrorCode errorCode, string message)
         {
             try

--- a/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
@@ -114,7 +114,7 @@ internal class ActivationMigrationManager : SystemTarget, IActivationMigrationMa
             {
                 lock (activation)
                 {
-                    if (activation.State is not (ActivationState.Valid or ActivationState.Invalid or ActivationState.FailedToActivate))
+                    if (activation.State is not (ActivationState.Valid or ActivationState.Invalid))
                     {
                         allActiveOrTerminal = false;
                         break;
@@ -316,7 +316,7 @@ internal class ActivationMigrationManager : SystemTarget, IActivationMigrationMa
             workerTasks.Add(value.PumpTask);
         }
 
-        await Task.WhenAll(workerTasks).WithCancellation(cancellationToken);
+        await Task.WhenAll(workerTasks).WaitAsync(cancellationToken);
     }
 
     void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/Catalog/ActivationState.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationState.cs
@@ -5,7 +5,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Activation is being created
         /// </summary>
-        Create,
+        Creating,
         
         /// <summary>
         /// Activation is in the middle of activation process.
@@ -25,11 +25,6 @@ namespace Orleans.Runtime
         /// <summary>
         /// Tombstone for an activation which has terminated.
         /// </summary>
-        Invalid,
-        
-        /// <summary>
-        /// Tombstone for an activation that threw an exception during activation.
-        /// </summary>
-        FailedToActivate,
+        Invalid
     }
 }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -476,7 +476,7 @@ namespace Orleans.Runtime
                 if (activationsToShutdown.Count > 0)
                 {
                     var reasonText = $"This activation is being deactivated due to a failure of server {updatedSilo}, since it was responsible for this activation's grain directory registration.";
-                    var reason = new DeactivationReason(DeactivationReasonCode.InternalFailure, reasonText);
+                    var reason = new DeactivationReason(DeactivationReasonCode.DirectoryFailure, reasonText);
                     StartDeactivatingActivations(reason, activationsToShutdown);
                 }
             }

--- a/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
+++ b/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
@@ -6,22 +6,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime
 {
-    internal class GrainLifecycle : LifecycleSubject, IGrainLifecycle
+    internal class GrainLifecycle(ILogger logger) : LifecycleSubject(logger), IGrainLifecycle
     {
         private static readonly ImmutableDictionary<int, string> StageNames = GetStageNames(typeof(GrainLifecycleStage));
         private List<IGrainMigrationParticipant> _migrationParticipants;
 
-        public GrainLifecycle(ILogger logger) : base(logger)
-        {
-        }
-
-        public IEnumerable<IGrainMigrationParticipant> GetMigrationParticipants() => _migrationParticipants ?? (IEnumerable<IGrainMigrationParticipant>)Array.Empty<IGrainMigrationParticipant>();
+        public IEnumerable<IGrainMigrationParticipant> GetMigrationParticipants() => _migrationParticipants ?? (IEnumerable<IGrainMigrationParticipant>)[];
 
         public void AddMigrationParticipant(IGrainMigrationParticipant participant)
         {
             lock (this)
             {
-                _migrationParticipants ??= new();
+                _migrationParticipants ??= [];
                 _migrationParticipants.Add(participant);
             }
         }

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.GrainDirectory;
 using Orleans.GrainReferences;
 using Orleans.Metadata;
+using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Placement;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.TypeSystem;
@@ -51,6 +53,8 @@ public class GrainTypeSharedContext
         MaxWarningRequestProcessingTime = messagingOptions.Value.ResponseTimeout.Multiply(5);
         MaxRequestProcessingTime = messagingOptions.Value.MaxRequestProcessingTime;
         PlacementStrategy = placementStrategyResolver.GetPlacementStrategy(grainType);
+        var grainDirectoryResolver = serviceProvider.GetRequiredService<GrainDirectoryResolver>();
+        GrainDirectory = PlacementStrategy.IsUsingGrainDirectory ? grainDirectoryResolver.Resolve(grainType) : null;
         SchedulingOptions = schedulingOptions.Value;
         Runtime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
@@ -161,6 +165,11 @@ public class GrainTypeSharedContext
     /// Gets the placement strategy used by grains of this type.
     /// </summary>
     public PlacementStrategy PlacementStrategy { get; }
+
+    /// <summary>
+    /// Gets the grain directory used by grains of this type, if this type uses a grain directory.
+    /// </summary>
+    public IGrainDirectory? GrainDirectory { get; }
 
     /// <summary>
     /// Gets the scheduling options.

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -95,8 +95,7 @@ internal class GrainRuntime : IGrainRuntime
             void ThrowMissingContext() => throw new InvalidOperationException("Activation access violation. A non-activation thread attempted to access activation services.");
         }
 
-        if (context is ActivationData activation
-            && (activation.State == ActivationState.Invalid || activation.State == ActivationState.FailedToActivate))
+        if (context is ActivationData activation && activation.State == ActivationState.Invalid)
         {
             // Move exceptions into local functions to help inlining this method.
             ThrowInvalidActivation(activation);

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -262,11 +262,11 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
                 string activation = await grain.DoSomething();
                 Assert.Fail("Should have thrown.");
             }
-            catch(InvalidOperationException exc)
+            catch (OrleansMessageRejectionException exc)
             {
                 this.Logger.LogInformation(exc, "Thrown as expected");
                 Assert.True(
-                    exc.Message.Contains("DeactivateOnIdle from within OnActivateAsync"),
+                    exc.Message.Contains("Forwarding failed"),
                     "Did not get expected exception message returned: " + exc.Message);
             }  
         }


### PR DESCRIPTION
This PR cleans up activation lifecycle around shutdown, removing some duplication and improving hygiene around cancellation.

It enables deactivation to be triggered while a grain is still activating, eliminating the `"Calling DeactivateOnIdle from within OnActivateAsync is not supported"` message. When deactivation is triggered, the `CancellationToken` passed to the ongoing `OnActivateAsync` will be canceled.

This PR also fixes a possible `NullReferenceException` when a silo is shutting down ungracefully and a grain is disposed without first being deactivated, which can happen during ungraceful shutdown.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9116)