### PR TITLE
Add IConfiguration support for Azure Redis Cache

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
@@ -10,7 +10,10 @@ using System;
 using System.Threading.Tasks;
 
 [assembly: RegisterProvider("Redis", "Clustering", "Silo", typeof(RedisClusteringProviderBuilder))]
+[assembly: RegisterProvider("AzureRedisCache", "Clustering", "Silo", typeof(RedisClusteringProviderBuilder))]
+
 [assembly: RegisterProvider("Redis", "Clustering", "Client", typeof(RedisClusteringProviderBuilder))]
+[assembly: RegisterProvider("AzureRedisCache", "Clustering", "Client", typeof(RedisClusteringProviderBuilder))]
 
 namespace Orleans.Clustering.Redis.Hosting;
 

--- a/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 
 [assembly: RegisterProvider("Redis", "GrainDirectory", "Silo", typeof(RedisGrainDirectoryProviderBuilder))]
+[assembly: RegisterProvider("AzureRedisCache", "GrainDirectory", "Silo", typeof(RedisGrainDirectoryProviderBuilder))]
 
 namespace Orleans.Hosting;
 

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Storage;
 
 [assembly: RegisterProvider("Redis", "GrainStorage", "Silo", typeof(RedisGrainStorageProviderBuilder))]
+[assembly: RegisterProvider("AzureRedisCache", "GrainStorage", "Silo", typeof(RedisGrainStorageProviderBuilder))]
 
 namespace Orleans.Hosting;
 

--- a/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
@@ -9,6 +9,7 @@ using Orleans.Configuration;
 using System.Threading.Tasks;
 
 [assembly: RegisterProvider("Redis", "Reminders", "Silo", typeof(RedisRemindersProviderBuilder))]
+[assembly: RegisterProvider("AzureRedisCache", "Reminders", "Silo", typeof(RedisRemindersProviderBuilder))]
 
 namespace Orleans.Hosting;
 


### PR DESCRIPTION
This PR adds `"AzureRedisCache"` as an alias for `"Redis"` in IConfiguration processing. This allows us to support Azure Redis Cache in the Orleans Aspire integration
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9395)