### PR TITLE
Support for .NET CancellationTokens

### DIFF
--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
@@ -1,3 +1,8 @@
-﻿; Unshipped analyzer release
+; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+ORLEANS0109 | Usage | Error | Method has multiple CancellationToken parameters

--- a/src/Orleans.CodeGenerator/Diagnostics/MultipleCancellationTokenParametersDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/MultipleCancellationTokenParametersDiagnostic.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+public static class MultipleCancellationTokenParametersDiagnostic
+{
+    public const string DiagnosticId = "ORLEANS0109";
+    public const string Title = "Grain method has multiple parameters of type CancellationToken";
+    public const string MessageFormat = "The type {0} contains method {1} which has multiple CancellationToken parameters. Only a single CancellationToken parameter is supported.";
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+    internal static Diagnostic CreateDiagnostic(IMethodSymbol symbol) => Diagnostic.Create(Rule, symbol.Locations.First(), symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), symbol.Name);
+}

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -609,7 +609,12 @@ namespace Orleans.CodeGenerator
                     ),
                     TryStatement().WithBlock(
                         Block(
-                             ((INamedTypeSymbol)method.Method.ReturnType).ConstructedFrom is { IsGenericType: true }
+                            ExpressionStatement(
+                                InvocationExpression(
+                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("cancellationToken"),
+                                        IdentifierName("ThrowIfCancellationRequested")))),
+                            ((INamedTypeSymbol)method.Method.ReturnType).ConstructedFrom is { IsGenericType: true }
                                 ? ReturnStatement(
                                     AwaitExpression(
                                         InvocationExpression(methodCall, ArgumentList(args))

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -553,6 +553,9 @@ namespace Orleans.CodeGenerator
             }
             else if (method.IsCancellable)
             {
+                var defaultCancellationTokenFieldName = fields.OfType<MethodParameterFieldDescription>()
+                    .First(p => SymbolEqualityComparer.Default.Equals(LibraryTypes.CancellationToken, p.Parameter.Type)).FieldName;
+
                 body = Block(
                     LocalDeclarationStatement(
                         VariableDeclaration(
@@ -594,7 +597,9 @@ namespace Orleans.CodeGenerator
                                                         IdentifierName("RegisterCancellableToken")))
                                                 .AddArgumentListArguments(
                                                     Argument(
-                                                        IdentifierName("cancellableTokenId")))),
+                                                        IdentifierName("cancellableTokenId")),
+                                                    Argument(
+                                                        IdentifierName(defaultCancellationTokenFieldName)))),
                                             DefaultExpression(LibraryTypes.CancellationToken.ToTypeSyntax())
                                         )
                                     )

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -40,6 +40,7 @@ namespace Orleans.CodeGenerator
             ConstructorAttributeTypes = options.ConstructorAttributes.Select(Type).ToArray();
             AliasAttribute = Type("Orleans.AliasAttribute");
             IInvokable = Type("Orleans.Serialization.Invocation.IInvokable");
+            ICancellableInvokable = Type("Orleans.Serialization.Invocation.ICancellableInvokable");
             InvokeMethodNameAttribute = Type("Orleans.InvokeMethodNameAttribute");
             RuntimeHelpers = Type("System.Runtime.CompilerServices.RuntimeHelpers");
             InvokableCustomInitializerAttribute = Type("Orleans.InvokableCustomInitializerAttribute");
@@ -58,6 +59,8 @@ namespace Orleans.CodeGenerator
             SuppressReferenceTrackingAttribute = Type("Orleans.SuppressReferenceTrackingAttribute");
             OmitDefaultMemberValuesAttribute = Type("Orleans.OmitDefaultMemberValuesAttribute");
             ITargetHolder = Type("Orleans.Serialization.Invocation.ITargetHolder");
+            ICancellationRuntime = Type("Orleans.Serialization.Invocation.ICancellationRuntime");
+            ICancellableInvokableGrainExtension = TypeOrDefault("Orleans.Runtime.ICancellableInvokableGrainExtension");
             TypeManifestProviderAttribute = Type("Orleans.Serialization.Configuration.TypeManifestProviderAttribute");
             NonSerializedAttribute = Type("System.NonSerializedAttribute");
             ObsoleteAttribute = Type("System.ObsoleteAttribute");
