### PR TITLE
chore(3.x): switch to KubernetesClient.Classic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -77,10 +77,10 @@
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
 
     <!-- Microsoft packages -->
-    <MicrosoftBuildVersion>17.3.0</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>16.11.6</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>4.5.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
-    <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
+    <MicrosoftBclAsyncInterfacesVersion>7.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
 
@@ -131,8 +131,7 @@
     <NSubstituteAnalyzersCSharpVersion>1.0.14</NSubstituteAnalyzersCSharpVersion>
     <ZooKeeperNetExVersion>3.4.12.4</ZooKeeperNetExVersion>
     <StackExchangeRedis>2.2.88</StackExchangeRedis>
-    <Netstandard20KubernetesClientVersion>4.0.5</Netstandard20KubernetesClientVersion>
-    <KubernetesClientVersion>9.0.38</KubernetesClientVersion>
+    <KubernetesClientClassicVersion>10.0.16</KubernetesClientClassicVersion>
 
     <!-- Test related packages -->
     <FluentAssertionsVersion>6.2.0</FluentAssertionsVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "feature",
-    "version": "6.0.400"
+    "version": "8.0.414"
   }
 }

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClientExtensions.cs
@@ -1,9 +1,5 @@
 using k8s;
-#if NETSTANDARD2_0
-using Microsoft.Rest;
-#else
 using k8s.Autorest;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -215,19 +215,11 @@ namespace Orleans.Hosting.Kubernetes
                         break;
                     }
 
-#if NETSTANDARD2_0
-                    var pods = await _client.ListNamespacedPodWithHttpMessagesAsync(
-                        namespaceParameter: _podNamespace,
-                        labelSelector: _podLabelSelector,
-                        watch: true,
-                        cancellationToken: _shutdownToken.Token);
-#else
                     var pods = await _client.CoreV1.ListNamespacedPodWithHttpMessagesAsync(
                         namespaceParameter: _podNamespace,
                         labelSelector: _podLabelSelector,
                         watch: true,
                         cancellationToken: _shutdownToken.Token);
-#endif
 
                     await foreach (var (eventType, pod) in pods.WatchAsync<V1PodList, V1Pod>(_shutdownToken.Token))
                     {

--- a/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
+++ b/src/Orleans.Hosting.Kubernetes/Orleans.Hosting.Kubernetes.csproj
@@ -14,14 +14,8 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="KubernetesClient" Version="$(Netstandard20KubernetesClientVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+  <ItemGroup>
+    <PackageReference Include="KubernetesClient.Classic" Version="$(KubernetesClientClassicVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This is a possible way to address issue #9687 by switching from KubernetesClient to KubernetesClient.Classic.
The lowest version that includes all the required features of KubernetesClient.Classic was selected.

## Summary
This pull request updates the Kubernetes hosting integration by modernizing dependencies, removing legacy compatibility code, and updating the .NET SDK version. The changes simplify the codebase by dropping support for `netstandard2.0` and switching to the newer `KubernetesClient.Classic` package, which streamlines package management and code paths.

**Dependency and SDK updates:**

* Updated the .NET SDK version in `global.json` from `6.0.400` to `8.0.414`, ensuring the project uses a more recent .NET environment.
* Upgraded `Microsoft.Bcl.AsyncInterfaces` to version `7.0.0` and replaced the `KubernetesClient` package with `KubernetesClient.Classic` version `10.0.16` in `Directory.Build.props`. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL80-R83) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL134-R134)

**Package management simplification:**

* Removed conditional package references for `netstandard2.0` in `Orleans.Hosting.Kubernetes.csproj` and now always reference `KubernetesClient.Classic`, reducing complexity and potential for mismatched dependencies.

**Code cleanup and modernization:**

* Removed `#if NETSTANDARD2_0` preprocessor directives and related legacy code in `KubernetesClientExtensions.cs` and `KubernetesClusterAgent.cs`, unifying code paths for Kubernetes client usage. [[1]](diffhunk://#diff-691642f5ad2f84eb53f776b19a316edd4c3f0a745d787277911f0a36fca5d423L2-L6) [[2]](diffhunk://#diff-89a14514487131941d99481509b9c3692e91c9942587f06ec3f8538d95f657f6L218-L230)