### PR TITLE
Add missing query CleanupDefunctSiloEntriesKey to PostgreSQL-Clustering

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/PostgreSQL-Clustering-3.7.0.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Migrations/PostgreSQL-Clustering-3.7.0.sql
@@ -7,4 +7,5 @@ VALUES
         AND @DeploymentId IS NOT NULL
         AND IAmAliveTime < @IAmAliveTime
         AND Status != 3;
-');
+')
+ON CONFLICT (QueryKey) DO NOTHING;

--- a/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql
@@ -344,3 +344,14 @@ VALUES
         AND Status = @Status AND @Status IS NOT NULL
         AND ProxyPort > 0;
 ');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'CleanupDefunctSiloEntriesKey',
+    'DELETE FROM OrleansMembershipTable
+    WHERE DeploymentId = @DeploymentId
+        AND @DeploymentId IS NOT NULL
+        AND IAmAliveTime < @IAmAliveTime
+        AND Status != 3;
+');


### PR DESCRIPTION
Solves #8676 for PostgreSQL scripts by adding missing query CleanupDefunctSiloEntriesKey.
Follows the same pattern as #8896.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9125)