### PR TITLE
Improve timely shutdown of directory partitions when snapshot transfer has been abandoned

### DIFF
--- a/playground/ChaoticCluster/ChaoticCluster.Silo/SiloBuilderConfigurator.cs
+++ b/playground/ChaoticCluster/ChaoticCluster.Silo/SiloBuilderConfigurator.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Orleans.Configuration;
 using Orleans.TestingHost;
 
 namespace ChaoticCluster.Silo;
@@ -8,9 +6,9 @@ class SiloBuilderConfigurator : ISiloConfigurator
     {
         public void Configure(ISiloBuilder siloBuilder)
         {
-#pragma warning disable ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -29,6 +29,9 @@ internal interface IGrainDirectoryClient : ISystemTarget
 {
     [Alias("GetRegisteredActivations")]
     ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation);
+
+    [Alias("RecoverRegisteredActivations")]
+    ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId);
 }
 
 [Alias("IGrainDirectoryReplicaTestHooks")]

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -153,7 +153,7 @@ namespace Orleans.Hosting
         /// <param name="siloBuilder">The silo builder to register the directory implementation with.</param>
         /// <param name="name">The name of the directory to register, or null to register the directory as the default.</param>
         /// <returns>The provided silo builder.</returns>
-        [Experimental("ORLEANSEXP002")]
+        [Experimental("ORLEANSEXP003")]
         public static ISiloBuilder AddDistributedGrainDirectory(this ISiloBuilder siloBuilder, string? name = null)
         {
             var services = siloBuilder.Services;

--- a/src/Orleans.TestingHost/ConfigureDistributedGrainDirectory.cs
+++ b/src/Orleans.TestingHost/ConfigureDistributedGrainDirectory.cs
@@ -4,7 +4,7 @@ namespace Orleans.TestingHost;
 
 internal class ConfigureDistributedGrainDirectory : ISiloConfigurator
 {
-#pragma warning disable ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public void Configure(ISiloBuilder siloBuilder) => siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/test/TesterInternal/GrainDirectory/GrainDirectoryResilienceTests.cs
+++ b/test/TesterInternal/GrainDirectory/GrainDirectoryResilienceTests.cs
@@ -173,9 +173,9 @@ public sealed class GrainDirectoryResilienceTests
         public void Configure(ISiloBuilder siloBuilder)
         {
             siloBuilder.Configure<SiloMessagingOptions>(o => o.ResponseTimeout = o.SystemResponseTimeout = TimeSpan.FromMinutes(2));
-#pragma warning disable ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
     }
 }


### PR DESCRIPTION
This fixes a bug preventing timely shutdown of silos with the experimental directory replacement implemented in #9103 in some cases.
Specifically, when leaving the cluster, replicas snapshot their directory partitions and wait for new owners to collect and acknowledge the snapshots. If the new owner decides to perform recovery instead of hand-off then the snapshot transfer is abandoned. Until this PR, there was no way to signal that the transfer had been abandoned. It is always safe to abandon a transfer, in which case recovery will be performed instead (at some added expense).

This PR tells the snapshot sender to abandon the snapshot in two scenarios:
1. It detects that there has been a non-contiguous membership version change. This is when membership versions jump directly from N to N + k where k > 1. In this scenario, the snapshot sender does not know who should receive the snapshot with certainty, so it abandons the request, forcing recovery to be performed. Most commonly, this will occur during fast scale-out and scale-in scenarios where multiple silos are added or removed in very quick succession.
2. It sees a recovery operation from a would-be snapshot receiver. This implies that the snapshot attempt has been abandoned by the receiver and therefore should be abandoned by the sender, too.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9197)