### PR TITLE
[CI] Add version suffix parameter to nightly-main.yml

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -27,7 +27,7 @@ parameters:
   - name: version_prefix
     displayName: Version prefix
     type: string
-    default: 9.0.0
+    default: 10.0.0
   - name: include_suffix
     displayName: Append version suffix
     type: boolean

--- a/.azure/pipelines/nightly-main.yaml
+++ b/.azure/pipelines/nightly-main.yaml
@@ -21,7 +21,11 @@ parameters:
   - name: version_prefix
     displayName: Version prefix
     type: string
-    default: 9.2.0
+    default: 10.0.0
+  - name: version_suffix
+    displayName: Version suffix
+    type: string
+    default: nightly.$(Build.BuildNumber)
   - name: include_suffix
     displayName: Append version suffix
     type: boolean
@@ -63,7 +67,7 @@ extends:
           build_configuration: Release
           version_prefix: ${{ parameters.version_prefix }}
           include_suffix: ${{ parameters.include_suffix }}
-          version_suffix: nightly.$(Build.BuildNumber)
+          version_suffix: ${{ parameters.version_suffix }}
           codesign: true
           publish_nightly: ${{ parameters.publish_nightly }}
           publish_nuget: ${{ parameters.publish_nuget }}


### PR DESCRIPTION
Added `version_suffix` parameter to `.azure/pipelines/nightly-main.yaml`, defaulting to `ci.$(Build.BuildNumber)`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9858)