### PR TITLE
Dashboard: Skip ValidateFrontendEmbeddedResources during pack --no-build

### DIFF
--- a/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
+++ b/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
@@ -107,8 +107,9 @@
 
   <!-- Validate that frontend assets were actually included as embedded resources.
        This runs after CreateManifestResourceNames has processed all EmbeddedResource items,
-       providing a final check that the resources will be compiled into the assembly. -->
-  <Target Name="ValidateFrontendEmbeddedResources" AfterTargets="CreateManifestResourceNames">
+       providing a final check that the resources will be compiled into the assembly.
+       Only runs during build (not during pack) by checking that IncludeFrontendAssets ran. -->
+  <Target Name="ValidateFrontendEmbeddedResources" AfterTargets="CreateManifestResourceNames" Condition="'@(_DistFiles)' != ''">
     <ItemGroup>
       <_FrontendEmbeddedResources Include="@(EmbeddedResource)" Condition="'%(Link)' != '' and $([System.String]::Copy('%(Link)').StartsWith('wwwroot'))" />
     </ItemGroup>
@@ -119,3 +120,4 @@
   </Target>
 
 </Project>
+


### PR DESCRIPTION
The validation target should only run when IncludeFrontendAssets has run, which populates the _DistFiles item group. During 'pack --no-build', the build targets don't run so _DistFiles is empty.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9861)