### PR TITLE
fix(3x): fix reminders usage

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage.Migration/AzureBlobSiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage.Migration/AzureBlobSiloBuilderExtensions.cs
@@ -141,7 +141,7 @@ namespace Orleans.Hosting
             Action<AzureTableReminderStorageOptions> configureStorageOptions,
             Action<AzureTableMigrationReminderStorageOptions> configureMigratedStorageOptions)
         {
-            services.AddSingleton<IReminderMigrationTable, MigrationAzureTableReminderStorage>();
+            services.AddSingleton<IReminderTable, MigrationAzureTableReminderStorage>();
             services.Configure<AzureTableReminderStorageOptions>(configureStorageOptions);
             services.Configure<AzureTableMigrationReminderStorageOptions>(configureMigratedStorageOptions);
             services.ConfigureFormatter<AzureTableReminderStorageOptions>();

--- a/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/MigrationAzureTableReminderStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/MigrationAzureTableReminderStorage.cs
@@ -1,4 +1,3 @@
-using Azure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -16,8 +15,12 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
     /// </summary>
     public class MigrationAzureTableReminderStorage : IReminderMigrationTable
     {
+        private readonly ILogger<MigrationAzureTableReminderStorage> _logger;
+
         public IReminderTable SourceReminderTable { get; }
         public IReminderTable DestinationReminderTable { get; }
+
+        private ReminderMigrationMode _reminderMigrationMode;
 
         public MigrationAzureTableReminderStorage(
             IGrainReferenceConverter grainReferenceConverter,
@@ -27,32 +30,221 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
             IOptions<AzureTableReminderStorageOptions> oldStorageOptions,
             IOptions<AzureTableMigrationReminderStorageOptions> migratedStorageOptions)
         {
+            _logger = loggerFactory.CreateLogger<MigrationAzureTableReminderStorage>();
+
             SourceReminderTable = new AzureBasedReminderTable(grainReferenceConverter, loggerFactory, clusterOptions, oldStorageOptions);
             DestinationReminderTable = new MigrationAzureBasedReminderTable(grainReferenceConverter, grainReferenceExtractor, loggerFactory, clusterOptions, migratedStorageOptions);
+
+            if (migratedStorageOptions?.Value is not null)
+            {
+                _reminderMigrationMode = migratedStorageOptions.Value.ReminderMigrationMode;
+            }
+        }
+
+        /// <summary>
+        /// Completely disables migration tooling to use only the source storage
+        /// </summary>
+        public void DisableMigrationTooling()
+        {
+            _reminderMigrationMode = ReminderMigrationMode.Disabled;
+        }
+
+        /// <summary>
+        /// Changes mode to specified one
+        /// </summary>
+        public void ChangeMode(ReminderMigrationMode mode)
+        {
+            _reminderMigrationMode = mode;
         }
 
         public async Task Init()
         {
-            await SourceReminderTable.Init();
-            await DestinationReminderTable.Init();
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                    await SourceReminderTable.Init();
+                    break;
+
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                    await SourceReminderTable.Init();
+                    await DestinationReminderTable.Init();
+                    break;
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    await DestinationReminderTable.Init();
+                    break;
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
         }
 
         public async Task<string> UpsertRow(ReminderEntry entry)
         {
-            await DestinationReminderTable.UpsertRow(entry);
-            return await SourceReminderTable.UpsertRow(entry);
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                    return await SourceReminderTable.UpsertRow(entry);
+
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                {
+                    await DestinationReminderTable.UpsertRow(entry);
+                    return await SourceReminderTable.UpsertRow(entry);
+                }
+
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                {
+                    var destinationResult = await DestinationReminderTable.UpsertRow(entry);
+                    await SourceReminderTable.UpsertRow(entry);
+                    return destinationResult;
+                }
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    return await DestinationReminderTable.UpsertRow(entry);
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
         }
 
         public async Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
         {
-            await DestinationReminderTable.RemoveRow(grainRef, reminderName, eTag);
-            return await SourceReminderTable.RemoveRow(grainRef, reminderName, eTag);
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                    return await SourceReminderTable.RemoveRow(grainRef, reminderName, eTag);
+
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                {
+                    await DestinationReminderTable.RemoveRow(grainRef, reminderName, eTag);
+                    return await SourceReminderTable.RemoveRow(grainRef, reminderName, eTag);
+                }
+
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                {
+                    var destinationResult = await DestinationReminderTable.RemoveRow(grainRef, reminderName, eTag);
+                    await SourceReminderTable.RemoveRow(grainRef, reminderName, eTag);
+                    return destinationResult;
+                }
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    return await DestinationReminderTable.RemoveRow(grainRef, reminderName, eTag);
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
         }
 
-        public Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName) => SourceReminderTable.ReadRow(grainRef, reminderName);
-        public Task<ReminderTableData> ReadRows(GrainReference key) => SourceReminderTable.ReadRows(key);
-        public Task<ReminderTableData> ReadRows(uint begin, uint end) => SourceReminderTable.ReadRows(begin, end);
-        public Task TestOnlyClearTable() => SourceReminderTable.TestOnlyClearTable();
+        public async Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
+        {
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                    return await SourceReminderTable.ReadRow(grainRef, reminderName);
+
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                {
+                    try
+                    {
+                        return await DestinationReminderTable.ReadRow(grainRef, reminderName);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "ReadRow error on destination reminder storage");
+                        return await SourceReminderTable.ReadRow(grainRef, reminderName);
+                    }
+                }
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    return await DestinationReminderTable.ReadRow(grainRef, reminderName);
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
+        }
+
+        public async Task<ReminderTableData> ReadRows(GrainReference key)
+        {
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                    return await SourceReminderTable.ReadRows(key);
+
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                    {
+                        try
+                        {
+                            return await DestinationReminderTable.ReadRows(key);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "ReadRows error on destination reminder storage [key={0}]", key);
+                            return await SourceReminderTable.ReadRows(key);
+                        }
+                    }
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    return await DestinationReminderTable.ReadRows(key);
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
+        }
+
+        public async Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                    return await SourceReminderTable.ReadRows(begin, end);
+
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                    {
+                        try
+                        {
+                            return await DestinationReminderTable.ReadRows(begin, end);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "ReadRows error on destination reminder storage [begin={0};end={1}]", begin, end);
+                            return await SourceReminderTable.ReadRows(begin, end);
+                        }
+                    }
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    return await DestinationReminderTable.ReadRows(begin, end);
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
+        }
+
+        public async Task TestOnlyClearTable()
+        {
+            switch (_reminderMigrationMode)
+            {
+                case ReminderMigrationMode.Disabled:
+                    await SourceReminderTable.TestOnlyClearTable();
+                    break;
+
+                case ReminderMigrationMode.ReadSource_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
+                case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                    await SourceReminderTable.TestOnlyClearTable();
+                    await DestinationReminderTable.TestOnlyClearTable();
+                    break;
+
+                case ReminderMigrationMode.ReadWriteDestination:
+                    await DestinationReminderTable.TestOnlyClearTable();
+                    break;
+
+                default: throw new ArgumentOutOfRangeException(nameof(_reminderMigrationMode));
+            }
+        }
 
         private class MigrationAzureBasedReminderTable : AzureBasedReminderTable
         {
@@ -66,5 +258,45 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
             {
             }
         }