@@ -77,11 +80,11 @@ namespace Orleans.CodeGenerator
             _dateOnly = TypeOrDefault("System.DateOnly");
             _dateTimeOffset = Type("System.DateTimeOffset");
             _bitVector32 = Type("System.Collections.Specialized.BitVector32");
-            _guid = Type("System.Guid");
             _compareInfo = Type("System.Globalization.CompareInfo");
             _cultureInfo = Type("System.Globalization.CultureInfo");
             _version = Type("System.Version");
             _timeOnly = TypeOrDefault("System.TimeOnly");
+            Guid = Type("System.Guid");
             ICodecProvider = Type("Orleans.Serialization.Serializers.ICodecProvider");
             ValueSerializer = Type("Orleans.Serialization.Serializers.IValueSerializer`1");
             ValueTask = Type("System.Threading.Tasks.ValueTask");
@@ -153,7 +156,7 @@ namespace Orleans.CodeGenerator
             TimeSpan = Type("System.TimeSpan");
             _ipAddress = Type("System.Net.IPAddress");
             _ipEndPoint = Type("System.Net.IPEndPoint");
-            _cancellationToken = Type("System.Threading.CancellationToken");
+            CancellationToken = Type("System.Threading.CancellationToken");
             _immutableContainerTypes = new[]
             {
                     compilation.GetSpecialType(SpecialType.System_Nullable_T),
@@ -218,7 +221,10 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol IActivator_1 { get; private set; }
         public INamedTypeSymbol IBufferWriter { get; private set; }
         public INamedTypeSymbol IInvokable { get; private set; }
+        public INamedTypeSymbol ICancellableInvokable { get; private set; }
         public INamedTypeSymbol ITargetHolder { get; private set; }
+        public INamedTypeSymbol ICancellationRuntime { get; private set; }
+        public INamedTypeSymbol? ICancellableInvokableGrainExtension { get; private set; }
         public INamedTypeSymbol TypeManifestProviderAttribute { get; private set; }
         public INamedTypeSymbol NonSerializedAttribute { get; private set; }
         public INamedTypeSymbol ObsoleteAttribute { get; private set; }
@@ -259,13 +265,13 @@ namespace Orleans.CodeGenerator
         public INamedTypeSymbol SuppressReferenceTrackingAttribute { get; private set; }
         public INamedTypeSymbol OmitDefaultMemberValuesAttribute { get; private set; }
         public INamedTypeSymbol CopyContext { get; private set; }
+        public INamedTypeSymbol CancellationToken { get; private set; }
+        public INamedTypeSymbol Guid { get; private set; }
         public Compilation Compilation { get; private set; }
         public INamedTypeSymbol TimeSpan { get; private set; }
         private INamedTypeSymbol _ipAddress;
         private INamedTypeSymbol _ipEndPoint;
-        private INamedTypeSymbol _cancellationToken;
         private INamedTypeSymbol[] _immutableContainerTypes;
-        private INamedTypeSymbol _guid;
         private INamedTypeSymbol _bitVector32;
         private INamedTypeSymbol _compareInfo;
         private INamedTypeSymbol _cultureInfo;
@@ -280,14 +286,14 @@ namespace Orleans.CodeGenerator
             _dateOnly,
             _timeOnly,
             _dateTimeOffset,
-            _guid,
+            Guid,
             _bitVector32,
             _compareInfo,
             _cultureInfo,
             _version,
             _ipAddress,
             _ipEndPoint,
-            _cancellationToken,
+            CancellationToken,
             Type,
             _uri,
             _uInt128,

--- a/src/Orleans.CodeGenerator/LibraryTypes.cs
+++ b/src/Orleans.CodeGenerator/LibraryTypes.cs
@@ -127,6 +127,7 @@ namespace Orleans.CodeGenerator
                     new(TypeOrDefault("System.Int128"), TypeOrDefault("Orleans.Serialization.Codecs.Int128Codec")),
                     new(TypeOrDefault("System.Half"), TypeOrDefault("Orleans.Serialization.Codecs.HalfCodec")),
                     new(Type("System.Uri"), Type("Orleans.Serialization.Codecs.UriCodec")),
+                    new(Type("System.Threading.CancellationToken"), Type("Orleans.Serialization.Codecs.CancellationTokenCodec")),
                 }.Where(desc => desc.UnderlyingType is { } && desc.CodecType is { }).ToArray();
             WellKnownCodecs = new WellKnownCodecDescription[]
             {

--- a/src/Orleans.CodeGenerator/Model/InvokableMethodDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/InvokableMethodDescription.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 
 namespace Orleans.CodeGenerator
 {
@@ -205,6 +206,11 @@ namespace Orleans.CodeGenerator
         /// Gets the interface which this type is contained in.
         /// </summary>
         public INamedTypeSymbol ContainingInterface { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this method is cancellable.
+        /// </summary>
+        public bool IsCancellable => Method.Parameters.Any(parameterSymbol => SymbolEqualityComparer.Default.Equals(CodeGenerator.LibraryTypes.CancellationToken, parameterSymbol.Type));
 
         public bool Equals(InvokableMethodDescription other) => Key.Equals(other.Key);
         public override bool Equals(object obj) => obj is InvokableMethodDescription imd && Equals(imd);

--- a/src/Orleans.CodeGenerator/ProxyGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxyGenerator.cs
@@ -151,6 +151,51 @@ namespace Orleans.CodeGenerator
                     .Concat(_codeGenerator.LibraryTypes.StaticCopiers)
                     .ToList();
 
+            // Ensure to hook up the cancellation token if the method has one
+            var cancellationTokenParameter = methodSymbol.Parameters.SingleOrDefault(parameter => SymbolEqualityComparer.Default.Equals(LibraryTypes.CancellationToken, parameter.Type));
+            if (cancellationTokenParameter is not null)
+            {
+                // Throw aggressively if cancellation is already requested
+                statements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(
+                            IdentifierName($"arg{cancellationTokenParameter.Ordinal}").Member("ThrowIfCancellationRequested"),
+                            ArgumentList()
+                        )
+                    )
+                );
+
+                // Register for cancellation
+                statements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(
+                            IdentifierName($"arg{cancellationTokenParameter.Ordinal}").Member("Register"))
+                        .WithArgumentList(
+                            ArgumentList(SeparatedList(new[]
+                            {
+                                Argument(
+                                    SimpleLambdaExpression(
+                                        Parameter(Identifier("arg")),
+                                        InvocationExpression(
+                                            InvocationExpression(ThisExpression().Member("AsReference", LibraryTypes.ICancellableInvokableGrainExtension.ToTypeSyntax())).Member("CancelRemoteToken"),
+                                            ArgumentList(SeparatedList(new[]
+                                            {
+                                                Argument(
+                                                    CastExpression(
+                                                        ParseTypeName(_codeGenerator.LibraryTypes.Guid.ToDisplayName()),
+                                                        IdentifierName("arg")
+                                                    )
+                                                ),
+                                            }))
+                                        )
+                                    )
+                                ),
+                                Argument(
+                                    InvocationExpression(
+                                        IdentifierName("request").Member(IdentifierName("GetCancellableTokenId"))))
+                            })))));
+            }
+
             // Set request object fields from method parameters.
             var parameterIndex = 0;
             var parameters = invokable.Members.OfType<MethodParameterFieldDescription>().Select(member => new SerializableMethodMember(member));

