### PR TITLE
Skip Consul tests when Docker daemon is unsupported

### DIFF
--- a/test/Extensions/Consul.Tests/ConsulTestUtils.cs
+++ b/test/Extensions/Consul.Tests/ConsulTestUtils.cs
@@ -1,3 +1,5 @@
+using Docker.DotNet;
+using DotNet.Testcontainers.Configurations;
 using Testcontainers.Consul;
 using Xunit;
 
@@ -8,10 +10,18 @@ namespace Consul.Tests
     /// </summary>
     public static class ConsulTestUtils
     {
+        private const string DockerUnavailableSkipReason = "Docker is unavailable, so Consul tests are skipped.";
+
+        private const string WindowsDockerModeSkipReason = "Docker is running in Windows container mode (OSType=windows), so Consul tests are skipped.";
+
+        private static readonly Lazy<string> DockerDaemonOsTypeLazy = new(GetDockerDaemonOsType);
+
+        private static readonly Lazy<string> EnsureConsulSkipReasonLazy = new(() => EnsureConsulAndGetSkipReasonAsync().GetAwaiter().GetResult());
+
         private static readonly ConsulContainer _container = new ConsulBuilder("public.ecr.aws/hashicorp/consul:1.19")
             .WithCreateParameterModifier(parameters =>
             {
-                if (parameters.HostConfig is not null)
+                if (parameters.HostConfig is not null && !IsWindowsDockerDaemon())
                 {
                     parameters.HostConfig.CapAdd = ["IPC_LOCK"];
                 }
@@ -26,28 +36,88 @@ namespace Consul.Tests
                 return _container.GetBaseAddress();
             }
         }
-        private static readonly Lazy<bool> EnsureConsulLazy = new Lazy<bool>(() => EnsureConsulAsync().Result);
 
         public static void EnsureConsul()
         {
-            if (!EnsureConsulLazy.Value)
-                throw new SkipException("Consul cluster isn't running");
+            var skipReason = EnsureConsulSkipReasonLazy.Value;
+            if (skipReason is not null)
+                throw new SkipException(skipReason);
         }
 
-        public static async Task<bool> EnsureConsulAsync()
+        public static Task<bool> EnsureConsulAsync()
         {
+            return Task.FromResult(EnsureConsulSkipReasonLazy.Value is null);
+        }
+
+        private static async Task<string> EnsureConsulAndGetSkipReasonAsync()
+        {
+            var skipReason = GetDockerSkipReason();
+            if (skipReason is not null)
+            {
+                return skipReason;
+            }
+
             try
             {
                 await _container.StartAsync();
-                return true;
+                return null;
             }
             catch (HttpRequestException)
             {
-                return false;
+                return DockerUnavailableSkipReason;
             }
             catch (OperationCanceledException)
             {
-                return false;
+                return DockerUnavailableSkipReason;
+            }
+        }
+
+        private static string GetDockerSkipReason()
+        {
+            var dockerDaemonOsType = DockerDaemonOsTypeLazy.Value;
+            if (string.IsNullOrWhiteSpace(dockerDaemonOsType))
+            {
+                return DockerUnavailableSkipReason;
+            }
+
+            if (string.Equals(dockerDaemonOsType, "windows", StringComparison.OrdinalIgnoreCase))
+            {
+                return WindowsDockerModeSkipReason;
+            }
+
+            return null;
+        }
+
+        private static bool IsWindowsDockerDaemon()
+        {
+            return string.Equals(DockerDaemonOsTypeLazy.Value, "windows", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetDockerDaemonOsType()
+        {
+            try
+            {
+                using var dockerClient = TestcontainersSettings.OS.DockerEndpointAuthConfig
+                    .GetDockerClientConfiguration(Guid.NewGuid())
+                    .CreateClient();
+                var dockerInfo = dockerClient.System.GetSystemInfoAsync().GetAwaiter().GetResult();
+                return dockerInfo.OSType;
+            }
+            catch (HttpRequestException)
+            {
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (DockerApiException)
+            {
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
             }
         }
     }


### PR DESCRIPTION
## Summary
- detect Docker daemon OSType via Testcontainers Docker endpoint config
- skip Consul tests with explicit reasons when Docker is unavailable or in Windows container mode
- only apply CAP_IPC_LOCK when daemon mode is not Windows containers

## Validation
- dotnet build test\Extensions\Consul.Tests\Consul.Tests.csproj -p:TargetFramework=net8.0
- dotnet test test\Extensions\Consul.Tests\Consul.Tests.csproj --framework net8.0 --filter Category=Consul --no-build -- -parallel none -noshadow
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9937)