### PR TITLE
Fix TLS memory pool configuration

### DIFF
--- a/src/Orleans.Core/Networking/Shared/TransportConnection.Features.cs
+++ b/src/Orleans.Core/Networking/Shared/TransportConnection.Features.cs
@@ -23,10 +23,6 @@ namespace Orleans.Networking.Shared
     {
         IDictionary<object, object> Items { get; set; }
     }
-    internal interface IMemoryPoolFeature
-    {
-        MemoryPool<byte> MemoryPool { get; }
-    }
 
     internal partial class TransportConnection : IConnectionIdFeature,
                                                  IConnectionTransportFeature,


### PR DESCRIPTION
In `TransportConnection.Features.cs`, we configure the `IMemoryPoolFeature`, which is from `Orleans.Networking.Shared`. At some point, this type was made public in `Microsoft.AspNetCore.Connections.Features`, which preempted the local type definition within `TlsClientConnectionMiddleware` and `TlsServiceConnectionMiddleward`. This prevented these types from using the pinned memory blocks, and instead used the default array pool (`SharedArrayPool<byte>`), which is the default for the StreamPipeReader/Writer.

This change removes the custom type in Orleans, allowing the TLS middlewares to utilize the proper memory pool instance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9864)