### PR TITLE
[CodeGeneration] Pragma Restore CS1591 on the last namespace

### DIFF
--- a/src/Orleans.CodeGenerator/CodeGenerator.cs
+++ b/src/Orleans.CodeGenerator/CodeGenerator.cs
@@ -380,7 +380,7 @@ namespace Orleans.CodeGenerator
 
             if (namespaces.Count > 0)
             {
-                namespaces[0] = namespaces[0]
+                namespaces[namespaces.Count - 1] = namespaces[namespaces.Count - 1]
                     .WithTrailingTrivia(
                        SyntaxFactory.TriviaList(
                            new List<SyntaxTrivia>


### PR DESCRIPTION
Generated code was only disabling CS1591 on the first, top-level namespace. Placing the restore on the last namespace should disable it for the whole "file"

Fixes #9410 