### PR TITLE
Activation migration: Improve resilience to faulty `IGrainMigrationParticipant` implementations

### DIFF
--- a/src/Orleans.Core/Lifecycle/MigrationContext.cs
+++ b/src/Orleans.Core/Lifecycle/MigrationContext.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.Session;
@@ -27,7 +28,7 @@ internal sealed class MigrationContext : IDehydrationContext, IRehydrationContex
     }
 
     [Id(0), Immutable]
-    private readonly Dictionary<string, (int Offset, int Length)> _indices = new(StringComparer.Ordinal);
+    private Dictionary<string, (int Offset, int Length)> _indices = new(StringComparer.Ordinal);
 
     [Id(1), Immutable]
     private PooledBuffer _buffer = new();
@@ -80,18 +81,27 @@ internal sealed class MigrationContext : IDehydrationContext, IRehydrationContex
 
     public IEnumerable<string> Keys => this;
 
-    public void Dispose()
+    public void Reset()
     {
-        _buffer.Reset();
-        _buffer = default;
+        lock (_lock)
+        {
+            _indices = [];
+            _buffer.Reset();
+            _buffer = default;
+        }
     }
+
+    public void Dispose() => Reset();
 
     public bool TryGetBytes(string key, out ReadOnlySequence<byte> value)
     {
-        if (_indices.TryGetValue(key, out var record))
+        lock (_lock)
         {
-            value = _buffer.AsReadOnlySequence().Slice(record.Offset, record.Length);
-            return true;
+            if (_indices.TryGetValue(key, out var record))
+            {
+                value = _buffer.AsReadOnlySequence().Slice(record.Offset, record.Length);
+                return true;
+            }
         }
 
         value = default;
@@ -100,14 +110,17 @@ internal sealed class MigrationContext : IDehydrationContext, IRehydrationContex
 
     public bool TryGetValue<T>(string key, [NotNullWhen(true)] out T? value)
     {
-        if (_indices.TryGetValue(key, out var record) && _sessionPool.CodecProvider.TryGetCodec<T>() is { } codec)
+        lock (_lock)
         {
-            using var session = _sessionPool.GetSession();
-            var source = _buffer.Slice(record.Offset, record.Length);
-            var reader = Reader.Create(source, session);
-            var field = reader.ReadFieldHeader();
-            value = codec.ReadValue(ref reader, field);
-            return value is not null;
+            if (_indices.TryGetValue(key, out var record) && _sessionPool.CodecProvider.TryGetCodec<T>() is { } codec)
+            {
+                using var session = _sessionPool.GetSession();
+                var source = _buffer.Slice(record.Offset, record.Length);
+                var reader = Reader.Create(source, session);
+                var field = reader.ReadFieldHeader();
+                value = codec.ReadValue(ref reader, field);
+                return value is not null;
+            }
         }
 
         value = default;

--- a/test/DefaultCluster.Tests/Migration/MigrationTests.cs
+++ b/test/DefaultCluster.Tests/Migration/MigrationTests.cs
@@ -309,21 +309,18 @@ namespace DefaultCluster.Tests.General
 
         public void OnDehydrate(IDehydrationContext migrationContext)
         {
+            if (RequestContext.Get("fail_rehydrate") is true)
+            {
+                migrationContext.TryAddValue("fail_rehydrate", true);
+            }
+
+            if (RequestContext.Get("fail_dehydrate") is true)
+            {
+                throw new InvalidOperationException("Failing to dehydrate on-command");
+            }
+
             migrationContext.TryAddValue("state", _state);
 
-            {
-                if (RequestContext.Get("fail_rehydrate") is bool fail && fail)
-                {
-                    migrationContext.TryAddValue("fail_rehydrate", true);
-                }
-            }
-
-            {
-                if (RequestContext.Get("fail_dehydrate") is bool fail && fail)
-                {
-                    throw new InvalidOperationException("Failing to dehydrate on-command");
-                }
-            }
         }
 
         public void OnRehydrate(IRehydrationContext migrationContext)


### PR DESCRIPTION
This pull request refactors the `MigrationContext` class and improves error handling and logging during the dehydration process in Orleans grain activation. The main changes focus on code consistency, thread safety, and clearer error reporting, while also simplifying the logic for test grain dehydration.

### MigrationContext refactoring and consistency improvements

* Renamed the internal session pool field to `SessionPool` and updated all references for consistency across methods and serialization hooks. [[1]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL21-R27) [[2]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL57-R54) [[3]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL66-R63) [[4]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL103-R108) [[5]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL143-R146)
* Changed the `_indices` dictionary to be mutable and added a thread-safe `Reset()` method, which is now called by `Dispose()`. This ensures proper cleanup and reuse of the context. [[1]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL21-R27) [[2]](diffhunk://#diff-3b1f72304f166c96e7484f1ea020f7682b51907a4a6a9d0e40214e0db6c4899eL83-R90)

### Error handling and logging improvements

* Added a new error logger `LogErrorDehydratingActivation` and wrapped the dehydration logic in a try-catch block to log errors that occur during dehydration. [[1]](diffhunk://#diff-4c37da62c550fa4b738ea2e6cda951b944941b5ae8c55a41c1786bbb4c293ed5R1221-R1227) [[2]](diffhunk://#diff-4c37da62c550fa4b738ea2e6cda951b944941b5ae8c55a41c1786bbb4c293ed5L1231-R1241) [[3]](diffhunk://#diff-4c37da62c550fa4b738ea2e6cda951b944941b5ae8c55a41c1786bbb4c293ed5R2277-R2282)

### Test grain dehydration logic simplification

* Simplified the test grain's dehydration logic by directly checking for boolean flags in the request context, reordering the logic, and ensuring the state is always added last.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9786)