### PR TITLE
[Breaking Change] ADO.NET providers: replace obsolete System.Data.SqlClient with Microsoft.Data.SqlClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
         -- -parallel none -noshadow
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
-        ORLEANSMSSQLCONNECTIONSTRING: "Server=127.0.0.1,1433;User Id=SA;Password=yourWeak(!)Password;"
+        ORLEANSMSSQLCONNECTIONSTRING: "Server=127.0.0.1,1433;User Id=SA;Password=yourWeak(!)Password;TrustServerCertificate=True;"
     - name: Archive Test Results
       if: always()
       uses: actions/upload-artifact@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <xUnitRunnerVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'netstandard2.1' ">2.4.5</xUnitRunnerVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- System packages -->
     <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="9.0.0" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.1" />
@@ -49,7 +50,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageVersion Include="Azure.Core" Version="1.46.2" />
+    <PackageVersion Include="Azure.Core" Version="1.47.1" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
@@ -100,7 +101,7 @@
     <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageVersion Include="NSubstitute" Version="4.4.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" />

--- a/src/AdoNet/Orleans.Clustering.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/README.md
@@ -12,7 +12,7 @@ dotnet add package Microsoft.Orleans.Clustering.AdoNet
 
 You will also need to install the appropriate database driver package for your database system:
 
-- SQL Server: `Microsoft.Data.SqlClient` or `System.Data.SqlClient`
+- SQL Server: `Microsoft.Data.SqlClient`
 - MySQL: `MySql.Data` or `MySqlConnector`
 - PostgreSQL: `Npgsql`
 - Oracle: `Oracle.ManagedDataAccess.Core`
@@ -93,7 +93,7 @@ var clientBuilder = Host.CreateApplicationBuilder(args)
             // Configure the client to use ADO.NET for clustering
             .UseAdoNetClustering(options =>
             {
-                options.Invariant = "System.Data.SqlClient";  // Or other providers like "MySql.Data.MySqlClient", "Npgsql", etc.
+                options.Invariant = "Microsoft.Data.SqlClient";  // Or other providers like "MySql.Data.MySqlClient", "Npgsql", etc.
                 options.ConnectionString = "Server=localhost;Database=OrleansCluster;User Id=myUsername;******;";
             });
     });

--- a/src/AdoNet/Orleans.Persistence.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/README.md
@@ -12,7 +12,7 @@ dotnet add package Microsoft.Orleans.Persistence.AdoNet
 
 You will also need to install the appropriate database driver package for your database system:
 
-- SQL Server: `Microsoft.Data.SqlClient` or `System.Data.SqlClient`
+- SQL Server: `Microsoft.Data.SqlClient`
 - MySQL: `MySql.Data` or `MySqlConnector`
 - PostgreSQL: `Npgsql`
 - Oracle: `Oracle.ManagedDataAccess.Core`
@@ -32,10 +32,10 @@ var builder = Host.CreateApplicationBuilder(args)
             .UseLocalhostClustering()
             // Configure ADO.NET as grain storage
             .AddAdoNetGrainStorage(
-                name: "AdoNetStore", 
+                name: "AdoNetStore",
                 configureOptions: options =>
                 {
-                    options.Invariant = "System.Data.SqlClient";  // Or other providers like "MySql.Data.MySqlClient", "Npgsql", etc.
+                    options.Invariant = "Microsoft.Data.SqlClient";  // Or other providers like "MySql.Data.MySqlClient", "Npgsql", etc.
                     options.ConnectionString = "Server=localhost;Database=OrleansStorage;User Id=myUsername;******;";
                     // Optional: Configure custom queries
                     options.UseJsonFormat = true; // Store as JSON instead of binary

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -63,7 +63,7 @@ namespace Orleans.Storage
     /// </para>
     /// <para>
     /// Optional configuration params:
-    /// <c>AdoInvariant</c> -- defaults to <c>System.Data.SqlClient</c>
+    /// <c>AdoInvariant</c> -- defaults to <c>Microsoft.Data.SqlClient</c>
     /// <c>UseJsonFormat</c> -- defaults to <c>false</c>
     /// <c>UseXmlFormat</c> -- defaults to <c>false</c>
     /// <c>UseBinaryFormat</c> -- defaults to <c>true</c>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/README.md
@@ -14,7 +14,7 @@ You will also need to install the appropriate ADO.NET provider for your database
 
 ```shell
 # For SQL Server
-dotnet add package System.Data.SqlClient
+dotnet add package Microsoft.Data.SqlClient
 
 # For MySQL
 dotnet add package MySql.Data
@@ -40,7 +40,7 @@ builder.UseOrleans(siloBuilder =>
         // Configure ADO.NET as reminder storage
         .UseAdoNetReminderService(options =>
         {
-            options.Invariant = "System.Data.SqlClient";  // For SQL Server
+            options.Invariant = "Microsoft.Data.SqlClient";  // For SQL Server
             options.ConnectionString = "Server=localhost;Database=OrleansReminders;User ID=orleans;******;";
         });
 });
@@ -80,7 +80,7 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
     public async Task StartReminder(string reminderName)
     {
         _reminderName = reminderName;
-        
+
         // Register a persistent reminder
         await RegisterOrUpdateReminder(
             reminderName,

--- a/src/AdoNet/Orleans.Streaming.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/README.md
@@ -14,7 +14,7 @@ You will also need to install the appropriate ADO.NET provider for your database
 
 ```shell
 # For SQL Server
-dotnet add package System.Data.SqlClient
+dotnet add package Microsoft.Data.SqlClient
 
 # For MySQL
 dotnet add package MySql.Data
@@ -39,7 +39,7 @@ var builder = Host.CreateApplicationBuilder(args)
                 name: "AdoNetStreamProvider",
                 configureOptions: options =>
                 {
-                    options.Invariant = "System.Data.SqlClient";  // For SQL Server
+                    options.Invariant = "Microsoft.Data.SqlClient";  // For SQL Server
                     options.ConnectionString = "Server=localhost;Database=OrleansStreaming;User ID=orleans;******;";
                 });
     });
