### PR TITLE
Avoid mutating `IPEndPoint` in `RedisGatewayListProvider`

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisGatewayListProvider.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisGatewayListProvider.cs
@@ -7,44 +7,37 @@ using Orleans.Configuration;
 using System.Linq;
 using Microsoft.Extensions.Options;
 
-namespace Orleans.Clustering.Redis
+namespace Orleans.Clustering.Redis;
+
+internal sealed class RedisGatewayListProvider(RedisMembershipTable table, IOptions<GatewayOptions> options) : IGatewayListProvider
 {
-    internal class RedisGatewayListProvider : IGatewayListProvider
+    private readonly RedisMembershipTable _table = table;
+    private readonly GatewayOptions _gatewayOptions = options.Value;
+
+    public TimeSpan MaxStaleness => _gatewayOptions.GatewayListRefreshPeriod;
+
+    public bool IsUpdatable => true;
+
+    public async Task<IList<Uri>> GetGateways()
     {
-        private readonly RedisMembershipTable _table;
-        private readonly GatewayOptions _gatewayOptions;
-
-        public RedisGatewayListProvider(RedisMembershipTable table, IOptions<GatewayOptions> options)
-        {
-            _gatewayOptions = options.Value;
-            _table = table;
-        }
-
-        public TimeSpan MaxStaleness => _gatewayOptions.GatewayListRefreshPeriod;
-
-        public bool IsUpdatable => true;
-
-        public async Task<IList<Uri>> GetGateways()
-        {
-            if (!_table.IsInitialized)
-            {
-                await _table.InitializeMembershipTable(true);
-            }
-
-            var all = await _table.ReadAll();
-            var result = all.Members
-               .Where(x => x.Item1.Status == SiloStatus.Active && x.Item1.ProxyPort != 0)
-               .Select(x =>
-                {
-                    x.Item1.SiloAddress.Endpoint.Port = x.Item1.ProxyPort;
-                    return x.Item1.SiloAddress.ToGatewayUri();
-                }).ToList();
-            return result;
-        }
-
-        public async Task InitializeGatewayListProvider()
+        if (!_table.IsInitialized)
         {
             await _table.InitializeMembershipTable(true);
         }
+
+        var all = await _table.ReadAll();
+        var result = all.Members
+           .Where(x => x.Item1.Status == SiloStatus.Active && x.Item1.ProxyPort != 0)
+           .Select(x =>
+            {
+                var entry = x.Item1;
+                return SiloAddress.New(entry.SiloAddress.Endpoint.Address, entry.ProxyPort, entry.SiloAddress.Generation).ToGatewayUri();
+            }).ToList();
+        return result;
+    }
+
+    public async Task InitializeGatewayListProvider()
+    {
+        await _table.InitializeMembershipTable(true);
     }
 }


### PR DESCRIPTION
Fixes #8649

Original code mutates the endpoint of a `SiloAddress`, which is never supposed to be mutated:

```csharp
x.Item1.SiloAddress.Endpoint.Port = x.Item1.ProxyPort;
return x.Item1.SiloAddress.ToGatewayUri();
```

New code:

```csharp
var entry = x.Item1;
return SiloAddress.New(entry.SiloAddress.Endpoint.Address, entry.ProxyPort, entry.SiloAddress.Generation).ToGatewayUri();
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9146)