### PR TITLE
Update documentation in IReminderTable

### DIFF
--- a/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs
@@ -38,7 +38,8 @@ namespace Orleans
         Task<ReminderTableData> ReadRows(GrainId grainId);
 
         /// <summary>
-        /// Return all rows that have their <see cref="GrainId.GetUniformHashCode"/> in the range (start, end]
+        /// Returns all rows that have their <see cref="GrainId.GetUniformHashCode"/> in the range (begin, end].
+        /// If begin >= end, returns all entries with hash > begin or hash <= end.
         /// </summary>
         /// <param name="begin">The exclusive lower bound.</param>
         /// <param name="end">The inclusive upper bound.</param>
@@ -46,7 +47,7 @@ namespace Orleans
         Task<ReminderTableData> ReadRows(uint begin, uint end);
 
         /// <summary>
-        /// Reads a specifie entry.
+        /// Reads the specified entry.
         /// </summary>
         /// <param name="grainId">The grain ID.</param>
         /// <param name="reminderName">Name of the reminder.</param>


### PR DESCRIPTION
I ran into issues when writing a Firestore-based implementation of Reminders.
In my case, Orleans calls into the ReminderTable implementation with begin: 0 and end: 0.

Based on the existing documentation one could have two interpretations:
- No entries should be returned; as given the range, no entry can be bigger than 0 and also smaller or equal to 0
- The entry with hash 0 should be returned

But given this left reminders inoperable, these interpretations don't seem to be correct.

When digging in the contrib repo, I found the handling in the MongoDB ReminderTable to interpret this case as "either bigger than begin or smaller or equal to end". This seems to have the intended effect in my implementation as well.

If this is how it is supposed to work, I think the documentation should be adjusted.

Thanks and have a great day!