### PR TITLE
chore: Update to setup-dotnet v4 and use global.json for versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Build
       run: dotnet build -bl
     - uses: actions/upload-artifact@v4
@@ -54,10 +53,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -89,10 +87,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -136,10 +133,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -179,10 +175,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -224,10 +219,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -266,10 +260,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)"
@@ -304,10 +297,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     # - name: Install emulator certificate
     #   run: |
     #     sleep 90s
@@ -364,10 +356,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -408,10 +399,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -453,10 +443,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
@@ -492,10 +481,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Build
       run: dotnet build
     - name: Test
@@ -526,10 +514,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
+        global-json-file: global.json
     - name: Test Code Generator
       run: dotnet test
         test/Orleans.CodeGenerator.Tests/Orleans.CodeGenerator.Tests.csproj

--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -13,13 +13,12 @@ jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
+          global-json-file: global.json
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Restore and build
         run: |
           set +e


### PR DESCRIPTION
preparation for #9543 to make update of SDK less painfull

Aligns all CI workflows to use setup-dotnet action v4, replacing v3, and switches from hardcoded .NET version to using global.json for version management. Improves consistency and future maintainability of .NET version selection across workflows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9546)