### PR TITLE
chore: Using IMeterFactory for metrics - ApplicationRequestInstruments

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -54,6 +54,7 @@ namespace Orleans
             services.AddLogging();
             services.AddOptions();
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+            services.AddSingleton<OrleansInstruments>();
 
             // Options logging
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));

--- a/src/Orleans.Core/Diagnostics/Metrics/ApplicationRequestInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/ApplicationRequestInstruments.cs
@@ -1,34 +1,41 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal static class ApplicationRequestInstruments
+internal class ApplicationRequestInstruments
 {
-    internal static Counter<long> TimedOutRequestsCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.APP_REQUESTS_TIMED_OUT);
-    internal static Counter<long> CanceledRequestsCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.APP_REQUESTS_CANCELED);
+    private readonly Counter<long> _timedOutRequestsCounter;
+    private readonly Counter<long> _canceledRequestsCounter;
 
-    private static readonly long[] AppRequestsLatencyHistogramBuckets = new long[] { 1, 2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1_000, 1_500, 2_000, 5_000, 10_000, 15_000 };
-    private static readonly HistogramAggregator AppRequestsLatencyHistogramAggregator = new(AppRequestsLatencyHistogramBuckets, Array.Empty<KeyValuePair<string, object>>(), value => new ("duration", $"{value}ms"));
-    private static readonly ObservableCounter<long> AppRequestsLatencyHistogramBucket = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-bucket", AppRequestsLatencyHistogramAggregator.CollectBuckets);
-    private static readonly ObservableCounter<long> AppRequestsLatencyHistogramCount = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-count", AppRequestsLatencyHistogramAggregator.CollectCount);
-    private static readonly ObservableCounter<long> AppRequestsLatencyHistogramSum = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-sum", AppRequestsLatencyHistogramAggregator.CollectSum);
+    private static readonly long[] AppRequestsLatencyHistogramBuckets = [1, 2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1_000, 1_500, 2_000, 5_000, 10_000, 15_000];
+    private readonly HistogramAggregator _appRequestsLatencyHistogramAggregator = new(AppRequestsLatencyHistogramBuckets, [], value => new ("duration", $"{value}ms"));
+    private readonly ObservableCounter<long> _appRequestsLatencyHistogramBucket;
+    private readonly ObservableCounter<long> _appRequestsLatencyHistogramCount;
+    private readonly ObservableCounter<long> _appRequestsLatencyHistogramSum;
 
