### PR TITLE
[Membership] Monitor all stale silos

### DIFF
--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -199,7 +199,7 @@ namespace Orleans.Runtime.MembershipService
                 if (candidate.IsSameLogicalSilo(this.localSiloDetails.SiloAddress)) continue;
 
                 bool isSuspected = candidateEntry.GetFreshVotes(now, this.clusterMembershipOptions.CurrentValue.DeathVoteExpirationTimeout).Count > 0;
-                if (isSuspected)
+                if (isSuspected || candidateEntry.HasMissedIAmAlives(options: this.clusterMembershipOptions.CurrentValue, now))
                 {
                     additionalSilos.Add(candidate);
                 }

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -138,7 +138,7 @@ namespace Orleans.Runtime.MembershipService
                         var entry = item.Value;
                         if (entry.Status != SiloStatus.Active) continue;
                         if (entry.SiloAddress.IsSameLogicalSilo(this.localSilo.SiloAddress)) continue;
-                        if (entry.HasMissedIAmAlivesSince(this.clusterMembershipOptions, now) != default) continue;
+                        if (entry.HasMissedIAmAlives(this.clusterMembershipOptions, now) != default) continue;
 
                         activeSilos.Add(entry.SiloAddress);
                     }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
@@ -1,23 +1,10 @@
 using System;
 using Orleans.Configuration;
 
-namespace Orleans.Runtime.MembershipService
+namespace Orleans.Runtime.MembershipService;
+
+internal static class MembershipTableEntryExtensions
 {
-    internal static class MembershipTableEntryExtensions
-    {
-        public static DateTime? HasMissedIAmAlivesSince(this MembershipEntry entry, ClusterMembershipOptions options, DateTime time)
-        {
-            var lastIAmAlive = entry.IAmAliveTime;
-
-            if (entry.IAmAliveTime.Equals(default))
-            {
-                // Since it has not written first IAmAlive yet, use its start time instead.
-                lastIAmAlive = entry.StartTime;
-            }
-
-            if (time - lastIAmAlive <= options.AllowedIAmAliveMissPeriod) return default;
-
-            return lastIAmAlive;
-        }
-    }
+    public static bool HasMissedIAmAlives(this MembershipEntry entry, ClusterMembershipOptions options, DateTimeOffset time)
+        => time - entry.EffectiveIAmAliveTime > options.AllowedIAmAliveMissPeriod;
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -503,9 +503,9 @@ namespace Orleans.Runtime.MembershipService
                 if (entry.Status != SiloStatus.Active) continue;
 
                 var now = GetDateTimeUtcNow();
-                var missedSince = entry.HasMissedIAmAlivesSince(this.clusterMembershipOptions, now);
-                if (missedSince != null)
+                if (entry.HasMissedIAmAlives(this.clusterMembershipOptions, now))
                 {
+                    var missedSince = entry.EffectiveIAmAliveTime;
                     log.LogWarning(
                         (int)ErrorCode.MembershipMissedIAmAliveTableUpdate,
                         "Noticed that silo {SiloAddress} has not updated it's IAmAliveTime table column recently."
@@ -617,7 +617,7 @@ namespace Orleans.Runtime.MembershipService
                 var entry = item.Value;
                 if (entry.SiloAddress.IsSameLogicalSilo(this.myAddress)) continue;
                 if (!IsFunctionalForMembership(entry.Status)) continue;
-                if (entry.HasMissedIAmAlivesSince(this.clusterMembershipOptions, now) != default) continue;
+                if (entry.HasMissedIAmAlives(this.clusterMembershipOptions, now)) continue;
 
                 gossipPartners.Add(entry.SiloAddress);
 

--- a/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/NonSilo.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
 using NSubstitute;
 using Orleans.Configuration;
-using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
 using TestExtensions;
 using Xunit;
@@ -76,6 +75,15 @@ namespace NonSilo.Tests.Membership
         }
 
         /// <summary>
+        /// Tests that when silos are stale, they are monitored by all other silos.
+        /// </summary>
+        [Fact]
+        public async Task ClusterHealthMonitor_MonitorAllStaleSilos()
+        {
+            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: true, numVotesForDeathDeclaration: 2, otherSilosAreStale: true);
+        }
+
+        /// <summary>
         /// Tests basic operation of <see cref="ClusterHealthMonitor"/> and <see cref="SiloHealthMonitor"/>, but with indirect probes disabled.
         /// </summary>
         [Fact]
@@ -138,11 +146,13 @@ namespace NonSilo.Tests.Membership
             await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: false, numVotesForDeathDeclaration: 3);
         }
 
