### PR TITLE
[3.x] turn on packaging for Orleans.Persistence.Cosmos

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos/Orleans.Persistence.Cosmos.csproj
+++ b/src/Azure/Orleans.Persistence.Cosmos/Orleans.Persistence.Cosmos.csproj
@@ -6,7 +6,6 @@
     <Description>Microsoft Orleans persistence providers for Azure Cosmos DB</Description>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable> <!-- explicitly is not packable: maybe will be released later -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
3.8.0-previewX version is missing due to `IsPackable=false` property: https://www.nuget.org/packages/Microsoft.Orleans.Persistence.Cosmos/3.8.0-preview2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9427)