### PR TITLE
Remove infinite timespan reminder checks

### DIFF
--- a/src/Orleans.Reminders/ReminderService/ReminderRegistry.cs
+++ b/src/Orleans.Reminders/ReminderService/ReminderRegistry.cs
@@ -25,12 +25,18 @@ namespace Orleans.Runtime.ReminderService
         public Task<IGrainReminder> RegisterOrUpdateReminder(GrainId callingGrainId, string reminderName, TimeSpan dueTime, TimeSpan period)
         {
             // Perform input volatility checks 
+            if (dueTime == Timeout.InfiniteTimeSpan)
+                throw new ArgumentOutOfRangeException(nameof(dueTime), "Cannot use InfiniteTimeSpan dueTime to create a reminder");
+
             if (dueTime.Ticks < 0)
                 throw new ArgumentOutOfRangeException(nameof(dueTime), "Cannot use negative dueTime to create a reminder");
-           
+
+            if (period == Timeout.InfiniteTimeSpan)
+                throw new ArgumentOutOfRangeException(nameof(period), "Cannot use InfiniteTimeSpan period to create a reminder");
+
             if (period.Ticks < 0)
                 throw new ArgumentOutOfRangeException(nameof(period), "Cannot use negative period to create a reminder");
-          
+            
             var minReminderPeriod = options.MinimumReminderPeriod;
             if (period < minReminderPeriod)
                 throw new ArgumentException($"Cannot register reminder {reminderName} as requested period ({period}) is less than minimum allowed reminder period ({minReminderPeriod})");


### PR DESCRIPTION
The source suggests that the usage "InfiniteTimeSpan" is allowed with Reminders, but it is not allowed. As such adding specific checks for InfiniteTimeSpan is more appropriate. The reference to timer.cs has been removed, as it no longer is consistent with the checks from timer.cs.

This resolves issue #9710 .
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9715)