### PR TITLE
Silo Metadata and Placement Filtering

### DIFF
--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -69,6 +69,11 @@ namespace Orleans.Metadata
         public const string PlacementStrategy = "placement-strategy";
 
         /// <summary>
+        /// The name of the placement strategy for grains of this type.
+        /// </summary>
+        public const string PlacementFilter = "placement-filter";
+
+        /// <summary>
         /// The directory policy for grains of this type.
         /// </summary>
         public const string GrainDirectory = "directory-policy";

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -43,8 +43,7 @@ using Microsoft.Extensions.Configuration;
 using Orleans.Serialization.Internal;
 using Orleans.Core;
 using Orleans.Placement.Repartitioning;
-using Orleans.GrainDirectory;
-using Orleans.Runtime.Hosting;
+using Orleans.Runtime.Placement.Filtering;
 
 namespace Orleans.Hosting
 {
@@ -205,6 +204,10 @@ namespace Orleans.Hosting
 
             // Configure the default placement strategy.
             services.TryAddSingleton<PlacementStrategy, RandomPlacement>();
+
+            // Placement filters
+            services.AddSingleton<PlacementFilterStrategyResolver>();
+            services.AddSingleton<PlacementFilterDirectorResolver>();
 
             // Placement directors
             services.AddPlacementDirector<RandomPlacement, RandomPlacementDirector>();

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataCache.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataCache.cs
@@ -1,0 +1,6 @@
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+#nullable enable
+public interface ISiloMetadataCache
+{
+    SiloMetadata GetMetadata(SiloAddress siloAddress);
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataClient.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataClient.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Orleans.Services;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+
+public interface ISiloMetadataClient : IGrainServiceClient<ISiloMetadataGrainService>
+{
+    Task<SiloMetadata> GetSiloMetadata(SiloAddress siloAddress);
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataGrainService.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/ISiloMetadataGrainService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Orleans.Services;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+
+[Alias("Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataGrainService")]
+public interface ISiloMetadataGrainService : IGrainService
+{
+    [Alias("GetSiloMetadata")]
+    Task<SiloMetadata> GetSiloMetadata();
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadaCache.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadaCache.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Internal;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+#nullable enable
+internal class SiloMetadataCache(
+    ISiloMetadataClient siloMetadataClient,
+    MembershipTableManager membershipTableManager,
+    ILogger<SiloMetadataCache> logger)
+    : ISiloMetadataCache, ILifecycleParticipant<ISiloLifecycle>, IDisposable
+{
+    private readonly ConcurrentDictionary<SiloAddress, SiloMetadata> _metadata = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
+    {
+        var tasks = new List<Task>(1);
+        var cancellation = new CancellationTokenSource();
+        Task OnRuntimeInitializeStart(CancellationToken _)
+        {
+            tasks.Add(Task.Run(() => this.ProcessMembershipUpdates(cancellation.Token)));
+            return Task.CompletedTask;
+        }
+
+        async Task OnRuntimeInitializeStop(CancellationToken ct)
+        {
+            cancellation.Cancel(throwOnFirstException: false);
+            var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
+            await Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
+        }
+
+        lifecycle.Subscribe(
+            nameof(ClusterMembershipService),
+            ServiceLifecycleStage.RuntimeInitialize,
+            OnRuntimeInitializeStart,
+            OnRuntimeInitializeStop);
+    }
+
+
+    private async Task ProcessMembershipUpdates(CancellationToken ct)
+    {
+        try
+        {
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Starting to process membership updates");
+            await foreach (var update in membershipTableManager.MembershipTableUpdates.WithCancellation(ct))
+            {
+                // Add entries for members that aren't already in the cache
+                foreach (var membershipEntry in update.Entries)
+                {
+                    if (!_metadata.ContainsKey(membershipEntry.Key))
+                    {
+                        try
+                        {
+                            var metadata = await siloMetadataClient.GetSiloMetadata(membershipEntry.Key);
+                            _metadata.TryAdd(membershipEntry.Key, metadata);
+                        }
+                        catch(Exception exception)
+                        {
+                            logger.LogError(exception, "Error fetching metadata for silo {Silo}", membershipEntry.Key);
+                        }
+                    }
+                }
+
+                // Remove entries for members that are no longer in the table
+                foreach (var silo in _metadata.Keys.ToList())
+                {
+                    if (!update.Entries.ContainsKey(silo))
+                    {
+                        _metadata.TryRemove(silo, out _);
+                    }
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Error processing membership updates");
+        }
+        finally
+        {
+            if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("Stopping membership update processor");
+        }
+    }
+
+    public SiloMetadata GetMetadata(SiloAddress siloAddress) => _metadata.GetValueOrDefault(siloAddress) ?? SiloMetadata.Empty;
+
+    public void SetMetadata(SiloAddress siloAddress, SiloMetadata metadata) => _metadata.TryAdd(siloAddress, metadata);
+
+    public void Dispose() => _cts.Cancel();
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadata.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadata.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+
+[GenerateSerializer]
+[Alias("Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadata")]
+public record SiloMetadata
+{
+    public static SiloMetadata Empty { get; } = new SiloMetadata();
+
+    [Id(0)]
+    public ImmutableDictionary<string, string> Metadata { get; private set; } = ImmutableDictionary<string, string>.Empty;
+
+    internal void AddMetadata(IEnumerable<KeyValuePair<string, string>> metadata) => Metadata = Metadata.AddRange(metadata);
+    internal void AddMetadata(string key, string value) => Metadata = Metadata.Add(key, value);
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadataClient.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadataClient.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Runtime.Services;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+
+public class SiloMetadataClient(IServiceProvider serviceProvider)
+    : GrainServiceClient<ISiloMetadataGrainService>(serviceProvider), ISiloMetadataClient
+{
+    public async Task<SiloMetadata> GetSiloMetadata(SiloAddress siloAddress)
+    {
+        var grainService = GetGrainService(siloAddress);
+        var metadata = await grainService.GetSiloMetadata();
+        return metadata;
+    }
+}

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadataGrainService.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadataGrainService.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Runtime.MembershipService.SiloMetadata;
+
+public class SiloMetadataGrainService : GrainService, ISiloMetadataGrainService
+{
+    private readonly SiloMetadata _siloMetadata;
+
+    public SiloMetadataGrainService(IOptions<SiloMetadata> siloMetadata) : base()
+    {
+        _siloMetadata = siloMetadata.Value;
+    }
+
+    public SiloMetadataGrainService(IOptions<SiloMetadata> siloMetadata, GrainId grainId, Silo silo, ILoggerFactory loggerFactory) : base(grainId, silo, loggerFactory)
+    {
+        _siloMetadata = siloMetadata.Value;
+    }
+
+    public Task<SiloMetadata> GetSiloMetadata() => Task.FromResult(_siloMetadata);
+}

--- a/src/Orleans.Runtime/Placement/Filtering/IPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/IPlacementFilterDirector.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+public interface IPlacementFilterDirector
+{
+    IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target,
+        IEnumerable<SiloAddress> silos);
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PlacementFilterAttribute.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PlacementFilterAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+/// <summary>
+/// Base for all placement filter marker attributes.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public abstract class PlacementFilterAttribute : Attribute, IGrainPropertiesProviderAttribute
+{
+    public PlacementFilterStrategy PlacementFilterStrategy { get; private set; }
+
+    protected PlacementFilterAttribute(PlacementFilterStrategy placement)
+    {
+        ArgumentNullException.ThrowIfNull(placement);
+        PlacementFilterStrategy = placement;
+    }
+
+    /// <inheritdoc />
+    public virtual void Populate(IServiceProvider services, Type grainClass, GrainType grainType, Dictionary<string, string> properties)
+        => PlacementFilterStrategy?.PopulateGrainProperties(services, grainClass, grainType, properties);
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PlacementFilterDirectorResolver.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PlacementFilterDirectorResolver.cs
@@ -1,0 +1,12 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+/// <summary>
+/// Responsible for resolving an <see cref="IPlacementFilterDirector"/> for a <see cref="PlacementFilterStrategy"/>.
+/// </summary>
+public sealed class PlacementFilterDirectorResolver(IServiceProvider services)
+{
+    public IPlacementFilterDirector GetFilterDirector(PlacementFilterStrategy placementFilterStrategy) => services.GetRequiredKeyedService<IPlacementFilterDirector>(placementFilterStrategy.GetType());
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PlacementFilterExtensions.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PlacementFilterExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+public static class PlacementFilterExtensions
+{
+    /// <summary>
+    /// Configures a <typeparamref name="TFilter"/> for filtering candidate grain placements.
+    /// </summary>
+    /// <typeparam name="TFilter">The placement filter.</typeparam>
+    /// <typeparam name="TDirector">The placement filter director.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="strategyLifetime">The lifetime of the placement strategy.</param>
+    /// <returns>The service collection.</returns>
+    public static void AddPlacementFilter<TFilter, TDirector>(this IServiceCollection services, ServiceLifetime strategyLifetime)
+        where TFilter : PlacementFilterStrategy
+        where TDirector : class, IPlacementFilterDirector
+    {
+        services.Add(ServiceDescriptor.DescribeKeyed(typeof(PlacementFilterStrategy), typeof(TFilter).Name, typeof(TFilter), strategyLifetime));
+        services.AddKeyedSingleton<IPlacementFilterDirector, TDirector>(typeof(TFilter));
+    }
+
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PlacementFilterStrategy.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PlacementFilterStrategy.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+public abstract class PlacementFilterStrategy
+{
+    /// <summary>
+    /// Initializes an instance of this type using the provided grain properties.
+    /// </summary>
+    /// <param name="properties">
+    /// The grain properties.
+    /// </param>
+    public virtual void Initialize(GrainProperties properties)
+    {
+    }
+
+    /// <summary>
+    /// Populates grain properties to specify the preferred placement strategy.
+    /// </summary>
+    /// <param name="services">The service provider.</param>
+    /// <param name="grainClass">The grain class.</param>
+    /// <param name="grainType">The grain type.</param>
+    /// <param name="properties">The grain properties which will be populated by this method call.</param>
+    public void PopulateGrainProperties(IServiceProvider services, Type grainClass, GrainType grainType, Dictionary<string, string> properties)
+    {
+        var typeName = GetType().Name;
+        if (properties.TryGetValue(WellKnownGrainTypeProperties.PlacementFilter, out var existingValue))
+        {
+            properties[WellKnownGrainTypeProperties.PlacementFilter] = $"{existingValue},{typeName}";
+        }
+        else
+        {
+            properties[WellKnownGrainTypeProperties.PlacementFilter] = typeName;
+        }
+
+        foreach (var additionalGrainProperty in GetAdditionalGrainProperties(services, grainClass, grainType, properties))
+        {
+            properties[$"{WellKnownGrainTypeProperties.PlacementFilter}.{typeName}.{additionalGrainProperty.Key}"] = additionalGrainProperty.Value;
+        }
+    }
+
+    protected string GetPlacementFilterGrainProperty(string key, GrainProperties properties)
+    {
+        var typeName = GetType().Name;
+        return properties.Properties.TryGetValue($"{WellKnownGrainTypeProperties.PlacementFilter}.{typeName}.{key}", out var value) ? value : null;
+    }
+
+    protected virtual IEnumerable<KeyValuePair<string, string>> GetAdditionalGrainProperties(IServiceProvider services, Type grainClass, GrainType grainType, IReadOnlyDictionary<string, string> existingProperties)
+        => Array.Empty<KeyValuePair<string, string>>();
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PlacementFilterStrategyResolver.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PlacementFilterStrategyResolver.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+/// <summary>
+/// Responsible for resolving an <see cref="PlacementFilterStrategy"/> for a <see cref="GrainType"/>.
+/// </summary>
+public sealed class PlacementFilterStrategyResolver
+{
+    private readonly ConcurrentDictionary<GrainType, PlacementFilterStrategy[]> _resolvedFilters = new();
+    private readonly Func<GrainType, PlacementFilterStrategy[]> _getFiltersInternal;
+    private readonly GrainPropertiesResolver _grainPropertiesResolver;
+    private readonly IServiceProvider _services;
+
+    /// <summary>
+    /// Create a <see cref="PlacementFilterStrategyResolver"/> instance.
+    /// </summary>
+    public PlacementFilterStrategyResolver(
+        IServiceProvider services,
+        GrainPropertiesResolver grainPropertiesResolver)
+    {
+        _services = services;
+        _getFiltersInternal = GetPlacementFilterStrategyInternal;
+        _grainPropertiesResolver = grainPropertiesResolver;
+    }
+
+    /// <summary>
+    /// Gets the placement filter strategy associated with the provided grain type.
+    /// </summary>
+    public PlacementFilterStrategy[] GetPlacementFilterStrategies(GrainType grainType) => _resolvedFilters.GetOrAdd(grainType, _getFiltersInternal);
+
+    private PlacementFilterStrategy[] GetPlacementFilterStrategyInternal(GrainType grainType)
+    {
+        _grainPropertiesResolver.TryGetGrainProperties(grainType, out var properties);
+
+        if (properties is not null
+            && properties.Properties.TryGetValue(WellKnownGrainTypeProperties.PlacementFilter, out var placementFilterIds)
+            && !string.IsNullOrWhiteSpace(placementFilterIds))
+        {
+            var filterList = new List<PlacementFilterStrategy>();
+            foreach (var filterId in placementFilterIds.Split(","))
+            {
+                var filter = _services.GetKeyedService<PlacementFilterStrategy>(filterId);
+                if (filter is not null)
+                {
+                    filter.Initialize(properties);
+                    filterList.Add(filter);
+                }
+                else
+                {
+                    throw new KeyNotFoundException($"Could not resolve placement filter strategy {filterId} for grain type {grainType}. Ensure that dependencies for that filter have been configured in the Container. This is often through a .Use* extension method provided by the implementation.");
+                }
+            }
+            return filterList.ToArray();
+        }
+
+        return [];
+    }
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterAttribute.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class PreferredSiloMetadataPlacementFilterAttribute(string[] orderedMetadataKeys)
+    : PlacementFilterAttribute(new PreferredSiloMetadataPlacementFilterStrategy(orderedMetadataKeys));

--- a/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterDirector.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Runtime.MembershipService.SiloMetadata;
+#nullable enable
+namespace Orleans.Runtime.Placement.Filtering;
+
+internal class PreferredSiloMetadataPlacementFilterDirector(
+    ILocalSiloDetails localSiloDetails,
+    ISiloMetadataCache siloMetadataCache)
+    : IPlacementFilterDirector
+{
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
+    {
+        var orderedMetadataKeys = (filterStrategy as PreferredSiloMetadataPlacementFilterStrategy)?.OrderedMetadataKeys ?? [];
+        var localSiloMetadata = siloMetadataCache.GetMetadata(localSiloDetails.SiloAddress).Metadata;
+
+        if (localSiloMetadata.Count == 0)
+        {
+            // yield return all silos if no metadata keys are configured
+            foreach (var silo in silos)
+            {
+                yield return silo;
+            }
+        }
+        else
+        {
+            // return the list of silos that match the most metadata keys. The first key in the list is the least important.
+            // This means that the last key in the list is the most important.
+            // If no silos match any metadata keys, return the original list of silos.
+
+            var siloList = silos.ToList();
+            var maxScore = 0;
+            var siloScores = new int[siloList.Count];
+            for (var i = 0; i < siloList.Count; i++)
+            {
+                var siloMetadata = siloMetadataCache.GetMetadata(siloList[i]).Metadata;
+                for (var j = orderedMetadataKeys.Length - 1; j >= 0; --j)
+                {
+                    if (siloMetadata.TryGetValue(orderedMetadataKeys[j], out var siloMetadataValue) &&
+                        localSiloMetadata.TryGetValue(orderedMetadataKeys[j], out var localSiloMetadataValue) &&
+                        siloMetadataValue == localSiloMetadataValue)
+                    {
+                        var newScore = siloScores[i]++;
+                        maxScore = Math.Max(maxScore, newScore);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (maxScore == 0)
+            {
+                // yield return all silos if no silos match any metadata keys
+                foreach (var silo in siloList)
+                {
+                    yield return silo;
+                }
+            }
+
+            // return the list of silos that match the most metadata keys
+            for (var i = 0; i < siloScores.Length; i++)
+            {
+                if (siloScores[i] == maxScore)
+                {
+                    yield return siloList[i];
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterStrategy.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PreferredSiloMetadataPlacementFilterStrategy.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+public class PreferredSiloMetadataPlacementFilterStrategy(string[] orderedMetadataKeys) : PlacementFilterStrategy
+{
+    public string[] OrderedMetadataKeys { get; set; } = orderedMetadataKeys;
+
+    public PreferredSiloMetadataPlacementFilterStrategy() : this([])
+    {
+    }
+
+    public override void Initialize(GrainProperties properties)
+    {
+        base.Initialize(properties);
+        OrderedMetadataKeys = GetPlacementFilterGrainProperty("ordered-metadata-keys", properties).Split(",");
+    }
+
+    protected override IEnumerable<KeyValuePair<string, string>> GetAdditionalGrainProperties(IServiceProvider services, Type grainClass, GrainType grainType,
+        IReadOnlyDictionary<string, string> existingProperties)
+    {
+        yield return new KeyValuePair<string, string>("ordered-metadata-keys", string.Join(",", OrderedMetadataKeys));
+    }
+}

--- a/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataFilterDirector.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Runtime.MembershipService.SiloMetadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+internal class RequiredSiloMetadataFilterDirector(ILocalSiloDetails localSiloDetails, ISiloMetadataCache siloMetadataCache)
+    : IPlacementFilterDirector
+{
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
+    {
+        var metadataKeys = (filterStrategy as RequiredSiloMetadataPlacementFilterStrategy)?.MetadataKeys ?? [];
+
+        // yield return all silos if no silos match any metadata keys
+        if (metadataKeys.Length == 0)
+        {
+            foreach (var silo in silos)
+            {
+                yield return silo;
+            }
+        }
+        else
+        {
+            var localMetadata = siloMetadataCache.GetMetadata(localSiloDetails.SiloAddress);
+            var localRequiredMetadata = GetMetadata(localMetadata, metadataKeys);
+            
+            foreach (var silo in silos)
+            {
+                var remoteMetadata = siloMetadataCache.GetMetadata(silo);
+                if(DoesMetadataMatch(localRequiredMetadata, remoteMetadata, metadataKeys))
+                {
+                    yield return silo;
+                }
+            }
+        }
+    }
+
+    private static bool DoesMetadataMatch(string[] localMetadata, SiloMetadata siloMetadata, string[] metadataKeys)
+    {
+        for (var i = 0; i < metadataKeys.Length; i++)
+        {
+            if(localMetadata[i] != siloMetadata.Metadata?.GetValueOrDefault(metadataKeys[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    private static string[] GetMetadata(SiloMetadata siloMetadata, string[] metadataKeys)
+    {
+        var result = new string[metadataKeys.Length];
+        for (var i = 0; i < metadataKeys.Length; i++)
+        {
+            result[i] = siloMetadata.Metadata?.GetValueOrDefault(metadataKeys[i]);
+        }
+        return result;
+    }
+}

--- a/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataPlacementFilterAttribute.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataPlacementFilterAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class RequiredSiloMetadataPlacementFilterAttribute(string[] orderedMetadataKeys)
+    : PlacementFilterAttribute(new RequiredSiloMetadataPlacementFilterStrategy(orderedMetadataKeys));

--- a/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataPlacementFilterStrategy.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/RequiredSiloMetadataPlacementFilterStrategy.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Placement.Filtering;
+
+public class RequiredSiloMetadataPlacementFilterStrategy(string[] metadataKeys) : PlacementFilterStrategy
+{
+    public string[] MetadataKeys { get; private set; } = metadataKeys;
+
+    public RequiredSiloMetadataPlacementFilterStrategy() : this([])
+    {
+    }
+
+    public override void Initialize(GrainProperties properties)
+    {
+        base.Initialize(properties);
+        MetadataKeys = GetPlacementFilterGrainProperty("metadata-keys", properties).Split(",");
+    }
+
+    protected override IEnumerable<KeyValuePair<string, string>> GetAdditionalGrainProperties(IServiceProvider services, Type grainClass, GrainType grainType,
+        IReadOnlyDictionary<string, string> existingProperties)
+    {
+        yield return new KeyValuePair<string, string>("metadata-keys", String.Join(",", MetadataKeys));
+    }
+}

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Internal;
+using Orleans.Runtime.Placement.Filtering;
 using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime.Placement
@@ -28,6 +29,8 @@ namespace Orleans.Runtime.Placement
         private readonly ISiloStatusOracle _siloStatusOracle;
         private readonly bool _assumeHomogeneousSilosForTesting;
         private readonly PlacementWorker[] _workers;
+        private readonly PlacementFilterStrategyResolver _filterStrategyResolver;
+        private readonly PlacementFilterDirectorResolver _placementFilterDirectoryResolver;
 
         /// <summary>
         /// Create a <see cref="PlacementService"/> instance.
@@ -41,11 +44,15 @@ namespace Orleans.Runtime.Placement
             GrainVersionManifest grainInterfaceVersions,
             CachedVersionSelectorManager versionSelectorManager,
             PlacementDirectorResolver directorResolver,
-            PlacementStrategyResolver strategyResolver)
+            PlacementStrategyResolver strategyResolver,
+            PlacementFilterStrategyResolver filterStrategyResolver,
+            PlacementFilterDirectorResolver placementFilterDirectoryResolver)
         {
             LocalSilo = localSiloDetails.SiloAddress;
             _strategyResolver = strategyResolver;
             _directorResolver = directorResolver;
+            _filterStrategyResolver = filterStrategyResolver;
+            _placementFilterDirectoryResolver = placementFilterDirectoryResolver;
             _logger = logger;
             _grainLocator = grainLocator;
             _grainInterfaceVersions = grainInterfaceVersions;
@@ -117,6 +124,22 @@ namespace Orleans.Runtime.Placement
                 : _grainInterfaceVersions.GetSupportedSilos(grainType).Result;
 
             var compatibleSilos = silos.Intersect(AllActiveSilos).ToArray();
+
+
+            var filters = _filterStrategyResolver.GetPlacementFilterStrategies(grainType);
+            if (filters.Length > 0)
+            {
+                IEnumerable<SiloAddress> filteredSilos = compatibleSilos;
+                foreach (var placementFilter in filters)
+                {
+                    var director = _placementFilterDirectoryResolver.GetFilterDirector(placementFilter);
+                    filteredSilos = director.Filter(placementFilter, target, filteredSilos);
+                }
+
+                compatibleSilos = filteredSilos.ToArray();
+            }
+
+
             if (compatibleSilos.Length == 0)
             {
                 var allWithType = _grainInterfaceVersions.GetSupportedSilos(grainType).Result;


### PR DESCRIPTION
This PR has two main features:
1. Placement Filter support: Adds ability to annotate grains with filters that can examine and manipulate the set of candidate silos that are passed to the Placement implementation
1. Silo Metadata: Ability to add (string, string) values to a silo that all silos in the cluster have access to.

Additionally, there are specific implementations of Placement Filtering using the Silo Metadata to specify either required keys that must match, or an ordered set of preferred keys to use for filtering down placement candidates.

- [ ] Add tests
- [ ] Create documentation