### PR TITLE
ADO.NET `IHashPicker` customization API + Orleans v3-compatible `IHashPicker` implementation

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using Orleans.Persistence.AdoNet.Storage;
 using Orleans.Runtime;
 using Orleans.Storage;
@@ -37,6 +38,11 @@ namespace Orleans.Configuration
 
         /// <inheritdoc/>
         public IGrainStorageSerializer GrainStorageSerializer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hasher picker to use for this storage provider. 
+        /// </summary>
+        public IStorageHasherPicker HashPicker { get; set; }
     }
 
     /// <summary>
@@ -70,6 +76,23 @@ namespace Orleans.Configuration
             {
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.ConnectionString)} is required.");
             }
+
+            if (this.options.HashPicker == null)
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} {name}. {nameof(options.HashPicker)} is required.");
+            }
+        }
+    }
+
+    public class DefaultAdoNetGrainStorageOptionsHashPickerConfigurator : IPostConfigureOptions<AdoNetGrainStorageOptions>
+    {
+        public void PostConfigure(string name, AdoNetGrainStorageOptions options)
+        {
+            // preserving explicitly configured HashPicker
+            if (options.HashPicker != null)
+                return;
+
+            options.HashPicker = new StorageHasherPicker(new[] { new OrleansDefaultHasher() });
         }
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -50,7 +50,7 @@ namespace Orleans.Configuration
         /// </summary>
         public void UseOrleans3CompatibleHasher()
         {
-            this.HashPicker = new StorageHasherPicker(new[] { new Orleans3CompatibleHasher() });
+            this.HashPicker = new Orleans3CompatibleStorageHashPicker();
         }
     }
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -104,7 +104,8 @@ namespace Orleans.Configuration
             if (options.HashPicker != null)
                 return;
 
-            options.HashPicker = new StorageHasherPicker(new[] { new OrleansDefaultHasher() });
+            // content-aware hashing with different pickers, unable to use standard StorageHasherPicker
+            options.HashPicker = new Orleans3CompatibleStorageHashPicker();
         }
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -43,6 +43,15 @@ namespace Orleans.Configuration
         /// Gets or sets the hasher picker to use for this storage provider. 
         /// </summary>
         public IStorageHasherPicker HashPicker { get; set; }
+
+        /// <summary>
+        /// Sets legacy Orleans v3-compatible hash picker to use for this storage provider. Invoke this method if you need to run
+        /// Orleans v7+ silo against existing Orleans v3-initialized database and keep existing grain state.
+        /// </summary>
+        public void UseOrleans3CompatibleHasher()
+        {
+            this.HashPicker = new StorageHasherPicker(new[] { new Orleans3CompatibleHasher() });
+        }
     }
 
     /// <summary>
@@ -84,6 +93,9 @@ namespace Orleans.Configuration
         }
     }
 
+    /// <summary>
+    /// Provides default configuration HashPicker for AdoNetGrainStorageOptions.
+    /// </summary>
     public class DefaultAdoNetGrainStorageOptionsHashPickerConfigurator : IPostConfigureOptions<AdoNetGrainStorageOptions>
     {
         public void PostConfigure(string name, AdoNetGrainStorageOptions options)

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -118,7 +118,7 @@ namespace Orleans.Storage
         /// <summary>
         /// The hash generator used to hash natural keys, grain ID and grain type to a more narrow index.
         /// </summary>
-        public IStorageHasherPicker HashPicker { get; set; } = new StorageHasherPicker(new[] { new OrleansDefaultHasher() });
+        public IStorageHasherPicker HashPicker { get; set; }
 
         private readonly AdoNetGrainStorageOptions options;
         private readonly IProviderRuntime providerRuntime;
@@ -137,6 +137,7 @@ namespace Orleans.Storage
             this.logger = logger;
             this.serviceId = clusterOptions.Value.ServiceId;
             this.Serializer = options.Value.GrainStorageSerializer;
+            this.HashPicker = options.Value.HashPicker;
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageServiceCollectionExtensions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorageServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ namespace Orleans.Hosting
             configureOptions?.Invoke(services.AddOptions<AdoNetGrainStorageOptions>(name));
             services.ConfigureNamedOptionForLogging<AdoNetGrainStorageOptions>(name);
             services.AddTransient<IPostConfigureOptions<AdoNetGrainStorageOptions>, DefaultStorageProviderSerializerOptionsConfigurator<AdoNetGrainStorageOptions>>();
+            services.AddTransient<IPostConfigureOptions<AdoNetGrainStorageOptions>, DefaultAdoNetGrainStorageOptionsHashPickerConfigurator>();
             services.AddTransient<IConfigurationValidator>(sp => new AdoNetGrainStorageOptionsValidator(sp.GetRequiredService<IOptionsMonitor<AdoNetGrainStorageOptions>>().Get(name), name));
             return services.AddGrainStorage(name, AdoNetGrainStorageFactory.Create);
         }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/JenkinsHash.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/JenkinsHash.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Text;
