### PR TITLE
Fix flake in StuckGrainTest_StuckDetectionOnDeactivation

### DIFF
--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -41,7 +41,13 @@ namespace UnitTests.Grains
                 throw new InvalidOperationException();
 
 
-            return Task.Run(() => mre.Wait(1000));
+            return Task.Run(() =>
+            {
+                if (!mre.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting for grain deactivation to start.");
+                }
+            });
         }
 
         public static void SetDeactivationStarted(GrainId key)


### PR DESCRIPTION
Summary: make WaitForDeactivationStart deterministic by waiting up to 10 seconds and throwing TimeoutException when deactivation does not start. Validation: targeted test passed plus 20 repeated net10.0 runs and a cross-TFM run.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9915)