### PR TITLE
feat(3.x): support multiple underlying storage registrations

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos.Migration/ReferenceExtractorGrainStateTypeInfoProvider.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos.Migration/ReferenceExtractorGrainStateTypeInfoProvider.cs
@@ -73,14 +73,14 @@ namespace Orleans.Persistence.Cosmos.Migration
             }
 
             var baseType = grainClass.BaseType;
-            if (baseType is null)
+            while (baseType != null)
             {
-                return null;
-            }
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(Grain<>))
+                {
+                    return "state";
+                }
 
-            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(Grain<>))
-            {
-                return "state";
+                baseType = baseType.BaseType;
             }
 
             return null;

--- a/src/Orleans.Persistence.Migration/DataMigrator.cs
+++ b/src/Orleans.Persistence.Migration/DataMigrator.cs
@@ -24,8 +24,11 @@ namespace Orleans.Persistence.Migration
         private readonly CancellationTokenSource _backgroundWorkCts = new();
         private object _lastProcessedGrainCursor;
 
+        public string Name { get; }
+
         public DataMigrator(
             ILogger<DataMigrator> logger,
+            string name,
             IClusterMembershipService clusterMembershipService,
             ILocalSiloDetails localSiloDetails,
             IGrainStorage sourceStorage,
@@ -35,6 +38,7 @@ namespace Orleans.Persistence.Migration
         {
             _logger = logger;
             _options = options ?? new();
+            Name = name;
 
             _clusterMembershipService = clusterMembershipService;
             _localSiloDetails = localSiloDetails;

--- a/src/Orleans.Persistence.Migration/DataMigrator.cs
+++ b/src/Orleans.Persistence.Migration/DataMigrator.cs
@@ -24,7 +24,10 @@ namespace Orleans.Persistence.Migration
         private readonly CancellationTokenSource _backgroundWorkCts = new();
         private object _lastProcessedGrainCursor;
 
-        public string Name { get; }
+        /// <summary>
+        /// Registration name
+        /// </summary>
+        internal string Name { get; }
 
         public DataMigrator(
             ILogger<DataMigrator> logger,

--- a/src/Orleans.Persistence.Migration/HostingExtensions.cs
+++ b/src/Orleans.Persistence.Migration/HostingExtensions.cs
@@ -110,25 +110,26 @@ namespace Orleans.Persistence.Migration
         /// <summary>
         /// Configure a component to migrate inner data in storages.
         /// Should be registered once per each source-destination migration storage pair.
+        /// Method registers DataMigrator with "default" name.
         /// </summary>
-        /// <param name="builder">DI of the app</param>
-        /// <param name="oldStorage">source storage (one you were already using)</param>
-        /// <param name="newStorage">(one you would like to migrate to)</param>
-        /// <param name="configureOptions">options of data migrator configuration</param>
-        /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
+        /// <param name="builder">The silo builder</param>
+        /// <param name="oldStorage">Source storage (one you were already using)</param>
+        /// <param name="newStorage">Destination storage (one you would like to migrate to)</param>
+        /// <param name="configureOptions">Options of data migrator configuration</param>
+        /// <param name="runAsBackgroundService">If true, the migrator will be started as a background service</param>
         public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, Action<DataMigratorOptions> configureOptions, bool runAsBackgroundService = false)
-            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, "dataMigrator", configureOptions, runAsBackgroundService));
+            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, "default", configureOptions, runAsBackgroundService));
 
         /// <summary>
         /// Configure a component to migrate inner data in storages.
         /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
-        /// <param name="builder">DI of the app</param>
-        /// <param name="oldStorage">source storage (one you were already using)</param>
-        /// <param name="newStorage">(one you would like to migrate to)</param>
-        /// <param name="name">this data migrator registration name</param>
-        /// <param name="configureOptions">options of data migrator configuration</param>
-        /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
+        /// <param name="builder">The silo builder</param>
+        /// <param name="oldStorage">Source storage (one you were already using)</param>
+        /// <param name="newStorage">Destination storage (one you would like to migrate to)</param>
+        /// <param name="name">This data migrator registration name. Should be unique for each pair of source/destination storages</param>
+        /// <param name="configureOptions">Options of data migrator configuration</param>
+        /// <param name="runAsBackgroundService">If true, the migrator will be started as a background service</param>
         public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, string name, Action<DataMigratorOptions> configureOptions, bool runAsBackgroundService = false)
             => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, name, configureOptions, runAsBackgroundService));
 
