### PR TITLE
Stabilize SingleWorkerInvocationUnderLoad test

### DIFF
--- a/test/Tester/StatelessWorkerActivationTests.cs
+++ b/test/Tester/StatelessWorkerActivationTests.cs
@@ -58,11 +58,13 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
     public async Task SingleWorkerInvocationUnderLoad()
     {
         var workerGrain = _fixture.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(0);
+        var managementGrain = _fixture.GrainFactory.GetGrain<IManagementGrain>(0);
+        var grainReference = (GrainReference)workerGrain;
 
         for (var i = 0; i < 100; i++)
         {
-            var activationCount = await workerGrain.GetActivationCount();
-            Assert.Equal(1, activationCount);
+            await workerGrain.GetActivationCount();
+            await Until(async () => 1 == await managementGrain.GetGrainActivationCount(grainReference), 5_000);
         }
     }
 


### PR DESCRIPTION
## Summary
- replace timing-based delay in `SingleWorkerInvocationUnderLoad` with deterministic state polling
- use `IManagementGrain.GetGrainActivationCount` plus the existing `Until` helper to wait for a single activation
- keep scope limited to the flaky test

## Testing
- dotnet test .\test\Tester\Tester.csproj --filter "FullyQualifiedName=UnitTests.General.StatelessWorkerActivationTests.SingleWorkerInvocationUnderLoad" (30 iterations)
- dotnet test .\test\Tester\Tester.csproj --filter "FullyQualifiedName~UnitTests.General.StatelessWorkerActivationTests" --no-build
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9919)