### PR TITLE
Create copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+## General
+
+* Make only high confidence suggestions when reviewing code changes.
+* Always use the latest version C#, currently C# 13 features.
+* Never change global.json unless explicitly asked to.
+
+## Formatting
+
+* Apply code-formatting style defined in `.editorconfig`.
+* Prefer file-scoped namespace declarations and single-line using directives.
+* Insert a newline before the opening curly brace of any code block (e.g., after `if`, `for`, `while`, `foreach`, `using`, `try`, etc.).
+* Ensure that the final return statement of a method is on its own line.
+* Use pattern matching and switch expressions wherever possible.
+* Use `nameof` instead of string literals when referring to member names.
+* Ensure that XML doc comments are created for any public APIs. When applicable, include `<example>` and `<code>` documentation in the comments.
+
+### Nullable Reference Types
+
+* Declare variables non-nullable, and check for `null` at entry points.
+* Always use `is null` or `is not null` instead of `== null` or `!= null`.
+* Trust the C# null annotations and don't add null checks when the type system says a value cannot be null.
+
+### Testing
+
+* We use xUnit SDK v3 for tests.
+* Do not emit "Act", "Arrange" or "Assert" comments.
+* Use NSubstitute for mocking in tests.
+* Copy existing style in nearby files for test method names and capitalization.


### PR DESCRIPTION
Spotted copilot doing changes to `global.json` in https://github.com/dotnet/orleans/pull/9515#discussion_r2104709759, so adding a special copilot instructions file to manage behavior.

Copy & pasted most of it from [aspnetcore](https://github.com/dotnet/aspnetcore/blob/main/.github/copilot-instructions.md)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9523)