### PR TITLE
Makes `ImmovableAttribute` configurable

### DIFF
--- a/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using Orleans.Placement;
+
 namespace Orleans.Runtime.Placement.Repartitioning;
 
 internal interface IRepartitionerMessageFilter
@@ -22,8 +24,8 @@ internal sealed class RepartitionerMessageFilter(GrainMigratabilityChecker check
             return false;
         }
 
-        isSenderMigratable = checker.IsMigratable(message.SendingGrain.Type);
-        isTargetMigratable = checker.IsMigratable(message.TargetGrain.Type);
+        isSenderMigratable = checker.IsMigratable(message.SendingGrain.Type, ImmovableKind.Repartitioner);
+        isTargetMigratable = checker.IsMigratable(message.TargetGrain.Type, ImmovableKind.Repartitioner);
 
         // If both are not migratable types we ignore this. But if one of them is not, then we allow passing, as we wish to move grains closer to them, as with any type of grain.
         return isSenderMigratable || isTargetMigratable;

--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Metadata;
+using Orleans.Placement;
 using Orleans.Providers;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Placement;
@@ -307,7 +308,7 @@ namespace Orleans.Runtime
             var remainingCount = count;
             foreach (var (grainId, grainContext) in activationDirectory)
             {
-                if (!_migratabilityChecker.IsMigratable(grainId.Type))
+                if (!_migratabilityChecker.IsMigratable(grainId.Type, ImmovableKind.Rebalancer))
                 {
                     continue;
                 }

--- a/test/TesterInternal/ActivationRepartitioningTests/CustomToleranceTests.cs
+++ b/test/TesterInternal/ActivationRepartitioningTests/CustomToleranceTests.cs
@@ -213,7 +213,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
     /// This is simply to achieve initial balance between the 2 silos, as by default the primary
     /// will have 1 more activation than the secondary. That activations is 'sys.svc.clustering.dev'
     /// </summary>
-    [Immovable]
+    [Immovable(ImmovableKind.Repartitioner)]
     public class X : Grain, IX
     {
         public Task Ping() => Task.CompletedTask;

--- a/test/TesterInternal/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/TesterInternal/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -461,7 +461,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         }
     }
 
-    [Immovable]
+    [Immovable(ImmovableKind.Repartitioner)]
     public class CImmovable : GrainBase, ICImmovable
     {
         public Task Ping(Scenario scenario) =>
@@ -482,7 +482,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
             };
     }
 
-    [Immovable]
+    [Immovable(ImmovableKind.Repartitioner)]
     public class SP : GrainBase, ISP
     {
         // We are just 'Immovable' on this type, because we just want it to push messages to the stream,


### PR DESCRIPTION
Following some discussions in discord, its apparent that automatic migration by means of LAR or MAR _can_ be mutually inclusive, even for short periods of time. It appears to be beneficial to allow a grain type to be migrated automatically by the runtime component (LAR, MAR, AA placement (future)) but not allow for others.

This PR adds a an enum `ImmovableKind` as an optional parameter to  `ImmovableAttribute`

```
/// <summary>
/// Emphasizes that immovability is restricted to certain components.
/// </summary>
[Flags]
public enum ImmovableKind : byte
{
    /// <summary>
    /// Activations of this grain type will not be migrated by the repartitioner.
    /// </summary>
    Repartitioner = 1,
    /// <summary>
    /// Activations of this grain type will not be migrated by the rebalancer.
    /// </summary>
    Rebalancer = 2,
    /// <summary>
    /// Activations of this grain type will not be migrated by anything.
    /// </summary>
    Any = Repartitioner | Rebalancer
}
```