### PR TITLE
Added missing OrleansBuildTimeCodeGen project properties

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans clustering provider backed by AWS DynamoDB</Description>
     <PackageTags>$(PackageTags) AWS DynamoDB</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Orleans.Persistence.DynamoDB.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans persistence providers backed by AWS DynamoDB</Description>
     <PackageTags>$(PackageTags) AWS DynamoDB</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Orleans.Reminders.DynamoDB.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans reminders provider backed by AWS DynamoDB</Description>
     <PackageTags>$(PackageTags) AWS DynamoDB</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans clustering provider backed by ADO.NET</Description>
     <PackageTags>$(PackageTags) ADO.NET SQL MySQL PostgreSQL Oracle</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans persistence providers backed by ADO.NET</Description>
     <PackageTags>$(PackageTags) ADO.NET SQL MySQL PostgreSQL Oracle</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Orleans reminders provider backed by ADO.NET</Description>
     <PackageTags>$(PackageTags) ADO.NET SQL MySQL PostgreSQL Oracle</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.csproj
+++ b/src/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <VersionSuffix Condition="$(VersionSuffix) != ''">$(VersionSuffix).alpha.1</VersionSuffix>
     <VersionSuffix Condition="$(VersionSuffix) == ''">alpha.1</VersionSuffix>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>Orleans.Transactions.AzureStorage</AssemblyName>
     <RootNamespace>Orleans.Transactions.AzureStorage</RootNamespace>
     <DefineConstants>$(DefineConstants);ORLEANS_TRANSACTIONS</DefineConstants>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
+++ b/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
@@ -6,6 +6,7 @@
     <PackageTags>$(PackageTags) Consul</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Orleans.Clustering.Consul</AssemblyName>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
+++ b/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
@@ -6,6 +6,7 @@
     <PackageTags>$(PackageTags) ZooKeeper</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Orleans.Clustering.ZooKeeper</AssemblyName>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Connections.Security/Orleans.Connections.Security.csproj
+++ b/src/Orleans.Connections.Security/Orleans.Connections.Security.csproj
@@ -6,6 +6,7 @@
     <Description>Support for security communication using TLS in Microsoft Orleans.</Description>
     <PackageTags>$(PackageTags) TLS SSL</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
+++ b/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
@@ -6,6 +6,7 @@
     <Description>Microsoft Orleans hosting support for Kubernetes</Description>
     <PackageTags>$(PackageTags) Kubernetes k8s</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There are some extension projects which had no code gen turned on. This prevented Orleans from automatically loading the extensions because the ApplicationPart assembly attributes were never generated.

This fixes #9448 