### PR TITLE
Removing out-of-support Cassandra version from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         provider: ["Cassandra"]
-        dbversion: ["3.11", "4.0", "4.1", "5.0"]
+        dbversion: ["4.0", "4.1", "5.0"]
         framework: [net8.0]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Version 3.11 was out of support 6 months ago when 5.0 was released. 4.0, 4.1, and 5.0 are the current supported versions: https://endoflife.date/apache-cassandra