### PR TITLE
[Placement Filtering] Adding missing generic constraint

### DIFF
--- a/src/Orleans.Core/Placement/PlacementFilterExtensions.cs
+++ b/src/Orleans.Core/Placement/PlacementFilterExtensions.cs
@@ -14,7 +14,7 @@ public static class PlacementFilterExtensions
     /// <param name="strategyLifetime">The lifetime of the placement strategy.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddPlacementFilter<TFilter, TDirector>(this IServiceCollection services, ServiceLifetime strategyLifetime)
-        where TFilter : PlacementFilterStrategy
+        where TFilter : PlacementFilterStrategy, new()
         where TDirector : class, IPlacementFilterDirector
     {
         services.Add(ServiceDescriptor.DescribeKeyed(typeof(PlacementFilterStrategy), typeof(TFilter).Name, typeof(TFilter), strategyLifetime));


### PR DESCRIPTION
An empty constructor is used to create an instance during bootstrapping so the `TFilter` needs the `new()` constraint