+    }
+
+    /// <summary>
+    /// Controls the reminder migration mode of the underlying reminder storage
+    /// </summary>
+    public enum ReminderMigrationMode
+    {
+        /// <summary>
+        /// Reminder migration is completely disabled.
+        /// Only source storage will be used for read/write and clear operations.
+        /// </summary>
+        Disabled = 0,
+
+        /// <summary>
+        /// Reading would happen from source storage only, and writes will target both source and destination storages.
+        /// <br/>
+        /// <i>Should be used as a first step of migration.</i>
+        /// </summary>
+        ReadSource_WriteBoth = 1,
+
+        /// <summary>
+        /// Reading would happen from destination storage, and if entry does not exist, will also check source storage.
+        /// Write will target both storages.
+        /// <br/>
+        /// <i>Should be used as latter step of migration.</i>
+        /// </summary>
+        ReadDestinationWithFallback_WriteBoth = 2,
+
+        /// <summary>
+        /// Reading would happen from destination storage, and if entry does not exist, will also check source storage.
+        /// Write will target only destination.
+        /// <br/>
+        /// <i>Should be used as latter step of migration.</i>
+        /// </summary>
+        ReadDestinationWithFallback_WriteDestination = 3,
+
+        /// <summary>
+        /// Reading and writing happens only against destination storage
+        /// </summary>
+        ReadWriteDestination = 4
     }
 }

