### PR TITLE
Fix Azure Queue Streaming IConfiguration provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- System packages -->
+    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="9.0.0" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.1" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" NoWarn="NU5104" />
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs
@@ -63,9 +63,22 @@ public sealed class AzureQueueStreamProviderBuilder : IProviderBuilder<ISiloBuil
 
                     if (!string.IsNullOrEmpty(connectionString))
                     {
-                        options.QueueServiceClient = Uri.TryCreate(connectionString, UriKind.Absolute, out var uri)
-                            ? new QueueServiceClient(uri)
-                            : new QueueServiceClient(connectionString);
+                        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+                        {
+                            if (!string.IsNullOrEmpty(uri.Query))
+                            {
+                                // SAS URI
+                                options.QueueServiceClient = new QueueServiceClient(uri);
+                            }
+                            else
+                            {
+                                options.QueueServiceClient = new QueueServiceClient(uri, credential: new Azure.Identity.DefaultAzureCredential());
+                            }
+                        }
+                        else
+                        {
+                            options.QueueServiceClient = new QueueServiceClient(connectionString);
+                        }
                     }
                 }
             });

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Streaming\Orleans.Streaming.csproj" />
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Azure.Data.Tables" />

--- a/src/Orleans.Streaming/Hosting/SiloBuilderStreamingExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/SiloBuilderStreamingExtensions.cs
@@ -5,7 +5,7 @@ using Orleans.Streams.Filtering;
 namespace Orleans.Hosting
 {
     /// <summary>
-    /// Extension methods for confiiguring streaming on silos.
+    /// Extension methods for configuring streaming on silos.
     /// </summary>
     public static class SiloBuilderStreamingExtensions
     {

--- a/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -1,5 +1,7 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -13,80 +15,111 @@ using Xunit;
 namespace Tester.AzureUtils.Streaming
 {
     [TestCategory("Streaming"), TestCategory("AzureStorage"), TestCategory("AzureQueue")]
-    public class AQStreamingTests : TestClusterPerTest
+    public class AQStreamingTests : IClassFixture<AQStreamingTests.Fixture>
     {
         public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
         public const string SmsStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
-        private SingleStreamTestRunner runner;
         private const int queueCount = 8;
-        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        private readonly Fixture _fixture;
+
+        public sealed class Fixture : IAsyncLifetime
         {
-            TestUtils.CheckForAzureStorage();
-            builder.ConfigureHostConfiguration(cb =>
+            public Fixture()
             {
-                Dictionary<string, string> queueConfig = [];
-                void ConfigureStreaming(string option, string value)
+                var builder = new InProcessTestClusterBuilder();
+
+                TestUtils.CheckForAzureStorage();
+                builder.ConfigureHost(cb =>
                 {
-                    var prefix = $"Orleans:Streaming:{AzureQueueStreamProviderName}:";
-                    queueConfig[$"{prefix}{option}"] = value;
-                }
-
-                ConfigureStreaming("ProviderType", "AzureQueueStorage");
-                ConfigureStreaming("ConnectionString", TestDefaultConfiguration.UseAadAuthentication
-                    ? TestDefaultConfiguration.DataQueueUri.AbsoluteUri
-                    : TestDefaultConfiguration.DataConnectionString);
-
-                var names = AzureQueueUtilities.GenerateQueueNames(builder.Options.ClusterId, queueCount);
-                for (var i = 0; i < names.Count; i++)
-                {
-                    ConfigureStreaming($"QueueNames:{i}", names[i]);
-                }
-
-                cb.AddInMemoryCollection(queueConfig);
-            });
-
-            builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
-        }
-
-        private class SiloBuilderConfigurator : ISiloConfigurator
-        {
-            public void Configure(ISiloBuilder hostBuilder)
-            {
-                hostBuilder
-                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
+                    Dictionary<string, string> queueConfig = [];
+                    void ConfigureStreaming(string option, string value)
                     {
-                        options.ConfigureTestDefaults();
-                        options.DeleteStateOnClear = true;
-                    }))
-                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
+                        var prefix = $"Orleans:Streaming:{AzureQueueStreamProviderName}:";
+                        queueConfig[$"{prefix}{option}"] = value;
+                    }
+
+                    ConfigureStreaming("ProviderType", "AzureQueueStorage");
+                    if (TestDefaultConfiguration.UseAadAuthentication)
+                    {
+                        cb.AddKeyedAzureQueueClient(AzureQueueStreamProviderName, settings =>
+                        {
+                            settings.ServiceUri = TestDefaultConfiguration.DataQueueUri;
+                            settings.Credential = TestDefaultConfiguration.TokenCredential;
+                        });
+                        ConfigureStreaming("ServiceKey", AzureQueueStreamProviderName);
+                    }
+                    else
+                    {
+                        ConfigureStreaming("ConnectionString", TestDefaultConfiguration.DataConnectionString);
+                    }
+
+                    var names = AzureQueueUtilities.GenerateQueueNames(builder.Options.ClusterId, queueCount);
+                    for (var i = 0; i < names.Count; i++)
+                    {
+                        ConfigureStreaming($"QueueNames:{i}", names[i]);
+                    }
+
+                    cb.Configuration.AddInMemoryCollection(queueConfig);
+                });
+                builder.ConfigureSilo((options, siloBuilder) =>
+                {
+                    siloBuilder
+                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure(options =>
                         {
                             options.ConfigureTestDefaults();
                             options.DeleteStateOnClear = true;
                         }))
-                    .AddMemoryGrainStorage("MemoryStore");
+                        .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure(options =>
+                            {
+                                options.ConfigureTestDefaults();
+                                options.DeleteStateOnClear = true;
+                            }))
+                        .AddMemoryGrainStorage("MemoryStore");
+                });
+                builder.ConfigureClient(clientBuilder =>
+                {
+                    clientBuilder
+                        .AddAzureQueueStreams(AzureQueueStreamProviderName, b=>
+                        b.ConfigureAzureQueue(ob=>ob.Configure<IOptions<ClusterOptions>>(
+                            (options, dep) =>
+                            {
+                                options.ConfigureTestDefaults();
+                                options.QueueNames = AzureQueueUtilities.GenerateQueueNames(dep.Value.ClusterId, queueCount);
+                            })));
+                });
+                Cluster = builder.Build();
+            }
+
+            public InProcessTestCluster Cluster { get; }
+            public SingleStreamTestRunner Runner { get; private set; }
+
+            public async Task DisposeAsync()
+            {
+                try
+                {
+                    TestUtils.CheckForAzureStorage();
+                    await AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
+                        AzureQueueUtilities.GenerateQueueNames(Cluster.Options.ClusterId, queueCount),
+                        new AzureQueueOptions().ConfigureTestDefaults());
+                }
+                catch (SkipException)
+                {
+                    // ignore
+                }
+
+                await Cluster.DisposeAsync();
+            }
+
+            public async Task InitializeAsync()
+            {
+                await Cluster.DeployAsync();
+                Runner = new SingleStreamTestRunner(Cluster.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME);
             }
         }
 
