### PR TITLE
feat(grain-directory): enable rolling upgrade to DistributedGrainDirectory

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -106,19 +106,6 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// FOR TESTING PURPOSES ONLY!!
-        /// </summary>
-        /// <param name="grain"></param>
-        internal int UnregisterGrainForTesting(GrainId grain)
-        {
-            var activation = activations.FindTarget(grain);
-            if (activation is null) return 0;
-
-            UnregisterMessageTarget(activation);
-            return 1;
-        }
-
-        /// <summary>
         /// If activation already exists, return it.
         /// Otherwise, creates a new activation, begins rehydrating it and activating it, then returns it.
         /// </summary>

--- a/src/Orleans.Runtime/Core/InternalGrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/InternalGrainRuntime.cs
@@ -18,7 +18,6 @@ namespace Orleans.Runtime
         GrainLocator grainLocator,
         CompatibilityDirectorManager compatibilityDirectorManager,
         IOptions<GrainCollectionOptions> collectionOptions,
-        ILocalGrainDirectory localGrainDirectory,
         IActivationWorkingSet activationWorkingSet,
         ActivationCollector activationCollector)
     {
@@ -30,7 +29,6 @@ namespace Orleans.Runtime
         public CompatibilityDirectorManager CompatibilityDirectorManager { get; } = compatibilityDirectorManager;
         public GrainLocator GrainLocator { get; } = grainLocator;
         public IOptions<GrainCollectionOptions> CollectionOptions { get; } = collectionOptions;
-        public ILocalGrainDirectory LocalGrainDirectory { get; } = localGrainDirectory;
         public IActivationWorkingSet ActivationWorkingSet { get; } = activationWorkingSet;
         public ActivationCollector ActivationCollector { get; } = activationCollector;
     }

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime.GrainDirectory
     /// <summary>
     /// Implementation of <see cref="IGrainLocator"/> that uses <see cref="IGrainDirectory"/> stores.
     /// </summary>
