### PR TITLE
feat(streaming): support JSON serialization for Azure Queue migration

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
         /// <returns>The client builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
             string name,
             Action<ClusterClientAzureQueueJsonStreamConfigurator> configure)
@@ -56,7 +56,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
         /// <returns>The client builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 
@@ -25,8 +26,41 @@ namespace Orleans.Hosting
         public static IClientBuilder AddAzureQueueStreams(this IClientBuilder builder,
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueStreams(name, b=>
-                 b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueStreams(name, b => b.ConfigureAzureQueue(configureOptions));
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure cluster client to use Azure Queue persistent streams with JSON serialization.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The client builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
+        /// <returns>The client builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
+            string name,
+            Action<ClusterClientAzureQueueJsonStreamConfigurator> configure)
+        {
+            var configurator = new ClusterClientAzureQueueJsonStreamConfigurator(name, builder);
+            configure?.Invoke(configurator);
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure cluster client to use Azure Queue persistent streams with JSON serialization and default settings.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The client builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
+        /// <returns>The client builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
+            string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
+        {
+            builder.AddAzureQueueJsonStreams(name, b=> b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
         /// <returns>The silo builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name,
             Action<SiloAzureQueueJsonStreamConfigurator> configure)
         {
@@ -55,7 +55,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
         /// <returns>The silo builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
             builder.AddAzureQueueJsonStreams(name, b =>b.ConfigureAzureQueue(configureOptions));

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -15,8 +16,7 @@ namespace Orleans.Hosting
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name,
             Action<SiloAzureQueueStreamConfigurator> configure)
         {
-            var configurator = new SiloAzureQueueStreamConfigurator(name,
-                configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
+            var configurator = new SiloAzureQueueStreamConfigurator(name, configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
             configure?.Invoke(configurator);
             return builder;
         }
@@ -26,8 +26,39 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueStreams(name, b =>
-                 b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueStreams(name, b => b.ConfigureAzureQueue(configureOptions));
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure silo to use Azure Queue persistent streams with JSON serialization.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The silo builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
+        /// <returns>The silo builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name,
+            Action<SiloAzureQueueJsonStreamConfigurator> configure)
+        {
+            var configurator = new SiloAzureQueueJsonStreamConfigurator(name, configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
+            configure?.Invoke(configurator);
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure silo to use Azure Queue persistent streams with JSON serialization and default settings.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The silo builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
+        /// <returns>The silo builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
+        {
+            builder.AddAzureQueueJsonStreams(name, b =>b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -104,8 +104,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="cacheSize">The cache size.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
         }
@@ -115,8 +116,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
         }
@@ -126,8 +128,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
         }
@@ -137,7 +140,7 @@ namespace Orleans.Hosting
     /// Silo configurator for Azure Queue streams with JSON serialization support.
     /// This configurator automatically sets up the JSON data adapter and required dependencies.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator
     {
         public SiloAzureQueueJsonStreamConfigurator(string name, Action<Action<IServiceCollection>> configureServicesDelegate)
@@ -171,7 +174,7 @@ namespace Orleans.Hosting
     /// Cluster client configurator interface for Azure Queue streams with JSON serialization.
     /// This feature is experimental and subject to change in future updates.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public interface IClusterClientAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, IClusterClientPersistentStreamConfigurator { }
 
     /// <summary>
@@ -184,8 +187,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
         }
@@ -195,8 +199,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
         }
@@ -206,7 +211,7 @@ namespace Orleans.Hosting
     /// Cluster client configurator for Azure Queue streams with JSON serialization support.
     /// This configurator automatically sets up the JSON data adapter and required dependencies.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator
     {
         public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Configuration;
+using Orleans.Serialization;
 using Orleans.Streams;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 
 namespace Orleans.Hosting
 {
@@ -80,6 +84,153 @@ namespace Orleans.Hosting
                 }
             }));
             this.ConfigureDelegate(services => services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueDataAdapterV2>());
+        }
+    }
+
+    /// <summary>
+    /// Silo configurator interface for Azure Queue streams with JSON serialization.
+    /// This feature is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public interface ISiloAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, ISiloPersistentStreamConfigurator { }
+
+    /// <summary>
+    /// Extension methods for JSON-enabled silo Azure Queue stream configurator.
+    /// </summary>
+    public static class SiloAzureQueueJsonStreamConfiguratorExtensions
+    {
+        /// <summary>
+        /// Configures the cache size for the JSON-enabled Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="cacheSize">The cache size.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
+        {
+            configurator.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
+        }
+
+        /// <summary>
+        /// Configures JSON serializer options for the Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+        }
+
+        /// <summary>
+        /// Configures the JSON data adapter behavior options.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+        }
+    }
+
+    /// <summary>
+    /// Silo configurator for Azure Queue streams with JSON serialization support.
+    /// This configurator automatically sets up the JSON data adapter and required dependencies.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator
+    {
+        public SiloAzureQueueJsonStreamConfigurator(string name, Action<Action<IServiceCollection>> configureServicesDelegate)
+            : base(name, configureServicesDelegate, AzureQueueAdapterFactory.Create)
+        {
+            this.ConfigureComponent(AzureQueueOptionsValidator.Create);
+            this.ConfigureComponent(SimpleQueueCacheOptionsValidator.Create);
+
+            // Configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId,
+                            this.Name);
+                }
+            }));
+
+            // Configure JSON serialization dependencies and data adapter
+            this.ConfigureDelegate(services =>
+            {
+                services.TryAddSingleton<OrleansJsonSerializer>();
+                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
+                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
+            });
+        }
+    }
+
+    /// <summary>
+    /// Cluster client configurator interface for Azure Queue streams with JSON serialization.
+    /// This feature is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public interface IClusterClientAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, IClusterClientPersistentStreamConfigurator { }
+
+    /// <summary>
+    /// Extension methods for JSON-enabled cluster client Azure Queue stream configurator.
+    /// </summary>
+    public static class ClusterClientAzureQueueJsonStreamConfiguratorExtensions
+    {
+        /// <summary>
+        /// Configures JSON serializer options for the Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+        }
+
+        /// <summary>
+        /// Configures the JSON data adapter behavior options.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+        }
+    }
+
+    /// <summary>
+    /// Cluster client configurator for Azure Queue streams with JSON serialization support.
+    /// This configurator automatically sets up the JSON data adapter and required dependencies.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator
+    {
+        public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder)
+            : base(name, builder, AzureQueueAdapterFactory.Create)
+        {
+            this.ConfigureComponent(AzureQueueOptionsValidator.Create);
+
+            // Configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId, this.Name);
+                }
+            }));
+
+            // Configure JSON serialization dependencies and data adapter
+            this.ConfigureDelegate(services =>
+            {
+                services.TryAddSingleton<OrleansJsonSerializer>();
+                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
+                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
+            });
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.AzureQueue
@@ -92,6 +96,110 @@ namespace Orleans.Providers.Streams.AzureQueue
         void IOnDeserialized.OnDeserialized(DeserializationContext context)
         {
             this.serializer = context.ServiceProvider.GetRequiredService<Serializer<AzureQueueBatchContainerV2>>();
+        }
+    }
+
+    /// <summary>
+    /// Data adapter that uses OrleansJsonSerializer for serializing stream event data with fallback support.
+    /// This adapter is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [SerializationCallbacks(typeof(OnDeserializedCallbacks))]
+    public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>, IOnDeserialized
+    {
+        private readonly AzureQueueJsonDataAdapterOptions _options;
+        private readonly ILogger<AzureQueueJsonDataAdapter> _logger;
+
+        private OrleansJsonSerializer _jsonSerializer;
+        private readonly IQueueDataAdapter<string, IBatchContainer> _fallbackAdapter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQueueJsonDataAdapter"/> class.
+        /// </summary>
+        /// <param name="jsonSerializer">The JSON serializer.</param>
+        /// <param name="fallbackAdapter">The fallback data adapter (typically AzureQueueDataAdapterV2).</param>
+        /// <param name="options">The adapter options.</param>
+        /// <param name="logger">The logger.</param>
+        public AzureQueueJsonDataAdapter(
+            OrleansJsonSerializer jsonSerializer,
+            AzureQueueDataAdapterV2 fallbackAdapter,
+            AzureQueueJsonDataAdapterOptions options,
+            ILogger<AzureQueueJsonDataAdapter> logger)
+        {
+            _jsonSerializer = jsonSerializer;
+            _fallbackAdapter = fallbackAdapter;
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates a cloud queue message from stream event data.
+        /// </summary>
+        public string ToQueueMessage<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
+        {
+            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamId, events.Cast<object>().ToList(), requestContext);
+
+            try
+            {
+                return _options.PreferJson
+                    ? _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2))
+                    : _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+            }
+            catch (Exception ex) when (this._options.EnableFallback)
+            {
+                if (_options.PreferJson)
+                {
+                    _logger.LogDebug(ex, "JSON serialization failed for stream {StreamId}, falling back to binary serialization", streamId);
+                    return _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+                }
+                else
+                {
+                    _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
+                    return _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a batch container from a cloud queue message
+        /// </summary>
+        public IBatchContainer FromQueueMessage(string cloudMsg, long sequenceId)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(cloudMsg, nameof(cloudMsg));
+
+            try
+            {
+                if (_options.PreferJson)
+                {
+                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
+                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+                    return azureQueueBatch;
+                }
+                else
+                {
+                    return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
+                }
+            }
+            catch (Exception ex) when (_options.EnableFallback)
+            {
+                if (_options.PreferJson)
+                {
+                    _logger.LogDebug(ex, "Failed to deserialize cloud message using JSON, falling back to binary deserialization");
+                    return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
+                }
+                else
+                {
+                    _logger.LogDebug(ex, "Binary deserialization failed for cloudMsg {cloudMsg}, falling back to JSON deserialization", cloudMsg);
+                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
+                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+                    return azureQueueBatch;
+                }
+            }
+        }
+
+        void IOnDeserialized.OnDeserialized(DeserializationContext context)
+        {
+            _jsonSerializer = context.ServiceProvider.GetRequiredService<OrleansJsonSerializer>();
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -103,7 +103,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     /// Data adapter that uses OrleansJsonSerializer for serializing stream event data with fallback support.
     /// This adapter is experimental and subject to change in future updates.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     [SerializationCallbacks(typeof(OnDeserializedCallbacks))]
     public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>, IOnDeserialized
     {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 /// <summary>
 /// Configuration options for the Azure Queue JSON data adapter.
 /// </summary>
-[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
 public class AzureQueueJsonDataAdapterOptions
 {
     /// <summary>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
+
+/// <summary>
+/// Configuration options for the Azure Queue JSON data adapter.
+/// </summary>
+[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+public class AzureQueueJsonDataAdapterOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable fallback to binary serialization when JSON serialization fails.
+    /// Default is true.
+    /// </summary>
+    public bool EnableFallback { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to prefer JSON serialization/deserialization first, then fallback to binary.
+    /// When false, it will try binary serialization/deserialization first, then fallback to JSON.
+    /// </summary>
+    public bool PreferJson { get; set; } = false;
+}

--- a/test/Extensions/TesterAzureUtils/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/TesterAzureUtils/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -1,0 +1,259 @@
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using System.Buffers.Text;
+using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.AzureUtils.Streaming
+{
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestCategory("AzureStorage"), TestCategory("Streaming")]
+    public class AzureQueueJsonDataAdapterTests : AzureStorageBasicTests, IAsyncLifetime
+    {
+        private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture fixture;
+        private const int NumBatches = 20;
+        private const int NumMessagesPerBatch = 20;
+        public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
+        private readonly ILoggerFactory loggerFactory;
+        private static readonly List<string> azureQueueNames = AzureQueueUtilities.GenerateQueueNames($"AzureQueueAdapterTests-{Guid.NewGuid()}", 8);
+
+        public AzureQueueJsonDataAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
+        {
+            this.output = output;
+            this.fixture = fixture;
+            this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
+        }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            try
+            {
+                TestUtils.CheckForAzureStorage();
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, azureQueueNames, new AzureQueueOptions().ConfigureTestDefaults());
+            }
+            catch (SkipException) { }
+        }
+
+        private AzureQueueJsonDataAdapter InitializeQueueJsonDataAdapter(bool enableFallback, bool preferJson)
+        {
+            var serializer = this.fixture.Services.GetService<Serializer>();
+            var azureQueueDataAdapterV2 = new AzureQueueDataAdapterV2(serializer);
+            var jsonOrleansSerializer = new OrleansJsonSerializer(Options.Create(new OrleansJsonSerializerOptions()));
+            var logger = Substitute.For<ILogger<AzureQueueJsonDataAdapter>>();
+
+            var jsonQueueDataAdapter = new AzureQueueJsonDataAdapter(
+                jsonOrleansSerializer,
+                fallbackAdapter: azureQueueDataAdapterV2,
+                new AzureQueueJsonDataAdapterOptions() { EnableFallback = enableFallback, PreferJson = preferJson },
+                logger);
+
+            return jsonQueueDataAdapter;
+        }
+
+        private AzureQueueDataAdapterV2 InitializeBinaryOnlyAdapter()
+        {
+            var serializer = this.fixture.Services.GetService<Serializer>();
+
+            var codec = serializer.SessionPool.CodecProvider.TryGetCodec<EventData>();
+            Assert.NotNull(codec);
+            this.output.WriteLine("Codec for EventData: {0}", codec);
+
+            return new AzureQueueDataAdapterV2(serializer);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void ToAndFromQueueMessage_SerializesAccordingToFormat()
+        {
+            var options = new AzureQueueOptions
+            {
+                MessageVisibilityTimeout = TimeSpan.FromSeconds(30),
+                QueueNames = azureQueueNames
+            };
+            options.ConfigureTestDefaults();
+            var queueCacheOptions = new SimpleQueueCacheOptions();
+            var queueDataAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+
+            var data = new EventData();
+            var token = new EventSequenceTokenV2();
+
+            var msg = queueDataAdapter.ToQueueMessage(
+                StreamId.Create("ns", Guid.NewGuid()),
+                [data],
+                token,
+                new Dictionary<string, object>());
+
+            this.output.WriteLine("Serialized message: {0}", msg);
+            Assert.True(IsValidJson(msg), "Message should be valid JSON");
+
+            var batchContainer = queueDataAdapter.FromQueueMessage(msg, token.SequenceNumber);
+            var deserializedMsg = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            Assert.NotNull(deserializedMsg);
+            Assert.Equal(data, deserializedMsg.Item1);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void BinaryOnlyAdapter_SerializesToBinaryFormat()
+        {
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 123, Name = "BinaryTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("binary-ns", Guid.NewGuid());
+
+            var msg = binaryAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "source", "binary-test" } });
+
+            this.output.WriteLine("Binary serialized message: {0}", msg);
+            
+            // Should be base64 encoded binary data, not JSON
+            Assert.False(IsValidJson(msg), "Binary adapter should not produce JSON");
+            Assert.True(IsValidBase64String(msg), "Binary adapter should produce valid base64");
+
+            // Verify round-trip works
+            var batchContainer = binaryAdapter.FromQueueMessage(msg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void JsonAdapter_FallsBackToBinaryWhenDeserializingBinaryData()
+        {
+            // First create a binary message using the V2 adapter
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 456, Name = "FallbackTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("fallback-ns", Guid.NewGuid());
+
+            var binaryMsg = binaryAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "format", "binary" } });
+
+            this.output.WriteLine("Original binary message: {0}", binaryMsg);
+            Assert.True(IsValidBase64String(binaryMsg), "Should be valid base64 binary data");
+
+            // Now try to deserialize it with JSON adapter
+            var jsonAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            
+            var batchContainer = jsonAdapter.FromQueueMessage(binaryMsg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void BinaryPreferredAdapter_FallsBackToJsonWhenDeserializingJsonData()
+        {
+            // First create a JSON message using JSON-preferred adapter
+            var jsonFirstAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            var data = new EventData { Id = 789, Name = "JsonToJsonTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("json-fallback-ns", Guid.NewGuid());
+
+            var jsonMsg = jsonFirstAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "format", "json" } });
+
+            this.output.WriteLine("Original JSON message: {0}", jsonMsg);
+            Assert.True(IsValidJson(jsonMsg), "Should be valid JSON data");
+
+            // Now try to deserialize it with binary-preferred adapter
+            var binaryPreferredAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: false);
+            
+            var batchContainer = binaryPreferredAdapter.FromQueueMessage(jsonMsg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void JsonAdapter_WithoutFallback_FailsOnIncompatibleData()
+        {
+            // Create a binary message
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 999, Name = "FailureTest" };
+            var token = new EventSequenceTokenV2();
+
+            var binaryMsg = binaryAdapter.ToQueueMessage(
+                StreamId.Create("failure-ns", Guid.NewGuid()),
+                [data],
+                token,
+                new Dictionary<string, object>());
+
+            // Try to deserialize with JSON adapter that has fallback disabled
+            var jsonAdapterNoFallback = InitializeQueueJsonDataAdapter(enableFallback: false, preferJson: true);
+            
+            Assert.ThrowsAny<Exception>(() => jsonAdapterNoFallback.FromQueueMessage(binaryMsg, token.SequenceNumber));
+        }
+
+        [GenerateSerializer]
+        public class EventData : IEquatable<EventData>
+        {
+            [Id(0)]
+            public int Id { get; set; }
+            
+            [Id(1)]
+            public string Name { get; set; }
+
+            public override bool Equals(object obj) => Equals(obj as EventData);
+            public bool Equals(EventData other) => other is not null && Id == other.Id && Name == other.Name;
+            public override int GetHashCode() => HashCode.Combine(Id, Name);
+
+            public static bool operator ==(EventData left, EventData right) => EqualityComparer<EventData>.Default.Equals(left, right);
+            public static bool operator !=(EventData left, EventData right) => !(left == right);
+        }
+
+        private static bool IsValidJson(string msg)
+        {
+            try
+            {
+                _ = JsonConvert.DeserializeObject(msg);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsValidBase64String(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+                return false;
+
+            // generated by copilot
+            return Base64.IsValid(s);
+        }
+    }
+}
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
+++ b/test/Extensions/TesterAzureUtils/Tester.AzureUtils.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PR proposes to support `OrleansJsonSerializer` to be used for serialization/deserialization payload in Orleans streaming. That capability is added as experimental feature, and should only be used for migration from Orleans 3.x purposes.

A 3.x side for https://github.com/dotnet/orleans/pull/9599. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9618)