### PR TITLE
Add in-process test cluster

### DIFF
--- a/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportConnection.cs
+++ b/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportConnection.cs
@@ -87,4 +87,6 @@ internal class InMemoryTransportConnection : TransportConnection
 
         _connectionClosedTokenSource.Dispose();
     }
+
+    public override string ToString() => $"InMem({LocalEndPoint}<->{RemoteEndPoint})";
 }

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -1,0 +1,754 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.TestingHost.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Orleans.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
+using Orleans.TestingHost.InMemoryTransport;
+using System.Net;
+using Orleans.Statistics;
+using Orleans.TestingHost.InProcess;
+using Orleans.Runtime.Hosting;
+using Orleans.GrainDirectory;
+using Orleans.Messaging;
+using Orleans.Hosting;
+using Orleans.Runtime.TestHooks;
+using Orleans.Configuration.Internal;
+using Orleans.TestingHost.Logging;
+
+namespace Orleans.TestingHost;
+
+/// <summary>
+/// A host class for local testing with Orleans using in-process silos. 
+/// </summary>
+public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
+{
+    private readonly List<InProcessSiloHandle> _silos = [];
+    private readonly StringBuilder _log = new();
+    private readonly InMemoryTransportConnectionHub _transportHub = new();
+    private readonly InProcessGrainDirectory _grainDirectory;
+    private readonly InProcessMembershipTable _membershipTable;
+    private bool _disposed;
+    private int _startedInstances;
+
+    /// <summary>
+    /// Collection of all known silos.
+    /// </summary>
+    public ReadOnlyCollection<InProcessSiloHandle> Silos
+    {
+        get
+        {
+            lock (_silos)
+            {
+                return new List<InProcessSiloHandle>(_silos).AsReadOnly();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Options used to configure the test cluster.
+    /// </summary>
+    /// <remarks>This is the options you configured your test cluster with, or the default one. 
+    /// If the cluster is being configured via ClusterConfiguration, then this object may not reflect the true settings.
+    /// </remarks>
+    public InProcessTestClusterOptions Options { get; }
+
+    /// <summary>
+    /// The internal client interface.
+    /// </summary>
+    internal IHost ClientHost { get; private set; }
+
+    /// <summary>
+    /// The internal client interface.
+    /// </summary>
+    internal IInternalClusterClient InternalClient => ClientHost?.Services.GetRequiredService<IInternalClusterClient>();
+
+    /// <summary>
+    /// The client.
+    /// </summary>
+    public IClusterClient Client => ClientHost?.Services.GetRequiredService<IInternalClusterClient>();
+
+    /// <summary>
+    /// The port allocator.
+    /// </summary>
+    public ITestClusterPortAllocator PortAllocator { get; }
+
+    /// <summary>
+    /// Configures the test cluster plus client in-process.
+    /// </summary>
+    public InProcessTestCluster(
+        InProcessTestClusterOptions options,
+        ITestClusterPortAllocator portAllocator)
+    {
+        Options = options;
+        PortAllocator = portAllocator;
+        _membershipTable = new(options.ClusterId);
+        _grainDirectory = new(_membershipTable.GetSiloStatus);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="IServiceProvider"/> associated with the given <paramref name="silo"/>.
+    /// </summary>
+    /// <param name="silo">The silo process to the the service provider for.</param>
+    /// <remarks>If <paramref name="silo"/> is <see langword="null"/> one of the existing silos will be picked randomly.</remarks>
+    public IServiceProvider GetSiloServiceProvider(SiloAddress silo = null)
+    {
+        if (silo != null)
+        {
+            var handle = Silos.FirstOrDefault(x => x.SiloAddress.Equals(silo));
+            return handle != null ? handle.SiloHost.Services :
+                throw new ArgumentException($"The provided silo address '{silo}' is unknown.");
+        }
+        else
+        {
+            var index = Random.Shared.Next(Silos.Count);
+            return Silos[index].SiloHost.Services;
+        }
+    }
+
+    /// <summary>
+    /// Deploys the cluster using the specified configuration and starts the client in-process.
+    /// </summary>
+    public async Task DeployAsync()
+    {
+        if (_silos.Count > 0) throw new InvalidOperationException("Cluster host already deployed.");
+
+        AppDomain.CurrentDomain.UnhandledException += ReportUnobservedException;
+
+        try
+        {
+            string startMsg = "----------------------------- STARTING NEW UNIT TEST SILO HOST: " + GetType().FullName + " -------------------------------------";
+            WriteLog(startMsg);
+            await InitializeAsync();
+
+            if (Options.InitializeClientOnDeploy)
+            {
+                await WaitForInitialStabilization();
+            }
+        }
+        catch (TimeoutException te)
+        {
+            FlushLogToConsole();
+            throw new TimeoutException("Timeout during test initialization", te);
+        }
+        catch (Exception ex)
+        {
+            await StopAllSilosAsync();
+
+            Exception baseExc = ex.GetBaseException();
+            FlushLogToConsole();
+
+            if (baseExc is TimeoutException)
+            {
+                throw new TimeoutException("Timeout during test initialization", ex);
+            }
+
+            // IMPORTANT:
+            // Do NOT re-throw the original exception here, also not as an internal exception inside AggregateException
+            // Due to the way MS tests works, if the original exception is an Orleans exception,
+            // it's assembly might not be loaded yet in this phase of the test.
+            // As a result, we will get "MSTest: Unit Test Adapter threw exception: Type is not resolved for member XXX"
+            // and will loose the original exception. This makes debugging tests super hard!
+            // The root cause has to do with us initializing our tests from Test constructor and not from TestInitialize method.
+            // More details: http://dobrzanski.net/2010/09/20/mstest-unit-test-adapter-threw-exception-type-is-not-resolved-for-member/
+            //throw new Exception(
+            //    string.Format("Exception during test initialization: {0}",
+            //        LogFormatter.PrintException(baseExc)));
+            throw;
+        }
+    }
+
+    private async Task WaitForInitialStabilization()
+    {
+        // Poll each silo to check that it knows the expected number of active silos.
+        // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
+        // If the cluster membership has not stabilized after a certain period of time, give up and continue anyway.
+        var totalWait = Stopwatch.StartNew();
+        while (true)
+        {
+            var silos = Silos;
+            var expectedCount = silos.Count;
+            var remainingSilos = expectedCount;
+
+            foreach (var silo in silos)
+            {
+                var hooks = InternalClient.GetTestHooks(silo);
+                var statuses = await hooks.GetApproximateSiloStatuses();
+                var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
+                if (activeCount != expectedCount) break;
+                remainingSilos--;
+            }
+
+            if (remainingSilos == 0)
+            {
+                totalWait.Stop();
+                break;
+            }
+
+            WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+            if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
+            {
+                WriteLog($"Warning! {remainingSilos} silos do not have a consistent cluster view after {totalWait.ElapsedMilliseconds}ms, continuing without stabilization.");
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get the list of current active silos.
+    /// </summary>
+    /// <returns>List of current silos.</returns>
+    public IEnumerable<InProcessSiloHandle> GetActiveSilos()
+    {
+        var additional = new List<InProcessSiloHandle>();
+        lock (_silos)
+        {
+            additional.AddRange(_silos);
+        }
+
+        WriteLog("GetActiveSilos: {0} Silos={1}",
+            additional.Count, Runtime.Utils.EnumerableToString(additional));
+
+        if (additional.Count > 0)
+            foreach (var s in additional)
+                if (s?.IsActive == true)
+                    yield return s;
+    }
+
+    /// <summary>
+    /// Find the silo handle for the specified silo address.
+    /// </summary>
+    /// <param name="siloAddress">Silo address to be found.</param>
+    /// <returns>SiloHandle of the appropriate silo, or <c>null</c> if not found.</returns>
+    public InProcessSiloHandle GetSiloForAddress(SiloAddress siloAddress)
+    {
+        var activeSilos = GetActiveSilos().ToList();
+        var ret = activeSilos.Find(s => s.SiloAddress.Equals(siloAddress));
+        return ret;
+    }
+
+    /// <summary>
+    /// Wait for the silo liveness sub-system to detect and act on any recent cluster membership changes.
+    /// </summary>
+    /// <param name="didKill">Whether recent membership changes we done by graceful Stop.</param>
+    public async Task WaitForLivenessToStabilizeAsync(bool didKill = false)
+    {
+        var clusterMembershipOptions = Client.ServiceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
+        TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
+        WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is about to sleep for {0}", stabilizationTime);
+        await Task.Delay(stabilizationTime);
+        WriteLog("WaitForLivenessToStabilize is done sleeping");
+    }
+
+    /// <summary>
+    /// Get the timeout value to use to wait for the silo liveness sub-system to detect and act on any recent cluster membership changes.
+    /// <seealso cref="WaitForLivenessToStabilizeAsync"/>
+    /// </summary>
+    public static TimeSpan GetLivenessStabilizationTime(ClusterMembershipOptions clusterMembershipOptions, bool didKill = false)
+    {
+        TimeSpan stabilizationTime = TimeSpan.Zero;
+        if (didKill)
+        {
+            // in case of hard kill (kill and not Stop), we should give silos time to detect failures first.
+            stabilizationTime = TestingUtils.Multiply(clusterMembershipOptions.ProbeTimeout, clusterMembershipOptions.NumMissedProbesLimit);
+        }
+        if (clusterMembershipOptions.UseLivenessGossip)
+        {
+            stabilizationTime += TimeSpan.FromSeconds(5);
+        }
+        else
+        {
+            stabilizationTime += TestingUtils.Multiply(clusterMembershipOptions.TableRefreshTimeout, 2);
+        }
+        return stabilizationTime;
+    }
+
+    /// <summary>
+    /// Start an additional silo, so that it joins the existing cluster.
+    /// </summary>
+    /// <returns>SiloHandle for the newly started silo.</returns>
+    public InProcessSiloHandle StartAdditionalSilo(bool startAdditionalSiloOnNewPort = false)
+    {
+        return StartAdditionalSiloAsync(startAdditionalSiloOnNewPort).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Start an additional silo, so that it joins the existing cluster.
+    /// </summary>
+    /// <returns>SiloHandle for the newly started silo.</returns>
+    public async Task<InProcessSiloHandle> StartAdditionalSiloAsync(bool startAdditionalSiloOnNewPort = false)
+    {
+        return (await StartSilosAsync(1, startAdditionalSiloOnNewPort)).Single();
+    }
+
+    /// <summary>
+    /// Start a number of additional silo, so that they join the existing cluster.
+    /// </summary>
+    /// <param name="silosToStart">Number of silos to start.</param>
+    /// <param name="startAdditionalSiloOnNewPort"></param>
+    /// <returns>List of SiloHandles for the newly started silos.</returns>
+    public async Task<List<InProcessSiloHandle>> StartSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort = false)
+    {
+        var instances = new List<InProcessSiloHandle>();
+        if (silosToStart > 0)
+        {
+            var siloStartTasks = Enumerable.Range(_startedInstances, silosToStart)
+                .Select(instanceNumber => Task.Run(() => StartSiloAsync((short)instanceNumber, Options, startSiloOnNewPort: startAdditionalSiloOnNewPort))).ToArray();
+
+            try
+            {
+                await Task.WhenAll(siloStartTasks);
+            }
+            catch (Exception)
+            {
+                lock (_silos)
+                {
+                    _silos.AddRange(siloStartTasks.Where(t => t.Exception == null).Select(t => t.Result));
+                }
+
+                throw;
+            }
+
+            instances.AddRange(siloStartTasks.Select(t => t.Result));
+            lock (_silos)
+            {
+                _silos.AddRange(instances);
+            }
+        }
+
+        return instances;
+    }
+
+    /// <summary>
+    /// Stop all silos.
+    /// </summary>
+    public async Task StopSilosAsync()
+    {
+        foreach (var instance in _silos.ToList())
+        {
+            await StopSiloAsync(instance);
+        }
+    }
+
+    /// <summary>
+    /// Stop cluster client as an asynchronous operation.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task StopClusterClientAsync()
+    {
+        var client = ClientHost;
+        try
+        {
+            if (client is not null)
+            {
+                await client.StopAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception exc)
+        {
+            WriteLog("Exception stopping client: {0}", exc);
+        }
+        finally
+        {
+            await DisposeAsync(client).ConfigureAwait(false);
+            ClientHost = null;
+        }
+    }
+
+    /// <summary>
+    /// Stop all current silos.
+    /// </summary>
+    public void StopAllSilos()
+    {
+        StopAllSilosAsync().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Stop all current silos.
+    /// </summary>
+    public async Task StopAllSilosAsync()
+    {
+        await StopClusterClientAsync();
+        await StopSilosAsync();
+        AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
+    }
+
+    /// <summary>
+    /// Do a semi-graceful Stop of the specified silo.
+    /// </summary>
+    /// <param name="instance">Silo to be stopped.</param>
+    public async Task StopSiloAsync(InProcessSiloHandle instance)
+    {
+        if (instance != null)
+        {
+            await StopSiloAsync(instance, true);
+            lock (_silos)
+            {
+                _silos.Remove(instance);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Do an immediate Kill of the specified silo.
+    /// </summary>
+    /// <param name="instance">Silo to be killed.</param>
+    public async Task KillSiloAsync(InProcessSiloHandle instance)
+    {
+        if (instance != null)
+        {
+            // do NOT stop, just kill directly, to simulate crash.
+            await StopSiloAsync(instance, false);
+            lock (_silos)
+            {
+                _silos.Remove(instance);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a hard kill on client.  Client will not cleanup resources.
+    /// </summary>
+    public async Task KillClientAsync()
+    {
+        var client = ClientHost;
+        if (client != null)
+        {
+            var cancelled = new CancellationTokenSource();
+            cancelled.Cancel();
+            try
+            {
+                await client.StopAsync(cancelled.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                await DisposeAsync(client);
+                ClientHost = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Do a Stop or Kill of the specified silo, followed by a restart.
+    /// </summary>
+    /// <param name="instance">Silo to be restarted.</param>
+    public async Task<InProcessSiloHandle> RestartSiloAsync(InProcessSiloHandle instance)
+    {
+        if (instance != null)
+        {
+            var instanceNumber = instance.InstanceNumber;
+            await StopSiloAsync(instance);
+            var newInstance = await StartSiloAsync(instanceNumber, Options);
+            lock (_silos)
+            {
+                _silos.Add(newInstance);
+            }
+
+            return newInstance;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Restart a previously stopped.
+    /// </summary>
+    /// <param name="siloName">Silo to be restarted.</param>
+    public async Task<InProcessSiloHandle> RestartStoppedSecondarySiloAsync(string siloName)
+    {
+        if (siloName == null) throw new ArgumentNullException(nameof(siloName));
+        var siloHandle = Silos.Single(s => s.Name.Equals(siloName, StringComparison.Ordinal));
+        var newInstance = await StartSiloAsync(Silos.IndexOf(siloHandle), Options);
+        lock (_silos)
+        {
+            _silos.Add(newInstance);
+        }
+        return newInstance;
+    }
+
+    /// <summary>
+    /// Initialize the grain client. This should be already done by <see cref="DeployAsync"/>
+    /// </summary>
+    public async Task InitializeClientAsync()
+    {
+        WriteLog("Initializing Cluster Client");
+
+        if (ClientHost is not null)
+        {
+            await StopClusterClientAsync();
+        }
+
+        var hostBuilder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = Environments.Development,
+            ApplicationName = "TestClusterClient",
+            DisableDefaults = true,
+        });
+
+        hostBuilder.UseOrleansClient(clientBuilder =>
+        {
+            if (Options.UseTestClusterMembership)
+            {
+                clientBuilder.Services.AddSingleton<IGatewayListProvider>(_membershipTable);
+            }
+
+            clientBuilder.UseInMemoryConnectionTransport(_transportHub);
+        });
+
+        TryConfigureFileLogging(Options, hostBuilder.Services, "TestClusterClient");
+
+        foreach (var hostDelegate in Options.ClientHostConfigurationDelegates)
+        {
+            hostDelegate(hostBuilder);
+        }
+
+        ClientHost = hostBuilder.Build();
+        await ClientHost.StartAsync();
+    }
+
+    private async Task InitializeAsync()
+    {
+        var silosToStart = Options.InitialSilosCount;
+
+        if (silosToStart > 0)
+        {
+            await StartSilosAsync(silosToStart);
+        }
+
+        WriteLog("Done initializing cluster");
+
+        if (Options.InitializeClientOnDeploy)
+        {
+            await InitializeClientAsync();
+        }
+    }
+
+    public async Task<InProcessSiloHandle> CreateSiloAsync(InProcessTestSiloSpecificOptions siloOptions)
+    {
+        var host = await Task.Run(async () =>
+        {
+            var siloName = siloOptions.SiloName;
+
+            var appBuilder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+            {
+                ApplicationName = siloName,
+                EnvironmentName = Environments.Development,
+                DisableDefaults = true
+            });
+
+            var services = appBuilder.Services;
+            TryConfigureFileLogging(Options, services, siloName);
+
+            if (Debugger.IsAttached)
+            {
+                // Test is running inside debugger - Make timeout ~= infinite
+                services.Configure<SiloMessagingOptions>(op => op.ResponseTimeout = TimeSpan.FromMilliseconds(1000000));
+            }
+
+            appBuilder.UseOrleans(siloBuilder =>
+            {
+                siloBuilder.Configure<SiloOptions>(o =>
+                {
+                    o.SiloName = siloOptions.SiloName;
+                });
+
+                siloBuilder.Configure<EndpointOptions>(o =>
+                {
+                    o.AdvertisedIPAddress = IPAddress.Loopback;
+                    o.SiloPort = siloOptions.SiloPort;
+                    o.GatewayPort = siloOptions.GatewayPort;
+                });
+
+                siloBuilder.Services
+                    .Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
+
+                if (Options.UseTestClusterMembership)
+                {
+                    services.AddSingleton<IMembershipTable>(_membershipTable);
+                    siloBuilder.AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (_, _) => _grainDirectory);
+                }
+
+                siloBuilder.UseInMemoryConnectionTransport(_transportHub);
+
+                services.AddSingleton<TestHooksEnvironmentStatisticsProvider>();
+                services.AddSingleton<TestHooksSystemTarget>();
+                if (!Options.UseRealEnvironmentStatistics)
+                {
+                    services.AddFromExisting<IEnvironmentStatisticsProvider, TestHooksEnvironmentStatisticsProvider>();
+                }
+            });
+
+            foreach (var hostDelegate in Options.SiloHostConfigurationDelegates)
+            {
+                hostDelegate(siloOptions, appBuilder);
+            }
+
+            var host = appBuilder.Build();
+            InitializeTestHooksSystemTarget(host);
+            await host.StartAsync();
+            return host;
+        });
+
+        return new InProcessSiloHandle
+        {
+            Name = siloOptions.SiloName,
+            SiloHost = host,
+            SiloAddress = host.Services.GetRequiredService<ILocalSiloDetails>().SiloAddress,
+            GatewayAddress = host.Services.GetRequiredService<ILocalSiloDetails>().GatewayAddress,
+        };
+    }
+
+    /// <summary>
+    /// Start a new silo in the target cluster
+    /// </summary>
+    /// <param name="cluster">The InProcessTestCluster in which the silo should be deployed</param>
+    /// <param name="instanceNumber">The instance number to deploy</param>
+    /// <param name="clusterOptions">The options to use.</param>
+    /// <param name="configurationOverrides">Configuration overrides.</param>
+    /// <param name="startSiloOnNewPort">Whether we start this silo on a new port, instead of the default one</param>
+    /// <returns>A handle to the silo deployed</returns>
+    public static async Task<InProcessSiloHandle> StartSiloAsync(InProcessTestCluster cluster, int instanceNumber, InProcessTestClusterOptions clusterOptions, IReadOnlyList<IConfigurationSource> configurationOverrides = null, bool startSiloOnNewPort = false)
+    {
+        if (cluster == null) throw new ArgumentNullException(nameof(cluster));
+        return await cluster.StartSiloAsync(instanceNumber, clusterOptions, configurationOverrides, startSiloOnNewPort);
+    }
+
+    /// <summary>
+    /// Starts a new silo.
+    /// </summary>
+    /// <param name="instanceNumber">The instance number to deploy</param>
+    /// <param name="clusterOptions">The options to use.</param>
+    /// <param name="configurationOverrides">Configuration overrides.</param>
+    /// <param name="startSiloOnNewPort">Whether we start this silo on a new port, instead of the default one</param>
+    /// <returns>A handle to the deployed silo.</returns>
+    public async Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions, IReadOnlyList<IConfigurationSource> configurationOverrides = null, bool startSiloOnNewPort = false)
+    {
+        var siloOptions = InProcessTestSiloSpecificOptions.Create(this, clusterOptions, instanceNumber, startSiloOnNewPort);
+        var handle = await CreateSiloAsync(siloOptions);
+        handle.InstanceNumber = (short)instanceNumber;
+        Interlocked.Increment(ref _startedInstances);
+        return handle;
+    }
+
+    private async Task StopSiloAsync(InProcessSiloHandle instance, bool stopGracefully)
+    {
+        try
+        {
+            await instance.StopSiloAsync(stopGracefully).ConfigureAwait(false);
+        }
+        finally
+        {
+            await DisposeAsync(instance).ConfigureAwait(false);
+
+            Interlocked.Decrement(ref _startedInstances);
+        }
+    }
+
+    /// <summary>
+    /// Gets the log.
+    /// </summary>
+    /// <returns>The log contents.</returns>
+    public string GetLog()
+    {
+        return _log.ToString();
+    }
+
+    private void ReportUnobservedException(object sender, UnhandledExceptionEventArgs eventArgs)
+    {
+        Exception exception = (Exception)eventArgs.ExceptionObject;
+        WriteLog("Unobserved exception: {0}", exception);
+    }
+
+    private void WriteLog(string format, params object[] args)
+    {
+        _log.AppendFormat(format + Environment.NewLine, args);
+    }
+
+    private void FlushLogToConsole()
+    {
+        Console.WriteLine(GetLog());
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await Task.Run(async () =>
+        {
+            foreach (var handle in Silos)
+            {
+                await DisposeAsync(handle).ConfigureAwait(false);
+            }
+
+            await DisposeAsync(ClientHost).ConfigureAwait(false);
+            ClientHost = null;
+
+            PortAllocator?.Dispose();
+        });
+
+        _disposed = true;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        foreach (var handle in Silos)
+        {
+            handle.Dispose();
+        }
+
+        ClientHost?.Dispose();
+        PortAllocator?.Dispose();
+
+        _disposed = true;
+    }
+
+    private static async Task DisposeAsync(IDisposable value)
+    {
+        if (value is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else if (value is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+    }
+    private static void TryConfigureFileLogging(InProcessTestClusterOptions options, IServiceCollection services, string name)
+    {
+        if (options.ConfigureFileLogging)
+        {
+            var fileName = TestingUtils.CreateTraceFileName(name, options.ClusterId);
+            services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
+        }
+    }
+
+    private static void InitializeTestHooksSystemTarget(IHost host)
+    {
+        var testHook = host.Services.GetRequiredService<TestHooksSystemTarget>();
+        var catalog = host.Services.GetRequiredService<Catalog>();
+        catalog.RegisterSystemTarget(testHook);
+    }
+}

--- a/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost;
+
+/// <summary>Configuration builder for starting a <see cref="InProcessTestCluster"/>.</summary>
+public sealed class InProcessTestClusterBuilder
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="InProcessTestClusterBuilder"/> using the default options.
+    /// </summary>
+    public InProcessTestClusterBuilder()
+        : this(2)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InProcessTestClusterBuilder"/> overriding the initial silos count.
+    /// </summary>
+    /// <param name="initialSilosCount">The number of initial silos to deploy.</param>
+    public InProcessTestClusterBuilder(short initialSilosCount)
+    {
+        Options = new InProcessTestClusterOptions
+        {
+            InitialSilosCount = initialSilosCount,
+            ClusterId = CreateClusterId(),
+            ServiceId = Guid.NewGuid().ToString("N"),
+            UseTestClusterMembership = true,
+            InitializeClientOnDeploy = true,
+            ConfigureFileLogging = true,
+            AssumeHomogenousSilosForTesting = true
+        };
+    }
+
+    /// <summary>
+    /// Gets the options.
+    /// </summary>
+    /// <value>The options.</value>
+    public InProcessTestClusterOptions Options { get; }
+
+    /// <summary>
+    /// The port allocator.
+    /// </summary>
+    public ITestClusterPortAllocator PortAllocator { get; } = new TestClusterPortAllocator();
+
+    /// <summary>
+    /// Adds a delegate for configuring silo and client hosts.
+    /// </summary>
+    public InProcessTestClusterBuilder ConfigureHost(Action<IHostApplicationBuilder> configureDelegate)
+    {
+        Options.SiloHostConfigurationDelegates.Add((_, hostBuilder) => configureDelegate(hostBuilder));
+        Options.ClientHostConfigurationDelegates.Add(configureDelegate);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a delegate to configure silos.
+    /// </summary>
+    /// <returns>The builder.</returns>
+    public InProcessTestClusterBuilder ConfigureSilo(Action<InProcessTestSiloSpecificOptions, ISiloBuilder> configureSiloDelegate)
+    {
+        Options.SiloHostConfigurationDelegates.Add((options, hostBuilder) => hostBuilder.UseOrleans(siloBuilder => configureSiloDelegate(options, siloBuilder)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a delegate to configure silo hosts.
+    /// </summary>
+    /// <returns>The builder.</returns>
+    public InProcessTestClusterBuilder ConfigureSiloHost(Action<InProcessTestSiloSpecificOptions, IHostApplicationBuilder> configureSiloHostDelegate)
+    {
+        Options.SiloHostConfigurationDelegates.Add(configureSiloHostDelegate);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a delegate to configure clients.
+    /// </summary>
+    /// <returns>The builder.</returns>
+    public InProcessTestClusterBuilder ConfigureClient(Action<IClientBuilder> configureClientDelegate)
+    {
+        Options.ClientHostConfigurationDelegates.Add(hostBuilder => hostBuilder.UseOrleansClient(clientBuilder => configureClientDelegate(clientBuilder)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a delegate to configure clients hosts.
+    /// </summary>
+    /// <returns>The builder.</returns>
+    public InProcessTestClusterBuilder ConfigureClientHost(Action<IHostApplicationBuilder> configureHostDelegate)
+    {
+        Options.ClientHostConfigurationDelegates.Add(hostBuilder => configureHostDelegate(hostBuilder));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds this instance.
+    /// </summary>
+    /// <returns>InProcessTestCluster.</returns>
+    public InProcessTestCluster Build()
+    {
+        var portAllocator = PortAllocator;
+
+        ConfigureDefaultPorts();
+
+        var testCluster = new InProcessTestCluster(Options, portAllocator);
+        return testCluster;
+    }
+
+    /// <summary>
+    /// Creates a cluster identifier.
+    /// </summary>
+    /// <returns>A new cluster identifier.</returns>
+    public static string CreateClusterId()
+    {
+        string prefix = "testcluster-";
+        int randomSuffix = Random.Shared.Next(1000);
+        DateTime now = DateTime.UtcNow;
+        string DateTimeFormat = @"yyyy-MM-dd\tHH-mm-ss";
+        return $"{prefix}{now.ToString(DateTimeFormat, CultureInfo.InvariantCulture)}-{randomSuffix}";
+    }
+
+    private void ConfigureDefaultPorts()
+    {
+        // Set base ports if none are currently set.
+        (int baseSiloPort, int baseGatewayPort) = PortAllocator.AllocateConsecutivePortPairs(Options.InitialSilosCount + 3);
+        if (Options.BaseSiloPort == 0) Options.BaseSiloPort = baseSiloPort;
+        if (Options.BaseGatewayPort == 0) Options.BaseGatewayPort = baseGatewayPort;
+    }
+
+    internal class ConfigureStaticClusterDeploymentOptions : IHostConfigurator
+    {
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((context, services) =>
+            {
+                var initialSilos = int.Parse(context.Configuration[nameof(InProcessTestClusterOptions.InitialSilosCount)]);
+                var siloNames = Enumerable.Range(0, initialSilos).Select(GetSiloName).ToList();
+                services.Configure<StaticClusterDeploymentOptions>(options => options.SiloNames = siloNames);
+            });
+        }
+
+        private static string GetSiloName(int instanceNumber)
+        {
+            return instanceNumber == 0 ? Silo.PrimarySiloName : $"Secondary_{instanceNumber}";
+        }
+    }
+}

--- a/src/Orleans.TestingHost/InProcTestClusterOptions.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterOptions.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Hosting;
+using Orleans.Configuration;
+using Orleans.Hosting;
+
+namespace Orleans.TestingHost;
+
+/// <summary>
+/// Configuration options for test clusters.
+/// </summary>
+public sealed class InProcessTestClusterOptions
+{
+    /// <summary>
+    /// Gets or sets the cluster identifier.
+    /// </summary>
+    /// <seealso cref="ClusterOptions.ClusterId"/>
+    /// <value>The cluster identifier.</value>
+    public string ClusterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the service identifier.
+    /// </summary>
+    /// <seealso cref="ClusterOptions.ServiceId"/>
+    /// <value>The service identifier.</value>
+    public string ServiceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base silo port, which is the port for the first silo. Other silos will use subsequent ports.
+    /// </summary>
+    /// <value>The base silo port.</value>
+    internal int BaseSiloPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base gateway port, which is the gateway port for the first silo. Other silos will use subsequent ports.
+    /// </summary>
+    /// <value>The base gateway port.</value>
+    internal int BaseGatewayPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use test cluster membership.
+    /// </summary>
+    /// <value><see langword="true" /> if test cluster membership should be used; otherwise, <see langword="false" />.</value>
+    internal bool UseTestClusterMembership { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the real environment statistics.
+    /// </summary>
+    public bool UseRealEnvironmentStatistics { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to initialize the client immediately on deployment.
+    /// </summary>
+    /// <value><see langword="true" /> if the client should be initialized immediately on deployment; otherwise, <see langword="false" />.</value>
+    public bool InitializeClientOnDeploy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the initial silos count.
+    /// </summary>
+    /// <value>The initial silos count.</value>
+    public short InitialSilosCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to configure file logging.
+    /// </summary>
+    /// <value><see langword="true" /> if file logging should be configured; otherwise, <see langword="false" />.</value>
+    public bool ConfigureFileLogging { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to assume homogeneous silos for testing purposes.
+    /// </summary>
+    /// <value><see langword="true" /> if the cluster should assume homogeneous silos; otherwise, <see langword="false" />.</value>
+    public bool AssumeHomogenousSilosForTesting { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether each silo should host a gateway.
+    /// </summary>
+    /// <value><see langword="true" /> if each silo should host a gateway; otherwise, <see langword="false" />.</value>
+    public bool GatewayPerSilo { get; set; } = true;
+
+    /// <summary>
+    /// Gets the silo host configuration delegates.
+    /// </summary>
+    /// <value>The silo host configuration delegates.</value>
+    public List<Action<InProcessTestSiloSpecificOptions, IHostApplicationBuilder>> SiloHostConfigurationDelegates { get; } = [];
+
+    /// <summary>
+    /// Gets the client host configuration delegates.
+    /// </summary>
+    /// <value>The client host configuration delegates.</value>
+    public List<Action<IHostApplicationBuilder>> ClientHostConfigurationDelegates { get; } = [];
+}

--- a/src/Orleans.TestingHost/InProcTestSiloSpecificOptions.cs
+++ b/src/Orleans.TestingHost/InProcTestSiloSpecificOptions.cs
@@ -1,0 +1,55 @@
+namespace Orleans.TestingHost;
+
+/// <summary>
+/// Configuration overrides for individual silos.
+/// </summary>
+public sealed class InProcessTestSiloSpecificOptions
+{
+    /// <summary>
+    /// Gets or sets the silo port.
+    /// </summary>
+    /// <value>The silo port.</value>
+    public int SiloPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets the gateway port.
+    /// </summary>
+    /// <value>The gateway port.</value>
+    public int GatewayPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the silo.
+    /// </summary>
+    /// <value>The name of the silo.</value>
+    public string SiloName { get; set; }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="TestSiloSpecificOptions"/> class.
+    /// </summary>
+    /// <param name="testCluster">The test cluster.</param>
+    /// <param name="testClusterOptions">The test cluster options.</param>
+    /// <param name="instanceNumber">The instance number.</param>
+    /// <param name="assignNewPort">if set to <see langword="true" />, assign a new port for the silo.</param>
+    /// <returns>The options.</returns>
+    public static InProcessTestSiloSpecificOptions Create(InProcessTestCluster testCluster, InProcessTestClusterOptions testClusterOptions, int instanceNumber, bool assignNewPort = false)
+    {
+        var result = new InProcessTestSiloSpecificOptions
+        {
+            SiloName = $"Silo_{instanceNumber}",
+        };
+
+        if (assignNewPort)
+        {
+            var (siloPort, gatewayPort) = testCluster.PortAllocator.AllocateConsecutivePortPairs(1);
+            result.SiloPort = siloPort;
+            result.GatewayPort = (instanceNumber == 0 || testClusterOptions.GatewayPerSilo) ? gatewayPort : 0;
+        }
+        else
+        {
+            result.SiloPort = testClusterOptions.BaseSiloPort + instanceNumber;
+            result.GatewayPort = (instanceNumber == 0 || testClusterOptions.GatewayPerSilo) ? testClusterOptions.BaseGatewayPort + instanceNumber : 0;
+        }
+
+        return result;
+    }
+}

--- a/src/Orleans.TestingHost/InProcess/InProcessGrainDirectory.cs
+++ b/src/Orleans.TestingHost/InProcess/InProcessGrainDirectory.cs
@@ -1,0 +1,82 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.GrainDirectory;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost.InProcess;
+internal sealed class InProcessGrainDirectory(Func<SiloAddress, SiloStatus> getSiloStatus) : IGrainDirectory
+{
+    private readonly ConcurrentDictionary<GrainId, GrainAddress> _entries = [];
+
+    public Task<GrainAddress?> Lookup(GrainId grainId)
+    {
+        if (_entries.TryGetValue(grainId, out var result) && !IsSiloDead(result))
+        {
+            return Task.FromResult<GrainAddress?>(result); 
+        }
+
+        return Task.FromResult<GrainAddress?>(null);
+    }
+
+    public Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        var result = _entries.AddOrUpdate(
+            address.GrainId,
+            static (grainId, state) => state.Address,
+            static (grainId, existing, state) =>
+            {
+                if (existing is null || state.PreviousAddress is { } prev && existing.Matches(prev) || state.Self.IsSiloDead(existing))
+                {
+                    return state.Address;
+                }
+
+                return existing;
+            },
+            (Self: this, Address: address, PreviousAddress: previousAddress));
+
+        if (result is null || IsSiloDead(result))
+        {
+            return Task.FromResult<GrainAddress?>(null);
+        }
+
+        return Task.FromResult<GrainAddress?>(result);
+    }
+
+    public Task<GrainAddress?> Register(GrainAddress address) => Register(address, null);
+
+    public Task Unregister(GrainAddress address)
+    {
+        if (!((IDictionary<GrainId, GrainAddress>)_entries).Remove(KeyValuePair.Create(address.GrainId, address)))
+        {
+            if (_entries.TryGetValue(address.GrainId, out var existing) && (existing.Matches(address) || IsSiloDead(existing)))
+            {
+                ((IDictionary<GrainId, GrainAddress>)_entries).Remove(KeyValuePair.Create(existing.GrainId, existing));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UnregisterSilos(List<SiloAddress> siloAddresses)
+    {
+        foreach (var entry in _entries)
+        {
+            foreach (var silo in siloAddresses)
+            {
+                if (silo.Equals(entry.Value.SiloAddress))
+                {
+                    ((IDictionary<GrainId, GrainAddress>)_entries).Remove(entry);
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private bool IsSiloDead(GrainAddress existing) => existing.SiloAddress is not { } address || getSiloStatus(address) is SiloStatus.Dead or SiloStatus.None;
+}

--- a/src/Orleans.TestingHost/InProcess/InProcessMembershipTable.cs
+++ b/src/Orleans.TestingHost/InProcess/InProcessMembershipTable.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Runtime;
+using System.Globalization;
+using System.Threading.Tasks;
+using Orleans.Messaging;
+
+namespace Orleans.TestingHost.InProcess;
+
+/// <summary>
+/// An in-memory implementation of <see cref="IMembershipTable"/> for testing purposes.
+/// </summary>
+internal sealed class InProcessMembershipTable(string clusterId) : IMembershipTableSystemTarget, IGatewayListProvider
+{
+    private readonly Table _table = new();
+    private readonly string _clusterId = clusterId;
+
+    public TimeSpan MaxStaleness => TimeSpan.Zero;
+    public bool IsUpdatable => true;
+
+    public Task InitializeMembershipTable(bool tryInitTableVersion) => Task.CompletedTask;
+
+    public Task DeleteMembershipTableEntries(string clusterId)
+    {
+        if (string.Equals(_clusterId, clusterId, StringComparison.Ordinal))
+        {
+            _table.Clear();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<MembershipTableData> ReadRow(SiloAddress key) => Task.FromResult(_table.Read(key));
+
+    public Task<MembershipTableData> ReadAll() => Task.FromResult(_table.ReadAll());
+
+    public Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion) => Task.FromResult(_table.Insert(entry, tableVersion));
+
+    public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion) => Task.FromResult(_table.Update(entry, etag, tableVersion));
+
+    public Task UpdateIAmAlive(MembershipEntry entry)
+    {
+        _table.UpdateIAmAlive(entry);
+        return Task.CompletedTask;
+    }
+
+    public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
+    {
+        _table.CleanupDefunctSiloEntries(beforeDate);
+        return Task.CompletedTask;
+    }
+
+    public Task InitializeGatewayListProvider() => Task.CompletedTask;
+
+    public Task<IList<Uri>> GetGateways()
+    {
+        var table = _table.ReadAll();
+        var result = table.Members
+           .Where(x => x.Item1.Status == SiloStatus.Active && x.Item1.ProxyPort != 0)
+           .Select(x =>
+            {
+                var entry = x.Item1;
+                return SiloAddress.New(entry.SiloAddress.Endpoint.Address, entry.ProxyPort, entry.SiloAddress.Generation).ToGatewayUri();
+            }).ToList();
+        return Task.FromResult<IList<Uri>>(result);
+    }
+
+    public SiloStatus GetSiloStatus(SiloAddress address) => _table.GetSiloStatus(address);
+
+    private sealed class Table
+    {
+        private readonly object _lock = new();
+        private readonly Dictionary<SiloAddress, (MembershipEntry Entry, string ETag)> _table = [];
+        private TableVersion _tableVersion;
+        private long _lastETagCounter;
+
+        public Table()
+        {
+            _tableVersion = new TableVersion(0, NewETag());
+        }
+        public SiloStatus GetSiloStatus(SiloAddress key)
+        {
+            lock (_lock)
+            {
+                return _table.TryGetValue(key, out var data) ? data.Entry.Status : SiloStatus.None;
+            }
+        }
+
+        public MembershipTableData Read(SiloAddress key)
+        {
+            lock (_lock)
+            {
+                return _table.TryGetValue(key, out var data) ?
+                    new MembershipTableData(Tuple.Create(data.Entry.Copy(), data.ETag), _tableVersion)
+                    : new MembershipTableData(_tableVersion);
+            }
+        }
+
+        public MembershipTableData ReadAll()
+        {
+            lock (_lock)
+            {
+                return new MembershipTableData(_table.Values.Select(data => Tuple.Create(data.Entry.Copy(), data.ETag)).ToList(), _tableVersion);
+            }
+        }
+
+        public TableVersion ReadTableVersion() => _tableVersion;
+
+        public bool Insert(MembershipEntry entry, TableVersion version)
+        {
+            lock (_lock)
+            {
+                if (_table.TryGetValue(entry.SiloAddress, out var data))
+                {
+                    return false;
+                }
+
+                if (!_tableVersion.VersionEtag.Equals(version.VersionEtag))
+                {
+                    return false;
+                }
+
+                _table[entry.SiloAddress] = (entry.Copy(), _lastETagCounter++.ToString(CultureInfo.InvariantCulture));
+                _tableVersion = new TableVersion(version.Version, NewETag());
+                return true;
+            }
+        }
+
+        public bool Update(MembershipEntry entry, string etag, TableVersion version)
+        {
+            lock (_lock)
+            {
+                if (!_table.TryGetValue(entry.SiloAddress, out var data))
+                {
+                    return false;
+                }
+
+                if (!data.ETag.Equals(etag) || !_tableVersion.VersionEtag.Equals(version.VersionEtag))
+                {
+                    return false;
+                }
+
+                _table[entry.SiloAddress] = (entry.Copy(), _lastETagCounter++.ToString(CultureInfo.InvariantCulture));
+                _tableVersion = new TableVersion(version.Version, NewETag());
+                return true;
+            }
+        }
+
+        public void UpdateIAmAlive(MembershipEntry entry)
+        {
+            lock (_lock)
+            {
+                if (!_table.TryGetValue(entry.SiloAddress, out var data))
+                {
+                    return;
+                }
+
+                data.Entry.IAmAliveTime = entry.IAmAliveTime;
+                _table[entry.SiloAddress] = (data.Entry, NewETag());
+            }
+        }
+
+        public void CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
+        {
+            lock (_lock)
+            {
+                var entries = _table.Values.ToList();
+                foreach (var (entry, _) in entries)
+                {
+                    if (entry.Status == SiloStatus.Dead
+                        && new DateTime(Math.Max(entry.IAmAliveTime.Ticks, entry.StartTime.Ticks), DateTimeKind.Utc) < beforeDate)
+                    {
+                        _table.Remove(entry.SiloAddress, out _);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        internal void Clear()
+        {
+            lock (_lock)
+            {
+                _table.Clear();
+            }
+        }
+
+        public override string ToString() => $"Table = {ReadAll()}, ETagCounter={_lastETagCounter}";
+
+        private string NewETag() => _lastETagCounter++.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -16,7 +16,12 @@ namespace Orleans.TestingHost
         private bool isActive = true;
         
         /// <summary>Gets a reference to the silo host.</summary>
-        public IHost SiloHost { get; private set; }
+        public IHost SiloHost { get; init; }
+
+        /// <summary>
+        /// Gets the silo's service provider.
+        /// </summary>
+        public IServiceProvider ServiceProvider => SiloHost.Services;
 
         /// <inheritdoc />
         public override bool IsActive => isActive;
@@ -28,7 +33,7 @@ namespace Orleans.TestingHost
         /// <param name="configuration">The configuration.</param>
         /// <param name="postConfigureHostBuilder">An optional delegate which is invoked just prior to building the host builder.</param>
         /// <returns>The silo handle.</returns>
-        public static async Task<SiloHandle> CreateAsync(
+        public static async Task<InProcessSiloHandle> CreateAsync(
             string siloName,
             IConfiguration configuration,
             Action<IHostBuilder> postConfigureHostBuilder = null)

--- a/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
@@ -1,0 +1,81 @@
+using System.Runtime.ExceptionServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.TestingHost;
+
+namespace TestExtensions;
+
+public abstract class BaseInProcessTestClusterFixture : Xunit.IAsyncLifetime
+{
+    private readonly ExceptionDispatchInfo preconditionsException;
+
+    static BaseInProcessTestClusterFixture()
+    {
+        TestDefaultConfiguration.InitializeDefaults();
+    }
+
+    protected BaseInProcessTestClusterFixture()
+    {
+        try
+        {
+            CheckPreconditionsOrThrow();
+        }
+        catch (Exception ex)
+        {
+            preconditionsException = ExceptionDispatchInfo.Capture(ex);
+            return;
+        }
+    }
+
+    public void EnsurePreconditionsMet()
+    {
+        preconditionsException?.Throw();
+    }
+
+    protected virtual void CheckPreconditionsOrThrow() { }
+
+    protected virtual void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+    {
+    }
+
+    public InProcessTestCluster HostedCluster { get; private set; }
+
+    public IGrainFactory GrainFactory => Client;
+
+    public IClusterClient Client => HostedCluster?.Client;
+
+    public ILogger Logger { get; private set; }
+
+    public string GetClientServiceId() => Client.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ServiceId;
+
+    public virtual async Task InitializeAsync()
+    {
+        EnsurePreconditionsMet();
+        var builder = new InProcessTestClusterBuilder();
+        builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+        ConfigureTestCluster(builder);
+
+        var testCluster = builder.Build();
+        await testCluster.DeployAsync().ConfigureAwait(false);
+
+        HostedCluster = testCluster;
+        Logger = Client.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Application");
+    }
+
+    public virtual async Task DisposeAsync()
+    {
+        var cluster = HostedCluster;
+        if (cluster is null) return;
+
+        try
+        {
+            await cluster.StopAllSilosAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await cluster.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an in-process test cluster, `InProcessTestCluster`. The advantages of this over the existing `TestCluster` are:

* Silos & clients can be configured using simple delegates (rather than 'configurator' types). This makes it much easier to configure shared dependencies across silos & clients
* Silos expose their `IServiceProvider`, so dependencies can be retrieved and called as part of your test (eg, for fault injection, state inspection)
* The cluster uses a new in-memory clustering & directory provider, so tests which start & stop silos do not need to worry about stopping the 'Primary' silo.

Here's an example:

```csharp
// Setup
var builder = new InProcessTestClusterBuilder(initialSilosCount: 4);
builder.ConfigureClient(c => c.AddMemoryStreams("foo"));
builder.ConfigureSilo((siloOptions, siloBuilder) => siloBuilder.AddMemoryStreams("foo"));
await using var cluster = builder.Build();
await cluster.DeployAsync();

// Act
var value = await cluster.Client.GetGrain<IEchoGrain>(Guid.NewGuid()).Echo("test");

// Assert
Assert.Equal("test", value);
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9148)