### PR TITLE
[Journaling] Align status serialization for both read and write in `DurableTaskCompletionSource`

### DIFF
--- a/src/Orleans.Journaling/DurableTaskCompletionSource.cs
+++ b/src/Orleans.Journaling/DurableTaskCompletionSource.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
@@ -141,7 +141,7 @@ internal sealed class DurableTaskCompletionSource<T> : IDurableTaskCompletionSou
             throw new NotSupportedException($"This instance of {nameof(DurableTaskCompletionSource<T>)} supports version {(uint)SupportedVersion} and not version {(uint)version}.");
         }
 
-        _status = (DurableTaskCompletionSourceStatus)reader.ReadVarUInt32();
+        _status = (DurableTaskCompletionSourceStatus)reader.ReadByte();
         switch (_status)
         {
             case DurableTaskCompletionSourceStatus.Completed:


### PR DESCRIPTION
The `DurableTaskCompletionSource` has a serialization bug where the status gets written as a byte but read back as a VarUInt32.  This can leave the buffer reader misaligned for subsequent reads of the result / exception payload(s), causing an insufficient data exception.

This change aligns both operations to use ReadByte/WriteByte, ensuring the Reader advances predictably.