### PR TITLE
chore(3.x): add dataMigrator operation rate limiter & test fixes

### DIFF
--- a/src/Orleans.Persistence.Migration/DataMigrator.cs
+++ b/src/Orleans.Persistence.Migration/DataMigrator.cs
@@ -12,6 +12,8 @@ namespace Orleans.Persistence.Migration
     {
         private readonly ILogger<DataMigrator> _logger;
         private readonly DataMigratorOptions _options;
+        private readonly OperationsRateLimiter _sourceStorageOpsRateLimiter;
+        private readonly OperationsRateLimiter _destinationStorageOpsRateLimiter;
 
         private readonly IClusterMembershipService _clusterMembershipService;
         private readonly ILocalSiloDetails _localSiloDetails;
@@ -43,6 +45,9 @@ namespace Orleans.Persistence.Migration
             _options = options ?? new();
             Name = name;
 
+            _sourceStorageOpsRateLimiter = new OperationsRateLimiter(options.SourceStorageMaxOperationsPerMinute);
+            _destinationStorageOpsRateLimiter = new OperationsRateLimiter(options.SourceStorageMaxOperationsPerMinute);
+
             _clusterMembershipService = clusterMembershipService;
             _localSiloDetails = localSiloDetails;
 
@@ -56,6 +61,22 @@ namespace Orleans.Persistence.Migration
             _reminderMigrationStorage = (reminderTable is IReminderMigrationTable reminderMigrationTable)
                 ? reminderMigrationTable
                 : null!;
+        }
+
+        /// <summary>
+        /// Updates the upper limit on the number of operations per minute to be performed by the migrator against source storage.
+        /// </summary>
+        public void UpdateSourceStorageOperationsRateLimit(int limit)
+        {
+            _sourceStorageOpsRateLimiter.UpdateLimit(limit);
+        }
+
+        /// <summary>
+        /// Updates the upper limit on the number of operations per minute to be performed by the migrator against destination storage.
+        /// </summary>
+        public void UpdateDestinationStorageOperationsRateLimit(int limit)
+        {
+            _destinationStorageOpsRateLimiter.UpdateLimit(limit);
         }
 
         public Task StartAsync(CancellationToken cancellationToken) => _executeBackgroundMigrationTask = ExecuteBackgroundMigrationAsync(_backgroundWorkCts.Token);
@@ -149,6 +170,9 @@ namespace Orleans.Persistence.Migration
             var migrationStats = new MigrationStats();
             await foreach (var storageEntry in _sourceStorage.GetAll(_lastProcessedGrainCursor, cancellationToken))
             {
+                await _sourceStorageOpsRateLimiter.WaitIfNeededAsync(increment: 1, cancellationToken);
+                await _destinationStorageOpsRateLimiter.WaitIfNeededAsync(increment: 2, cancellationToken);
+
                 migrationStats.EntriesProcessed++;
                 if (!_options.ProcessMigratedEntries)
                 {
@@ -318,5 +342,17 @@ namespace Orleans.Persistence.Migration
         /// If you want to skip awaiting, set it to null.
         /// </summary>
         public TimeSpan? BackgroundTaskInitialDelay { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Maximum operations per minute to be performed by the migrator against source storage.
+        /// Defaults to 1000000 (basically no limit)
+        /// </summary>
+        public int SourceStorageMaxOperationsPerMinute { get; set; } = 1000000;
+
+        /// <summary>
+        /// Maximum operations per minute to be performed by the migrator against destination storage.
+        /// Defaults to 1000000 (basically no limit)
+        /// </summary>
+        public int DestinationStorageMaxOperationsPerMinute { get; set; } = 1000000;
     }
 }

--- a/src/Orleans.Persistence.Migration/OperationsRateLimiter.cs
+++ b/src/Orleans.Persistence.Migration/OperationsRateLimiter.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Persistence.Migration
+{
+    internal class OperationsRateLimiter
+    {
+        private int maxOpsPerMinute;
+        private int opsThisMinute = 0;
+        private DateTime lastReset = DateTime.UtcNow;
+
+        public OperationsRateLimiter(int maxOpsPerMinute)
+        {
+            UpdateLimit(maxOpsPerMinute);
+        }
+
+        public void UpdateLimit(int newLimit)
+        {
+            if (newLimit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(newLimit), "Must be > 0");
+            }
+
+            maxOpsPerMinute = newLimit;
+            opsThisMinute = 0;
+            lastReset = DateTime.UtcNow;
+        }
+
+        public async Task WaitIfNeededAsync(int increment, CancellationToken cancellationToken)
+        {
+            var now = DateTime.UtcNow;
+
+            if ((now - lastReset).TotalMinutes >= 1)
+            {
+                opsThisMinute = 0;
+                lastReset = now;
+            }
+
+            if (opsThisMinute >= maxOpsPerMinute)
+            {
+                var delay = 60000 - (int)(now - lastReset).TotalMilliseconds;
+                if (delay > 0)
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+
+                opsThisMinute = 0;
+                lastReset = DateTime.UtcNow;
+            }
+
+            opsThisMinute += increment;
+        }
+    }
+}

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationBaseTests.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
                 return this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(id, grainClassNamePrefix: customType.FullName);
             }
 
