### PR TITLE
Additional logic for Silo Cleanup test

### DIFF
--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -233,7 +233,7 @@ namespace Orleans.Runtime.Membership
 
             foreach (var entry in allRegistrations)
             {
-                if (entry.Registration.IAmAliveTime < beforeDate)
+                if (entry.Registration.IAmAliveTime < beforeDate && entry.Registration.Status != SiloStatus.Active)
                 {
                     await _consulClient.KV.DeleteTree(entry.RegistrationKey);
                 }


### PR DESCRIPTION
This ensures that all old entries that are not Active are cleaned up.

Previously this behavior has been inconsistent in clustering providers. This is to better align behavior across providers.