### PR TITLE
Mark AdoNetGrainDirectoryServiceCollectionExtensions and OrleansRelationalDownloadStream internal

### DIFF
--- a/src/AdoNet/Orleans.GrainDirectory.AdoNet/Hosting/AdoNetGrainDirectoryServiceCollectionExtensions.cs
+++ b/src/AdoNet/Orleans.GrainDirectory.AdoNet/Hosting/AdoNetGrainDirectoryServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ namespace Orleans.Hosting;
 /// <summary>
 /// <see cref="IServiceCollection"/> extensions.
 /// </summary>
-public static class AdoNetGrainDirectoryServiceCollectionExtensions
+internal static class AdoNetGrainDirectoryServiceCollectionExtensions
 {
     internal static IServiceCollection AddAdoNetGrainDirectory(
         this IServiceCollection services,

--- a/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
+++ b/src/AdoNet/Shared/Storage/OrleansRelationalDownloadStream.cs
@@ -26,7 +26,7 @@ namespace Orleans.Tests.SqlUtils
     /// This is a chunked read implementation for ADO.NET providers which do
     /// not otherwise implement <see cref="DbDataReader.GetStream(int)"/> natively.
     /// </summary>
-    public class OrleansRelationalDownloadStream : Stream
+    internal class OrleansRelationalDownloadStream : Stream
     {
         /// <summary>
         /// A cached task as if there are multiple rounds of reads, it is likely


### PR DESCRIPTION
These do not need to be exposed publicly as far as I can tell, so we should mark them as internal.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9584)