### PR TITLE
Simplify IGrainFactory interface and add methods to allow GetGrain() methods to be implemented as extensions

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainFactory.cs
@@ -4,58 +4,303 @@ using Orleans.Runtime;
 
 namespace Orleans
 {
+    public static class GrainFactoryExtensions
+    {
+        /// <summary>
+        /// Validates the provided grain key extension.
+        /// </summary>
+        /// <param name="keyExt">The grain key extension.</param>
+        /// <exception cref="ArgumentNullException">The key is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The key is empty or contains only whitespace.</exception>
+        private static void ValidateGrainKeyExtension(string keyExt)
+        {
+            if (!string.IsNullOrWhiteSpace(keyExt)) return;
+
+            ArgumentNullException.ThrowIfNull(keyExt);
+
+            throw new ArgumentException("Key extension is empty or white space.", nameof(keyExt));
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, string primaryKey, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithStringKey
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(primaryKey);
+            var grainKey = IdSpan.Create(primaryKey);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithGuidCompoundKey
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Gets a reference to a grain.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
+        /// <param name="primaryKey">The primary key of the grain.</param>
+        /// <param name="keyExtension">The key extension of the grain.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>A reference to the specified grain.</returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, long primaryKey, string keyExtension, string grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithIntegerCompoundKey
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            ValidateGrainKeyExtension(keyExtension);
+
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey, keyExtension);
+            return (TGrainInterface)grainFactory.GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, string grainPrimaryKey)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(grainPrimaryKey);
+            var grainKey = IdSpan.Create(grainPrimaryKey);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateGuidKey(grainPrimaryKey, keyExtension);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="keyExtension">
+        /// The grain key extension component.
+        /// </param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(grainPrimaryKey, keyExtension);
+            return grainFactory.GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
+        }
+
+        /// <summary>
+        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </summary>
+        /// <param name="grainInterfaceType">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </param>
+        /// <param name="grainPrimaryKey">
+        /// The primary key of the grain
+        /// </param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
+        /// <returns>
+        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// </returns>
+        /// <summary>
+        /// Gets a grain reference which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
+        /// </summary>
+        /// <remarks>
+        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="grainInterfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
+        /// </remarks>
+        /// <returns>A grain reference which implements the provided interface.</returns>
+        public static IGrain GetGrain(this IGrainFactory grainFactory, Type grainInterfaceType, IdSpan grainPrimaryKey, string grainClassNamePrefix = null)
+        {
+            var interfaceType = grainFactory.GetGrainInterfaceType(grainInterfaceType);
+
+            GrainType grainType;
+            if (!string.IsNullOrWhiteSpace(grainClassNamePrefix))
+            {
+                grainType = grainFactory.GetGrainType(interfaceType, grainClassNamePrefix);
+            }
+            else
+            {
+                grainType = grainFactory.GetGrainType(interfaceType);
+            }
+
+            var grainId = GrainId.Create(grainType, grainPrimaryKey);
+            var grain = grainFactory.CreateGrainReference(grainId, interfaceType);
+            return (IGrain)grain;
+        }
+
+        /// <summary>
+        /// Returns a reference to the specified grain which implements the specified interface.
+        /// </summary>
+        /// <param name="grainId">
+        /// The grain id.
+        /// </param>
+        /// <typeparam name="TGrainInterface">
+        /// The grain interface type which the returned grain reference must implement.
+        /// </typeparam>
+        /// <returns>
+        /// A reference to the specified grain which implements the specified interface.
+        /// </returns>
+        public static TGrainInterface GetGrain<TGrainInterface>(this IGrainFactory grainFactory, GrainId grainId) where TGrainInterface : IAddressable
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
+            var grainInterfaceType = grainFactory.GetGrainInterfaceType(typeof(TGrainInterface));
+            return (TGrainInterface)grainFactory.CreateGrainReference(grainId, grainInterfaceType);
+        }
+
+        /// <summary>
+        /// Returns an untyped reference for the provided grain id.
+        /// </summary>
+        /// <param name="grainId">
+        /// The grain id.
+        /// </param>
+        /// <returns>
+        /// An untyped reference for the provided grain id.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, GrainId grainId)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            return grainFactory.GetGrain(grainId, default);
+        }
+
+        /// <summary>
+        /// Returns a reference for the provided grain id which implements the specified interface type.
+        /// </summary>
+        /// <param name="grainId">
+        /// The grain id.
+        /// </param>
+        /// <param name="interfaceType">
+        /// The interface type which the returned grain reference must implement.
+        /// </param>
+        /// <returns>
+        /// A reference for the provided grain id which implements the specified interface type.
+        /// </returns>
+        public static IAddressable GetGrain(this IGrainFactory grainFactory, GrainId grainId, GrainInterfaceType interfaceType)
+        {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            return grainFactory.CreateGrainReference(grainId, interfaceType);
+        }
+    }
+
     /// <summary>
     /// Functionality for creating references to grains.
     /// </summary>
     public interface IGrainFactory
     {
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidCompoundKey;
-
-        /// <summary>
-        /// Gets a reference to a grain.
-        /// </summary>
-        /// <typeparam name="TGrainInterface">The interface type.</typeparam>
-        /// <param name="primaryKey">The primary key of the grain.</param>
-        /// <param name="keyExtension">The key extension of the grain.</param>
-        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
-        /// <returns>A reference to the specified grain.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerCompoundKey;
-
         /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.
         /// </summary>
@@ -77,118 +322,32 @@ namespace Orleans
         void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// Gets the unique <see cref="GrainInterfaceType"/> for the specified grain interface <paramref name="interfaceType"/>.
         /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
+        /// <param name="interfaceType">The grain interface type to retrieve the identifier for.</param>
         /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// The <see cref="GrainInterfaceType"/> that uniquely identifies the specified grain interface type.
         /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey);
