### PR TITLE
[Azure] Package version bumps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,10 +49,10 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageVersion Include="Azure.Core" Version="1.44.1" />
-    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.5" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.21.0" />
+    <PackageVersion Include="Azure.Core" Version="1.45.0" />
+    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.1" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.0.0" />

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -186,7 +186,7 @@ namespace Orleans.Streaming.EventHubs
             if (!this.checkpointer.CheckpointExists)
             {
                 this.checkpointer.Update(
-                    messages[0].Offset.ToString(),
+                    messages[0].OffsetString,
                     DateTime.UtcNow);
             }
             return batches;

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -100,16 +100,36 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         public static EventData ToEventData<T>(Serializer bodySerializer, StreamId streamId, IEnumerable<T> events, Dictionary<string, object> requestContext)
         {
+            var eventData = new EventData();
+
+            UpdateEventData(eventData, bodySerializer, streamId, events.Cast<object>().ToList(), requestContext);
+            return eventData;
+        }
+
+        /// <summary>
+        ///   Updates the event data with the events list and its context.
+        /// </summary>
+        /// <param name="eventData">The <see cref="EventData"/> instance to update with a new body and context.</param>
+        /// <param name="bodySerializer">The serializer to use for creating the event body payload.</param>
+        /// <param name="streamId">The stream identifier to associate with the event context.</param>
+        /// <param name="events">The events list to use for the payload.</param>
+        /// <param name="requestContext">The request context to associate with the event.</param>
+        public static void UpdateEventData<T>(EventData eventData, Serializer bodySerializer, StreamId streamId, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        {
+            eventData.EventBody = CreateEventDataBody(bodySerializer, events, requestContext);
+            eventData.SetStreamNamespaceProperty(streamId.GetNamespace());
+        }
+
+        private static BinaryData CreateEventDataBody<T>(Serializer bodySerializer, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        {
             var payload = new Body
             {
                 Events = events.Cast<object>().ToList(),
                 RequestContext = requestContext
             };
-            var bytes = bodySerializer.SerializeToArray(payload);
-            var eventData = new EventData(bytes);
 
-            eventData.SetStreamNamespaceProperty(streamId.GetNamespace());
-            return eventData;
+            var bytes = bodySerializer.SerializeToArray(payload);
+            return new BinaryData(bytes);
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -63,7 +63,7 @@ namespace Orleans.Streaming.EventHubs
         {
             return new CachedMessage()
             {
-                StreamId = streamPosition.StreamId, 
+                StreamId = streamPosition.StreamId,
                 SequenceNumber = queueMessage.SequenceNumber,
                 EventIndex = streamPosition.SequenceToken.EventIndex,
                 EnqueueTimeUtc = queueMessage.EnqueuedTime.UtcDateTime,
@@ -76,7 +76,7 @@ namespace Orleans.Streaming.EventHubs
         {
             StreamId streamId = this.GetStreamIdentity(queueMessage);
             StreamSequenceToken token =
-                new EventHubSequenceTokenV2(queueMessage.Offset.ToString(), queueMessage.SequenceNumber, 0);
+                new EventHubSequenceTokenV2(queueMessage.OffsetString, queueMessage.SequenceNumber, 0);
             return new StreamPosition(streamId, token);
         }
 
@@ -114,7 +114,7 @@ namespace Orleans.Streaming.EventHubs
         {
             byte[] propertiesBytes = queueMessage.SerializeProperties(this.serializer);
             var payload = queueMessage.Body.Span;
-            var offset = queueMessage.Offset.ToString();
+            var offset = queueMessage.OffsetString;
             // get size of namespace, offset, partitionkey, properties, and payload
             int size = SegmentBuilder.CalculateAppendSize(offset) +
                 SegmentBuilder.CalculateAppendSize(queueMessage.PartitionKey) +

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -56,13 +56,8 @@ namespace Orleans.Streaming.EventHubs
                 // If we have a starting offset, read from offset
                 if (offset != EventHubConstants.StartOfStream)
                 {
-                    if (!long.TryParse(offset, out var longOffset))
-                    {
-                        throw new InvalidOperationException("Offset must be a number.");
-                    }
-
                     LogInfoStartingRead(logger, options.EventHubName, partitionSettings.Partition, offset);
-                    eventPosition = EventPosition.FromOffset(longOffset, true);
+                    eventPosition = EventPosition.FromOffset(offset, true);
                 }
                 // else, if configured to start from now, start reading from most recent data
                 else if (partitionSettings.ReceiverOptions.StartFromNow)

--- a/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -11,6 +11,7 @@ using Azure.Messaging.EventHubs;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization;
 using Orleans.Statistics;
+using System.Globalization;
 
 namespace ServiceBus.Tests.EvictionStrategyTests
 {
@@ -55,7 +56,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
         }
 
         [Fact, TestCategory("BVT")]
-        public async Task EventhubQueueCache_WontPurge_WhenUnderPressure()
+        public async Task EventHubQueueCache_WontPurge_WhenUnderPressure()
         {
             InitForTesting();
             var tasks = new List<Task>();
@@ -78,7 +79,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
         }
 
         [Fact, TestCategory("BVT")]
-        public async Task EventhubQueueCache_WontPurge_WhenTimePurgePredicateSaysDontPurge()
+        public async Task EventHubQueueCache_WontPurge_WhenTimePurgePredicateSaysDontPurge()
         {
             InitForTesting();
             var tasks = new List<Task>();
@@ -103,7 +104,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
         }
 
         [Fact, TestCategory("BVT")]
-        public async Task EventhubQueueCache_WillPurge_WhenTimePurgePredicateSaysPurge_And_NotUnderPressure()
+        public async Task EventHubQueueCache_WillPurge_WhenTimePurgePredicateSaysPurge_And_NotUnderPressure()
         {
             InitForTesting();
             var tasks = new List<Task>();
@@ -129,7 +130,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
         }
 
         [Fact, TestCategory("BVT")]
-        public async Task EventhubQueueCache_EvictionStrategy_Behavior()
+        public async Task EventHubQueueCache_EvictionStrategy_Behavior()
         {
             InitForTesting();
             var tasks = new List<Task>();
@@ -197,7 +198,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
                 EventHubPath = this.ehSettings.Hub.EventHubName,
             };
 
-            this.receiver1 = new EventHubAdapterReceiver(this.ehSettings, this.CacheFactory, this.CheckPointerFactory, NullLoggerFactory.Instance, 
+            this.receiver1 = new EventHubAdapterReceiver(this.ehSettings, this.CacheFactory, this.CheckPointerFactory, NullLoggerFactory.Instance,
                 new DefaultEventHubReceiverMonitor(monitorDimensions), new LoadSheddingOptions(), _hostEnvironmentStatistics);
             this.receiver2 = new EventHubAdapterReceiver(this.ehSettings, this.CacheFactory, this.CheckPointerFactory, NullLoggerFactory.Instance,
                 new DefaultEventHubReceiverMonitor(monitorDimensions), new LoadSheddingOptions(), _hostEnvironmentStatistics);
@@ -226,20 +227,13 @@ namespace ServiceBus.Tests.EvictionStrategyTests
 
         private static EventData MakeEventData(long sequenceNumber)
         {
-            byte[] ignore = { 12, 23 };
             var now = DateTime.UtcNow;
-            var eventData = new TestEventData(ignore,
-                offset: now.Ticks,
+            var eventData = EventHubsModelFactory.EventData(
+                eventBody: new BinaryData([12, 23]),
+                offsetString: now.Ticks.ToString(CultureInfo.InvariantCulture),
                 sequenceNumber: sequenceNumber,
                 enqueuedTime: now);
             return eventData;
-        }
-
-        private class TestEventData : EventData
-        {
-            public TestEventData(ReadOnlyMemory<byte> eventBody, IDictionary<string, object> properties = null, IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = long.MinValue, long offset = long.MinValue, DateTimeOffset enqueuedTime = default, string partitionKey = null) : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
-            {
-            }
         }
 
         private Task<IStreamQueueCheckpointer<string>> CheckPointerFactory(string partition)

--- a/test/Extensions/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Extensions/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
@@ -14,7 +14,7 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
         {
             var streamId = StreamId.Create(new StreamIdentity(GetPartitionGuid(partition), null));
             StreamSequenceToken token =
-            new EventHubSequenceTokenV2(queueMessage.Offset.ToString(), queueMessage.SequenceNumber, 0);
+            new EventHubSequenceTokenV2(queueMessage.OffsetString, queueMessage.SequenceNumber, 0);
 
             return new StreamPosition(streamId, token);
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to bump Azure SDK package versions.  Of particular note is Event Hubs, which absorbed a service contract change that requires offsets to be treated as strings, as the format is no longer guaranteed to be numeric. In response to this, uses of offset-related members were shifted to the `OffsetString` version.  In addition, I removed some use of deprecated protected constructors in favor of the model factory for creating instances with overrides for broker-owned fields.