--- a/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/MigrationAzureTableReminderStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/MigrationAzureTableReminderStorage.cs
@@ -147,13 +147,13 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
                 {
-                    try
+                    var entry = await DestinationReminderTable.ReadRow(grainRef, reminderName);
+                    if (entry is not null)
                     {
-                        return await DestinationReminderTable.ReadRow(grainRef, reminderName);
+                        return entry;
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        _logger.LogWarning(ex, "ReadRow error on destination reminder storage");
                         return await SourceReminderTable.ReadRow(grainRef, reminderName);
                     }
                 }
@@ -175,17 +175,17 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
 
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                {
+                    var entry = await DestinationReminderTable.ReadRows(key);
+                    if (entry is not null)
                     {
-                        try
-                        {
-                            return await DestinationReminderTable.ReadRows(key);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "ReadRows error on destination reminder storage [key={0}]", key);
-                            return await SourceReminderTable.ReadRows(key);
-                        }
+                        return entry;
                     }
+                    else
+                    {
+                        return await SourceReminderTable.ReadRows(key);
+                    }
+                }
 
                 case ReminderMigrationMode.ReadWriteDestination:
                     return await DestinationReminderTable.ReadRows(key);
@@ -204,17 +204,17 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders
 
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth:
                 case ReminderMigrationMode.ReadDestinationWithFallback_WriteDestination:
+                {
+                    var entry = await DestinationReminderTable.ReadRows(begin, end);
+                    if (entry is not null)
                     {
-                        try
-                        {
-                            return await DestinationReminderTable.ReadRows(begin, end);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "ReadRows error on destination reminder storage [begin={0};end={1}]", begin, end);
-                            return await SourceReminderTable.ReadRows(begin, end);
-                        }
+                        return entry;
                     }
+                    else
+                    {
+                        return await SourceReminderTable.ReadRows(begin, end);
+                    }
+                }
 
                 case ReminderMigrationMode.ReadWriteDestination:
                     return await DestinationReminderTable.ReadRows(begin, end);

--- a/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/Storage/AzureTableMigrationReminderStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage.Migration/Reminders/Storage/AzureTableMigrationReminderStorageOptions.cs
@@ -7,5 +7,6 @@ namespace Orleans.Persistence.AzureStorage.Migration.Reminders.Storage
     /// </summary>
     public class AzureTableMigrationReminderStorageOptions : AzureTableReminderStorageOptions
     {
+        public ReminderMigrationMode ReminderMigrationMode { get; set; } = ReminderMigrationMode.Disabled;
     }
 }

--- a/src/Orleans.Persistence.Migration/DataMigrator.cs
+++ b/src/Orleans.Persistence.Migration/DataMigrator.cs
@@ -30,7 +30,7 @@ namespace Orleans.Persistence.Migration
             ILocalSiloDetails localSiloDetails,
             IGrainStorage sourceStorage,
             IGrainStorage destinationStorage,