@@ -136,33 +137,33 @@ namespace Orleans.Persistence.Migration
         /// Configure a component to migrate inner data in storages.
         /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
-        /// <param name="builder">DI of the app</param>
-        /// <param name="oldStorage">source storage (one you were already using)</param>
-        /// <param name="newStorage">(one you would like to migrate to)</param>
-        /// <param name="name">this data migrator registration name</param>
-        /// <param name="configureOptions">options of data migrator configuration</param>
-        /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
-        public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, string name = "dataMigrator", Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null, bool runAsBackgroundService = false)
+        /// <param name="builder">The silo builder</param>
+        /// <param name="oldStorage">Source storage (one you were already using)</param>
+        /// <param name="newStorage">Destination storage (one you would like to migrate to)</param>
+        /// <param name="name">This data migrator registration name. Should be unique for each pair of source/destination storages</param>
+        /// <param name="configureOptions">Options of data migrator configuration</param>
+        /// <param name="runAsBackgroundService">If true, the migrator will be started as a background service</param>
+        public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, string name = "default", Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null, bool runAsBackgroundService = false)
             => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, name, configureOptions, runAsBackgroundService));
 
-        public static IServiceCollection AddDataMigrator(this IServiceCollection services, string oldStorageName, string newStorageName, string name = "dataMigrator", Action<DataMigratorOptions> configureOptions = null, bool runAsBackgroundService = false)
+        public static IServiceCollection AddDataMigrator(this IServiceCollection services, string oldStorageName, string newStorageName, string name = "default", Action<DataMigratorOptions> configureOptions = null, bool runAsBackgroundService = false)
             => services.AddDataMigrator(oldStorageName, newStorageName, name, ob => ob.Configure(configureOptions), runAsBackgroundService);
 
         /// <summary>
         /// Configure a component to migrate inner data in storages.
         /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
-        /// <param name="services">DI of the app</param>
-        /// <param name="oldStorageName">source storage (one you were already using)</param>
-        /// <param name="newStorageName">(one you would like to migrate to)</param>
-        /// <param name="name">this data migrator registration name</param>
-        /// <param name="configureOptions">options of data migrator configuration</param>
-        /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
+        /// <param name="services">The service collection to add the data migrator to</param>
+        /// <param name="oldStorageName">Source storage (one you were already using)</param>
+        /// <param name="newStorageName">Destination storage (one you would like to migrate to)</param>
+        /// <param name="name">This data migrator registration name. Should be unique for each pair of source/destination storages</param>
+        /// <param name="configureOptions">Options of data migrator configuration</param>
+        /// <param name="runAsBackgroundService">If true, the migrator will be started as a background service</param>
         public static IServiceCollection AddDataMigrator(
             this IServiceCollection services,
             string oldStorageName,
             string newStorageName,
-            string name = "dataMigrator",
+            string name = "default",
             Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null,
             bool runAsBackgroundService = false)
         {

--- a/src/Orleans.Persistence.Migration/HostingExtensions.cs
+++ b/src/Orleans.Persistence.Migration/HostingExtensions.cs
@@ -108,7 +108,8 @@ namespace Orleans.Persistence.Migration
         }
 
         /// <summary>
-        /// Configure a component to migrate inner data in storages
+        /// Configure a component to migrate inner data in storages.
+        /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
         /// <param name="builder">DI of the app</param>
         /// <param name="oldStorage">source storage (one you were already using)</param>
@@ -116,46 +117,69 @@ namespace Orleans.Persistence.Migration
         /// <param name="configureOptions">options of data migrator configuration</param>
         /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
         public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, Action<DataMigratorOptions> configureOptions, bool runAsBackgroundService = false)
-            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, configureOptions, runAsBackgroundService));
+            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, "dataMigrator", configureOptions, runAsBackgroundService));
 
         /// <summary>
-        /// Configure a component to migrate inner data in storages
+        /// Configure a component to migrate inner data in storages.
+        /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
         /// <param name="builder">DI of the app</param>
         /// <param name="oldStorage">source storage (one you were already using)</param>
         /// <param name="newStorage">(one you would like to migrate to)</param>