@@ -60,7 +60,7 @@ public class ProducerGrain : Grain, IProducerGrain
         // Get a reference to a stream
         var streamProvider = GetStreamProvider("AdoNetStreamProvider");
         _stream = streamProvider.GetStream<string>(Guid.NewGuid(), "MyStreamNamespace");
-        
+
         return base.OnActivateAsync(cancellationToken);
     }
 
@@ -81,10 +81,10 @@ public class ConsumerGrain : Grain, IConsumerGrain, IAsyncObserver<string>
         // Get a reference to a stream
         var streamProvider = GetStreamProvider("AdoNetStreamProvider");
         var stream = streamProvider.GetStream<string>(this.GetPrimaryKey(), "MyStreamNamespace");
-        
+
         // Subscribe to the stream
         _subscription = await stream.SubscribeAsync(this);
-        
+
         await base.OnActivateAsync(cancellationToken);
     }
 

--- a/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
+++ b/src/AdoNet/Shared/Storage/AdoNetInvariants.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -35,14 +36,13 @@ namespace Orleans.Tests.SqlUtils
             InvariantNamePostgreSql,
             InvariantNameSqlLite,
             InvariantNameSqlServer,
-            InvariantNameSqlServerDotnetCore,
             InvariantNameMySqlConnector
         }));
 
         /// <summary>
         /// Microsoft SQL Server invariant name string.
         /// </summary>
-        public const string InvariantNameSqlServer = "System.Data.SqlClient";
+        public const string InvariantNameSqlServer = "Microsoft.Data.SqlClient";
 
         /// <summary>
         /// Oracle Database server invariant name string.
@@ -67,7 +67,8 @@ namespace Orleans.Tests.SqlUtils
         /// <summary>
         /// Dotnet core Microsoft SQL Server invariant name string.
         /// </summary>
-        public const string InvariantNameSqlServerDotnetCore = "Microsoft.Data.SqlClient";
+        [Obsolete("Use InvariantNameSqlServer instead.")]
+        public const string InvariantNameSqlServerDotnetCore = InvariantNameSqlServer;
 
         /// <summary>
         /// An open source implementation of the MySQL connector library.

