### PR TITLE
Fix race condition in TransactionInfo.Fork PendingCalls increment

### DIFF
--- a/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Orleans.Serialization;
 using Orleans.Transactions.Abstractions;
 
@@ -70,7 +71,7 @@ namespace Orleans.Transactions
 
         public TransactionInfo Fork()
         {
-            PendingCalls++;
+            Interlocked.Increment(ref PendingCalls);
             return new TransactionInfo(this);
         }
 


### PR DESCRIPTION
## Environment
- .NET Orleans 9.2.1
- Local silo + client executed
- Repro repo: https://github.com/bknote71/OrleansTxInfoForkRaceConditionTest

## Background

<img width="1788" height="470" alt="스크린샷 2025-10-02 133349" src="https://github.com/user-attachments/assets/13f5ab7c-ed2f-436e-94c5-bc2bc5b8ff43" />

https://github.com/bknote71/OrleansTxInfoForkRaceConditionTest/blob/6fce8178d7f646d0ffcf06b49c5003b31bf41794/Client/Program.cs#L32

### Cause:
- `Task.Run` / `Parallel.ForEachAsync` flows ExecutionContext including `AsyncLocal<TransactionInfo>` in TransactionContext.
https://github.com/dotnet/orleans/blob/daeddff9cdb35df8686c8cedb0fc7f94c725141c/src/Orleans.Transactions/TransactionContext.cs#L7
- Multiple child tasks initially share the same TransactionInfo reference.
- Concurrent `Fork()` calls execute `PendingCalls++` without synchronization → race condition. 
https://github.com/dotnet/orleans/blob/daeddff9cdb35df8686c8cedb0fc7f94c725141c/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs#L73
- At reconcile, joined.Count can exceed PendingCalls, leading to errors.

## How
Make PendingCalls atomic to match joined’s thread safety.
```csharp
// before
PendingCalls++;

// after
Interlocked.Increment(ref PendingCalls);
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9702)