### PR TITLE
[Membership] Preserve latest IAmAliveTime across updates

### DIFF
--- a/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
+++ b/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 
 namespace Orleans.Runtime
@@ -7,6 +9,8 @@ namespace Orleans.Runtime
     [GenerateSerializer, Immutable]
     internal sealed class MembershipTableSnapshot
     {
+        private static readonly MembershipTableSnapshot InitialValue = new(MembershipVersion.MinValue, ImmutableDictionary<SiloAddress, MembershipEntry>.Empty);
+
         public MembershipTableSnapshot(
             MembershipVersion version,
             ImmutableDictionary<SiloAddress, MembershipEntry> entries)
@@ -15,41 +19,52 @@ namespace Orleans.Runtime
             this.Entries = entries;
         }
 
-        public static MembershipTableSnapshot Create(MembershipTableData table)
+        public static MembershipTableSnapshot Create(MembershipTableData table) => Update(InitialValue, table);
+
+        public static MembershipTableSnapshot Update(MembershipTableSnapshot previousSnapshot, MembershipTableData table)
         {
+            ArgumentNullException.ThrowIfNull(previousSnapshot);
             ArgumentNullException.ThrowIfNull(table);
-
-            var entries = ImmutableDictionary.CreateBuilder<SiloAddress, MembershipEntry>();
-            if (table.Members != null)
-            {
-                foreach (var item in table.Members)
-                {
-                    var entry = item.Item1;
-                    entries.Add(entry.SiloAddress, entry);
-                }
-            }
-
             var version = (table.Version.Version == 0 && table.Version.VersionEtag == "0")
               ? MembershipVersion.MinValue
               : new MembershipVersion(table.Version.Version);
+            return Update(previousSnapshot, version, table.Members.Select(t => t.Item1));
+        }
+
+        public static MembershipTableSnapshot Update(MembershipTableSnapshot previousSnapshot, MembershipTableSnapshot updated)
+        {
+            ArgumentNullException.ThrowIfNull(previousSnapshot);
+            ArgumentNullException.ThrowIfNull(updated);
+            return Update(previousSnapshot, updated.Version, updated.Entries.Values);
+        }
+
+        private static MembershipTableSnapshot Update(MembershipTableSnapshot previousSnapshot, MembershipVersion version, IEnumerable<MembershipEntry> updatedEntries)
+        {
+            ArgumentNullException.ThrowIfNull(previousSnapshot);
+            ArgumentNullException.ThrowIfNull(updatedEntries);
+
+            var entries = ImmutableDictionary.CreateBuilder<SiloAddress, MembershipEntry>();
+            foreach (var item in updatedEntries)
+            {
+                var entry = item;
+                entry = PreserveIAmAliveTime(previousSnapshot, entry);
+                entries.Add(entry.SiloAddress, entry);
+            }
+
             return new MembershipTableSnapshot(version, entries.ToImmutable());
         }
 
-        public static MembershipTableSnapshot Create(MembershipTableSnapshot snapshot)
+        private static MembershipEntry PreserveIAmAliveTime(MembershipTableSnapshot previousSnapshot, MembershipEntry entry)
         {
-            ArgumentNullException.ThrowIfNull(snapshot);
-
-            var entries = ImmutableDictionary.CreateBuilder<SiloAddress, MembershipEntry>();
-            if (snapshot.Entries != null)
+            // Retain the maximum IAmAliveTime, since IAmAliveTime updates do not increase membership version
+            // and therefore can be clobbered by torn reads.
+            if (previousSnapshot.Entries.TryGetValue(entry.SiloAddress, out var previousEntry)
+                && previousEntry.IAmAliveTime > entry.IAmAliveTime)
             {
-                foreach (var item in snapshot.Entries)
-                {
-                    var entry = item.Value;
-                    entries.Add(entry.SiloAddress, entry);
-                }
+                entry = entry.WithIAmAliveTime(previousEntry.IAmAliveTime);
             }
 
-            return new MembershipTableSnapshot(snapshot.Version, entries.ToImmutable());
+            return entry;
         }
 
         [Id(0)]
@@ -91,6 +106,45 @@ namespace Orleans.Runtime
             }
 
             return status;
+        }
+
+        public bool IsSuccessorTo(MembershipTableSnapshot other)
+        {
+            if (Version > other.Version)
+            {
+                return true;
+            }
+
+            if (Version < other.Version)
+            {
+                return false;
+            }
+
+            if (Entries.Count > other.Entries.Count)
+            {
+                // Something is amiss.
+                return false;
+            }
+
+            foreach (var entry in Entries)
+            {
+                if (!other.Entries.TryGetValue(entry.Key, out var otherEntry))
+                {
+                    // Something is amiss.
+                    return false;
+                }
+            }
+
+            // This is a successor if any silo has a later EffectiveIAmAliveTime.
+            foreach (var entry in Entries)
+            {
+                if (entry.Value.EffectiveIAmAliveTime > other.Entries[entry.Key].EffectiveIAmAliveTime)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override string ToString()

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -306,6 +307,8 @@ namespace Orleans
         [Id(10)]
         public DateTime IAmAliveTime { get; set; }
 
+        internal DateTimeOffset EffectiveIAmAliveTime => StartTime > IAmAliveTime ? StartTime : IAmAliveTime;
+
         public void AddOrUpdateSuspector(SiloAddress localSilo, DateTime voteTime, int maxVotes)
         {
             var allVotes = SuspectTimes ??= new List<Tuple<SiloAddress, DateTime>>();
@@ -369,6 +372,13 @@ namespace Orleans
         {
             var updated = this.Copy();
             updated.Status = status;
+            return updated;
+        }
+
+        internal MembershipEntry WithIAmAliveTime(DateTime iAmAliveTime)
+        {
+            var updated = this.Copy();
+            updated.IAmAliveTime = iAmAliveTime;
             return updated;
         }
 


### PR DESCRIPTION
In subsequent PRs, we leverage the `IAmAliveTime` value for more behavior related to disaster recovery scenarios. Each silo's `IAmAliveTime` value is updated on the membership table directly by that silo and it does not bump the membership table's version. Therefore, we cannot use `IAmAliveTime` in any algorithm which requires consistent membership views (eg, monitoring graph construction, directory membership). `IAmAliveTime` updates can be occasionally ignored or regressed by membership snapshot updates depending on when the snapshot was captured. That is undesirable but incrementing the membership version for every IAmAliveTiem would greatly increase write contention on the table and cause unnecessary churn for algorithms based on membership version, such as directory membership.

This PR improves upon the situation by locally preserving the latest known `IAmAliveTime` values for each silo across membership snapshots. It also allows updating snapshots without incrementing the snapshot version by determining if a snapshot is a logical successor to a previous snapshot (higher version or equal version with at least one greater IAmAliveTime value).

The goal is to decrease the chance of incorrectly treating a silo as "stale" (having missed multiple `IAmAliveTime` updates).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9303)