### PR TITLE
Do not set cached hash code from GetConsistentHashCode(int)

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -280,9 +280,7 @@ namespace Orleans.Runtime
             BinaryPrimitives.WriteInt32LittleEndian(buf[20..], Generation);
             BinaryPrimitives.WriteInt32LittleEndian(buf[24..], seed);
 
-            hashCode = (int)StableHash.ComputeHash(buf);
-            hashCodeSet = true;
-            return hashCode;
+            return (int)StableHash.ComputeHash(buf);
         }
 
         private int CalculateConsistentHashCode()


### PR DESCRIPTION
Fixes #9348
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9349)