### PR TITLE
Add `CancelUnknownRequestOnStatusUpdate` option, default `CancelRequestOnTimeout` to `false`

### DIFF
--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -66,9 +66,9 @@ namespace Orleans.Configuration
         /// </summary>
         /// <remarks>
         /// Request cancellation may involve sending a cancellation message to the silo which hosts the target grain.
-        /// Defaults to <see langword="true"/>.
+        /// Defaults to <see langword="false"/>.
         /// </remarks>
-        public bool CancelRequestOnTimeout { get; set; } = true;
+        public bool CancelRequestOnTimeout { get; set; }
 
         /// <summary>
         /// Whether local calls should be cancelled immediately when cancellation is signaled (<see langword="false"/>)
@@ -78,5 +78,16 @@ namespace Orleans.Configuration
         /// Defaults to <see langword="false"/>.
         /// </remarks>
         public bool WaitForCancellationAcknowledgement { get; set; }
+
+        /// <summary>
+        /// Whether request cancellation should be attempted when a status update is received for an unknown request.
+        /// </summary>
+        /// <remarks>
+        /// A status update for an unknown request likely indicates that the request previously timed out and was subsequently dropped.
+        /// Request cancellation may involve sending a cancellation message to the silo which hosts the target grain.
+        /// If the remote callee does not support cancellation, this setting has no effect.
+        /// Defaults to <see langword="false"/>.
+        /// </remarks>
+        public bool CancelUnknownRequestOnStatusUpdate { get; set; }
     }
 }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -315,7 +315,7 @@ namespace Orleans
                 }
                 else
                 {
-                    if (clientMessagingOptions.CancelRequestOnTimeout)
+                    if (clientMessagingOptions.CancelUnknownRequestOnStatusUpdate)
                     {
                         // Cancel the call since the caller has abandoned it.
                         // Note that the target and sender arguments are swapped because this is a response to the original request.

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -421,7 +421,7 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    if (messagingOptions.CancelRequestOnTimeout)
+                    if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
                     {
                         // Cancel the call since the caller has abandoned it.
                         // Note that the target and sender arguments are swapped because this is a response to the original request.


### PR DESCRIPTION
- Not all targets (eg, grain observers, system targets) support cancellation, so these automatic cancellation attempts result in error logs (unsupported extension). We can reconsider enabling this once all targets support cancellation requests
- Timeout vs status update are distinct events, so we can use distinct options for each.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9831)