### PR TITLE
[Cassandra] Safer consistency settings

### DIFF
--- a/src/Cassandra/Orleans.Clustering.Cassandra/OrleansQueries.cs
+++ b/src/Cassandra/Orleans.Clustering.Cassandra/OrleansQueries.cs
@@ -27,33 +27,14 @@ internal sealed class OrleansQueries
 
     public static Task<OrleansQueries> CreateInstance(ISession session)
     {
-        string? dc = null;
-        var isMultiDataCenter = false;
-        foreach (var dataCenter in session.Cluster.AllHosts().Where(h => h?.Datacenter is not null).Select(h => h.Datacenter))
-        {
-            dc ??= dataCenter;
-            if (dc != dataCenter)
-            {
-                isMultiDataCenter = true;
-                break;
-            }
-        }
-
-        return Task.FromResult(new OrleansQueries(session, isMultiDataCenter));
+        return Task.FromResult(new OrleansQueries(session));
     }
 
-    private OrleansQueries(ISession session, bool isMultiDataCenter)
+    private OrleansQueries(ISession session)
     {
-        if (isMultiDataCenter)
-        {
-            MembershipReadConsistencyLevel = ConsistencyLevel.LocalQuorum;
-            MembershipWriteConsistencyLevel = ConsistencyLevel.EachQuorum;
-        }
-        else
-        {
-            MembershipReadConsistencyLevel = ConsistencyLevel.Quorum;
-            MembershipWriteConsistencyLevel = ConsistencyLevel.Quorum;
-        }
+        MembershipReadConsistencyLevel = ConsistencyLevel.Quorum;
+        MembershipWriteConsistencyLevel = ConsistencyLevel.Quorum;
+
         Session = session;
     }
 


### PR DESCRIPTION
While the EACH_QUORUM/LOCAL_QUORUM is correct for consistency and does provider a faster read, it also will make it impossible to write if a single data center is unreachable.

For example, a Cassandra cluster across three data centers would need to be able to have each individual data center achieve it's own quorum for the write to be successful. 
With using QUORUM/QUORUM for write/read, there only needs to be a single quorum across the whole cluster. If an entire data center in the three DC scenario is unreachable, then you can still have a Quorum from nodes in the reachable two data centers to complete a write.

The EACH_QUORUM for writes seems like it's more dangerous than the equally consistent QUORUM/QUORUM settings.