+        GrainInterfaceType GetGrainInterfaceType(Type interfaceType);
 
         /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// Creates a grain reference for the specified <paramref name="grainId"/> and <paramref name="interfaceType"/>.
         /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
+        /// <param name="grainId">The unique identifier of the grain.</param>
+        /// <param name="interfaceType">The grain interface type that the returned reference must implement.</param>
         /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// An <see cref="IAddressable"/> reference to the grain identified by <paramref name="grainId"/> and implementing <paramref name="interfaceType"/>.
         /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey);
+        IAddressable CreateGrainReference(GrainId grainId, GrainInterfaceType interfaceType);
 
         /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// Gets the grain type for the specified grain interface type and optional class name prefix.
         /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
+        /// <param name="grainInterfaceType">The grain interface type.</param>
+        /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
         /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
+        /// The <see cref="GrainType"/> corresponding to the specified interface type and class name prefix.
         /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension);
-
-        /// <summary>
-        /// Returns a reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </summary>
-        /// <param name="grainInterfaceType">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </param>
-        /// <param name="grainPrimaryKey">
-        /// The primary key of the grain
-        /// </param>
-        /// <param name="keyExtension">
-        /// The grain key extension component.
-        /// </param>
-        /// <returns>
-        /// A reference to the grain which is the primary implementation of the provided interface type and has the provided primary key.
-        /// </returns>
-        IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension);
-
-        /// <summary>
-        /// Returns a reference to the specified grain which implements the specified interface.
-        /// </summary>
-        /// <param name="grainId">
-        /// The grain id.
-        /// </param>
-        /// <typeparam name="TGrainInterface">
-        /// The grain interface type which the returned grain reference must implement.
-        /// </typeparam>
-        /// <returns>
-        /// A reference to the specified grain which implements the specified interface.
-        /// </returns>
-        TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable;
-
-        /// <summary>
-        /// Returns an untyped reference for the provided grain id.
-        /// </summary>
-        /// <param name="grainId">
-        /// The grain id.
-        /// </param>
-        /// <returns>
-        /// An untyped reference for the provided grain id.
-        /// </returns>
-        IAddressable GetGrain(GrainId grainId);
-
-        /// <summary>
-        /// Returns a reference for the provided grain id which implements the specified interface type.
-        /// </summary>
-        /// <param name="grainId">
-        /// The grain id.
-        /// </param>
-        /// <param name="interfaceType">
-        /// The interface type which the returned grain reference must implement.
-        /// </param>
-        /// <returns>
-        /// A reference for the provided grain id which implements the specified interface type.
-        /// </returns>
-        IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType);
+        GrainType GetGrainType(GrainInterfaceType grainInterfaceType, string grainClassNamePrefix = null);
     }
 }

