### PR TITLE
CI: Use correct variable syntax for Azure DevOps

### DIFF
--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -270,7 +270,7 @@ jobs:
           outputs:
           - output: pipelineArtifact
             targetPath: '$(Build.ArtifactStagingDirectory)/test_outputs_${{category}}_${{framework}}_$(Build.BuildId)'
-            artifactName: 'test_outputs_${{category}}_${{framework}}_${{System.JobAttempt}}'
+            artifactName: 'test_outputs_${{category}}_${{framework}}_$(System.JobAttempt)'
             condition: succeededOrFailed()
         steps:
         - checkout: self


### PR DESCRIPTION
#9212 included a change to include the CI attempt number in the artifact name to prevent retries from causing a pipeline error. It used the wrong syntax. Somehow, that was not an issue at the time, but it's an issue now. This PR fixes it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9230)