### PR TITLE
[FIX] Rebalancer-compatible Tolerance Rule

### DIFF
--- a/src/Orleans.Runtime/Placement/Repartitioning/RebalancerCompatibleRule.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/RebalancerCompatibleRule.cs
@@ -29,7 +29,8 @@ internal class RebalancerCompatibleRule(IServiceProvider provider) :
     private readonly ISiloStatusOracle _oracle = provider.GetRequiredService<ISiloStatusOracle>();
     private readonly IActivationRebalancer? _rebalancer = provider.GetService<IActivationRebalancer>();
 
-    public bool IsSatisfiedBy(uint imbalance) => imbalance <= _pairwiseImbalance;
+    public bool IsSatisfiedBy(uint imbalance) =>
+        imbalance <= Volatile.Read(ref _pairwiseImbalance); // uint reads are atomic on all dotnet platforms.
 
     public void SiloStatusChangeNotification(SiloAddress silo, SiloStatus status)
     {
@@ -37,16 +38,7 @@ internal class RebalancerCompatibleRule(IServiceProvider provider) :
         {
             ref var statusRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_silos, silo, out _);
             statusRef = status;
-
-            var activeSilos = _silos.Count(s => s.Value == SiloStatus.Active);
-            var percentageOfBaseline = 100d / (1 + Math.Exp(0.07d * activeSilos - 4.8d));
-
-            if (percentageOfBaseline < 10d) percentageOfBaseline = 10d;
-
-            var pairwiseImbalance = (uint)Math.Round(10.1d * percentageOfBaseline, 0);
-            var toleranceFactor = Math.Cos(Math.PI * _clusterImbalance / 2);  // This will always be 1 if rebalancer is not registered.
-
-            _pairwiseImbalance = (uint)Math.Max(pairwiseImbalance * toleranceFactor, 0);
+            UpdatePairwiseImbalance();
         }
     }
 
@@ -59,7 +51,21 @@ internal class RebalancerCompatibleRule(IServiceProvider provider) :
         lock (_lock)
         {
             _clusterImbalance = report.ClusterImbalance;
+            UpdatePairwiseImbalance();
         }
+    }
+
+    private void UpdatePairwiseImbalance()
+    {
+        var activeSilos = _silos.Count(s => s.Value == SiloStatus.Active);
+        var percentageOfBaseline = 100d / (1 + Math.Exp(0.07d * activeSilos - 4.8d));
+
+        if (percentageOfBaseline < 10d) percentageOfBaseline = 10d;
+
+        var pairwiseImbalance = (uint)Math.Round(10.1d * percentageOfBaseline, 0);
+        var toleranceFactor = Math.Cos(Math.PI * _clusterImbalance / 2);  // This will always be 1 if rebalancer is not registered.
+
+        _pairwiseImbalance = (uint)Math.Max(pairwiseImbalance * toleranceFactor, 0);
     }
 
     public Task OnStart(CancellationToken cancellationToken)


### PR DESCRIPTION
In this [PR](https://github.com/dotnet/orleans/pull/9464) i've introduced the rebalancer-compatible tolerance rule. But there are two problems with it:

1. The `_pairwiseImbalance` is updated only upon silo status changes, and not during cluster imbalance changes. This means a cluster imbalance change would be reflected in the rule only after there was another silo status change. So it would lag-behind.
2. Reading of the `_pairwiseImbalance`: While reads are naturally atomic on all platforms for `uint`, we can avoid stale-reads, and it is more natural to go "thread-safe" all the way.