--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -32,12 +32,11 @@ namespace Orleans.Tests.SqlUtils
         private static readonly Dictionary<string, List<Tuple<string, string>>> providerFactoryTypeMap =
             new Dictionary<string, List<Tuple<string, string>>>
             {
-                { AdoNetInvariants.InvariantNameSqlServer, new List<Tuple<string, string>>{ new Tuple<string, string>("System.Data.SqlClient", "System.Data.SqlClient.SqlClientFactory") } },
+                { AdoNetInvariants.InvariantNameSqlServer, new List<Tuple<string, string>>{ new Tuple<string, string>("Microsoft.Data.SqlClient", "Microsoft.Data.SqlClient.SqlClientFactory") } },
                 { AdoNetInvariants.InvariantNameMySql, new List<Tuple<string, string>>{ new Tuple<string, string>("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory") } },
                 { AdoNetInvariants.InvariantNameOracleDatabase, new List<Tuple<string, string>>{ new Tuple<string, string>("Oracle.ManagedDataAccess", "Oracle.ManagedDataAccess.Client.OracleClientFactory") } },
                 { AdoNetInvariants.InvariantNamePostgreSql, new List<Tuple<string, string>>{ new Tuple<string, string>("Npgsql", "Npgsql.NpgsqlFactory") } },
                 { AdoNetInvariants.InvariantNameSqlLite, new List<Tuple<string, string>>{ new Tuple<string, string>("Microsoft.Data.Sqlite", "Microsoft.Data.Sqlite.SqliteFactory") } },
-                { AdoNetInvariants.InvariantNameSqlServerDotnetCore,new List<Tuple<string, string>>{ new Tuple<string, string>("Microsoft.Data.SqlClient", "Microsoft.Data.SqlClient.SqlClientFactory") } },
                 { AdoNetInvariants.InvariantNameMySqlConnector, new List<Tuple<string, string>>{ new Tuple<string, string>("MySqlConnector", "MySqlConnector.MySqlConnectorFactory") , new Tuple<string, string>("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory") } },
             };
 