--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -81,26 +81,6 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-
-        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver => ((IGrainFactory)_runtimeClient.InternalGrainFactory).CreateObjectReference<TGrainObserverInterface>(obj);
 
@@ -120,38 +100,17 @@ namespace Orleans
         TGrainInterface IInternalGrainFactory.Cast<TGrainInterface>(IAddressable grain) => _runtimeClient.InternalGrainFactory.Cast<TGrainInterface>(grain);
 
         /// <inheritdoc />
-        TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain<TGrainInterface>(grainId);
-
-        /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId) => _runtimeClient.InternalGrainFactory.GetGrain(grainId);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainInterfaceType, grainPrimaryKey, keyExtension);
-
-        /// <inheritdoc />
         public object Cast(IAddressable grain, Type outputGrainInterfaceType)
             => _runtimeClient.InternalGrainFactory.Cast(grain, outputGrainInterfaceType);
 
         /// <inheritdoc />
-        public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
-            => _runtimeClient.InternalGrainFactory.GetGrain(grainId, interfaceType);
+        public GrainInterfaceType GetGrainInterfaceType(Type interfaceType) => _runtimeClient.InternalGrainFactory.GetGrainInterfaceType(interfaceType);
+     
+        /// <inheritdoc />
+        public IAddressable CreateGrainReference(GrainId grainId, GrainInterfaceType interfaceType) => _runtimeClient.InternalGrainFactory.CreateGrainReference(grainId, interfaceType);
+   
+        /// <inheritdoc />
+        public GrainType GetGrainType(GrainInterfaceType grainInterfaceType, string grainClassNamePrefix = null) => _runtimeClient.InternalGrainFactory.GetGrainType(grainInterfaceType, grainClassNamePrefix);
 
         [LoggerMessage(
             Level = LogLevel.Information,

--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -38,50 +38,6 @@ namespace Orleans
         private GrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ??= (GrainReferenceRuntime)this.runtimeClient.GrainReferenceRuntime;
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey
-        {
-            ArgumentNullException.ThrowIfNullOrWhiteSpace(primaryKey);
-            var grainKey = IdSpan.Create(primaryKey);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey
-        {
-            ValidateGrainKeyExtension(keyExtension);
-
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(primaryKey, keyExtension);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey
-        {
-            ValidateGrainKeyExtension(keyExtension);
-
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(primaryKey, keyExtension);
-            return (TGrainInterface)GetGrain(typeof(TGrainInterface), grainKey, grainClassNamePrefix: grainClassNamePrefix);
-        }
-
-
-        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver
         {
@@ -139,99 +95,17 @@ namespace Orleans
             }
         }
 
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable
-        {
-            return (TGrainInterface)this.CreateGrainReference(typeof(TGrainInterface), grainId);
-        }
-
-        /// <inheritdoc />
-        public IAddressable GetGrain(GrainId grainId) => this.referenceActivator.CreateReference(grainId, default);
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid key)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long key)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string key)
-        {
-            ArgumentNullException.ThrowIfNullOrWhiteSpace(key);
-            var grainKey = IdSpan.Create(key);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid key, string keyExtension)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateGuidKey(key, keyExtension);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long key, string keyExtension)
-        {
-            var grainKey = GrainIdKeyExtensions.CreateIntegerKey(key, keyExtension);
-            return (IGrain)GetGrain(grainInterfaceType, grainKey, grainClassNamePrefix: null);
-        }
-
-        /// <inheritdoc />
-        public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
-        {
-            return this.referenceActivator.CreateReference(grainId, interfaceType);
-        }
-
-        /// <summary>
-        /// Gets a grain reference which implements the specified grain interface type and has the specified grain key, without specifying the grain type directly.
-        /// </summary>
-        /// <remarks>
-        /// This method infers the most appropriate <see cref="GrainId.Type"/> value based on the <paramref name="interfaceType"/> argument and optional <paramref name="grainClassNamePrefix"/> argument.
-        /// The <see cref="GrainInterfaceTypeToGrainTypeResolver"/> type is responsible for determining the most appropriate grain type.
-        /// </remarks>
-        /// <param name="interfaceType">The interface type which the returned grain reference will implement.</param>
-        /// <param name="grainKey">The <see cref="GrainId.Key"/> portion of the grain id.</param>
-        /// <param name="grainClassNamePrefix">An optional grain class name prefix.</param>
-        /// <returns>A grain reference which implements the provided interface.</returns>
-        private IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix)
-        {
-            var grainInterfaceType = this.interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
-
-            GrainType grainType;
-            if (!string.IsNullOrWhiteSpace(grainClassNamePrefix))
-            {
-                grainType = this.interfaceTypeToGrainTypeResolver.GetGrainType(grainInterfaceType, grainClassNamePrefix);
-            }
-            else
-            {
-                grainType = this.interfaceTypeToGrainTypeResolver.GetGrainType(grainInterfaceType);
-            }
-
-            var grainId = GrainId.Create(grainType, grainKey);
-            var grain = this.referenceActivator.CreateReference(grainId, grainInterfaceType);
-            return grain;
-        }
-
         /// <summary>
         /// Creates a grain reference.
         /// </summary>
