### PR TITLE
Ensure that exceptions propagated to Connection's Initialized task is observed

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -150,6 +150,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             _initializationTcs.TrySetException(exception ?? new ConnectionAbortedException("Connection initialization failed"));
+            _initializationTcs.Task.Ignore();
 
             if (this.Log.IsEnabled(LogLevel.Information))
             {


### PR DESCRIPTION
Issue: https://github.com/dotnet/orleans/issues/9245

**Connection tested with curl**
```
C:\Users\djagoda>curl localhost:11111
curl: (1) Received HTTP/0.9 when not allowed
```
**Test Silo after bad connection**

* Before

```
Silo0 started.
Press enter to trigger GC
info: Orleans.Runtime.Messaging.NetworkingTrace[0]
      Closing connection [Local: 127.0.0.1:11111, Remote: 127.0.0.1:53288, ConnectionId: 0HN9KH9UUKKLM]
      System.InvalidOperationException: Remote connection sent preamble length of 542393671, which is greater than maximum allowed size of 1024.
         at Orleans.Runtime.Messaging.ConnectionPreambleHelper.Read(ConnectionContext connection) in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\ConnectionPreamble.cs:line 96
         at Orleans.Runtime.Messaging.SiloConnection.<RunInternal>g__ReadPreamble|26_1() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 222
         at Orleans.Runtime.Messaging.SiloConnection.RunInternal() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 192
         at Orleans.Runtime.Messaging.Connection.Run() in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\Connection.cs:line 88
info: Orleans.Runtime.Messaging.NetworkingTrace[0]
      Connection [Local: 127.0.0.1:11111, Remote: 127.0.0.1:53288, ConnectionId: 0HN9KH9UUKKLN] terminated

Triggered GC
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Remote connection sent preamble length of 542393671, which is greater than maximum allowed size of 1024.)
 ---> System.InvalidOperationException: Remote connection sent preamble length of 542393671, which is greater than maximum allowed size of 1024.
   at Orleans.Runtime.Messaging.ConnectionPreambleHelper.Read(ConnectionContext connection) in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\ConnectionPreamble.cs:line 96
   at Orleans.Runtime.Messaging.SiloConnection.<RunInternal>g__ReadPreamble|26_1() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 222
   at Orleans.Runtime.Messaging.SiloConnection.RunInternal() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 192
   at Orleans.Runtime.Messaging.Connection.Run() in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\Connection.cs:line 88
   --- End of inner exception stack trace ---
```

* After

```
Silo0 started.
Press enter to trigger GC
info: Orleans.Runtime.Messaging.NetworkingTrace[0]
      Closing connection [Local: 127.0.0.1:11111, Remote: 127.0.0.1:53365, ConnectionId: 0HN9KHB0C36DS]
      System.InvalidOperationException: Remote connection sent preamble length of 542393671, which is greater than maximum allowed size of 1024.
         at Orleans.Runtime.Messaging.ConnectionPreambleHelper.Read(ConnectionContext connection) in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\ConnectionPreamble.cs:line 96
         at Orleans.Runtime.Messaging.SiloConnection.<RunInternal>g__ReadPreamble|26_1() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 222
         at Orleans.Runtime.Messaging.SiloConnection.RunInternal() in D:\Projects\External\djagoda\orleans\src\Orleans.Runtime\Networking\SiloConnection.cs:line 192
         at Orleans.Runtime.Messaging.Connection.Run() in D:\Projects\External\djagoda\orleans\src\Orleans.Core\Networking\Connection.cs:line 88
info: Orleans.Runtime.Messaging.NetworkingTrace[0]
      Connection [Local: 127.0.0.1:11111, Remote: 127.0.0.1:53365, ConnectionId: 0HN9KHB0C36DT] terminated

Triggered GC
Triggered GC
```