--- a/src/AdoNet/Shared/Storage/DbConstantsStore.cs
+++ b/src/AdoNet/Shared/Storage/DbConstantsStore.cs
@@ -61,16 +61,6 @@ namespace Orleans.Tests.SqlUtils
 
                 },
                 {
-                    AdoNetInvariants.InvariantNameSqlServerDotnetCore,
-                    new DbConstants(startEscapeIndicator: '[',
-                                    endEscapeIndicator: ']',
-                                    unionAllSelectTemplate: " UNION ALL SELECT ",
-                                    isSynchronousAdoNetImplementation: false,
-                                    supportsStreamNatively: true,
-                                    supportsCommandCancellation: true,
-                                    commandInterceptor: NoOpCommandInterceptor.Instance)
-                },
-                {
                     AdoNetInvariants.InvariantNameMySqlConnector,
                     new DbConstants(startEscapeIndicator: '[',
                                     endEscapeIndicator: ']',

--- a/test/Benchmarks.AdoNet/Streaming/MessageDequeueingBenchmark.cs
+++ b/test/Benchmarks.AdoNet/Streaming/MessageDequeueingBenchmark.cs
@@ -1,6 +1,6 @@
-using System.Data.SqlClient;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using Microsoft.Data.SqlClient;
 using Orleans.Streaming.AdoNet;
 using Orleans.Tests.SqlUtils;
 using UnitTests.General;

--- a/test/Benchmarks.AdoNet/Streaming/MessageQueueingBenchmark.cs
+++ b/test/Benchmarks.AdoNet/Streaming/MessageQueueingBenchmark.cs
@@ -1,6 +1,6 @@
-using System.Data.SqlClient;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using Microsoft.Data.SqlClient;
 using Orleans.Tests.SqlUtils;
 using UnitTests.General;
 using static System.String;

--- a/test/Extensions/TesterAdoNet/PackageReferences.cs
+++ b/test/Extensions/TesterAdoNet/PackageReferences.cs
@@ -6,12 +6,11 @@ namespace Tester.AdoNet
     {
         public static readonly DbProviderFactory[] Factories =
         {
-            System.Data.SqlClient.SqlClientFactory.Instance,
+            Microsoft.Data.SqlClient.SqlClientFactory.Instance,
             MySql.Data.MySqlClient.MySqlClientFactory.Instance,
             //Oracle.ManagedDataAccess.Client.OracleClientFactory.Instance, // no tests currently
             Npgsql.NpgsqlFactory.Instance,
             //Microsoft.Data.Sqlite.SqliteFactory.Instance, // no tests currently
-            //Microsoft.Data.SqlClient.SqlClientFactory.Instance, // no tests currently
             //MySqlConnector.MySqlConnectorFactory.Instance, // no tests currently
         };
     }

--- a/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/TesterAdoNet/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -1,4 +1,4 @@
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
 

--- a/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
+++ b/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
@@ -10,9 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />-->
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <!--<PackageReference Include="MySqlConnector" Version="1.2.1" />-->
-    <PackageReference Include="System.Data.SqlClient" />
     <!--<PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.2" />-->
     <PackageReference Include="Npgsql" />
     <PackageReference Include="MySql.Data" />


### PR DESCRIPTION
This pull request updates the Orleans ADO.NET clustering, persistence, reminders, and streaming packages to use `Microsoft.Data.SqlClient` as the default and recommended SQL Server provider, replacing `System.Data.SqlClient`. The change is reflected across documentation, code, and test utilities to ensure consistency and modern provider support.

### Provider and Invariant Updates

* Changed the default SQL Server provider invariant string from `"System.Data.SqlClient"` to `"Microsoft.Data.SqlClient"` throughout the codebase (`AdoNetInvariants`, configuration examples, and documentation). [[1]](diffhunk://#diff-33015a492810fb4c3b2d9df074f485520457fe69f353942c32c49e11fb3fc357L38-R45) [[2]](diffhunk://#diff-0213051de840a4a4cf9b9a860378a0063a1feb2921403ab9b35ed00837195364L15-R15) [[3]](diffhunk://#diff-48cec834930f27d4f3bf8a3f176256a72659ccff2a1c37d619d316c878708351L15-R15) Fa1d1c87L14R14, [[4]](diffhunk://#diff-38e44e39cc992157deb43cf2a2a9528669cf905238ca20c1dcf3eae927dc6518L17-R17)
* Marked the old `InvariantNameSqlServerDotnetCore` constant as obsolete and redirected its value to the new default.

### Documentation and Sample Code

* Updated all README files for clustering, persistence, reminders, and streaming to recommend installing and configuring `Microsoft.Data.SqlClient` instead of `System.Data.SqlClient`. [[1]](diffhunk://#diff-0213051de840a4a4cf9b9a860378a0063a1feb2921403ab9b35ed00837195364L15-R15) [[2]](diffhunk://#diff-0213051de840a4a4cf9b9a860378a0063a1feb2921403ab9b35ed00837195364L96-R96) [[3]](diffhunk://#diff-48cec834930f27d4f3bf8a3f176256a72659ccff2a1c37d619d316c878708351L15-R15) [[4]](diffhunk://#diff-48cec834930f27d4f3bf8a3f176256a72659ccff2a1c37d619d316c878708351L38-R38) Fa1d1c87L14R14, [[5]](diffhunk://#diff-95f5c1517a9a07190d88bc844ea0228f11a80fe0a70c1ea2b231c5a9aa14556cL43-R43) [[6]](diffhunk://#diff-38e44e39cc992157deb43cf2a2a9528669cf905238ca20c1dcf3eae927dc6518L17-R17) [[7]](diffhunk://#diff-38e44e39cc992157deb43cf2a2a9528669cf905238ca20c1dcf3eae927dc6518L42-R42)

### Codebase and Test Adjustments

* Updated provider factory mappings and test utilities to use `Microsoft.Data.SqlClient.SqlClientFactory` instead of the legacy provider. [[1]](diffhunk://#diff-0f6d2fdce7f507b85d7ce0e619b38e8e4b5cc60ccbd91e84a392cac96ac6e0d8L35-L40) [[2]](diffhunk://#diff-d86462a942c035634517485cb91f5dba9167faa8178bd39ad305607042df9bcdL9-L14) [[3]](diffhunk://#diff-d58c27adaf83b7117ac7f461b509ac40aec66e9af8a55aa389ce40c76d1a5b4eL1-R1) [[4]](diffhunk://#diff-8b91e5c10bd22d85bdf48dd9b76725c63932fe01052478d098025dd88b641076L13-L15)

### Cleanup and Obsolete Removal

* Removed references and configuration for the obsolete `InvariantNameSqlServerDotnetCore` from provider mappings and constants stores. [[1]](diffhunk://#diff-0f6d2fdce7f507b85d7ce0e619b38e8e4b5cc60ccbd91e84a392cac96ac6e0d8L35-L40) [[2]](diffhunk://#diff-c5701b663f87ac428a9c4cc82344f67cdb4228a545d5f8b19d3bde6665d5ef55L63-L72)

### Configuration Defaults

* Updated configuration comments and defaults to reference `Microsoft.Data.SqlClient` for clarity and guidance in sample code and XML documentation. [[1]](diffhunk://#diff-b8f617b671a19ffc4518b9b03b390e13436e5bff3b20d2c6c50721225baa67c5L66-R66) [[2]](diffhunk://#diff-48cec834930f27d4f3bf8a3f176256a72659ccff2a1c37d619d316c878708351L38-R38) [[3]](diffhunk://#diff-0213051de840a4a4cf9b9a860378a0063a1feb2921403ab9b35ed00837195364L96-R96) [[4]](diffhunk://#diff-38e44e39cc992157deb43cf2a2a9528669cf905238ca20c1dcf3eae927dc6518L42-R42)

These changes modernize Orleans' support for SQL Server and ensure developers are guided toward the actively maintained and supported ADO.NET provider.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9787)