-        public override async Task InitializeAsync()
+        public AQStreamingTests(Fixture fixture)
         {
-            await base.InitializeAsync();
-            runner = new SingleStreamTestRunner(this.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME);
-        }
-
-        public override async Task DisposeAsync()
-        {
-            await base.DisposeAsync();
-            try
-            {
-                TestUtils.CheckForAzureStorage();
-                await AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance,
-                    AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    new AzureQueueOptions().ConfigureTestDefaults());
-            }
-            catch (SkipException)
-            {
-                // ignore
-            }
+            _fixture = fixture;
         }
 
         ////------------------------ One to One ----------------------//
@@ -94,25 +127,25 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_01_OneProducerGrainOneConsumerGrain()
         {
-            await runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+            await _fixture.Runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_02_OneProducerGrainOneConsumerClient()
         {
-            await runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+            await _fixture.Runner.StreamTest_02_OneProducerGrainOneConsumerClient();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_03_OneProducerClientOneConsumerGrain()
         {
-            await runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+            await _fixture.Runner.StreamTest_03_OneProducerClientOneConsumerGrain();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_04_OneProducerClientOneConsumerClient()
         {
-            await runner.StreamTest_04_OneProducerClientOneConsumerClient();
+            await _fixture.Runner.StreamTest_04_OneProducerClientOneConsumerClient();
         }
 
         //------------------------ MANY to Many different grains ----------------------//
@@ -120,50 +153,50 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await _fixture.Runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
         {
-            await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+            await _fixture.Runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
         }
 
         [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/5648"), TestCategory("Functional")]
         public async Task AQ_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+            await _fixture.Runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
         {
-            await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+            await _fixture.Runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
         }
 
         //------------------------ MANY to Many Same grains ----------------------//
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_09_ManySame_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+            await _fixture.Runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_10_ManySame_ManyConsumerGrainsManyProducerGrains()
         {
-            await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+            await _fixture.Runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_11_ManySame_ManyProducerGrainsManyConsumerClients()
         {
-            await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+            await _fixture.Runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_12_ManySame_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+            await _fixture.Runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
         }
 
         //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -171,13 +204,13 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_13_SameGrain_ConsumerFirstProducerLater()
         {
-            await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+            await _fixture.Runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_14_SameGrain_ProducerFirstConsumerLater()
         {
-            await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+            await _fixture.Runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
         }
 
         //----------------------------------------------//
@@ -185,22 +218,22 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_15_ConsumeAtProducersRequest()
         {
-            await runner.StreamTest_15_ConsumeAtProducersRequest();
+            await _fixture.Runner.StreamTest_15_ConsumeAtProducersRequest();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false);
+            var multiRunner = new MultipleStreamsTestRunner(_fixture.Cluster.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task AQ_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false);
+            var multiRunner = new MultipleStreamsTestRunner(_fixture.Cluster.InternalClient, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-                this.HostedCluster.StartAdditionalSilo);
+                _fixture.Cluster.StartAdditionalSilo);
         }
 
         //[SkippableFact, TestCategory("BVT")]
@@ -216,21 +249,21 @@ namespace Tester.AzureUtils.Streaming
         public async Task AQ_19_ConsumerImplicitlySubscribedToProducerClient()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient();
+            await _fixture.Runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient();
         }
 
         [SkippableFact]
         public async Task AQ_20_ConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain();
+            await _fixture.Runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain();
         }
 
         [SkippableFact(Skip = "Ignored"), TestCategory("Failures")]
         public async Task AQ_21_GenericConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain();
+            await _fixture.Runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain();
         }
     }
 }

--- a/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
+++ b/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Storage.Queues" />
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Azure.Identity" />


### PR DESCRIPTION
Unlike the Table & Blob clients, the Queue client's constructor taking a single URI expects that URI to contain a shared access signature. This PR changes the way we construct the queue client to check if the URI is a SAS URI and, if not, call an alternative constructor which accepts a token credential.

In tests, we use the Asire Azure Storage Queues package to configure a client.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9320)