### PR TITLE
Add additional context and logging when a grain constructor throws

### DIFF
--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime
         private readonly IServiceProvider _serviceProvider;
         private readonly IActivationWorkingSet _activationWorkingSet;
         private readonly ILogger<WorkItemGroup> _workItemGroupLogger;
+        private readonly ILogger<Grain> _grainLogger;
         private readonly ILogger<ActivationTaskScheduler> _activationTaskSchedulerLogger;
         private readonly IOptions<SchedulingOptions> _schedulingOptions;
         private readonly GrainTypeSharedContextResolver _sharedComponentsResolver;
@@ -27,12 +28,14 @@ namespace Orleans.Runtime
             GrainReferenceActivator grainReferenceActivator,
             GrainTypeSharedContextResolver sharedComponentsResolver,
             IActivationWorkingSet activationWorkingSet,
+            ILogger<Grain> grainLogger,
             ILogger<WorkItemGroup> workItemGroupLogger,
             ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
             IOptions<SchedulingOptions> schedulingOptions)
         {
             _activationWorkingSet = activationWorkingSet;
             _workItemGroupLogger = workItemGroupLogger;
+            _grainLogger = grainLogger;
             _activationTaskSchedulerLogger = activationTaskSchedulerLogger;
             _schedulingOptions = schedulingOptions;
             _sharedComponentsResolver = sharedComponentsResolver;
@@ -61,6 +64,7 @@ namespace Orleans.Runtime
                 instanceActivator,
                 _serviceProvider,
                 sharedContext,
+                _grainLogger,
                 _workItemGroupLogger,
                 _activationTaskSchedulerLogger,
                 _schedulingOptions);
@@ -85,12 +89,14 @@ namespace Orleans.Runtime
             private readonly IGrainActivator _grainActivator;
             private readonly IServiceProvider _serviceProvider;
             private readonly GrainTypeSharedContext _sharedComponents;
+            private readonly ILogger<Grain> _grainLogger;
             private readonly Func<IGrainContext, WorkItemGroup> _createWorkItemGroup;
 
             public ActivationDataActivator(
                 IGrainActivator grainActivator,
                 IServiceProvider serviceProvider,
                 GrainTypeSharedContext sharedComponents,
+                ILogger<Grain> grainLogger,
                 ILogger<WorkItemGroup> workItemGroupLogger,
                 ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
                 IOptions<SchedulingOptions> schedulingOptions)
@@ -101,6 +107,7 @@ namespace Orleans.Runtime
                 _grainActivator = grainActivator;
                 _serviceProvider = serviceProvider;
                 _sharedComponents = sharedComponents;
+                _grainLogger = grainLogger;
                 _createWorkItemGroup = context => new WorkItemGroup(
                     context,
                     _workItemGroupLogger,
@@ -123,6 +130,11 @@ namespace Orleans.Runtime
                     // Instantiate the grain itself
                     var instance = _grainActivator.CreateInstance(context);
                     context.SetGrainInstance(instance);
+                }
+                catch (Exception exception)
+                {
+                    _grainLogger.LogError(exception, "Failed to construct grain '{GrainId}'.", activationAddress.GrainId);
+                    throw;
                 }
                 finally
                 {

--- a/src/Orleans.Runtime/Facet/GrainConstructorArgumentFactory.cs
+++ b/src/Orleans.Runtime/Facet/GrainConstructorArgumentFactory.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime
 
                 // Since the IAttributeToFactoryMapper is specific to the attribute specialization, we create a generic method to provide a attribute independent call pattern.
                 var getFactory = GetFactoryMethod.MakeGenericMethod(attribute.GetType());
-                var argumentFactory = (Factory<IGrainContext, object>)getFactory.Invoke(this, new object[] { serviceProvider, parameter, attribute, grainType });
+                var argumentFactory = (Factory<IGrainContext, object>)getFactory.Invoke(this, [serviceProvider, parameter, attribute, grainType]);
 
                 // Record the argument factory
                 _argumentFactories.Add(argumentFactory);

--- a/src/Orleans.Runtime/Facet/Persistent/PersistentStateAttributeMapper.cs
+++ b/src/Orleans.Runtime/Facet/Persistent/PersistentStateAttributeMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
@@ -9,7 +10,7 @@ namespace Orleans
     /// </summary>
     public class PersistentStateAttributeMapper : IAttributeToFactoryMapper<PersistentStateAttribute>
     {
-        private static readonly MethodInfo create = typeof(IPersistentStateFactory).GetMethod("Create");
+        private static readonly MethodInfo CreateMethodInfo = typeof(IPersistentStateFactory).GetMethod("Create");
 
         /// <inheritdoc/>
         public Factory<IGrainContext, object> GetFactory(ParameterInfo parameter, PersistentStateAttribute attribute)
@@ -20,15 +21,24 @@ namespace Orleans
             {
                 config = new PersistentStateConfiguration() { StateName = parameter.Name, StorageName = attribute.StorageName };
             }
+
+            if (!parameter.ParameterType.IsGenericType || !typeof(IPersistentState<>).Equals(parameter.ParameterType.GetGenericTypeDefinition()))
+            {
+                throw new ArgumentException(
+                    $"Parameter '{parameter.Name}' on the constructor for '{parameter.Member.DeclaringType}' has an unsupported type, '{parameter.ParameterType}'. "
+                    + $"It must be an instance of generic type '{typeof(IPersistentState<>)}' because it has an associated [PersistentState(...)] attribute.",
+                    parameter.Name);
+            }
+
             // use generic type args to define collection type.
-            MethodInfo genericCreate = create.MakeGenericMethod(parameter.ParameterType.GetGenericArguments());
+            MethodInfo genericCreate = CreateMethodInfo.MakeGenericMethod(parameter.ParameterType.GetGenericArguments());
             return context => Create(context, genericCreate, config);
         }
 
-        private object Create(IGrainContext context, MethodInfo genericCreate, IPersistentStateConfiguration config)
+        private static object Create(IGrainContext context, MethodInfo genericCreate, IPersistentStateConfiguration config)
         {
             IPersistentStateFactory factory = context.ActivationServices.GetRequiredService<IPersistentStateFactory>();
-            object[] args = new object[] { context, config };
+            object[] args = [context, config];
             return genericCreate.Invoke(factory, args);
         }
 

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -28,8 +28,10 @@ namespace DefaultCluster.Tests.General
 
             for (int i = 0; i < 100; i++)
             {
-                var ex = await Assert.ThrowsAsync<Exception>(() => grain.Ping());
-                Assert.Equal("oops", ex.Message);
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.Ping());
+                Assert.Contains("Failed to create an instance of grain type", ex.Message);
+                var iex = Assert.IsType<Exception>(ex.InnerException);
+                Assert.Equal("oops", iex.Message);
             }
         }
 

--- a/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
+++ b/test/DependencyInjection.Tests/DependencyInjectionGrainTestsRunner.cs
@@ -153,7 +153,8 @@ namespace DependencyInjection.Tests
         {
             ISimpleDIGrain grain = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.GetLongValue());
-            Assert.Contains("Unable to resolve service for type 'System.String' while attempting to activate 'UnitTests.Grains.ExplicitlyRegisteredSimpleDIGrain'", exception.Message);
+            var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Contains("Unable to resolve service for type 'System.String' while attempting to activate 'UnitTests.Grains.ExplicitlyRegisteredSimpleDIGrain'", innerException.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds clearer error logs & exceptions when a grain class cannot be constructed.
It also adds a specific, more informative, exception for the case where a grain constructor parameter has a `[PersistentState(...)]` attribute but the parameter type is not `IPersistentState<T>`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9399)