### PR TITLE
Do not allocate new buffer if the current buffer is sufficient

### DIFF
--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -222,7 +222,7 @@ namespace Orleans.Serialization.Buffers
         public void EnsureContiguous(int length)
         {
             // The current buffer is adequate.
-            if (_bufferPos + length < _currentSpan.Length)
+            if (_bufferPos + length <= _currentSpan.Length)
             {
                 return;
             }


### PR DESCRIPTION
Current behavior is that if the currentSpan.Length == buffPos + length, then it will allocate a new buffer. It's not really a problem, but it over-allocates a buffer, when the current one is adequate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9775)