### PR TITLE
[Journaling] Avoid increase version after recovery for `DurableState`

### DIFF
--- a/src/Orleans.Journaling/DurableState.cs
+++ b/src/Orleans.Journaling/DurableState.cs
@@ -37,14 +37,11 @@ internal sealed class DurableState<T> : IPersistentState<T>, IDurableStateMachin
     string IStorage.Etag => $"{_version}";
     bool IStorage.RecordExists => _version > 0;
 
-    private void OnValuePersisted()
+    void IDurableStateMachine.OnWriteCompleted()
     {
-        ++_version;
+        _version++;
         OnPersisted?.Invoke();
     }
-
-    void IDurableStateMachine.OnRecoveryCompleted() => OnValuePersisted();
-    void IDurableStateMachine.OnWriteCompleted() => OnValuePersisted();
 
     void IDurableStateMachine.Reset(IStateMachineLogWriter storage) => _value = default;
 


### PR DESCRIPTION
The state `_version` is incorrectly incremented after the recovery phase. This causes the `RecordExists` property to erroneously report `true`, therefor preventing initial state setup/migration logic in `OnActivateAsync`. Either way, the version should be advanced only (i think) when a write occurs.