### PR TITLE
Source link on dashboard to main orleans repo

### DIFF
--- a/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
@@ -144,7 +144,7 @@ function getVersion() {
         />
         <a
           style={{ color: '#b8c7ce', textDecoration: 'underline' }}
-          href="https://github.com/OrleansContrib/OrleansDashboard/"
+          href="https://github.com/dotnet/orleans/tree/main/src/Dashboard/Orleans.Dashboard"
         >
           Source
         </a>


### PR DESCRIPTION
The Source link still pointed to the Contrib repo, which might put people on the wrong track.

<img width="219" height="111" alt="image" src="https://github.com/user-attachments/assets/ae62b7b3-1639-4189-a50d-9a773bb2da64" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9911)