### PR TITLE
[Draft] Adding distinction between Placement Filters that use Request Context…

### DIFF
--- a/src/Orleans.Core/Placement/IPlacementFilterDirector.cs
+++ b/src/Orleans.Core/Placement/IPlacementFilterDirector.cs
@@ -7,5 +7,22 @@ namespace Orleans.Placement;
 
 public interface IPlacementFilterDirector
 {
+}
+
+
+/// <summary>
+/// Does not have access to the request context data, but has the ability for filtering to be cached in some cases.
+/// </summary>
+public interface IPlacementFilterDirectorWithoutRequestContext : IPlacementFilterDirector
+{
     IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos);
 }
+
+/// <summary>
+/// Has access to the request context data, but does not have the ability for filtering to be cached. Filtering logic must be run on every activation.
+/// </summary>
+public interface IPlacementFilterDirectorWithRequestContext : IPlacementFilterDirector
+{
+    IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos);
+}
+

--- a/src/Orleans.Core/Placement/PlacementFilterExtensions.cs
+++ b/src/Orleans.Core/Placement/PlacementFilterExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 #nullable enable
@@ -17,10 +18,16 @@ public static class PlacementFilterExtensions
         where TFilter : PlacementFilterStrategy, new()
         where TDirector : class, IPlacementFilterDirector
     {
-        services.Add(ServiceDescriptor.DescribeKeyed(typeof(PlacementFilterStrategy), typeof(TFilter).Name, typeof(TFilter), strategyLifetime));
-        services.AddKeyedSingleton<IPlacementFilterDirector, TDirector>(typeof(TFilter));
+        if (typeof(TDirector).IsAssignableTo(typeof(IPlacementFilterDirectorWithRequestContext))
+            || typeof(TDirector).IsAssignableTo(typeof(IPlacementFilterDirectorWithoutRequestContext)))
+        {
+            services.Add(ServiceDescriptor.DescribeKeyed(typeof(PlacementFilterStrategy), typeof(TFilter).Name,
+                typeof(TFilter), strategyLifetime));
+            services.AddKeyedSingleton<IPlacementFilterDirector, TDirector>(typeof(TFilter));
 
-        return services;
+            return services;
+        }
+        throw new ArgumentException("TDirector must implement either IPlacementFilterDirectorWithRequestContext or IPlacementFilterDirectorWithoutRequestContext.");
     }
 
 }

--- a/src/Orleans.Runtime/Placement/Filtering/PreferredMatchSiloMetadataPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PreferredMatchSiloMetadataPlacementFilterDirector.cs
@@ -10,7 +10,7 @@ namespace Orleans.Runtime.Placement.Filtering;
 internal class PreferredMatchSiloMetadataPlacementFilterDirector(
     ILocalSiloDetails localSiloDetails,
     ISiloMetadataCache siloMetadataCache)
-    : IPlacementFilterDirector
+    : IPlacementFilterDirectorWithoutRequestContext
 {
     public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
     {

--- a/src/Orleans.Runtime/Placement/Filtering/RequiredMatchSiloMetadataPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/RequiredMatchSiloMetadataPlacementFilterDirector.cs
@@ -7,7 +7,7 @@ using Orleans.Runtime.MembershipService.SiloMetadata;
 namespace Orleans.Runtime.Placement.Filtering;
 
 internal class RequiredMatchSiloMetadataPlacementFilterDirector(ILocalSiloDetails localSiloDetails, ISiloMetadataCache siloMetadataCache)
-    : IPlacementFilterDirector
+    : IPlacementFilterDirectorWithoutRequestContext
 {
     public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
     {

--- a/test/TesterInternal/PlacementFilterTests/GrainPlacementFilterTests.cs
+++ b/test/TesterInternal/PlacementFilterTests/GrainPlacementFilterTests.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Placement;
-using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
-using TestExtensions;
 using Xunit;
 
 namespace UnitTests.PlacementFilterTests;
@@ -119,7 +117,7 @@ public class GrainPlacementFilterTests(GrainPlacementFilterTests.Fixture fixture
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await testGrain.Ping();
-        }); 
+        });
     }
 }
 
@@ -143,7 +141,7 @@ public class TestPlacementFilterStrategy(int order) : PlacementFilterStrategy(or
     }
 }
 
-public class TestPlacementFilterDirector() : IPlacementFilterDirector
+public class TestPlacementFilterDirector() : IPlacementFilterDirectorWithoutRequestContext
 {
     public static SemaphoreSlim Triggered { get; } = new(0);
 
@@ -165,7 +163,7 @@ public class OrderAPlacementFilterStrategy(int order) : PlacementFilterStrategy(
     }
 }
 
-public class OrderAPlacementFilterDirector : IPlacementFilterDirector
+public class OrderAPlacementFilterDirector : IPlacementFilterDirectorWithoutRequestContext
 {
     public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
     {
@@ -187,7 +185,7 @@ public class OrderBPlacementFilterStrategy(int order) : PlacementFilterStrategy(
     }
 }
 
-public class OrderBPlacementFilterDirector() : IPlacementFilterDirector
+public class OrderBPlacementFilterDirector() : IPlacementFilterDirectorWithoutRequestContext
 {
     public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
     {


### PR DESCRIPTION
… and those that don't

This would be to allow usage of the Request Context if required but also allow for filters without accessing it. Those filters that don't access RequestContext can potentially cache results between membership updates (though that does assume that they wouldn't return any different results if the membership stayed the same).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9480)