### PR TITLE
Fix activation-count placement fallback for partial statistics

### DIFF
--- a/test/NonSilo.Tests/Runtime/ActivationCountPlacementDirectorTests.cs
+++ b/test/NonSilo.Tests/Runtime/ActivationCountPlacementDirectorTests.cs
@@ -1,8 +1,10 @@
+using System;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Runtime.Placement;
+using Orleans.Statistics;
 using Xunit;
 
 namespace UnitTests.Runtime
@@ -38,6 +40,50 @@ namespace UnitTests.Runtime
             Assert.Equal(localSilo, result);
         }
 
+        [Fact]
+        public async Task OnAddActivation_WhenSomeCompatibleSilosHaveNoStats_PrefersSilosWithStats()
+        {
+            var localSilo = Silo("127.0.0.1:100@1");
+            var siloWithStats = Silo("127.0.0.1:101@1");
+            var siloWithoutStats = Silo("127.0.0.1:102@1");
+            var director = CreateDirector(localSilo);
+            var placementContext = CreatePlacementContext(siloWithStats, siloWithoutStats);
+            director.SiloStatisticsChangeNotification(siloWithStats, CreateSiloRuntimeStatistics(overloaded: false, recentlyUsedActivationCount: 10));
+
+            var result = await director.OnAddActivation(strategy: null!, target: default, placementContext);
+
+            Assert.Equal(siloWithStats, result);
+        }
+
+        [Fact]
+        public async Task OnAddActivation_WhenAllCompatibleSilosWithStatsAreOverloaded_Throws()
+        {
+            var localSilo = Silo("127.0.0.1:100@1");
+            var overloadedSilo1 = Silo("127.0.0.1:101@1");
+            var overloadedSilo2 = Silo("127.0.0.1:102@1");
+            var director = CreateDirector(localSilo);
+            var placementContext = CreatePlacementContext(overloadedSilo1, overloadedSilo2);
+            director.SiloStatisticsChangeNotification(overloadedSilo1, CreateSiloRuntimeStatistics(overloaded: true));
+            director.SiloStatisticsChangeNotification(overloadedSilo2, CreateSiloRuntimeStatistics(overloaded: true));
+
+            await Assert.ThrowsAsync<SiloUnavailableException>(() => director.OnAddActivation(strategy: null!, target: default, placementContext));
+        }
+
+        [Fact]
+        public async Task OnAddActivation_WhenSilosWithStatsAreOverloadedAndWithoutStatsExist_FallsBackToWithoutStats()
+        {
+            var localSilo = Silo("127.0.0.1:100@1");
+            var overloadedSilo = Silo("127.0.0.1:101@1");
+            var siloWithoutStats = Silo("127.0.0.1:102@1");
+            var director = CreateDirector(localSilo);
+            var placementContext = CreatePlacementContext(overloadedSilo, siloWithoutStats);
+            director.SiloStatisticsChangeNotification(overloadedSilo, CreateSiloRuntimeStatistics(overloaded: true));
+
+            var result = await director.OnAddActivation(strategy: null!, target: default, placementContext);
+
+            Assert.Equal(siloWithoutStats, result);
+        }
+
         private static ActivationCountPlacementDirector CreateDirector(SiloAddress localSilo)
         {
             var localSiloDetails = Substitute.For<ILocalSiloDetails>();
@@ -47,6 +93,39 @@ namespace UnitTests.Runtime
                 localSiloDetails,
                 deploymentLoadPublisher: null!,
                 Options.Create(new ActivationCountBasedPlacementOptions()));
+        }
+
+        private static IPlacementContext CreatePlacementContext(params SiloAddress[] compatibleSilos)
+        {
+            var placementContext = Substitute.For<IPlacementContext>();
+            placementContext.GetCompatibleSilos(Arg.Any<PlacementTarget>()).Returns(compatibleSilos);
+            return placementContext;
+        }
+
+        private static SiloRuntimeStatistics CreateSiloRuntimeStatistics(bool overloaded, int recentlyUsedActivationCount = 0)
+        {
+            var environmentStatisticsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
+            var maxMemoryBytes = 1000L;
+            var memoryUsageBytes = overloaded ? 950L : 100L;
+            var availableMemoryBytes = maxMemoryBytes - memoryUsageBytes;
+            var cpuUsagePercentage = overloaded ? 100f : 0f;
+
+            environmentStatisticsProvider.GetEnvironmentStatistics().Returns(
+                new EnvironmentStatistics(
+                    cpuUsagePercentage: cpuUsagePercentage,
+                    rawCpuUsagePercentage: cpuUsagePercentage,
+                    memoryUsageBytes: memoryUsageBytes,
+                    rawMemoryUsageBytes: memoryUsageBytes,
+                    availableMemoryBytes: availableMemoryBytes,
+                    rawAvailableMemoryBytes: availableMemoryBytes,
+                    maximumAvailableMemoryBytes: maxMemoryBytes));
+
+            return new SiloRuntimeStatistics(
+                activationCount: 0,
+                recentlyUsedActivationCount: recentlyUsedActivationCount,
+                environmentStatisticsProvider,
+                Options.Create(new LoadSheddingOptions { LoadSheddingEnabled = overloaded }),
+                DateTime.UtcNow);
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);


### PR DESCRIPTION
## Summary
- avoid per-placement `HashSet` allocation in `ActivationCountPlacementDirector`
- use direct random compatible-silo fallback when no compatible silo stats are available
- preserve overload rejection when all compatible silos are known and overloaded

## Validation
- `dotnet test .\\test\\TesterInternal\\TesterInternal.csproj --filter "FullyQualifiedName~UnitTests.General.ElasticPlacementTests.LoadAwareGrainShouldNotAttemptToCreateActivationsOnOverloadedSilo" --nologo --verbosity minimal`
- repeated flaky-case validation: 5x `--no-build` runs of the same test
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9914)