### PR TITLE
Use Activator.CreateInstance in CosmosGrainStorage when recordd does not exist

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -75,7 +75,7 @@ public class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLife
             }
             else
             {
-                grainState.State = ActivatorUtilities.CreateInstance<T>(_serviceProvider);
+                grainState.State = Activator.CreateInstance<T>();
                 grainState.RecordExists = false;
             }
 
@@ -86,7 +86,7 @@ public class CosmosGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLife
             if (dce.StatusCode == HttpStatusCode.NotFound)
             {
                 // State is new, just activate a default and return
-                grainState.State = ActivatorUtilities.CreateInstance<T>(_serviceProvider);
+                grainState.State = Activator.CreateInstance<T>();
                 grainState.RecordExists = false;
                 return;
             }


### PR DESCRIPTION
This changes how `CosmosGrainStorage` creates state objects if the object was not found in database container. This change allows users to define state objects with primary constructors, something that is not possible otherwise. For example:

```csharp
public record class MyState(string Foo);
```

Throws an exception since  `ActivatorUtilities.CreateInstance<T>(_serviceProvider)` will try to resolve a `string` from the `_serviceProvider`.

Another reason why I think the original behavior is a mistake is that all other storage providers use `Activator.CreateInstance<T>()` to create the state object if it is missing from the store. 