-        private async Task ClusterHealthMonitor_BasicScenario_Runner(bool enableIndirectProbes, int? numVotesForDeathDeclaration = default)
+        private async Task ClusterHealthMonitor_BasicScenario_Runner(bool enableIndirectProbes, int? numVotesForDeathDeclaration = default, bool otherSilosAreStale = false)
         {
+            var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
             {
                 EnableIndirectProbes = enableIndirectProbes,
+                NumProbedSilos = 3,
             };
 
             if (numVotesForDeathDeclaration.HasValue)
@@ -171,17 +181,18 @@ namespace NonSilo.Tests.Membership
             await this.lifecycle.OnStart();
             Assert.Empty(testRig.TestAccessor.MonitoredSilos);
 
+            var iAmAliveTime = otherSilosAreStale ? now.Subtract(TimeSpan.FromHours(1)) : now;
             var otherSilos = new[]
             {
-                Entry(Silo("127.0.0.200:100@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:200@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:300@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:400@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:500@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:600@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:700@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:800@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:900@100"), SiloStatus.Active)
+                Entry(Silo("127.0.0.200:100@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:200@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:300@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:400@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:500@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:600@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:700@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:800@100"), SiloStatus.Active, iAmAliveTime),
+                Entry(Silo("127.0.0.200:900@100"), SiloStatus.Active, iAmAliveTime)
             };
 
             var lastVersion = testRig.TestAccessor.ObservedVersion;
@@ -211,12 +222,13 @@ namespace NonSilo.Tests.Membership
             await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
             Assert.NotEmpty(this.timers);
             Assert.DoesNotContain(testRig.TestAccessor.MonitoredSilos, s => s.Key.Equals(this.localSilo));
-            Assert.Equal(clusterMembershipOptions.NumProbedSilos, testRig.TestAccessor.MonitoredSilos.Count);
+            var expectedNumProbedSilos = otherSilosAreStale ? otherSilos.Length : clusterMembershipOptions.NumProbedSilos;
+            Assert.Equal(expectedNumProbedSilos, testRig.TestAccessor.MonitoredSilos.Count);
             Assert.All(testRig.TestAccessor.MonitoredSilos, m => m.Key.Equals(m.Value.SiloAddress));
             Assert.Empty(probeCalls);
 
             // Check that those silos are actually being probed periodically
-            await UntilEqual(clusterMembershipOptions.NumProbedSilos, () =>
+            await UntilEqual(expectedNumProbedSilos, () =>
             {
                 if (this.timerCalls.TryDequeue(out var timer))
                 {
@@ -225,7 +237,7 @@ namespace NonSilo.Tests.Membership
 
                 return probeCalls.Count;
             });
-            Assert.Equal(clusterMembershipOptions.NumProbedSilos, probeCalls.Count);
+            Assert.Equal(expectedNumProbedSilos, probeCalls.Count);
             while (probeCalls.TryDequeue(out var call)) Assert.Contains(testRig.TestAccessor.MonitoredSilos, k => k.Key.Equals(call.Item1));
 
             var monitoredSilos = testRig.TestAccessor.MonitoredSilos.Values.ToList();
@@ -257,11 +269,10 @@ namespace NonSilo.Tests.Membership
 
             for (var expectedMissedProbes = 1; expectedMissedProbes <= clusterMembershipOptions.NumMissedProbesLimit; expectedMissedProbes++)
             {
-                var now = DateTime.UtcNow;
                 this.membershipTable.ClearCalls();
 
                 // Wait for probes to be fired
-                await UntilEqual(clusterMembershipOptions.NumProbedSilos, () =>
+                await UntilEqual(expectedNumProbedSilos, () =>
                 {
                     if (this.timerCalls.TryDequeue(out var timer))
                     {
@@ -280,7 +291,7 @@ namespace NonSilo.Tests.Membership
                     Assert.Equal(expectedMissedProbes, ((SiloHealthMonitor.ITestAccessor)siloMonitor).MissedProbes);
 
                     var entry = table.Members.Single(m => m.Item1.SiloAddress.Equals(siloMonitor.SiloAddress)).Item1;
-                    var votes = entry.GetFreshVotes(now, clusterMembershipOptions.DeathVoteExpirationTimeout);
+                    var votes = entry.GetFreshVotes(now.UtcDateTime, clusterMembershipOptions.DeathVoteExpirationTimeout);
                     if (expectedMissedProbes < clusterMembershipOptions.NumMissedProbesLimit)
                     {
                         Assert.Empty(votes);
@@ -300,7 +311,7 @@ namespace NonSilo.Tests.Membership
             if (enableIndirectProbes && numVotesForDeathDeclaration <= 2 || numVotesForDeathDeclaration == 1)
             {
                 table = await this.membershipTable.ReadAll();
-                Assert.Equal(clusterMembershipOptions.NumProbedSilos, table.Members.Count(m => m.Item1.Status == SiloStatus.Dead));
+                Assert.Equal(expectedNumProbedSilos, table.Members.Count(m => m.Item1.Status == SiloStatus.Dead));
 
                 // There is no more to test here, since all of the monitored silos have been killed.
                 return;
@@ -357,6 +368,7 @@ namespace NonSilo.Tests.Membership
 
         private async Task ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(bool evictWhenMaxJoinAttemptTimeExceeded = true, int? numVotesForDeathDeclaration = default)
         {
+            var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
             {
                 EvictWhenMaxJoinAttemptTimeExceeded = evictWhenMaxJoinAttemptTimeExceeded
@@ -371,15 +383,15 @@ namespace NonSilo.Tests.Membership
 
             var otherSilos = new[]
             {
-                Entry(Silo("127.0.0.200:100@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:200@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:300@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:400@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:500@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:600@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:700@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:800@100"), SiloStatus.Active),
-                Entry(Silo("127.0.0.200:900@100"), SiloStatus.Active)
+                Entry(Silo("127.0.0.200:100@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:200@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:300@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:400@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:500@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:600@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:700@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:800@100"), SiloStatus.Active, now),
+                Entry(Silo("127.0.0.200:900@100"), SiloStatus.Active, now)
             };
 
             var joiningSilo = "127.0.0.200:111@100";
@@ -482,7 +494,7 @@ namespace NonSilo.Tests.Membership
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTime startTime = default) => new MembershipEntry { SiloAddress = address, Status = status, StartTime = startTime };
+        private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset startTime = default) => new MembershipEntry { SiloAddress = address, Status = status, StartTime = startTime.UtcDateTime, IAmAliveTime = startTime.UtcDateTime };
 
         private static async Task UntilEqual<T>(T expected, Func<T> getActual)
         {


### PR DESCRIPTION
When scaling a large cluster down rapidly and ungracefully (eg, a full cluster restart + scaling operation), the situation can arise where active silos take a long time to evict the ungracefully removed silos (still incorrectly silos marked `Active`).

This PR changes how silos select which other silos they monitor so that all silos monitor all 'stale' silos. This allows a small number of silos to monitor and therefore quickly evict a large number of inactive silos.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9304)