+        /// <param name="name">this data migrator registration name</param>
         /// <param name="configureOptions">options of data migrator configuration</param>
         /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
-        public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null, bool runAsBackgroundService = false)
-            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, configureOptions, runAsBackgroundService));
-
-
-        public static IServiceCollection AddDataMigrator(this IServiceCollection services, string oldStorageName, string newStorageName, Action<DataMigratorOptions> configureOptions = null, bool runAsBackgroundService = false)
-            => services.AddDataMigrator(oldStorageName, newStorageName, ob => ob.Configure(configureOptions), runAsBackgroundService);
+        public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, string name, Action<DataMigratorOptions> configureOptions, bool runAsBackgroundService = false)
+            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, name, configureOptions, runAsBackgroundService));
 
         /// <summary>
-        /// Configure a component to migrate inner data in storages
+        /// Configure a component to migrate inner data in storages.
+        /// Should be registered once per each source-destination migration storage pair.
+        /// </summary>
+        /// <param name="builder">DI of the app</param>
+        /// <param name="oldStorage">source storage (one you were already using)</param>
+        /// <param name="newStorage">(one you would like to migrate to)</param>
+        /// <param name="name">this data migrator registration name</param>
+        /// <param name="configureOptions">options of data migrator configuration</param>
+        /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
+        public static ISiloBuilder AddDataMigrator(this ISiloBuilder builder, string oldStorage, string newStorage, string name = "dataMigrator", Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null, bool runAsBackgroundService = false)
+            => builder.ConfigureServices(services => services.AddDataMigrator(oldStorage, newStorage, name, configureOptions, runAsBackgroundService));
+
+        public static IServiceCollection AddDataMigrator(this IServiceCollection services, string oldStorageName, string newStorageName, string name = "dataMigrator", Action<DataMigratorOptions> configureOptions = null, bool runAsBackgroundService = false)
+            => services.AddDataMigrator(oldStorageName, newStorageName, name, ob => ob.Configure(configureOptions), runAsBackgroundService);
+
+        /// <summary>
+        /// Configure a component to migrate inner data in storages.
+        /// Should be registered once per each source-destination migration storage pair.
         /// </summary>
         /// <param name="services">DI of the app</param>
         /// <param name="oldStorageName">source storage (one you were already using)</param>
         /// <param name="newStorageName">(one you would like to migrate to)</param>
