### PR TITLE
Ensure `PerformUpdate` method should not be called within a read-only trasnaction

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionCoordinatorGrain.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.Concurrency;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.TestKit.Correctnesss;
 
@@ -36,5 +37,9 @@ namespace Orleans.Transactions.TestKit
 
         [Transaction(TransactionOption.Create)]
         Task MultiGrainAdd(ITransactionCommitterTestGrain committer, ITransactionCommitOperation<IRemoteCommitService> operation, List<ITransactionTestGrain> grains, int numberToAdd);
+
+        [Transaction(TransactionOption.Create)]
+        [ReadOnly]
+        Task UpdateViolated(ITransactionTestGrain grains, int numberToAdd);
     }
 }

--- a/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
@@ -57,6 +57,11 @@ namespace Orleans.Transactions.TestKit
             return Task.WhenAll(tasks);
         }
 
+        public Task UpdateViolated(ITransactionTestGrain grain, int numberToAdd)
+        {
+            return grain.Add(numberToAdd);
+        }
+
         private async Task Double(ITransactionTestGrain grain)
         {
             int[] values = await grain.Get();

--- a/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs
@@ -23,6 +23,15 @@ namespace Orleans.Transactions.TestKit.xUnit
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
+        public override Task AbortTransactionOnReadOnlyViolatedException(string grainStates)
+        {
+            return base.AbortTransactionOnReadOnlyViolatedException(grainStates);
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
+        [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
+        [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
         public override Task MultiGrainAbortTransactionOnExceptions(string grainStates)
         {
             return base.MultiGrainAbortTransactionOnExceptions(grainStates);

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
@@ -37,7 +37,7 @@ namespace Orleans.Transactions
 
             LogTraceStartTransaction(new(stopwatch), guid, new(ts));
             this.statistics.TrackTransactionStarted();
-            return Task.FromResult<TransactionInfo>(new TransactionInfo(guid, ts, ts));
+            return Task.FromResult<TransactionInfo>(new TransactionInfo(guid, ts, ts, readOnly));
         }
 
         public async Task<(TransactionalStatus, Exception)> Resolve(TransactionInfo transactionInfo)

--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -132,7 +132,7 @@ namespace Orleans
         }
 
         private TransactionInfo SetTransactionInfo()
-        { 
+        {
             // Clear transaction info if transaction operation requires new transaction.
             var transactionInfo = TransactionContext.GetTransactionInfo();
 
@@ -180,7 +180,7 @@ namespace Orleans
                     var transactionTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(10);
 
                     // Start a new transaction
-                    var isReadOnly = (this.Options | InvokeMethodOptions.ReadOnly) == InvokeMethodOptions.ReadOnly;
+                    var isReadOnly = (this.Options & InvokeMethodOptions.ReadOnly) == InvokeMethodOptions.ReadOnly;
                     transactionInfo = await TransactionAgent.StartTransaction(isReadOnly, transactionTimeout);
                     startedNewTransaction = true;
                 }
@@ -312,7 +312,7 @@ namespace Orleans
     }
 
     [SerializerTransparent]
-    public abstract class TransactionRequest : TransactionRequestBase 
+    public abstract class TransactionRequest : TransactionRequestBase
     {
         protected TransactionRequest(Serializer<OrleansTransactionAbortedException> exceptionSerializer, IServiceProvider serviceProvider) : base(exceptionSerializer, serviceProvider)
         {


### PR DESCRIPTION
## Background
The transactional method with `[ReadOnly]`  attribute states that It's a read-only transaction, which is not intended to allow `PerformUpdate` within the transactional context.

## Review
I'm not sure if this is the right approach.

```cs
var isReadOnly = (this.Options & InvokeMethodOptions.ReadOnly) == InvokeMethodOptions.ReadOnly;
```