-        /// <param name="interfaceType">The interface type which the reference must implement..</param>
+        /// <param name="grainInterfaceType">The interface type which the reference must implement..</param>
         /// <param name="grainId">The grain id which the reference will target.</param>
         /// <returns>A grain reference.</returns>
-        private object CreateGrainReference(Type interfaceType, GrainId grainId)
+        public IAddressable CreateGrainReference(GrainId grainId, GrainInterfaceType grainInterfaceType)
         {
-            var grainInterfaceType = this.interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
             return this.referenceActivator.CreateReference(grainId, grainInterfaceType);
         }
-
+       
         /// <summary>
         /// Creates an object reference which points to the provided object.
         /// </summary>
@@ -254,22 +128,10 @@ namespace Orleans
             return this.Cast(this.runtimeClient.CreateObjectReference(obj), interfaceType);
         }
 
-        /// <summary>
-        /// Validates the provided grain key extension.
-        /// </summary>
-        /// <param name="keyExt">The grain key extension.</param>
-        /// <exception cref="ArgumentNullException">The key is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException">The key is empty or contains only whitespace.</exception>
-        private static void ValidateGrainKeyExtension(string keyExt)
-        {
-            if (!string.IsNullOrWhiteSpace(keyExt)) return;
+        /// <inheritdoc />
+        public GrainInterfaceType GetGrainInterfaceType(Type interfaceType) => interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
 
-            if (null == keyExt)
-            {
-                throw new ArgumentNullException(nameof(keyExt)); 
-            }
-            
-            throw new ArgumentException("Key extension is empty or white space.", nameof(keyExt));
-        }
+        /// <inheritdoc />
+        public GrainType GetGrainType(GrainInterfaceType grainInterfaceType, string grainClassNamePrefix = null) =>  interfaceTypeToGrainTypeResolver.GetGrainType(grainInterfaceType, grainClassNamePrefix);
     }
 }

--- a/src/Orleans.Runtime/Core/InternalClusterClient.cs
+++ b/src/Orleans.Runtime/Core/InternalClusterClient.cs
@@ -7,148 +7,51 @@ namespace Orleans.Runtime
     /// </summary>
     internal class InternalClusterClient : IInternalClusterClient
     {
-        private readonly IRuntimeClient runtimeClient;
-        private readonly IInternalGrainFactory grainFactory;
+        private readonly IRuntimeClient _runtimeClient;
+        private readonly IInternalGrainFactory _grainFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InternalClusterClient"/> class.
         /// </summary>
         public InternalClusterClient(IRuntimeClient runtimeClient, IInternalGrainFactory grainFactory)
         {
-            this.runtimeClient = runtimeClient;
-            this.grainFactory = grainFactory;
+            _runtimeClient = runtimeClient;
+            _grainFactory = grainFactory;
         }
 
         /// <inheritdoc />
-        public IGrainFactory GrainFactory => this.grainFactory;
-
-        /// <inheritdoc />
-        public IServiceProvider ServiceProvider => this.runtimeClient.ServiceProvider;
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithStringKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-        }
-
-        /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithIntegerCompoundKey
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix);
-        }
+        public IServiceProvider ServiceProvider => _runtimeClient.ServiceProvider;
 
         /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
