### PR TITLE
Fix SQLite CI package resolution for net8/net10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.Crank.EventSources" Version="0.2.0-alpha.23422.5" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.11" />
     <PackageVersion Include="Microsoft.DotNet.GenAPI.Task" Version="9.0.103-servicing.25065.25" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
@@ -90,6 +91,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageVersion Include="protobuf-net" Version="3.2.30" />
     <PackageVersion Include="SpanJson" Version="4.0.1" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
     <PackageVersion Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
     <PackageVersion Include="System.CodeDom" Version="10.0.0" />
@@ -124,6 +126,7 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="5.0.0" />
+    <PackageVersion Update="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />

--- a/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
+++ b/test/Extensions/TesterAdoNet/Tester.AdoNet.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <!--<PackageReference Include="MySqlConnector" Version="1.2.1" />-->
-    <PackageReference Include="Microsoft.Data.Sqlite" VersionOverride="5.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="System.Drawing.Common" /> <!-- For some reason it's a dependency of MySql.Data. We want to force it to a specific version -->


### PR DESCRIPTION
## Summary
- move `Microsoft.Data.Sqlite` versioning into central package management
- keep `Microsoft.Data.Sqlite` at `8.0.11` by default and use `10.0.3` for `net10.0` via conditional update
- remove per-project `VersionOverride` from `test/Extensions/TesterAdoNet/Tester.AdoNet.csproj`
- pin `SQLitePCLRaw.bundle_e_sqlite3` to `2.1.11` to avoid NETSDK1206 `alpine-x64` RID warning while satisfying net10 dependency constraints

## Validation
- `dotnet build test/Extensions/TesterAdoNet/Tester.AdoNet.csproj -f net8.0`
- `dotnet build test/Extensions/TesterAdoNet/Tester.AdoNet.csproj -f net10.0`
- `dotnet test test/Extensions/TesterAdoNet/Tester.AdoNet.csproj -f net8.0 --filter "FullyQualifiedName~SqlitePersistenceGrainStorageTests"`
- `dotnet test test/Extensions/TesterAdoNet/Tester.AdoNet.csproj -f net10.0 --filter "FullyQualifiedName~SqlitePersistenceGrainStorageTests"`
- `dotnet build`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9920)