+        /// <param name="name">this data migrator registration name</param>
         /// <param name="configureOptions">options of data migrator configuration</param>
         /// <param name="runAsBackgroundService">if true, the migrator will be started as a background service</param>
         public static IServiceCollection AddDataMigrator(
             this IServiceCollection services,
             string oldStorageName,
             string newStorageName,
+            string name = "dataMigrator",
             Action<OptionsBuilder<DataMigratorOptions>> configureOptions = null,
             bool runAsBackgroundService = false)
         {
-            configureOptions?.Invoke(services.AddOptions<DataMigratorOptions>("dataMigrator"));
+            configureOptions?.Invoke(services.AddOptions<DataMigratorOptions>(name));
 
-            services.AddSingleton(sp =>
+            if (services.Any(sd => sd.ImplementationInstance is DataMigrator dm && string.Equals(dm.Name, name, StringComparison.InvariantCultureIgnoreCase)))
             {
-                var options = sp.GetRequiredService<IOptionsMonitor<DataMigratorOptions>>().Get("dataMigrator");
+                throw new InvalidOperationException($"A DataMigrator with the name '{name}' is already registered.");
+            }
+
+            services.AddSingletonNamedService(name, (sp, name) =>
+            {
+                var options = sp.GetRequiredService<IOptionsMonitor<DataMigratorOptions>>().Get(name);
 
                 return new DataMigrator(
                     sp.GetService<ILogger<DataMigrator>>(),
+                    name,
                     sp.GetRequiredService<IClusterMembershipService>(),
                     sp.GetRequiredService<ILocalSiloDetails>(),
                     sp.GetRequiredServiceByName<IGrainStorage>(oldStorageName),
@@ -166,7 +190,7 @@ namespace Orleans.Persistence.Migration
 
             if (runAsBackgroundService)
             {
-                services.AddHostedService(sp => sp.GetService<DataMigrator>());
+                services.AddHostedService(sp => sp.GetServiceByName<DataMigrator>(name));
             }
             return services;
         }

--- a/src/Orleans.Persistence.Migration/HostingExtensions.cs
+++ b/src/Orleans.Persistence.Migration/HostingExtensions.cs
@@ -169,11 +169,6 @@ namespace Orleans.Persistence.Migration
         {
             configureOptions?.Invoke(services.AddOptions<DataMigratorOptions>(name));
 
-            if (services.Any(sd => sd.ImplementationInstance is DataMigrator dm && string.Equals(dm.Name, name, StringComparison.InvariantCultureIgnoreCase)))
-            {
-                throw new InvalidOperationException($"A DataMigrator with the name '{name}' is already registered.");
-            }
-
             services.AddSingletonNamedService(name, (sp, name) =>
             {
                 var options = sp.GetRequiredService<IOptionsMonitor<DataMigratorOptions>>().Get(name);

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
@@ -26,6 +26,16 @@ namespace Tester.AzureUtils.Migration.Abstractions
             this.fixture = fixture;
         }
 
+        protected ISimplePersistentMigrationGrain GetMigrationGrain(long id, Type? customType = null)
+        {
+            if (customType is not null)
+            {
+                return this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(id, grainClassNamePrefix: customType.FullName);
+            }
+
+            return this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(id);
+        }
+
         private IServiceProvider? serviceProvider;
         protected IServiceProvider ServiceProvider
         {
@@ -65,9 +75,9 @@ namespace Tester.AzureUtils.Migration.Abstractions
                 return this.sourceStorage;
             }
         }
+        protected IExtendedGrainStorage? SourceExtendedStorage => (SourceStorage as IExtendedGrainStorage) ?? null;
 
-        protected IExtendedGrainStorage? SourceExtendedStorage
-            => (SourceStorage as IExtendedGrainStorage) ?? null;
+        protected IGrainStorage GetStorage(string name) => ServiceProvider.GetRequiredServiceByName<IGrainStorage>(name);
 
         private IGrainStorage? destinationStorage;
         protected IGrainStorage DestinationStorage
@@ -125,6 +135,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
                 return this.dataMigrator;
             }
         }
+        protected DataMigrator GetDataMigrator(string name) => ServiceProvider.GetRequiredServiceByName<DataMigrator>(name);
 
         private IDocumentIdProvider? cosmosDocumentIdProvider;
         protected IDocumentIdProvider DocumentIdProvider

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTestsWithStorageRegistrations.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTestsWithStorageRegistrations.cs
@@ -1,0 +1,206 @@
+using Microsoft.Azure.Cosmos;
+using Orleans;
+using Orleans.Runtime;
+using Tester.AzureUtils.Migration.Grains;
+using Tester.AzureUtils.Migration.Helpers;
+using Xunit;
+
+namespace Tester.AzureUtils.Migration.Abstractions
+{
+    public abstract class MigrationTableStorageToCosmosTestsWithStorageRegistrations : MigrationBaseTests
+    {
+        const int baseId = 700;
+
+        public const string Migration1 = "migration1";
+        public const string Migration2 = "migration2";
+        public const string Source1 = "source1";
+        public const string Source2 = "source2";
+        public const string Destination1 = "destination1";
+        public const string Destination2 = "destination2";
+
+        readonly string _databaseName;
+        readonly string _containerName;
+
+        readonly CosmosClient _cosmosClient;
+
+        protected MigrationTableStorageToCosmosTestsWithStorageRegistrations(BaseAzureTestClusterFixture fixture)
+            : base(fixture)
+        {
+            _databaseName = MigrationAzureStorageTableToCosmosDbTestsWithStorageRegistrations.OrleansDatabase;
+            _containerName = MigrationAzureStorageTableToCosmosDbTestsWithStorageRegistrations.OrleansContainer;
+
+            _cosmosClient = CosmosClientHelpers.BuildClient();
+        }
+
+        [SkippableFact]
+        public async Task ReadFromSourceTest()
+        {
+            var grain1 = GetMigrationGrain(baseId + 1, typeof(MigrationTestGrainStorage1));
+            var grain2 = GetMigrationGrain(baseId + 2, typeof(MigrationTestGrainStorage2));
+            var grainState1 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+            var grainState2 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+
+            var stateName1 = typeof(MigrationTestGrainStorage1).FullName;
+            var stateName2 = typeof(MigrationTestGrainStorage2).FullName;
+
+            // Write directly to source storage
+            await GetStorage(Source1).WriteStateAsync(stateName1, (GrainReference)grain1, grainState1);
+            Assert.Equal(grainState1.State.A, await grain1.GetA());
+            Assert.Equal(grainState1.State.A * grainState1.State.B, await grain1.GetAxB());
+
+            await GetStorage(Source2).WriteStateAsync(stateName2, (GrainReference)grain2, grainState2);
+            Assert.Equal(grainState2.State.A, await grain2.GetA());
+            Assert.Equal(grainState2.State.A * grainState2.State.B, await grain2.GetAxB());
+        }
+
+        [SkippableFact]
+        public async Task UpdatesStatesInBothStorages_ForDifferentStorages()
+        {
+            var grain = GetMigrationGrain(baseId + 3, customType: typeof(MigrationTestGrainStorage1));
+            var grain2 = GetMigrationGrain(baseId + 4, customType: typeof(MigrationTestGrainStorage2));
+            var oldGrainState1 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+            var oldGrainState2 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+            var newState = new MigrationTestGrain_State { A = 20, B = 30 };
+            var stateName = typeof(MigrationTestGrainStorage1).FullName;
+            var stateName2 = typeof(MigrationTestGrainStorage2).FullName;
+
+            // should write to both storages at this point
+            await grain.SetA(33);
+            await grain.SetB(806);
+
+            await grain2.SetA(33);
+            await grain2.SetB(806);
+
+            // lets fetch data through cosmosClient
+            var cosmosGrainState = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain);
+
+            Assert.Equal(33, cosmosGrainState.A);
+            Assert.Equal(806, cosmosGrainState.B);
+
+            var cosmosGrainState2 = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain2);
+
+            Assert.Equal(33, cosmosGrainState2.A);
+            Assert.Equal(806, cosmosGrainState2.B);
+
+            // and data in azure table storage should be in sync
+            await GetStorage(Source1).ReadStateAsync(stateName, (GrainReference)grain, oldGrainState1);
+            Assert.Equal(cosmosGrainState.A, oldGrainState1.State.A);
+            Assert.Equal(cosmosGrainState.B, oldGrainState1.State.B);
+
+            await GetStorage(Source2).ReadStateAsync(stateName2, (GrainReference)grain2, oldGrainState2);
+            Assert.Equal(cosmosGrainState.A, oldGrainState2.State.A);
+            Assert.Equal(cosmosGrainState.B, oldGrainState2.State.B);
+
+            // update grain to a new state. Should happen in both storages again
+            await grain.SetA(newState.A);
+            await grain.SetB(newState.B);
+
+            await grain2.SetA(newState.A);
+            await grain2.SetB(newState.B);
+
+            // verify updated state in both storages
+            cosmosGrainState = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain);
+
+            Assert.Equal(20, cosmosGrainState.A);
+            Assert.Equal(30, cosmosGrainState.B);
+
+            cosmosGrainState2 = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain2);
+
+            Assert.Equal(20, cosmosGrainState.A);
+            Assert.Equal(30, cosmosGrainState.B);
+
+            await GetStorage(Source1).ReadStateAsync(stateName, (GrainReference)grain, oldGrainState1);
+            Assert.Equal(cosmosGrainState.A, oldGrainState1.State.A);
+            Assert.Equal(cosmosGrainState.B, oldGrainState1.State.B);
+
+            await GetStorage(Source2).ReadStateAsync(stateName2, (GrainReference)grain2, oldGrainState2);
+            Assert.Equal(cosmosGrainState2.A, oldGrainState2.State.A);
+            Assert.Equal(cosmosGrainState2.B, oldGrainState2.State.B);
+
+            // lets make a final check - getting grain state via grain API should return same data
+            Assert.Equal(cosmosGrainState.A, await grain.GetA());
+            Assert.Equal(cosmosGrainState.A * cosmosGrainState.B, await grain.GetAxB());
+
+            Assert.Equal(cosmosGrainState2.A, await grain2.GetA());
+            Assert.Equal(cosmosGrainState2.A * cosmosGrainState2.B, await grain2.GetAxB());
+        }
+
+        [SkippableFact]
+        public async Task DataMigrator_MovesDataToDestinationStorage()
+        {
+            var grain1 = GetMigrationGrain(baseId + 5, typeof(MigrationTestGrainStorage1));
+            var grain2 = GetMigrationGrain(baseId + 6, typeof(MigrationTestGrainStorage2));
+            var oldGrainState1 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+            var oldGrainState2 = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
+            var stateName1 = typeof(MigrationTestGrain).FullName;
+            var stateName2 = typeof(MigrationTestGrain).FullName;
+
+            await GetStorage(Source1).WriteStateAsync(stateName1, (GrainReference)grain1, oldGrainState1);
+            await GetStorage(Source2).WriteStateAsync(stateName2, (GrainReference)grain2, oldGrainState2);
+
+            // we don't launch DataMigrator2 and we will ensure it did not run
+            await GetDataMigrator(Migration1).MigrateGrainsAsync(CancellationToken.None);
+
+            var cosmosGrainState1 = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain1);
+
+            Assert.Equal(oldGrainState1.State.A, cosmosGrainState1.A);
+            Assert.Equal(oldGrainState1.State.B, cosmosGrainState1.B);
+
+            try
+            {
+                _ = await GetGrainStateFromCosmosAsync(
+                    _cosmosClient,
+                    databaseName: _databaseName,
+                    containerName: _containerName,
+                    DocumentIdProvider,
+                    (GrainReference)grain2);
+
+                Assert.False(true, "DataMigrator2 should not run and therefore should not migrate data to Cosmos DB for grain2");
+            }
+            catch (Exception ex)
+            {
+                Assert.NotNull(ex);
+            }
+
+            // rerun data migrator should not invoke anything -> all data is migrated already
+            var statsRun2 = await GetDataMigrator(Migration1).MigrateGrainsAsync(CancellationToken.None);
+            Assert.True(statsRun2.SkippedAllEntries || statsRun2.SkippedEntries != 0); // it should skip entries (at least one - the one that we migrated on 1st DataMigrator.MigrateGrainsAsync() run)
+
+            // ensure state one more time
+            var cosmosGrainState11 = await GetGrainStateFromCosmosAsync(
+                _cosmosClient,
+                databaseName: _databaseName,
+                containerName: _containerName,
+                DocumentIdProvider,
+                (GrainReference)grain1);
+
+            Assert.Equal(oldGrainState1.State.A, cosmosGrainState11.A);
+            Assert.Equal(oldGrainState1.State.B, cosmosGrainState11.B);
+        }
+    }
+}

