### PR TITLE
fix(3.x): source link translation visualstudio.com to dev.azure.com

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,13 +6,14 @@
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
 
   <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and '$(IncludeBuildOutput)'=='true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>
     <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
     <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
-    <_TranslateUrlPattern>https://.*\.visualstudio\.com/.*/_git/[^/]*</_TranslateUrlPattern>
+    <_TranslateUrlPattern>(https://.*\.visualstudio\.com/.*/_git/[^/]*)|(https://dev\.azure\.com/.*/_git/[^/]*)</_TranslateUrlPattern>
     <_TranslateUrlReplacement>$(PublicRepositoryUrl)</_TranslateUrlReplacement>
   </PropertyGroup>
 


### PR DESCRIPTION
Candidate build for 3.x migration tooling did not have a proper source link due to not having a proper source link translation
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9413)