### PR TITLE
Add regression test for Azure Blob storage with custom IBlobContainerFactory

### DIFF
--- a/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
+++ b/test/Extensions/TesterAzureUtils/Persistence/PersistenceStateTests_AzureBlobStore.cs
@@ -68,7 +68,7 @@ public class PersistenceStateTests_AzureBlobStore_CustomContainerFactory : Base_
                 hostBuilder.AddAzureBlobGrainStorage("GrainStorageForTest", (AzureBlobStorageOptions options) =>
                 {
                     options.ConfigureTestDefaults();
-                    options.DeleteStateOnClear = false;
+                    options.DeleteStateOnClear = true;
                     options.BuildContainerFactory = (_, _) => new TestBlobContainerFactory();
                 });
             }


### PR DESCRIPTION
This change introduces a new test fixture, `PersistenceStateTests_AzureBlobStore_CustomContainerFactory`, which configures Azure Blob grain storage with a custom `IBlobContainerFactory` implementation. This custom container factory does not create blob container at the initialization, since the container name is derived from the grainId.
With this test fixture, test scenarios executed in [GrainPersistenceTestRunner](https://github.com/dotnet/orleans/blob/main/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs), where `grain.DoWrite` is invoked, would fail without the fix introduced in PR #[9842 ](https://github.com/dotnet/orleans/pull/9842).
This fixture therefore serves as a regression test to ensure that Azure Blob grain storage correctly supports custom IBlobContainerFactory implementations that rely on lazy container creation.

**Note**:
This test fixture sets `DeleteStateOnClear` to `true`. If this option is disabled, the [ClearStateAsync_Before_WriteStateAsync](https://github.com/dotnet/orleans/blob/main/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs#L43) scenario would fail with a _container not found_ exception. In this scenario, `ClearStateAsync` attempts to upload an empty blob before any call to `WriteStateAsync`, and the target container has not yet been created. Container creation is expected to occur during `WriteStateAsync`, which has not been invoked at that point.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9847)