### PR TITLE
follow-up: memory shedding

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -355,7 +355,7 @@ namespace Orleans.Runtime
                 targetActivationLimit = 0;
             }
 
-            LogCurrentMemoryStats(
+            LogCurrentHighMemoryPressureStats(
                 maxAvailableMemoryMb: (double)stats.MaximumAvailableMemoryBytes / 1024 / 1024,
                 rawAvailableMemoryMb: (double)stats.RawAvailableMemoryBytes / 1024 / 1024,
                 usedMemoryMb: (double)usedMemory / 1024 / 1024,
@@ -736,9 +736,9 @@ namespace Orleans.Runtime
 
         [LoggerMessage(
             Level = LogLevel.Debug,
-            Message = "[Memory Stats] maxAvailableMemoryMb={maxAvailableMemoryMb}, rawAvailableMemoryMb={rawAvailableMemoryMb}, usedMemoryMb={usedMemoryMb}, activationCount={activationCount}, activationSize={activationSize}, thresholdMemoryLoad={threshold}, currentMemoryLoad={currentMemoryLoad}"
+            Message = "[High Memory Pressure Stats] maxAvailableMemoryMb={maxAvailableMemoryMb}, rawAvailableMemoryMb={rawAvailableMemoryMb}, usedMemoryMb={usedMemoryMb}, activationCount={activationCount}, activationSize={activationSize}, thresholdMemoryLoad={threshold}, currentMemoryLoad={currentMemoryLoad}"
         )]
-        private partial void LogCurrentMemoryStats(double maxAvailableMemoryMb, double rawAvailableMemoryMb, double usedMemoryMb, int activationCount, double activationSize, double threshold, double currentMemoryLoad);
+        private partial void LogCurrentHighMemoryPressureStats(double maxAvailableMemoryMb, double rawAvailableMemoryMb, double usedMemoryMb, int activationCount, double activationSize, double threshold, double currentMemoryLoad);
 
         [LoggerMessage(
             Level = LogLevel.Error,

--- a/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
@@ -48,38 +48,18 @@ namespace Orleans.Configuration
         /// The default value for <see cref="DeactivationTimeout"/>.
         /// </summary>
         public static readonly TimeSpan DEFAULT_DEACTIVATION_TIMEOUT = TimeSpan.FromSeconds(30);
-
-        /// <summary>
-        /// Controls behavior of grain collection based on available memory.
-        /// </summary>
-        public MemoryPressureGrainCollectionOptions MemoryPressureGrainCollectionOptions { get; set; } = new();
     }
 
     /// <summary>
     /// Options for grain collection based on memory pressure.
     /// </summary>
-    public class MemoryPressureGrainCollectionOptions
+    public sealed class MemoryPressureGrainCollectionOptions
     {
-        /// <summary>
-        /// The same control as <see cref="MemoryUsageCollectionEnabled"/> but via the environment variable.
-        /// </summary>
-        public const string MemoryUsageCollectionEnabledEnvironmentVariable = "ORLEANS_MEMORY_PRESSURE_GRAIN_COLLECTION_ENABLED";
-
         /// <summary>
         /// Indicates if memory-based grain collection is enabled.
         /// Is enabled by default.
         /// </summary>
         public bool MemoryUsageCollectionEnabled { get; set; } = true;
-
-        internal bool IsMemoryUsageCollectionEnabled()
-        {
-            if (bool.TryParse(Environment.GetEnvironmentVariable(MemoryUsageCollectionEnabledEnvironmentVariable), out var enabled))
-            {
-                return enabled;
-            }
-
-            return MemoryUsageCollectionEnabled;
-        }
 
         /// <summary>
         /// The interval at which memory usage is polled.

--- a/src/Orleans.Runtime/Configuration/Validators/MemoryPressureGrainCollectionOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/MemoryPressureGrainCollectionOptionsValidator.cs
@@ -10,16 +10,16 @@ namespace Orleans.Configuration;
 
 internal class MemoryPressureGrainCollectionOptionsValidator : IConfigurationValidator
 {
-    private readonly IOptions<GrainCollectionOptions> grainCollectionOptions;
+    private readonly IOptions<MemoryPressureGrainCollectionOptions> _memoryPressureGrainCollectionOptions;
 
-    public MemoryPressureGrainCollectionOptionsValidator(IOptions<GrainCollectionOptions> options)
+    public MemoryPressureGrainCollectionOptionsValidator(IOptions<MemoryPressureGrainCollectionOptions> options)
     {
-        this.grainCollectionOptions = options;
+        _memoryPressureGrainCollectionOptions = options;
     }
 
     public void ValidateConfiguration()
     {
-        var options = grainCollectionOptions.Value.MemoryPressureGrainCollectionOptions;
+        var options = _memoryPressureGrainCollectionOptions.Value;
         if (!options.MemoryUsageCollectionEnabled)
         {
             return;


### PR DESCRIPTION
Adding logs and refactoring configuration of https://github.com/dotnet/orleans/pull/9532.
also testing whether the memory pressure works against CI agents here.