--- a/src/Orleans.CodeGenerator/SerializerGenerator.cs
+++ b/src/Orleans.CodeGenerator/SerializerGenerator.cs
@@ -47,6 +47,10 @@ namespace Orleans.CodeGenerator
                 {
                     members.Add(new SerializableMethodMember(methodParameter));
                 }
+                else if (member is CancellableTokenFieldDescription cancellableTokenField)
+                {
+                    members.Add(new SerializableCancellableTokenMember(_codeGenerator, cancellableTokenField));
+                }
             }
 
             var fieldDescriptions = GetFieldDescriptions(type, members);
@@ -1137,6 +1141,8 @@ namespace Orleans.CodeGenerator
 
             public bool IsShallowCopyable => LibraryTypes.IsShallowCopyable(_member.Parameter.Type) || _member.Parameter.HasAnyAttribute(LibraryTypes.ImmutableAttributes);
 
+            public bool IsCancellationToken => SymbolEqualityComparer.Default.Equals(LibraryTypes.CancellationToken, _member.Parameter.Type);
+
             /// <summary>
             /// Gets syntax representing the type of this field.
             /// </summary>
@@ -1145,6 +1151,56 @@ namespace Orleans.CodeGenerator
             public bool IsValueType => _member.Type.IsValueType;
 
             public bool IsPrimaryConstructorParameter => _member.IsPrimaryConstructorParameter;
