### PR TITLE
F# serialization of DUs - more cases covered

### DIFF
--- a/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/FSharpUtils.cs
@@ -11,6 +11,7 @@ namespace Orleans.CodeGenerator
     internal static class FSharpUtilities
     {
         private const int SourceConstructFlagsSumTypeValue = 1;
+        private const int SourceConstructFlagsKindMaskValue = 31;
         private const int SourceConstructFlagsRecordTypeValue = 2;
 
         public static bool IsUnionCase(LibraryTypes libraryTypes, INamedTypeSymbol symbol, out INamedTypeSymbol sumType)
@@ -56,7 +57,7 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            if ((int)sourceConstructFlagsArgument.Value != SourceConstructFlagsSumTypeValue)
+            if (sourceConstructFlagsArgument.Value != null && ((int)sourceConstructFlagsArgument.Value & SourceConstructFlagsKindMaskValue) != SourceConstructFlagsSumTypeValue)
             {
                 return false;
             }
@@ -116,10 +117,7 @@ namespace Orleans.CodeGenerator
                 List<IFieldSymbol> dataMembers = new();
                 foreach (var field in symbol.GetDeclaredInstanceMembers<IFieldSymbol>())
                 {
-                    if (field.Name.StartsWith("item", System.StringComparison.Ordinal) || field.Name.Equals("_tag", System.StringComparison.Ordinal))
-                    {
-                        dataMembers.Add(field);
-                    }
+                    dataMembers.Add(field);
                 }
 
                 dataMembers.Sort(FSharpUnionCasePropertyNameComparer.Default);

--- a/test/Grains/TestFSharp/Types.fs
+++ b/test/Grains/TestFSharp/Types.fs
@@ -94,6 +94,17 @@ and [<Immutable; GenerateSerializer>] DURecursive =
     | Case1 of DUMutually
     | Case2 of DURecursive * DUMutually
 
+[<Struct; GenerateSerializer>]
+type SingleCaseStructDU = Case of string
+
+[<Struct; GenerateSerializer>]
+type MulticaseStructDU =
+    | Case1 of value: string
+    | Case2 of value: string
+    | Case3 of valueInt: int
+    | Case4
+    | Case5 of int64
+
 [<Immutable; GenerateSerializer>]
 type Record = {  [<Id(1u)>] A: SingleCaseDU } with
     static member ofInt x = { A = SingleCaseDU.ofInt x }

--- a/test/Grains/TestFSharp/Types.fs
+++ b/test/Grains/TestFSharp/Types.fs
@@ -25,6 +25,22 @@ type GenericDU<'T> =
     | Case2
 
 [<Immutable; GenerateSerializer>]
+type PrivateConstructorDU =
+    private Constructor of string
+        static member SomeValue =
+            Constructor "some value"
+
+[<Immutable; GenerateSerializer>]
+type PrivateConstructorDoubleCaseDU =
+    private
+        | ConstructorOne of string
+        | ConstructorTwo of value: int
+    static member One =
+        ConstructorOne "some one"
+    static member Two =
+        ConstructorTwo 2
+
+[<Immutable; GenerateSerializer>]
 type SingleCaseDU =
     | Case1 of int
     static member ofInt i = Case1 i
@@ -32,7 +48,7 @@ type SingleCaseDU =
 [<Immutable; GenerateSerializer>]
 type DoubleCaseDU =
     | Case1 of string
-    | Case2 of int
+    | Case2 of number: int
 
 [<Immutable; GenerateSerializer>]
 type TripleCaseDU =
@@ -48,12 +64,35 @@ type QuadrupleCaseDU =
     | Case4 of byte
 
 [<Immutable; GenerateSerializer>]
+type NamedFieldsSingleCaseDU =
+    | Case1 of something: string
+
+[<Immutable; GenerateSerializer>]
+type NamedFieldsDoubleCaseDU =
+    | Case1 of something: string * int
+    | Case2 of other: string
+
+[<Immutable; GenerateSerializer>]
+type NamedFieldsTripleCaseDU =
+    | Case1 of something: string
+    | Case2 of other: string * byte
+    | Case3 of string * second: string * third: int
+
+[<Immutable; GenerateSerializer>]
 type QuintupleCaseDU =
     | Case1
-    | Case2 of int
+    | Case2 of number: int * string
     | Case3
-    | Case4 of byte
+    | Case4 of theByte: byte * theLong: int64
     | Case5 of string
+
+[<Immutable; GenerateSerializer>]
+type DUMutually =
+    | Case1 of int
+    | Case2 of DURecursive
+and [<Immutable; GenerateSerializer>] DURecursive =
+    | Case1 of DUMutually
+    | Case2 of DURecursive * DUMutually
 
 [<Immutable; GenerateSerializer>]
 type Record = {  [<Id(1u)>] A: SingleCaseDU } with
@@ -74,7 +113,7 @@ type GenericRecord<'T> = { [<Id(1u)>] Value: 'T } with
     static member ofT x = { Value = x }
 
 [<Immutable; GenerateSerializer>]
