### PR TITLE
[Journaling] Thread-safety issue during recovery

### DIFF
--- a/src/Orleans.Journaling/StateMachineManager.cs
+++ b/src/Orleans.Journaling/StateMachineManager.cs
@@ -303,9 +303,12 @@ internal sealed partial class StateMachineManager : IStateMachineManager, ILifec
             }
         }
 
-        foreach (var stateMachine in _stateMachines.Values)
+        lock (_lock)
         {
-            stateMachine.OnRecoveryCompleted();
+            foreach (var stateMachine in _stateMachines.Values)
+            {
+                stateMachine.OnRecoveryCompleted();
+            }
         }
     }
 


### PR DESCRIPTION
On recovery, the `StateMachineManager` notifies all state machines that the operation has completed, but it does so without holding a lock. This can result in the typical *Collection was modified; enumeration operation may not execute.*, especially when exceptions happen in grain code which triggers recovery, while another grain is activating and registering its state machines with the manager.