+
+            /// <summary>
+            /// Returns syntax for retrieving the value of this field, deep copying it if necessary.
+            /// </summary>
+            /// <param name="instance">The instance of the containing type.</param>
+            /// <returns>Syntax for retrieving the value of this field.</returns>
+            public ExpressionSyntax GetGetter(ExpressionSyntax instance) => instance.Member(_member.FieldName);
+
+            /// <summary>
+            /// Returns syntax for setting the value of this field.
+            /// </summary>
+            /// <param name="instance">The instance of the containing type.</param>
+            /// <param name="value">Syntax for the new value.</param>
+            /// <returns>Syntax for setting the value of this field.</returns>
+            public ExpressionSyntax GetSetter(ExpressionSyntax instance, ExpressionSyntax value) => AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        instance.Member(_member.FieldName),
+                        value);
+
+            public FieldAccessorDescription GetGetterFieldDescription() => null;
+            public FieldAccessorDescription GetSetterFieldDescription() => null;
+        }
+
+        internal class SerializableCancellableTokenMember : ISerializableMember
+        {
+            private readonly CodeGenerator _codeGenerator;
+            private readonly CancellableTokenFieldDescription _member;
+
+            public SerializableCancellableTokenMember(CodeGenerator codeGenerator, CancellableTokenFieldDescription member)
+            {
+                _codeGenerator = codeGenerator;
+                _member = member;
+            }
+
+            public IMemberDescription Member => _member;
+
+            private LibraryTypes LibraryTypes => _codeGenerator.LibraryTypes;
+
+            public bool IsShallowCopyable => LibraryTypes.IsShallowCopyable(_member.Type);
+
+            public bool IsCancellationToken => false;
+
+            /// <summary>
+            /// Gets syntax representing the type of this field.
+            /// </summary>
+            public TypeSyntax TypeSyntax => _member.TypeSyntax;
+
+            public bool IsValueType => _member.Type.IsValueType;
+
+            public bool IsPrimaryConstructorParameter => false;
 
             /// <summary>
             /// Returns syntax for retrieving the value of this field, deep copying it if necessary.

--- a/src/Orleans.Core.Abstractions/Cancellation/ICancellableInvokableGrainExtension.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/ICancellableInvokableGrainExtension.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Concurrency;
+
+namespace Orleans.Runtime;
+
+public interface ICancellableInvokableGrainExtension : IGrainExtension
+{
+    /// <summary>
+    /// Indicates that a cancellation token has been canceled.
+    /// </summary>
+    /// <param name="tokenId">
+    /// The token id</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the operation.
+    /// </returns>
+    [AlwaysInterleave]
+    Task CancelRemoteToken(Guid tokenId);
+}

--- a/src/Orleans.Runtime/Cancellation/CancellableInvokableGrainExtension.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellableInvokableGrainExtension.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Cancellation;
+
+internal class CancellableInvokableGrainExtension : ICancellableInvokableGrainExtension
+{
+    public Task CancelRemoteToken(Guid tokenId)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Orleans.Runtime/Cancellation/CancellableInvokableGrainExtension.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellableInvokableGrainExtension.cs
@@ -1,12 +1,33 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Serialization.Invocation;
 
 namespace Orleans.Runtime.Cancellation;
 
-internal class CancellableInvokableGrainExtension : ICancellableInvokableGrainExtension
+internal class CancellableInvokableGrainExtension : ICancellableInvokableGrainExtension, IDisposable
 {
+    readonly ICancellationRuntime _runtime;
+    readonly Timer _cleanupTimer;
+
+    public CancellableInvokableGrainExtension(IGrainContext grainContext)
+    {
+        _runtime = grainContext.GetComponent<ICancellationRuntime>();
+        _cleanupTimer = new Timer(obj => ((CancellableInvokableGrainExtension)obj)._runtime.ExpireTokens(), this, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
     public Task CancelRemoteToken(Guid tokenId)
     {
-        throw new NotImplementedException();
+        if (_runtime is not null)
+        {
+            _runtime.Cancel(tokenId, lastCall: false);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _cleanupTimer.Dispose();
     }
 }

--- a/src/Orleans.Runtime/Cancellation/CancellationRuntime.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellationRuntime.cs
@@ -57,12 +57,23 @@ internal class CancellationRuntime : ICancellationRuntime
                 // Dispose if we failed to reuse
                 entry.Source.Dispose();
             }
+
+            lock (_cancellationTokens)
+            {
+                _cancellationTokens.Remove(tokenId);
+            }
         }
     }
 
-    public CancellationToken RegisterCancellableToken(Guid tokenId)
+    public CancellationToken RegisterCancellableToken(Guid tokenId, CancellationToken @default)
     {
         var entry = GetOrCreateEntry(tokenId);
+
+        if (@default != CancellationToken.None)
+        {
+            return CancellationTokenSource.CreateLinkedTokenSource(@default, entry.Source.Token).Token;
+        }
+
         return entry.Source.Token;
     }
 

--- a/src/Orleans.Runtime/Cancellation/CancellationRuntime.cs
+++ b/src/Orleans.Runtime/Cancellation/CancellationRuntime.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Orleans.Serialization.Invocation;
+
+namespace Orleans.Runtime.Cancellation;
+
+internal class CancellationRuntime : ICancellationRuntime
+{
+    readonly ConcurrentDictionary<Guid, TokenEntry> _cancellationTokens = new ConcurrentDictionary<Guid, TokenEntry>();
+
+    TokenEntry GetOrCreateEntry(Guid tokenId)
+    {
+        return _cancellationTokens.GetOrAdd(tokenId, _ => new TokenEntry(new CancellationTokenSource()));
+    }
+
+    public void Cancel(Guid tokenId, bool lastCall)
+    {
+        if (lastCall)
+        {
+            // On a last call, we can remove the token entry and dispose of it. If no entry exists then we can ignore the call.
+            if (_cancellationTokens.TryRemove(tokenId, out var entry))
+            {
+                entry.CancellationTokenSource.Cancel();
+                entry.Dispose();
+            }
+        }
+        else
+        {
+            // If our invokable has yet to complete, we can cancel the token and leave the entry in place.
+            var entry = GetOrCreateEntry(tokenId);
+            entry.CancellationTokenSource.Cancel();
+        }
+    }
+
+    public CancellationToken RegisterCancellableToken(Guid tokenId)
+    {
+        var entry = GetOrCreateEntry(tokenId);
+        return entry.CancellationTokenSource.Token;
+    }
+
+    readonly record struct TokenEntry(CancellationTokenSource CancellationTokenSource) : IDisposable
+    {
+        // TODO: Expire the entry after a certain amount of time
+
+        public void Dispose() => CancellationTokenSource.Dispose();
+    }
+}

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -43,6 +43,8 @@ using Microsoft.Extensions.Configuration;
 using Orleans.Serialization.Internal;
 using Orleans.Core;
 using Orleans.Placement.Repartitioning;
+using Orleans.Runtime.Cancellation;
+using Orleans.Serialization.Invocation;
 
 namespace Orleans.Hosting
 {
@@ -99,6 +101,9 @@ namespace Orleans.Hosting
             services.TryAddSingleton<IGrainCancellationTokenRuntime, GrainCancellationTokenRuntime>();
             services.AddTransient<CancellationSourcesExtension>();
             services.AddKeyedTransient<IGrainExtension>(typeof(ICancellationSourcesExtension), (sp, _) => sp.GetRequiredService<CancellationSourcesExtension>());
+            services.TryAddTransient<ICancellationRuntime, CancellationRuntime>();
+            services.AddTransient<CancellableInvokableGrainExtension>();
+            services.AddKeyedTransient<IGrainExtension>(typeof(ICancellableInvokableGrainExtension), (sp, _) => sp.GetRequiredService<CancellableInvokableGrainExtension>());
             services.TryAddSingleton<GrainFactory>(sp => sp.GetRequiredService<InsideRuntimeClient>().ConcreteGrainFactory);
             services.TryAddSingleton<InterfaceToImplementationMappingCache>();
             services.TryAddSingleton<GrainInterfaceTypeToGrainTypeResolver>();

--- a/src/Orleans.Serialization/Codecs/CancellationTokenCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CancellationTokenCodec.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.WireProtocol;
+
+namespace Orleans.Serialization.Codecs
+{
+    /// <summary>
+    /// Serializer for <see cref="CancellationToken"/>.
+    /// </summary>
+    [RegisterSerializer]
+    public sealed class CancellationTokenCodec : IFieldCodec<CancellationToken>
+    {
+        void IFieldCodec<CancellationToken>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, CancellationToken value)
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(CancellationToken), WireType.Fixed32);
+            writer.WriteInt32(value.IsCancellationRequested ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Writes a field without type info (expected type is statically known).
+        /// </summary>
+        /// <typeparam name="TBufferWriter">The buffer writer type.</typeparam>
+        /// <param name="writer">The writer.</param>
+        /// <param name="fieldIdDelta">The field identifier delta.</param>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, CancellationToken value) where TBufferWriter : IBufferWriter<byte>
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteFieldHeaderExpected(fieldIdDelta, WireType.Fixed32);
+            writer.WriteInt32(value.IsCancellationRequested ? 1 : 0);
+        }
+
+        /// <inheritdoc />
+        CancellationToken IFieldCodec<CancellationToken>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
+
+        /// <summary>
+        /// Reads a value.
+        /// </summary>
+        /// <typeparam name="TInput">The reader input type.</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <param name="field">The field.</param>
+        /// <returns>The value.</returns>
+        public static CancellationToken ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+        {
+            ReferenceCodec.MarkValueField(reader.Session);
+            field.EnsureWireType(WireType.Fixed32);
+            return new CancellationToken(reader.ReadInt32() == 1 ? true : false);
+        }
+    }
+}

--- a/src/Orleans.Serialization/Invocation/ICancellableInvokable.cs
+++ b/src/Orleans.Serialization/Invocation/ICancellableInvokable.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System;
+
+namespace Orleans.Serialization.Invocation
+{
+    /// <summary>
+    /// Represents an invokable that can be canceled
+    /// </summary>
+    public interface ICancellableInvokable : IInvokable
+    {
+        /// <summary>
+        /// Returns an id that uniquely identifies this invokable
+        /// </summary>
+        Guid GetCancellableTokenId();
+    }
+}

--- a/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
+++ b/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Serialization.Invocation;
+
+/// <summary>
+/// An optional runtime to fascilitate in cancelling invokables 
+/// </summary>
+public interface ICancellationRuntime
+{
+    /// <summary>
+    /// Registers the token and returns a cancellation token linked to the token id
+    /// </summary>
+    /// <param name="tokenId">The token id to register</param>
+    /// <returns>A cancellationToken that will be cancelled once Cancel for the token has been called</returns>
+    CancellationToken RegisterCancellableToken(Guid tokenId);
+
+    /// <summary>
+    /// Cancels the invokable with the specified token id
+    /// </summary>
+    /// <param name="tokenId">The token id to cancel</param>
+    /// <param name="lastCall">Whether this is the last call associated with the token</param>
+    void Cancel(Guid tokenId, bool lastCall);
+}

--- a/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
+++ b/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
@@ -16,8 +16,9 @@ public interface ICancellationRuntime
     /// Registers the token and returns a cancellation token linked to the token id
     /// </summary>
     /// <param name="tokenId">The token id to register</param>
+    /// <param name="default">The default cancellationToken to consider</param>
     /// <returns>A cancellationToken that will be cancelled once Cancel for the token has been called</returns>
-    CancellationToken RegisterCancellableToken(Guid tokenId);
+    CancellationToken RegisterCancellableToken(Guid tokenId, CancellationToken @default);
 
     /// <summary>
     /// Cancels the invokable with the specified token id

--- a/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
+++ b/src/Orleans.Serialization/Invocation/ICancellationRuntime.cs
@@ -25,4 +25,9 @@ public interface ICancellationRuntime
     /// <param name="tokenId">The token id to cancel</param>
     /// <param name="lastCall">Whether this is the last call associated with the token</param>
     void Cancel(Guid tokenId, bool lastCall);
+
+    /// <summary>
+    /// Expires any tokens that have not yet been cancelled and have been inactive for a period of time
+    /// </summary>
+    void ExpireTokens();
 }

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -193,15 +193,19 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetRuntimeInstanceIdWithDelay(TimeSpan delay);
 
         Task LongWait(GrainCancellationToken tc, TimeSpan delay);