-            where TGrainObserverInterface : IGrainObserver
-        {
-            return this.grainFactory.CreateObjectReference<TGrainObserverInterface>(obj);
-        }
+            where TGrainObserverInterface : IGrainObserver => _grainFactory.CreateObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />
-        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
-        {
-            this.grainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
-        }
+        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver => _grainFactory.DeleteObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IAddressable obj)
-            where TGrainObserverInterface : IAddressable
-        {
-            return this.grainFactory.CreateObjectReference<TGrainObserverInterface>(obj);
-        }
+            where TGrainObserverInterface : IAddressable => _grainFactory.CreateObjectReference<TGrainObserverInterface>(obj);
 
         /// <inheritdoc />
-        TGrainInterface IInternalGrainFactory.GetSystemTarget<TGrainInterface>(GrainType grainType, SiloAddress destination)
-        {
-            return this.grainFactory.GetSystemTarget<TGrainInterface>(grainType, destination);
-        }
+        TGrainInterface IInternalGrainFactory.GetSystemTarget<TGrainInterface>(GrainType grainType, SiloAddress destination) => _grainFactory.GetSystemTarget<TGrainInterface>(grainType, destination);
 
         /// <inheritdoc />
-        TGrainInterface IInternalGrainFactory.GetSystemTarget<TGrainInterface>(GrainId grainId)
-        {
-            return this.grainFactory.GetSystemTarget<TGrainInterface>(grainId);
-        }
+        TGrainInterface IInternalGrainFactory.GetSystemTarget<TGrainInterface>(GrainId grainId) => _grainFactory.GetSystemTarget<TGrainInterface>(grainId);
 
         /// <inheritdoc />
-        TGrainInterface IInternalGrainFactory.Cast<TGrainInterface>(IAddressable grain)
-        {
-            return this.grainFactory.Cast<TGrainInterface>(grain);
-        }
+        TGrainInterface IInternalGrainFactory.Cast<TGrainInterface>(IAddressable grain) => _grainFactory.Cast<TGrainInterface>(grain);
 
         /// <inheritdoc />
-        object IInternalGrainFactory.Cast(IAddressable grain, Type interfaceType)
-        {
-            return this.grainFactory.Cast(grain, interfaceType);
-        }
+        object IInternalGrainFactory.Cast(IAddressable grain, Type interfaceType) => _grainFactory.Cast(grain, interfaceType);
 
         /// <inheritdoc />
-        TGrainInterface IGrainFactory.GetGrain<TGrainInterface>(GrainId grainId)
-        {
-            return this.grainFactory.GetGrain<TGrainInterface>(grainId);
-        }
+        public GrainInterfaceType GetGrainInterfaceType(Type interfaceType) => _grainFactory.GetGrainInterfaceType(interfaceType);
+        
+        /// <inheritdoc />
+        public IAddressable CreateGrainReference(GrainId grainId, GrainInterfaceType interfaceType) => _grainFactory.CreateGrainReference(grainId, interfaceType);
 
         /// <inheritdoc />
-        IAddressable IGrainFactory.GetGrain(GrainId grainId)
-        {
-            return this.grainFactory.GetGrain(grainId);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension)
-        {
-            return this.grainFactory.GetGrain(grainInterfaceType, grainPrimaryKey);
-        }
-
-        public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceId)
-        {
-            return this.grainFactory.GetGrain(grainId, interfaceId);
-        }
+        public GrainType GetGrainType(GrainInterfaceType grainInterfaceType, string grainClassNamePrefix = null) => _grainFactory.GetGrainType(grainInterfaceType, grainClassNamePrefix);
     }
 }


### PR DESCRIPTION
This PR adds GetGrainType() and GetGrainInterfaceType() methods to IGrainFactory to facilitate extension methods that allow developers to add their own GetGrain() IGrainFactory extension methods that take key types they require.

This PR moves all of the existing GetGrain() methods from IGrainFactory to extension methods of IGrainFactory too. This simplifies implementation of IGrainFactory.
