### PR TITLE
Derive filtered available mem from the filtered mem usage

### DIFF
--- a/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
@@ -26,7 +26,6 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
 
     private readonly DualModeKalmanFilter _cpuUsageFilter = new();
     private readonly DualModeKalmanFilter _memoryUsageFilter = new();
-    private readonly DualModeKalmanFilter _availableMemoryFilter = new();
 
     public EnvironmentStatisticsProvider()
     {
@@ -47,7 +46,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
         var availableMemory = maximumAvailableMemoryBytes - memoryUsage;
         var filteredCpuUsage = _cpuUsageFilter.Filter(cpuUsage);
         var filteredMemoryUsage = (long)_memoryUsageFilter.Filter(memoryUsage);
-        var filteredAvailableMemory = (long)_availableMemoryFilter.Filter(availableMemory);
+        var filteredAvailableMemory = maximumAvailableMemoryBytes - filteredMemoryUsage;
 
         var result = new EnvironmentStatistics(
             cpuUsagePercentage: filteredCpuUsage,


### PR DESCRIPTION
This PR derives available memory directly from the filtered memory usage to ensure mathematical consistency. This prevents potential drift between independent filters that may have caused normalized scores in ROP to exceed the [0, 1] range. By filtering only usage, we maintain the intended pessimistic safety logic where available memory drops immediately during resource spikes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9857)