### PR TITLE
Use UTC DateTime instead of DateTimeOffset in IAmAliveTime comparison

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -307,7 +307,15 @@ namespace Orleans
         [Id(10)]
         public DateTime IAmAliveTime { get; set; }
 
-        internal DateTimeOffset EffectiveIAmAliveTime => StartTime > IAmAliveTime ? StartTime : IAmAliveTime;
+        internal DateTime EffectiveIAmAliveTime
+        {
+            get
+            {
+                var startTimeUtc = DateTime.SpecifyKind(StartTime, DateTimeKind.Utc);
+                var iAmAliveTimeUtc = DateTime.SpecifyKind(IAmAliveTime, DateTimeKind.Utc);
+                return startTimeUtc > iAmAliveTimeUtc ? startTimeUtc : iAmAliveTimeUtc;
+            }
+        }
 
         public void AddOrUpdateSuspector(SiloAddress localSilo, DateTime voteTime, int maxVotes)
         {

--- a/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableEntryExtensions.cs
@@ -5,6 +5,6 @@ namespace Orleans.Runtime.MembershipService;
 
 internal static class MembershipTableEntryExtensions
 {
-    public static bool HasMissedIAmAlives(this MembershipEntry entry, ClusterMembershipOptions options, DateTimeOffset time)
+    public static bool HasMissedIAmAlives(this MembershipEntry entry, ClusterMembershipOptions options, DateTime time)
         => time - entry.EffectiveIAmAliveTime > options.AllowedIAmAliveMissPeriod;
 }


### PR DESCRIPTION
In #9303 I added an internal [EffectiveIAmAliveTime](https://github.com/dotnet/orleans/pull/9303/files#diff-f6037508ae03bc926c78a208f8ad1f303acdfe5307d009e3da6dc1770b3c7da6R310) to incorporate the `StartTime` and `IAmAliveTime` into a single property returning the maximum. The property was typed `DateTimeOffset` but when comparing to the `DateTime` values returned from some membership providers (such as ADO.NET with SqlClient), the stored value was being retrieved with an unspecified `DateTimeKind` and this caused it to be treated as a local time, causing warnings such as:

`13:44:41:507 [WRN] [MembershipTableManager ] Noticed that silo xxx.xxx.xxx.xxx:11122:98364351 has not updated it's IAmAliveTime table column recently. Last update was at 12-2-2025 12:44:25 +01:00, now is 12-2-2025 12:44:41, no update for 01:00:16.3675547, which is more than 00:01:30.`


This PR changes that property to a `DateTime` instead and treats the `StartTime` and `IAmAliveTime` properties as though they were UTC times.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9341)