### PR TITLE
[Tests] Improve reliability of `ActivationTaskScheduler` tests

### DIFF
--- a/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
+++ b/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
@@ -21,7 +21,7 @@ namespace Orleans.Threading
             this.spinCondition = this.TryGet;
         }
 
-        private static int ThreadId => localThreadId != 0 ? localThreadId : localThreadId = Thread.CurrentThread.ManagedThreadId;
+        private static int ThreadId => localThreadId != 0 ? localThreadId : localThreadId = Environment.CurrentManagedThreadId;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGet()

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -94,7 +94,7 @@ namespace Orleans.Runtime.Scheduler
             turnsExecutedStatistic.Increment();
 #endif
 #if DEBUG
-            LogTraceTryExecuteTaskInlineYes(myId, task.Id, Thread.CurrentThread.ManagedThreadId);
+            LogTraceTryExecuteTaskInlineYes(myId, task.Id, System.Environment.CurrentManagedThreadId);
 #endif
             // Try to run the task.
             bool done = TryExecuteTask(task);
@@ -104,7 +104,7 @@ namespace Orleans.Runtime.Scheduler
                 LogWarnTryExecuteTaskNotDone(task.Id, task.Status);
             }
 
-            LogTraceTryExecuteTaskInlineCompleted(myId, task.Id, Thread.CurrentThread.ManagedThreadId, done);
+            LogTraceTryExecuteTaskInlineCompleted(myId, task.Id, System.Environment.CurrentManagedThreadId, done);
 #endif
             return done;
         }

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -242,7 +242,7 @@ internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
             (int)ErrorCode.Runtime_Error_100032,
             ex,
             "Worker thread {Thread} caught an exception thrown from IWorkItem.Execute",
-            Thread.CurrentThread.ManagedThreadId);
+            Environment.CurrentManagedThreadId);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -261,7 +261,7 @@ internal sealed class WorkItemGroup : IThreadPoolWorkItem, IWorkItemScheduler
             GrainContext.ToString(),
             taskDuration.ToString("g"),
             _schedulingOptions.TurnWarningLengthThreshold,
-            Thread.CurrentThread.ManagedThreadId.ToString());
+            Environment.CurrentManagedThreadId.ToString());
     }
 
     public override string ToString() => $"{(GrainContext is SystemTarget ? "System*" : "")}WorkItemGroup:Name={GrainContext?.ToString() ?? "Unknown"},WorkGroupStatus={_state}";