+        Task LongWait(CancellationToken tc, TimeSpan delay);
         Task<T> LongRunningTask(T t, TimeSpan delay);
         Task<T> CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay);
         Task<T> FanOutOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay, int degreeOfParallelism);
         Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, GrainCancellationToken tc, TimeSpan delay);
+        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay);
         Task CallOtherLongRunningTaskWithLocalToken(ILongRunningTaskGrain<T> target, TimeSpan delay,
             TimeSpan delayBeforeCancel);
         Task<bool> CancellationTokenCallbackResolve(GrainCancellationToken tc);
+        Task<bool> CancellationTokenCallbackResolve(CancellationToken tc);
         Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target);
         Task CancellationTokenCallbackThrow(GrainCancellationToken tc);
+        Task CancellationTokenCallbackThrow(CancellationToken tc);
         Task<T> GetLastValue();
     }
 

--- a/test/Tester/CancellationTests/CancellationTokenTests.cs
+++ b/test/Tester/CancellationTests/CancellationTokenTests.cs
@@ -1,0 +1,247 @@
+using Microsoft.Extensions.Logging;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.CancellationTests
+{
+    public class CancellationTokenTests : OrleansTestingBase, IClassFixture<CancellationTokenTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                base.ConfigureTestCluster(builder);
+                builder.AddSiloBuilderConfigurator<SiloConfig>();
+            }
+
+            private class SiloConfig : ISiloConfigurator
+            {
+                public void Configure(ISiloBuilder siloBuilder)
+                {
+                    siloBuilder.ConfigureLogging(logging => logging.AddDebug());
+                }
+            }
+        }
+
+        public CancellationTokenTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task GrainTaskCancellation(int delay)
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            var grainTask = grain.LongWait(tcs.Token, TimeSpan.FromSeconds(10));
+            await Task.Delay(TimeSpan.FromMilliseconds(delay));
+            await tcs.CancelAsync();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task MultipleGrainsTaskCancellation(int delay)
+        {
+            var tcs = new CancellationTokenSource();
+            var grainTasks = Enumerable.Range(0, 5)
+                .Select(i => this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid())
+                            .LongWait(tcs.Token, TimeSpan.FromSeconds(10)))
+                            .Select(task => Assert.ThrowsAsync<TaskCanceledException>(() => task)).ToList();
+            await Task.Delay(TimeSpan.FromMilliseconds(delay));
+            await tcs.CancelAsync();
+            await Task.WhenAll(grainTasks);
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task GrainTaskMultipleCancellations(int delay)
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var grainTasks = Enumerable.Range(0, 5)
+                .Select(async i =>
+                {
+                    var tcs = new CancellationTokenSource();
+                    var task = grain.LongWait(tcs.Token, TimeSpan.FromSeconds(10));
+                    await Task.WhenAny(task, Task.Delay(TimeSpan.FromMilliseconds(delay)));
+                    await tcs.CancelAsync();
+                    try
+                    {
+                        await task;
+                        Assert.Fail("Expected TaskCancelledException, but message completed");
+                    }
+                    catch (TaskCanceledException) { }
+                })
+                .ToList();
+            await Task.WhenAll(grainTasks);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task MultipleGrainTasksSingleCancellation()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+
+            var primaryTsc = new CancellationTokenSource();
+            var primaryTask = grain.LongWait(primaryTsc.Token, TimeSpan.FromSeconds(10));
+            var otherTsc = new CancellationTokenSource();
+            var otherGrainTask = grain.LongWait(otherTsc.Token, TimeSpan.FromSeconds(10));
+
+            primaryTsc.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => primaryTask);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            Assert.Equal(TaskStatus.Running, otherGrainTask.Status);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task TokenPassingWithoutCancellation_NoExceptionShouldBeThrown()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            try
+            {
+                await grain.LongWait(tcs.Token, TimeSpan.FromMilliseconds(1));
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception, but got: " + ex.Message);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task PreCancelledTokenPassing()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            await tcs.CancelAsync();
+
+            // Except a OperationCanceledException to be thrown as the token is already cancelled
+            Assert.Throws<OperationCanceledException>(() => grain.LongWait(tcs.Token, TimeSpan.FromSeconds(10)).Ignore());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task CancellationTokenCallbacksExecutionContext()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            var grainTask = grain.CancellationTokenCallbackResolve(tcs.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await tcs.CancelAsync();
+            var result = await grainTask;
+            Assert.True(result);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task CancellationTokenCallbacksTaskSchedulerContext()
+        {
+            var grains = await GetGrains<bool>(false);
+
+            var tcs = new CancellationTokenSource();
+            var grainTask = grains.Item1.CallOtherCancellationTokenCallbackResolve(grains.Item2);
+            await tcs.CancelAsync();
+            var result = await grainTask;
+            Assert.True(result);
+        }
+
+        [Fact, TestCategory("Cancellation")]
+        public async Task CancellationTokenCallbacksThrow_ExceptionDoesNotPropagate()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            _ = grain.CancellationTokenCallbackThrow(tcs.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            // Cancellation is a cooperative mechanism, so we don't expect the exception to propagate
+            await tcs.CancelAsync();
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task InSiloGrainCancellation(int delay)
+        {
+            await GrainGrainCancellation(false, delay);
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task InterSiloGrainCancellation(int delay)
+        {
+            await GrainGrainCancellation(true, delay);
+        }
+
+        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/5654"), TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task InterSiloClientCancellationTokenPassing(int delay)
+        {
+            await ClientGrainGrainTokenPassing(delay, true);
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(300)]
+        public async Task InSiloClientCancellationTokenPassing(int delay)
+        {
+            await ClientGrainGrainTokenPassing(delay, false);
+        }
+
+        private async Task ClientGrainGrainTokenPassing(int delay, bool interSilo)
+        {
+            var grains = await GetGrains<bool>(interSilo);
+            var grain = grains.Item1;
+            var target = grains.Item2;
+            var tcs = new CancellationTokenSource();
+            var grainTask = grain.CallOtherLongRunningTask(target, tcs.Token, TimeSpan.FromSeconds(10));
+            await Task.Delay(TimeSpan.FromMilliseconds(delay));
+            await tcs.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+        }
+
+        private async Task GrainGrainCancellation(bool interSilo, int delay)
+        {
+            var grains = await GetGrains<bool>(interSilo);
+            var grain = grains.Item1;
+            var target = grains.Item2;
+            var grainTask = grain.CallOtherLongRunningTaskWithLocalToken(target, TimeSpan.FromSeconds(10),
+                TimeSpan.FromMilliseconds(delay));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+        }
+
+        private async Task<Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>> GetGrains<T1>(bool placeOnDifferentSilos = true)
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+            var instanceId = await grain.GetRuntimeInstanceId();
+            var target = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+            var targetInstanceId = await target.GetRuntimeInstanceId();
+            var retriesCount = 0;
+            var retriesLimit = 10;
+
+            while ((placeOnDifferentSilos && instanceId.Equals(targetInstanceId))
+                || (!placeOnDifferentSilos && !instanceId.Equals(targetInstanceId)))
+            {
+                if (retriesCount >= retriesLimit) throw new Exception("Could not make requested grains placement");
+                target = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+                targetInstanceId = await target.GetRuntimeInstanceId();
+                retriesCount++;
+            }
+
+            return new Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>(grain, target);
+        }
+    }
+}


### PR DESCRIPTION
This PR allows for grain methods to be cancelled using a CancellationToken. The implementation is loosely based on the existing GrainCancellationToken support that is already available. 

1. CodeGen detects the use of a `CancellationToken` in a grain interface method
2. If multiple CancellationTokens are used within the same grain interface method then ORLEANS0109 diagnostic is raised
3. The generated proxy throws early if cancellation is requested. Otherwise it will register for cancellation and sends a one-way message to `ICancellableInvokableGrainExtension.CancelRemoteToken` to mark this token as canceled
4. `CancellableInvokableGrainExtension` looks up the grains `ICancellationRuntime` component to mark the token as canceled
5. The generated invokable implements an additional interface: `ICancellableInvokable` which exposes the method: `GetCancellableTokenId`
6. Each instance of a `CancellableInvokable` sets a cancellableTokenId as `Guid.NewGuid()`
7. The `InvokeInner` implementation on the invokable can optionally interact with an `ICancellationRuntime` to track cancellation of this invokable.

Once the invokable completes, its CancellationTokenSource obtained through the `ICancellationRuntime` is always Canceled
