### PR TITLE
Removed unnecessary Task.Run in OnConnectionAsync methods

### DIFF
--- a/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
@@ -38,7 +38,7 @@ namespace Orleans.Connections.Security
 
         public Task OnConnectionAsync(ConnectionContext context)
         {
-            return Task.Run(() => InnerOnConnectionAsync(context));
+            return InnerOnConnectionAsync(context);
         }
 
         private async Task InnerOnConnectionAsync(ConnectionContext context)

--- a/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
@@ -52,7 +52,7 @@ namespace Orleans.Connections.Security
 
         public Task OnConnectionAsync(ConnectionContext context)
         {
-            return Task.Run(() => InnerOnConnectionAsync(context));
+            return InnerOnConnectionAsync(context);
         }
 
         private async Task InnerOnConnectionAsync(ConnectionContext context)


### PR DESCRIPTION
Removed unnecessary Task.Run in OnConnectionAsync methods for TlsClientConnectionMiddleware and TlsServerConnectionMiddleware. This change simplifies the code and improves performance by directly returning the Task from InnerOnConnectionAsync.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9650)