### PR TITLE
Allow empty IdSpan

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/ClientGrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ClientGrainId.cs
@@ -26,7 +26,11 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a new <see cref="ClientGrainId"/> instance.
         /// </summary>
-        public static ClientGrainId Create(string id) => Create(IdSpan.Create(id));
+        public static ClientGrainId Create(string id)
+        {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(id);
+            return Create(IdSpan.Create(id));
+        }
 
         /// <summary>
         /// Creates a new <see cref="ClientGrainId"/> instance.

--- a/src/Orleans.Core.Abstractions/IDs/GrainId.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainId.cs
@@ -56,7 +56,11 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a new <see cref="GrainType"/> instance.
         /// </summary>
-        public static GrainId Create(GrainType type, string key) => new GrainId(type, IdSpan.Create(key));
+        public static GrainId Create(GrainType type, string key)
+        {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(key);
+            return new GrainId(type, IdSpan.Create(key));
+        }
 
         /// <summary>
         /// Creates a new <see cref="GrainType"/> instance.

--- a/src/Orleans.Core.Abstractions/IDs/GrainInterfaceType.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainInterfaceType.cs
@@ -18,7 +18,11 @@ namespace Orleans.Runtime
         /// <summary>
         /// Creates a <see cref="GrainInterfaceType"/> instance.
         /// </summary>
-        public GrainInterfaceType(string value) => _value = IdSpan.Create(value);
+        public GrainInterfaceType(string value)
+        {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(value);
+            _value = IdSpan.Create(value);
+        }
 
         /// <summary>
         /// Creates a <see cref="GrainInterfaceType"/> instance.

--- a/src/Orleans.Core.Abstractions/IDs/GrainType.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainType.cs
@@ -66,7 +66,11 @@ namespace Orleans.Runtime
         /// <returns>
         /// The newly created <see cref="GrainType"/> instance.
         /// </returns>
-        public static GrainType Create(string value) => new GrainType(Encoding.UTF8.GetBytes(value));
+        public static GrainType Create(string value)
+        {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(value);
+            return new GrainType(Encoding.UTF8.GetBytes(value));
+        }
 
         /// <summary>
         /// Converts a <see cref="GrainType"/> to a <see cref="IdSpan"/>.

--- a/src/Orleans.Core.Abstractions/IDs/IdSpan.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IdSpan.cs
@@ -81,12 +81,7 @@ namespace Orleans.Runtime
         /// <returns>
         /// A new <see cref="IdSpan"/> corresponding to the provided id.
         /// </returns>
-        /// <exception cref="ArgumentException"/>
-        public static IdSpan Create(string id)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(id, nameof(id));
-            return new IdSpan(Encoding.UTF8.GetBytes(id));
-        }
+        public static IdSpan Create(string id) => new(Encoding.UTF8.GetBytes(id));
 
         /// <summary>
         /// Returns a span representation of this instance.

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -55,6 +55,7 @@ namespace Orleans
         public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithStringKey
         {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(primaryKey);
             var grainKey = IdSpan.Create(primaryKey);
             return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
         }
@@ -164,6 +165,7 @@ namespace Orleans
         /// <inheritdoc />
         public IGrain GetGrain(Type grainInterfaceType, string key)
         {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(key);
             var grainKey = IdSpan.Create(key);
             return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
         }


### PR DESCRIPTION
This PR changes `IdSpan` to allows empty strings and instead prevents empty `GrainType`, `GrainInterfaceType`, and `GrainId.Key` values. This fixes an issue with transactions which is present in 'main' but not in any released build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9175)