### PR TITLE
fix(3.x): provide a strict version for SourceLink packages

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,8 +6,8 @@
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
 
   <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and '$(IncludeBuildOutput)'=='true'">
-    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(SourceLinkVersion)" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Mitigating following error
> ##[error]src\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj(0,0): Error NU1604: Project dependency Microsoft.SourceLink.AzureRepos.Git does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.