### PR TITLE
Reduce log noise during debugging

### DIFF
--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -92,8 +92,8 @@ namespace Orleans.Runtime.MembershipService
                     {
                         if (!newMonitoredSilos.ContainsKey(pair.Key))
                         {
-                            var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.CurrentValue.ProbeTimeout).Token;
-                            await pair.Value.StopAsync(cancellation);
+                            using var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.CurrentValue.ProbeTimeout);
+                            await pair.Value.StopAsync(cancellation.Token);
                         }
                     }
 

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -246,18 +246,13 @@ internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void LogTaskRunError(Task task, Exception ex)
-    {
-        _log.LogError(
-            (int)ErrorCode.SchedulerExceptionFromExecute,
-            ex,
-            "Worker thread caught an exception thrown from Execute by task {Task}",
-            task);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private void LogLongRunningTurn(Task task, long taskDurationMs)
     {
+        if (Debugger.IsAttached)
+        {
+            return;
+        }
+
         var taskDuration = TimeSpan.FromMilliseconds(taskDurationMs);
         _log.LogWarning(
             (int)ErrorCode.SchedulerTurnTooLong3,

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -76,11 +77,14 @@ namespace Orleans.Runtime
             var overshoot = GetOvershootDelay(now, dueTime);
             if (overshoot > TimeSpan.Zero)
             {
-                this.log?.LogWarning(
-                    "Timer should have fired at {DueTime} but fired at {CurrentTime}, which is {Overshoot} longer than expected",
-                    dueTime,
-                    now,
-                    overshoot);
+                if (!Debugger.IsAttached)
+                {
+                    this.log?.LogWarning(
+                        "Timer should have fired at {DueTime} but fired at {CurrentTime}, which is {Overshoot} longer than expected",
+                        dueTime,
+                        now,
+                        overshoot);
+                }
             }
 
             expected = default;
@@ -103,7 +107,7 @@ namespace Orleans.Runtime
             var now = DateTime.UtcNow;
             var due = this.expected;
             var overshoot = GetOvershootDelay(now, due);
-            if (overshoot > TimeSpan.Zero)
+            if (overshoot > TimeSpan.Zero && !Debugger.IsAttached)
             {
                 reason = $"{this.name} timer should have fired at {due}, which is {overshoot} ago";
                 return false;


### PR DESCRIPTION
There are various performance & timing-related log messages which Orleans emits for diagnostic purposes, as well as liveness checks, which can result in log noise or evicted silos during a debugging session.

This PR adds additional debugger checks to suppress log noise and extend liveness check leeway.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9397)