### PR TITLE
Memory pressure based activation shedding

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -302,7 +302,12 @@ namespace Orleans
         /// <summary>
         /// The runtime requested to deactivate this activation.
         /// </summary>
-        RuntimeRequested
+        RuntimeRequested,
+
+        /// <summary>
+        /// Runtime detected that app is running on low memory, and forcefully decided to deactivate.
+        /// </summary>
+        MemoryLow,
     }
 
     internal static class DeactivationReasonCodeExtensions

--- a/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
@@ -48,5 +48,30 @@ namespace Orleans.Configuration
         /// The default value for <see cref="DeactivationTimeout"/>.
         /// </summary>
         public static readonly TimeSpan DEFAULT_DEACTIVATION_TIMEOUT = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Controls behavior of grain collection based on available memory.
+        /// Must be assigned to a non-null value to be enabled.
+        /// </summary>
+        public MemoryBasedGrainCollectionOptions MemoryBasedOptions { get; set; } = null!;
+    }
+
+    public class MemoryBasedGrainCollectionOptions
+    {
+        /// <summary>
+        /// Regulates the periodic check of memory load.
+        /// </summary>
+        public TimeSpan MemoryStatsValidationQuantum { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Memory load percentage threshold above which grain collection will be triggered.
+        /// </summary>
+        public double MemoryLoadThresholdPercentage { get; set; } = 90;
+
+        /// <summary>
+        /// Controls how many of the grains should be collected when the <see cref="MemoryLoadThresholdPercentage"/> is exceeded.
+        /// Targets the memory load percentage which node will be running at after the grain collection happened.
+        /// </summary>
+        public double TargetMemoryLoadPercentage { get; set; } = 80;
     }
 }

--- a/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
@@ -61,7 +61,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Regulates the periodic check of memory load.
         /// </summary>
-        public TimeSpan MemoryStatsValidationQuantum { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan MemoryLoadValidationQuantum { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// Memory load percentage threshold above which grain collection will be triggered.


### PR DESCRIPTION
Implemented memory-based deactivation mechanism. There is a separate timer on the `ActivationCollector` which periodically fetches environment statistics, and checks if app is running on low memory (below user-defined threshold).

If that is the case, then it will go through the buckets of activations (ordered starting from the lower time), and will remove every activation up to N activations.

There is new public API:
```diff
namespace Orleans.Configuration
{
    public class GrainCollectionOptions
    {
+        /// <summary>
+        /// Controls behavior of grain collection based on available memory.
+        /// Must be assigned to a non-null value to be enabled.
+        /// </summary>
+        public MemoryBasedGrainCollectionOptions MemoryBasedOptions { get; set; } = null!;
    }

+    public class MemoryBasedGrainCollectionOptions
+    {
+        /// <summary>
+        /// Regulates the periodic check of memory load.
+        /// </summary>
+        public TimeSpan MemoryLoadValidationQuantum { get; set; } = TimeSpan.FromSeconds(1+0);

+        /// <summary>
+        /// Memory load percentage threshold above which grain collection will be triggered.
+        /// </summary>
+        public double MemoryLoadThresholdPercentage { get; set; } = +90;

+        /// <summary>
+        /// Controls how many of the grains should be collected when the <see cref="MemoryLoadThresholdPercentage"/> is exceeded.
+        /// Targets the memory load percentage which node will be running at after the grain collection happened.
+        /// </summary>
+        public double TargetMemoryLoadPercentage { get; set; } = 80;
+    }
}
```

As you can see, there is a threshold which defines what memory load should trigger forceful deactivation, and there is a target memory threshold (what memory load should be target after forceful deactivation).

In order to determine how many activations should be removed, we are using an over-estimation:
```
var targetUsedMemory = targetThreshold * stats.MaximumAvailableMemoryBytes / 100.0;
var memoryToFree = usedMemory - targetUsedMemory;
var activationSize = usedMemory / (double)_activationCount; // heap size / activation number
targetDeactivationNumber = (int)Math.Ceiling(memoryToFree / activationSize);
```

This allows to calculate how many deactivations to perform, and since app is running on low memory (IMO) we should not differ between state of the activation - we should deactivate forcefully.

Implements #9528