-
-    internal static void OnAppRequestsEnd(long durationMilliseconds)
+    internal ApplicationRequestInstruments(OrleansInstruments instruments)
     {
-        if (AppRequestsLatencyHistogramSum.Enabled)
-            AppRequestsLatencyHistogramAggregator.Record(durationMilliseconds);
+        _timedOutRequestsCounter = instruments.Meter.CreateCounter<long>(InstrumentNames.APP_REQUESTS_TIMED_OUT);
+        _canceledRequestsCounter = instruments.Meter.CreateCounter<long>(InstrumentNames.APP_REQUESTS_CANCELED);
+        _appRequestsLatencyHistogramAggregator = new(AppRequestsLatencyHistogramBuckets, [], value => new("duration", $"{value}ms"));
+        _appRequestsLatencyHistogramBucket = instruments.Meter.CreateObservableCounter(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-bucket", _appRequestsLatencyHistogramAggregator.CollectBuckets);
+        _appRequestsLatencyHistogramCount = instruments.Meter.CreateObservableCounter(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-count", _appRequestsLatencyHistogramAggregator.CollectCount);
+        _appRequestsLatencyHistogramSum = instruments.Meter.CreateObservableCounter(InstrumentNames.APP_REQUESTS_LATENCY_HISTOGRAM + "-sum", _appRequestsLatencyHistogramAggregator.CollectSum);
     }
 
-    internal static void OnAppRequestsTimedOut()
+    internal void OnAppRequestsEnd(long durationMilliseconds)
     {
-        TimedOutRequestsCounter.Add(1);
+        if (_appRequestsLatencyHistogramSum.Enabled)
+            _appRequestsLatencyHistogramAggregator.Record(durationMilliseconds);
     }
 
-    internal static void OnAppRequestsCanceled()
+    internal void OnAppRequestsTimedOut()
     {
-        CanceledRequestsCounter.Add(1);
+        _timedOutRequestsCounter.Add(1);
+    }
+
+    internal void OnAppRequestsCanceled()
+    {
+        _canceledRequestsCounter.Add(1);
     }
 }

--- a/src/Orleans.Core/Diagnostics/Metrics/OrleansInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/OrleansInstruments.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics.Metrics;
+
+namespace Orleans.Runtime;
+
+public class OrleansInstruments(IMeterFactory meterFactory)
+{
+    public Meter Meter { get; } = meterFactory.Create("Microsoft.Orleans");
+}

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -11,6 +11,7 @@ namespace Orleans.Runtime
     {
         private readonly SharedCallbackData shared;
         private readonly IResponseCompletionSource context;
+        private readonly ApplicationRequestInstruments _applicationRequestInstruments;
         private int completed;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
@@ -19,11 +20,13 @@ namespace Orleans.Runtime
         public CallbackData(
             SharedCallbackData shared,
             IResponseCompletionSource ctx,
-            Message msg)
+            Message msg,
+            ApplicationRequestInstruments applicationRequestInstruments)
         {
             this.shared = shared;
             this.context = ctx;
             this.Message = msg;
+            _applicationRequestInstruments = applicationRequestInstruments;
             this.stopwatch = ValueStopwatch.StartNew();
         }
 
@@ -92,8 +95,8 @@ namespace Orleans.Runtime
             stopwatch.Stop();
             SignalCancellation();
             shared.Unregister(Message);
-            ApplicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
-            ApplicationRequestInstruments.OnAppRequestsTimedOut();
+            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsTimedOut();
             OrleansCallBackDataEvent.Log.OnCanceled(Message);
             context.Complete(Response.FromException(new OperationCanceledException(_cancellationTokenRegistration.Token)));
             _cancellationTokenRegistration.Dispose();
@@ -114,8 +117,8 @@ namespace Orleans.Runtime
 
             this.shared.Unregister(this.Message);
             _cancellationTokenRegistration.Dispose();
-            ApplicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
-            ApplicationRequestInstruments.OnAppRequestsTimedOut();
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsTimedOut();
 
             OrleansCallBackDataEvent.Log.OnTimeout(this.Message);
 
@@ -139,7 +142,7 @@ namespace Orleans.Runtime
             this.stopwatch.Stop();
             this.shared.Unregister(this.Message);
             _cancellationTokenRegistration.Dispose();
-            ApplicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             OrleansCallBackDataEvent.Log.OnTargetSiloFail(this.Message);
             var msg = this.Message;
@@ -160,7 +163,7 @@ namespace Orleans.Runtime
 
             this.stopwatch.Stop();
             _cancellationTokenRegistration.Dispose();
-            ApplicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -32,6 +32,7 @@ namespace Orleans
 
         private readonly MessagingTrace messagingTrace;
         private readonly InterfaceToImplementationMappingCache _interfaceToImplementationMapping;
+        private readonly ApplicationRequestInstruments _applicationRequestInstruments;
         private IGrainCallCancellationManager _cancellationManager;
         private IClusterConnectionStatusObserver[] _statusObservers;
 
@@ -71,10 +72,12 @@ namespace Orleans
             MessagingTrace messagingTrace,
             IServiceProvider serviceProvider,
             TimeProvider timeProvider,
-            InterfaceToImplementationMappingCache interfaceToImplementationMapping)
+            InterfaceToImplementationMappingCache interfaceToImplementationMapping,
+            OrleansInstruments orleansInstruments)
         {
             TimeProvider = timeProvider;
             _interfaceToImplementationMapping = interfaceToImplementationMapping;
+            _applicationRequestInstruments = new(orleansInstruments);
             this.ServiceProvider = serviceProvider;
             _localClientDetails = localClientDetails;
             this.loggerFactory = loggerFactory;
@@ -281,7 +284,7 @@ namespace Orleans
 
             if (!oneWay)
             {
-                var callbackData = new CallbackData(this.sharedCallbackData, context, message);
+                var callbackData = new CallbackData(this.sharedCallbackData, context, message, _applicationRequestInstruments);
                 callbackData.SubscribeForCancellation(cancellationToken);
                 callbacks.TryAdd(message.Id, callbackData);
             }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -40,6 +40,7 @@ namespace Orleans.Runtime
         private MessageCenter messageCenter;
         private List<IIncomingGrainCallFilter> grainCallFilters;
         private readonly DeepCopier _deepCopier;
+        private readonly ApplicationRequestInstruments _applicationRequestInstruments;
         private IGrainCallCancellationManager _cancellationManager;
         private HostedClient hostedClient;
 
@@ -62,11 +63,13 @@ namespace Orleans.Runtime
             GrainInterfaceTypeToGrainTypeResolver interfaceToTypeResolver,
             DeepCopier deepCopier,
             TimeProvider timeProvider,
-            InterfaceToImplementationMappingCache interfaceToImplementationMapping)
+            InterfaceToImplementationMappingCache interfaceToImplementationMapping,
+            OrleansInstruments orleansInstruments)
         {
             TimeProvider = timeProvider;
             this.interfaceToImplementationMapping = interfaceToImplementationMapping;
             this._deepCopier = deepCopier;
+            this._applicationRequestInstruments = new(orleansInstruments);
             this.ServiceProvider = serviceProvider;
             this.MySilo = siloDetails.SiloAddress;
             this.callbacks = new ConcurrentDictionary<(GrainId, CorrelationId), CallbackData>();
@@ -172,7 +175,7 @@ namespace Orleans.Runtime
                 Debug.Assert(context is not null);
 
                 // Register a callback for the request.
-                var callbackData = new CallbackData(sharedData, context, message);
+                var callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
                 callbacks.TryAdd((message.SendingGrain, message.Id), callbackData);
                 callbackData.SubscribeForCancellation(cancellationToken);
             }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -65,6 +65,7 @@ namespace Orleans.Hosting
             services.AddLogging();
             services.AddOptions();
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+            services.AddSingleton<OrleansInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));


### PR DESCRIPTION
related to #9608

Converts static ApplicationRequestInstruments to instance-based implementation that receives OrleansInstruments through constructor injection.

Introduces OrleansInstruments as a new service that wraps meter creation functionality and registers it in both client and silo service containers.

Updates CallbackData constructors to accept ApplicationRequestInstruments parameter, enabling proper dependency injection throughout the request lifecycle.

Improves testability and follows dependency injection patterns consistently across the Orleans runtime.