### PR TITLE
[Cassandra] DefunctSiloCleanup - Specify datetime kind

### DIFF
--- a/src/Cassandra/Orleans.Clustering.Cassandra/CassandraClusteringTable.cs
+++ b/src/Cassandra/Orleans.Clustering.Cassandra/CassandraClusteringTable.cs
@@ -204,7 +204,7 @@ internal sealed class CassandraClusteringTable : IMembershipTable
 
         foreach (var e in allEntries)
         {
-            if (e is not { Status: SiloStatus.Active } && new DateTime(Math.Max(e.IAmAliveTime.Ticks, e.StartTime.Ticks)) < beforeDate)
+            if (e is not { Status: SiloStatus.Active } && new DateTime(Math.Max(e.IAmAliveTime.Ticks, e.StartTime.Ticks), DateTimeKind.Utc) < beforeDate)
             {
                 await Session.ExecuteAsync(await Queries.DeleteMembershipEntry(_identifier, e));
             }


### PR DESCRIPTION
This comes out as unspecified kind and when comparied to a UTC timestamp, it assumes it's local and will try to convert that to UTC, but the underlying `DateTime` value is actually UTC already.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9382)