### PR TITLE
[FIX] Dispose `StatelessWorkerGrainContext` when it contains no more workers

### DIFF
--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -175,6 +175,8 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                                     // When the last worker is destroyed, we can consider the stateless worker grain
                                     // activation to be destroyed as well
                                     _shared.InternalRuntime.Catalog.UnregisterMessageTarget(this);
+                                    var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                                    EnqueueWorkItem(WorkItemType.DisposeAsync, new DisposeAsyncWorkItemState(completion));
                                 }
                                 break;
                             }


### PR DESCRIPTION
When the inspection timer is created, the SW context itself is passed as the `state` argument. When all workers are destroyed the reference to `this` from the timer keeps the SW context itself alive from a GC perspective, so dispose wont get called.

This PR enqueues a `DisposeAsync` command when there are no more workers, as we can consider the SW to be destroyed as well.

fix #9634