### PR TITLE
Addressing contention on startup

### DIFF
--- a/src/Cassandra/Orleans.Clustering.Cassandra/OrleansQueries.cs
+++ b/src/Cassandra/Orleans.Clustering.Cassandra/OrleansQueries.cs
@@ -44,6 +44,10 @@ internal sealed class OrleansQueries
 
     public ConsistencyLevel MembershipReadConsistencyLevel { get; set; }
 
+    public IStatement CheckIfTableExists(string keyspace) =>
+        new SimpleStatement(
+                $"SELECT * FROM system_schema.tables WHERE keyspace_name = '{keyspace}' AND table_name = 'membership';")
+            .SetConsistencyLevel(ConsistencyLevel.LocalOne);
     /// <remarks>
     /// In Cassandra, a table-level <c>default_time_to_live</c> of <c>0</c> is treated as <c>disabled</c>.
     /// <para/>
@@ -71,7 +75,7 @@ internal sealed class OrleansQueries
           WITH compression = { 'class' : 'LZ4Compressor', 'enabled' : true }
             AND default_time_to_live = {{defaultTimeToLiveSeconds.GetValueOrDefault(0)}};
           """);
-
+    
     public IStatement EnsureIndexExists => new SimpleStatement("""
             CREATE INDEX IF NOT EXISTS ix_membership_status ON membership(status);
             """);


### PR DESCRIPTION
When large numbers of silos start at the same time, contention on the database can cause many service recycles before being able to start up healthy. This change avoids the Lightweight Transaction (LWT) on creating the table if the table already exists.