### PR TITLE
Revert "Deprecate IStartupTask and AddStartupTask with warnings"

### DIFF
--- a/src/Orleans.Runtime/Hosting/SiloBuilderStartupExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/SiloBuilderStartupExtensions.cs
@@ -28,7 +28,6 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloBuilder"/>.
         /// </returns>
-        [Obsolete("AddStartupTask is deprecated. Use BackgroundService or IHostedService instead. See https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/startup-tasks for more information.", error: false)]
         public static ISiloBuilder AddStartupTask<TStartup>(
             this ISiloBuilder builder,
             int stage = ServiceLifecycleStage.Active)
@@ -52,7 +51,6 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloBuilder"/>.
         /// </returns>
-        [Obsolete("AddStartupTask is deprecated. Use BackgroundService or IHostedService instead. See https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/startup-tasks for more information.", error: false)]
         public static ISiloBuilder AddStartupTask(
             this ISiloBuilder builder,
             IStartupTask startupTask,
@@ -76,7 +74,6 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloBuilder"/>.
         /// </returns>
-        [Obsolete("AddStartupTask is deprecated. Use BackgroundService or IHostedService instead. See https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/startup-tasks for more information.", error: false)]
         public static ISiloBuilder AddStartupTask(
             this ISiloBuilder builder,
             Func<IServiceProvider, CancellationToken, Task> startupTask,

--- a/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
+++ b/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Runtime
@@ -7,7 +6,6 @@ namespace Orleans.Runtime
     /// <summary>
     /// Defines an action to be taken after silo startup.
     /// </summary>
-    [Obsolete("IStartupTask is deprecated. Use BackgroundService or IHostedService instead. See https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/startup-tasks for more information.", error: false)]
     public interface IStartupTask
     {
         /// <summary>

--- a/test/Tester/StartupTaskTests.cs
+++ b/test/Tester/StartupTaskTests.cs
@@ -8,8 +8,6 @@ using UnitTests.GrainInterfaces;
 
 using Xunit;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 namespace DefaultCluster.Tests
 {
     [TestCategory("BVT"), TestCategory("Lifecycle")]


### PR DESCRIPTION
Reverts dotnet/orleans#9763

We should wait until we have a better alternative in place. For now, documentation is our best bet. We can add docs to these methods and `IStartupTask` itself, too.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9784)