### PR TITLE
Upgrade AWS SDK package versions for DynamoDB and SQS

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,8 +67,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <!-- 3rd party packages -->
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="1.0.0-beta13" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.300.6" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.300" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.2.2" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.14" />
     <PackageVersion Include="Consul" Version="1.7.14.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
     <PackageVersion Include="protobuf-net" Version="3.2.30" />


### PR DESCRIPTION
This PR upgrades the AWS SDK packages from v3 to the latest available v4 versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9659)