### PR TITLE
Avoid attempting to cancel SystemTarget calls

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
             }, this);
         }
 
-        private void SignalCancellation() => shared.CancellationManager.SignalCancellation(Message.TargetSilo, Message.TargetGrain, Message.SendingGrain, Message.Id);
+        private void SignalCancellation() => shared.CancellationManager?.SignalCancellation(Message.TargetSilo, Message.TargetGrain, Message.SendingGrain, Message.Id);
 
         public void OnStatusUpdate(StatusResponse status)
         {


### PR DESCRIPTION
`SystemTarget` does not (yet) support call cancellation, so attempts to cancel `SystemTarget` calls will result in a benign error today.

This PR sets the `IGrainCallCancellationManager` to `null` for calls to `SystemTarget` instances, so cancellation will not be attempted.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9606)