--- a/test/Extensions/Tester.AzureUtils.Migration/MigrationAzureStorageTableToCosmosDbTests_StorageRegistrations.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/MigrationAzureStorageTableToCosmosDbTests_StorageRegistrations.cs
@@ -1,0 +1,95 @@
+using Orleans.Hosting;
+using Orleans.Persistence.Cosmos.Migration;
+using Orleans.Persistence.Migration;
+using Orleans.TestingHost;
+using Tester.AzureUtils.Migration.Abstractions;
+using Xunit;
+using Orleans;
+using Tester.AzureUtils.Migration.Helpers;
+using Orleans.Persistence.Cosmos;
+using Orleans.Persistence.Cosmos.DocumentIdProviders;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TesterInternal.AzureInfra;
+
+namespace Tester.AzureUtils.Migration
+{
+    [TestCategory("Functional"), TestCategory("Migration"), TestCategory("Azure"), TestCategory("AzureTableStorage")]
+    public class MigrationAzureStorageTableToCosmosDbTestsWithStorageRegistrations : MigrationTableStorageToCosmosTestsWithStorageRegistrations, IClassFixture<MigrationAzureStorageTableToCosmosDbTestsWithStorageRegistrations.Fixture>
+    {
+        public static string OrleansDatabase = Resources.MigrationDatabase;
+        public static string OrleansContainer = Resources.MigrationLatestContainer;
+
+        public static string RandomIdentifier = Guid.NewGuid().ToString("N");
+
+        public MigrationAzureStorageTableToCosmosDbTestsWithStorageRegistrations(Fixture fixture) : base(fixture)
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+
+        public class Fixture : BaseAzureTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+        }
+
+        private class SiloConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder siloBuilder)
+            {
+                siloBuilder
+                    .ConfigureServices(services =>
+                    {
+                        services.TryAddSingleton<IDocumentIdProvider, ClusterDocumentIdProvider>();
+                    });
+
+                siloBuilder.AddMigrationTools();
+
+                siloBuilder
+                    .AddDataMigrator(Source1, Destination1, name: Migration1)
+                    .AddMigrationGrainStorage(Migration1, options =>
+                    {
+                        options.SourceStorageName = Source1;
+                        options.DestinationStorageName = Destination1;
+
+                        options.Mode = GrainMigrationMode.ReadDestinationWithFallback_WriteBoth;
+                    })
+                    .AddAzureTableGrainStorage(Source1, options =>
+                    {
+                        options.ConfigureTestDefaults();
+                        options.TableName = $"source1{RandomIdentifier}";
+                    })
+                    .AddMigrationAzureCosmosGrainStorage(Destination1, options =>
+                    {
+                        options.ConfigureCosmosStorageOptions();
+
+                        options.ContainerName = OrleansContainer;
+                        options.DatabaseName = OrleansDatabase;
+                    });
+
+                siloBuilder
+                    .AddDataMigrator(Source2, Destination2, name: Migration2)
+                    .AddMigrationGrainStorage(Migration2, options =>
+                    {
+                        options.SourceStorageName = Source2;
+                        options.DestinationStorageName = Destination2;
+
+                        options.Mode = GrainMigrationMode.ReadDestinationWithFallback_WriteBoth;
+                    })
+                    .AddAzureTableGrainStorage(Source2, options =>
+                    {
+                        options.ConfigureTestDefaults();
+                        options.TableName = $"source2{RandomIdentifier}";
+                    })
+                    .AddMigrationAzureCosmosGrainStorage(Destination2, options =>
+                    {
+                        options.ConfigureCosmosStorageOptions();
+
+                        options.ContainerName = OrleansContainer;
+                        options.DatabaseName = OrleansDatabase;
+                    });
+            }
+        }
+    }
+}

