### PR TITLE
fix: correct CI to run if no approval is required

### DIFF
--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -57,7 +57,6 @@ jobs:
 - job: PreDeploymentApprovalJob
   displayName: Pre-Deployment Approval
   timeoutInMinutes: 2880
-  pool: server
   steps:
     - ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
       - task: ManualValidation@1
@@ -65,7 +64,7 @@ jobs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
     - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
-      - checkout: self
+      - script: echo "Skipping pre-deployment approval"
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -54,17 +54,18 @@ parameters:
 jobs:
 
 # Approval needed for publishing to nuget.org
-- ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
-  - job: PreDeploymentApprovalJob
-    displayName: Pre-Deployment Approval
-    condition: succeeded()
-    timeoutInMinutes: 2880
-    pool: server
-    steps:
-    - task: ManualValidation@1
-      inputs:
-        notifyUsers: ${{ variables.notifyUsers }}
-        approvers: ${{ variables.approvers }}
+- job: PreDeploymentApprovalJob
+  displayName: Pre-Deployment Approval
+  timeoutInMinutes: 2880
+  pool: server
+  steps:
+    - ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
+      - task: ManualValidation@1
+        inputs:
+          notifyUsers: ${{ variables.notifyUsers }}
+          approvers: ${{ variables.approvers }}
+    - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
+      - script: echo "No approval required. Skipping manual validation."
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -65,13 +65,9 @@ jobs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
     - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
-      - task: AzureCLI@2
-        inputs:
-          azureSubscription: 'dummy'
-          scriptType: 'bash'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            echo "No approval required. Skipping manual validation."
+      - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+        displayName: 'Set CI CodeQL3000 tag'
+        condition: ne(variables.CODEQL_DIST,'')
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -65,9 +65,7 @@ jobs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
     - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
-      - script: "echo ##vso[build.addbuildtag]CodeQL3000"
-        displayName: 'Set CI CodeQL3000 tag'
-        condition: ne(variables.CODEQL_DIST,'')
+      - checkout: self
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -65,7 +65,11 @@ jobs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
     - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
-      - script: echo "No approval required. Skipping manual validation."
+      - task: PowerShell@2
+        inputs:
+          targetType: 'inline'
+          script: |
+            Write-Host "No approval required. Skipping manual validation."
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -65,11 +65,13 @@ jobs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
     - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
-      - task: PowerShell@2
+      - task: AzureCLI@2
         inputs:
-          targetType: 'inline'
-          script: |
-            Write-Host "No approval required. Skipping manual validation."
+          azureSubscription: 'dummy'
+          scriptType: 'bash'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            echo "No approval required. Skipping manual validation."
 
 # Build, sign dlls, build nuget pkgs, then sign them
 - job: Build

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -50,9 +50,6 @@ parameters:
     default: false
     displayName: Run CodeQL3000 tasks
     type: boolean
-  - name: isApprovalRequired
-    type: boolean
-    default: ${{ and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}
 
 
 jobs:
@@ -61,15 +58,15 @@ jobs:
 - job: PreDeploymentApprovalJob
   displayName: Pre-Deployment Approval
   timeoutInMinutes: 2880
-  ${{ if eq(parameters.isApprovalRequired, true) }}:
+  ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
     pool: server
   steps:
-    - ${{ if eq(parameters.isApprovalRequired, true) }}:
+    - ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
       - task: ManualValidation@1
         inputs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
-    - ${{ if eq(parameters.isApprovalRequired, false) }}:
+    - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
       - script: echo "Skipping pre-deployment approval"
 
 # Build, sign dlls, build nuget pkgs, then sign them

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -50,6 +50,10 @@ parameters:
     default: false
     displayName: Run CodeQL3000 tasks
     type: boolean
+  - name: isApprovalRequired
+    type: boolean
+    default: ${{ and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}
+
 
 jobs:
 
@@ -57,13 +61,15 @@ jobs:
 - job: PreDeploymentApprovalJob
   displayName: Pre-Deployment Approval
   timeoutInMinutes: 2880
+  ${{ if eq(parameters.isApprovalRequired, true) }}:
+    pool: server
   steps:
-    - ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
+    - ${{ if eq(parameters.isApprovalRequired, true) }}:
       - task: ManualValidation@1
         inputs:
           notifyUsers: ${{ variables.notifyUsers }}
           approvers: ${{ variables.approvers }}
-    - ${{ if not(and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true))) }}:
+    - ${{ if eq(parameters.isApprovalRequired, false) }}:
       - script: echo "Skipping pre-deployment approval"
 
 # Build, sign dlls, build nuget pkgs, then sign them


### PR DESCRIPTION
Currently CI for `main` fails with error: "Stage build_test must contain at least one job with no dependencies.". That happens because first job is not unconditional:
```yml
- ${{ if and(eq(parameters.codesign, true), eq(parameters.publish_nuget, true)) }}:
  - job: PreDeploymentApprovalJob
```

I fixed to run job agentlessly (see `pool: server`) with manualValidation task; or on our pool with a simple echo of "Skipping pre-deployment approval". It takes 1 min to run this dummy-job, so not impacting the overall duration much.

related #9461
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9484)