+
+namespace Orleans.Storage
+{
+    // Based on the version in http://home.comcast.net/~bretm/hash/7.html, which is based on that
+    // in http://burtleburtle.net/bob/hash/evahash.html.
+    // Note that we only use the version that takes three ulongs, which was written by the Orleans team.
+    // implementation restored from Orleans v3.7.2: https://github.com/dotnet/orleans/blob/b24e446abfd883f0e4ed614f5267eaa3331548dc/src/Orleans.Core.Abstractions/IDs/JenkinsHash.cs
+    internal static class JenkinsHash
+    {
+        private static void Mix(ref uint a, ref uint b, ref uint c)
+        {
+            a -= b; a -= c; a ^= (c >> 13);
+            b -= c; b -= a; b ^= (a << 8);
+            c -= a; c -= b; c ^= (b >> 13);
+            a -= b; a -= c; a ^= (c >> 12);
+            b -= c; b -= a; b ^= (a << 16);
+            c -= a; c -= b; c ^= (b >> 5);
+            a -= b; a -= c; a ^= (c >> 3);
+            b -= c; b -= a; b ^= (a << 10);
+            c -= a; c -= b; c ^= (b >> 15);
+        }
+
+        // This is the reference implementation of the Jenkins hash.
+        public static uint ComputeHash(byte[] data)
+        {
+            return ComputeHash(data.AsSpan());
+        }
+
+        // This is the reference implementation of the Jenkins hash.
+        public static uint ComputeHash(ReadOnlySpan<byte> data)
+        {
+            int len = data.Length;
+            uint a = 0x9e3779b9;
+            uint b = a;
+            uint c = 0;
+            int i = 0;
+
+            while (i + 12 <= len)
+            {
+                a += (uint)data[i++] |
+                    ((uint)data[i++] << 8) |
+                    ((uint)data[i++] << 16) |
+                    ((uint)data[i++] << 24);
+                b += (uint)data[i++] |
+                    ((uint)data[i++] << 8) |
+                    ((uint)data[i++] << 16) |
+                    ((uint)data[i++] << 24);
+                c += (uint)data[i++] |
+                    ((uint)data[i++] << 8) |
+                    ((uint)data[i++] << 16) |
+                    ((uint)data[i++] << 24);
+                Mix(ref a, ref b, ref c);
+            }
+            c += (uint)len;
+            if (i < len)
+                a += data[i++];
+            if (i < len)
+                a += (uint)data[i++] << 8;
+            if (i < len)
+                a += (uint)data[i++] << 16;
+            if (i < len)
+                a += (uint)data[i++] << 24;
+            if (i < len)
+                b += (uint)data[i++];
+            if (i < len)
+                b += (uint)data[i++] << 8;
+            if (i < len)
+                b += (uint)data[i++] << 16;
+            if (i < len)
+                b += (uint)data[i++] << 24;
+            if (i < len)
+                c += (uint)data[i++] << 8;
+            if (i < len)
+                c += (uint)data[i++] << 16;
+            if (i < len)
+                c += (uint)data[i++] << 24;
+            Mix(ref a, ref b, ref c);
+            return c;
+        }
+
+        public static uint ComputeHash(string data)
+        {
+            byte[] bytesToHash = Encoding.UTF8.GetBytes(data);
+            return ComputeHash(bytesToHash);
+        }
+
+        // This implementation calculates the exact same hash value as the above, but is
+        // optimized for the case where the input is exactly 24 bytes of data provided as
+        // three 8-byte unsigned integers.
+        public static uint ComputeHash(ulong u1, ulong u2, ulong u3)
+        {
+            uint a = 0x9e3779b9;
+            uint b = a;
+            uint c = 0;
+
+            unchecked
+            {
+                a += (uint)u1;
+                b += (uint)((u1 ^ (uint)u1) >> 32);
+                c += (uint)u2;
+                Mix(ref a, ref b, ref c);
+                a += (uint)((u2 ^ (uint)u2) >> 32);
+                b += (uint)u3;
+                c += (uint)((u3 ^ (uint)u3) >> 32);
+            }
+            Mix(ref a, ref b, ref c);
+            c += 24;
+            Mix(ref a, ref b, ref c);
+            return c;
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleHasher.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleHasher.cs
@@ -1,9 +1,11 @@
+using Orleans.Storage;
+
 namespace Orleans.Storage
 {
     /// <summary>
-    /// Orleans v3-compatible hasher implementation which can be used in Orleans v3 -> v7 migration scenarios without persistent data loss.
+    /// Orleans v3-compatible hasher implementation for non-string-only grain key ids.
     /// </summary>
-    public class Orleans3CompatibleHasher : IHasher
+    internal class Orleans3CompatibleHasher : IHasher
     {
         /// <summary>
         /// <see cref="IHasher.Description"/>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleHasher.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleHasher.cs
@@ -1,0 +1,22 @@
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Orleans v3-compatible hasher implementation which can be used in Orleans v3 -> v7 migration scenarios without persistent data loss.
+    /// </summary>
+    public class Orleans3CompatibleHasher : IHasher
+    {
+        /// <summary>
+        /// <see cref="IHasher.Description"/>
+        /// </summary>
+        public string Description { get; } = $"Orleans v3 hash function ({nameof(JenkinsHash)}).";
+
+        /// <summary>
+        /// <see cref="IHasher.Hash(byte[])"/>.
+        /// </summary>
+        public int Hash(byte[] data)
+        {
+            // implementation restored from Orleans v3.7.2: https://github.com/dotnet/orleans/blob/b24e446abfd883f0e4ed614f5267eaa3331548dc/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/OrleansDefaultHasher.cs
+            return unchecked((int)JenkinsHash.ComputeHash(data));
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleStorageHashPicker.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleStorageHashPicker.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Orleans.Runtime;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Orleans v3-compatible hash picker implementation for Orleans v3 -> v7+ migration scenarios.
+    /// </summary>
+    public class Orleans3CompatibleStorageHashPicker : IStorageHasherPicker
+    {
+        private readonly Orleans3CompatibleHasher _nonStringHasher;
+
+        /// <summary>
+        /// <see cref="IStorageHasherPicker.HashProviders"/>.
+        /// </summary>
+        public ICollection<IHasher> HashProviders { get; }
+
+        /// <summary>
+        /// A constructor.
+        /// </summary>
+        public Orleans3CompatibleStorageHashPicker()
+        {
+            _nonStringHasher = new();
+            HashProviders = [_nonStringHasher];
+        }
+
+        /// <summary>
+        /// <see cref="IStorageHasherPicker.PickHasher{T}"/>.
+        /// </summary>
+        public IHasher PickHasher<T>(
+            string serviceId,
+            string storageProviderInstanceName,
+            string grainType,
+            GrainId grainId,
+            IGrainState<T> grainState,
+            string tag = null)
+        {
+            // string-only grain keys had special behaviour in Orleans v3
+            if (grainId.TryGetIntegerKey(out _, out _) || grainId.TryGetGuidKey(out _, out _))
+                return _nonStringHasher;
+
+            // unable to cache hasher instances: content-aware behaviour, see hasher implementation for details
+            return new Orleans3CompatibleStringKeyHasher(_nonStringHasher, grainType);
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleStringKeyHasher.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/Orleans3CompatibleStringKeyHasher.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Orleans v3-compatible hasher implementation for string-only grain key ids.
+    /// </summary>
+    internal class Orleans3CompatibleStringKeyHasher : IHasher
+    {
+        private readonly Orleans3CompatibleHasher _innerHasher;
+        private readonly string _grainType;
+
+        public Orleans3CompatibleStringKeyHasher(Orleans3CompatibleHasher innerHasher, string grainType)
+        {
+            _innerHasher = innerHasher;
+            _grainType = grainType;
+        }
+
+        /// <summary>
+        /// <see cref="IHasher.Description"/>
+        /// </summary>
+        public string Description { get; } = $"Orleans v3 hash function ({nameof(JenkinsHash)}).";
+
+        /// <summary>
+        /// <see cref="IHasher.Hash(byte[])"/>.
+        /// </summary>
+        public int Hash(byte[] data)
+        {
+            // Orleans v3 treats string-only keys as integer keys with extension (AdoGrainKey.IsLongKey == true),
+            // so data must be extended for string-only grain keys.
+            // But AdoNetGrainStorage implementation also uses such code:
+            //    ...
+            //    var grainIdHash = HashPicker.PickHasher(serviceId, this.name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes());
+            //    var grainTypeHash = HashPicker.PickHasher(serviceId, this.name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType));
+            //    ...
+            // PickHasher parameters are the same for both calls so we need to analyze data content to distinguish these cases.
+            // It doesn't word if string key is equal to grain type name, but we consider this edge case to be negligibly rare.
+
+            // reducing allocations if data is not a grain type
+            if (data.Length >= _grainType.Length && Encoding.UTF8.GetByteCount(_grainType) == data.Length)
+            {
+                var grainTypeBytes = Encoding.UTF8.GetBytes(_grainType);
+                if (grainTypeBytes.AsSpan().SequenceEqual(data))
+                    return _innerHasher.Hash(data);
+            }
+
+            var extendedData = new byte[data.Length + 8];
+            data.CopyTo(extendedData, 0);
+            return _innerHasher.Hash(extendedData);
+        }
+    }
+}


### PR DESCRIPTION
references: #9141

In this PR:

* added property `AdoNetGrainStorageOptions.IHashPicker` to support the hash picker customization via DI
* added a new `IHashPicker` implementation `Orleans3CompatibleStorageHashPicker` for Orleans v3 -> v7+ migration scenarios
* added method `AdoNetGrainStorageOptions.UseOrleans3CompatibleHasher()` for easier `Orleans3CompatibleStorageHashPicker` configuration