### PR TITLE
Add manual validation when NuGet publishing is enabled

### DIFF
--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -58,16 +58,9 @@ jobs:
   displayName: Build and create NuGet packages
   variables:
     ${{ if eq(parameters.codesign, true) }}:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        esrp_signing: false
-        microbuild_signing: true
-        publishVstsFeed: 'public/orleans-nightly'
-      ${{ else }}:
-        esrp_signing: true
-        microbuild_signing: false
-        publishVstsFeed: 'orleans-public/orleans-nightly'
+      microbuild_signing: true
+      publishVstsFeed: 'public/orleans-nightly'
     ${{ else }}:
-      esrp_signing: false
       microbuild_signing: false
   ${{ if ne(variables['System.TeamProject'], 'GitHub - PR Builds') }}:
     templateContext:
@@ -131,78 +124,6 @@ jobs:
   - ${{ if eq(variables.runCodeQL3000, 'true') }}:
     - task: CodeQL3000Finalize@0
       displayName: CodeQL Finalize
-  # DLL code signing
-  - ${{ if eq(variables.esrp_signing, true) }}:
-    - task: UseDotNet@2
-      displayName: 'Codesign: Use .NET Core'
-      inputs:
-        packageType: runtime
-        version: $(codesign_runtime)
-    - task: CopyFiles@2
-      displayName: 'Codesign: Copy Files for signing'
-      inputs:
-        SourceFolder: '$(build.sourcesdirectory)'
-        Contents: |
-          src/**/bin/${{parameters.build_configuration}}/**/Orleans*.dll
-          src/**/bin/${{parameters.build_configuration}}/**/Microsoft.Orleans.*.dll
-          !src/BootstrapBuild/**
-        TargetFolder: '$(build.artifactstagingdirectory)\codesign'
-        CleanTargetFolder: true
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-      displayName: 'Codesign: ESRP CodeSigning'
-      inputs:
-        ConnectedServiceName: 'CodeSign Service (NuGet)'
-        FolderPath: '$(build.artifactstagingdirectory)\codesign'
-        Pattern: '*'
-        signConfigType: inlineSignParams
-        inlineOperation: |
-          [
-            {
-              "keyCode": "CP-230012",
-              "operationSetCode": "SigntoolSign",
-              "parameters": [
-                {
-                  "parameterName": "OpusName",
-                  "parameterValue": "Microsoft"
-                },
-                {
-                  "parameterName": "OpusInfo",
-                  "parameterValue": "http://www.microsoft.com"
-                },
-                {
-                  "parameterName": "FileDigest",
-                  "parameterValue": "/fd \"SHA256\""
-                },
-                {
-                  "parameterName": "PageHash",
-                  "parameterValue": "/NPH"
-                },
-                {
-                  "parameterName": "TimeStamp",
-                  "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                }
-              ],
-                "toolName": "sign",
-                "toolVersion": "1.0"
-              },
-              {
-                "keyCode": "CP-230012",
-                "operationSetCode": "SigntoolVerify",
-                "parameters": [ ],
-                "toolName": "sign",
-                "toolVersion": "1.0"
-            }
-          ]
-        SessionTimeout: 180
-        VerboseLogin: true
-    - task: CopyFiles@2
-      displayName: 'Codesign: Copy Signed Files Back'
-      inputs:
-        SourceFolder: '$(build.artifactstagingdirectory)\codesign'
-        Contents: '**\*'
-        TargetFolder: '$(build.sourcesdirectory)'
-        OverWrite: true
-    # End DLL code signing
   - task: CmdLine@2
     displayName: Pack
     inputs:
@@ -212,39 +133,6 @@ jobs:
       ${{ if eq(parameters.include_suffix, true) }}:
         VersionSuffix: ${{parameters.version_suffix}}
       OfficialBuild: $(official_build)
-  # NuGet code signing
-  - ${{ if eq(variables.esrp_signing, true) }}:
-    - task: UseDotNet@2
-      displayName: 'Codesign: Use .NET Core'
-      inputs:
-        packageType: runtime
-        version: $(codesign_runtime)
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-      displayName: 'Codesign: ESRP CodeSigning (nuget)'
-      inputs:
-        ConnectedServiceName: 'CodeSign Service (NuGet)'
-        FolderPath: '$(build.sourcesdirectory)/Artifacts/${{parameters.build_configuration}}'
-        Pattern: '*.nupkg'
-        signConfigType: inlineSignParams
-        inlineOperation: |
-          [
-            {
-              "keyCode": "CP-401405",
-              "operationSetCode": "NuGetSign",
-              "parameters": [],
-              "toolName": "sign",
-              "toolVersion": "1.0"
-            },
-            {
-              "keyCode": "CP-401405",
-              "operationSetCode": "NuGetVerify",
-              "parameters": [ ],
-              "toolName": "sign",
-              "toolVersion": "1.0"
-            }
-          ]
-        SessionTimeout: 180
-        VerboseLogin: true
   # Signing
   - ${{ if eq(variables.microbuild_signing, true) }}:
     - task: NuGetCommand@2

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -53,9 +53,23 @@ parameters:
 
 jobs:
 
+# Approval needed for publishing to nuget.org
+- ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
+  - job: PreDeploymentApprovalJob
+    displayName: Pre-Deployment Approval
+    condition: succeeded()
+    timeoutInMinutes: 2880
+    pool: server
+    steps:
+    - task: ManualValidation@1
+      inputs:
+        notifyUsers: ${{ variables.notifyUsers }}
+        approvers: ${{ variables.approvers }}
+
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build
   displayName: Build and create NuGet packages
+  dependsOn: PreDeploymentApprovalJob
   variables:
     ${{ if eq(parameters.codesign, true) }}:
       microbuild_signing: true


### PR DESCRIPTION
- Removed reference to ESRP (not used anymore)
- Add manual validation when NuGet publishing is enabled

Ideally, we should run the pre-approval after the NuGet package is built, so we can check them manually, but templating makes it a bit more difficult.