### PR TITLE
IAsyncEnumerable: Fix cancellation propagation, bound operation times, use mark-and-sweep cleanup

### DIFF
--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -55,5 +55,10 @@ namespace Orleans.Configuration
         /// </summary>
         /// <value>The maximum message body size is 100 MB by default.</value>
         public int MaxMessageBodySize { get; set; } = 100 * 1024 * 1024;
+
+        /// <summary>
+        /// Gets the response timeout underlying the <see cref="ResponseTimeout"/> property, without debugger checks.
+        /// </summary>
+        internal TimeSpan ConfiguredResponseTimeout => _responseTimeout;
     }
 }

--- a/test/Grains/TestGrainInterfaces/IObservableGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IObservableGrain.cs
@@ -1,4 +1,4 @@
-﻿namespace UnitTests.GrainInterfaces
+namespace UnitTests.GrainInterfaces
 {
     /// <summary>
     /// A grain which returns IAsyncEnumerable

--- a/test/Grains/TestInternalGrains/ObservableGrain.cs
+++ b/test/Grains/TestInternalGrains/ObservableGrain.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Channels;
+using System.Threading.Channels;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -17,6 +17,11 @@ namespace UnitTests.Grains
             {
                 if (i == errorIndex)
                 {
+                    if (errorMessage == "cancel")
+                    {
+                        throw new OperationCanceledException(errorMessage);
+                    }
+
                     throw new InvalidOperationException(errorMessage);
                 }
 


### PR DESCRIPTION
This PR improves the implementation of `IAsyncEnumerable<T>` support.
1. Canceled tasks are propagated to callers.
2. All asynchronous operations (`MoveNextAsync`, cancellation, disposal) have bounded times, based on `MessagingOptions.ResponseTimeout`.
3. Cleanup is reimplemented based on a mark-and-sweep algorithm which won't clean up enumerators which are actively in-use.
4. Test coverage has been improved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9387)