### PR TITLE
Propagate IAsyncEnumerable exceptions correctly

### DIFF
--- a/test/DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
+++ b/test/DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime;
 using TestExtensions;
@@ -40,6 +40,43 @@ public class AsyncEnumerableGrainCallTests : HostedTestClusterEnsureDefaultStart
         }
 
         Assert.Equal(5, values.Count);
+
+        // Check that the enumerator is disposed
+        var grainCalls = await grain.GetIncomingCalls();
+        Assert.Contains(grainCalls, c => c.InterfaceName.Contains(nameof(IAsyncEnumerableGrainExtension)) && c.MethodName.Contains(nameof(IAsyncDisposable.DisposeAsync)));
+    }
+
+    [Theory, TestCategory("BVT"), TestCategory("Observable")]
+    [InlineData(0, false)]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(9, false)]
+    [InlineData(9, true)]
+    [InlineData(10, false)]
+    [InlineData(10, true)]
+    [InlineData(11, false)]
+    [InlineData(11, true)]
+    public async Task ObservableGrain_AsyncEnumerable_Throws(int errorIndex, bool waitAfterYield)
+    {
+        const string ErrorMessage = "This is my error!";
+        var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
+
+        var values = new List<int>();
+        try
+        {
+            await foreach (var entry in grain.GetValuesWithError(errorIndex, waitAfterYield, ErrorMessage).WithBatchSize(10))
+            {
+                values.Add(entry);
+                Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
+            }
+        }
+        catch (InvalidOperationException iox)
+        {
+            Assert.Equal(ErrorMessage, iox.Message);
+        }
+
+        Assert.Equal(errorIndex, values.Count);
 
         // Check that the enumerator is disposed
         var grainCalls = await grain.GetIncomingCalls();

--- a/test/Grains/TestGrainInterfaces/IObservableGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IObservableGrain.cs
@@ -1,4 +1,4 @@
-namespace UnitTests.GrainInterfaces
+﻿namespace UnitTests.GrainInterfaces
 {
     /// <summary>
     /// A grain which returns IAsyncEnumerable
@@ -10,6 +10,7 @@ namespace UnitTests.GrainInterfaces
         ValueTask Deactivate();
         ValueTask OnNext(string data);
         IAsyncEnumerable<string> GetValues();
+        IAsyncEnumerable<int> GetValuesWithError(int errorIndex, bool waitAfterYield, string errorMessage);
 
         ValueTask<List<(string InterfaceName, string MethodName)>> GetIncomingCalls();
     }

--- a/test/Grains/TestInternalGrains/ObservableGrain.cs
+++ b/test/Grains/TestInternalGrains/ObservableGrain.cs
@@ -1,4 +1,4 @@
-using System.Threading.Channels;
+﻿using System.Threading.Channels;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -9,6 +9,21 @@ namespace UnitTests.Grains
         private readonly Channel<string> _updates = Channel.CreateUnbounded<string>();
 
         public IAsyncEnumerable<string> GetValues() => _updates.Reader.ReadAllAsync();
+
+        public async IAsyncEnumerable<int> GetValuesWithError(int errorIndex, bool waitAfterYield, string errorMessage)
+        {
+            await Task.CompletedTask;
+            for (var i = 0; i < int.MaxValue; i++)
+            {
+                if (i == errorIndex)
+                {
+                    throw new InvalidOperationException(errorMessage);
+                }
+
+                yield return i;
+                await Task.Yield();
+            }
+        }
 
         public ValueTask Complete()
         {


### PR DESCRIPTION
Currently, exceptions thrown in `IAsyncEnumerable<T>` methods are not being correctly propagated to callers, leading to potential hangs.

This PR implements correct handling of exceptions thrown from `IAsyncEnumerable<T>` methods, propagating the error in-band to the caller and cleaning up the enumerator.