### PR TITLE
fix(main): fix azure login error in ci

### DIFF
--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -193,6 +193,7 @@ jobs:
             displayName: Azure Login
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
             inputs:
               azureSubscription: 'dotnet-orleans-test'
               useGlobalConfig: true


### PR DESCRIPTION
Both `main` and `3.x` pipelines fail today due to Azure Login step failing with 
> ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: Can't get attribute 'NormalizedResponse' on <module 'msal.throttled_http_client' from 'C:\\Program Files\\Microsoft SDKs\\Azure\\CLI2\\Lib\\site-packages\\msal\\throttled_http_client.pyc'>
Traceback (most recent call last):

In [issue at Azure/azure-cli](https://github.com/Azure/azure-cli/issues/31419#issuecomment-2858720156) recommendation is to set env `AZURE_CORE_USE_MSAL_HTTP_CACHE` to `false`.

I have changed that and now az cli login is done successfully 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9486)

same fix goes for 3.x in #9486