--- a/test/Grains/TestGrainsNet8/MigrationTestGrain.cs
+++ b/test/Grains/TestGrainsNet8/MigrationTestGrain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
+using Orleans.Providers;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
@@ -19,6 +20,24 @@ namespace Tester.AzureUtils.Migration.Grains
     {
         public int A { get; set; }
         public int B { get; set; }
+    }
+
+    [StorageProvider(ProviderName = "migration1")]
+    [Orleans.Persistence.Cosmos.GrainType("migrationtestgrain")]
+    public class MigrationTestGrainStorage1 : MigrationTestGrain
+    {
+        public MigrationTestGrainStorage1(ILoggerFactory loggerFactory) : base(loggerFactory)
+        {
+        }
+    }
+
+    [StorageProvider(ProviderName = "migration2")]
+    [Orleans.Persistence.Cosmos.GrainType("migrationtestgrain")]
+    public class MigrationTestGrainStorage2 : MigrationTestGrain
+    {
+        public MigrationTestGrainStorage2(ILoggerFactory loggerFactory) : base(loggerFactory)
+        {
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
The ask was to support different underlying storage registrations if grains explicitly define what storage they are using via `Orleans.Providers.StorageProviderAttribute` like:
```csharp
[StorageProvider(ProviderName = "migration1")]
public class MigrationTestGrainStorage1 : MigrationTestGrain
{
   ...
}

[StorageProvider(ProviderName = "migration2")]
public class MigrationTestGrainStorage2 : MigrationTestGrain
{
   ...
}
```

I have added tests for such a case and noted that `DataMigrator` does not allow multiple registrations, so I have added a "name" to it, meaning user will need to register one `DataMigrator` per each pair of source-destination storages:
```csharp
siloBuilder
    .AddDataMigrator(Source1, Destination1, name: Migration1)
    .AddMigrationGrainStorage(Migration1, options => ...)
    .AddAzureTableGrainStorage(Source1, options => ...)
    .AddMigrationAzureCosmosGrainStorage(Destination1, options => ...);
    
siloBuilder
    .AddDataMigrator(Source2, Destination2, name: Migration2)
    .AddMigrationGrainStorage(Migration2, options => ...)
    .AddAzureTableGrainStorage(Source2, options => ...)
    .AddMigrationAzureCosmosGrainStorage(Destination2, options => ...);
```

Moreover, I added a validation check on DataMigrator name uniqueness (in case users pass in same name for different `DataMigrator` registrations).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9454)