### PR TITLE
Add loopback fallback when local IP discovery finds no candidates

### DIFF
--- a/src/Orleans.Core/Configuration/ConfigUtilities.cs
+++ b/src/Orleans.Core/Configuration/ConfigUtilities.cs
@@ -201,7 +201,26 @@ namespace Orleans.Runtime.Configuration
                     }
                 }
             }
-            if (candidates.Count > 0) return PickIPAddress(candidates);
+            return ResolveLocalIPAddress(candidates, family, interfaceName);
+        }
+
+        internal static IPAddress ResolveLocalIPAddress(IReadOnlyList<IPAddress> candidates, AddressFamily family, string interfaceName)
+        {
+            if (candidates.Count > 0)
+            {
+                return PickIPAddress(candidates);
+            }
+
+            if (string.IsNullOrWhiteSpace(interfaceName))
+            {
+                return family switch
+                {
+                    AddressFamily.InterNetwork => IPAddress.Loopback,
+                    AddressFamily.InterNetworkV6 => IPAddress.IPv6Loopback,
+                    _ => throw new OrleansException("Failed to get a local IP address."),
+                };
+            }
+
             throw new OrleansException("Failed to get a local IP address.");
         }
 

--- a/test/NonSilo.Tests/ConfigTests.cs
+++ b/test/NonSilo.Tests/ConfigTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Orleans.Runtime.Configuration;
 using Xunit;
 using Xunit.Abstractions;
@@ -51,6 +53,26 @@ namespace UnitTests
             output.WriteLine("Output = " + sqlConnectionString);
             Assert.True(sqlConnectionString.EndsWith("Password=<--SNIP-->", StringComparison.InvariantCultureIgnoreCase),
                 "Removed password info from SqlServer connection string " + sqlConnectionString);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void Config_LocalIPAddressFallback_UsesIPv4Loopback()
+        {
+            var result = ConfigUtilities.ResolveLocalIPAddress(Array.Empty<IPAddress>(), AddressFamily.InterNetwork, interfaceName: null);
+            Assert.Equal(IPAddress.Loopback, result);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void Config_LocalIPAddressFallback_UsesIPv6Loopback()
+        {
+            var result = ConfigUtilities.ResolveLocalIPAddress(Array.Empty<IPAddress>(), AddressFamily.InterNetworkV6, interfaceName: null);
+            Assert.Equal(IPAddress.IPv6Loopback, result);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void Config_LocalIPAddressFallback_ThrowsForExplicitInterface()
+        {
+            Assert.Throws<Orleans.Runtime.OrleansException>(() => ConfigUtilities.ResolveLocalIPAddress(Array.Empty<IPAddress>(), AddressFamily.InterNetwork, "en0"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a local-address resolution helper in `ConfigUtilities`
- fall back to IPv4/IPv6 loopback when no candidate address is discovered and no explicit interface is configured
- preserve existing exception behavior when `NetworkInterfaceName` is explicitly set
- add regression tests in `NonSilo.Tests` for IPv4 fallback, IPv6 fallback, and explicit-interface failure

## Testing
- `dotnet test test\NonSilo.Tests\NonSilo.Tests.csproj --filter "FullyQualifiedName~Config_LocalIPAddressFallback" -v minimal --nologo`
- `dotnet test test\TesterInternal\TesterInternal.csproj --filter "FullyQualifiedName~DisabledCallChainReentrancyTests.NonReentrantGrain" -v minimal --nologo`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9926)