### PR TITLE
Fix table creation logging to reflect existing tables correctly

### DIFF
--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -81,10 +81,10 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 TableServiceClient tableCreationClient = await GetCloudTableCreationClientAsync();
                 var table = tableCreationClient.GetTableClient(TableName);
-                var tableItem = await table.CreateIfNotExistsAsync();
-                var didCreate = tableItem is not null;
+                var response = await table.CreateIfNotExistsAsync();
+                var alreadyExisted = response.GetRawResponse().Status == (int)HttpStatusCode.Conflict;
 
-                LogInfoTableCreation(Logger, didCreate ? "Created" : "Attached to", TableName);
+                LogInfoTableCreation(Logger, alreadyExisted ? "Attached to" : "Created", TableName);
                 Table = table;
             }
             catch (TimeoutException te)


### PR DESCRIPTION
 The `CreateIfNotExistsAsync` method's response will have a 409-statuscode if the table already exists and will always return the `TableItem` if the call is successful.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9696)