### PR TITLE
Add type filtering to GetDetailedGrainStatistics

### DIFF
--- a/src/Orleans.Runtime/Silo/SiloControl.cs
+++ b/src/Orleans.Runtime/Silo/SiloControl.cs
@@ -158,7 +158,7 @@ namespace Orleans.Runtime
 
         public Task<List<DetailedGrainStatistic>> GetDetailedGrainStatistics(string[]? types = null)
         {
-            var stats = GetDetailedGrainStatisticsCore();
+            var stats = GetDetailedGrainStatisticsCore(types);
             return Task.FromResult(stats);
         }
 


### PR DESCRIPTION
This commit fixes an issue where the types parameter in GetDetailedGrainStatistics was declared but not used.

https://github.com/dotnet/orleans/issues/9526
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9527)