### PR TITLE
replace dead link with app service / container apps / fabric docs

### DIFF
--- a/src/Azure/Orleans.Hosting.AzureCloudServices/README.md
+++ b/src/Azure/Orleans.Hosting.AzureCloudServices/README.md
@@ -55,7 +55,9 @@ public class WorkerRole : RoleEntryPoint
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Hosting in Azure](https://learn.microsoft.com/en-us/dotnet/orleans/host/azure-cloud-services)
+- [Hosting in Azure App Service](https://learn.microsoft.com/en-us/dotnet/orleans/deployment/deploy-to-azure-app-service)
+- [Hosting in Azure Container Apps](https://learn.microsoft.com/en-us/dotnet/orleans/deployment/deploy-to-azure-container-apps)
+- [Hosting in Service Fabric](https://learn.microsoft.com/en-us/dotnet/orleans/deployment/service-fabric)
 - [Silo Configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/typical-configurations)
 
 ## Feedback & Contributing


### PR DESCRIPTION
A very minor error that I found while reading the docs. The link https://learn.microsoft.com/en-us/dotnet/orleans/host/azure-cloud-services gives a 404, so I've replaced it with the corresponding Azure service-specific pages

https://learn.microsoft.com/en-us/dotnet/orleans/deployment/deploy-to-azure-app-service
https://learn.microsoft.com/en-us/dotnet/orleans/deployment/deploy-to-azure-container-apps
https://learn.microsoft.com/en-us/dotnet/orleans/deployment/service-fabric
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9760)