### PR TITLE
Fix flaky NonReentrantGrainTimer_NoKeepAlive_Test

### DIFF
--- a/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -539,7 +539,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             var grain = this.testCluster.GrainFactory.GetGrain<INonReentrantTimerCallGrain>(GetRandomGrainId());
 
             // Schedule a timer to fire at the 30s mark which will not extend the grain's lifetime.
-            await grain.StartTimer(testName, TimeSpan.FromSeconds(4), keepAlive: false);
+            await grain.StartTimer(testName, TimeSpan.FromSeconds(30), keepAlive: false);
             await Task.Delay(TimeSpan.FromSeconds(7));
 
             var tickCount = await grain.GetTickCount();


### PR DESCRIPTION
## Summary
- fix NonReentrantGrainTimer_NoKeepAlive_Test flakiness by aligning timer scheduling with the test's intent
- change the test timer due time from 4s to 30s so the timer cannot fire before idle collection executes

## Testing
- dotnet test test/TesterInternal/TesterInternal.csproj --filter "FullyQualifiedName=UnitTests.ActivationsLifeCycleTests.ActivationCollectorTests.NonReentrantGrainTimer_NoKeepAlive_Test" (run repeatedly; 10/10 passed post-fix)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9925)