### PR TITLE
Use public ECR for Consul Testcontainers image

### DIFF
--- a/test/Extensions/Consul.Tests/ConsulTestUtils.cs
+++ b/test/Extensions/Consul.Tests/ConsulTestUtils.cs
@@ -8,7 +8,7 @@ namespace Consul.Tests
     /// </summary>
     public static class ConsulTestUtils
     {
-        private static readonly ConsulContainer _container = new ConsulBuilder("hashicorp/consul:1.19")
+        private static readonly ConsulContainer _container = new ConsulBuilder("public.ecr.aws/hashicorp/consul:1.19")
             .WithCreateParameterModifier(parameters =>
             {
                 if (parameters.HostConfig is not null)


### PR DESCRIPTION
## Summary
- switch Consul test container image source from Docker Hub to public ECR
- keep Consul version pinned at 1.19
- avoid Azure DevOps pull failures when registry-1.docker.io is unreachable

## Testing
- dotnet test test\\Extensions\\Consul.Tests\\Consul.Tests.csproj --filter "FullyQualifiedName~ConsulClusteringOptionsTests" -- -parallel none -noshadow
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9933)