### PR TITLE
[Journaling] Schedule manager work loop to `ThreadPoolTaskScheduler`

### DIFF
--- a/src/Orleans.Journaling/StateMachineManager.cs
+++ b/src/Orleans.Journaling/StateMachineManager.cs
@@ -81,7 +81,7 @@ internal sealed partial class StateMachineManager : IStateMachineManager, ILifec
     private Task Start()
     {
         using var suppressExecutionContext = new ExecutionContextSuppressor();
-        return WorkLoop();
+        return Task.Run(WorkLoop);
     }
 
     private async Task WorkLoop()


### PR DESCRIPTION
Explicitly schedule the work loop task of the `StateMachineManager` to the `ThreadPoolTaskScheduler`.

Short version: The work loop can hijack the activation's scheduler after a fast re-activation of a grain.
Long version: [read here](https://www.ledjonbehluli.com/posts/orleans_scheduler_hijacking/)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9722)