### PR TITLE
Start ActivationRebalancerMonitor without eagerly fetching a report

### DIFF
--- a/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
+++ b/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
@@ -78,11 +78,7 @@ internal sealed partial class ActivationRebalancerMonitor : SystemTarget, IActiv
                     || elapsedSinceHeartbeat >= IActivationRebalancerMonitor.WorkerReportPeriod;
                 if (shouldFetchReport)
                 {
-                    if (elapsedSinceHeartbeat >= IActivationRebalancerMonitor.WorkerReportPeriod)
-                    {
-                        LogStartingRebalancer(elapsedSinceHeartbeat, IActivationRebalancerMonitor.WorkerReportPeriod);
-                    }
-
+                    LogStartingRebalancer(elapsedSinceHeartbeat, IActivationRebalancerMonitor.WorkerReportPeriod);
                     _latestReport = await _rebalancerGrain.GetReport().AsTask().WaitAsync(ct);
                 }
 


### PR DESCRIPTION
Eager fetching of a report when starting the host adds an extra point of failure.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9228)