### PR TITLE
Enable crash dump collection for CI test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,3 +658,13 @@ jobs:
         --blame-hang-dump-type full
         --logger "trx;LogFileName=test_results_${{ matrix.framework }}.trx"
         --
+        -parallel none -noshadow
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test_output_${{ github.job }}_${{ matrix.os }}_${{ matrix.framework }}
+        retention-days: 1
+        path: |
+          **/TestResults/*
+          **/logs/*


### PR DESCRIPTION
## Summary
- enable crash dump capture for all `dotnet test` invocations in `.github/workflows/ci.yml`
- add explicit `--blame-crash-dump-type full` and `--blame-hang-dump-type full` options
- add the same diagnostics options to the code generator test job

## Context
A recent CI test run crashed without collecting a dump: https://github.com/dotnet/orleans/actions/runs/22079624610/job/63802063364?pr=9910