### PR TITLE
Align AsyncEnumerable cancellation semantics to .NET expectations

### DIFF
--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -271,7 +271,10 @@ namespace Orleans.Hosting.Kubernetes
                         previous = update;
                     }
                 }
-                catch (Exception exception) when (!(_shutdownToken.IsCancellationRequested && (exception is TaskCanceledException || exception is OperationCanceledException)))
+                catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
+                {
+                }
+                catch (Exception exception)
                 {
                     if (_logger.IsEnabled(LogLevel.Debug))
                     {

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -137,7 +137,9 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 this.shutdownToken.Cancel();
                 if (listenToClusterChangeTask != default && !ct.IsCancellationRequested)
-                    await listenToClusterChangeTask.WaitAsync(ct);
+                {
+                    await listenToClusterChangeTask.WaitAsync(ct).SuppressThrowing();
+                }
             };
             lifecycle.Subscribe(nameof(CachedGrainLocator), ServiceLifecycleStage.RuntimeGrainServices, OnStart, OnStop);
         }

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -394,6 +394,7 @@ internal sealed class ClientDirectory : SystemTarget, ILocalClientDirectory, IRe
             catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
             {
                 // Ignore during shutdown.
+                break;
             }
             catch (Exception exception)
             {
@@ -492,7 +493,7 @@ internal sealed class ClientDirectory : SystemTarget, ILocalClientDirectory, IRe
                 {
                     // The target has already seen the latest version for this silo.
                     builder.Remove(silo);
-                } 
+                }
             }
         }
 

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -101,6 +101,10 @@ namespace Orleans.Runtime.MembershipService
                     this.observedMembershipVersion = tableSnapshot.Version;
                 }
             }
+            catch (OperationCanceledException) when (shutdownCancellation.IsCancellationRequested)
+            {
+                // Ignore and continue shutting down.
+            }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
                 this.fatalErrorHandler.OnFatalException(this, nameof(ProcessMembershipUpdates), exception);

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipService.cs
@@ -87,6 +87,10 @@ namespace Orleans.Runtime
                     this.updates.TryPublish(tableSnapshot.CreateClusterMembershipSnapshot());
                 }
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Ignore and continue shutting down.
+            }
             catch (Exception exception) when (this.fatalErrorHandler.IsUnexpected(exception))
             {
                 this.log.LogError(exception, "Error processing membership updates");

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -87,6 +87,10 @@ internal class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
                 previous = snapshot;
             }
         }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+        {
+            // Ignore and continue shutting down.
+        }
         catch (Exception exception) when (_fatalErrorHandler.IsUnexpected(exception))
         {
             _logger.LogError(exception, "Error processing membership updates.");

--- a/src/Orleans.Streaming/QueueBalancer/QueueBalancerBase.cs
+++ b/src/Orleans.Streaming/QueueBalancer/QueueBalancerBase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Internal;
 
@@ -65,7 +66,7 @@ namespace Orleans.Streams
                 Logger.LogError(exc, "Error signaling shutdown token.");
             }
 
-            await _listenForClusterChangesTask;
+            await _listenForClusterChangesTask.SuppressThrowing();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The norm in .NET is that if cancellation is triggered while awaiting enumeration of an `IAsyncEnumerable<T>`, that will result in an exception being thrown.

The current behavior in the `AsyncEnumerable<T>` class is that it ends enumeration instead (as though there were no more items). This is more graceful and results in less exceptions being thrown during shutdown, but it's not the normal or expected behavior.

This PR aligns `AsyncEnumerable<T>` to the normal .NET behavior, causing cancellation to throw instead or ending enumeration without an exception.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9359)