-            IReminderMigrationTable reminderMigrationTable,
+            IReminderTable reminderTable,
             DataMigratorOptions options)
         {
             _logger = logger;
@@ -46,7 +46,9 @@ namespace Orleans.Persistence.Migration
                 : throw new ArgumentException($"Implement {nameof(IExtendedGrainStorage)} on grain storage to support data migration.", paramName: nameof(sourceStorage));
             _destinationStorage = destinationStorage;
 
-            _reminderMigrationStorage = reminderMigrationTable;
+            _reminderMigrationStorage = (reminderTable is IReminderMigrationTable reminderMigrationTable)
+                ? reminderMigrationTable
+                : null!;
         }
 
         public Task StartAsync(CancellationToken cancellationToken) => _executeBackgroundMigrationTask = ExecuteBackgroundMigrationAsync(_backgroundWorkCts.Token);

--- a/src/Orleans.Persistence.Migration/HostingExtensions.cs
+++ b/src/Orleans.Persistence.Migration/HostingExtensions.cs
@@ -160,7 +160,7 @@ namespace Orleans.Persistence.Migration
                     sp.GetRequiredService<ILocalSiloDetails>(),
                     sp.GetRequiredServiceByName<IGrainStorage>(oldStorageName),
                     sp.GetRequiredServiceByName<IGrainStorage>(newStorageName),
-                    sp.GetService<IReminderMigrationTable>(),
+                    sp.GetService<IReminderTable>(),
                     options);
             });
 

--- a/src/Orleans.Persistence.Migration/MigrationGrainStorage.cs
+++ b/src/Orleans.Persistence.Migration/MigrationGrainStorage.cs
@@ -225,6 +225,9 @@ namespace Orleans.Persistence.Migration
         public GrainMigrationMode Mode { get; set; } = GrainMigrationMode.Disabled;
     }
 
+    /// <summary>
+    /// Controls the grain migration mode of the underlying grain storage
+    /// </summary>
     public enum GrainMigrationMode
     {
         /// <summary>

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
@@ -100,7 +100,13 @@ namespace Tester.AzureUtils.Migration.Abstractions
         {
             if (reminderTable == null)
             {
-                reminderTable = ServiceProvider.GetRequiredService<IReminderMigrationTable>();
+                var tmp = ServiceProvider.GetRequiredService<IReminderTable>();
+                if (tmp is not IReminderMigrationTable reminderMigrationTable)
+                {
+                    throw new ArgumentException("Not a reminder migration table");
+                }
+
+                reminderTable = reminderMigrationTable;
                 await reminderTable.Init();
             }
 

--- a/test/Extensions/Tester.AzureUtils.Migration/MigrationAzureTableRemindersTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/MigrationAzureTableRemindersTests.cs
@@ -1,4 +1,5 @@
 using Orleans.Hosting;
+using Orleans.Persistence.AzureStorage.Migration.Reminders;
 using Orleans.Persistence.Migration;
 using Orleans.TestingHost;
 using Tester.AzureUtils.Migration.Abstractions;
@@ -61,6 +62,8 @@ namespace Tester.AzureUtils.Migration
                         {
                             migrationOptions.ConfigureTestDefaults();
                             migrationOptions.TableName = DestinationTableName;
+
+                            migrationOptions.ReminderMigrationMode = ReminderMigrationMode.ReadDestinationWithFallback_WriteBoth;
                         }
                     )
                     .AddDataMigrator(SourceStorageName, DestinationStorageName);


### PR DESCRIPTION
There are 2 problems I spotted with NuGet usage:
1) reminders cant be used with `UseMigrationAzureTableReminderStorage` registration, because `MigrationAzureTableReminderStorage` should be registered as `IReminderTable` instead of `IReminderMigrationTable` (otherwise resolve does not work)

2) I added a `ReminderMigrationMode` which controls what invocation is used in `MigrationAzureTableReminderStorage` (and in which priority). Something similar to `GrainMigrationMode`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9428)