### PR TITLE
Make orphan-call transaction abort deterministic

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionCoordinatorGrain.cs
@@ -24,7 +24,7 @@ namespace Orleans.Transactions.TestKit
         Task MultiGrainDoubleByWRWR(List<ITransactionTestGrain> grains, int numberToAdd);
 
         [Transaction(TransactionOption.Create)]
-        Task OrphanCallTransaction(ITransactionTestGrain grain);
+        Task OrphanCallTransaction();
 
         [Transaction(TransactionOption.Create)]
         Task AddAndThrow(ITransactionTestGrain grain, int numberToAdd);

--- a/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
@@ -27,7 +27,7 @@ namespace Orleans.Transactions.TestKit
             return Task.WhenAll(grains.Select(Double));
         }
 
-        public Task OrphanCallTransaction(ITransactionTestGrain grain)
+        public Task OrphanCallTransaction()
         {
             _ = TransactionContext.GetRequiredTransactionInfo().Fork();
             return Task.CompletedTask;

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/GrainFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/GrainFaultTransactionTestRunner.cs
@@ -145,7 +145,7 @@ namespace Orleans.Transactions.TestKit
             ITransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
 
             await grain.Set(expected);
-            Func<Task> task = () => coordinator.OrphanCallTransaction(grain);
+            Func<Task> task = () => coordinator.OrphanCallTransaction();
             await task.Should().ThrowAsync<OrleansOrphanCallException>();
 
             //await Task.Delay(20000); // give time for GC

--- a/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
+++ b/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
@@ -323,7 +323,7 @@ namespace Orleans.Transactions.TestKit
         [Transaction(TransactionOption.Create)]
         System.Threading.Tasks.Task MultiGrainSetBit(System.Collections.Generic.List<Correctnesss.ITransactionalBitArrayGrain> grains, int bitIndex);
         [Transaction(TransactionOption.Create)]
-        System.Threading.Tasks.Task OrphanCallTransaction(ITransactionTestGrain grain);
+        System.Threading.Tasks.Task OrphanCallTransaction();
         [Transaction(TransactionOption.Create)]
         [Concurrency.ReadOnly]
         System.Threading.Tasks.Task UpdateViolated(ITransactionTestGrain grains, int numberToAdd);
@@ -719,7 +719,7 @@ namespace Orleans.Transactions.TestKit
 
         public System.Threading.Tasks.Task MultiGrainSetBit(System.Collections.Generic.List<Correctnesss.ITransactionalBitArrayGrain> grains, int bitIndex) { throw null; }
 
-        public System.Threading.Tasks.Task OrphanCallTransaction(ITransactionTestGrain grain) { throw null; }
+        public System.Threading.Tasks.Task OrphanCallTransaction() { throw null; }
 
         public System.Threading.Tasks.Task UpdateViolated(ITransactionTestGrain grain, int numberToAdd) { throw null; }
     }


### PR DESCRIPTION
## Summary
- make AbortTransactionOnOrphanCalls deterministic by forking ambient transaction info directly in TransactionCoordinatorGrain.OrphanCallTransaction
- avoid OneWay + Transaction combinations

## Testing
- dotnet test (targeted AbortTransactionOnOrphanCalls)
- 40x stress run of targeted test (--no-build)
- dotnet test for GrainFaultTransactionMemoryTests (--no-build)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9930)