### PR TITLE
Modifying Endpoint to use Pascale Casing as EndPoint for consistency

### DIFF
--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -410,9 +410,9 @@ namespace Orleans.Messaging
 
         [LoggerMessage(
             Level = LogLevel.Information,
-            Message = "Closing connection to '{Endpoint}' because it has been marked as dead."
+            Message = "Closing connection to '{EndPoint}' because it has been marked as dead."
         )]
-        private static partial void LogClosingConnectionToDeadGateway(ILogger logger, SiloAddress endpoint);
+        private static partial void LogClosingConnectionToDeadGateway(ILogger logger, SiloAddress endPoint);
 
         [LoggerMessage(
             EventId = (int)ErrorCode.GatewayManager_AllGatewaysDead,


### PR DESCRIPTION
Modifying log column for endpoint to be more consistent in Pascal casing for endPoint logs in other files. 

We noticed after integrating with Orleans in our project we got some new columns in our log tables for Endpoint and EndPoint. 

I'm seeing more logs using EndPoint as a string so I'm changing this case to be more consistent.

Here is an example of EndPoint being used:
https://github.com/dotnet/orleans/blob/1aef90b6f337f955fd67b72fb585474cc7e239cc/src/Orleans.Core/Networking/ConnectionManager.cs#L405 