-    internal class CachedGrainLocator : IGrainLocator, ILifecycleParticipant<ISiloLifecycle>, CachedGrainLocator.ITestAccessor
+    internal sealed class CachedGrainLocator : IGrainLocator, ILifecycleParticipant<ISiloLifecycle>, CachedGrainLocator.ITestAccessor
     {
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly IGrainDirectoryCache cache;

--- a/src/Orleans.Runtime/GrainDirectory/DhtGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DhtGrainLocator.cs
@@ -34,7 +34,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public async ValueTask<GrainAddress?> Lookup(GrainId grainId) => (await _localGrainDirectory.LookupAsync(grainId)).Address;
 
-        public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => (await _localGrainDirectory.RegisterAsync(address, currentRegistration: previousAddress)).Address;
+        public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => (await _localGrainDirectory.RegisterAsync(address, currentRegistration: previousAddress, hopCount: 0)).Address;
 
         public Task Unregister(GrainAddress address, UnregistrationCause cause)
         {
@@ -138,7 +138,7 @@ namespace Orleans.Runtime.GrainDirectory
 
                         if (operations.Count > 0)
                         {
-                            await _localGrainDirectory.UnregisterManyAsync(addresses, _cause);
+                            await _localGrainDirectory.UnregisterManyAsync(addresses, _cause, hopCount: 0);
                             foreach (var op in operations)
                             {
                                 op.TrySetResult(true);

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -67,6 +67,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     private readonly DirectoryInstruments _directoryInstruments;
     private readonly TimeSpan _deadSiloLeaseDuration;
     private readonly TimeProvider _timeProvider;
+    private readonly ActivationDirectory _localActivations;
 
     internal CancellationToken OnStoppedToken => _stoppedCts.Token;
     internal DirectoryInstruments DirectoryInstruments => _directoryInstruments;
@@ -83,7 +84,6 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     private long _recoveryMembershipVersion;
     internal long RecoveryMembershipVersion => Volatile.Read(ref _recoveryMembershipVersion);
     private Task _runTask = Task.CompletedTask;
-    private ActivationDirectory _localActivations;
     private GrainDirectoryResolver? _grainDirectoryResolver;
     private Task? _leaseCleanupTask;
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -838,14 +838,14 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 {
                     var innerSw = ValueStopwatch.StartNew();
                     Immutable<List<GrainAddress>> result = default;
-                        if (isValidation)
-                        {
-                            result = await client.GetRegisteredActivations(version, range, isValidation: true, cancellationToken);
-                        }
-                        else
-                        {
-                            result = await client.RecoverRegisteredActivations(version, range, _id, _partitionIndex, cancellationToken);
-                        }
+                    if (isValidation)
+                    {
+                        result = await client.GetRegisteredActivations(version, range, isValidation: true, cancellationToken);
+                    }
+                    else
+                    {
+                        result = await client.RecoverRegisteredActivations(version, range, _id, _partitionIndex, cancellationToken);
+                    }
 
                     return result;
                 },
@@ -947,7 +947,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             {
                 if (ex is not OrleansMessageRejectionException)
                 {
-                    LogErrorErrorInvokingOperation(_logger, ex, operationName, siloAddress);
+                    LogWarningErrorInvokingOperation(_logger, ex, operationName, siloAddress);
                 }
 
                 await _owner.RefreshViewAsync(default, ShutdownToken);
@@ -1371,10 +1371,10 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     private static partial void LogDebugRecoveredEntries(ILogger logger, int count, SiloAddress siloAddress, RingRange range, MembershipVersion version, double elapsedMilliseconds);
 
     [LoggerMessage(
-        Level = LogLevel.Error,
+        Level = LogLevel.Warning,
         Message = "Error invoking operation '{Operation}' on silo '{SiloAddress}'."
     )]
-    private static partial void LogErrorErrorInvokingOperation(ILogger logger, Exception exception, string operation, SiloAddress siloAddress);
+    private static partial void LogWarningErrorInvokingOperation(ILogger logger, Exception exception, string operation, SiloAddress siloAddress);
 
     [LoggerMessage(
         Level = LogLevel.Error,

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryResolver.cs
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public IGrainDirectory? Resolve(GrainType grainType) => this.directoryPerType.GetOrAdd(grainType, this.getGrainDirectoryInternal);
 
-        public bool IsUsingDefaultDirectory(GrainType grainType) => Resolve(grainType) == null;
+        public bool IsUsingDhtGrainDirectory(GrainType grainType) => Resolve(grainType) == null;
 
         private IGrainDirectory? GetGrainDirectoryPerType(GrainType grainType)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocatorResolver.cs
@@ -12,20 +12,19 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IServiceProvider _servicesProvider;
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly CachedGrainLocator cachedGrainLocator;
-        private readonly DhtGrainLocator dhtGrainLocator;
+        private readonly DhtGrainLocator? dhtGrainLocator;
         private ClientGrainLocator? _clientGrainLocator;
 
         public GrainLocatorResolver(
             IServiceProvider servicesProvider,
             GrainDirectoryResolver grainDirectoryResolver,
-            CachedGrainLocator cachedGrainLocator,
-            DhtGrainLocator dhtGrainLocator)
+            CachedGrainLocator cachedGrainLocator)
         {
             this.getLocatorInternal = GetGrainLocatorInternal;
             _servicesProvider = servicesProvider;
             this.grainDirectoryResolver = grainDirectoryResolver;
             this.cachedGrainLocator = cachedGrainLocator;
-            this.dhtGrainLocator = dhtGrainLocator;
+            this.dhtGrainLocator = servicesProvider.GetService<LocalGrainDirectory>() is null ? null : servicesProvider.GetService<DhtGrainLocator>();
         }
 
         public IGrainLocator GetGrainLocator(GrainType grainType) => resolvedLocators.GetOrAdd(grainType, this.getLocatorInternal);
@@ -37,7 +36,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 result = this._clientGrainLocator ??= _servicesProvider.GetRequiredService<ClientGrainLocator>();
             }
-            else if (this.grainDirectoryResolver.IsUsingDefaultDirectory(grainType))
+            else if (this.grainDirectoryResolver.IsUsingDhtGrainDirectory(grainType) && dhtGrainLocator is not null)
             {
                 result = this.dhtGrainLocator;
             }

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -17,9 +17,6 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         Task StopAsync();
 
-        RemoteGrainDirectory RemoteGrainDirectory { get; }
-        RemoteGrainDirectory CacheValidator { get; }
-
         /// <summary>
         /// Removes the record for an non-existing activation from the directory service.
         /// This is used when a request is received for an activation that cannot be found, 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -368,7 +368,7 @@ namespace Orleans.Runtime.GrainDirectory
                     var activationData = activation.Value;
                     var placementStrategy = activationData.GetComponent<PlacementStrategy>();
                     var isUsingGrainDirectory = placementStrategy is { IsUsingGrainDirectory: true };
-                    if (!isUsingGrainDirectory || !resolver.IsUsingDefaultDirectory(activationData.GrainId.Type))
+                    if (!isUsingGrainDirectory || !resolver.IsUsingDhtGrainDirectory(activationData.GrainId.Type))
                     {
                         continue;
                     }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
@@ -117,11 +117,11 @@ namespace Orleans.Runtime.GrainDirectory
 
         internal int Count { get { return partitionData.Count; } }
 
-        public LocalGrainDirectoryPartition(IClusterMembershipService clusterMembershipService, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
+        public LocalGrainDirectoryPartition(IClusterMembershipService clusterMembershipService, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILogger<LocalGrainDirectoryPartition> logger)
         {
             partitionData = new Dictionary<GrainId, GrainInfo>();
             lockable = new object();
-            log = loggerFactory.CreateLogger<LocalGrainDirectoryPartition>();
+            log = logger;
             this.clusterMembershipService = clusterMembershipService;
             this.grainDirectoryOptions = grainDirectoryOptions;
         }

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -173,7 +173,17 @@ namespace Orleans.Hosting
             if (!services.Contains(DirectoryDescriptor))
             {
                 services.Add(DirectoryDescriptor);
-                services.AddGrainDirectory<DistributedGrainDirectory>(name, (sp, name) => sp.GetRequiredService<DistributedGrainDirectory>());
+                services.AddGrainDirectory<DistributedGrainDirectory>(name!, (sp, name) => sp.GetRequiredService<DistributedGrainDirectory>());
+            }
+
+            if (string.Equals(name, GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, StringComparison.Ordinal))
+            {
+                // Remove LocalGrainDirectory service registrations since DistributedGrainDirectory is taking over.
+                // Silos which are still using LocalGrainDirectory can continue to issue directory requests to this
+                // silo during a rolling upgrade: DistributedGrainDirectory registers system targets which implement
+                // the legacy IRemoteGrainDirectory interface on its behalf. See DistributedRemoteGrainDirectory.
+                TaggedServiceDescriptor.RemoveAllForImplementation<LocalGrainDirectory>(services);
+                services.RemoveAll<DhtGrainLocator>();
             }
 
             return siloBuilder;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -151,7 +151,7 @@ namespace Orleans.Hosting
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, LocalGrainDirectory>();
             services.AddSingleton<GrainLocator>();
             services.AddSingleton<GrainLocatorResolver>();
-            services.AddSingleton<DhtGrainLocator>(sp => DhtGrainLocator.FromLocalGrainDirectory(sp.GetService<LocalGrainDirectory>()!));
+            services.AddSingleton<DhtGrainLocator>(sp => DhtGrainLocator.FromLocalGrainDirectory(sp.GetRequiredService<LocalGrainDirectory>()));
             services.AddSingleton<GrainDirectoryResolver>();
             services.AddSingleton<IGrainDirectoryResolver, GenericGrainDirectoryResolver>();
             services.AddSingleton<CachedGrainLocator>();

--- a/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -10,8 +10,6 @@ namespace Orleans.Runtime.TestHooks
         Task<string> GetConsistentRingProviderDiagnosticInfo();
         Task<string> GetServiceId();
         Task<bool> HasStorageProvider(string providerName);
-        Task<bool> HasStreamProvider(string providerName);
-        Task<int> UnregisterGrainForTesting(GrainId grain);
         Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses();
         Task<bool> WaitForActiveSilos(SiloAddress[] expectedActiveSilos, TimeSpan timeout);
         Task<bool> WaitForClusterManifest(SiloAddress[] expectedSilos, TimeSpan timeout);

--- a/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -87,8 +87,6 @@ namespace Orleans.Runtime.TestHooks
             return Task.FromResult(this.serviceProvider.GetKeyedService<IGrainStorage>(providerName) != null);
         }
 
-        public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(this.serviceProvider.GetRequiredService<Catalog>().UnregisterGrainForTesting(grain));
-
         public Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses() => Task.FromResult(this.siloStatusOracle.GetApproximateSiloStatuses());
 
         public async Task<bool> WaitForActiveSilos(SiloAddress[] expectedActiveSilos, TimeSpan timeout)

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -94,6 +94,13 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         InProcessTestClusterOptions options,
         ITestClusterPortAllocator portAllocator)
     {
+        if (options.UseTestClusterGrainDirectory && !options.UseTestClusterMembership)
+        {
+            throw new ArgumentException(
+                $"{nameof(options.UseTestClusterGrainDirectory)} requires {nameof(options.UseTestClusterMembership)} to be enabled.",
+                nameof(options));
+        }
+
         Options = options;
         PortAllocator = portAllocator;
         _membershipTable = new(options.ClusterId);

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -218,7 +218,6 @@ namespace UnitTests.Grains
 
         public OneWayGrain(GrainLocator grainLocator) => this.grainLocator = grainLocator;
 
-        private ILocalGrainDirectory LocalGrainDirectory => this.ServiceProvider.GetRequiredService<ILocalGrainDirectory>();
         private ILocalSiloDetails LocalSiloDetails => this.ServiceProvider.GetRequiredService<ILocalSiloDetails>();
 
         public Task Notify()
@@ -326,7 +325,12 @@ namespace UnitTests.Grains
         public Task<SiloAddress> GetPrimaryForGrain()
         {
             var grainId = (GrainId)this.GrainId;
-            var primaryForGrain = this.LocalGrainDirectory.GetPrimaryForGrain(grainId);
+            if (ServiceProvider.GetService<DistributedGrainDirectory>() is { } distributedGrainDirectory)
+            {
+                return Task.FromResult(((DistributedGrainDirectory.ITestHooks)distributedGrainDirectory).GetPrimaryForGrain(grainId)!);
+            }
+
+            var primaryForGrain = ServiceProvider.GetRequiredService<ILocalGrainDirectory>().GetPrimaryForGrain(grainId);
             return Task.FromResult(primaryForGrain!);
         }
 

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -158,7 +158,7 @@ namespace UnitTests.Directory
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
                 membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
-                this.loggerFactory);
+                this.loggerFactory.CreateLogger<LocalGrainDirectoryPartition>());
             var systemTargetShared = new SystemTargetShared(
                 runtimeClient: null!,
                 localSiloDetails: localSiloDetails,
@@ -214,7 +214,7 @@ namespace UnitTests.Directory
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
                 membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
-                this.loggerFactory);
+                this.loggerFactory.CreateLogger<LocalGrainDirectoryPartition>());
             var systemTargetShared = new SystemTargetShared(
                 runtimeClient: null!,
                 localSiloDetails: localSiloDetails,
@@ -282,7 +282,7 @@ namespace UnitTests.Directory
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
                 membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
-                this.loggerFactory);
+                this.loggerFactory.CreateLogger<LocalGrainDirectoryPartition>());
             var systemTargetShared = new SystemTargetShared(
                 runtimeClient: null!,
                 localSiloDetails: localSiloDetails,

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -12,6 +12,7 @@ using Orleans.GrainDirectory;
 using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Messaging;
 using Orleans.TestingHost;
 using Xunit;
 using Xunit.Abstractions;
@@ -1751,7 +1752,6 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             long grainKey,
             CancellationToken cancellationToken)
         {
-            const int MaxAttempts = 2;
             for (var attempt = 1; ; attempt++)
             {
                 try
@@ -1762,18 +1762,31 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 {
                     throw;
                 }
-                catch (Exception exception) when (attempt < MaxAttempts && IsTransientUpgradeFailure(exception))
+                catch (Exception exception) when (ShouldRetryUpgradeFailure(exception, attempt))
                 {
                     _transientFailures.Enqueue(new(callPhase, worker, grainKey, exception, DateTimeOffset.UtcNow));
-                    await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+                    await Task.Delay(GetTransientUpgradeRetryDelay(exception), cancellationToken);
                 }
             }
         }
 
+        private static bool ShouldRetryUpgradeFailure(Exception exception, int attempt) =>
+            IsTransientUpgradeFailure(exception)
+            && attempt < (ContainsConnectionFailure(exception) ? 3 : 2);
+
         private static bool IsTransientUpgradeFailure(Exception exception) =>
-            exception.GetBaseException() is TimeoutException
+            exception is TimeoutException
                 or SiloUnavailableException
-                or OrleansMessageRejectionException;
+                or OrleansMessageRejectionException
+                or ConnectionFailedException
+            || exception.InnerException is not null && IsTransientUpgradeFailure(exception.InnerException);
+
+        private static TimeSpan GetTransientUpgradeRetryDelay(Exception exception) =>
+            ContainsConnectionFailure(exception) ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(250);
+
+        private static bool ContainsConnectionFailure(Exception exception) =>
+            exception is ConnectionFailedException
+            || exception.InnerException is not null && ContainsConnectionFailure(exception.InnerException);
 
         private void SignalProgress()
         {

--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Runtime;
@@ -28,21 +29,21 @@ namespace UnitTests;
 /// This is essential for maintaining Orleans' single activation guarantee.
 /// </summary>
 [TestCategory("BVT"), TestCategory("GrainDirectory")]
-public class GrainDirectoryPartitionTests
+public class LocalGrainDirectoryPartitionTests
 {
     private readonly LocalGrainDirectoryPartition _target;
     private readonly MockClusterMembershipService _clusterMembershipService;
     private static readonly SiloAddress LocalSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
     private static readonly SiloAddress OtherSiloAddress = SiloAddress.FromParsableString("127.0.0.2:11111@456");
 
-    public GrainDirectoryPartitionTests()
+    public LocalGrainDirectoryPartitionTests()
     {
         _clusterMembershipService = new MockClusterMembershipService();
         _clusterMembershipService.SetSiloStatus(LocalSiloAddress, SiloStatus.Active);
         _target = new LocalGrainDirectoryPartition(
             _clusterMembershipService,
             Options.Create(new GrainDirectoryOptions()),
-            new LoggerFactory());
+            NullLogger<LocalGrainDirectoryPartition>.Instance);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR enables basic support for rolling upgrades from the legacy DHT-based `LocalGrainDirectory` to the `DistributedGrainDirectory` (enabled by calling `ISiloBuilder.AddDistributedGrainDirectory()`). When performing an upgrade, users must follow the procedure detailed under the 'Rolling Upgrade Path' header.

There are caveats to this rolling uprade support. In particular, there will be inconsistency during the rollout: there can be duplicate activations created for a given grain, since different hosts have different ideas of what the correct directory for a given grain is. After the rollout is complete and all hosts are running the `DistributedGrainDirectory`, there is no more chance for inconsistency and there will be no orphaned (unregistered) or duplicate activations.

A different strategy could include attempts to reduce the chance for inconsistency during the rollout window. For now, that is not something I intend to pursue since it greatly increases complexity for dubious benefit.

## Changes

- Added `DelegatingRemoteGrainDirectory` - A system target that handles `IRemoteGrainDirectory` requests from old silos still using `LocalGrainDirectory`. This allows old silos to communicate with new silos during a rolling upgrade. It implements the same grain types (Constants.DirectoryServiceType, Constants.DirectoryCacheValidatorType) that `LocalGrainDirectory` uses.
- Changed service registration - `DistributedGrainDirectory` and `DirectoryMembershipService` are now registered on all silos by default (not just when explicitly enabled). This ensures `IGrainDirectoryClient` is available for recovery queries during rolling upgrades. When `AddDistributedGrainDirectory()` is called:
  - Removes `LocalGrainDirectory` lifecycle participation
  - Swaps `IGrainLocator` from `DhtGrainLocator` to `CachedGrainLocator`
  - Registers the delegating system targets
- Removed `LocalGrainDirectoryPartition` from DI - It's now created directly by `LocalGrainDirectory` instead of being injected.
- Added `UseTestClusterGrainDirectory` option to `InProcTestClusterOptions` for testing.
- Added `GrainDirectoryMigrationTests` - Tests covering rolling upgrade scenarios.

## Rolling Upgrade Path

To take advantage of this new functionality, you will need to perform two complete rollouts. The first adds support for the new directory on all hosts. The second switches to it by default.

1. Rollout 1: Upgrade all hosts to Orleans v10.0.0.
2. Rollout 2: Add a call to `AddDistributedGrainDirectory()` in your silo configuration.
  - Old silos send `IRemoteGrainDirectory` messages to new silos, which are handled by `DelegatingRemoteGrainDirectory`.
  - New silos use `DistributedGrainDirectory` for all directory operations.
  - You may see duplicate activations during the rollout.

Fixes #9356