### PR TITLE
Enable to activate Grain after clearing its state

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -157,6 +157,8 @@ namespace Orleans.Storage
             }
             else
             {
+                grainState.RecordExists = false;
+                grainState.ETag = null;
                 grainState.State = this.activatorProvider.GetActivator<T>().Create();
             }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -16,6 +16,7 @@ using Orleans.Configuration.Overrides;
 using Orleans.Persistence.AzureStorage;
 using Orleans.Providers.Azure;
 using Orleans.Runtime;
+using Orleans.Serialization.Serializers;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.Storage
@@ -28,6 +29,7 @@ namespace Orleans.Storage
         private readonly AzureTableStorageOptions options;
         private readonly ClusterOptions clusterOptions;
         private readonly IGrainStorageSerializer storageSerializer;
+        private readonly IActivatorProvider activatorProvider;
         private readonly ILogger logger;
 
         private GrainStateTableDataManager tableDataManager;
@@ -55,6 +57,7 @@ namespace Orleans.Storage
             this.clusterOptions = clusterOptions.Value;
             this.name = name;
             this.storageSerializer = options.GrainStorageSerializer;
+            this.activatorProvider = services.GetRequiredService<IActivatorProvider>();
             this.logger = logger;
         }
 
@@ -80,6 +83,10 @@ namespace Orleans.Storage
                 grainState.RecordExists = loadedState != null;
                 grainState.State = loadedState ?? Activator.CreateInstance<T>();
                 grainState.ETag = entity.ETag.ToString();
+            }
+            else
+            {
+                grainState.State = this.activatorProvider.GetActivator<T>().Create();
             }
             // Else leave grainState in previous default condition
         }
@@ -160,6 +167,7 @@ namespace Orleans.Storage
                 else
                 {
                     await DoOptimisticUpdate(() => tableDataManager.Write(entity), grainType, grainId, this.options.TableName, grainState.ETag).ConfigureAwait(false);
+                    grainState.State = this.activatorProvider.GetActivator<T>().Create();
                 }
 
                 grainState.ETag = entity.ETag.ToString(); // Update in-memory data to the new ETag
@@ -351,7 +359,8 @@ namespace Orleans.Storage
                 var input = binaryData.Length > 0
                     ? new BinaryData(binaryData)
                     : new BinaryData(stringData);
-                dataValue = this.storageSerializer.Deserialize<T>(input);
+                if(input.Length > 0)
+                    dataValue = this.storageSerializer.Deserialize<T>(input);
             }
             catch (Exception exc)
             {

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -86,6 +86,8 @@ namespace Orleans.Storage
             }
             else
             {
+                grainState.RecordExists = false;
+                grainState.ETag = null;
                 grainState.State = this.activatorProvider.GetActivator<T>().Create();
             }
             // Else leave grainState in previous default condition


### PR DESCRIPTION
resolve #9154 

## Background
The ClearStateAsync funcction doesn't remove the entry from storage by default.
Instead it only sets the state value to null,

If ReadStateAsync() is invoked when the value is null,
then it occurs an error from Serializer. `Insufficient data present in buffer.`

This error happens during the process of restarting our cluster.

1. The default value of [DeleteStateOnClear](https://github.com/dotnet/orleans/blob/0804e05b417e1ded3aa02d9e2727fbea3b19838b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs#L20) is false.
2. The PubSubRendezvousGrain activates upon stream registration. 
3. [It calls `ClearStateAsync()` if there are no producers.](https://github.com/dotnet/orleans/blob/ae262c8f12f037898a30b4e46c0acba036d4fad9/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs#L140-L142)
4. the grain reactivates after being deactivated, `ReadStateAsync()` is invoked
5. This leads to an error -> `Insufficient data present in buffer.`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9165)