### PR TITLE
Fix `IGrainLocator` nullability

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/GrainAddress.cs
@@ -58,7 +58,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="other"> The other <see cref="GrainAddress"/> to compare this one with.</param>
         /// <returns> Returns <c>true</c> if the two <see cref="GrainAddress"/> are considered to match.</returns>
-        public bool Matches(GrainAddress? other)
+        public bool Matches([NotNullWhen(true)] GrainAddress? other)
         {
             if (ReferenceEquals(this, other)) return true;
             return MatchesGrainIdAndSilo(this, other)

--- a/src/Orleans.Core/GrainDirectory/IGrainLocator.cs
+++ b/src/Orleans.Core/GrainDirectory/IGrainLocator.cs
@@ -15,7 +15,7 @@ namespace Orleans.GrainDirectory
         /// </summary>
         /// <param name="address">The address to register.</param>
         /// <returns>The grain address which is registered in the directory immediately following this call.</returns>
-        Task<GrainAddress> Register(GrainAddress address, GrainAddress? previousRegistration);
+        Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousRegistration);
 
         /// <summary>
         /// Deregisters a grain address from the directory.

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -97,6 +97,12 @@ namespace Orleans.Runtime.GrainDirectory
 
             var result = await GetGrainDirectory(grainType).Register(address, previousAddress);
 
+            if (result is null)
+            {
+                // If the registration failed, we return a null address
+                return null;
+            }
+
             // Check if the entry point to a dead silo
             if (IsKnownDeadSilo(result))
             {
@@ -109,6 +115,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.cache.AddOrUpdate(result, (int)result.MembershipVersion.Value);
 
             return result;
+
         }
 
         public async Task Unregister(GrainAddress address, UnregistrationCause cause)

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public ValueTask<GrainAddress?> Lookup(GrainId grainId) => GetGrainLocator(grainId.Type).Lookup(grainId);
 
-        public Task<GrainAddress> Register(GrainAddress address, GrainAddress? previousRegistration) => GetGrainLocator(address.GrainId.Type).Register(address, previousRegistration);
+        public Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousRegistration) => GetGrainLocator(address.GrainId.Type).Register(address, previousRegistration);
 
         public Task Unregister(GrainAddress address, UnregistrationCause cause) => GetGrainLocator(address.GrainId.Type).Unregister(address, cause);
 


### PR DESCRIPTION
`Register` can return null when all directory instances are unable to register a grain (eg because the last node in the cluster is shutting down)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9604)