--- a/src/Orleans.TestingHost/Logging/FileLogger.cs
+++ b/src/Orleans.TestingHost/Logging/FileLogger.cs
@@ -90,7 +90,7 @@ namespace Orleans.TestingHost.Logging
             var exc = LogFormatter.PrintException(exception);
             var msg = string.Format("[{0} {1}\t{2}\t{3}\t{4}]\t{5}\t{6}",
                 LogFormatter.PrintDate(timestamp),           //0
-                Thread.CurrentThread.ManagedThreadId,   //1
+                Environment.CurrentManagedThreadId,   //1
                 logLevel.ToString(),    //2
                 errorCode.ToString(),                              //3
                 caller,                                 //4

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Grains
                 TaskScheduler={TaskScheduler.Current}
                 RuntimeContext={RuntimeContext.Current}
                 WorkerPoolThread={Thread.CurrentThread.Name}
-                Thread.CurrentThread.ManagedThreadId={Thread.CurrentThread.ManagedThreadId}
+                Thread.CurrentThread.ManagedThreadId={Environment.CurrentManagedThreadId}
                 StackTrace={callStack}
                 """;
         }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Scheduler;
@@ -48,15 +49,18 @@ namespace UnitTests.SchedulerTests
             // is completely and thoroughly broken and both closures are executed "simultaneously"
 
             int n = 0;
+            var gate = new SemaphoreSlim(0, 1);
             // ReSharper disable AccessToModifiedClosure
-            var task1 = new Task(() => { Thread.Sleep(100); n = n + 5; });
+            var task1 = new Task(() => { gate.Wait(); n = n + 5; });
             Task task2 = new Task(() => { n = n * 3; });
             // ReSharper restore AccessToModifiedClosure
 
             task1.Start(scheduler);
             task2.Start(scheduler);
 
-            // Pause to let things run
+            // Release gate to allow task1 to proceed
+            gate.Release();
+
             await task1;
             await task2;
 
@@ -103,27 +107,33 @@ namespace UnitTests.SchedulerTests
 
             var finished = new TaskCompletionSource();
             int numCompleted = 0;
+            var gates = new SemaphoreSlim[10];
+            for (int i = 0; i < 10; i++)
+            {
+                gates[i] = new SemaphoreSlim(0, 1);
+            }
+
             void action()
             {
                 LogContext("WorkItem-task " + Task.CurrentId);
 
                 for (int i = 0; i < 10; i++)
                 {
+                    int taskIndex = i;
                     int id = -1;
-                    Task.Factory.StartNew(async () =>
+                    Task.Factory.StartNew(() =>
                     {
                         id = Task.CurrentId.HasValue ? (int)Task.CurrentId : -1;
 
                         // ReSharper disable AccessToModifiedClosure
                         LogContext("Sub-task " + id + " n=" + n);
                         int k = n;
-                        this.output.WriteLine("Sub-task " + id + " sleeping");
-                        Thread.Sleep(10);
+                        this.output.WriteLine("Sub-task " + id + " waiting for gate");
+                        gates[taskIndex].Wait();
                         this.output.WriteLine("Sub-task " + id + " awake");
                         n = k + 1;
                         // ReSharper restore AccessToModifiedClosure
                     })
-                    .Unwrap()
                     .ContinueWith(tsk =>
                     {
                         LogContext("Sub-task " + id + "-ContinueWith");
@@ -135,16 +145,22 @@ namespace UnitTests.SchedulerTests
                         }
                     });
                 }
+
+                // Release all gates in sequence to ensure sequential execution
+                for (int i = 0; i < 10; i++)
+                {
+                    gates[i].Release();
+                }
             }
 
             Task t = new Task(action);
 
             t.Start(scheduler);
 
-            // Pause to let things run
-            this.output.WriteLine("Main-task sleeping");
+            // Wait for completion
+            this.output.WriteLine("Main-task waiting");
             await finished.Task;
-            this.output.WriteLine("Main-task awake");
+            this.output.WriteLine("Main-task done");
 
             // N should be 10, because all tasks should execute serially
             Assert.True(n != 0, "Work items did not get executed");
@@ -156,11 +172,12 @@ namespace UnitTests.SchedulerTests
         {
             var result = new TaskCompletionSource<bool>();
             int n = 0;
+            var gate = new SemaphoreSlim(0, 1);
 
             Task wrapper = new Task(() =>
             {
                 // ReSharper disable AccessToModifiedClosure
-                Task task1 = Task.Factory.StartNew(async () => { this.output.WriteLine("===> 1a"); await Task.Delay(1000); n = n + 3; this.output.WriteLine("===> 1b"); }).Unwrap();
+                Task task1 = Task.Factory.StartNew(() => { this.output.WriteLine("===> 1a"); gate.Wait(); n = n + 3; this.output.WriteLine("===> 1b"); });
                 Task task2 = task1.ContinueWith(task => { n = n * 5; this.output.WriteLine("===> 2"); });
                 Task task3 = task2.ContinueWith(task => { n = n / 5; this.output.WriteLine("===> 3"); });
                 Task task4 = task3.ContinueWith(task => { n = n - 2; this.output.WriteLine("===> 4"); result.SetResult(true); });
@@ -170,6 +187,9 @@ namespace UnitTests.SchedulerTests
                     this.output.WriteLine("Done Faulted={0}", task.IsFaulted);
                     Assert.False(task.IsFaulted, "Faulted with Exception=" + task.Exception);
                 });
+
+                // Release gate to allow task1 to complete
+                gate.Release();
             });
             wrapper.Start(scheduler);
 
@@ -247,6 +267,7 @@ namespace UnitTests.SchedulerTests
             ManualResetEvent pause1 = new ManualResetEvent(false);
             ManualResetEvent pause2 = new ManualResetEvent(false);
             var finish = new TaskCompletionSource<bool>();
+            var fakeTimeProvider = new FakeTimeProvider();
             Task<int> task1 = null;
             Task<int> task2 = null;
             Task join = null;
@@ -269,7 +290,7 @@ namespace UnitTests.SchedulerTests
                     return 2;
                 });
 
-                join = Task.WhenAny(task1, task2, Task.Delay(TimeSpan.FromSeconds(2)));
+                join = Task.WhenAny(task1, task2, Task.Delay(TimeSpan.FromSeconds(2), fakeTimeProvider));
 
                 finish.SetResult(true);
             });
@@ -284,6 +305,9 @@ namespace UnitTests.SchedulerTests
             {
                 Assert.Fail("Result did not arrive before timeout " + timeoutLimit);
             }
+
+            // Advance time to trigger the delay timeout
+            fakeTimeProvider.Advance(TimeSpan.FromSeconds(2));
 
             Assert.NotNull(join);
             await join;
@@ -304,6 +328,7 @@ namespace UnitTests.SchedulerTests
             var pause1 = new TaskCompletionSource<bool>();
             var pause2 = new TaskCompletionSource<bool>();
             var finish = new TaskCompletionSource<bool>();
+            var fakeTimeProvider = new FakeTimeProvider();
             Task<int> task1 = null;
             Task<int> task2 = null;
             Task join = null;
@@ -314,12 +339,7 @@ namespace UnitTests.SchedulerTests
                     this.output.WriteLine("Task-1 Started");
                     Assert.Equal(scheduler, TaskScheduler.Current);
                     int num1 = 1;
-#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-                    while (!pause1.Task.Result) // Infinite busy loop
-                    {
-                        num1 = Random.Shared.Next();
-                    }
-#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+                    pause1.Task.Wait();
                     this.output.WriteLine("Task-1 Done");
                     return num1;
                 });
@@ -328,17 +348,17 @@ namespace UnitTests.SchedulerTests
                     this.output.WriteLine("Task-2 Started");
                     Assert.Equal(scheduler, TaskScheduler.Current);
                     int num2 = 2;
-#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-                    while (!pause2.Task.Result) // Infinite busy loop
-                    {
-                        num2 = Random.Shared.Next();
-                    }
-#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+                    pause2.Task.Wait();
                     this.output.WriteLine("Task-2 Done");
                     return num2;
                 });
 
-                join = Task.WhenAny(task1, task2, Task.Delay(TimeSpan.FromSeconds(2)));
+                var delayTask = Task.Delay(TimeSpan.FromSeconds(2), fakeTimeProvider);
+
+                // Advance time immediately to trigger the delay
+                fakeTimeProvider.Advance(TimeSpan.FromSeconds(2));
+
+                join = Task.WhenAny(task1, task2, delayTask);
 
                 finish.SetResult(true);
             });
@@ -531,10 +551,12 @@ namespace UnitTests.SchedulerTests
             bool[] executingChain = new bool[NumChains];
             int[] stageComplete = new int[NumChains];
             int executingGlobal = -1;
+            var gates = new ManualResetEventSlim[NumChains];
+
             for (int i = 0; i < NumChains; i++)
             {
+                gates[i] = new ManualResetEventSlim(false);
                 int chainNum = i; // Capture
-                int sleepTime = Random.Shared.Next(10);
                 resultHandles[chainNum] = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 Task task = taskChains[chainNum] = new Task(() =>
                 {
@@ -547,7 +569,7 @@ namespace UnitTests.SchedulerTests
                         executingGlobal = chainNum;
                         executingChain[chainNum] = true;
 
-                        Thread.Sleep(sleepTime);
+                        gates[chainNum].Wait();
                     }
                     finally
                     {
@@ -559,7 +581,7 @@ namespace UnitTests.SchedulerTests
                 for (int j = 1; j < ChainLength; j++)
                 {
                     int taskNum = j; // Capture
-                    task = task.ContinueWith(async t =>
+                    task = task.ContinueWith(t =>
                     {
                         if (t.IsFaulted) throw t.Exception;
                         this.output.WriteLine("Inside Chain {0} Task {1}", chainNum, taskNum);
@@ -572,7 +594,7 @@ namespace UnitTests.SchedulerTests
                             executingGlobal = chainNum;
                             executingChain[chainNum] = true;
 
-                            Thread.Sleep(sleepTime);
+                            gates[chainNum].Wait();
                         }
                         finally
                         {
@@ -580,7 +602,7 @@ namespace UnitTests.SchedulerTests
                             executingChain[chainNum] = false;
                             executingGlobal = -1;
                         }
-                    }, scheduler).Unwrap();
+                    }, scheduler);
                 }
                 taskChainEnds[chainNum] = task.ContinueWith(t =>
                 {
@@ -593,6 +615,12 @@ namespace UnitTests.SchedulerTests
             for (int i = 0; i < NumChains; i++)
             {
                 taskChains[i].Start(scheduler);
+            }
+
+            // Set all gates to allow execution to proceed
+            for (int i = 0; i < NumChains; i++)
+            {
+                gates[i].Set();
             }
 
             for (int i = 0; i < NumChains; i++)

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -1,12 +1,9 @@
 using Microsoft.Extensions.Logging;
-using Orleans.Runtime;
 using Orleans.Runtime.Scheduler;
 using UnitTests.TesterInternal;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.TestingHost.Utils;
-using Orleans.Internal;
-using Orleans;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -66,7 +63,7 @@ namespace UnitTests.SchedulerTests
         void IGrainContext.Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
         void IGrainContext.Migrate(Dictionary<string, object> requestContext, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
-    
+
     /// <summary>
     /// Basic tests for the Orleans task scheduler, which is the core component responsible for scheduling grain work items.
     /// The scheduler ensures single-threaded execution semantics for grains while efficiently utilizing thread pool resources.
@@ -75,18 +72,18 @@ namespace UnitTests.SchedulerTests
     [TestCategory("BVT"), TestCategory("Scheduler")]
     public class OrleansTaskSchedulerBasicTests : IDisposable
     {
-        private readonly ITestOutputHelper output;
-        private static readonly object Lockable = new object();
-        private readonly UnitTestSchedulingContext rootContext;
-        private readonly ILoggerFactory loggerFactory;
+        private static readonly object Lockable = new();
+        private readonly ITestOutputHelper _output;
+        private readonly UnitTestSchedulingContext _rootContext;
+        private readonly ILoggerFactory _loggerFactory;
         public OrleansTaskSchedulerBasicTests(ITestOutputHelper output)
         {
-            this.output = output;
+            _output = output;
             SynchronizationContext.SetSynchronizationContext(null);
-            this.loggerFactory = InitSchedulerLogging();
-            this.rootContext = UnitTestSchedulingContext.Create(loggerFactory);
+            _loggerFactory = InitSchedulerLogging();
+            _rootContext = UnitTestSchedulingContext.Create(_loggerFactory);
         }
-        
+
         public void Dispose()
         {
             SynchronizationContext.SetSynchronizationContext(null);
@@ -99,12 +96,12 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("AsynchronyPrimitives")]
         public async Task Async_Task_Start_ActivationTaskScheduler()
         {
-            int expected = 2;
-            bool done = false;
-            Task<int> t = new Task<int>(() => { done = true; return expected; });
-            rootContext.Scheduler.QueueTask(t);
+            var expected = 2;
+            var done = false;
+            var t = new Task<int>(() => { done = true; return expected; });
+            _rootContext.Scheduler.QueueTask(t);
 
-            int received = await t;
+            var received = await t;
             Assert.True(t.IsCompleted, "Task should have completed");
             Assert.False(t.IsFaulted, "Task should not thrown exception: " + t.Exception);
             Assert.True(done, "Task should be done");
@@ -112,26 +109,27 @@ namespace UnitTests.SchedulerTests
         }
 
         [Fact]
-        public void Sched_SimpleFifoTest()
+        public async Task Sched_SimpleFifoTest()
         {
             // This is not a great test because there's a 50/50 shot that it will work even if the scheduling
             // is completely and thoroughly broken and both closures are executed "simultaneously"
 
-            int n = 0;
+            var n = 0;
+            var completed = new TaskCompletionSource<bool>();
             // ReSharper disable AccessToModifiedClosure
             void item1() { n = n + 5; }
-            void item2() { n = n * 3; }
+            void item2() { n = n * 3; completed.SetResult(true); }
             // ReSharper restore AccessToModifiedClosure
-            this.rootContext.Scheduler.QueueAction(item1);
-            rootContext.Scheduler.QueueAction(item2);
+            _rootContext.Scheduler.QueueAction(item1);
+            _rootContext.Scheduler.QueueAction(item2);
 
-            // Pause to let things run
-            Thread.Sleep(1000);
+            // Wait for completion
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             // N should be 15, because the two tasks should execute in order
             Assert.True(n != 0, "Work items did not get executed");
             Assert.Equal(15, n);
-            this.output.WriteLine("Test executed OK.");
+            _output.WriteLine("Test executed OK.");
         }
 
         [Fact]
@@ -140,15 +138,19 @@ namespace UnitTests.SchedulerTests
             // This is not a great test because there's a 50/50 shot that it will work even if the scheduling
             // is completely and thoroughly broken and both closures are executed "simultaneously"
 
-            int n = 0;
+            var n = 0;
+            var gate = new SemaphoreSlim(0, 1);
 
             // ReSharper disable AccessToModifiedClosure
-            Task task1 = new Task(() => { Thread.Sleep(1000); n = n + 5; });
-            Task task2 = new Task(() => { n = n * 3; });
+            var task1 = new Task(() => { gate.Wait(); n = n + 5; });
+            var task2 = new Task(() => { n = n * 3; });
             // ReSharper restore AccessToModifiedClosure
 
-            rootContext.Scheduler.QueueTask(task1);
-            rootContext.Scheduler.QueueTask(task2);
+            _rootContext.Scheduler.QueueTask(task1);
+            _rootContext.Scheduler.QueueTask(task2);
+
+            // Release task1 to proceed
+            gate.Release();
 
             await Task.WhenAll(task1, task2).WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -162,43 +164,43 @@ namespace UnitTests.SchedulerTests
         {
             const int NumTasks = 10;
 
-            ManualResetEvent[] flags = new ManualResetEvent[NumTasks];
-            for (int i = 0; i < NumTasks; i++)
+            var flags = new ManualResetEvent[NumTasks];
+            for (var i = 0; i < NumTasks; i++)
             {
                 flags[i] = new ManualResetEvent(false);
             }
 
-            Task[] tasks = new Task[NumTasks];
-            for (int i = 0; i < NumTasks; i++)
+            var tasks = new Task[NumTasks];
+            for (var i = 0; i < NumTasks; i++)
             {
-                int taskNum = i; // Capture
-                tasks[i] = new Task(() => { this.output.WriteLine("Inside Task-" + taskNum); flags[taskNum].WaitOne(); });
+                var taskNum = i; // Capture
+                tasks[i] = new Task(() => { _output.WriteLine("Inside Task-" + taskNum); flags[taskNum].WaitOne(); });
             }
 
-            Action[] workItems = new Action[NumTasks];
-            for (int i = 0; i < NumTasks; i++)
+            var workItems = new Action[NumTasks];
+            for (var i = 0; i < NumTasks; i++)
             {
-                int taskNum = i; // Capture
+                var taskNum = i; // Capture
                 workItems[i] = () =>
                 {
-                    this.output.WriteLine("Inside ClosureWorkItem-" + taskNum);
+                    _output.WriteLine("Inside ClosureWorkItem-" + taskNum);
                     tasks[taskNum].Start(TaskScheduler.Default);
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-                    bool ok = tasks[taskNum].Wait(TimeSpan.FromMilliseconds(NumTasks * 100));
+                    var ok = tasks[taskNum].Wait(TimeSpan.FromMilliseconds(NumTasks * 100));
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
                     Assert.True(ok, "Wait completed successfully inside ClosureWorkItem-" + taskNum);
                 };
             }
 
-            foreach (var workItem in workItems) this.rootContext.Scheduler.QueueAction(workItem);
+            foreach (var workItem in workItems) _rootContext.Scheduler.QueueAction(workItem);
             foreach (var flag in flags) flag.Set();
-            for (int i = 0; i < tasks.Length; i++)
+            for (var i = 0; i < tasks.Length; i++)
             {
                 await tasks[i].WaitAsync(TimeSpan.FromMilliseconds(NumTasks * 150));
             }
 
 
-            for (int i = 0; i < tasks.Length; i++)
+            for (var i = 0; i < tasks.Length; i++)
             {
                 Assert.False(tasks[i].IsFaulted, "Task.IsFaulted-" + i + " Exception=" + tasks[i].Exception);
                 Assert.True(tasks[i].IsCompleted, "Task.IsCompleted-" + i);
@@ -212,20 +214,20 @@ namespace UnitTests.SchedulerTests
             var result1 = new TaskCompletionSource<bool>();
 
             Task t1 = null;
-            rootContext.Scheduler.QueueAction(() =>
+            _rootContext.Scheduler.QueueAction(() =>
             {
                 try
                 {
-                    this.output.WriteLine("#0 - TaskWorkItem - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+                    _output.WriteLine("#0 - TaskWorkItem - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                         SynchronizationContext.Current, TaskScheduler.Current);
-                    var taskScheduler = ((WorkItemGroup)rootContext.Scheduler).TaskScheduler;
+                    var taskScheduler = ((WorkItemGroup)_rootContext.Scheduler).TaskScheduler;
                     Assert.Equal(taskScheduler, TaskScheduler.Current); //
 
                     t1 = new Task(() =>
                     {
-                        this.output.WriteLine("#1 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+                        _output.WriteLine("#1 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                             SynchronizationContext.Current, TaskScheduler.Current);
-                        var taskScheduler = ((WorkItemGroup)rootContext.Scheduler).TaskScheduler;  // "TaskScheduler.Current #1"
+                        var taskScheduler = ((WorkItemGroup)_rootContext.Scheduler).TaskScheduler;  // "TaskScheduler.Current #1"
                         Assert.Equal(taskScheduler, TaskScheduler.Current); //
                         result1.SetResult(true);
                     });
@@ -252,22 +254,29 @@ namespace UnitTests.SchedulerTests
             Assert.False(t1.IsFaulted, "Task-1 faulted: " + t1.Exception);
             Assert.True(await result1.Task, "Task-1 completed");
         }
-                
+
         [Fact]
         public async Task Sched_Task_SubTaskExecutionSequencing()
         {
             LogContext("Main-task " + Task.CurrentId);
 
-            int n = 0;
-            TaskCompletionSource<int> finished = new TaskCompletionSource<int>();
+            var n = 0;
+            var finished = new TaskCompletionSource<int>();
             var numCompleted = new[] {0};
+            var gates = new SemaphoreSlim[10];
+            for (var i = 0; i < 10; i++)
+            {
+                gates[i] = new SemaphoreSlim(0, 1);
+            }
+
             void closure()
             {
                 LogContext("ClosureWorkItem-task " + Task.CurrentId);
 
-                for (int i = 0; i < 10; i++)
+                for (var i = 0; i < 10; i++)
                 {
-                    int id = -1;
+                    var taskIndex = i;
+                    var id = -1;
                     void action()
                     {
                         id = Task.CurrentId.HasValue ? (int)Task.CurrentId : -1;
@@ -275,10 +284,10 @@ namespace UnitTests.SchedulerTests
                         // ReSharper disable AccessToModifiedClosure
                         LogContext("Sub-task " + id + " n=" + n);
 
-                        int k = n;
-                        this.output.WriteLine("Sub-task " + id + " sleeping");
-                        Thread.Sleep(100);
-                        this.output.WriteLine("Sub-task " + id + " awake");
+                        var k = n;
+                        _output.WriteLine("Sub-task " + id + " waiting for gate");
+                        gates[taskIndex].Wait();
+                        _output.WriteLine("Sub-task " + id + " proceeding");
                         n = k + 1;
                         // ReSharper restore AccessToModifiedClosure
                     }
@@ -286,55 +295,61 @@ namespace UnitTests.SchedulerTests
                     {
                         LogContext("Sub-task " + id + "-ContinueWith");
 
-                        this.output.WriteLine("Sub-task " + id + " Done");
+                        _output.WriteLine("Sub-task " + id + " Done");
                         if (Interlocked.Increment(ref numCompleted[0]) == 10)
                         {
                             finished.SetResult(0);
                         }
                     });
                 }
+
+                // Release all gates in sequence to ensure sequential execution
+                for (var i = 0; i < 10; i++)
+                {
+                    gates[i].Release();
+                }
             }
 
-            rootContext.Scheduler.QueueAction(closure);
+            _rootContext.Scheduler.QueueAction(closure);
 
-            // Pause to let things run
-            this.output.WriteLine("Main-task sleeping");
-            await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(10)), finished.Task);
-            this.output.WriteLine("Main-task awake");
+            // Wait for completion
+            _output.WriteLine("Main-task waiting");
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            _output.WriteLine("Main-task done");
 
             // N should be 10, because all tasks should execute serially
             Assert.True(n != 0, "Work items did not get executed");
             Assert.Equal(10, n);  // "Work items executed concurrently"
         }
-        
+
         [Fact]
         public async Task Sched_AC_RequestContext_StartNew_ContinueWith()
         {
             const string key = "A";
-            int val = Random.Shared.Next();
+            var val = Random.Shared.Next();
             RequestContext.Set(key, val);
 
-            this.output.WriteLine("Initial - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+            _output.WriteLine("Initial - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                 SynchronizationContext.Current, TaskScheduler.Current);
 
             Assert.Equal(val, RequestContext.Get(key));  // "RequestContext.Get Initial"
 
             Task t0 = Task.Factory.StartNew(async () =>
             {
-                this.output.WriteLine("#0 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+                _output.WriteLine("#0 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                     SynchronizationContext.Current, TaskScheduler.Current);
 
                 Assert.Equal(val, RequestContext.Get(key));  // "RequestContext.Get #0"
 
                 Task t1 = Task.Factory.StartNew(() =>
                 {
-                    this.output.WriteLine("#1 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+                    _output.WriteLine("#1 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                         SynchronizationContext.Current, TaskScheduler.Current);
                     Assert.Equal(val, RequestContext.Get(key));  // "RequestContext.Get #1"
                 });
                 Task t2 = t1.ContinueWith((_) =>
                 {
-                    this.output.WriteLine("#2 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
+                    _output.WriteLine("#2 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                         SynchronizationContext.Current, TaskScheduler.Current);
                     Assert.Equal(val, RequestContext.Get(key));  // "RequestContext.Get #2"
                 });
@@ -347,16 +362,16 @@ namespace UnitTests.SchedulerTests
         [Fact]
         public async Task RequestContextProtectedInQueuedTasksTest()
         {
-            string key = Guid.NewGuid().ToString();
-            string value = Guid.NewGuid().ToString();
+            var key = Guid.NewGuid().ToString();
+            var value = Guid.NewGuid().ToString();
 
             // Caller RequestContext is protected from clear within QueueTask
             RequestContext.Set(key, value);
-            await rootContext.QueueTask(() => AsyncCheckClearRequestContext(key));
+            await _rootContext.QueueTask(() => AsyncCheckClearRequestContext(key));
             Assert.Equal(value, (string)RequestContext.Get(key));
 
             // Caller RequestContext is protected from clear within QueueTask even if work is not actually asynchronous.
-            await this.rootContext.QueueTask(() => NonAsyncCheckClearRequestContext(key));
+            await _rootContext.QueueTask(() => NonAsyncCheckClearRequestContext(key));
             Assert.Equal(value, (string)RequestContext.Get(key));
 
             // Caller RequestContext is protected from clear when work is asynchronous.
@@ -378,25 +393,25 @@ namespace UnitTests.SchedulerTests
             }
             await nonAsyncCheckClearRequestContext();
             Assert.Null(RequestContext.Get(key));
-        }
 
-        private static async Task AsyncCheckClearRequestContext(string key)
-        {
-            Assert.Null(RequestContext.Get(key));
-            await Task.Delay(TimeSpan.Zero);
-        }
+            static async Task AsyncCheckClearRequestContext(string key)
+            {
+                Assert.Null(RequestContext.Get(key));
+                await Task.Delay(TimeSpan.Zero);
+            }
 
-        private static Task NonAsyncCheckClearRequestContext(string key)
-        {
-            Assert.Null(RequestContext.Get(key));
-            return Task.CompletedTask;
+            static Task NonAsyncCheckClearRequestContext(string key)
+            {
+                Assert.Null(RequestContext.Get(key));
+                return Task.CompletedTask;
+            }
         }
 
         private void LogContext(string what)
         {
             lock (Lockable)
             {
-                this.output.WriteLine(
+                _output.WriteLine(
                     "{0}\n"
                     + " TaskScheduler.Current={1}\n"
                     + " Task.Factory.Scheduler={2}\n"

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -358,7 +358,7 @@ namespace UnitTests.General
         {
             RequestContext.Set("threadId", i);
             int contextId = (int)(RequestContext.Get("threadId") ?? -1);
-            output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Thread.CurrentThread.ManagedThreadId, contextId);
+            output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, contextId);
             await FrameworkContextVerification(i).ConfigureAwait(false);
         }
 
@@ -368,7 +368,7 @@ namespace UnitTests.General
             {
                 await Task.Delay(10);
                 int contextId = (int)(RequestContext.Get("threadId") ?? -1);
-                output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Thread.CurrentThread.ManagedThreadId, id, contextId);
+                output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, id, contextId);
                 Assert.Equal(id, contextId);
             }
         }
@@ -405,7 +405,7 @@ namespace UnitTests.General
         {
             threadId.Value = i;
             int contextId = threadId.Value;
-            output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Thread.CurrentThread.ManagedThreadId, contextId);
+            output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, contextId);
             await FrameworkContextVerification(i).ConfigureAwait(false);
         }
 
@@ -415,7 +415,7 @@ namespace UnitTests.General
             {
                 await Task.Delay(10);
                 int contextId = threadId.Value;
-                output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Thread.CurrentThread.ManagedThreadId, id, contextId);
+                output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, id, contextId);
                 Assert.Equal(id, contextId);
             }
         }


### PR DESCRIPTION
This changes the `ActivationTaskScheduler` tests to rely less (or not at all) on timing (eg, `Thread.Sleep(...)`).

This also includes some drive-by fixes suggested by analyzers.