### PR TITLE
Provide more descriptive error messages in `RuntimeTypeNameParser`

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -109,7 +109,7 @@ public static class RuntimeTypeNameParser
                 }
             }
 
-            coreType = new TupleTypeSpec(elements.ToArray(), input.TotalGenericArity);
+            coreType = new TupleTypeSpec([.. elements], input.TotalGenericArity);
         }
         else
         {
@@ -378,7 +378,7 @@ public static class RuntimeTypeNameParser
                 var c = Input[Index];
                 if (assertChar != c)
                 {
-                    ThrowUnexpectedCharacter(assertChar, c);
+                    ThrowUnexpectedCharacter(Input, Index, assertChar, c);
                 }
 
                 ++Index;
@@ -396,7 +396,13 @@ public static class RuntimeTypeNameParser
             }
         }
 
-        private static void ThrowUnexpectedCharacter(char expected, char actual) => throw new InvalidOperationException($"Encountered unexpected character. Expected '{expected}', actual '{actual}'.");
+        private static void ThrowUnexpectedCharacter(ReadOnlySpan<char> value, int position, char expected, char actual)
+        {
+            var valueString = new string(value);
+            var posString = position > 0 ? new string(' ', position) : "";
+            var message = $"Encountered unexpected character. Expected '{expected}', actual '{actual}' in string:\n> {valueString}\n> {posString}^";
+            throw new InvalidOperationException(message);
+        }
 
         private static void ThrowEndOfInput() => throw new InvalidOperationException("Tried to read past the end of the input");
 

--- a/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
+++ b/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
@@ -70,7 +70,6 @@ namespace NonSilo.Tests
         /// </summary>
         [Fact]
         public void ParsedTypeNamesAreIdenticalToFormattedNames()
-
         {
             foreach (var type in _types)
             {
@@ -85,7 +84,17 @@ namespace NonSilo.Tests
                 _output.WriteLine($"Reparsed     : {reparsed}");
                 Assert.Equal(formatted, reparsed.Format());
             }
-        } 
+        }
+
+        [Fact]
+        public void InvalidNamesThrowDescriptiveErrorMessage()
+        {
+            var input = "MalformedName[`";
+            var exception = Assert.Throws<InvalidOperationException>(() => RuntimeTypeNameParser.Parse(input));
+            _output.WriteLine(exception.Message);
+            Assert.Contains(input, exception.Message);
+            Assert.Contains("^", exception.Message); // Position indicator
+        }
         
         public class Inner<T>
         {


### PR DESCRIPTION
When malformed strings are passed to `RuntimeTypeNameParser`, it is currently difficult to know where the issue lies. This PR changes the output error message to include the input string and a visual position indicator + index. Example:

```
 Encountered unexpected character. Expected ',', actual '`' in string:
 > MalformedName[`
 >               ^
 ```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9343)