### PR TITLE
Pass PlacementTarget into Filter method

### DIFF
--- a/src/Orleans.Core/Placement/IPlacementFilterDirector.cs
+++ b/src/Orleans.Core/Placement/IPlacementFilterDirector.cs
@@ -7,5 +7,5 @@ namespace Orleans.Placement;
 
 public interface IPlacementFilterDirector
 {
-    IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos);
+    IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos);
 }

--- a/src/Orleans.Core/Placement/PlacementFilterContext.cs
+++ b/src/Orleans.Core/Placement/PlacementFilterContext.cs
@@ -1,6 +1,0 @@
-﻿using Orleans.Runtime;
-
-#nullable enable
-namespace Orleans.Placement;
-
-public readonly record struct PlacementFilterContext(GrainType GrainType, GrainInterfaceType InterfaceType, ushort InterfaceVersion);

--- a/src/Orleans.Runtime/Placement/Filtering/PreferredMatchSiloMetadataPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/PreferredMatchSiloMetadataPlacementFilterDirector.cs
@@ -12,7 +12,7 @@ internal class PreferredMatchSiloMetadataPlacementFilterDirector(
     ISiloMetadataCache siloMetadataCache)
     : IPlacementFilterDirector
 {
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
     {
         var preferredMatchSiloMetadataPlacementFilterStrategy = filterStrategy as PreferredMatchSiloMetadataPlacementFilterStrategy;
         var minCandidates = preferredMatchSiloMetadataPlacementFilterStrategy?.MinCandidates ?? 1;

--- a/src/Orleans.Runtime/Placement/Filtering/RequiredMatchSiloMetadataPlacementFilterDirector.cs
+++ b/src/Orleans.Runtime/Placement/Filtering/RequiredMatchSiloMetadataPlacementFilterDirector.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime.Placement.Filtering;
 internal class RequiredMatchSiloMetadataPlacementFilterDirector(ILocalSiloDetails localSiloDetails, ISiloMetadataCache siloMetadataCache)
     : IPlacementFilterDirector
 {
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
     {
         var metadataKeys = (filterStrategy as RequiredMatchSiloMetadataPlacementFilterStrategy)?.MetadataKeys ?? [];
 

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -121,11 +121,10 @@ namespace Orleans.Runtime.Placement
             if (filters.Length > 0)
             {
                 IEnumerable<SiloAddress> filteredSilos = compatibleSilos;
-                var context = new PlacementFilterContext(target.GrainIdentity.Type, target.InterfaceType, target.InterfaceVersion);
                 foreach (var placementFilter in filters)
                 {
                     var director = _placementFilterDirectoryResolver.GetFilterDirector(placementFilter);
-                    filteredSilos = director.Filter(placementFilter, context, filteredSilos);
+                    filteredSilos = director.Filter(placementFilter, target, filteredSilos);
                 }
 
                 compatibleSilos = filteredSilos.ToArray();

--- a/test/TesterInternal/PlacementFilterTests/GrainPlacementFilterTests.cs
+++ b/test/TesterInternal/PlacementFilterTests/GrainPlacementFilterTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Placement;
 using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
-using TestExtensions;
 using Xunit;
 
 namespace UnitTests.PlacementFilterTests;
@@ -147,7 +146,7 @@ public class TestPlacementFilterDirector() : IPlacementFilterDirector
 {
     public static SemaphoreSlim Triggered { get; } = new(0);
 
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
     {
         Triggered.Release(1);
         return silos;
@@ -167,10 +166,10 @@ public class OrderAPlacementFilterStrategy(int order) : PlacementFilterStrategy(
 
 public class OrderAPlacementFilterDirector : IPlacementFilterDirector
 {
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
     {
         var dict = GrainPlacementFilterTests.FilterScratchpad;
-        var list = dict.GetValueOrAddNew(context.GrainType.ToString());
+        var list = dict.GetValueOrAddNew(target.GrainIdentity.Type.ToString());
         list.Add("A");
         return silos;
     }
@@ -189,10 +188,10 @@ public class OrderBPlacementFilterStrategy(int order) : PlacementFilterStrategy(
 
 public class OrderBPlacementFilterDirector() : IPlacementFilterDirector
 {
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementFilterContext context, IEnumerable<SiloAddress> silos)
+    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
     {
         var dict = GrainPlacementFilterTests.FilterScratchpad;
-        var list = dict.GetValueOrAddNew(context.GrainType.ToString());
+        var list = dict.GetValueOrAddNew(target.GrainIdentity.Type.ToString());
         list.Add("B");
         return silos;
     }


### PR DESCRIPTION
This allows for Request Context to be used for placement decisions.

In the future we may want to allow for caching of filtering decisions (between membership updates and potentially some other criteria that we get from the implementation of a filter), but that would need to be opt-in from the filter implementation and the filter would need to accept that it's results may be cached. This would still be possible after this change as it would rely on the filter implementation's intent to be cached and not strictly enforced (this is a similar pattern to `[Immutable]`)