### PR TITLE
Don't update DynamoDB Table TTL when AttributeName is the same

### DIFF
--- a/src/AWS/Shared/Storage/DynamoDBStorage.cs
+++ b/src/AWS/Shared/Storage/DynamoDBStorage.cs
@@ -359,7 +359,7 @@ namespace Orleans.Transactions.DynamoDB
                 return tableDescription;
             }
 
-            if (string.IsNullOrEmpty(ttlAttributeName))
+            if (string.IsNullOrEmpty(ttlAttributeName) || describeTimeToLive.AttributeName == ttlAttributeName)
             {
                 return tableDescription;
             }


### PR DESCRIPTION
While working on #9499 with PR #9500 I missed out a crucial piece of code. Current code attempts to apply the TTL when the attribute name is the same, which is incorrect. This fixes it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9588)