### PR TITLE
refactor(streaming): add typed cache cursor results

### DIFF
--- a/docs/site/src/content/docs/streaming/subscription-start-positions.md
+++ b/docs/site/src/content/docs/streaming/subscription-start-positions.md
@@ -57,9 +57,9 @@ For Azure Event Hubs, `EarliestAvailable` keeps the partition receiver and its c
 
 ## Handle queue cache support
 
-The built-in pooled, simple, memory, generator, and Event Hubs queue caches support `EarliestAvailable`. A custom persistent-stream cache participates by implementing <xref:Orleans.Streams.IQueueCache.GetCacheCursorAtPosition*>.
+The built-in pooled, simple, memory, generator, and Event Hubs queue caches support `EarliestAvailable`. A custom persistent-stream cache participates by implementing <xref:Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition*> and returning a successful cursor result positioned inclusively at the oldest retained message for the stream.
 
-The default queue-cache interface behavior maps `Latest` to the existing tokenless cursor path and reports <xref:System.NotSupportedException> for `EarliestAvailable`. An explicit subscription which requests the unsupported position receives the error and is faulted. When `EarliestAvailable` is the provider default for an implicit subscription, Orleans reports the error to the consumer and keeps the implicit subscription live at its current position.
+The default queue-cache interface behavior maps `Latest` to tokenless acquisition through <xref:Orleans.Streams.IQueueCache.TryGetCacheCursor*> and returns <xref:Orleans.Streams.QueueCacheCursorResultKind.NotSupported> for `EarliestAvailable`. The pulling agent translates an unsupported position into <xref:System.NotSupportedException> at the subscription boundary. An explicit subscription which requests the unsupported position receives the error and is faulted. When `EarliestAvailable` is the provider default for an implicit subscription, Orleans reports the error to the consumer and keeps the implicit subscription live at its current position.
 
 A custom <xref:Orleans.Streams.IAsyncObservable`1> implementation receives equivalent extension-overload compatibility: `Latest` uses its tokenless subscription path, and `EarliestAvailable` reports <xref:System.NotSupportedException> until the observable implements Orleans start-position subscriptions.
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -251,15 +251,43 @@ namespace Orleans.Streaming.EventHubs
             return false;
         }
 
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
         {
             return new Cursor(this.cache!, streamId, token);
         }
 
-        public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        /// <inheritdoc />
+        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
         {
             return new Cursor(this.cache!, streamId, startPosition);
         }
+
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
+            StreamId streamId,
+            StreamSequenceToken? token)
+        {
+            return WrapCursorResult(this.cache!.TryGetCursor(streamId, token));
+        }
+
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            return WrapCursorResult(this.cache!.TryGetCursorAtPosition(streamId, startPosition));
+        }
+
+        private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
+            => result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new Cursor(this.cache!, result.Cursor!)),
+                QueueCacheCursorResultKind.CacheMiss => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(result.CacheMiss!.Value),
+                QueueCacheCursorResultKind.NotSupported => QueueCacheCursorResult<IQueueCacheCursor>.NotSupported,
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
 
         public bool IsUnderPressure()
         {
@@ -423,13 +451,23 @@ namespace Orleans.Streaming.EventHubs
             public Cursor(IEventHubQueueCache cache, StreamId streamId, StreamSequenceToken? token)
             {
                 this.cache = cache;
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
                 this.cursor = cache.GetCursor(streamId, token);
+#pragma warning restore CS0618
             }
 
             public Cursor(IEventHubQueueCache cache, StreamId streamId, StreamSubscriptionStartPosition startPosition)
             {
                 this.cache = cache;
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
                 this.cursor = cache.GetCursorAtPosition(streamId, startPosition);
+#pragma warning restore CS0618
+            }
+
+            public Cursor(IEventHubQueueCache cache, object cursor)
+            {
+                this.cache = cache;
+                this.cursor = cursor;
             }
 
             public void Dispose()
@@ -442,16 +480,26 @@ namespace Orleans.Streaming.EventHubs
                 return this.current;
             }
 
+            [Obsolete("Use MoveNextWithResult instead.")]
             public bool MoveNext()
             {
-                IBatchContainer? next;
-                if (!this.cache.TryGetNextMessage(this.cursor, out next))
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
+                if (!this.cache.TryGetNextMessage(this.cursor, out var next))
+#pragma warning restore CS0618
                 {
+                    this.current = null;
                     return false;
                 }
 
                 this.current = next;
                 return true;
+            }
+
+            public QueueCacheCursorMoveResult MoveNextWithResult()
+            {
+                var result = this.cache.TryGetNextMessageWithResult(this.cursor, out var next);
+                this.current = result.Kind == QueueCacheCursorMoveResultKind.Success ? next : null;
+                return result;
             }
 
             public void Refresh(StreamSequenceToken? token)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -257,15 +257,6 @@ namespace Orleans.Streaming.EventHubs
             return new Cursor(this.cache!, streamId, token);
         }
 
-        /// <inheritdoc />
-        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
-            return new Cursor(this.cache!, streamId, startPosition);
-        }
-
         QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
             StreamId streamId,
             StreamSequenceToken? token)
@@ -453,14 +444,6 @@ namespace Orleans.Streaming.EventHubs
                 this.cache = cache;
 #pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
                 this.cursor = cache.GetCursor(streamId, token);
-#pragma warning restore CS0618
-            }
-
-            public Cursor(IEventHubQueueCache cache, StreamId streamId, StreamSubscriptionStartPosition startPosition)
-            {
-                this.cache = cache;
-#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
-                this.cursor = cache.GetCursorAtPosition(streamId, startPosition);
 #pragma warning restore CS0618
             }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -136,14 +136,42 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="sequenceToken">The position from which to begin reading.</param>
         /// <returns>A cache cursor.</returns>
+        [Obsolete("Use TryGetCursor instead.")]
         public object GetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
         {
-            return cache.GetCursor(streamId, sequenceToken);
+            var result = cache.TryGetCursor(streamId, sequenceToken);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                _ => throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}."),
+            };
         }
 
-        object IEventHubQueueCache.GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        /// <inheritdoc />
+        public QueueCacheCursorResult<object> TryGetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
+            => cache.TryGetCursor(streamId, sequenceToken);
+
+        /// <inheritdoc />
+        public QueueCacheCursorResult<object> TryGetCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+            => cache.TryGetCursorAtPosition(streamId, startPosition);
+
+        [Obsolete("Use TryGetCursorAtPosition instead.")]
+        object IEventHubQueueCache.GetCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
         {
-            return cache.GetCursorAtPosition(streamId, startPosition);
+            var result = cache.TryGetCursorAtPosition(streamId, startPosition);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
+                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
         }
 
         /// <inheritdoc />
@@ -158,16 +186,42 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="cursorObj">The cache cursor.</param>
         /// <param name="message">The next message when one is available.</param>
         /// <returns><see langword="true"/> when a message was returned; otherwise, <see langword="false"/>.</returns>
+        [Obsolete("Use TryGetNextMessageWithResult instead.")]
         public bool TryGetNextMessage(object cursorObj, [NotNullWhen(true)] out IBatchContainer? message)
         {
-            if (!cache.TryGetNextMessage(cursorObj, out message))
-                return false;
+            var result = TryGetNextMessageWithResult(cursorObj, out message);
+            if (result.CacheMiss is { } cacheMiss)
+            {
+                throw cacheMiss.ToException();
+            }
+
+            return result.Kind switch
+            {
+                QueueCacheCursorMoveResultKind.Success => true,
+                QueueCacheCursorMoveResultKind.NoData => false,
+                _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+            };
+        }
+
+        /// <inheritdoc />
+        public QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out IBatchContainer? message)
+        {
+            var result = cache.TryGetNextMessageWithResult(cursorObj, out message);
+            if (result.Kind == QueueCacheCursorMoveResultKind.Success)
+            {
+                RecordCachePressure(message!);
+            }
+
+            return result;
+        }
+
+        private void RecordCachePressure(IBatchContainer message)
+        {
             double cachePressureContribution;
             cachePressureMonitor.RecordCachePressureContribution(
                 TryCalculateCachePressureContribution(message.SequenceToken, out cachePressureContribution)
                     ? cachePressureContribution
                     : 0.0);
-            return true;
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -158,22 +158,6 @@ namespace Orleans.Streaming.EventHubs
             StreamSubscriptionStartPosition startPosition)
             => cache.TryGetCursorAtPosition(streamId, startPosition);
 
-        [Obsolete("Use TryGetCursorAtPosition instead.")]
-        object IEventHubQueueCache.GetCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
-            var result = cache.TryGetCursorAtPosition(streamId, startPosition);
-            return result.Kind switch
-            {
-                QueueCacheCursorResultKind.Success => result.Cursor!,
-                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
-                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
-                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
-                _ => throw new InvalidOperationException("The cursor result is not initialized."),
-            };
-        }
-
         /// <inheritdoc />
         public void Refresh(object cursor, StreamSequenceToken? sequenceToken)
         {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -23,22 +23,56 @@ namespace Orleans.Streaming.EventHubs
         /// <summary>
         /// Get a cursor into the cache to read events from a stream.
         /// </summary>
-        /// <param name="streamId"></param>
-        /// <param name="sequenceToken"></param>
-        /// <returns></returns>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="sequenceToken">The position from which to begin reading.</param>
+        /// <returns>The acquired cache cursor.</returns>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested token is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use TryGetCursor instead.")]
         object GetCursor(StreamId streamId, StreamSequenceToken? sequenceToken);
 
         /// <summary>
-        /// Gets a cursor into the cache at the specified subscription start position.
+        /// Attempts to get a cursor into the cache to read events from a stream.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="sequenceToken">The position from which to begin reading.</param>
+        /// <returns>
+        /// A successful result containing the acquired cursor, or a cache-miss result containing the
+        /// unavailable position and current cache bounds.
+        /// </returns>
+        QueueCacheCursorResult<object> TryGetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
+        {
+            try
+            {
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy method.
+                return QueueCacheCursorResult<object>.FromCursor(GetCursor(streamId, sequenceToken));
+#pragma warning restore CS0618
+            }
+            catch (QueueCacheMissException exception)
+            {
+                return QueueCacheCursorResult<object>.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
+            }
+        }
+
+        /// <summary>
+        /// Attempts to get a cursor into the cache at the specified subscription start position.
         /// </summary>
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="startPosition">The initial subscription position.</param>
-        /// <returns>The cache cursor.</returns>
-        object GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        /// <returns>
+        /// A successful result containing the acquired cursor, a cache-miss result containing the unavailable
+        /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        QueueCacheCursorResult<object> TryGetCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
         {
             if (startPosition == StreamSubscriptionStartPosition.Latest)
             {
-                return GetCursor(streamId, null);
+                return TryGetCursor(streamId, null);
             }
 
             if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
@@ -46,8 +80,41 @@ namespace Orleans.Streaming.EventHubs
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
-            throw new NotSupportedException(
-                $"{GetType().FullName} does not support {StreamSubscriptionStartPosition.EarliestAvailable} cursor positioning.");
+            return QueueCacheCursorResult<object>.NotSupported;
+        }
+
+        /// <summary>
+        /// Gets a cursor into the cache at the specified subscription start position.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="startPosition">The initial subscription position.</param>
+        /// <returns>The cache cursor.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested position is older than the messages retained by the cache.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// The cache does not support <paramref name="startPosition"/>.
+        /// </exception>
+        [Obsolete("Use TryGetCursorAtPosition instead.")]
+        object GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        {
+            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            {
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
+                return GetCursor(streamId, null);
+#pragma warning restore CS0618
+            }
+
+            var result = TryGetCursorAtPosition(streamId, startPosition);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
+                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
         }
 
         /// <summary>
@@ -60,10 +127,41 @@ namespace Orleans.Streaming.EventHubs
         /// <summary>
         /// Try to get the next message in the cache for the provided cursor.
         /// </summary>
-        /// <param name="cursorObj"></param>
-        /// <param name="message"></param>
-        /// <returns></returns>
+        /// <param name="cursorObj">The cache cursor.</param>
+        /// <param name="message">The next message when one is available.</param>
+        /// <returns><see langword="true"/> when a message was returned; otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="QueueCacheMissException">
+        /// The cursor position is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use TryGetNextMessageWithResult instead.")]
         bool TryGetNextMessage(object cursorObj, [NotNullWhen(true)] out IBatchContainer? message);
+
+        /// <summary>
+        /// Attempts to get the next message in the cache for the provided cursor.
+        /// </summary>
+        /// <param name="cursorObj">The cache cursor.</param>
+        /// <param name="message">The next message when one is available.</param>
+        /// <returns>
+        /// A successful result with a non-null <paramref name="message"/>, <see cref="QueueCacheCursorMoveResultKind.NoData"/>
+        /// with a null message, or a cache-miss result with a null message.
+        /// </returns>
+        QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out IBatchContainer? message)
+        {
+            try
+            {
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy method.
+                return TryGetNextMessage(cursorObj, out message)
+                    ? QueueCacheCursorMoveResult.Success
+                    : QueueCacheCursorMoveResult.NoData;
+#pragma warning restore CS0618
+            }
+            catch (QueueCacheMissException exception)
+            {
+                message = null;
+                return QueueCacheCursorMoveResult.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
+            }
+        }
 
         /// <summary>
         /// Add cache pressure monitor to the cache's back pressure algorithm

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -65,22 +65,31 @@ namespace Orleans.Streaming.EventHubs
         /// A successful result containing the acquired cursor, a cache-miss result containing the unavailable
         /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
         /// </returns>
+        /// <remarks>
+        /// The default implementation adapts <see cref="GetCursorAtPosition"/> so that existing
+        /// providers retain their positioning behavior. Providers implementing this method directly
+        /// should also implement the obsolete positioning method for legacy callers.
+        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
         QueueCacheCursorResult<object> TryGetCursorAtPosition(
             StreamId streamId,
             StreamSubscriptionStartPosition startPosition)
         {
-            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            try
             {
-                return TryGetCursor(streamId, null);
+#pragma warning disable CS0618 // Preserve positioning implemented by existing providers.
+                return QueueCacheCursorResult<object>.FromCursor(GetCursorAtPosition(streamId, startPosition));
+#pragma warning restore CS0618
             }
-
-            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
+            catch (QueueCacheMissException exception)
             {
-                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+                return QueueCacheCursorResult<object>.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
             }
-
-            return QueueCacheCursorResult<object>.NotSupported;
+            catch (NotSupportedException)
+            {
+                return QueueCacheCursorResult<object>.NotSupported;
+            }
         }
 
         /// <summary>
@@ -106,15 +115,13 @@ namespace Orleans.Streaming.EventHubs
 #pragma warning restore CS0618
             }
 
-            var result = TryGetCursorAtPosition(streamId, startPosition);
-            return result.Kind switch
+            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
             {
-                QueueCacheCursorResultKind.Success => result.Cursor!,
-                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
-                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
-                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
-                _ => throw new InvalidOperationException("The cursor result is not initialized."),
-            };
+                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+            }
+
+            throw new NotSupportedException(
+                $"{GetType().FullName} does not support {startPosition} cursor positioning.");
         }
 
         /// <summary>
@@ -150,10 +157,14 @@ namespace Orleans.Streaming.EventHubs
             try
             {
 #pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy method.
-                return TryGetNextMessage(cursorObj, out message)
-                    ? QueueCacheCursorMoveResult.Success
-                    : QueueCacheCursorMoveResult.NoData;
+                if (TryGetNextMessage(cursorObj, out message))
+                {
+                    return QueueCacheCursorMoveResult.Success;
+                }
 #pragma warning restore CS0618
+
+                message = null;
+                return QueueCacheCursorMoveResult.NoData;
             }
             catch (QueueCacheMissException exception)
             {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -66,53 +66,18 @@ namespace Orleans.Streaming.EventHubs
         /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
         /// </returns>
         /// <remarks>
-        /// The default implementation adapts <see cref="GetCursorAtPosition"/> so that existing
-        /// providers retain their positioning behavior. Providers implementing this method directly
-        /// should also implement the obsolete positioning method for legacy callers.
+        /// The default implementation acquires the latest cursor using <see cref="TryGetCursor"/>
+        /// with a null token. Providers support earliest positioning by implementing this method
+        /// and returning a cursor positioned inclusively at the oldest retained message for the stream.
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
         QueueCacheCursorResult<object> TryGetCursorAtPosition(
             StreamId streamId,
             StreamSubscriptionStartPosition startPosition)
         {
-            try
-            {
-#pragma warning disable CS0618 // Preserve positioning implemented by existing providers.
-                return QueueCacheCursorResult<object>.FromCursor(GetCursorAtPosition(streamId, startPosition));
-#pragma warning restore CS0618
-            }
-            catch (QueueCacheMissException exception)
-            {
-                return QueueCacheCursorResult<object>.FromCacheMiss(
-                    new(exception.Requested, exception.Low, exception.High));
-            }
-            catch (NotSupportedException)
-            {
-                return QueueCacheCursorResult<object>.NotSupported;
-            }
-        }
-
-        /// <summary>
-        /// Gets a cursor into the cache at the specified subscription start position.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="startPosition">The initial subscription position.</param>
-        /// <returns>The cache cursor.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
-        /// <exception cref="QueueCacheMissException">
-        /// The requested position is older than the messages retained by the cache.
-        /// </exception>
-        /// <exception cref="NotSupportedException">
-        /// The cache does not support <paramref name="startPosition"/>.
-        /// </exception>
-        [Obsolete("Use TryGetCursorAtPosition instead.")]
-        object GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
-        {
             if (startPosition == StreamSubscriptionStartPosition.Latest)
             {
-#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
-                return GetCursor(streamId, null);
-#pragma warning restore CS0618
+                return TryGetCursor(streamId, null);
             }
 
             if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
@@ -120,8 +85,7 @@ namespace Orleans.Streaming.EventHubs
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
-            throw new NotSupportedException(
-                $"{GetType().FullName} does not support {startPosition} cursor positioning.");
+            return QueueCacheCursorResult<object>.NotSupported;
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -112,12 +112,71 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="streamId">stream identity</param>
         /// <param name="sequenceToken"></param>
-        /// <returns></returns>
+        /// <returns>The acquired cache cursor.</returns>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested token is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use TryGetCursor instead.")]
         public object GetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
         {
+            var result = TryGetCursor(streamId, sequenceToken);
+            if (result.CacheMiss is { } cacheMiss)
+            {
+                throw cacheMiss.ToException();
+            }
+
+            return result.Cursor!;
+        }
+
+        /// <summary>
+        /// Attempts to acquire a cursor at the provided sequence token.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="sequenceToken">The sequence token.</param>
+        /// <returns>
+        /// A successful result containing the acquired cursor, or a cache-miss result containing the
+        /// unavailable position and current cache bounds.
+        /// </returns>
+        public QueueCacheCursorResult<object> TryGetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
+        {
+            if (TryGetCacheMiss(streamId, sequenceToken, out var cacheMiss))
+            {
+                return QueueCacheCursorResult<object>.FromCacheMiss(cacheMiss);
+            }
+
             var cursor = new Cursor(streamId);
-            SetCursor(cursor, sequenceToken);
-            return cursor;
+            if (SetCursor(cursor, sequenceToken) is { } racedCacheMiss)
+            {
+                return QueueCacheCursorResult<object>.FromCacheMiss(racedCacheMiss);
+            }
+
+            return QueueCacheCursorResult<object>.FromCursor(cursor);
+        }
+
+        /// <summary>
+        /// Attempts to acquire a cursor at the specified subscription start position.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="startPosition">The initial subscription position.</param>
+        /// <returns>A successful result containing the acquired cursor.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        public QueueCacheCursorResult<object> TryGetCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            {
+                return TryGetCursor(streamId, null);
+            }
+
+            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+            }
+
+            var result = new Cursor(streamId);
+            SetCursorAtEarliestAvailable(result);
+            return QueueCacheCursorResult<object>.FromCursor(result);
         }
 
         /// <summary>
@@ -126,21 +185,25 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="startPosition">The initial subscription position.</param>
         /// <returns>The cache cursor.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested position is older than the messages retained by the cache.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// The cache does not support <paramref name="startPosition"/>.
+        /// </exception>
+        [Obsolete("Use TryGetCursorAtPosition instead.")]
         public object GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
         {
-            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            var result = TryGetCursorAtPosition(streamId, startPosition);
+            return result.Kind switch
             {
-                return GetCursor(streamId, null);
-            }
-
-            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
-            }
-
-            var cursor = new Cursor(streamId);
-            SetCursorAtEarliestAvailable(cursor);
-            return cursor;
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
+                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
         }
 
         /// <summary>
@@ -179,7 +242,10 @@ namespace Orleans.Providers.Streams.Common
             }
 
             cursor.State = CursorStates.Unset;
-            SetCursor(cursor, sequenceToken);
+            if (SetCursor(cursor, sequenceToken) is { } cacheMiss)
+            {
+                throw cacheMiss.ToException();
+            }
         }
 
         private void ReportCacheMessageStatistics()
@@ -227,14 +293,14 @@ namespace Orleans.Providers.Streams.Common
             this.periodicMetadaPurging.TryAction(now);
         }
 
-        private void SetCursor(Cursor cursor, StreamSequenceToken? sequenceToken)
+        private QueueCacheMissInfo? SetCursor(Cursor cursor, StreamSequenceToken? sequenceToken)
         {
             // If nothing in cache, unset token and wait for more data.
             if (IsEmpty)
             {
                 cursor.State = CursorStates.Unset;
                 cursor.SequenceToken = sequenceToken;
-                return;
+                return null;
             }
 
             LinkedListNode<CachedMessageBlock> newestBlock = messageBlocks.First!; // messageBlocks.Count != 0 (checked above).
@@ -246,7 +312,7 @@ namespace Orleans.Providers.Streams.Common
                 cursor.CurrentBlock = newestBlock;
                 cursor.Index = newestBlock.Value.NewestMessageIndex;
                 cursor.SequenceToken = newestBlock.Value.GetNewestSequenceToken(cacheDataAdapter);
-                return;
+                return null;
             }
 
             // If sequenceToken is too new to be in cache, unset token, and wait for more data.
@@ -255,7 +321,7 @@ namespace Orleans.Providers.Streams.Common
             {
                 cursor.State = CursorStates.Unset;
                 cursor.SequenceToken = sequenceToken;
-                return;
+                return null;
             }
 
             // Check to see if sequenceToken is too old to be in cache
@@ -271,13 +337,11 @@ namespace Orleans.Providers.Streams.Common
                     cursor.CurrentBlock = oldestBlock;
                     cursor.Index = oldestBlock.Value.OldestMessageIndex;
                     cursor.SequenceToken = oldestBlock.Value.GetOldestSequenceToken(cacheDataAdapter);
-                    return;
+                    return null;
                 }
                 else
                 {
-                    throw new QueueCacheMissException(sequenceToken,
-                        messageBlocks.Last!.Value.GetOldestSequenceToken(cacheDataAdapter), // messageBlocks.Count != 0 (checked above).
-                        messageBlocks.First!.Value.GetNewestSequenceToken(cacheDataAdapter)); // messageBlocks.Count != 0 (checked above).
+                    return CreateCacheMissInfo(sequenceToken);
                 }
             }
 
@@ -313,11 +377,44 @@ namespace Orleans.Providers.Streams.Common
                 else
                 {
                     cursor.State = CursorStates.Idle;
-                    return;
+                    return null;
                 }
             }
             cursor.SequenceToken = cursor.CurrentBlock!.Value.GetSequenceToken(cursor.Index, cacheDataAdapter); // CurrentBlock was set to a valid block above in every path that reaches this point.
             cursor.State = CursorStates.Set;
+            return null;
+        }
+
+        private bool TryGetCacheMiss(
+            StreamId streamId,
+            StreamSequenceToken? sequenceToken,
+            out QueueCacheMissInfo cacheMiss)
+        {
+            if (sequenceToken is null || IsEmpty)
+            {
+                cacheMiss = default;
+                return false;
+            }
+
+            var newestBlock = messageBlocks.First!;
+            var newestMessage = newestBlock.Value.NewestMessage;
+            if (newestMessage.Compare(sequenceToken) < 0)
+            {
+                cacheMiss = default;
+                return false;
+            }
+
+            var oldestMessage = messageBlocks.Last!.Value.OldestMessage;
+            if (oldestMessage.Compare(sequenceToken) <= 0
+                || lastPurgedToken.TryGetValue(streamId, out var entry)
+                    && sequenceToken.CompareTo(entry.Token) >= 0)
+            {
+                cacheMiss = default;
+                return false;
+            }
+
+            cacheMiss = CreateCacheMissInfo(sequenceToken);
+            return true;
         }
 
         private void SetCursorAtEarliestAvailable(Cursor cursor)
@@ -400,8 +497,36 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="cursorObj"></param>
         /// <param name="message"></param>
-        /// <returns></returns>
+        /// <returns><see langword="true"/> when a message was returned; otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="cursorObj"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="cursorObj"/> is not a cache cursor.</exception>
+        /// <exception cref="QueueCacheMissException">
+        /// The cursor position is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use TryGetNextMessageWithResult instead.")]
         public bool TryGetNextMessage(object cursorObj, [NotNullWhen(true)] out IBatchContainer? message)
+        {
+            var result = TryGetNextMessageWithResult(cursorObj, out message);
+            if (result.CacheMiss is { } cacheMiss)
+            {
+                throw cacheMiss.ToException();
+            }
+
+            return result.Kind == QueueCacheCursorMoveResultKind.Success;
+        }
+
+        /// <summary>
+        /// Attempts to acquire the next message in the cache at the provided cursor.
+        /// </summary>
+        /// <param name="cursorObj">The cache cursor.</param>
+        /// <param name="message">The next message when one is available.</param>
+        /// <returns>
+        /// A successful result with a non-null <paramref name="message"/>, <see cref="QueueCacheCursorMoveResultKind.NoData"/>
+        /// with a null message, or a cache-miss result with a null message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="cursorObj"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="cursorObj"/> is not a cache cursor.</exception>
+        public QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out IBatchContainer? message)
         {
             message = null;
 
@@ -438,15 +563,19 @@ namespace Orleans.Providers.Streams.Common
             if (cursor.State == CursorStates.EarliestAvailableWaiting
                 && !TrySetCursorAtFirstMatchingMessageAfterAnchor(cursor))
             {
-                return false;
+                return QueueCacheCursorMoveResult.NoData;
             }
 
             if (cursor.State is not CursorStates.Set and not CursorStates.EarliestAvailableSet)
             {
-                SetCursor(cursor, cursor.SequenceToken);
+                if (SetCursor(cursor, cursor.SequenceToken) is { } cacheMiss)
+                {
+                    return QueueCacheCursorMoveResult.FromCacheMiss(cacheMiss);
+                }
+
                 if (cursor.State != CursorStates.Set)
                 {
-                    return false;
+                    return QueueCacheCursorMoveResult.NoData;
                 }
             }
 
@@ -455,9 +584,7 @@ namespace Orleans.Providers.Streams.Common
             if (cursor.State == CursorStates.Set
                 && oldestMessage.Compare(cursor.SequenceToken!) > 0) // Cursor is Set, so SequenceToken is guaranteed non-null.
             {
-                throw new QueueCacheMissException(cursor.SequenceToken!, // Cursor is Set, so SequenceToken is guaranteed non-null.
-                    messageBlocks.Last!.Value.GetOldestSequenceToken(cacheDataAdapter), // Cursor is Set, so the cache is non-empty.
-                    messageBlocks.First!.Value.GetNewestSequenceToken(cacheDataAdapter)); // Cursor is Set, so the cache is non-empty.
+                return QueueCacheCursorMoveResult.FromCacheMiss(CreateCacheMissInfo(cursor.SequenceToken!));
             }
 
             // Iterate forward (in time) in the cache until we find a message on the stream or run out of cached messages.
@@ -508,12 +635,18 @@ namespace Orleans.Providers.Streams.Common
                     cursor.SequenceToken = cursor.IsEarliestAvailable
                         ? cacheDataAdapter.GetSequenceToken(ref currentMessage)
                         : cursor.CurrentBlock!.Value.GetSequenceToken(cursor.Index, cacheDataAdapter); // Non-null while cursor.State is Set.
-                    return true;
+                    return QueueCacheCursorMoveResult.Success;
                 }
             }
 
-            return false;
+            return QueueCacheCursorMoveResult.NoData;
         }
+
+        private QueueCacheMissInfo CreateCacheMissInfo(StreamSequenceToken requestedToken)
+            => new(
+                requestedToken,
+                messageBlocks.Last!.Value.GetOldestSequenceToken(cacheDataAdapter),
+                messageBlocks.First!.Value.GetNewestSequenceToken(cacheDataAdapter));
 
         /// <summary>
         /// Add a list of queue message to the cache 

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -180,33 +180,6 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Acquires a cursor at the specified subscription start position.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="startPosition">The initial subscription position.</param>
-        /// <returns>The cache cursor.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
-        /// <exception cref="QueueCacheMissException">
-        /// The requested position is older than the messages retained by the cache.
-        /// </exception>
-        /// <exception cref="NotSupportedException">
-        /// The cache does not support <paramref name="startPosition"/>.
-        /// </exception>
-        [Obsolete("Use TryGetCursorAtPosition instead.")]
-        public object GetCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
-        {
-            var result = TryGetCursorAtPosition(streamId, startPosition);
-            return result.Kind switch
-            {
-                QueueCacheCursorResultKind.Success => result.Cursor!,
-                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
-                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
-                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
-                _ => throw new InvalidOperationException("The cursor result is not initialized."),
-            };
-        }
-
-        /// <summary>
         /// Repositions an idle or unset cursor at the provided sequence token.
         /// </summary>
         /// <param name="cursorObj">The cursor to refresh.</param>

--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
@@ -239,11 +239,6 @@ namespace Orleans.Providers.Streams.Common
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
-            if (GetType() != typeof(SimpleQueueCache))
-            {
-                return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
-            }
-
             var cursor = new SimpleQueueCacheCursor(this, streamId, logger);
             InitializeCursorAtEarliestAvailable(cursor);
             return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(cursor);

--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
@@ -142,20 +142,96 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <inheritdoc />
+        /// <exception cref="QueueCacheMissException">
+        /// The requested token is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public virtual IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
         {
+            if (TryGetCacheMiss(token, out var cacheMiss))
+            {
+                throw cacheMiss.ToException();
+            }
+
             var cursor = new SimpleQueueCacheCursor(this, streamId, logger);
-            InitializeCursor(cursor, token);
+            if (InitializeCursor(cursor, token) is { } racedCacheMiss)
+            {
+                throw racedCacheMiss.ToException();
+            }
+
             return cursor;
         }
 
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
+            StreamId streamId,
+            StreamSequenceToken? token)
+        {
+            if (GetType() != typeof(SimpleQueueCache))
+            {
+                try
+                {
+#pragma warning disable CS0618 // Required for compatibility with derived caches which override the legacy method.
+                    return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursor(streamId, token));
+#pragma warning restore CS0618
+                }
+                catch (QueueCacheMissException exception)
+                {
+                    return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(
+                        new(exception.Requested, exception.Low, exception.High));
+                }
+            }
+
+            if (TryGetCacheMiss(token, out var cacheMiss))
+            {
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(cacheMiss);
+            }
+
+            var cursor = new SimpleQueueCacheCursor(this, streamId, logger);
+            if (InitializeCursor(cursor, token) is { } racedCacheMiss)
+            {
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(racedCacheMiss);
+            }
+
+            return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(cursor);
+        }
+
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
         {
             if (startPosition == StreamSubscriptionStartPosition.Latest)
             {
-                var latestCursor = GetCacheCursor(streamId, null);
-                latestCursor.MoveNext();
-                return latestCursor;
+                var result = ((IQueueCache)this).TryGetCacheCursor(streamId, null);
+                if (result.Kind != QueueCacheCursorResultKind.Success)
+                {
+                    return result;
+                }
+
+                var latestCursor = result.Cursor!;
+                var retainCursor = false;
+                try
+                {
+                    var moveResult = latestCursor.MoveNextWithResult();
+                    if (moveResult.CacheMiss is { } cacheMiss)
+                    {
+                        return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(cacheMiss);
+                    }
+
+                    if (moveResult.Kind is not QueueCacheCursorMoveResultKind.Success and not QueueCacheCursorMoveResultKind.NoData)
+                    {
+                        throw new InvalidOperationException("The cursor move result is not initialized.");
+                    }
+
+                    retainCursor = true;
+                    return result;
+                }
+                finally
+                {
+                    if (!retainCursor)
+                    {
+                        latestCursor.Dispose();
+                    }
+                }
             }
 
             if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
@@ -163,9 +239,53 @@ namespace Orleans.Providers.Streams.Common
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
+            if (GetType() != typeof(SimpleQueueCache))
+            {
+                return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
+            }
+
             var cursor = new SimpleQueueCacheCursor(this, streamId, logger);
             InitializeCursorAtEarliestAvailable(cursor);
-            return cursor;
+            return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(cursor);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            {
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
+                var cursor = GetCacheCursor(streamId, null);
+#pragma warning restore CS0618
+                var retainCursor = false;
+                try
+                {
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
+                    cursor.MoveNext();
+#pragma warning restore CS0618
+                    retainCursor = true;
+                    return cursor;
+                }
+                finally
+                {
+                    if (!retainCursor)
+                    {
+                        cursor.Dispose();
+                    }
+                }
+            }
+
+            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+            }
+
+            var earliestCursor = new SimpleQueueCacheCursor(this, streamId, logger);
+            InitializeCursorAtEarliestAvailable(earliestCursor);
+            return earliestCursor;
         }
 
         private void InitializeCursorAtEarliestAvailable(SimpleQueueCacheCursor cursor)
@@ -184,7 +304,7 @@ namespace Orleans.Providers.Streams.Common
             cursor.WaitingForEarliestAvailable = true;
         }
 
-        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken? sequenceToken)
+        internal QueueCacheMissInfo? InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken? sequenceToken)
         {
             LogDebugInitializeCursor(cursor, sequenceToken);
 
@@ -192,7 +312,7 @@ namespace Orleans.Providers.Streams.Common
             if (cachedMessages.Count == 0)
             {
                 UnsetCursor(cursor, sequenceToken);
-                return;
+                return null;
             }
 
             // if no token is provided, set token to item at end of cache
@@ -202,14 +322,14 @@ namespace Orleans.Providers.Streams.Common
             if (sequenceToken.Newer(cachedMessages.First!.Value.SequenceToken)) // cachedMessages.Count > 0 here (checked above), so First is guaranteed non-null.
             {
                 UnsetCursor(cursor, sequenceToken);
-                return;
+                return null;
             }
 
             LinkedListNode<SimpleQueueCacheItem> lastMessage = cachedMessages.Last!; // cachedMessages.Count > 0 here (checked above), so Last is guaranteed non-null.
             // Check to see if offset is too old to be in cache
             if (sequenceToken.Older(lastMessage.Value.SequenceToken))
             {
-                throw new QueueCacheMissException(sequenceToken, cachedMessages.Last!.Value.SequenceToken, cachedMessages.First.Value.SequenceToken);
+                return CreateCacheMissInfo(sequenceToken);
             }
 
             // Now the requested sequenceToken is set and is also within the limits of the cache.
@@ -232,6 +352,7 @@ namespace Orleans.Providers.Streams.Common
 
             // return cursor from start.
             SetCursor(cursor, node!); // Guaranteed non-null: node starts as First (non-null since Count > 0) and is only ever reassigned to node.Next after a non-null check.
+            return null;
         }
 
         internal void RefreshCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken? sequenceToken)
@@ -247,9 +368,30 @@ namespace Orleans.Providers.Streams.Common
                     return;
                 }
 
-                InitializeCursor(cursor, cursor.SequenceToken ?? sequenceToken);
+                var token = cursor.SequenceToken ?? sequenceToken;
+                if (InitializeCursor(cursor, token) is { } cacheMiss)
+                {
+                    throw cacheMiss.ToException();
+                }
             }
         }
+
+        private bool TryGetCacheMiss(StreamSequenceToken? sequenceToken, out QueueCacheMissInfo cacheMiss)
+        {
+            if (sequenceToken is null
+                || cachedMessages.Count == 0
+                || !sequenceToken.Older(cachedMessages.Last!.Value.SequenceToken))
+            {
+                cacheMiss = default;
+                return false;
+            }
+
+            cacheMiss = CreateCacheMissInfo(sequenceToken);
+            return true;
+        }
+
+        private QueueCacheMissInfo CreateCacheMissInfo(StreamSequenceToken requestedToken)
+            => new(requestedToken, cachedMessages.Last!.Value.SequenceToken, cachedMessages.First!.Value.SequenceToken);
 
         /// <summary>
         /// Acquires the next message in the cache at the provided cursor

--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
@@ -244,45 +244,6 @@ namespace Orleans.Providers.Streams.Common
             return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(cursor);
         }
 
-        /// <inheritdoc />
-        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
-            if (startPosition == StreamSubscriptionStartPosition.Latest)
-            {
-#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
-                var cursor = GetCacheCursor(streamId, null);
-#pragma warning restore CS0618
-                var retainCursor = false;
-                try
-                {
-#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
-                    cursor.MoveNext();
-#pragma warning restore CS0618
-                    retainCursor = true;
-                    return cursor;
-                }
-                finally
-                {
-                    if (!retainCursor)
-                    {
-                        cursor.Dispose();
-                    }
-                }
-            }
-
-            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
-            }
-
-            var earliestCursor = new SimpleQueueCacheCursor(this, streamId, logger);
-            InitializeCursorAtEarliestAvailable(earliestCursor);
-            return earliestCursor;
-        }
-
         private void InitializeCursorAtEarliestAvailable(SimpleQueueCacheCursor cursor)
         {
             for (var node = cachedMessages.Last; node is not null; node = node.Previous)

--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -73,6 +73,7 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <inheritdoc />
+        [Obsolete("Use MoveNextWithResult instead.")]
         public virtual bool MoveNext()
         {
             if (current == null && IsSet && IsInStream(Element!.Value.Batch)) // IsSet is true, so Element is non-null.
@@ -94,6 +95,22 @@ namespace Orleans.Providers.Streams.Common
 
             deliveryBatch?.Track(Element!);
             return true;
+        }
+
+        /// <inheritdoc />
+        public virtual QueueCacheCursorMoveResult MoveNextWithResult()
+        {
+            try
+            {
+#pragma warning disable CS0618 // Preserve virtual dispatch for derived cursors which override the legacy method.
+                return MoveNext() ? QueueCacheCursorMoveResult.Success : QueueCacheCursorMoveResult.NoData;
+#pragma warning restore CS0618
+            }
+            catch (QueueCacheMissException exception)
+            {
+                return QueueCacheCursorMoveResult.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
+            }
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -117,7 +117,7 @@ namespace Orleans.Providers.Streams.Generator
             public Cursor(PooledQueueCache cache, StreamId streamId, StreamSequenceToken? token)
             {
                 this.cache = cache;
-                cursor = cache.GetCursor(streamId, token);
+                cursor = GetCursorOrThrow(cache, streamId, token);
             }
 
             public Cursor(PooledQueueCache cache, object cursor)
@@ -136,16 +136,29 @@ namespace Orleans.Providers.Streams.Generator
                 return current;
             }
 
+            [Obsolete("Use MoveNextWithResult instead.")]
             public bool MoveNext()
             {
-                IBatchContainer? next;
-                if (!cache.TryGetNextMessage(cursor, out next))
+                var result = cache.TryGetNextMessageWithResult(cursor, out var next);
+                if (result.CacheMiss is { } cacheMiss)
                 {
-                    return false;
+                    throw cacheMiss.ToException();
                 }
 
-                current = next;
-                return true;
+                current = result.Kind == QueueCacheCursorMoveResultKind.Success ? next : null;
+                return result.Kind switch
+                {
+                    QueueCacheCursorMoveResultKind.Success => true,
+                    QueueCacheCursorMoveResultKind.NoData => false,
+                    _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+                };
+            }
+
+            public QueueCacheCursorMoveResult MoveNextWithResult()
+            {
+                var result = cache.TryGetNextMessageWithResult(cursor, out var next);
+                current = result.Kind == QueueCacheCursorMoveResultKind.Success ? next : null;
+                return result;
             }
 
             public void Refresh(StreamSequenceToken token)
@@ -155,6 +168,20 @@ namespace Orleans.Providers.Streams.Generator
 
             public void RecordDeliveryFailure()
             {
+            }
+
+            private static object GetCursorOrThrow(
+                PooledQueueCache cache,
+                StreamId streamId,
+                StreamSequenceToken? token)
+            {
+                var result = cache.TryGetCursor(streamId, token);
+                return result.Kind switch
+                {
+                    QueueCacheCursorResultKind.Success => result.Cursor!,
+                    QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                    _ => throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}."),
+                };
             }
         }
 
@@ -181,15 +208,34 @@ namespace Orleans.Providers.Streams.Generator
         }
 
         /// <inheritdoc />
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
         {
             return new Cursor(cache, streamId, token);
         }
 
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
+            StreamId streamId,
+            StreamSequenceToken? token)
         {
-            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
+            return WrapCursorResult(cache.TryGetCursor(streamId, token));
         }
+
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
+        }
+
+        private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
+            => result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new Cursor(cache, result.Cursor!)),
+                QueueCacheCursorResultKind.CacheMiss => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(result.CacheMiss!.Value),
+                QueueCacheCursorResultKind.NotSupported => QueueCacheCursorResult<IQueueCacheCursor>.NotSupported,
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
 
         /// <inheritdoc />
         public bool IsUnderPressure()

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -228,6 +228,17 @@ namespace Orleans.Providers.Streams.Generator
             return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
         }
 
+        /// <inheritdoc />
+        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+#pragma warning disable CS0618 // Translate the pooled cache result for legacy callers.
+            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
+#pragma warning restore CS0618
+        }
+
         private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
             => result.Kind switch
             {

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -228,17 +228,6 @@ namespace Orleans.Providers.Streams.Generator
             return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
         }
 
-        /// <inheritdoc />
-        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
-#pragma warning disable CS0618 // Translate the pooled cache result for legacy callers.
-            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
-#pragma warning restore CS0618
-        }
-
         private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
             => result.Kind switch
             {

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -108,7 +108,7 @@ namespace Orleans.Providers
                 StreamSequenceToken? token)
             {
                 this.cache = cache;
-                cursor = cache.GetCursor(streamId, token);
+                cursor = GetCursorOrThrow(cache, streamId, token);
             }
 
             public Cursor(PooledQueueCache cache, object cursor)
@@ -127,16 +127,29 @@ namespace Orleans.Providers
                 return current;
             }
 
+            [Obsolete("Use MoveNextWithResult instead.")]
             public bool MoveNext()
             {
-                IBatchContainer? next;
-                if (!cache.TryGetNextMessage(cursor, out next))
+                var result = cache.TryGetNextMessageWithResult(cursor, out var next);
+                if (result.CacheMiss is { } cacheMiss)
                 {
-                    return false;
+                    throw cacheMiss.ToException();
                 }
 
-                current = next;
-                return true;
+                current = result.Kind == QueueCacheCursorMoveResultKind.Success ? next : null;
+                return result.Kind switch
+                {
+                    QueueCacheCursorMoveResultKind.Success => true,
+                    QueueCacheCursorMoveResultKind.NoData => false,
+                    _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+                };
+            }
+
+            public QueueCacheCursorMoveResult MoveNextWithResult()
+            {
+                var result = cache.TryGetNextMessageWithResult(cursor, out var next);
+                current = result.Kind == QueueCacheCursorMoveResultKind.Success ? next : null;
+                return result;
             }
 
             public void Refresh(StreamSequenceToken token)
@@ -146,6 +159,20 @@ namespace Orleans.Providers
 
             public void RecordDeliveryFailure()
             {
+            }
+
+            private static object GetCursorOrThrow(
+                PooledQueueCache cache,
+                StreamId streamId,
+                StreamSequenceToken? token)
+            {
+                var result = cache.TryGetCursor(streamId, token);
+                return result.Kind switch
+                {
+                    QueueCacheCursorResultKind.Success => result.Cursor!,
+                    QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                    _ => throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}."),
+                };
             }
         }
 
@@ -176,15 +203,34 @@ namespace Orleans.Providers
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
         {
             return new Cursor(cache, streamId, token);
         }
 
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
+            StreamId streamId,
+            StreamSequenceToken? token)
         {
-            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
+            return WrapCursorResult(cache.TryGetCursor(streamId, token));
         }
+
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
+        }
+
+        private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
+            => result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new Cursor(cache, result.Cursor!)),
+                QueueCacheCursorResultKind.CacheMiss => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(result.CacheMiss!.Value),
+                QueueCacheCursorResultKind.NotSupported => QueueCacheCursorResult<IQueueCacheCursor>.NotSupported,
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
 
         /// <inheritdoc/>
         public bool IsUnderPressure()

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -223,6 +223,17 @@ namespace Orleans.Providers
             return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
         }
 
+        /// <inheritdoc />
+        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+#pragma warning disable CS0618 // Translate the pooled cache result for legacy callers.
+            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
+#pragma warning restore CS0618
+        }
+
         private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
             => result.Kind switch
             {

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -223,17 +223,6 @@ namespace Orleans.Providers
             return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
         }
 
-        /// <inheritdoc />
-        [Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
-#pragma warning disable CS0618 // Translate the pooled cache result for legacy callers.
-            return new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
-#pragma warning restore CS0618
-        }
-
         private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
             => result.Kind switch
             {

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -416,23 +416,28 @@ namespace Orleans.Streams
                         && effectiveHandshakeToken.Token is { } requestedToken)
                     {
                         consumerData.SafeDisposeCursor(logger);
-                        try
+                        if (effectiveHandshakeToken is DeliveryToken
+                            || effectiveHandshakeToken is StartToken
+                                && SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
                         {
-                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, requestedToken);
-                            if (effectiveHandshakeToken is DeliveryToken
-                                || effectiveHandshakeToken is StartToken
-                                    && SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
-                            {
-                                // Delivery tokens and implicit recovery tokens identify already processed events.
-                                consumerData.PendingBatch = AdvanceCursorPastToken(consumerData.Cursor, requestedToken);
-                            }
+                            // Delivery tokens and implicit recovery tokens identify already processed events.
+                            consumerData.Cursor = GetAdvancedCursorOrFallback(
+                                consumerData.StreamId,
+                                requestedToken,
+                                cacheToken,
+                                out consumerData.PendingBatch);
                         }
-                        catch (QueueCacheMissException) when (cacheToken is not null)
+                        else
                         {
-                            // A cold stream's triggering batch is the receiver's first available
-                            // message, so resume there if the consumer's prior token was evicted.
-                            consumerData.SafeDisposeCursor(logger);
-                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, cacheToken);
+                            var result = queueCache.TryGetCacheCursor(consumerData.StreamId, requestedToken);
+                            consumerData.Cursor = result.Kind switch
+                            {
+                                QueueCacheCursorResultKind.Success => result.Cursor!,
+                                QueueCacheCursorResultKind.CacheMiss when cacheToken is not null
+                                    => GetCacheCursorOrThrow(consumerData.StreamId, cacheToken),
+                                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                                _ => throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}."),
+                            };
                         }
                     }
                     else if (effectiveHandshakeToken is not null)
@@ -444,7 +449,7 @@ namespace Orleans.Streams
                     {
                         var registrationToken = cacheToken ?? consumerData.PendingStartToken;
                         if (consumerData.Cursor == null) // if the consumer did not ask for a specific token and we already have a cursor, just keep using it.
-                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, registrationToken);
+                            consumerData.Cursor = GetCacheCursorOrThrow(consumerData.StreamId, registrationToken);
                     }
                 }
                 catch (Exception exception)
@@ -466,7 +471,8 @@ namespace Orleans.Streams
                             || effectiveHandshakeToken is StartPositionToken
                                 && exceptionOccured is NotSupportedException);
                     var providerFallbackAllowed = providerDefaultRequest
-                        && SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid);
+                        && SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid)
+                        && exceptionOccured is NotSupportedException;
                     if (faultedSubscription
                         || effectiveHandshakeToken is StartPositionToken && !providerFallbackAllowed)
                     {
@@ -485,11 +491,11 @@ namespace Orleans.Streams
                 try
                 {
                     var registrationToken = cacheToken ?? consumerData.PendingStartToken;
-                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, registrationToken);
+                    consumerData.Cursor = GetCacheCursorOrThrow(consumerData.StreamId, registrationToken);
                 }
                 catch (Exception)
                 {
-                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, null); // just in case last GetCacheCursor failed.
+                    consumerData.Cursor = GetCacheCursorOrThrow(consumerData.StreamId, null);
                 }
             }
             return true;
@@ -502,10 +508,25 @@ namespace Orleans.Streams
                     || consumerData.LastToken is StartPositionToken startPositionToken
                         && startPositionToken.StartPosition == options.InitialSubscriptionStartPosition);
 
-        private static IBatchContainer? AdvanceCursorPastToken(IQueueCacheCursor cursor, StreamSequenceToken token)
+        private static QueueCacheCursorMoveResult AdvanceCursorPastToken(
+            IQueueCacheCursor cursor,
+            StreamSequenceToken token,
+            out IBatchContainer? pendingBatch)
         {
-            while (cursor.MoveNext())
+            pendingBatch = null;
+            while (true)
             {
+                var result = cursor.MoveNextWithResult();
+                if (result.Kind is QueueCacheCursorMoveResultKind.NoData or QueueCacheCursorMoveResultKind.CacheMiss)
+                {
+                    return result;
+                }
+
+                if (result.Kind != QueueCacheCursorMoveResultKind.Success)
+                {
+                    throw new QueueCacheCursorContractException("The cursor move result is not initialized.");
+                }
+
                 var batch = cursor.GetCurrent(out var exception);
                 if (exception is not null)
                 {
@@ -514,42 +535,62 @@ namespace Orleans.Streams
 
                 if (batch is null)
                 {
-                    throw new InvalidOperationException("A stream cursor returned no current batch after advancing.");
+                    throw new QueueCacheCursorContractException("A successful cursor move did not produce a current item.");
                 }
 
                 var comparison = batch.SequenceToken.CompareTo(token);
                 if (comparison >= 0)
                 {
-                    return comparison > 0 ? batch : null;
+                    pendingBatch = comparison > 0 ? batch : null;
+                    return result;
                 }
             }
-
-            return null;
         }
 
         private IQueueCacheCursor GetCacheCursorAtStartPosition(
             QualifiedStreamId streamId,
             StartPositionToken startPositionToken,
             StreamSequenceToken? latestBoundary)
-            => startPositionToken.StartPosition == StreamSubscriptionStartPosition.Latest
-                && latestBoundary is not null
-                    ? queueCache!.GetCacheCursor(streamId, latestBoundary)
-                    : queueCache!.GetCacheCursorAtPosition(streamId, startPositionToken.StartPosition);
+        {
+            if (startPositionToken.StartPosition == StreamSubscriptionStartPosition.Latest
+                && latestBoundary is not null)
+            {
+                return GetCacheCursorOrThrow(streamId, latestBoundary);
+            }
+
+            var result = queueCache!.TryGetCacheCursorAtPosition(streamId, startPositionToken.StartPosition);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
+                    $"{queueCache.GetType().FullName} does not support {startPositionToken.StartPosition} cursor positioning."),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
+        }
 
         private IQueueCacheCursor GetRecoveryCursor(StreamConsumerData consumerData)
         {
             if (consumerData.LastProcessedToken is { } lastProcessedToken)
             {
-                try
+                var result = queueCache!.TryGetCacheCursor(consumerData.StreamId, lastProcessedToken);
+                if (result.Kind == QueueCacheCursorResultKind.CacheMiss)
                 {
-                    var cursor = queueCache!.GetCacheCursor(consumerData.StreamId, lastProcessedToken);
-                    consumerData.PendingBatch = AdvanceCursorPastToken(cursor, lastProcessedToken);
-                    return cursor;
+                    return GetCacheCursorOrThrow(consumerData.StreamId, null);
                 }
-                catch (QueueCacheMissException)
+
+                if (result.Kind != QueueCacheCursorResultKind.Success)
                 {
-                    return queueCache!.GetCacheCursor(consumerData.StreamId, null);
+                    throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}.");
                 }
+
+                var cursor = result.Cursor!;
+                if (!TryAdvanceRecoveryCursor(cursor, lastProcessedToken, out consumerData.PendingBatch))
+                {
+                    return GetCacheCursorOrThrow(consumerData.StreamId, null);
+                }
+
+                return cursor;
             }
 
             if (consumerData.LastToken is StartPositionToken startPositionToken)
@@ -560,38 +601,136 @@ namespace Orleans.Streams
             if (consumerData.LastToken is StartToken or DeliveryToken
                 && consumerData.LastToken.Token is { } handshakeSequenceToken)
             {
-                try
+                var result = queueCache!.TryGetCacheCursor(consumerData.StreamId, handshakeSequenceToken);
+                if (result.Kind == QueueCacheCursorResultKind.CacheMiss)
                 {
-                    var cursor = queueCache!.GetCacheCursor(consumerData.StreamId, handshakeSequenceToken);
-                    if (consumerData.LastToken is DeliveryToken
-                        || SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
-                    {
-                        consumerData.PendingBatch = AdvanceCursorPastToken(cursor, handshakeSequenceToken);
-                    }
+                    return GetCacheCursorOrThrow(consumerData.StreamId, null);
+                }
 
-                    return cursor;
-                }
-                catch (QueueCacheMissException)
+                if (result.Kind != QueueCacheCursorResultKind.Success)
                 {
-                    return queueCache!.GetCacheCursor(consumerData.StreamId, null);
+                    throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}.");
                 }
+
+                var cursor = result.Cursor!;
+                if (consumerData.LastToken is DeliveryToken
+                    || SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
+                {
+                    if (!TryAdvanceRecoveryCursor(cursor, handshakeSequenceToken, out consumerData.PendingBatch))
+                    {
+                        return GetCacheCursorOrThrow(consumerData.StreamId, null);
+                    }
+                }
+
+                return cursor;
             }
 
-            return queueCache!.GetCacheCursor(consumerData.StreamId, null);
+            return GetCacheCursorOrThrow(consumerData.StreamId, null);
+        }
+
+        private IQueueCacheCursor GetCacheCursorOrThrow(StreamId streamId, StreamSequenceToken? token)
+        {
+            var result = queueCache!.TryGetCacheCursor(streamId, token);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                _ => throw new InvalidOperationException($"Unexpected cursor result: {result.Kind}."),
+            };
+        }
+
+        private IQueueCacheCursor GetAdvancedCursorOrFallback(
+            StreamId streamId,
+            StreamSequenceToken token,
+            StreamSequenceToken? fallbackToken,
+            out IBatchContainer? pendingBatch)
+        {
+            pendingBatch = null;
+            var acquisitionResult = queueCache!.TryGetCacheCursor(streamId, token);
+            if (acquisitionResult.Kind == QueueCacheCursorResultKind.CacheMiss)
+            {
+                return fallbackToken is not null
+                    ? GetCacheCursorOrThrow(streamId, fallbackToken)
+                    : throw acquisitionResult.CacheMiss!.Value.ToException();
+            }
+
+            if (acquisitionResult.Kind != QueueCacheCursorResultKind.Success)
+            {
+                throw new InvalidOperationException($"Unexpected cursor result: {acquisitionResult.Kind}.");
+            }
+
+            var cursor = acquisitionResult.Cursor!;
+            var retainCursor = false;
+            try
+            {
+                var moveResult = AdvanceCursorPastToken(cursor, token, out pendingBatch);
+                if (moveResult.Kind == QueueCacheCursorMoveResultKind.CacheMiss)
+                {
+                    return fallbackToken is not null
+                        ? GetCacheCursorOrThrow(streamId, fallbackToken)
+                        : throw moveResult.CacheMiss!.Value.ToException();
+                }
+
+                if (moveResult.Kind is not QueueCacheCursorMoveResultKind.Success and not QueueCacheCursorMoveResultKind.NoData)
+                {
+                    throw new InvalidOperationException("The cursor move result is not initialized.");
+                }
+
+                retainCursor = true;
+                return cursor;
+            }
+            finally
+            {
+                if (!retainCursor)
+                {
+                    cursor.Dispose();
+                }
+            }
+        }
+
+        private static bool TryAdvanceRecoveryCursor(
+            IQueueCacheCursor cursor,
+            StreamSequenceToken token,
+            out IBatchContainer? pendingBatch)
+        {
+            var retainCursor = false;
+            try
+            {
+                var result = AdvanceCursorPastToken(cursor, token, out pendingBatch);
+                if (result.Kind == QueueCacheCursorMoveResultKind.CacheMiss)
+                {
+                    return false;
+                }
+
+                if (result.Kind is not QueueCacheCursorMoveResultKind.Success and not QueueCacheCursorMoveResultKind.NoData)
+                {
+                    throw new InvalidOperationException($"Unexpected cursor move result: {result.Kind}.");
+                }
+
+                retainCursor = true;
+                return true;
+            }
+            finally
+            {
+                if (!retainCursor)
+                {
+                    cursor.Dispose();
+                }
+            }
         }
 
         private IQueueCacheCursor GetCacheMissRecoveryCursor(StreamConsumerData consumerData)
         {
-            try
+            var result = queueCache!.TryGetCacheCursorAtPosition(
+                consumerData.StreamId,
+                StreamSubscriptionStartPosition.EarliestAvailable);
+            return result.Kind switch
             {
-                return queueCache!.GetCacheCursorAtPosition(
-                    consumerData.StreamId,
-                    StreamSubscriptionStartPosition.EarliestAvailable);
-            }
-            catch (NotSupportedException)
-            {
-                return GetRecoveryCursor(consumerData);
-            }
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => GetRecoveryCursor(consumerData),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
         }
 
         public Task RemoveSubscriber(GuidId subscriptionId, QualifiedStreamId streamId, CancellationToken cancellationToken)
@@ -893,7 +1032,7 @@ namespace Orleans.Streams
             // That way we will not purge the event from the cache, until we talk to pub sub.
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer)
             // and later production.
-            var pinCursor = queueCache?.GetCacheCursor(streamId, firstToken);
+            var pinCursor = queueCache is null ? null : GetCacheCursorOrThrow(streamId, firstToken);
             streamData.RegistrationTask = RegisterStreamAsync();
             pubSubCache.Add(streamId, streamData);
 
@@ -1048,6 +1187,18 @@ namespace Orleans.Streams
                     try
                     {
                         nextBatch = GetBatchForConsumer(consumerData);
+                        if (nextBatch.CursorResult.Kind == QueueCacheCursorMoveResultKind.CacheMiss)
+                        {
+                            consumerData.SafeDisposeCursor(logger);
+                            consumerData.Cursor = GetCacheMissRecoveryCursor(consumerData);
+                            continue;
+                        }
+
+                        if (nextBatch.CursorResult.Kind == QueueCacheCursorMoveResultKind.Invalid)
+                        {
+                            throw new QueueCacheCursorContractException("The cursor move result is not initialized.");
+                        }
+
                         if (!nextBatch.HasProgress)
                         {
                             // Only emit cursor-drained when we transitioned from delivering to empty,
@@ -1057,11 +1208,10 @@ namespace Orleans.Streams
                             break;
                         }
                     }
-                    catch (QueueCacheMissException exc)
+                    catch (QueueCacheCursorContractException)
                     {
-                        exceptionOccured = exc;
                         consumerData.SafeDisposeCursor(logger);
-                        consumerData.Cursor = GetCacheMissRecoveryCursor(consumerData);
+                        throw;
                     }
                     catch (Exception exc)
                     {
@@ -1134,23 +1284,18 @@ namespace Orleans.Streams
                                     if (SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
                                     {
                                         consumerData.LastProcessedToken = sequenceToken;
-                                        try
-                                        {
-                                            newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, sequenceToken);
-                                            // An implicit recovery token identifies the last event processed by the prior activation.
-                                            pendingBatch = AdvanceCursorPastToken(newCursor, sequenceToken);
-                                        }
-                                        catch (QueueCacheMissException)
-                                        {
-                                            // The current batch is the receiver's first available message.
-                                            // Keep it pending when the prior activation's token was evicted.
-                                            newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, batch.SequenceToken);
-                                        }
+                                        // An implicit recovery token identifies the last event processed by the prior activation.
+                                        // The current batch is the receiver's first available message if that token was evicted.
+                                        newCursor = GetAdvancedCursorOrFallback(
+                                            consumerData.StreamId,
+                                            sequenceToken,
+                                            batch.SequenceToken,
+                                            out pendingBatch);
                                     }
                                     else
                                     {
                                         consumerData.LastProcessedToken = null;
-                                        newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, sequenceToken);
+                                        newCursor = GetCacheCursorOrThrow(consumerData.StreamId, sequenceToken);
                                     }
                                 }
                                 else if (newToken is DeliveryToken)
@@ -1158,18 +1303,13 @@ namespace Orleans.Streams
                                     var sequenceToken = newToken.Token
                                         ?? throw new InvalidOperationException("A delivery handshake token must contain a stream sequence token.");
                                     consumerData.LastProcessedToken = sequenceToken;
-                                    try
-                                    {
-                                        newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, sequenceToken); // queueCache must be non-null here: consumerData.Cursor was only ever populated via queueCache.GetCacheCursor.
-                                        // The handshake token points to an already processed event, so advance past it.
-                                        pendingBatch = AdvanceCursorPastToken(newCursor, sequenceToken);
-                                    }
-                                    catch (QueueCacheMissException)
-                                    {
-                                        // The current batch is the receiver's first available message.
-                                        // Keep it pending when the consumer resumes from an evicted token.
-                                        newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, batch.SequenceToken);
-                                    }
+                                    // The handshake token points to an already processed event, so advance past it.
+                                    // The current batch is the receiver's first available message if that token was evicted.
+                                    newCursor = GetAdvancedCursorOrFallback(
+                                        consumerData.StreamId,
+                                        sequenceToken,
+                                        batch.SequenceToken,
+                                        out pendingBatch);
                                 }
                                 else
                                 {
@@ -1241,10 +1381,14 @@ namespace Orleans.Streams
             {
                 Batch = batch;
                 ProgressToken = progressToken;
+                CursorResult = QueueCacheCursorMoveResult.Success;
             }
+
+            public ConsumerBatch(QueueCacheCursorMoveResult cursorResult) => CursorResult = cursorResult;
 
             public IBatchContainer? Batch { get; }
             public StreamSequenceToken? ProgressToken { get; }
+            public QueueCacheCursorMoveResult CursorResult { get; }
             public bool HasProgress => ProgressToken is not null;
         }
 
@@ -1263,13 +1407,21 @@ namespace Orleans.Streams
                 {
                     batchContainer = pendingBatch;
                 }
-                else if (cursor.MoveNext())
-                {
-                    batchContainer = cursor.GetCurrent(out _)!; // MoveNext returned true, so GetCurrent is guaranteed non-null here.
-                }
                 else
                 {
-                    return default;
+                    var result = cursor.MoveNextWithResult();
+                    if (result.Kind is QueueCacheCursorMoveResultKind.NoData or QueueCacheCursorMoveResultKind.CacheMiss)
+                    {
+                        return new ConsumerBatch(result);
+                    }
+
+                    if (result.Kind != QueueCacheCursorMoveResultKind.Success)
+                    {
+                        throw new QueueCacheCursorContractException("The cursor move result is not initialized.");
+                    }
+
+                    batchContainer = cursor.GetCurrent(out _)
+                        ?? throw new QueueCacheCursorContractException("A successful cursor move did not produce a current item.");
                 }
 
                 return ShouldDeliverBatch(streamId, batchContainer, filterData)
@@ -1294,12 +1446,24 @@ namespace Orleans.Streams
 
                 while (i < this.options.BatchContainerBatchSize)
                 {
-                    if (!cursor.MoveNext())
+                    var result = cursor.MoveNextWithResult();
+                    if (result.Kind == QueueCacheCursorMoveResultKind.CacheMiss)
+                    {
+                        return new ConsumerBatch(result);
+                    }
+
+                    if (result.Kind == QueueCacheCursorMoveResultKind.NoData)
                     {
                         break;
                     }
 
-                    var batchContainer = cursor.GetCurrent(out _)!; // MoveNext returned true, so GetCurrent is guaranteed non-null here.
+                    if (result.Kind != QueueCacheCursorMoveResultKind.Success)
+                    {
+                        throw new QueueCacheCursorContractException("The cursor move result is not initialized.");
+                    }
+
+                    var batchContainer = cursor.GetCurrent(out _)
+                        ?? throw new QueueCacheCursorContractException("A successful cursor move did not produce a current item.");
                     progressToken = batchContainer.SequenceToken;
 
                     if (!ShouldDeliverBatch(streamId, batchContainer, filterData))
@@ -1311,7 +1475,7 @@ namespace Orleans.Streams
 
                 if (progressToken is null)
                 {
-                    return default;
+                    return new ConsumerBatch(QueueCacheCursorMoveResult.NoData);
                 }
 
                 return i == 0
@@ -1321,6 +1485,8 @@ namespace Orleans.Streams
 
             return default;
         }
+
+        private sealed class QueueCacheCursorContractException(string message) : InvalidOperationException(message);
 
         private async Task<StreamHandshakeToken?> DeliverBatchToConsumer(
             StreamConsumerData consumerData,

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -30,22 +30,53 @@ namespace Orleans.Streams
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="token">The token.</param>
         /// <returns>The queue cache cursor.</returns>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested token is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use TryGetCacheCursor instead.")]
         IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token);
 
         /// <summary>
-        /// Acquires a stream message cursor at the specified subscription start position.
+        /// Attempts to acquire a stream message cursor at the location indicated by the provided token.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="token">The token.</param>
+        /// <returns>
+        /// A successful result containing the acquired cursor, or a cache-miss result containing the
+        /// unavailable position and current cache bounds.
+        /// </returns>
+        QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+        {
+            try
+            {
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy method.
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursor(streamId, token));
+#pragma warning restore CS0618
+            }
+            catch (QueueCacheMissException exception)
+            {
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
+            }
+        }
+
+        /// <summary>
+        /// Attempts to acquire a stream message cursor at the specified subscription start position.
         /// </summary>
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="startPosition">The initial subscription position.</param>
-        /// <returns>The queue cache cursor.</returns>
-        /// <exception cref="NotSupportedException">
-        /// Thrown when <paramref name="startPosition"/> is not supported by this cache.
-        /// </exception>
-        IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+        /// <returns>
+        /// A successful result containing the acquired cursor, a cache-miss result containing the unavailable
+        /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
         {
             if (startPosition == StreamSubscriptionStartPosition.Latest)
             {
-                return GetCacheCursor(streamId, null);
+                return TryGetCacheCursor(streamId, null);
             }
 
             if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
@@ -53,8 +84,43 @@ namespace Orleans.Streams
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
-            throw new NotSupportedException(
-                $"{GetType().FullName} does not support {StreamSubscriptionStartPosition.EarliestAvailable} cursor positioning.");
+            return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
+        }
+
+        /// <summary>
+        /// Acquires a stream message cursor at the specified subscription start position.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="startPosition">The initial subscription position.</param>
+        /// <returns>The queue cache cursor.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
+        /// <exception cref="QueueCacheMissException">
+        /// The requested position is older than the messages retained by the cache.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// The cache does not support <paramref name="startPosition"/>.
+        /// </exception>
+        [Obsolete("Use TryGetCacheCursorAtPosition instead.")]
+        IQueueCacheCursor GetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            {
+#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
+                return GetCacheCursor(streamId, null);
+#pragma warning restore CS0618
+            }
+
+            var result = TryGetCacheCursorAtPosition(streamId, startPosition);
+            return result.Kind switch
+            {
+                QueueCacheCursorResultKind.Success => result.Cursor!,
+                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
+                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
+                _ => throw new InvalidOperationException("The cursor result is not initialized."),
+            };
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -69,22 +69,31 @@ namespace Orleans.Streams
         /// A successful result containing the acquired cursor, a cache-miss result containing the unavailable
         /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
         /// </returns>
+        /// <remarks>
+        /// The default implementation adapts <see cref="GetCacheCursorAtPosition"/> so that existing
+        /// providers retain their positioning behavior. Providers implementing this method directly
+        /// should also implement the obsolete positioning method for legacy callers.
+        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
         QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
             StreamId streamId,
             StreamSubscriptionStartPosition startPosition)
         {
-            if (startPosition == StreamSubscriptionStartPosition.Latest)
+            try
             {
-                return TryGetCacheCursor(streamId, null);
+#pragma warning disable CS0618 // Preserve positioning implemented by existing providers.
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursorAtPosition(streamId, startPosition));
+#pragma warning restore CS0618
             }
-
-            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
+            catch (QueueCacheMissException exception)
             {
-                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
             }
-
-            return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
+            catch (NotSupportedException)
+            {
+                return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
+            }
         }
 
         /// <summary>
@@ -112,15 +121,13 @@ namespace Orleans.Streams
 #pragma warning restore CS0618
             }
 
-            var result = TryGetCacheCursorAtPosition(streamId, startPosition);
-            return result.Kind switch
+            if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
             {
-                QueueCacheCursorResultKind.Success => result.Cursor!,
-                QueueCacheCursorResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
-                QueueCacheCursorResultKind.NotSupported => throw new NotSupportedException(
-                    $"{GetType().FullName} does not support {startPosition} cursor positioning."),
-                _ => throw new InvalidOperationException("The cursor result is not initialized."),
-            };
+                throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
+            }
+
+            throw new NotSupportedException(
+                $"{GetType().FullName} does not support {startPosition} cursor positioning.");
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -70,55 +70,18 @@ namespace Orleans.Streams
         /// position and current cache bounds, or <see cref="QueueCacheCursorResultKind.NotSupported"/>.
         /// </returns>
         /// <remarks>
-        /// The default implementation adapts <see cref="GetCacheCursorAtPosition"/> so that existing
-        /// providers retain their positioning behavior. Providers implementing this method directly
-        /// should also implement the obsolete positioning method for legacy callers.
+        /// The default implementation acquires the latest cursor using <see cref="TryGetCacheCursor"/>
+        /// with a null token. Providers support earliest positioning by implementing this method
+        /// and returning a cursor positioned inclusively at the oldest retained message for the stream.
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
         QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
             StreamId streamId,
             StreamSubscriptionStartPosition startPosition)
         {
-            try
-            {
-#pragma warning disable CS0618 // Preserve positioning implemented by existing providers.
-                return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursorAtPosition(streamId, startPosition));
-#pragma warning restore CS0618
-            }
-            catch (QueueCacheMissException exception)
-            {
-                return QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(
-                    new(exception.Requested, exception.Low, exception.High));
-            }
-            catch (NotSupportedException)
-            {
-                return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
-            }
-        }
-
-        /// <summary>
-        /// Acquires a stream message cursor at the specified subscription start position.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="startPosition">The initial subscription position.</param>
-        /// <returns>The queue cache cursor.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="startPosition"/> is not defined.</exception>
-        /// <exception cref="QueueCacheMissException">
-        /// The requested position is older than the messages retained by the cache.
-        /// </exception>
-        /// <exception cref="NotSupportedException">
-        /// The cache does not support <paramref name="startPosition"/>.
-        /// </exception>
-        [Obsolete("Use TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor GetCacheCursorAtPosition(
-            StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
-        {
             if (startPosition == StreamSubscriptionStartPosition.Latest)
             {
-#pragma warning disable CS0618 // Preserve the exact legacy exception and cursor behavior.
-                return GetCacheCursor(streamId, null);
-#pragma warning restore CS0618
+                return TryGetCacheCursor(streamId, null);
             }
 
             if (startPosition != StreamSubscriptionStartPosition.EarliestAvailable)
@@ -126,8 +89,7 @@ namespace Orleans.Streams
                 throw new ArgumentOutOfRangeException(nameof(startPosition), startPosition, "The subscription start position is not defined.");
             }
 
-            throw new NotSupportedException(
-                $"{GetType().FullName} does not support {startPosition} cursor positioning.");
+            return QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCacheCursor.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCacheCursor.cs
@@ -25,7 +25,33 @@ namespace Orleans.Streams
         ///  stream.
         /// </summary>
         /// <returns><see langword="true"/> if there are more items, <see langword="false"/> otherwise</returns>
+        /// <exception cref="QueueCacheMissException">
+        /// The cursor position is older than the messages retained by the cache.
+        /// </exception>
+        [Obsolete("Use MoveNextWithResult instead.")]
         bool MoveNext();
+
+        /// <summary>
+        /// Attempts to move to the next message in the stream.
+        /// </summary>
+        /// <returns>
+        /// A successful result when the cursor has a current item, <see cref="QueueCacheCursorMoveResultKind.NoData"/>
+        /// when no item is available, or a cache-miss result containing the unavailable position and cache bounds.
+        /// </returns>
+        QueueCacheCursorMoveResult MoveNextWithResult()
+        {
+            try
+            {
+#pragma warning disable CS0618 // Required for compatibility with cursors which only implement the legacy method.
+                return MoveNext() ? QueueCacheCursorMoveResult.Success : QueueCacheCursorMoveResult.NoData;
+#pragma warning restore CS0618
+            }
+            catch (QueueCacheMissException exception)
+            {
+                return QueueCacheCursorMoveResult.FromCacheMiss(
+                    new(exception.Requested, exception.Low, exception.High));
+            }
+        }
 
         /// <summary>
         /// Refreshes the cache cursor. Called when new data is added into a cache.

--- a/src/Orleans.Streaming/QueueAdapters/QueueCacheCursorResult.cs
+++ b/src/Orleans.Streaming/QueueAdapters/QueueCacheCursorResult.cs
@@ -1,0 +1,244 @@
+using System;
+
+namespace Orleans.Streams;
+
+/// <summary>
+/// Describes the outcome of acquiring a queue cache cursor.
+/// </summary>
+public enum QueueCacheCursorResultKind
+{
+    /// <summary>
+    /// The result is not initialized.
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// A cursor was acquired.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The requested position is older than the messages retained by the cache.
+    /// </summary>
+    CacheMiss,
+
+    /// <summary>
+    /// The requested operation is not supported by the cache.
+    /// </summary>
+    NotSupported,
+}
+
+/// <summary>
+/// Describes the outcome of advancing a queue cache cursor.
+/// </summary>
+public enum QueueCacheCursorMoveResultKind
+{
+    /// <summary>
+    /// The result is not initialized.
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// The cursor advanced to a message.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// No message is currently available.
+    /// </summary>
+    NoData,
+
+    /// <summary>
+    /// The cursor position is older than the messages retained by the cache.
+    /// </summary>
+    CacheMiss,
+}
+
+/// <summary>
+/// Describes a queue cache miss.
+/// </summary>
+public readonly struct QueueCacheMissInfo
+{
+    private readonly object? _requested;
+    private readonly object? _low;
+    private readonly object? _high;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueueCacheMissInfo"/> struct.
+    /// </summary>
+    /// <param name="requested">The requested sequence token.</param>
+    /// <param name="low">The earliest available sequence token.</param>
+    /// <param name="high">The latest available sequence token.</param>
+    public QueueCacheMissInfo(StreamSequenceToken requested, StreamSequenceToken low, StreamSequenceToken high)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+        ArgumentNullException.ThrowIfNull(low);
+        ArgumentNullException.ThrowIfNull(high);
+        _requested = requested;
+        _low = low;
+        _high = high;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueueCacheMissInfo"/> struct.
+    /// </summary>
+    /// <param name="requested">The requested sequence token.</param>
+    /// <param name="low">The earliest available sequence token.</param>
+    /// <param name="high">The latest available sequence token.</param>
+    public QueueCacheMissInfo(string? requested, string? low, string? high)
+    {
+        _requested = requested;
+        _low = low;
+        _high = high;
+    }
+
+    /// <summary>
+    /// Gets the requested sequence token.
+    /// </summary>
+    public string? Requested => _requested?.ToString();
+
+    /// <summary>
+    /// Gets the earliest available sequence token.
+    /// </summary>
+    public string? Low => _low?.ToString();
+
+    /// <summary>
+    /// Gets the latest available sequence token.
+    /// </summary>
+    public string? High => _high?.ToString();
+
+    /// <summary>
+    /// Gets the requested sequence token when it is available.
+    /// </summary>
+    public StreamSequenceToken? RequestedToken => _requested as StreamSequenceToken;
+
+    /// <summary>
+    /// Gets the earliest available sequence token when it is available.
+    /// </summary>
+    public StreamSequenceToken? LowToken => _low as StreamSequenceToken;
+
+    /// <summary>
+    /// Gets the latest available sequence token when it is available.
+    /// </summary>
+    public StreamSequenceToken? HighToken => _high as StreamSequenceToken;
+
+    /// <summary>
+    /// Creates an exception representing this cache miss.
+    /// </summary>
+    /// <returns>A queue cache miss exception.</returns>
+    public QueueCacheMissException ToException() => new(Requested, Low, High);
+}
+
+/// <summary>
+/// Represents the result of acquiring a queue cache cursor.
+/// </summary>
+/// <typeparam name="TCursor">The cursor type.</typeparam>
+/// <remarks>
+/// A <see cref="QueueCacheCursorResultKind.Success"/> result contains a non-null <see cref="Cursor"/>.
+/// All other results contain no cursor. A <see cref="QueueCacheCursorResultKind.CacheMiss"/> result
+/// contains <see cref="CacheMiss"/> details, while other results contain no cache-miss details.
+/// </remarks>
+public readonly struct QueueCacheCursorResult<TCursor> where TCursor : class
+{
+    private readonly TCursor? _cursor;
+    private readonly QueueCacheMissInfo _cacheMiss;
+
+    private QueueCacheCursorResult(
+        QueueCacheCursorResultKind kind,
+        TCursor? cursor = null,
+        QueueCacheMissInfo cacheMiss = default)
+    {
+        Kind = kind;
+        _cursor = cursor;
+        _cacheMiss = cacheMiss;
+    }
+
+    /// <summary>
+    /// Gets the result kind.
+    /// </summary>
+    public QueueCacheCursorResultKind Kind { get; }
+
+    /// <summary>
+    /// Gets the acquired cursor when <see cref="Kind"/> is <see cref="QueueCacheCursorResultKind.Success"/>.
+    /// </summary>
+    public TCursor? Cursor => Kind == QueueCacheCursorResultKind.Success ? _cursor : null;
+
+    /// <summary>
+    /// Gets the cache miss details when <see cref="Kind"/> is <see cref="QueueCacheCursorResultKind.CacheMiss"/>.
+    /// </summary>
+    public QueueCacheMissInfo? CacheMiss => Kind == QueueCacheCursorResultKind.CacheMiss ? _cacheMiss : null;
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    /// <param name="cursor">The acquired cursor.</param>
+    /// <returns>A successful cursor result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="cursor"/> is <see langword="null"/>.</exception>
+    public static QueueCacheCursorResult<TCursor> FromCursor(TCursor cursor)
+    {
+        ArgumentNullException.ThrowIfNull(cursor);
+        return new(QueueCacheCursorResultKind.Success, cursor);
+    }
+
+    /// <summary>
+    /// Creates a cache miss result.
+    /// </summary>
+    /// <param name="cacheMiss">The cache miss details.</param>
+    /// <returns>A cache miss result.</returns>
+    public static QueueCacheCursorResult<TCursor> FromCacheMiss(QueueCacheMissInfo cacheMiss)
+        => new(QueueCacheCursorResultKind.CacheMiss, cacheMiss: cacheMiss);
+
+    /// <summary>
+    /// Gets a result which indicates that the operation is not supported.
+    /// </summary>
+    public static QueueCacheCursorResult<TCursor> NotSupported { get; } = new(QueueCacheCursorResultKind.NotSupported);
+}
+
+/// <summary>
+/// Represents the result of advancing a queue cache cursor.
+/// </summary>
+/// <remarks>
+/// A <see cref="QueueCacheCursorMoveResultKind.Success"/> result indicates that the cursor has a valid
+/// current item. All other results indicate that no current item was produced. A
+/// <see cref="QueueCacheCursorMoveResultKind.CacheMiss"/> result contains <see cref="CacheMiss"/> details.
+/// </remarks>
+public readonly struct QueueCacheCursorMoveResult
+{
+    private readonly QueueCacheMissInfo _cacheMiss;
+
+    private QueueCacheCursorMoveResult(
+        QueueCacheCursorMoveResultKind kind,
+        QueueCacheMissInfo cacheMiss = default)
+    {
+        Kind = kind;
+        _cacheMiss = cacheMiss;
+    }
+
+    /// <summary>
+    /// Gets the result kind.
+    /// </summary>
+    public QueueCacheCursorMoveResultKind Kind { get; }
+
+    /// <summary>
+    /// Gets the cache miss details when <see cref="Kind"/> is <see cref="QueueCacheCursorMoveResultKind.CacheMiss"/>.
+    /// </summary>
+    public QueueCacheMissInfo? CacheMiss => Kind == QueueCacheCursorMoveResultKind.CacheMiss ? _cacheMiss : null;
+
+    /// <summary>
+    /// Gets a successful cursor advancement result.
+    /// </summary>
+    public static QueueCacheCursorMoveResult Success { get; } = new(QueueCacheCursorMoveResultKind.Success);
+
+    /// <summary>
+    /// Gets a result which indicates that no message is currently available.
+    /// </summary>
+    public static QueueCacheCursorMoveResult NoData { get; } = new(QueueCacheCursorMoveResultKind.NoData);
+
+    /// <summary>
+    /// Creates a cache miss result.
+    /// </summary>
+    /// <param name="cacheMiss">The cache miss details.</param>
+    /// <returns>A cache miss result.</returns>
+    public static QueueCacheCursorMoveResult FromCacheMiss(QueueCacheMissInfo cacheMiss)
+        => new(QueueCacheCursorMoveResultKind.CacheMiss, cacheMiss);
+}

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -482,17 +482,26 @@ namespace Orleans.Streaming.EventHubs
 
         public void Dispose() { }
 
+        [System.Obsolete("Use TryGetCursor instead.")]
         public object GetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken) { throw null; }
 
         public int GetMaxAddCount() { throw null; }
 
+        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
         object IEventHubQueueCache.GetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         public void Refresh(object cursor, Streams.StreamSequenceToken? sequenceToken) { }
 
         public void SignalPurge() { }
 
+        public Streams.QueueCacheCursorResult<object> TryGetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken) { throw null; }
+
+        public Streams.QueueCacheCursorResult<object> TryGetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+
+        [System.Obsolete("Use TryGetNextMessageWithResult instead.")]
         public bool TryGetNextMessage(object cursorObj, out Streams.IBatchContainer? message) { throw null; }
+
+        public Streams.QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out Streams.IBatchContainer? message) { throw null; }
     }
 
     public partial class EventHubQueueCacheFactory : IEventHubQueueCacheFactory
@@ -571,11 +580,17 @@ namespace Orleans.Streaming.EventHubs
     {
         System.Collections.Generic.List<Streams.StreamPosition> Add(System.Collections.Generic.List<Azure.Messaging.EventHubs.EventData> message, System.DateTime dequeueTimeUtc);
         void AddCachePressureMonitor(ICachePressureMonitor monitor);
+        [System.Obsolete("Use TryGetCursor instead.")]
         object GetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken);
+        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
         object GetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition);
         void Refresh(object cursor, Streams.StreamSequenceToken? sequenceToken);
         void SignalPurge();
+        Streams.QueueCacheCursorResult<object> TryGetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken);
+        Streams.QueueCacheCursorResult<object> TryGetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition);
+        [System.Obsolete("Use TryGetNextMessageWithResult instead.")]
         bool TryGetNextMessage(object cursorObj, out Streams.IBatchContainer? message);
+        Streams.QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out Streams.IBatchContainer? message);
     }
 
     public partial interface IEventHubQueueCacheFactory

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -487,9 +487,6 @@ namespace Orleans.Streaming.EventHubs
 
         public int GetMaxAddCount() { throw null; }
 
-        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
-        object IEventHubQueueCache.GetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
-
         public void Refresh(object cursor, Streams.StreamSequenceToken? sequenceToken) { }
 
         public void SignalPurge() { }
@@ -582,8 +579,6 @@ namespace Orleans.Streaming.EventHubs
         void AddCachePressureMonitor(ICachePressureMonitor monitor);
         [System.Obsolete("Use TryGetCursor instead.")]
         object GetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken);
-        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
-        object GetCursorAtPosition(Runtime.StreamId streamId, Streams.StreamSubscriptionStartPosition startPosition);
         void Refresh(object cursor, Streams.StreamSequenceToken? sequenceToken);
         void SignalPurge();
         Streams.QueueCacheCursorResult<object> TryGetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken? sequenceToken);

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -465,6 +465,9 @@ namespace Orleans.Providers
 
         public bool IsUnderPressure() { throw null; }
 
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
@@ -1050,6 +1053,9 @@ namespace Orleans.Providers.Streams.Generator
         public Orleans.Streams.StreamSequenceToken GetSequenceToken(ref Common.CachedMessage cachedMessage) { throw null; }
 
         public bool IsUnderPressure() { throw null; }
+
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
+        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -456,6 +456,7 @@ namespace Orleans.Providers
 
         public Orleans.Streams.IBatchContainer GetBatchContainer(ref Streams.Common.CachedMessage cachedMessage) { throw null; }
 
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public Orleans.Streams.IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
         public int GetMaxAddCount() { throw null; }
@@ -464,7 +465,9 @@ namespace Orleans.Providers
 
         public bool IsUnderPressure() { throw null; }
 
-        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
+
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         public bool TryPurgeFromCache(out System.Collections.Generic.IList<Orleans.Streams.IBatchContainer> purgedItems) { throw null; }
     }
@@ -836,15 +839,24 @@ namespace Orleans.Providers.Streams.Common
 
         public void Add(System.Collections.Generic.List<CachedMessage> messages, System.DateTime dequeueTime) { }
 
+        [System.Obsolete("Use TryGetCursor instead.")]
         public object GetCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? sequenceToken) { throw null; }
 
+        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
         public object GetCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         public void Refresh(object cursorObj, Orleans.Streams.StreamSequenceToken? sequenceToken) { }
 
         public void RemoveOldestMessage() { }
 
+        public Orleans.Streams.QueueCacheCursorResult<object> TryGetCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? sequenceToken) { throw null; }
+
+        public Orleans.Streams.QueueCacheCursorResult<object> TryGetCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+
+        [System.Obsolete("Use TryGetNextMessageWithResult instead.")]
         public bool TryGetNextMessage(object cursorObj, out Orleans.Streams.IBatchContainer? message) { throw null; }
+
+        public Orleans.Streams.QueueCacheCursorMoveResult TryGetNextMessageWithResult(object cursorObj, out Orleans.Streams.IBatchContainer? message) { throw null; }
     }
 
     public abstract partial class PooledResource<T> : System.IDisposable where T : PooledResource<T>, System.IDisposable
@@ -898,13 +910,19 @@ namespace Orleans.Providers.Streams.Common
 
         public virtual void AddToCache(System.Collections.Generic.IList<Orleans.Streams.IBatchContainer> msgs) { }
 
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public virtual Orleans.Streams.IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
         public int GetMaxAddCount() { throw null; }
 
         public virtual bool IsUnderPressure() { throw null; }
 
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
         Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
+
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         public virtual bool TryPurgeFromCache(out System.Collections.Generic.IList<Orleans.Streams.IBatchContainer> purgedItems) { throw null; }
     }
@@ -919,7 +937,10 @@ namespace Orleans.Providers.Streams.Common
 
         public virtual Orleans.Streams.IBatchContainer? GetCurrent(out System.Exception? exception) { throw null; }
 
+        [System.Obsolete("Use MoveNextWithResult instead.")]
         public virtual bool MoveNext() { throw null; }
+
+        public virtual Orleans.Streams.QueueCacheCursorMoveResult MoveNextWithResult() { throw null; }
 
         public void RecordDeliveryFailure() { }
 
@@ -1021,6 +1042,7 @@ namespace Orleans.Providers.Streams.Generator
 
         public Orleans.Streams.IBatchContainer GetBatchContainer(ref Common.CachedMessage cachedMessage) { throw null; }
 
+        [System.Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
         public Orleans.Streams.IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
         public int GetMaxAddCount() { throw null; }
@@ -1029,7 +1051,9 @@ namespace Orleans.Providers.Streams.Generator
 
         public bool IsUnderPressure() { throw null; }
 
-        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
+
+        Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         public bool TryPurgeFromCache(out System.Collections.Generic.IList<Orleans.Streams.IBatchContainer> purgedItems) { throw null; }
     }
@@ -1202,6 +1226,7 @@ namespace Orleans.Streaming.Diagnostics
             public readonly Runtime.StreamId StreamId;
             public readonly System.Guid SubscriptionId;
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
+
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, string clusterId, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
         }
 
@@ -1671,9 +1696,13 @@ namespace Orleans.Streams
     public partial interface IQueueCache : IQueueFlowController
     {
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
+        [System.Obsolete("Use TryGetCacheCursor instead.")]
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken? token);
+        [System.Obsolete("Use TryGetCacheCursorAtPosition instead.")]
         IQueueCacheCursor GetCacheCursorAtPosition(Runtime.StreamId streamId, StreamSubscriptionStartPosition startPosition);
         bool IsUnderPressure();
+        QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken? token);
+        QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(Runtime.StreamId streamId, StreamSubscriptionStartPosition startPosition);
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
         void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, System.DateTime utcNow);
     }
@@ -1681,7 +1710,9 @@ namespace Orleans.Streams
     public partial interface IQueueCacheCursor : System.IDisposable
     {
         IBatchContainer? GetCurrent(out System.Exception? exception);
+        [System.Obsolete("Use MoveNextWithResult instead.")]
         bool MoveNext();
+        QueueCacheCursorMoveResult MoveNextWithResult();
         void RecordDeliveryFailure();
         void Refresh(StreamSequenceToken token);
     }
@@ -1959,6 +1990,55 @@ namespace Orleans.Streams
         public bool UnSubscribeFromQueueDistributionChangeEvents(IStreamQueueBalanceListener observer) { throw null; }
     }
 
+    public readonly partial struct QueueCacheCursorMoveResult
+    {
+        private readonly int _dummyPrimitive;
+        public QueueCacheMissInfo? CacheMiss { get { throw null; } }
+
+        public QueueCacheCursorMoveResultKind Kind { get { throw null; } }
+
+        public static QueueCacheCursorMoveResult NoData { get { throw null; } }
+
+        public static QueueCacheCursorMoveResult Success { get { throw null; } }
+
+        public static QueueCacheCursorMoveResult FromCacheMiss(QueueCacheMissInfo cacheMiss) { throw null; }
+    }
+
+    public enum QueueCacheCursorMoveResultKind
+    {
+        Invalid = 0,
+        Success = 1,
+        NoData = 2,
+        CacheMiss = 3
+    }
+
+    public enum QueueCacheCursorResultKind
+    {
+        Invalid = 0,
+        Success = 1,
+        CacheMiss = 2,
+        NotSupported = 3
+    }
+
+    public readonly partial struct QueueCacheCursorResult<TCursor>
+        where TCursor : class
+    {
+        private readonly TCursor? _cursor;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public QueueCacheMissInfo? CacheMiss { get { throw null; } }
+
+        public TCursor? Cursor { get { throw null; } }
+
+        public QueueCacheCursorResultKind Kind { get { throw null; } }
+
+        public static QueueCacheCursorResult<TCursor> NotSupported { get { throw null; } }
+
+        public static QueueCacheCursorResult<TCursor> FromCacheMiss(QueueCacheMissInfo cacheMiss) { throw null; }
+
+        public static QueueCacheCursorResult<TCursor> FromCursor(TCursor cursor) { throw null; }
+    }
+
     [GenerateSerializer]
     public sealed partial class QueueCacheMissException : DataNotAvailableException
     {
@@ -1983,6 +2063,29 @@ namespace Orleans.Streams
 
         [System.Obsolete]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public readonly partial struct QueueCacheMissInfo
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public QueueCacheMissInfo(StreamSequenceToken requested, StreamSequenceToken low, StreamSequenceToken high) { }
+
+        public QueueCacheMissInfo(string? requested, string? low, string? high) { }
+
+        public string? High { get { throw null; } }
+
+        public StreamSequenceToken? HighToken { get { throw null; } }
+
+        public string? Low { get { throw null; } }
+
+        public StreamSequenceToken? LowToken { get { throw null; } }
+
+        public string? Requested { get { throw null; } }
+
+        public StreamSequenceToken? RequestedToken { get { throw null; } }
+
+        public readonly QueueCacheMissException ToException() { throw null; }
     }
 
     [Immutable]

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -465,9 +465,6 @@ namespace Orleans.Providers
 
         public bool IsUnderPressure() { throw null; }
 
-        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
-
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
@@ -845,9 +842,6 @@ namespace Orleans.Providers.Streams.Common
         [System.Obsolete("Use TryGetCursor instead.")]
         public object GetCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? sequenceToken) { throw null; }
 
-        [System.Obsolete("Use TryGetCursorAtPosition instead.")]
-        public object GetCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
-
         public void Refresh(object cursorObj, Orleans.Streams.StreamSequenceToken? sequenceToken) { }
 
         public void RemoveOldestMessage() { }
@@ -919,9 +913,6 @@ namespace Orleans.Providers.Streams.Common
         public int GetMaxAddCount() { throw null; }
 
         public virtual bool IsUnderPressure() { throw null; }
-
-        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
@@ -1053,9 +1044,6 @@ namespace Orleans.Providers.Streams.Generator
         public Orleans.Streams.StreamSequenceToken GetSequenceToken(ref Common.CachedMessage cachedMessage) { throw null; }
 
         public bool IsUnderPressure() { throw null; }
-
-        [System.Obsolete("Use IQueueCache.TryGetCacheCursorAtPosition instead.")]
-        Orleans.Streams.IQueueCacheCursor Orleans.Streams.IQueueCache.GetCacheCursorAtPosition(Runtime.StreamId streamId, Orleans.Streams.StreamSubscriptionStartPosition startPosition) { throw null; }
 
         Orleans.Streams.QueueCacheCursorResult<Orleans.Streams.IQueueCacheCursor> Orleans.Streams.IQueueCache.TryGetCacheCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken? token) { throw null; }
 
@@ -1704,8 +1692,6 @@ namespace Orleans.Streams
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         [System.Obsolete("Use TryGetCacheCursor instead.")]
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken? token);
-        [System.Obsolete("Use TryGetCacheCursorAtPosition instead.")]
-        IQueueCacheCursor GetCacheCursorAtPosition(Runtime.StreamId streamId, StreamSubscriptionStartPosition startPosition);
         bool IsUnderPressure();
         QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken? token);
         QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(Runtime.StreamId streamId, StreamSubscriptionStartPosition startPosition);

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
@@ -236,11 +236,14 @@ namespace AWSUtils.Tests.Streaming
                 foreach (StreamId streamGuid in kvp.Value)
                 {
                     // read all messages in cache for stream
-                    IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
+                    var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    var cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     int messageCount = 0;
                     StreamSequenceToken? tenthInCache = null;
                     StreamSequenceToken lastToken = firstInCache;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         Exception? ex;
                         messageCount++;
@@ -259,9 +262,12 @@ namespace AWSUtils.Tests.Streaming
                     Assert.NotNull(tenthInCache);
 
                     // read all messages from the 10th
-                    cursor = qCache.GetCacheCursor(streamGuid, tenthInCache);
+                    cursorResult = qCache.TryGetCacheCursor(streamGuid, tenthInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     messageCount = 0;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         messageCount++;
                     }
@@ -270,6 +276,18 @@ namespace AWSUtils.Tests.Streaming
                     Assert.Equal(expected, messageCount);
                 }
             }
+        }
+
+        private static bool MoveNext(IQueueCacheCursor cursor)
+        {
+            var result = cursor.MoveNextWithResult();
+            return result.Kind switch
+            {
+                QueueCacheCursorMoveResultKind.Success => true,
+                QueueCacheCursorMoveResultKind.NoData => false,
+                QueueCacheCursorMoveResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+            };
         }
 
         private static async Task AwaitWithCancellation(Task task, CancellationToken cancellationToken)

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSDataAdapterTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSDataAdapterTests.cs
@@ -168,11 +168,14 @@ public class SQSDataAdapterTests : IAsyncLifetime
             foreach (StreamId streamGuid in kvp.Value)
             {
                 // read all messages in cache for stream
-                IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
+                var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
+                Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                var cursor = cursorResult.Cursor;
+                Assert.NotNull(cursor);
                 int messageCount = 0;
                 StreamSequenceToken? tenthInCache = null;
                 StreamSequenceToken lastToken = firstInCache;
-                while (cursor.MoveNext())
+                while (MoveNext(cursor))
                 {
                     Exception? ex;
                     messageCount++;
@@ -191,9 +194,12 @@ public class SQSDataAdapterTests : IAsyncLifetime
                 Assert.NotNull(tenthInCache);
 
                 // read all messages from the 10th
-                cursor = qCache.GetCacheCursor(streamGuid, tenthInCache);
+                cursorResult = qCache.TryGetCacheCursor(streamGuid, tenthInCache);
+                Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                cursor = cursorResult.Cursor;
+                Assert.NotNull(cursor);
                 messageCount = 0;
-                while (cursor.MoveNext())
+                while (MoveNext(cursor))
                 {
                     messageCount++;
                 }
@@ -202,6 +208,18 @@ public class SQSDataAdapterTests : IAsyncLifetime
                 Assert.Equal(expected, messageCount);
             }
         }
+    }
+
+    private static bool MoveNext(IQueueCacheCursor cursor)
+    {
+        var result = cursor.MoveNextWithResult();
+        return result.Kind switch
+        {
+            QueueCacheCursorMoveResultKind.Success => true,
+            QueueCacheCursorMoveResultKind.NoData => false,
+            QueueCacheCursorMoveResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+            _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+        };
     }
 
     private static async Task AwaitWithCancellation(Task task, CancellationToken cancellationToken)

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
@@ -168,11 +168,14 @@ namespace Tester.AzureUtils.Streaming
                 foreach (StreamId streamGuid in kvp.Value)
                 {
                     // read all messages in cache for stream
-                    IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
+                    var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    var cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     int messageCount = 0;
                     StreamSequenceToken? tenthInCache = null;
                     StreamSequenceToken lastToken = firstInCache;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         Exception? ex;
                         messageCount++;
@@ -191,9 +194,12 @@ namespace Tester.AzureUtils.Streaming
                     Assert.NotNull(tenthInCache);
 
                     // read all messages from the 10th
-                    cursor = qCache.GetCacheCursor(streamGuid, tenthInCache);
+                    cursorResult = qCache.TryGetCacheCursor(streamGuid, tenthInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     messageCount = 0;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         messageCount++;
                     }
@@ -202,6 +208,18 @@ namespace Tester.AzureUtils.Streaming
                     Assert.Equal(expected, messageCount);
                 }
             }
+        }
+
+        private static bool MoveNext(IQueueCacheCursor cursor)
+        {
+            var result = cursor.MoveNextWithResult();
+            return result.Kind switch
+            {
+                QueueCacheCursorMoveResultKind.Success => true,
+                QueueCacheCursorMoveResultKind.NoData => false,
+                QueueCacheCursorMoveResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+            };
         }
 
         private List<object> CreateEvents(int count)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -64,7 +64,7 @@ public class EventHubCheckpointerTests
         }
     }
 
-    private sealed class TestEventHubQueueCache : IEventHubQueueCache
+    private class TestEventHubQueueCache : IEventHubQueueCache
     {
         private readonly IStreamQueueCheckpointer<string>? checkpointer;
 
@@ -81,6 +81,7 @@ public class EventHubCheckpointerTests
         public StreamSequenceToken? RefreshToken { get; private set; }
         public QueueCacheMissException? CursorException { get; set; }
         public QueueCacheMissException? MoveNextException { get; set; }
+        public IBatchContainer? NoDataMessage { get; set; }
 
         public int GetMaxAddCount() => 1_000;
 
@@ -106,7 +107,7 @@ public class EventHubCheckpointerTests
                 throw exception;
             }
 
-            message = null!;
+            message = NoDataMessage!;
             return false;
         }
 
@@ -164,6 +165,112 @@ public class EventHubCheckpointerTests
 
         Assert.Same(expected, actual);
         Assert.Same(innerException, actual.InnerException);
+    }
+
+    [Theory, TestCategory("BVT")]
+    [InlineData(StreamSubscriptionStartPosition.Latest)]
+    [InlineData(StreamSubscriptionStartPosition.EarliestAvailable)]
+    public void TypedPositionDispatchesToLegacyEventHubProvider(StreamSubscriptionStartPosition position)
+    {
+        var provider = new LegacyPositionEventHubQueueCache
+        {
+            CursorException = new QueueCacheMissException("Token acquisition must not be used for positioning."),
+        };
+        IEventHubQueueCache cache = provider;
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+
+        var result = cache.TryGetCursorAtPosition(stream, position);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.Same(provider.Cursor, result.Cursor);
+        Assert.Null(result.CacheMiss);
+        Assert.Equal((stream, position), provider.Request);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void TypedPositionAdaptsLegacyEventHubFailures()
+    {
+        var provider = new LegacyPositionEventHubQueueCache
+        {
+            PositionException = new QueueCacheMissException("requested", "low", "high"),
+        };
+        IEventHubQueueCache cache = provider;
+
+        var result = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+        Assert.Null(result.Cursor);
+        var miss = Assert.NotNull(result.CacheMiss);
+        Assert.Equal("requested", miss.Requested);
+        Assert.Equal("low", miss.Low);
+        Assert.Equal("high", miss.High);
+
+        provider.PositionException = new NotSupportedException();
+        result = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.Null(result.Cursor);
+        Assert.Null(result.CacheMiss);
+
+        var failure = new InvalidOperationException("Provider failure");
+        provider.PositionException = failure;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(
+            () => cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.Latest)));
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void TypedPositionPreservesLegacyEventHubDefaults()
+    {
+        var provider = new TestEventHubQueueCache();
+        IEventHubQueueCache cache = provider;
+
+        var latest = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.Latest);
+        Assert.Equal(QueueCacheCursorResultKind.Success, latest.Kind);
+        Assert.Same(provider.Cursor, latest.Cursor);
+
+        var earliest = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, earliest.Kind);
+        Assert.Null(earliest.Cursor);
+        Assert.Null(earliest.CacheMiss);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => cache.TryGetCursorAtPosition(default, (StreamSubscriptionStartPosition)123));
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void TypedNoDataClearsLegacyEventHubMessage()
+    {
+        var provider = new TestEventHubQueueCache
+        {
+            NoDataMessage = new Orleans.Providers.Streams.Generator.GeneratedBatchContainer(
+                StreamId.Create("namespace", Guid.NewGuid()),
+                1,
+                new EventSequenceTokenV2(1)),
+        };
+        IEventHubQueueCache cache = provider;
+
+        var result = cache.TryGetNextMessageWithResult(provider.Cursor, out var message);
+
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, result.Kind);
+        Assert.Null(message);
+        Assert.Null(result.CacheMiss);
+    }
+
+    private sealed class LegacyPositionEventHubQueueCache : TestEventHubQueueCache, IEventHubQueueCache
+    {
+        public Exception? PositionException { get; set; }
+        public (StreamId, StreamSubscriptionStartPosition)? Request { get; private set; }
+
+        object IEventHubQueueCache.GetCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+        {
+            Request = (streamId, startPosition);
+            if (PositionException is { } exception)
+            {
+                throw exception;
+            }
+
+            return Cursor;
+        }
     }
 
     private sealed class NullReturningEventHubReceiver : IEventHubReceiver

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -79,6 +79,8 @@ public class EventHubCheckpointerTests
         public object Cursor { get; } = new();
         public object? RefreshedCursor { get; private set; }
         public StreamSequenceToken? RefreshToken { get; private set; }
+        public QueueCacheMissException? CursorException { get; set; }
+        public QueueCacheMissException? MoveNextException { get; set; }
 
         public int GetMaxAddCount() => 1_000;
 
@@ -88,7 +90,8 @@ public class EventHubCheckpointerTests
             return [];
         }
 
-        public object GetCursor(StreamId streamId, StreamSequenceToken? sequenceToken) => Cursor;
+        public object GetCursor(StreamId streamId, StreamSequenceToken? sequenceToken)
+            => CursorException is { } exception ? throw exception : Cursor;
 
         public void Refresh(object cursor, StreamSequenceToken? sequenceToken)
         {
@@ -98,6 +101,11 @@ public class EventHubCheckpointerTests
 
         public bool TryGetNextMessage(object cursorObj, out IBatchContainer message)
         {
+            if (MoveNextException is { } exception)
+            {
+                throw exception;
+            }
+
             message = null!;
             return false;
         }
@@ -134,6 +142,28 @@ public class EventHubCheckpointerTests
             CloseCount++;
             return Task.CompletedTask;
         }
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void GetCursorAtPositionPreservesLegacyEventHubCacheBehavior()
+    {
+        IEventHubQueueCache cache = new TestEventHubQueueCache();
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+        Assert.Same(cache.GetCursor(streamId, null), cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.Latest));
+        Assert.Throws<NotSupportedException>(
+            () => cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.EarliestAvailable));
+
+        var innerException = new InvalidOperationException("inner");
+        var expected = new QueueCacheMissException("provider message", innerException);
+        cache = new TestEventHubQueueCache { CursorException = expected };
+        var actual = Assert.Throws<QueueCacheMissException>(
+            () => cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.Latest));
+#pragma warning restore CS0618
+
+        Assert.Same(expected, actual);
+        Assert.Same(innerException, actual.InnerException);
     }
 
     private sealed class NullReturningEventHubReceiver : IEventHubReceiver
@@ -320,13 +350,47 @@ public class EventHubCheckpointerTests
     {
         var cache = new TestEventHubQueueCache();
         var receiver = await CreateReceiver(new TestCheckpointer(), cache);
-        var cursor = receiver.GetCacheCursor(StreamId.Create("namespace", Guid.NewGuid()), MakeToken(1));
+        var result = ((IQueueCache)receiver).TryGetCacheCursor(
+            StreamId.Create("namespace", Guid.NewGuid()),
+            MakeToken(1));
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        var cursor = result.Cursor;
+        Assert.NotNull(cursor);
         var refreshToken = MakeToken(2);
 
         cursor.Refresh(refreshToken);
 
         Assert.Same(cache.Cursor, cache.RefreshedCursor);
         Assert.Same(refreshToken, cache.RefreshToken);
+    }
+
+    [TestSuite("BVT")]
+    [Fact, TestCategory("BVT")]
+    public async Task LegacyReceiverCursorPreservesProviderExceptions()
+    {
+        var acquisitionInnerException = new InvalidOperationException("acquisition inner");
+        var acquisitionException = new QueueCacheMissException("acquisition", acquisitionInnerException);
+        var cache = new TestEventHubQueueCache { CursorException = acquisitionException };
+        var receiver = await CreateReceiver(new TestCheckpointer(), cache);
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete cursor APIs.
+        var actualAcquisitionException = Assert.Throws<QueueCacheMissException>(
+            () => ((IQueueCache)receiver).GetCacheCursor(streamId, MakeToken(1)));
+#pragma warning restore CS0618
+        Assert.Same(acquisitionException, actualAcquisitionException);
+        Assert.Same(acquisitionInnerException, actualAcquisitionException.InnerException);
+
+        cache.CursorException = null;
+        var movementInnerException = new InvalidOperationException("movement inner");
+        var movementException = new QueueCacheMissException("movement", movementInnerException);
+        cache.MoveNextException = movementException;
+#pragma warning disable CS0618 // Verify compatibility of the obsolete cursor APIs.
+        var cursor = ((IQueueCache)receiver).GetCacheCursor(streamId, MakeToken(1));
+        var actualMovementException = Assert.Throws<QueueCacheMissException>(() => cursor.MoveNext());
+#pragma warning restore CS0618
+        Assert.Same(movementException, actualMovementException);
+        Assert.Same(movementInnerException, actualMovementException.InnerException);
     }
 
     [TestSuite("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -79,7 +79,7 @@ public class EventHubCheckpointerTests
         public object Cursor { get; } = new();
         public object? RefreshedCursor { get; private set; }
         public StreamSequenceToken? RefreshToken { get; private set; }
-        public QueueCacheMissException? CursorException { get; set; }
+        public Exception? CursorException { get; set; }
         public QueueCacheMissException? MoveNextException { get; set; }
         public IBatchContainer? NoDataMessage { get; set; }
 
@@ -146,57 +146,46 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public void GetCursorAtPositionPreservesLegacyEventHubCacheBehavior()
+    public void GetCursorPreservesLegacyEventHubCacheBehavior()
     {
-        IEventHubQueueCache cache = new TestEventHubQueueCache();
+        var provider = new TestEventHubQueueCache();
+        IEventHubQueueCache cache = provider;
         var streamId = StreamId.Create("namespace", Guid.NewGuid());
 
 #pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
-        Assert.Same(cache.GetCursor(streamId, null), cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.Latest));
-        Assert.Throws<NotSupportedException>(
-            () => cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.EarliestAvailable));
+        Assert.Same(provider.Cursor, cache.GetCursor(streamId, null));
 
         var innerException = new InvalidOperationException("inner");
         var expected = new QueueCacheMissException("provider message", innerException);
         cache = new TestEventHubQueueCache { CursorException = expected };
         var actual = Assert.Throws<QueueCacheMissException>(
-            () => cache.GetCursorAtPosition(streamId, StreamSubscriptionStartPosition.Latest));
+            () => cache.GetCursor(streamId, null));
 #pragma warning restore CS0618
 
         Assert.Same(expected, actual);
         Assert.Same(innerException, actual.InnerException);
     }
 
-    [Theory, TestCategory("BVT")]
-    [InlineData(StreamSubscriptionStartPosition.Latest)]
-    [InlineData(StreamSubscriptionStartPosition.EarliestAvailable)]
-    public void TypedPositionDispatchesToLegacyEventHubProvider(StreamSubscriptionStartPosition position)
+    [Fact, TestCategory("BVT")]
+    public void TypedLatestPositionUsesEventHubTypedAcquisition()
     {
-        var provider = new LegacyPositionEventHubQueueCache
+        var provider = new TypedAcquisitionEventHubQueueCache
         {
-            CursorException = new QueueCacheMissException("Token acquisition must not be used for positioning."),
+            CursorException = new InvalidOperationException("Positioning must use typed acquisition."),
         };
         IEventHubQueueCache cache = provider;
         var stream = StreamId.Create("namespace", Guid.NewGuid());
 
-        var result = cache.TryGetCursorAtPosition(stream, position);
+        var result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
 
         Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
         Assert.Same(provider.Cursor, result.Cursor);
         Assert.Null(result.CacheMiss);
-        Assert.Equal((stream, position), provider.Request);
-    }
+        Assert.Equal(stream, provider.Request!.Value.StreamId);
+        Assert.Null(provider.Request.Value.Token);
 
-    [Fact, TestCategory("BVT")]
-    public void TypedPositionAdaptsLegacyEventHubFailures()
-    {
-        var provider = new LegacyPositionEventHubQueueCache
-        {
-            PositionException = new QueueCacheMissException("requested", "low", "high"),
-        };
-        IEventHubQueueCache cache = provider;
-
-        var result = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        provider.Result = QueueCacheCursorResult<object>.FromCacheMiss(new("requested", "low", "high"));
+        result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
         Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
         Assert.Null(result.Cursor);
         var miss = Assert.NotNull(result.CacheMiss);
@@ -204,16 +193,16 @@ public class EventHubCheckpointerTests
         Assert.Equal("low", miss.Low);
         Assert.Equal("high", miss.High);
 
-        provider.PositionException = new NotSupportedException();
-        result = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        provider.Result = QueueCacheCursorResult<object>.NotSupported;
+        result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
         Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
         Assert.Null(result.Cursor);
         Assert.Null(result.CacheMiss);
 
-        var failure = new InvalidOperationException("Provider failure");
-        provider.PositionException = failure;
-        Assert.Same(failure, Assert.Throws<InvalidOperationException>(
-            () => cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.Latest)));
+        provider.Request = null;
+        result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.Null(provider.Request);
     }
 
     [Fact, TestCategory("BVT")]
@@ -233,6 +222,31 @@ public class EventHubCheckpointerTests
 
         Assert.Throws<ArgumentOutOfRangeException>(
             () => cache.TryGetCursorAtPosition(default, (StreamSubscriptionStartPosition)123));
+
+        provider.CursorException = new QueueCacheMissException("requested", "low", "high");
+        latest = cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.Latest);
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, latest.Kind);
+        Assert.Null(latest.Cursor);
+        var miss = Assert.NotNull(latest.CacheMiss);
+        Assert.Equal("requested", miss.Requested);
+        Assert.Equal("low", miss.Low);
+        Assert.Equal("high", miss.High);
+    }
+
+    [Theory, TestCategory("BVT")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TypedLatestPositionPropagatesUnexpectedEventHubErrors(bool notSupported)
+    {
+        Exception expected = notSupported
+            ? new NotSupportedException("Token acquisition failure")
+            : new InvalidOperationException("Provider failure");
+        IEventHubQueueCache cache = new TestEventHubQueueCache { CursorException = expected };
+
+        var actual = Record.Exception(
+            () => cache.TryGetCursorAtPosition(default, StreamSubscriptionStartPosition.Latest));
+
+        Assert.Same(expected, actual);
     }
 
     [Fact, TestCategory("BVT")]
@@ -254,22 +268,17 @@ public class EventHubCheckpointerTests
         Assert.Null(result.CacheMiss);
     }
 
-    private sealed class LegacyPositionEventHubQueueCache : TestEventHubQueueCache, IEventHubQueueCache
+    private sealed class TypedAcquisitionEventHubQueueCache : TestEventHubQueueCache, IEventHubQueueCache
     {
-        public Exception? PositionException { get; set; }
-        public (StreamId, StreamSubscriptionStartPosition)? Request { get; private set; }
+        public QueueCacheCursorResult<object>? Result { get; set; }
+        public (StreamId StreamId, StreamSequenceToken? Token)? Request { get; set; }
 
-        object IEventHubQueueCache.GetCursorAtPosition(
+        QueueCacheCursorResult<object> IEventHubQueueCache.TryGetCursor(
             StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
+            StreamSequenceToken? token)
         {
-            Request = (streamId, startPosition);
-            if (PositionException is { } exception)
-            {
-                throw exception;
-            }
-
-            return Cursor;
+            Request = (streamId, token);
+            return Result ?? QueueCacheCursorResult<object>.FromCursor(Cursor);
         }
     }
 

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
@@ -159,11 +159,14 @@ namespace Orleans.Streaming.Kinesis.Tests
                 foreach (StreamId streamGuid in kvp.Value)
                 {
                     // read all messages in cache for stream
-                    IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
+                    var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    var cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     int messageCount = 0;
                     StreamSequenceToken? tenthInCache = null;
                     StreamSequenceToken lastToken = firstInCache;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         messageCount++;
                         IBatchContainer? batch = cursor.GetCurrent(out var ex);
@@ -182,9 +185,12 @@ namespace Orleans.Streaming.Kinesis.Tests
                     Assert.NotNull(tenthInCache);
 
                     // read all messages from the 10th
-                    cursor = qCache.GetCacheCursor(streamGuid, tenthInCache);
+                    cursorResult = qCache.TryGetCacheCursor(streamGuid, tenthInCache);
+                    Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                    cursor = cursorResult.Cursor;
+                    Assert.NotNull(cursor);
                     messageCount = 0;
-                    while (cursor.MoveNext())
+                    while (MoveNext(cursor))
                     {
                         messageCount++;
                     }
@@ -195,6 +201,18 @@ namespace Orleans.Streaming.Kinesis.Tests
             }
 
             await Task.WhenAll(receivers.Values.Select(receiver => receiver.Shutdown(TimeSpan.FromSeconds(5))));
+        }
+
+        private static bool MoveNext(IQueueCacheCursor cursor)
+        {
+            var result = cursor.MoveNextWithResult();
+            return result.Kind switch
+            {
+                QueueCacheCursorMoveResultKind.Success => true,
+                QueueCacheCursorMoveResultKind.NoData => false,
+                QueueCacheCursorMoveResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+                _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+            };
         }
 
         private List<object> CreateEvents(int count)

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
@@ -203,11 +203,14 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
                 Assert.True(firstTokensPerQueue.TryGetValue((kvp.Key, streamGuid), out var firstInCache));
 
                 // read all messages in cache for stream
-                IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
+                var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
+                Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                var cursor = cursorResult.Cursor;
+                Assert.NotNull(cursor);
                 int messageCount = 0;
                 StreamSequenceToken? tenthInCache = null;
                 StreamSequenceToken lastToken = firstInCache;
-                while (cursor.MoveNext())
+                while (MoveNext(cursor))
                 {
                     messageCount++;
                     var batch = cursor.GetCurrent(out var ex);
@@ -228,9 +231,12 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
                 Assert.NotNull(tenthInCache);
 
                 // read all messages from the 10th
-                cursor = qCache.GetCacheCursor(streamGuid, tenthInCache);
+                cursorResult = qCache.TryGetCacheCursor(streamGuid, tenthInCache);
+                Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);
+                cursor = cursorResult.Cursor;
+                Assert.NotNull(cursor);
                 messageCount = 0;
-                while (cursor.MoveNext())
+                while (MoveNext(cursor))
                 {
                     messageCount++;
                 }
@@ -241,6 +247,18 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
                 Assert.Equal(expected, messageCount);
             }
         }
+    }
+
+    private static bool MoveNext(IQueueCacheCursor cursor)
+    {
+        var result = cursor.MoveNextWithResult();
+        return result.Kind switch
+        {
+            QueueCacheCursorMoveResultKind.Success => true,
+            QueueCacheCursorMoveResultKind.NoData => false,
+            QueueCacheCursorMoveResultKind.CacheMiss => throw result.CacheMiss!.Value.ToException(),
+            _ => throw new InvalidOperationException("The cursor move result is not initialized."),
+        };
     }
 
     private static List<object> CreateEvents(int count)

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheCompatibilityTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheCompatibilityTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Providers.Streams.Generator;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public class PooledCacheCompatibilityTests
+{
+    [Theory]
+    [InlineData(false, StreamSubscriptionStartPosition.Latest)]
+    [InlineData(false, StreamSubscriptionStartPosition.EarliestAvailable)]
+    [InlineData(true, StreamSubscriptionStartPosition.Latest)]
+    [InlineData(true, StreamSubscriptionStartPosition.EarliestAvailable)]
+    public void LegacyPositionPreservesPooledProviderBehavior(
+        bool useMemoryCache,
+        StreamSubscriptionStartPosition position)
+    {
+        using var services = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var pool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(1024));
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        IQueueCache cache;
+        if (useMemoryCache)
+        {
+            var serializer = new DefaultMemoryMessageBodySerializer(services.GetRequiredService<Serializer<MemoryMessageBody>>());
+            cache = new MemoryPooledCache<DefaultMemoryMessageBodySerializer>(
+                pool,
+                new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)),
+                NullLogger.Instance,
+                serializer,
+                cacheMonitor: null,
+                monitorWriteInterval: null,
+                purgeMetadataInterval: null);
+            cache.AddToCache(
+            [
+                new MemoryBatchContainer<DefaultMemoryMessageBodySerializer>(
+                    new MemoryMessageData
+                    {
+                        StreamId = stream,
+                        SequenceNumber = 1,
+                        EnqueueTimeUtc = DateTime.UtcNow,
+                        Payload = serializer.Serialize(new MemoryMessageBody([1], requestContext: null)),
+                    },
+                    serializer),
+            ]);
+        }
+        else
+        {
+            cache = new GeneratorPooledCache(
+                pool,
+                NullLogger.Instance,
+                services.GetRequiredService<Serializer>(),
+                cacheMonitor: null,
+                monitorWriteInterval: null);
+            cache.AddToCache([new GeneratedBatchContainer(stream, 1, new EventSequenceTokenV2(1))]);
+        }
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+        using var legacyCursor = cache.GetCacheCursorAtPosition(stream, position);
+        var legacyHasMessage = legacyCursor.MoveNext();
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => cache.GetCacheCursorAtPosition(stream, (StreamSubscriptionStartPosition)123));
+#pragma warning restore CS0618
+
+        var result = cache.TryGetCacheCursorAtPosition(stream, position);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.NotNull(result.Cursor);
+        using var typedCursor = result.Cursor;
+        var expectedKind = position == StreamSubscriptionStartPosition.EarliestAvailable
+            ? QueueCacheCursorMoveResultKind.Success
+            : QueueCacheCursorMoveResultKind.NoData;
+        Assert.Equal(expectedKind == QueueCacheCursorMoveResultKind.Success, legacyHasMessage);
+        Assert.Equal(expectedKind, typedCursor.MoveNextWithResult().Kind);
+        if (legacyHasMessage)
+        {
+            Assert.Equal(1, legacyCursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
+            Assert.Equal(1, typedCursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
+        }
+        else
+        {
+            Assert.Null(legacyCursor.GetCurrent(out _));
+            Assert.Null(typedCursor.GetCurrent(out _));
+        }
+    }
+}

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheCompatibilityTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheCompatibilityTests.cs
@@ -20,7 +20,7 @@ public class PooledCacheCompatibilityTests
     [InlineData(false, StreamSubscriptionStartPosition.EarliestAvailable)]
     [InlineData(true, StreamSubscriptionStartPosition.Latest)]
     [InlineData(true, StreamSubscriptionStartPosition.EarliestAvailable)]
-    public void LegacyPositionPreservesPooledProviderBehavior(
+    public void TypedPositionMatchesReleasedTokenCursorBehavior(
         bool useMemoryCache,
         StreamSubscriptionStartPosition position)
     {
@@ -64,12 +64,14 @@ public class PooledCacheCompatibilityTests
         }
 
 #pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
-        using var legacyCursor = cache.GetCacheCursorAtPosition(stream, position);
+        using var legacyCursor = cache.GetCacheCursor(
+            stream,
+            position == StreamSubscriptionStartPosition.Latest ? null : new EventSequenceTokenV2(1));
         var legacyHasMessage = legacyCursor.MoveNext();
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => cache.GetCacheCursorAtPosition(stream, (StreamSubscriptionStartPosition)123));
 #pragma warning restore CS0618
 
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => cache.TryGetCacheCursorAtPosition(stream, (StreamSubscriptionStartPosition)123));
         var result = cache.TryGetCacheCursorAtPosition(stream, position);
         Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
         Assert.NotNull(result.Cursor);

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -5,6 +5,8 @@ using Orleans.Runtime;
 using Orleans.Streams;
 using Xunit;
 
+#pragma warning disable CS0618 // This suite verifies compatibility of the legacy cursor APIs alongside their replacements.
+
 namespace UnitTests.OrleansRuntime.Streams
 {
     [TestSuite("BVT")]
@@ -25,6 +27,53 @@ namespace UnitTests.OrleansRuntime.Streams
             public long SequenceNumber;
             public byte[] Data { get; init; } = FixedMessage;
             public DateTime EnqueueTimeUtc = DateTime.UtcNow;
+        }
+
+        private sealed class MutatingSequenceToken : StreamSequenceToken
+        {
+            private readonly long _sequenceNumber;
+            private readonly int _mutationRead;
+            private readonly Action _mutation;
+            private int _sequenceReads;
+
+            public MutatingSequenceToken(long sequenceNumber, int mutationRead, Action mutation)
+            {
+                _sequenceNumber = sequenceNumber;
+                _mutationRead = mutationRead;
+                _mutation = mutation;
+            }
+
+            public override long SequenceNumber
+            {
+                get
+                {
+                    if (Interlocked.Increment(ref _sequenceReads) == _mutationRead)
+                    {
+                        _mutation();
+                    }
+
+                    return _sequenceNumber;
+                }
+                protected set => throw new NotSupportedException();
+            }
+
+            public override int EventIndex
+            {
+                get => 0;
+                protected set => throw new NotSupportedException();
+            }
+
+            public override int CompareTo(StreamSequenceToken? other)
+                => other is null
+                    ? 1
+                    : _sequenceNumber != other.SequenceNumber
+                        ? _sequenceNumber.CompareTo(other.SequenceNumber)
+                        : EventIndex.CompareTo(other.EventIndex);
+
+            public override bool Equals(StreamSequenceToken? other)
+                => other is not null
+                    && _sequenceNumber == other.SequenceNumber
+                    && EventIndex == other.EventIndex;
         }
 
         [GenerateSerializer]
@@ -49,7 +98,6 @@ namespace UnitTests.OrleansRuntime.Streams
                 throw new NotImplementedException();
             }
         }
-
 
         private class TestCacheDataAdapter : ICacheDataAdapter
         {
@@ -189,13 +237,33 @@ namespace UnitTests.OrleansRuntime.Streams
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = targetStream, SequenceNumber = 3 }, now),
             ], now);
 
-            var cursor = cache.GetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var result = cache.TryGetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
 
             Assert.True(cache.TryGetNextMessage(cursor, out var first));
             Assert.Equal(1, first.SequenceToken.SequenceNumber);
             Assert.True(cache.TryGetNextMessage(cursor, out var second));
             Assert.Equal(3, second.SequenceToken.SequenceNumber);
             Assert.False(cache.TryGetNextMessage(cursor, out _));
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void GetCursorAtPositionPreservesLegacyCursorBehavior()
+        {
+            var (cache, converter) = CreateCache();
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            var now = DateTime.UtcNow;
+            cache.Add(
+            [
+                converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 1 }, now),
+            ], now);
+
+            var cursor = cache.GetCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+
+            Assert.True(cache.TryGetNextMessage(cursor, out var message));
+            Assert.Equal(1, message.SequenceToken.SequenceNumber);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -209,7 +277,10 @@ namespace UnitTests.OrleansRuntime.Streams
             [
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = otherStream, SequenceNumber = 100 }, now),
             ], now);
-            var cursor = cache.GetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var result = cache.TryGetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
 
             Assert.False(cache.TryGetNextMessage(cursor, out _));
 
@@ -230,7 +301,10 @@ namespace UnitTests.OrleansRuntime.Streams
             var (cache, converter) = CreateCache();
             var targetStream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
             var otherStream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
-            var cursor = cache.GetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var result = cache.TryGetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
             var now = DateTime.UtcNow;
 
             cache.Add(
@@ -259,7 +333,10 @@ namespace UnitTests.OrleansRuntime.Streams
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 1 }, now),
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 2 }, now),
             ], now);
-            var cursor = cache.GetCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
 
             cache.RemoveOldestMessage();
 
@@ -278,7 +355,10 @@ namespace UnitTests.OrleansRuntime.Streams
             [
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = otherStream, SequenceNumber = 100 }, now),
             ], now);
-            var cursor = cache.GetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var result = cache.TryGetCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
             Assert.False(cache.TryGetNextMessage(cursor, out _));
 
             cache.RemoveOldestMessage();
@@ -303,7 +383,10 @@ namespace UnitTests.OrleansRuntime.Streams
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 1 }, now),
             ], now);
 
-            var cursor = cache.GetCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
+            var result = cache.TryGetCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
+            Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+            Assert.NotNull(result.Cursor);
+            var cursor = result.Cursor;
 
             Assert.False(cache.TryGetNextMessage(cursor, out _));
             cache.Add(
@@ -700,7 +783,14 @@ namespace UnitTests.OrleansRuntime.Streams
             // Enqueue a new message for stream
             EnqueueMessage(streamKey);
 
-            // Should throw since we missed the second message destined for stream
+            var result = cache.TryGetNextMessageWithResult(cursor, out _);
+            Assert.Equal(QueueCacheCursorMoveResultKind.CacheMiss, result.Kind);
+            var cacheMiss = Assert.NotNull(result.CacheMiss);
+            Assert.NotNull(cacheMiss.Requested);
+            Assert.NotNull(cacheMiss.Low);
+            Assert.NotNull(cacheMiss.High);
+
+            // Preserve the legacy API behavior for existing cache implementations.
             Assert.Throws<QueueCacheMissException>(() => cache.TryGetNextMessage(cursor, out _));
 
             long EnqueueMessage(Guid streamId)
@@ -715,6 +805,63 @@ namespace UnitTests.OrleansRuntime.Streams
                 seqNumber++;
                 return msg.SequenceNumber;
             }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TryGetCursorReportsCacheMiss()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null, TimeSpan.FromSeconds(10));
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+            var streamId = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            var now = DateTime.UtcNow;
+            var message = new TestQueueMessage
+            {
+                StreamId = streamId,
+                SequenceNumber = 2,
+            };
+            cache.Add([converter.ToCachedMessage(message, now)], now);
+
+            var requestedToken = new EventSequenceTokenV2(1);
+            var result = cache.TryGetCursor(streamId, requestedToken);
+
+            Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+            Assert.Null(result.Cursor);
+            var cacheMiss = Assert.NotNull(result.CacheMiss);
+            Assert.Same(requestedToken, cacheMiss.RequestedToken);
+            Assert.Equal(message.SequenceNumber, cacheMiss.LowToken!.SequenceNumber);
+            Assert.Equal(message.SequenceNumber, cacheMiss.HighToken!.SequenceNumber);
+            Assert.Equal(requestedToken.ToString(), cacheMiss.Requested);
+            var exception = Assert.Throws<QueueCacheMissException>(() => cache.GetCursor(streamId, requestedToken));
+            Assert.Equal(cacheMiss.Requested, exception.Requested);
+            Assert.Equal(cacheMiss.Low, exception.Low);
+            Assert.Equal(cacheMiss.High, exception.High);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TryGetCursorPreservesCacheMissWhenCacheMutatesAfterPreflight()
+        {
+            var (cache, converter) = CreateCache();
+            var streamId = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            var now = DateTime.UtcNow;
+            cache.Add(
+            [
+                converter.ToCachedMessage(new TestQueueMessage { StreamId = streamId, SequenceNumber = 1 }, now),
+                converter.ToCachedMessage(new TestQueueMessage { StreamId = streamId, SequenceNumber = 2 }, now),
+            ], now);
+            var requestedToken = new MutatingSequenceToken(1, 3, cache.RemoveOldestMessage);
+
+            var result = cache.TryGetCursor(streamId, requestedToken);
+
+            Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+            Assert.Null(result.Cursor);
+            var cacheMiss = Assert.NotNull(result.CacheMiss);
+            Assert.Same(requestedToken, cacheMiss.RequestedToken);
+            Assert.Equal(2, cacheMiss.LowToken!.SequenceNumber);
+            Assert.Equal(2, cacheMiss.HighToken!.SequenceNumber);
         }
 
         /// <summary>
@@ -936,3 +1083,5 @@ namespace UnitTests.OrleansRuntime.Streams
         }
     }
 }
+
+#pragma warning restore CS0618

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -250,7 +250,7 @@ namespace UnitTests.OrleansRuntime.Streams
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public void GetCursorAtPositionPreservesLegacyCursorBehavior()
+        public void GetCursorPreservesLegacyCursorBehavior()
         {
             var (cache, converter) = CreateCache();
             var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
@@ -260,7 +260,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 1 }, now),
             ], now);
 
-            var cursor = cache.GetCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(1));
 
             Assert.True(cache.TryGetNextMessage(cursor, out var message));
             Assert.Equal(1, message.SequenceToken.SequenceNumber);

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
@@ -177,32 +177,108 @@ public class SimpleQueueCacheTests
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-    public void TryGetCacheCursorAtPositionDoesNotBypassDerivedCursorOverride()
+    public void EarliestAvailablePreservesDerivedCachePositioning()
     {
         var cache = new DerivedSimpleQueueCache();
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        cache.AddToCache([new TestBatchContainer(stream, 1), new TestBatchContainer(stream, 2)]);
 
         var result = ((IQueueCache)cache).TryGetCacheCursorAtPosition(
-            default,
+            stream,
             StreamSubscriptionStartPosition.EarliestAvailable);
 
-        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
         Assert.False(cache.GetCacheCursorCalled);
-        Assert.Null(result.Cursor);
+        using var cursor = Assert.IsType<SimpleQueueCacheCursor>(result.Cursor);
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+        Assert.Equal(1, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+        Assert.Equal(2, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-    public void GetCacheCursorAtPositionPreservesLegacyResultBehavior()
+    public void EarliestAvailablePreservesInheritedCursorBehavior()
     {
-        IQueueCache cache = new CacheMissPositionQueueCache();
+        IQueueCache cache = new PressureOverrideSimpleQueueCache();
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        cache.AddToCache([new TestBatchContainer(stream, 1)]);
 
+        var result = cache.TryGetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        using var cursor = Assert.IsType<SimpleQueueCacheCursor>(result.Cursor);
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+        Assert.Equal(1, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
+    }
+
+    [Theory]
+    [InlineData(StreamSubscriptionStartPosition.Latest)]
+    [InlineData(StreamSubscriptionStartPosition.EarliestAvailable)]
+    public void TypedPositionDispatchesToLegacyProvider(StreamSubscriptionStartPosition position)
+    {
+        var provider = new LegacyPositionQueueCache();
+        IQueueCache cache = provider;
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+
+        var result = cache.TryGetCacheCursorAtPosition(stream, position);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.Same(provider.Cursor, result.Cursor);
+        Assert.Null(result.CacheMiss);
+        Assert.Equal((stream, position), provider.Request);
+    }
+
+    [Fact]
+    public void TypedPositionAdaptsLegacyFailures()
+    {
+        var expected = new QueueCacheMissException("requested", "low", "high");
+        var provider = new LegacyPositionQueueCache { PositionException = expected };
+        IQueueCache cache = provider;
+
+        var result = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+        Assert.Null(result.Cursor);
+        var miss = Assert.NotNull(result.CacheMiss);
+        Assert.Equal("requested", miss.Requested);
+        Assert.Equal("low", miss.Low);
+        Assert.Equal("high", miss.High);
 #pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
-        var exception = Assert.Throws<QueueCacheMissException>(
-            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable));
+        Assert.Same(expected, Assert.Throws<QueueCacheMissException>(
+            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable)));
 #pragma warning restore CS0618
 
-        Assert.Equal("requested", exception.Requested);
-        Assert.Equal("low", exception.Low);
-        Assert.Equal("high", exception.High);
+        provider.PositionException = new NotSupportedException();
+        result = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.Null(result.Cursor);
+        Assert.Null(result.CacheMiss);
+
+        var failure = new InvalidOperationException("Provider failure");
+        provider.PositionException = failure;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(
+            () => cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest)));
+    }
+
+    [Fact]
+    public void TypedPositionPreservesLegacyDefaults()
+    {
+        IQueueCache cache = new LegacyThrowingQueueCache(new QueueCacheMissException("requested", "low", "high"));
+
+        var latest = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest);
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, latest.Kind);
+        Assert.Null(latest.Cursor);
+        Assert.Equal("requested", Assert.NotNull(latest.CacheMiss).Requested);
+
+        var earliest = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, earliest.Kind);
+        Assert.Null(earliest.Cursor);
+        Assert.Null(earliest.CacheMiss);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => cache.TryGetCacheCursorAtPosition(default, (StreamSubscriptionStartPosition)123));
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -265,8 +341,17 @@ public class SimpleQueueCacheTests
         }
     }
 
-    private sealed class CacheMissPositionQueueCache : IQueueCache
+    private sealed class PressureOverrideSimpleQueueCache() : SimpleQueueCache(10, NullLogger.Instance)
     {
+        public override bool IsUnderPressure() => false;
+    }
+
+    private sealed class LegacyPositionQueueCache : IQueueCache
+    {
+        public IQueueCacheCursor Cursor { get; } = new EmptyCursor();
+        public Exception? PositionException { get; set; }
+        public (StreamId, StreamSubscriptionStartPosition)? Request { get; private set; }
+
         public void AddToCache(IList<IBatchContainer> messages)
         {
         }
@@ -274,12 +359,20 @@ public class SimpleQueueCacheTests
         public int GetMaxAddCount() => 1;
 
         public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
-            => new EmptyCursor();
+            => throw new InvalidOperationException("Positioning must use the legacy position method.");
 
-        public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
             StreamId streamId,
             StreamSubscriptionStartPosition startPosition)
-            => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(new("requested", "low", "high"));
+        {
+            Request = (streamId, startPosition);
+            if (PositionException is { } exception)
+            {
+                throw exception;
+            }
+
+            return Cursor;
+        }
 
         public bool IsUnderPressure() => false;
 

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
@@ -24,13 +24,18 @@ public class SimpleQueueCacheTests
             new TestBatchContainer(targetStream, 3),
         ]);
 
-        var cursor = ((IQueueCache)cache).GetCacheCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+        var result = ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+            targetStream,
+            StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.NotNull(result.Cursor);
+        var cursor = result.Cursor;
 
-        Assert.True(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
         Assert.Equal(1, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
-        Assert.True(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
         Assert.Equal(3, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
-        Assert.False(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -40,20 +45,25 @@ public class SimpleQueueCacheTests
         var targetStream = StreamId.Create("namespace", Guid.NewGuid());
         var otherStream = StreamId.Create("namespace", Guid.NewGuid());
         cache.AddToCache([new TestBatchContainer(otherStream, 100)]);
-        var cursor = ((IQueueCache)cache).GetCacheCursorAtPosition(targetStream, StreamSubscriptionStartPosition.EarliestAvailable);
+        var result = ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+            targetStream,
+            StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.NotNull(result.Cursor);
+        var cursor = result.Cursor;
 
-        Assert.False(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
 
         var unrelatedToken = new EventSequenceTokenV2(101);
         cache.AddToCache([new TestBatchContainer(otherStream, unrelatedToken)]);
         cursor.Refresh(unrelatedToken);
-        Assert.False(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
 
         var targetToken = new EventSequenceTokenV2(1);
         cache.AddToCache([new TestBatchContainer(targetStream, targetToken)]);
         cursor.Refresh(targetToken);
 
-        Assert.True(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
         Assert.Equal(targetToken, cursor.GetCurrent(out _)!.SequenceToken);
     }
 
@@ -64,16 +74,360 @@ public class SimpleQueueCacheTests
         var stream = StreamId.Create("namespace", Guid.NewGuid());
         cache.AddToCache([new TestBatchContainer(stream, 1)]);
 
-        var cursor = ((IQueueCache)cache).GetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
+        var result = ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+            stream,
+            StreamSubscriptionStartPosition.Latest);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.NotNull(result.Cursor);
+        var cursor = result.Cursor;
 
-        Assert.False(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
 
         var futureToken = new EventSequenceTokenV2(2);
         cache.AddToCache([new TestBatchContainer(stream, futureToken)]);
         cursor.Refresh(futureToken);
 
-        Assert.True(cursor.MoveNext());
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
         Assert.Equal(futureToken, cursor.GetCurrent(out _)!.SequenceToken);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void LegacyLatestStartsAfterNewestRetainedMessage()
+    {
+        var cache = new SimpleQueueCache(10, NullLogger.Instance);
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        cache.AddToCache([new TestBatchContainer(stream, 1)]);
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+        var cursor = ((IQueueCache)cache).GetCacheCursorAtPosition(
+            stream,
+            StreamSubscriptionStartPosition.Latest);
+#pragma warning restore CS0618
+
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
+        var futureToken = new EventSequenceTokenV2(2);
+        cache.AddToCache([new TestBatchContainer(stream, futureToken)]);
+        cursor.Refresh(futureToken);
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+        Assert.Equal(futureToken, cursor.GetCurrent(out _)!.SequenceToken);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void TryGetCacheCursorPreservesDerivedCursorOverride()
+    {
+        var cache = new DerivedSimpleQueueCache();
+
+        var result = ((IQueueCache)cache).TryGetCacheCursor(default, null);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.True(cache.GetCacheCursorCalled);
+        Assert.Same(cache.Cursor, result.Cursor);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void TryGetCacheCursorPreservesCacheMissDetails()
+    {
+        var cache = new SimpleQueueCache(10, NullLogger.Instance);
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        var retainedToken = new EventSequenceTokenV2(2);
+        var requestedToken = new EventSequenceTokenV2(1);
+        cache.AddToCache([new TestBatchContainer(stream, retainedToken)]);
+
+        var result = ((IQueueCache)cache).TryGetCacheCursor(stream, requestedToken);
+
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+        Assert.Null(result.Cursor);
+        var cacheMiss = Assert.NotNull(result.CacheMiss);
+        Assert.Same(requestedToken, cacheMiss.RequestedToken);
+        Assert.Same(retainedToken, cacheMiss.LowToken);
+        Assert.Same(retainedToken, cacheMiss.HighToken);
+        var exception = cacheMiss.ToException();
+        Assert.Equal(cacheMiss.Requested, exception.Requested);
+        Assert.Equal(cacheMiss.Low, exception.Low);
+        Assert.Equal(cacheMiss.High, exception.High);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void CursorAcquisitionPreservesCacheMissWhenCacheMutatesAfterPreflight()
+    {
+        var (cache, stream, requestedToken, retainedToken, retainedCursor) = CreateCacheWithMutationDuringInitialization();
+        using (retainedCursor)
+        {
+            var result = ((IQueueCache)cache).TryGetCacheCursor(stream, requestedToken);
+
+            Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+            Assert.Null(result.Cursor);
+            var cacheMiss = Assert.NotNull(result.CacheMiss);
+            Assert.Same(requestedToken, cacheMiss.RequestedToken);
+            Assert.Equal(2, cacheMiss.LowToken!.SequenceNumber);
+            Assert.Equal(2, cacheMiss.HighToken!.SequenceNumber);
+        }
+
+        (cache, stream, requestedToken, retainedToken, retainedCursor) = CreateCacheWithMutationDuringInitialization();
+        using (retainedCursor)
+        {
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+            var exception = Assert.Throws<QueueCacheMissException>(() => cache.GetCacheCursor(stream, requestedToken));
+#pragma warning restore CS0618
+
+            Assert.Equal(requestedToken.ToString(), exception.Requested);
+            Assert.Equal(retainedToken.ToString(), exception.Low);
+            Assert.Equal(retainedToken.ToString(), exception.High);
+        }
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void TryGetCacheCursorAtPositionDoesNotBypassDerivedCursorOverride()
+    {
+        var cache = new DerivedSimpleQueueCache();
+
+        var result = ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+            default,
+            StreamSubscriptionStartPosition.EarliestAvailable);
+
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.False(cache.GetCacheCursorCalled);
+        Assert.Null(result.Cursor);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void GetCacheCursorAtPositionPreservesLegacyResultBehavior()
+    {
+        IQueueCache cache = new CacheMissPositionQueueCache();
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+        var exception = Assert.Throws<QueueCacheMissException>(
+            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable));
+#pragma warning restore CS0618
+
+        Assert.Equal("requested", exception.Requested);
+        Assert.Equal("low", exception.Low);
+        Assert.Equal("high", exception.High);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void LatestLegacyPositionPreservesProviderException()
+    {
+        var innerException = new InvalidOperationException("inner");
+        var expected = new QueueCacheMissException("provider message", innerException);
+        IQueueCache cache = new LegacyThrowingQueueCache(expected);
+
+#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
+        var actual = Assert.Throws<QueueCacheMissException>(
+            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest));
+#pragma warning restore CS0618
+
+        Assert.Same(expected, actual);
+        Assert.Same(innerException, actual.InnerException);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void LatestRejectsInvalidDerivedCursorMoveResult()
+    {
+        var cursor = new InvalidMoveResultCursor();
+        var cache = new DerivedSimpleQueueCache(cursor);
+
+        Assert.Throws<InvalidOperationException>(
+            () => ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+                default,
+                StreamSubscriptionStartPosition.Latest));
+        Assert.True(cursor.IsDisposed);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void LatestDisposesDerivedCursorWhenMoveThrows()
+    {
+        var cursor = new ThrowingMoveResultCursor();
+        var cache = new DerivedSimpleQueueCache(cursor);
+
+        Assert.Throws<InvalidOperationException>(
+            () => ((IQueueCache)cache).TryGetCacheCursorAtPosition(
+                default,
+                StreamSubscriptionStartPosition.Latest));
+        Assert.True(cursor.IsDisposed);
+    }
+
+    private sealed class DerivedSimpleQueueCache : SimpleQueueCache
+    {
+        public DerivedSimpleQueueCache(IQueueCacheCursor? cursor = null) : base(10, NullLogger.Instance)
+        {
+            Cursor = cursor ?? new EmptyCursor();
+        }
+
+        public IQueueCacheCursor Cursor { get; }
+        public bool GetCacheCursorCalled { get; private set; }
+
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
+        public override IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+        {
+            GetCacheCursorCalled = true;
+            return Cursor;
+        }
+    }
+
+    private sealed class CacheMissPositionQueueCache : IQueueCache
+    {
+        public void AddToCache(IList<IBatchContainer> messages)
+        {
+        }
+
+        public int GetMaxAddCount() => 1;
+
+        public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+            => new EmptyCursor();
+
+        public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+            StreamId streamId,
+            StreamSubscriptionStartPosition startPosition)
+            => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(new("requested", "low", "high"));
+
+        public bool IsUnderPressure() => false;
+
+        public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+        {
+            purgedItems = null!;
+            return false;
+        }
+    }
+
+    private sealed class LegacyThrowingQueueCache(QueueCacheMissException exception) : IQueueCache
+    {
+        public void AddToCache(IList<IBatchContainer> messages)
+        {
+        }
+
+        public int GetMaxAddCount() => 1;
+
+        public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token) => throw exception;
+
+        public bool IsUnderPressure() => false;
+
+        public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+        {
+            purgedItems = null!;
+            return false;
+        }
+    }
+
+    private static (
+        SimpleQueueCache Cache,
+        StreamId Stream,
+        StreamSequenceToken RequestedToken,
+        StreamSequenceToken RetainedToken,
+        IQueueCacheCursor RetainedCursor)
+        CreateCacheWithMutationDuringInitialization()
+    {
+        var cache = new SimpleQueueCache(10, NullLogger.Instance);
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+        var retainedToken = new EventSequenceTokenV2(2);
+        cache.AddToCache(
+        [
+            new TestBatchContainer(stream, 1),
+            new TestBatchContainer(stream, retainedToken),
+        ]);
+        var retainedCursorResult = ((IQueueCache)cache).TryGetCacheCursor(stream, retainedToken);
+        Assert.NotNull(retainedCursorResult.Cursor);
+        var retainedCursor = retainedCursorResult.Cursor;
+        var requestedToken = new MutatingCompareToken(
+            1,
+            2,
+            () =>
+            {
+                Assert.True(cache.TryPurgeFromCache(out var purgedItems));
+                Assert.Single(purgedItems);
+            });
+        return (cache, stream, requestedToken, retainedToken, retainedCursor);
+    }
+
+    private sealed class MutatingCompareToken : StreamSequenceToken
+    {
+        private readonly long _sequenceNumber;
+        private readonly int _mutationComparison;
+        private readonly Action _mutation;
+        private int _comparisons;
+
+        public MutatingCompareToken(long sequenceNumber, int mutationComparison, Action mutation)
+        {
+            _sequenceNumber = sequenceNumber;
+            _mutationComparison = mutationComparison;
+            _mutation = mutation;
+        }
+
+        public override long SequenceNumber
+        {
+            get => _sequenceNumber;
+            protected set => throw new NotSupportedException();
+        }
+
+        public override int EventIndex
+        {
+            get => 0;
+            protected set => throw new NotSupportedException();
+        }
+
+        public override int CompareTo(StreamSequenceToken? other)
+        {
+            if (Interlocked.Increment(ref _comparisons) == _mutationComparison)
+            {
+                _mutation();
+            }
+
+            return other is null
+                ? 1
+                : _sequenceNumber != other.SequenceNumber
+                    ? _sequenceNumber.CompareTo(other.SequenceNumber)
+                    : EventIndex.CompareTo(other.EventIndex);
+        }
+
+        public override bool Equals(StreamSequenceToken? other)
+            => other is not null
+                && _sequenceNumber == other.SequenceNumber
+                && EventIndex == other.EventIndex;
+    }
+
+    private sealed class InvalidMoveResultCursor : EmptyCursor
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override void Dispose() => IsDisposed = true;
+
+        public override QueueCacheCursorMoveResult MoveNextWithResult() => default;
+    }
+
+    private sealed class ThrowingMoveResultCursor : EmptyCursor
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override void Dispose() => IsDisposed = true;
+
+        public override QueueCacheCursorMoveResult MoveNextWithResult()
+            => throw new InvalidOperationException("Move failed.");
+    }
+
+    private class EmptyCursor : IQueueCacheCursor
+    {
+        public virtual void Dispose()
+        {
+        }
+
+        public IBatchContainer? GetCurrent(out Exception? exception)
+        {
+            exception = null;
+            return null;
+        }
+
+        public virtual bool MoveNext() => false;
+
+        public virtual QueueCacheCursorMoveResult MoveNextWithResult()
+            => QueueCacheCursorMoveResult.NoData;
+
+        public void Refresh(StreamSequenceToken token)
+        {
+        }
+
+        public void RecordDeliveryFailure()
+        {
+        }
     }
 
     private sealed class TestBatchContainer : IBatchContainer

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/SimpleQueueCacheTests.cs
@@ -92,18 +92,18 @@ public class SimpleQueueCacheTests
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-    public void LegacyLatestStartsAfterNewestRetainedMessage()
+    public void LegacyNullTokenStartsAtNewestRetainedMessage()
     {
         var cache = new SimpleQueueCache(10, NullLogger.Instance);
         var stream = StreamId.Create("namespace", Guid.NewGuid());
         cache.AddToCache([new TestBatchContainer(stream, 1)]);
 
 #pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
-        var cursor = ((IQueueCache)cache).GetCacheCursorAtPosition(
-            stream,
-            StreamSubscriptionStartPosition.Latest);
+        using var cursor = ((IQueueCache)cache).GetCacheCursor(stream, null);
 #pragma warning restore CS0618
 
+        Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+        Assert.Equal(1, cursor.GetCurrent(out _)!.SequenceToken.SequenceNumber);
         Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
         var futureToken = new EventSequenceTokenV2(2);
         cache.AddToCache([new TestBatchContainer(stream, futureToken)]);
@@ -122,6 +122,71 @@ public class SimpleQueueCacheTests
         Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
         Assert.True(cache.GetCacheCursorCalled);
         Assert.Same(cache.Cursor, result.Cursor);
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void LegacyCursorDefaultAdapterPreservesDerivedSimpleQueueCacheCursorOverrides()
+    {
+        var cache = new DerivedCursorSimpleQueueCache();
+        var stream = StreamId.Create("namespace", Guid.NewGuid());
+
+        var acquisition = ((IQueueCache)cache).TryGetCacheCursor(stream, null);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, acquisition.Kind);
+        var cursor = Assert.IsType<DerivedSimpleQueueCacheCursor>(acquisition.Cursor);
+        Assert.Same(cache.Cursor, cursor);
+        Assert.Equal(1, cache.GetCacheCursorCount);
+        try
+        {
+            IQueueCacheCursor interfaceCursor = cursor;
+            Assert.Equal(QueueCacheCursorMoveResultKind.NoData, interfaceCursor.MoveNextWithResult().Kind);
+
+            var first = new TestBatchContainer(stream, 1);
+            cache.AddToCache([first]);
+            interfaceCursor.Refresh(first.SequenceToken);
+            Assert.Equal(QueueCacheCursorMoveResultKind.Success, interfaceCursor.MoveNextWithResult().Kind);
+            Assert.Same(first, interfaceCursor.GetCurrent(out var firstException));
+            Assert.Null(firstException);
+            Assert.Equal(QueueCacheCursorMoveResultKind.NoData, interfaceCursor.MoveNextWithResult().Kind);
+
+            var second = new TestBatchContainer(stream, 2);
+            cache.AddToCache([second]);
+            interfaceCursor.Refresh(second.SequenceToken);
+            Assert.Equal(QueueCacheCursorMoveResultKind.Success, interfaceCursor.MoveNextWithResult().Kind);
+            Assert.Same(second, interfaceCursor.GetCurrent(out var secondException));
+            Assert.Null(secondException);
+
+            var requested = new EventSequenceTokenV2(0);
+            var low = new EventSequenceTokenV2(1);
+            var high = new EventSequenceTokenV2(2);
+            cursor.NextMoveException = new QueueCacheMissException(requested, low, high);
+            var cacheMissResult = interfaceCursor.MoveNextWithResult();
+            Assert.Equal(QueueCacheCursorMoveResultKind.CacheMiss, cacheMissResult.Kind);
+            var cacheMiss = Assert.NotNull(cacheMissResult.CacheMiss);
+            Assert.Equal(requested.ToString(), cacheMiss.Requested);
+            Assert.Equal(low.ToString(), cacheMiss.Low);
+            Assert.Equal(high.ToString(), cacheMiss.High);
+            var legacyException = cacheMiss.ToException();
+            Assert.Equal(requested.ToString(), legacyException.Requested);
+            Assert.Equal(low.ToString(), legacyException.Low);
+            Assert.Equal(high.ToString(), legacyException.High);
+
+            var unexpected = new InvalidOperationException("Provider failure");
+            cursor.NextMoveException = unexpected;
+            Assert.Same(
+                unexpected,
+                Assert.Throws<InvalidOperationException>(() => interfaceCursor.MoveNextWithResult()));
+
+            Assert.Equal(6, cursor.MoveNextCount);
+            Assert.Equal(2, cursor.GetCurrentCount);
+            Assert.Equal(0, cursor.DisposeCount);
+        }
+        finally
+        {
+            cursor.Dispose();
+        }
+
+        Assert.Equal(1, cursor.DisposeCount);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -213,53 +278,39 @@ public class SimpleQueueCacheTests
         Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
     }
 
-    [Theory]
-    [InlineData(StreamSubscriptionStartPosition.Latest)]
-    [InlineData(StreamSubscriptionStartPosition.EarliestAvailable)]
-    public void TypedPositionDispatchesToLegacyProvider(StreamSubscriptionStartPosition position)
+    [Fact]
+    public void LatestPositionUsesTypedAcquisition()
     {
-        var provider = new LegacyPositionQueueCache();
+        var provider = new TypedAcquisitionQueueCache();
         IQueueCache cache = provider;
         var stream = StreamId.Create("namespace", Guid.NewGuid());
 
-        var result = cache.TryGetCacheCursorAtPosition(stream, position);
+        var result = cache.TryGetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
 
         Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
         Assert.Same(provider.Cursor, result.Cursor);
         Assert.Null(result.CacheMiss);
-        Assert.Equal((stream, position), provider.Request);
-    }
+        Assert.Equal(stream, provider.Request!.Value.StreamId);
+        Assert.Null(provider.Request.Value.Token);
 
-    [Fact]
-    public void TypedPositionAdaptsLegacyFailures()
-    {
-        var expected = new QueueCacheMissException("requested", "low", "high");
-        var provider = new LegacyPositionQueueCache { PositionException = expected };
-        IQueueCache cache = provider;
-
-        var result = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
-
+        provider.Result = QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(new("requested", "low", "high"));
+        result = cache.TryGetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
         Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
         Assert.Null(result.Cursor);
         var miss = Assert.NotNull(result.CacheMiss);
         Assert.Equal("requested", miss.Requested);
         Assert.Equal("low", miss.Low);
         Assert.Equal("high", miss.High);
-#pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
-        Assert.Same(expected, Assert.Throws<QueueCacheMissException>(
-            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable)));
-#pragma warning restore CS0618
-
-        provider.PositionException = new NotSupportedException();
-        result = cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.EarliestAvailable);
+        provider.Result = QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
+        result = cache.TryGetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.Latest);
         Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
         Assert.Null(result.Cursor);
         Assert.Null(result.CacheMiss);
 
-        var failure = new InvalidOperationException("Provider failure");
-        provider.PositionException = failure;
-        Assert.Same(failure, Assert.Throws<InvalidOperationException>(
-            () => cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest)));
+        provider.Request = null;
+        result = cache.TryGetCacheCursorAtPosition(stream, StreamSubscriptionStartPosition.EarliestAvailable);
+        Assert.Equal(QueueCacheCursorResultKind.NotSupported, result.Kind);
+        Assert.Null(provider.Request);
     }
 
     [Fact]
@@ -282,7 +333,7 @@ public class SimpleQueueCacheTests
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-    public void LatestLegacyPositionPreservesProviderException()
+    public void LegacyAcquisitionPreservesProviderException()
     {
         var innerException = new InvalidOperationException("inner");
         var expected = new QueueCacheMissException("provider message", innerException);
@@ -290,11 +341,27 @@ public class SimpleQueueCacheTests
 
 #pragma warning disable CS0618 // Verify compatibility of the obsolete wrapper.
         var actual = Assert.Throws<QueueCacheMissException>(
-            () => cache.GetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest));
+            () => cache.GetCacheCursor(default, null));
 #pragma warning restore CS0618
 
         Assert.Same(expected, actual);
         Assert.Same(innerException, actual.InnerException);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LatestPositionPropagatesUnexpectedAcquisitionErrors(bool notSupported)
+    {
+        Exception expected = notSupported
+            ? new NotSupportedException("Token acquisition failure")
+            : new InvalidOperationException("Provider failure");
+        IQueueCache cache = new LegacyThrowingQueueCache(expected);
+
+        var actual = Record.Exception(
+            () => cache.TryGetCacheCursorAtPosition(default, StreamSubscriptionStartPosition.Latest));
+
+        Assert.Same(expected, actual);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -307,7 +374,8 @@ public class SimpleQueueCacheTests
             () => ((IQueueCache)cache).TryGetCacheCursorAtPosition(
                 default,
                 StreamSubscriptionStartPosition.Latest));
-        Assert.True(cursor.IsDisposed);
+        Assert.Same(cursor, cache.Cursor);
+        Assert.Equal(1, cursor.DisposeCount);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -320,7 +388,62 @@ public class SimpleQueueCacheTests
             () => ((IQueueCache)cache).TryGetCacheCursorAtPosition(
                 default,
                 StreamSubscriptionStartPosition.Latest));
-        Assert.True(cursor.IsDisposed);
+        Assert.Same(cursor, cache.Cursor);
+        Assert.Equal(1, cursor.DisposeCount);
+    }
+
+    private sealed class DerivedCursorSimpleQueueCache() : SimpleQueueCache(10, NullLogger.Instance)
+    {
+        public DerivedSimpleQueueCacheCursor? Cursor { get; private set; }
+        public int GetCacheCursorCount { get; private set; }
+
+        [Obsolete("Use IQueueCache.TryGetCacheCursor instead.")]
+        public override IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+        {
+            GetCacheCursorCount++;
+            var cursor = new DerivedSimpleQueueCacheCursor(this, streamId);
+            if (InitializeCursor(cursor, token) is { } cacheMiss)
+            {
+                throw cacheMiss.ToException();
+            }
+
+            return Cursor = cursor;
+        }
+    }
+
+    private sealed class DerivedSimpleQueueCacheCursor(
+        SimpleQueueCache cache,
+        StreamId streamId) : SimpleQueueCacheCursor(cache, streamId, NullLogger.Instance)
+    {
+        public Exception? NextMoveException { get; set; }
+        public int MoveNextCount { get; private set; }
+        public int GetCurrentCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        [Obsolete("Use MoveNextWithResult instead.")]
+        public override bool MoveNext()
+        {
+            MoveNextCount++;
+            if (NextMoveException is { } exception)
+            {
+                NextMoveException = null;
+                throw exception;
+            }
+
+            return base.MoveNext();
+        }
+
+        public override IBatchContainer? GetCurrent(out Exception? exception)
+        {
+            GetCurrentCount++;
+            return base.GetCurrent(out exception);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
     }
 
     private sealed class DerivedSimpleQueueCache : SimpleQueueCache
@@ -346,11 +469,11 @@ public class SimpleQueueCacheTests
         public override bool IsUnderPressure() => false;
     }
 
-    private sealed class LegacyPositionQueueCache : IQueueCache
+    private sealed class TypedAcquisitionQueueCache : IQueueCache
     {
         public IQueueCacheCursor Cursor { get; } = new EmptyCursor();
-        public Exception? PositionException { get; set; }
-        public (StreamId, StreamSubscriptionStartPosition)? Request { get; private set; }
+        public QueueCacheCursorResult<IQueueCacheCursor>? Result { get; set; }
+        public (StreamId StreamId, StreamSequenceToken? Token)? Request { get; set; }
 
         public void AddToCache(IList<IBatchContainer> messages)
         {
@@ -359,19 +482,14 @@ public class SimpleQueueCacheTests
         public int GetMaxAddCount() => 1;
 
         public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
-            => throw new InvalidOperationException("Positioning must use the legacy position method.");
+            => throw new InvalidOperationException("Positioning must use typed acquisition.");
 
-        IQueueCacheCursor IQueueCache.GetCacheCursorAtPosition(
+        QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursor(
             StreamId streamId,
-            StreamSubscriptionStartPosition startPosition)
+            StreamSequenceToken? token)
         {
-            Request = (streamId, startPosition);
-            if (PositionException is { } exception)
-            {
-                throw exception;
-            }
-
-            return Cursor;
+            Request = (streamId, token);
+            return Result ?? QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(Cursor);
         }
 
         public bool IsUnderPressure() => false;
@@ -383,7 +501,7 @@ public class SimpleQueueCacheTests
         }
     }
 
-    private sealed class LegacyThrowingQueueCache(QueueCacheMissException exception) : IQueueCache
+    private sealed class LegacyThrowingQueueCache(Exception exception) : IQueueCache
     {
         public void AddToCache(IList<IBatchContainer> messages)
         {
@@ -480,18 +598,18 @@ public class SimpleQueueCacheTests
 
     private sealed class InvalidMoveResultCursor : EmptyCursor
     {
-        public bool IsDisposed { get; private set; }
+        public int DisposeCount { get; private set; }
 
-        public override void Dispose() => IsDisposed = true;
+        public override void Dispose() => DisposeCount++;
 
         public override QueueCacheCursorMoveResult MoveNextWithResult() => default;
     }
 
     private sealed class ThrowingMoveResultCursor : EmptyCursor
     {
-        public bool IsDisposed { get; private set; }
+        public int DisposeCount { get; private set; }
 
-        public override void Dispose() => IsDisposed = true;
+        public override void Dispose() => DisposeCount++;
 
         public override QueueCacheCursorMoveResult MoveNextWithResult()
             => throw new InvalidOperationException("Move failed.");

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -730,11 +730,6 @@ namespace UnitTests.StreamingTests
                 return new EmptyCursor();
             }
 
-            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(
-                StreamId streamId,
-                StreamSequenceToken? token)
-                => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursor(streamId, token));
-
             public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
             {
                 startPositionRequested.TrySetResult(startPosition);
@@ -744,16 +739,6 @@ namespace UnitTests.StreamingTests
                 }
 
                 return new EmptyCursor();
-            }
-
-            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
-                StreamId streamId,
-                StreamSubscriptionStartPosition startPosition)
-            {
-                startPositionRequested.TrySetResult(startPosition);
-                return supportsEarliestAvailable
-                    ? QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new EmptyCursor())
-                    : QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
             }
 
             public bool IsUnderPressure() => false;

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -17,6 +17,8 @@ using Orleans.Timers;
 using TestExtensions;
 using Xunit;
 
+#pragma warning disable CS0618 // Test doubles and compatibility scenarios exercise legacy cursor APIs.
+
 namespace UnitTests.StreamingTests
 {
     public class PersistentStreamPullingAgentTests
@@ -204,6 +206,8 @@ namespace UnitTests.StreamingTests
                     ]);
                 });
             var queueCache = Substitute.For<IQueueCache>();
+            queueCache.TryGetCacheCursor(Arg.Any<StreamId>(), Arg.Any<StreamSequenceToken?>())
+                .Returns(QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new EmptyQueueCacheCursor()));
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(queueId).Returns(queueCache);
             var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
@@ -463,7 +467,7 @@ namespace UnitTests.StreamingTests
 
             public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
             {
-                return Substitute.For<IQueueCacheCursor>();
+                return new EmptyQueueCacheCursor();
             }
 
             public bool IsUnderPressure() => false;
@@ -478,6 +482,117 @@ namespace UnitTests.StreamingTests
             {
                 DeliveryProgressCallCount = 0;
                 DeliveryProgressTokens.Clear();
+            }
+        }
+
+        private sealed class InvalidPositionQueueCache : IQueueCache
+        {
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null!;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+                => new EmptyQueueCacheCursor();
+
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+                StreamId streamId,
+                StreamSubscriptionStartPosition startPosition)
+                => default;
+
+            public bool IsUnderPressure() => false;
+        }
+
+        private sealed class InvalidMoveQueueCache : IQueueCache
+        {
+            public InvalidMoveCursor Cursor { get; } = new();
+            public int CursorAcquisitionCount { get; private set; }
+
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null!;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+            {
+                CursorAcquisitionCount++;
+                return new EmptyQueueCacheCursor();
+            }
+
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(
+                StreamId streamId,
+                StreamSequenceToken? token)
+            {
+                CursorAcquisitionCount++;
+                return QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new EmptyQueueCacheCursor());
+            }
+
+            public bool IsUnderPressure() => false;
+
+            public void ResetAcquisitionCount() => CursorAcquisitionCount = 0;
+        }
+
+        private sealed class InvalidMoveCursor : IQueueCacheCursor
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose() => IsDisposed = true;
+
+            public IBatchContainer? GetCurrent(out Exception? exception)
+            {
+                exception = null;
+                return null;
+            }
+
+            public bool MoveNext() => false;
+
+            public QueueCacheCursorMoveResult MoveNextWithResult() => default;
+
+            public void Refresh(StreamSequenceToken token)
+            {
+            }
+
+            public void RecordDeliveryFailure()
+            {
+            }
+        }
+
+        private sealed class EmptyQueueCacheCursor : IQueueCacheCursor
+        {
+            public void Dispose()
+            {
+            }
+
+            public IBatchContainer? GetCurrent(out Exception? exception)
+            {
+                exception = null;
+                return null;
+            }
+
+            public bool MoveNext() => false;
+
+            public QueueCacheCursorMoveResult MoveNextWithResult() => QueueCacheCursorMoveResult.NoData;
+
+            public void Refresh(StreamSequenceToken token)
+            {
+            }
+
+            public void RecordDeliveryFailure()
+            {
             }
         }
 
@@ -575,6 +690,9 @@ namespace UnitTests.StreamingTests
 
             public bool MoveNext() => throw new QueueCacheMissException("The cache entry was purged.");
 
+            public QueueCacheCursorMoveResult MoveNextWithResult()
+                => QueueCacheCursorMoveResult.FromCacheMiss(new("requested", "low", "high"));
+
             public void Refresh(StreamSequenceToken token)
             {
             }
@@ -609,8 +727,13 @@ namespace UnitTests.StreamingTests
             public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
             {
                 cursorRequested.TrySetResult(token);
-                return Substitute.For<IQueueCacheCursor>();
+                return new EmptyCursor();
             }
+
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(
+                StreamId streamId,
+                StreamSequenceToken? token)
+                => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetCacheCursor(streamId, token));
 
             public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
             {
@@ -620,7 +743,17 @@ namespace UnitTests.StreamingTests
                     throw new NotSupportedException();
                 }
 
-                return Substitute.For<IQueueCacheCursor>();
+                return new EmptyCursor();
+            }
+
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+                StreamId streamId,
+                StreamSubscriptionStartPosition startPosition)
+            {
+                startPositionRequested.TrySetResult(startPosition);
+                return supportsEarliestAvailable
+                    ? QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new EmptyCursor())
+                    : QueueCacheCursorResult<IQueueCacheCursor>.NotSupported;
             }
 
             public bool IsUnderPressure() => false;
@@ -638,6 +771,31 @@ namespace UnitTests.StreamingTests
 
             private static TaskCompletionSource<StreamSubscriptionStartPosition> CreateStartPositionRequestedSource() =>
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private sealed class EmptyCursor : IQueueCacheCursor
+            {
+                public void Dispose()
+                {
+                }
+
+                public IBatchContainer? GetCurrent(out Exception? exception)
+                {
+                    exception = null;
+                    return null;
+                }
+
+                public bool MoveNext() => false;
+
+                public QueueCacheCursorMoveResult MoveNextWithResult() => QueueCacheCursorMoveResult.NoData;
+
+                public void Refresh(StreamSequenceToken token)
+                {
+                }
+
+                public void RecordDeliveryFailure()
+                {
+                }
+            }
 
             private sealed class CacheMissCursor(QueueCacheMissException cacheMissException) : IQueueCacheCursor
             {
@@ -699,8 +857,28 @@ namespace UnitTests.StreamingTests
             public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
                 => new Cursor(cache, cache.GetCursor(streamId, token));
 
-            public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
-                => new Cursor(cache, cache.GetCursorAtPosition(streamId, startPosition));
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursor(
+                StreamId streamId,
+                StreamSequenceToken? token)
+            {
+                return WrapCursorResult(cache.TryGetCursor(streamId, token));
+            }
+
+            public QueueCacheCursorResult<IQueueCacheCursor> TryGetCacheCursorAtPosition(
+                StreamId streamId,
+                StreamSubscriptionStartPosition startPosition)
+            {
+                return WrapCursorResult(cache.TryGetCursorAtPosition(streamId, startPosition));
+            }
+
+            private QueueCacheCursorResult<IQueueCacheCursor> WrapCursorResult(QueueCacheCursorResult<object> result)
+                => result.Kind switch
+                {
+                    QueueCacheCursorResultKind.Success => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(new Cursor(cache, result.Cursor!)),
+                    QueueCacheCursorResultKind.CacheMiss => QueueCacheCursorResult<IQueueCacheCursor>.FromCacheMiss(result.CacheMiss!.Value),
+                    QueueCacheCursorResultKind.NotSupported => QueueCacheCursorResult<IQueueCacheCursor>.NotSupported,
+                    _ => throw new InvalidOperationException("The cursor result is not initialized."),
+                };
 
             public bool IsUnderPressure() => false;
 
@@ -740,6 +918,9 @@ namespace UnitTests.StreamingTests
                 }
 
                 public bool MoveNext() => cache.TryGetNextMessage(cursor, out current);
+
+                public QueueCacheCursorMoveResult MoveNextWithResult()
+                    => cache.TryGetNextMessageWithResult(cursor, out current);
 
                 public void Refresh(StreamSequenceToken token) => cache.Refresh(cursor, token);
 
@@ -1733,6 +1914,85 @@ namespace UnitTests.StreamingTests
                 Arg.Any<CancellationToken>());
         }
 
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task ProviderDefaultEarliestRejectsInvalidCustomCacheResult()
+        {
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var queueCache = new InvalidPositionQueueCache();
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default, TestContext.Current.CancellationToken)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+            var agent = CreateAgent(
+                pubSub,
+                QueueId.GetQueueId("queue", 0u, 0u),
+                options: new StreamPullingAgentOptions
+                {
+                    InitialSubscriptionStartPosition = StreamSubscriptionStartPosition.EarliestAvailable,
+                },
+                queueAdapterCache: queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await accessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+            var consumer = new RecordingConsumer();
+            var streamData = (await accessor.GetPubSubCache()).Single().Value;
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(SubscriptionMarker.MarkAsImplictSubscriptionId(Guid.NewGuid())),
+                streamId,
+                consumer,
+                filterData: null,
+                now: DateTime.UtcNow);
+
+            Assert.False(await accessor.DoHandshakeWithConsumer(consumerData, cacheToken: null));
+
+            Assert.IsType<InvalidOperationException>(Assert.Single(consumer.Errors));
+            Assert.Null(consumerData.Cursor);
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunConsumerCursorStopsAfterInvalidMoveResult()
+        {
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var queueCache = new InvalidMoveQueueCache();
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default, TestContext.Current.CancellationToken)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+            var agent = CreateAgent(
+                pubSub,
+                QueueId.GetQueueId("queue", 0u, 0u),
+                queueAdapterCache: queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await accessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+            var streamData = (await accessor.GetPubSubCache()).Single().Value;
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                new RecordingConsumer(),
+                filterData: null,
+                now: DateTime.UtcNow);
+            consumerData.IsRegistered = true;
+            consumerData.Cursor = queueCache.Cursor;
+            queueCache.ResetAcquisitionCount();
+
+            var exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(
+                () => accessor.RunConsumerCursor(consumerData));
+
+            Assert.Equal("The cursor move result is not initialized.", exception.Message);
+            Assert.True(queueCache.Cursor.IsDisposed);
+            Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
+            Assert.Equal(0, queueCache.CursorAcquisitionCount);
+        }
+
         private sealed class RewindConsumer(StreamHandshakeToken rewindToken) : IStreamConsumerExtension
         {
             private bool rewindRequested;
@@ -2394,3 +2654,5 @@ namespace UnitTests.StreamingTests
         }
     }
 }
+
+#pragma warning restore CS0618

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -702,15 +702,45 @@ namespace UnitTests.StreamingTests
             }
         }
 
-        private sealed class RecoverableCacheMissQueueCache(
-            QueueCacheMissException cacheMissException,
-            bool supportsEarliestAvailable) : IQueueCache
+        private class RecoverableCacheMissQueueCache : IQueueCache
         {
+            private readonly QueueCacheMissException cacheMissException;
+            private readonly IReadOnlyList<IBatchContainer> retainedBatches;
             private TaskCompletionSource<StreamSequenceToken?> cursorRequested = CreateCursorRequestedSource();
             private TaskCompletionSource<StreamSubscriptionStartPosition> startPositionRequested = CreateStartPositionRequestedSource();
+            private LegacyBatchCursor? tokenCursor;
+            private LegacyBatchCursor? earliestCursor;
+            private CacheMissCursor? cacheMissCursor;
+
+            public RecoverableCacheMissQueueCache(
+                QueueCacheMissException cacheMissException,
+                IReadOnlyList<IBatchContainer>? retainedBatches = null)
+            {
+                this.cacheMissException = cacheMissException;
+                this.retainedBatches = retainedBatches ?? [];
+            }
+
+            public static RecoverableCacheMissQueueCache Create(
+                QueueCacheMissException cacheMissException,
+                bool supportsEarliestAvailable,
+                IReadOnlyList<IBatchContainer>? retainedBatches = null)
+                => supportsEarliestAvailable
+                    ? new EarliestAvailableRecoveryQueueCache(cacheMissException, retainedBatches)
+                    : new RecoverableCacheMissQueueCache(cacheMissException, retainedBatches);
 
             public Task<StreamSequenceToken?> CursorRequested => cursorRequested.Task;
             public Task<StreamSubscriptionStartPosition> StartPositionRequested => startPositionRequested.Task;
+            public List<(
+                StreamId StreamId,
+                StreamSequenceToken? Token,
+                StreamSubscriptionStartPosition? Position)> Requests { get; } = [];
+            public IQueueCacheCursor? OldCursor => cacheMissCursor;
+            public IQueueCacheCursor? ReplacementCursor => earliestCursor ?? tokenCursor;
+            public int OldCursorMoveNextCount => cacheMissCursor?.MoveNextCount ?? 0;
+            public int OldCursorDisposeCount => cacheMissCursor?.DisposeCount ?? 0;
+            public int ReplacementMoveNextCount => (earliestCursor ?? tokenCursor)?.MoveNextCount ?? 0;
+            public int ReplacementGetCurrentCount => (earliestCursor ?? tokenCursor)?.GetCurrentCount ?? 0;
+            public int ReplacementDisposeCount => (earliestCursor ?? tokenCursor)?.DisposeCount ?? 0;
 
             public int GetMaxAddCount() => 1000;
 
@@ -726,27 +756,43 @@ namespace UnitTests.StreamingTests
 
             public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
             {
+                Requests.Add((streamId, token, null));
                 cursorRequested.TrySetResult(token);
-                return new EmptyCursor();
+                return tokenCursor = new LegacyBatchCursor(retainedBatches);
             }
 
-            public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+            protected IQueueCacheCursor GetEarliestCursor(StreamId streamId)
             {
-                startPositionRequested.TrySetResult(startPosition);
-                if (!supportsEarliestAvailable)
-                {
-                    throw new NotSupportedException();
-                }
+                Requests.Add((streamId, null, StreamSubscriptionStartPosition.EarliestAvailable));
+                startPositionRequested.TrySetResult(StreamSubscriptionStartPosition.EarliestAvailable);
+                return earliestCursor = new LegacyBatchCursor(retainedBatches);
+            }
 
-                return new EmptyCursor();
+            private sealed class EarliestAvailableRecoveryQueueCache(
+                QueueCacheMissException cacheMissException,
+                IReadOnlyList<IBatchContainer>? retainedBatches)
+                : RecoverableCacheMissQueueCache(cacheMissException, retainedBatches), IQueueCache
+            {
+                QueueCacheCursorResult<IQueueCacheCursor> IQueueCache.TryGetCacheCursorAtPosition(
+                    StreamId streamId,
+                    StreamSubscriptionStartPosition startPosition)
+                    => startPosition switch
+                    {
+                        StreamSubscriptionStartPosition.EarliestAvailable
+                            => QueueCacheCursorResult<IQueueCacheCursor>.FromCursor(GetEarliestCursor(streamId)),
+                        StreamSubscriptionStartPosition.Latest => ((IQueueCache)this).TryGetCacheCursor(streamId, null),
+                        _ => throw new ArgumentOutOfRangeException(nameof(startPosition)),
+                    };
             }
 
             public bool IsUnderPressure() => false;
 
-            public IQueueCacheCursor CreateCacheMissCursor() => new CacheMissCursor(cacheMissException);
+            public IQueueCacheCursor CreateCacheMissCursor()
+                => cacheMissCursor = new CacheMissCursor(cacheMissException);
 
             public void ResetRequests()
             {
+                Requests.Clear();
                 cursorRequested = CreateCursorRequestedSource();
                 startPositionRequested = CreateStartPositionRequestedSource();
             }
@@ -757,21 +803,42 @@ namespace UnitTests.StreamingTests
             private static TaskCompletionSource<StreamSubscriptionStartPosition> CreateStartPositionRequestedSource() =>
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            private sealed class EmptyCursor : IQueueCacheCursor
+            private sealed class LegacyBatchCursor(IReadOnlyList<IBatchContainer> batches) : IQueueCacheCursor
             {
-                public void Dispose()
-                {
-                }
+                private int index = -1;
+
+                public int MoveNextCount { get; private set; }
+                public int GetCurrentCount { get; private set; }
+                public int DisposeCount { get; private set; }
+
+                public void Dispose() => DisposeCount++;
 
                 public IBatchContainer? GetCurrent(out Exception? exception)
                 {
+                    GetCurrentCount++;
                     exception = null;
-                    return null;
+                    return index >= 0 && index < batches.Count
+                        ? batches[index]
+                        : throw new InvalidOperationException("The cursor does not have a current item.");
                 }
 
-                public bool MoveNext() => false;
+                public bool MoveNext()
+                {
+                    MoveNextCount++;
+                    if (DisposeCount != 0)
+                    {
+                        throw new ObjectDisposedException(nameof(LegacyBatchCursor));
+                    }
 
-                public QueueCacheCursorMoveResult MoveNextWithResult() => QueueCacheCursorMoveResult.NoData;
+                    if (index + 1 >= batches.Count)
+                    {
+                        index = batches.Count;
+                        return false;
+                    }
+
+                    index++;
+                    return true;
+                }
 
                 public void Refresh(StreamSequenceToken token)
                 {
@@ -784,13 +851,18 @@ namespace UnitTests.StreamingTests
 
             private sealed class CacheMissCursor(QueueCacheMissException cacheMissException) : IQueueCacheCursor
             {
-                public void Dispose()
-                {
-                }
+                public int MoveNextCount { get; private set; }
+                public int DisposeCount { get; private set; }
+
+                public void Dispose() => DisposeCount++;
 
                 public IBatchContainer GetCurrent(out Exception exception) => throw new InvalidOperationException();
 
-                public bool MoveNext() => throw cacheMissException;
+                public bool MoveNext()
+                {
+                    MoveNextCount++;
+                    throw cacheMissException;
+                }
 
                 public void Refresh(StreamSequenceToken token)
                 {
@@ -958,6 +1030,37 @@ namespace UnitTests.StreamingTests
             public Task<StreamHandshakeToken?> GetSequenceToken(GuidId subscriptionId, CancellationToken cancellationToken) => Task.FromResult(requestedToken);
 
             public void ReleaseDelivery() => releaseDelivery.TrySetResult(true);
+        }
+
+        private sealed class ImmediateRecordingConsumer : IStreamConsumerExtension
+        {
+            public List<IBatchContainer> DeliveredBatches { get; } = [];
+            public List<StreamSequenceToken> DeliveredTokens { get; } = [];
+            public List<Exception> Errors { get; } = [];
+
+            public Task<StreamHandshakeToken?> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public Task<StreamHandshakeToken?> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public Task<StreamHandshakeToken?> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+            {
+                DeliveredBatches.Add(item);
+                DeliveredTokens.Add(item.SequenceToken);
+                return Task.FromResult<StreamHandshakeToken?>(null);
+            }
+
+            public Task CompleteStream(GuidId subscriptionId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task ErrorInStream(GuidId subscriptionId, Exception exc, CancellationToken cancellationToken)
+            {
+                Errors.Add(exc);
+                return Task.CompletedTask;
+            }
+
+            public Task<StreamHandshakeToken?> GetSequenceToken(GuidId subscriptionId, CancellationToken cancellationToken)
+                => Task.FromResult<StreamHandshakeToken?>(null);
         }
 
         private sealed class RenegotiatingEarliestConsumer : IStreamConsumerExtension
@@ -2099,14 +2202,129 @@ namespace UnitTests.StreamingTests
             var exception = new QueueCacheMissException("Cache miss from a custom queue cache");
 
             var queueCache = await RunCacheMissRecovery(exception, requestedToken, newestToken, supportsEarliestAvailable: false);
-            var recoveryPosition = await queueCache.StartPositionRequested.WaitAsync(
-                TimeSpan.FromSeconds(5),
-                TestContext.Current.CancellationToken);
             var recoveryToken = await queueCache.CursorRequested.WaitAsync(
                 TimeSpan.FromSeconds(5),
                 TestContext.Current.CancellationToken);
-            Assert.Equal(StreamSubscriptionStartPosition.EarliestAvailable, recoveryPosition);
+            Assert.False(queueCache.StartPositionRequested.IsCompleted);
             Assert.Null(recoveryToken);
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public Task RunConsumerCursor_RecoversThroughLegacyCursorAtEarliestAvailable()
+            => VerifyRunConsumerCursorRecoversThroughLegacyCursor(supportsEarliestAvailable: true);
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public Task RunConsumerCursor_RecoversThroughLegacyOnlyCacheWhenEarliestIsUnsupported()
+            => VerifyRunConsumerCursorRecoversThroughLegacyCursor(supportsEarliestAvailable: false);
+
+        private static async Task VerifyRunConsumerCursorRecoversThroughLegacyCursor(
+            bool supportsEarliestAvailable)
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default, TestContext.Current.CancellationToken)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(
+                    new HashSet<PubSubSubscriptionState>()));
+            pubSub.UnregisterProducer(default, default, TestContext.Current.CancellationToken)
+                .ReturnsForAnyArgs(Task.CompletedTask);
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var requestedToken = new EventSequenceTokenV2(0);
+            var firstRetainedToken = new EventSequenceTokenV2(1);
+            var secondRetainedToken = new EventSequenceTokenV2(2);
+            var firstRetainedBatch = new TestBatchContainer(streamId, firstRetainedToken);
+            var secondRetainedBatch = new TestBatchContainer(streamId, secondRetainedToken);
+            var queueCache = RecoverableCacheMissQueueCache.Create(
+                new QueueCacheMissException(requestedToken, firstRetainedToken, secondRetainedToken),
+                supportsEarliestAvailable,
+                [firstRetainedBatch, secondRetainedBatch]);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.Shutdown(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            var consumer = new ImmediateRecordingConsumer();
+            StreamConsumerData? consumerData = null;
+
+            try
+            {
+                await accessor.RegisterStream(qualifiedStreamId, firstRetainedToken, DateTime.UtcNow);
+                var streamData = (await accessor.GetPubSubCache()).Single().Value;
+                consumerData = streamData.AddConsumer(
+                    GuidId.GetGuidId(Guid.NewGuid()),
+                    qualifiedStreamId,
+                    consumer,
+                    filterData: null,
+                    now: DateTime.UtcNow);
+                consumerData.IsRegistered = true;
+                consumerData.LastProcessedToken = requestedToken;
+                consumerData.Cursor = queueCache.CreateCacheMissCursor();
+                Assert.Same(queueCache.OldCursor, consumerData.Cursor);
+                queueCache.ResetRequests();
+
+                await accessor.RunConsumerCursor(consumerData);
+
+                Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
+                Assert.Equal(1, queueCache.OldCursorMoveNextCount);
+                Assert.Equal(1, queueCache.OldCursorDisposeCount);
+                Assert.Same(queueCache.ReplacementCursor, consumerData.Cursor);
+                Assert.Equal(0, queueCache.ReplacementDisposeCount);
+                Assert.Null(consumerData.PendingBatch);
+                Assert.Empty(consumer.Errors);
+                Assert.Collection(
+                    consumer.DeliveredTokens,
+                    token => Assert.Same(firstRetainedToken, token),
+                    token => Assert.Same(secondRetainedToken, token));
+                Assert.Collection(
+                    consumer.DeliveredBatches,
+                    batch => Assert.Same(firstRetainedBatch, batch),
+                    batch => Assert.Same(secondRetainedBatch, batch));
+                Assert.Equal(3, queueCache.ReplacementMoveNextCount);
+                Assert.Equal(2, queueCache.ReplacementGetCurrentCount);
+
+                if (supportsEarliestAvailable)
+                {
+                    Assert.Collection(
+                        queueCache.Requests,
+                        request =>
+                        {
+                            Assert.Equal(streamId, request.StreamId);
+                            Assert.Null(request.Token);
+                            Assert.Equal(StreamSubscriptionStartPosition.EarliestAvailable, request.Position);
+                        });
+                }
+                else
+                {
+                    Assert.False(queueCache.StartPositionRequested.IsCompleted);
+                    Assert.Collection(
+                        queueCache.Requests,
+                        request =>
+                        {
+                            Assert.Equal(streamId, request.StreamId);
+                            Assert.Same(requestedToken, request.Token);
+                            Assert.Null(request.Position);
+                        });
+                }
+            }
+            finally
+            {
+                await accessor.Shutdown();
+            }
+
+            Assert.NotNull(consumerData);
+            Assert.Null(consumerData.Cursor);
+            Assert.Null(consumerData.PendingBatch);
+            Assert.Equal(1, queueCache.OldCursorDisposeCount);
+            Assert.Equal(1, queueCache.ReplacementDisposeCount);
         }
 
         private static async Task<RecoverableCacheMissQueueCache> RunCacheMissRecovery(
@@ -2122,7 +2340,7 @@ namespace UnitTests.StreamingTests
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
             var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
-            var queueCache = new RecoverableCacheMissQueueCache(exception, supportsEarliestAvailable);
+            var queueCache = RecoverableCacheMissQueueCache.Create(exception, supportsEarliestAvailable);
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
             var receiver = Substitute.For<IQueueAdapterReceiver>();

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -733,7 +733,8 @@ namespace UnitTests.StreamingTests
             public List<(
                 StreamId StreamId,
                 StreamSequenceToken? Token,
-                StreamSubscriptionStartPosition? Position)> Requests { get; } = [];
+                StreamSubscriptionStartPosition? Position)> Requests
+            { get; } = [];
             public IQueueCacheCursor? OldCursor => cacheMissCursor;
             public IQueueCacheCursor? ReplacementCursor => earliestCursor ?? tokenCursor;
             public int OldCursorMoveNextCount => cacheMissCursor?.MoveNextCount ?? 0;


### PR DESCRIPTION
Queue cache cursor acquisition and advancement currently use `QueueCacheMissException` for expected cursor states. This change introduces typed results so normal cache misses, empty/end states, and unsupported positioning can be handled without exception control flow.

This follows #9711, which owns the message-loss recovery behavior. The duplicate recovery implementation from the original version of this PR has been removed. Delivery cache misses continue inclusively from `EarliestAvailable`, while unsupported custom caches continue through their established token-based recovery path.

The change:

- adds allocation-conscious typed acquisition and movement results with structured cache-miss details
- implements the typed APIs directly in pooled, simple, generator, memory, and Event Hubs caches
- migrates `PersistentStreamPullingAgent` to typed results for expected cache states
- enforces cursor ownership invariants so rejected cursors are disposed and invalid results terminate instead of entering recovery loops
- retains existing public cursor APIs as obsolete compatibility wrappers with their legacy cursor, `QueueCacheMissException`, and `NotSupportedException` behavior
- preserves third-party cache and cursor implementations through default interface adapters
- regenerates the Orleans Streaming and Event Hubs public API surfaces

The branch history is consolidated into implementation/API and test commits.