-type DiscriminatedUnion = 
+type DiscriminatedUnion =
     | ArrayFieldCase of int array
     | ListFieldCase of int list
     | MapFieldCase of Map<int,string>

--- a/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
+++ b/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
@@ -127,9 +127,32 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal(du, copy)
 
     [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_NamedFieldsSingleCaseDiscriminatedUnion () =
+        let du = NamedFieldsSingleCaseDU.Case1 "str"
+        let roundtripped = cluster.RoundTripSerializationForTesting du
+        let copy = cluster.DeepCopy du
+        Assert.Equal(du, roundtripped)
+        Assert.Equal(du, copy)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
     let Serialization_Roundtrip_FSharp_DoubleCaseDiscriminatedUnion () =
         let case1 = DoubleCaseDU.Case1 "case 1"
         let case2 = DoubleCaseDU.Case2 2
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_NamedFieldsDoubleCaseDiscriminatedUnion () =
+        let case1 = NamedFieldsDoubleCaseDU.Case1 ("case 1", 123)
+        let case2 = NamedFieldsDoubleCaseDU.Case2 "case 2"
 
         let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
         let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
@@ -146,6 +169,26 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         let case1 = TripleCaseDU.Case1 "case 1"
         let case2 = TripleCaseDU.Case2 2
         let case3 = TripleCaseDU.Case3 'a'
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let roundtrippedCase3 = cluster.RoundTripSerializationForTesting case3
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        let copyCase3 = cluster.DeepCopy case3
+
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case3, roundtrippedCase3)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+        Assert.Equal(case3, copyCase3)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_NamedFieldsTripleCaseDiscriminatedUnion () =
+        let case1 = NamedFieldsTripleCaseDU.Case1 "case 1"
+        let case2 = NamedFieldsTripleCaseDU.Case2 ("case 2", 123uy)
+        let case3 = NamedFieldsTripleCaseDU.Case3 ("one", "two", 3)
 
         let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
         let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
@@ -191,9 +234,9 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
     [<TestCategory("BVT"); TestCategory("Serialization")>]
     let Serialization_Roundtrip_FSharp_QuintupleCaseDiscriminatedUnion () =
         let case1 = QuintupleCaseDU.Case1
-        let case2 = QuintupleCaseDU.Case2 2
+        let case2 = QuintupleCaseDU.Case2 (2, "some string")
         let case3 = QuintupleCaseDU.Case3
-        let case4 = QuintupleCaseDU.Case4 1uy
+        let case4 = QuintupleCaseDU.Case4 (1uy, 2L)
         let case5 = QuintupleCaseDU.Case5 "case 5"
 
         let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
@@ -217,3 +260,48 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal(case3, copyCase3);
         Assert.Equal(case4, copyCase4)
         Assert.Equal(case5, copyCase5)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_PrivateConstructorDiscriminatedUnion () =
