### PR TITLE
Assign `MinIdleCyclesBeforeRemoval` to default value in `StatelessWorkerOptions`

### DIFF
--- a/src/Orleans.Runtime/Configuration/Options/StatelessWorkerOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/StatelessWorkerOptions.cs
@@ -31,7 +31,7 @@ public class StatelessWorkerOptions
     public static readonly TimeSpan DEFAULT_IDLE_WORKERS_INSPECTION_PERIOD = TimeSpan.FromMilliseconds(500);
 
     /// <summary>
-    /// The minumun, consecutive number of idle cycles any given worker must exibit before it is deemed enough to remove the worker.
+    /// The minimum, consecutive number of idle cycles any given worker must exhibit before it is deemed enough to remove the worker.
     /// </summary>
     public int MinIdleCyclesBeforeRemoval { get; set; } = DEFAULT_MIN_IDLE_CYCLES_BEFORE_REMOVAL;
 


### PR DESCRIPTION
Assigns `MinIdleCyclesBeforeRemoval` to default value, and sets default value to 1 since that is what it was implicitly being set to.
The number is arbitrary and generally users should decide how aggressive the algo is (or isnt).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9860)