### PR TITLE
Remove Microsoft.Orleans.Clustering.ServiceFabric from exception message

### DIFF
--- a/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
@@ -19,7 +19,6 @@ namespace Orleans.Configuration.Validators
             + "\n  * Microsoft.Orleans.Clustering.AzureStorage"
             + "\n  * Microsoft.Orleans.Clustering.AdoNet for ADO.NET systems such as SQL Server, MySQL, PostgreSQL, and Oracle"
             + "\n  * Microsoft.Orleans.Clustering.DynamoDB"
-            + "\n  * Microsoft.Orleans.Clustering.ServiceFabric"
             + "\n  * Microsoft.Orleans.Clustering.Consul"
             + "\n  * Microsoft.Orleans.Clustering.ZooKeeper"
             + "\n  * Others, see: https://www.nuget.org/packages?q=Microsoft.Orleans.Clustering.";


### PR DESCRIPTION
Package was removed a number of years ago.