### PR TITLE
Improve the allocation pattern for CacheInvalidationHeaders

### DIFF
--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -276,14 +276,9 @@ namespace Orleans.Runtime
 
         internal void AddToCacheInvalidationHeader(GrainAddress invalidAddress, GrainAddress validAddress)
         {
-            var list = new List<GrainAddressCacheUpdate>();
-            if (CacheInvalidationHeader != null)
-            {
-                list.AddRange(CacheInvalidationHeader);
-            }
-
-            list.Add(new GrainAddressCacheUpdate(invalidAddress, validAddress));
-            CacheInvalidationHeader = list;
+            CacheInvalidationHeader ??= [];
+            var grainAddressCacheUpdate = new GrainAddressCacheUpdate(invalidAddress, validAddress);
+            CacheInvalidationHeader.Add(grainAddressCacheUpdate);
         }
 
         public override string ToString() => $"{this}";


### PR DESCRIPTION
The existing pattern allocates three times the required size:
- Once when calling AddRange (which sets the list capacity to the argument's count)
- Twice when calling add due to exponential growth

By using plain old List.Add, all this is avoided as that method will
grow the underlying buffer exponentially making each individual `Add`
amortized `O(1)`.

Contributes to https://github.com/dotnet/orleans/issues/9569
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9570)