-            return this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(id);
+            return this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(id, grainClassNamePrefix: typeof(MigrationTestGrain).FullName);
         }
 
         private IServiceProvider? serviceProvider;
@@ -130,7 +130,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
             {
                 if (this.dataMigrator == null)
                 {
-                    this.dataMigrator = ServiceProvider.GetRequiredService<DataMigrator>();
+                    this.dataMigrator = ServiceProvider.GetRequiredServiceByName<DataMigrator>("default");
                 }
                 return this.dataMigrator;
             }

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationGrainsReadonlyOriginalStorageTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationGrainsReadonlyOriginalStorageTests.cs
@@ -28,7 +28,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task ReadFromSourceTest()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 1);
+            var grain = GetMigrationGrain(baseId + 1);
             var grainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 
@@ -44,7 +44,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task UpdatesOnlyDestinationStorage()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 2);
+            var grain = GetMigrationGrain(baseId + 2);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var newState = new MigrationTestGrain_State { A = 20, B = 30 };
             var stateName = typeof(MigrationTestGrain).FullName;
@@ -99,7 +99,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task DataMigrator_MovesDataToDestinationStorage()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 3);
+            var grain = GetMigrationGrain(baseId + 3);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosLegacySerializationTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosLegacySerializationTests.cs
@@ -28,7 +28,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task ReadFromSourceTest()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 1);
+            var grain = GetMigrationGrain(baseId + 1);
             var grainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 
@@ -42,7 +42,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task UpdatesStatesInBothStorages()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 2);
+            var grain = GetMigrationGrain(baseId + 2);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var newState = new MigrationTestGrain_State { A = 20, B = 30 };
             var stateName = typeof(MigrationTestGrain).FullName;
@@ -98,7 +98,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task DataMigrator_MovesDataToDestinationStorage()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 3);
+            var grain = GetMigrationGrain(baseId + 3);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTests.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTests.cs
@@ -28,7 +28,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task ReadFromSourceTest()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 1);
+            var grain = GetMigrationGrain(baseId + 1);
             var grainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 
@@ -42,7 +42,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task UpdatesStatesInBothStorages()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 2);
+            var grain = GetMigrationGrain(baseId + 2);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var newState = new MigrationTestGrain_State { A = 20, B = 30 };
             var stateName = typeof(MigrationTestGrain).FullName;
@@ -94,7 +94,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task DataMigrator_MovesDataToDestinationStorage()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 3);
+            var grain = GetMigrationGrain(baseId + 3);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 

--- a/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTests_DataMigratorAsBackground.cs
+++ b/test/Extensions/Tester.AzureUtils.Migration/Abstractions/MigrationTableStorageToCosmosTests_DataMigratorAsBackground.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils.Migration.Abstractions
         [SkippableFact]
         public async Task DataMigrator_MovesDataToDestinationStorage()
         {
-            var grain = this.fixture.Client.GetGrain<ISimplePersistentMigrationGrain>(baseId + 1);
+            var grain = GetMigrationGrain(baseId + 1);
             var oldGrainState = new GrainState<MigrationTestGrain_State>(new() { A = 33, B = 806 });
             var stateName = typeof(MigrationTestGrain).FullName;
 


### PR DESCRIPTION
1) Adding ratelimiting for operations per minute against source and destination storage option for DataMigrator. Added a runtime override possibility as well.
2) Fixing test failures after merging https://github.com/dotnet/orleans/pull/9454
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9458)