+        let du = PrivateConstructorDU.SomeValue
+        let roundtripped = cluster.RoundTripSerializationForTesting du
+        let copy = cluster.DeepCopy du
+        Assert.Equal(du, roundtripped)
+        Assert.Equal(du, copy)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_PrivateConstructorDoubleCaseDiscriminatedUnion () =
+        let case1 = PrivateConstructorDoubleCaseDU.One
+        let case2 = PrivateConstructorDoubleCaseDU.Two
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact>]
+    [<TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_Mutually_Recursive_DU () =
+        let mutually_case1 = DUMutually.Case1 1
+        let mutually_case2_case1 = DUMutually.Case2 (DURecursive.Case1 (DUMutually.Case1 2))
+        let mutually_case2_case2 =
+            DUMutually.Case2 (DURecursive.Case2 (DURecursive.Case1 (DUMutually.Case1 3), DUMutually.Case2 (DURecursive.Case1 (DUMutually.Case1 1337))))
+
+        let roundtripped_mutually_case1 = cluster.RoundTripSerializationForTesting mutually_case1
+        let roundtripped_mutually_case2_case1 = cluster.RoundTripSerializationForTesting mutually_case2_case1
+        let roundtripped_mutually_case2_case2 = cluster.RoundTripSerializationForTesting mutually_case2_case2
+        let copy_mutually_case1 = cluster.DeepCopy mutually_case1
+        let copy_mutually_case2_case1 = cluster.DeepCopy mutually_case2_case1
+        let copy_mutually_case2_case2 = cluster.DeepCopy mutually_case2_case2
+
+        Assert.Equal(mutually_case1, roundtripped_mutually_case1)
+        Assert.Equal(mutually_case2_case1, roundtripped_mutually_case2_case1)
+        Assert.Equal(mutually_case2_case2, roundtripped_mutually_case2_case2)
+        Assert.Equal(mutually_case1, copy_mutually_case1)
+        Assert.Equal(mutually_case2_case1, copy_mutually_case2_case1)
+        Assert.Equal(mutually_case2_case2, copy_mutually_case2_case2)

--- a/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
+++ b/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
@@ -305,3 +305,42 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal(mutually_case1, copy_mutually_case1)
         Assert.Equal(mutually_case2_case1, copy_mutually_case2_case1)
         Assert.Equal(mutually_case2_case2, copy_mutually_case2_case2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_SingleCaseStructDiscriminatedUnion () =
+        let du = SingleCaseStructDU.Case "string"
+        let roundtripped = cluster.RoundTripSerializationForTesting du
+        let copy = cluster.DeepCopy du
+        Assert.Equal(du, roundtripped)
+        Assert.Equal(du, copy)
+
+    [<Fact>]
+    [<TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_MulticaseStructDiscriminatedUnion () =
+        let case1 = MulticaseStructDU.Case1 "case 1"
+        let case2 = MulticaseStructDU.Case2 "case 2"
+        let case3 = MulticaseStructDU.Case3 123
+        let case4 = MulticaseStructDU.Case4
+        let case5 = MulticaseStructDU.Case5 123L
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let roundtrippedCase3 = cluster.RoundTripSerializationForTesting case3
+        let roundtrippedCase4 = cluster.RoundTripSerializationForTesting case4
+        let roundtrippedCase5 = cluster.RoundTripSerializationForTesting case5
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        let copyCase3 = cluster.DeepCopy case3
+        let copyCase4 = cluster.DeepCopy case4
+        let copyCase5 = cluster.DeepCopy case5
+
+        Assert.Equal(case1, roundtrippedCase1);
+        Assert.Equal(case2, roundtrippedCase2);
+        Assert.Equal(case3, roundtrippedCase3);
+        Assert.Equal(case4, roundtrippedCase4);
+        Assert.Equal(case5, roundtrippedCase5);
+        Assert.Equal(case1, copyCase1);
+        Assert.Equal(case2, copyCase2);
+        Assert.Equal(case3, copyCase3);
+        Assert.Equal(case4, copyCase4)
+        Assert.Equal(case5, copyCase5)


### PR DESCRIPTION
This pull request addresses two problems when identifying and generating serializer code for F# discriminated unions:

## 1. Discriminated unions with private constructors weren't identified as Discriminated Unions 
DUs with private constructors, e.g.
```
type PrivateConstructorDU =
    private Constructor of string
```
get an additional [SourceConstructFlag](https://github.com/dotnet/fsharp/blob/main/src/FSharp.Core/prim-types.fsi#L68) `SourceConstructFlag.NonPublicRepresentation` in addition to the `SourceConstructFlag.SumType`, which "Indicates that the compiled entity had private or internal representation in F# source code". To identify a DU with this additional flag we can use the `SourceConstructFlag.KindMask` to mask away the `NonPublicRepresentation` flag. This is in line with how `FSharp.Reflection` [identifies a DU](https://github.com/dotnet/fsharp/blob/main/src/FSharp.Core/reflect.fs#L458) (note: the additional check of `BindingFlag.NonPublic` is simply to check if the user has asked for just `Public` or both `Public` and `NonPublic` types). 

## 2. DUs with named fields and some Struct DUs weren't (de)serialized correctly
DUs can optionally name the fields in a DU, e.g.
```
type DUWithNamedFields =
    | Case of something: string
```
With named fields, the IL code will now use these field names instead of the `item{0..N}` field names. Since we used to go looking for fields starting with `item`, these weren't correctly identified. I have changed this to simply identify all fields for serialization. This will cover both unnamed and named fields, in addition to the `_tag` field which we have to serialize for DUs of 4 cases or more.

Similarly, for [Struct DUs](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/discriminated-unions#struct-discriminated-unions), e.g.
```
[<Struct>]
type StructDU =
    | Case1 of value: int
    | Case2 of string
```
we need to specify field names for when the cases are of different data types. Choosing to serialize all fields covers this case as well.

## Additional test
F# also has to possibility to define [mutually recursive DUs](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/discriminated-unions#mutually-recursive-discriminated-unions). I have added a test to verify that these also work.