### PR TITLE
ADO.NET: Treat DateTime values as UTC

### DIFF
--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -145,11 +145,10 @@ namespace Orleans.Tests.SqlUtils
         /// use it since it expects .NET <see cref="System.DateTime"/>. This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>
         public static DateTime? GetDateTimeValueOrDefault(this IDataRecord record, string fieldName, DateTime? @default = default)
         {
-
             try
             {
                 var ordinal = record.GetOrdinal(fieldName);
-                return record.IsDBNull(ordinal) ? @default : record.GetDateTime(ordinal);
+                return record.IsDBNull(ordinal) ? @default : DateTime.SpecifyKind(record.GetDateTime(ordinal), DateTimeKind.Utc);
             }
             catch (IndexOutOfRangeException e)
             {
@@ -250,7 +249,7 @@ namespace Orleans.Tests.SqlUtils
             try
             {
                 var ordinal = record.GetOrdinal(fieldName);
-                return record.GetDateTime(ordinal);
+                return DateTime.SpecifyKind(record.GetDateTime(ordinal), DateTimeKind.Utc);
             }
             catch (IndexOutOfRangeException e)
             {


### PR DESCRIPTION
We universally use UTC times internally. When these values are stored via providers (eg, in clustering) and then later retrieved, there is a chance that they will be deserialized at non-UTC times. This PR fixes this case for ADO.NET, so that it treats all read times as UTC instead of leaving them as `DateTimeKind.Unspecified`, which is incorrectly treated as local time in some cases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9342)