### PR TITLE
fix(streaming): recover cache misses from oldest data

### DIFF
--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -547,7 +547,6 @@ namespace Orleans.Streams
                         consumerData.SafeDisposeCursor(logger);
                         // start from the entry at the low token, which is the first entry we know is still in the cache.
                         var match = SequenceNumberEventIndexRegex().Match(exc.Low);
-                        var tokenParsed = long.TryParse(exc.Low, out var lowTokenLong);
                         var lowToken = match.Success ? new EventSequenceToken(long.Parse(match.Groups[1].Value), int.Parse(match.Groups[2].Value)) : null;
                         consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, lowToken);
                     }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -12,8 +12,8 @@ using Orleans.Runtime;
 using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
 using Orleans.Streaming;
-using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 using Orleans.Streams.Filtering;
+using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 using TagList = System.Diagnostics.TagList;
 
 namespace Orleans.Streams
@@ -554,6 +554,20 @@ namespace Orleans.Streams
             return queueCache!.GetCacheCursor(consumerData.StreamId, null);
         }
 
+        private IQueueCacheCursor GetCacheMissRecoveryCursor(StreamConsumerData consumerData)
+        {
+            try
+            {
+                return queueCache!.GetCacheCursorAtPosition(
+                    consumerData.StreamId,
+                    StreamSubscriptionStartPosition.EarliestAvailable);
+            }
+            catch (NotSupportedException)
+            {
+                return GetRecoveryCursor(consumerData);
+            }
+        }
+
         public Task RemoveSubscriber(GuidId subscriptionId, QualifiedStreamId streamId, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -1016,6 +1030,12 @@ namespace Orleans.Streams
                                 StreamingEvents.EmitConsumerCursorDrained(streamProviderName, consumerData.StreamId.StreamId, consumerData.SubscriptionId.Guid, Silo);
                             break;
                         }
+                    }
+                    catch (QueueCacheMissException exc)
+                    {
+                        exceptionOccured = exc;
+                        consumerData.SafeDisposeCursor(logger);
+                        consumerData.Cursor = GetCacheMissRecoveryCursor(consumerData);
                     }
                     catch (Exception exc)
                     {

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -584,6 +584,81 @@ namespace UnitTests.StreamingTests
             }
         }
 
+        private sealed class RecoverableCacheMissQueueCache(
+            QueueCacheMissException cacheMissException,
+            bool supportsEarliestAvailable) : IQueueCache
+        {
+            private TaskCompletionSource<StreamSequenceToken?> cursorRequested = CreateCursorRequestedSource();
+            private TaskCompletionSource<StreamSubscriptionStartPosition> startPositionRequested = CreateStartPositionRequestedSource();
+
+            public Task<StreamSequenceToken?> CursorRequested => cursorRequested.Task;
+            public Task<StreamSubscriptionStartPosition> StartPositionRequested => startPositionRequested.Task;
+
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null!;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+            {
+                cursorRequested.TrySetResult(token);
+                return Substitute.For<IQueueCacheCursor>();
+            }
+
+            public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+            {
+                startPositionRequested.TrySetResult(startPosition);
+                if (!supportsEarliestAvailable)
+                {
+                    throw new NotSupportedException();
+                }
+
+                return Substitute.For<IQueueCacheCursor>();
+            }
+
+            public bool IsUnderPressure() => false;
+
+            public IQueueCacheCursor CreateCacheMissCursor() => new CacheMissCursor(cacheMissException);
+
+            public void ResetRequests()
+            {
+                cursorRequested = CreateCursorRequestedSource();
+                startPositionRequested = CreateStartPositionRequestedSource();
+            }
+
+            private static TaskCompletionSource<StreamSequenceToken?> CreateCursorRequestedSource() =>
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private static TaskCompletionSource<StreamSubscriptionStartPosition> CreateStartPositionRequestedSource() =>
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private sealed class CacheMissCursor(QueueCacheMissException cacheMissException) : IQueueCacheCursor
+            {
+                public void Dispose()
+                {
+                }
+
+                public IBatchContainer GetCurrent(out Exception exception) => throw new InvalidOperationException();
+
+                public bool MoveNext() => throw cacheMissException;
+
+                public void Refresh(StreamSequenceToken token)
+                {
+                }
+
+                public void RecordDeliveryFailure()
+                {
+                }
+            }
+        }
+
         private sealed class PurgeablePooledQueueCache : IQueueCache
         {
             private readonly PooledQueueCache cache = new(new CacheDataAdapter(), NullLogger.Instance, null, null);
@@ -1624,6 +1699,86 @@ namespace UnitTests.StreamingTests
 
             Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
             Assert.Equal(newToken, Assert.Single(consumer.DeliveredTokens));
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact]
+        public async Task ReadFromQueue_ResumesFromEarliestAvailableAfterCacheMiss()
+        {
+            var requestedToken = new EventSequenceTokenV2(1, 2);
+            var newestToken = new EventSequenceTokenV2(20, 4);
+            var exception = new QueueCacheMissException("The cache entry was purged.");
+
+            var queueCache = await RunCacheMissRecovery(exception, requestedToken, newestToken, supportsEarliestAvailable: true);
+            var recoveryPosition = await queueCache.StartPositionRequested.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            Assert.Equal(StreamSubscriptionStartPosition.EarliestAvailable, recoveryPosition);
+            Assert.False(queueCache.CursorRequested.IsCompleted);
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact]
+        public async Task ReadFromQueue_UsesExistingRecoveryWhenCacheDoesNotSupportEarliestAvailable()
+        {
+            var requestedToken = new EventSequenceTokenV2(1, 2);
+            var newestToken = new EventSequenceTokenV2(20, 4);
+            var exception = new QueueCacheMissException("Cache miss from a custom queue cache");
+
+            var queueCache = await RunCacheMissRecovery(exception, requestedToken, newestToken, supportsEarliestAvailable: false);
+            var recoveryPosition = await queueCache.StartPositionRequested.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            var recoveryToken = await queueCache.CursorRequested.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            Assert.Equal(StreamSubscriptionStartPosition.EarliestAvailable, recoveryPosition);
+            Assert.Null(recoveryToken);
+        }
+
+        private static async Task<RecoverableCacheMissQueueCache> RunCacheMissRecovery(
+            QueueCacheMissException exception,
+            StreamSequenceToken requestedToken,
+            StreamSequenceToken newestToken,
+            bool supportsEarliestAvailable)
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var queueCache = new RecoverableCacheMissQueueCache(exception, supportsEarliestAvailable);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, newestToken)]));
+
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(qualifiedStreamId, requestedToken, DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                new RecordingConsumer(),
+                filterData: null,
+                now: DateTime.UtcNow);
+            consumerData.IsRegistered = true;
+            consumerData.Cursor = queueCache.CreateCacheMissCursor();
+            queueCache.ResetRequests();
+
+            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
+
+            return queueCache;
         }
 
         [TestSuite("BVT")]


### PR DESCRIPTION
My goal is to fix issues with a stream that doesn't produce data very often. The problem is that the last sent value is no longer in the cache. However, the old value not being in the cache isn't really important. But when a new value comes for a stream that value is lost because when a QueueCacheMissException occurs and the cursor is set to start at the newest message and therefore skips the message that was just added, but is actually in the cache.

See https://github.com/BMagerMT/OrleansStreamingIssue as an example that produces this problem.

The issue is this fix is not great as it is parsing the token from the exception. However, there doesn't seem to be a way to create a cursor that starts with the oldest entries.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9711)