### PR TITLE
PlacementService: Use GetAwaiter().GetResult() instead of .Result to avoid wrapping exception in AggregateException

### DIFF
--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -350,7 +350,7 @@ namespace Orleans.Runtime.Placement
 
                 try
                 {
-                    var siloAddress = resultTask.Result;
+                    var siloAddress = resultTask.GetAwaiter().GetResult();
                     foreach (var message in messages)
                     {
                         _placementService.SetMessageTargetPlacement(message.Message, siloAddress);


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9388)