### PR TITLE
Implement slow-start budget for orphaned shard claims and enhance related logging

### DIFF
--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -91,7 +91,7 @@ public sealed class DurableJobsOptions
     /// <summary>
     /// Gets or sets the maximum number of orphaned shards a silo may claim immediately
     /// after startup. The cumulative budget grows linearly from this value to
-    /// <see cref="SlowStartMaxBudget"/> over <see cref="SlowStartRampUpDuration"/>,
+    /// <see cref="ShardClaimMaxBudget"/> over <see cref="ShardClaimRampUpDuration"/>,
     /// after which the limit is removed entirely.
     /// This prevents a freshly started silo from overwhelming itself by claiming all orphaned shards
     /// at once during disaster-recovery scenarios.
@@ -99,39 +99,39 @@ public sealed class DurableJobsOptions
     /// </summary>
     /// <example>
     /// <code>
-    /// options.SlowStartInitialBudget = 1;
+    /// options.ShardClaimInitialBudget = 1;
     /// </code>
     /// </example>
-    public int SlowStartInitialBudget { get; set; } = 2;
+    public int ShardClaimInitialBudget { get; set; } = 2;
 
     /// <summary>
     /// Gets or sets the total number of orphaned shards the silo is allowed to have claimed
-    /// by the end of the slow-start ramp-up period. The cumulative budget is linearly
-    /// interpolated between <see cref="SlowStartInitialBudget"/> at startup and this value
-    /// at <see cref="SlowStartRampUpDuration"/>.
+    /// by the end of the shard-claim ramp-up period. The cumulative budget is linearly
+    /// interpolated between <see cref="ShardClaimInitialBudget"/> at startup and this value
+    /// at <see cref="ShardClaimRampUpDuration"/>.
     /// Default: 20.
     /// </summary>
     /// <example>
     /// <code>
-    /// options.SlowStartMaxBudget = 50;
+    /// options.ShardClaimMaxBudget = 50;
     /// </code>
     /// </example>
-    public int SlowStartMaxBudget { get; set; } = 20;
+    public int ShardClaimMaxBudget { get; set; } = 20;
 
     /// <summary>
-    /// Gets or sets the duration of the slow-start ramp-up period after silo activation.
+    /// Gets or sets the duration of the shard-claim ramp-up period after silo activation.
     /// While the silo has been running for less than this duration, the number of orphaned shards
     /// it may claim is limited by a linearly increasing budget. Once this period elapses the
     /// silo claims all available orphaned shards without limit.
-    /// Set to <see cref="TimeSpan.Zero"/> to disable slow-start entirely.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable shard-claim ramp-up entirely.
     /// Default: 5 minutes.
     /// </summary>
     /// <example>
     /// <code>
-    /// options.SlowStartRampUpDuration = TimeSpan.FromMinutes(10);
+    /// options.ShardClaimRampUpDuration = TimeSpan.FromMinutes(10);
     /// </code>
     /// </example>
-    public TimeSpan SlowStartRampUpDuration { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan ShardClaimRampUpDuration { get; set; } = TimeSpan.FromMinutes(5);
 
     private static DateTimeOffset? DefaultShouldRetry(IJobRunContext jobContext, Exception ex)
     {
@@ -186,17 +186,17 @@ public sealed class DurableJobsOptionsValidator : IConfigurationValidator
         {
             throw new OrleansConfigurationException("DurableJobsOptions.MaxAdoptedCount must be greater than or equal to zero.");
         }
-        if (options.SlowStartInitialBudget < 0)
+        if (options.ShardClaimInitialBudget < 0)
         {
-            throw new OrleansConfigurationException("DurableJobsOptions.SlowStartInitialBudget must be non-negative.");
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardClaimInitialBudget must be non-negative.");
         }
-        if (options.SlowStartMaxBudget < options.SlowStartInitialBudget)
+        if (options.ShardClaimMaxBudget < options.ShardClaimInitialBudget)
         {
-            throw new OrleansConfigurationException("DurableJobsOptions.SlowStartMaxBudget must be greater than or equal to SlowStartInitialBudget.");
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardClaimMaxBudget must be greater than or equal to ShardClaimInitialBudget.");
         }
-        if (options.SlowStartRampUpDuration < TimeSpan.Zero)
+        if (options.ShardClaimRampUpDuration < TimeSpan.Zero)
         {
-            throw new OrleansConfigurationException("DurableJobsOptions.SlowStartRampUpDuration must be non-negative.");
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardClaimRampUpDuration must be non-negative.");
         }
         _logger.LogInformation("DurableJobsOptions validated: ShardDuration={ShardDuration}", options.ShardDuration);
     }

--- a/src/Orleans.DurableJobs/JobShardManager.cs
+++ b/src/Orleans.DurableJobs/JobShardManager.cs
@@ -164,6 +164,14 @@ internal class InMemoryJobShardManager : JobShardManager
                 {
                     if (ownership.Shard.StartTime <= maxDueTime)
                     {
+                        // Respect the slow-start budget: skip claiming if we've exhausted the budget.
+                        // This must be checked before incrementing AdoptedCount to avoid
+                        // inflating the count when the shard isn't actually claimed.
+                        if (adoptedShards.Count >= maxNewClaims)
+                        {
+                            continue;
+                        }
+
                         // If adopted from dead silo, increment adopted count
                         if (isFromDeadSilo)
                         {
@@ -175,12 +183,6 @@ internal class InMemoryJobShardManager : JobShardManager
                                 // Shard is poisoned - don't assign it
                                 continue;
                             }
-                        }
-
-                        // Respect the slow-start budget: skip claiming if we've exhausted the budget
-                        if (adoptedShards.Count >= maxNewClaims)
-                        {
-                            continue;
                         }
 
                         ownership.OwnerSiloAddress = SiloAddress.ToString();

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
@@ -131,4 +131,22 @@ internal partial class LocalDurableJobManager
         Message = "Creating new shard for key {ShardKey}"
     )]
     private static partial void LogCreatingNewShard(ILogger logger, DateTimeOffset shardKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Claimed {NewClaims} new orphaned shard(s) this cycle (total claimed: {TotalClaimed})"
+    )]
+    private static partial void LogOrphanedShardsClaimed(ILogger logger, int newClaims, int totalClaimed);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Shard claim budget: {Budget} (totalBudget={TotalBudget}, alreadyClaimed={AlreadyClaimed}, elapsed={Elapsed}, rampUpDuration={RampUpDuration})"
+    )]
+    private static partial void LogShardClaimBudget(ILogger logger, int budget, int totalBudget, int alreadyClaimed, TimeSpan elapsed, TimeSpan rampUpDuration);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Silo is overloaded, pausing all new shard claims"
+    )]
+    private static partial void LogOverloadPausingShardClaims(ILogger logger);
 }

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -38,7 +38,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
 
     // Slow-start state
     private long _startTimestamp;
-    private int _totalClaimedOrphanedShards;
+    private int _totalClaimedShards;
 
     private static readonly IDictionary<string, string> EmptyMetadata = new Dictionary<string, string>();
 
@@ -291,8 +291,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
 
                 if (newClaimsThisCycle > 0)
                 {
-                    _totalClaimedOrphanedShards += newClaimsThisCycle;
-                    LogOrphanedShardsClaimed(_logger, newClaimsThisCycle, _totalClaimedOrphanedShards);
+                    _totalClaimedShards += newClaimsThisCycle;
+                    LogOrphanedShardsClaimed(_logger, newClaimsThisCycle, _totalClaimedShards);
                 }
             }
             catch (OperationCanceledException)
@@ -321,29 +321,50 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
             return 0;
         }
 
-        // Slow-start disabled
-        if (_options.SlowStartRampUpDuration <= TimeSpan.Zero)
+        var elapsed = _timeProvider.GetElapsedTime(_startTimestamp);
+        var budget = ComputeClaimBudget(
+            _options.ShardClaimRampUpDuration,
+            _options.ShardClaimInitialBudget,
+            _options.ShardClaimMaxBudget,
+            elapsed,
+            _totalClaimedShards);
+
+        if (budget < int.MaxValue)
+        {
+            LogShardClaimBudget(_logger, budget, _options.ShardClaimInitialBudget + (int)(elapsed.TotalMilliseconds / _options.ShardClaimRampUpDuration.TotalMilliseconds * (_options.ShardClaimMaxBudget - _options.ShardClaimInitialBudget)), _totalClaimedShards, elapsed, _options.ShardClaimRampUpDuration);
+        }
+
+        return budget;
+    }
+
+    /// <summary>
+    /// Pure computation of shard-claim budget based on ramp-up parameters and elapsed time.
+    /// Returns <see cref="int.MaxValue"/> when unlimited (ramp-up complete or disabled).
+    /// </summary>
+    internal static int ComputeClaimBudget(
+        TimeSpan rampUpDuration,
+        int initialBudget,
+        int maxBudget,
+        TimeSpan elapsed,
+        int totalClaimedShards)
+    {
+        // Shard-claim ramp-up disabled
+        if (rampUpDuration <= TimeSpan.Zero)
         {
             return int.MaxValue;
         }
-
-        var elapsed = _timeProvider.GetElapsedTime(_startTimestamp);
 
         // After ramp-up period, no limit
-        if (elapsed >= _options.SlowStartRampUpDuration)
+        if (elapsed >= rampUpDuration)
         {
             return int.MaxValue;
         }
 
-        // Linear interpolation: InitialBudget at t=0, MaxBudget at t=RampUpDuration
-        var progress = elapsed.TotalMilliseconds / _options.SlowStartRampUpDuration.TotalMilliseconds;
-        var totalBudget = _options.SlowStartInitialBudget
-                        + (int)(progress * (_options.SlowStartMaxBudget - _options.SlowStartInitialBudget));
-        var remaining = totalBudget - _totalClaimedOrphanedShards;
-        var budget = Math.Max(0, remaining);
-
-        LogShardClaimBudget(_logger, budget, totalBudget, _totalClaimedOrphanedShards, elapsed, _options.SlowStartRampUpDuration);
-        return budget;
+        // Linear interpolation: initialBudget at t=0, maxBudget at t=rampUpDuration
+        var progress = elapsed.TotalMilliseconds / rampUpDuration.TotalMilliseconds;
+        var totalBudget = initialBudget + (int)(progress * (maxBudget - initialBudget));
+        var remaining = totalBudget - totalClaimedShards;
+        return Math.Max(0, remaining);
     }
 
     private void TryActivateShard(IJobShard shard)

--- a/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardBatchingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardBatchingTests.cs
@@ -119,7 +119,7 @@ public class AzureStorageJobShardBatchingTests : AzureStorageBasicTests, IAsyncD
         SetSiloStatus(newSiloAddress, SiloStatus.Active);
 
         var newManager = CreateManager(newSiloAddress);
-        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), cancellationToken);
+        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), maxNewClaims: int.MaxValue, cancellationToken);
         Assert.Single(shards);
 
         var consumedJobs = new List<string>();
@@ -168,7 +168,7 @@ public class AzureStorageJobShardBatchingTests : AzureStorageBasicTests, IAsyncD
         SetSiloStatus(newSiloAddress, SiloStatus.Active);
 
         var newManager = CreateManager(newSiloAddress);
-        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), cancellationToken);
+        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), maxNewClaims: int.MaxValue, cancellationToken);
         Assert.Single(shards);
 
         var consumedJobs = new List<string>();
@@ -222,7 +222,7 @@ public class AzureStorageJobShardBatchingTests : AzureStorageBasicTests, IAsyncD
         SetSiloStatus(newSiloAddress, SiloStatus.Active);
 
         var newManager = CreateManager(newSiloAddress);
-        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), cancellationToken);
+        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), maxNewClaims: int.MaxValue, cancellationToken);
         Assert.Single(shards);
 
         var consumedJobs = new List<string>();
@@ -290,7 +290,7 @@ public class AzureStorageJobShardBatchingTests : AzureStorageBasicTests, IAsyncD
         StorageOptions.Value.BatchFlushInterval = TimeSpan.FromMilliseconds(100);
 
         var newManager = CreateManager(newSiloAddress);
-        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), cancellationToken);
+        var shards = await newManager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(1), maxNewClaims: int.MaxValue, cancellationToken);
         Assert.Single(shards);
 
         var consumedJobs = new List<string>();

--- a/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardManagerTests.cs
@@ -179,4 +179,37 @@ public class AzureStorageJobShardManagerTests : AzureStorageBasicTests, IAsyncDi
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await _runner.UnregisterShard_WithJobsRemaining(cts.Token);
     }
+
+    /// <summary>
+    /// Tests that maxNewClaims limits the number of orphaned shards claimed.
+    /// This test is delegated to the runner for reuse across providers.
+    /// </summary>
+    [SkippableFact, TestCategory("Azure"), TestCategory("Functional")]
+    public async Task AzureStorageJobShardManager_SlowStart_LimitsOrphanedShardClaims()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_LimitsOrphanedShardClaims(cts.Token);
+    }
+
+    /// <summary>
+    /// Tests that maxNewClaims = 0 prevents claiming orphaned shards but returns owned shards.
+    /// This test is delegated to the runner for reuse across providers.
+    /// </summary>
+    [SkippableFact, TestCategory("Azure"), TestCategory("Functional")]
+    public async Task AzureStorageJobShardManager_SlowStart_ZeroBudgetClaimsNothing()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_ZeroBudgetClaimsNothing(cts.Token);
+    }
+
+    /// <summary>
+    /// Tests that maxNewClaims = int.MaxValue (unlimited) claims all orphaned shards.
+    /// This test is delegated to the runner for reuse across providers.
+    /// </summary>
+    [SkippableFact, TestCategory("Azure"), TestCategory("Functional")]
+    public async Task AzureStorageJobShardManager_SlowStart_UnlimitedBudgetClaimsAll()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_UnlimitedBudgetClaimsAll(cts.Token);
+    }
 }

--- a/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/DurableJobs/AzureStorageJobShardManagerTests.cs
@@ -212,4 +212,15 @@ public class AzureStorageJobShardManagerTests : AzureStorageBasicTests, IAsyncDi
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await _runner.SlowStart_UnlimitedBudgetClaimsAll(cts.Token);
     }
+
+    /// <summary>
+    /// Tests that budget exhaustion does not inflate the adopted count, avoiding false poison detection.
+    /// This test is delegated to the runner for reuse across providers.
+    /// </summary>
+    [SkippableFact, TestCategory("Azure"), TestCategory("Functional")]
+    public async Task AzureStorageJobShardManager_SlowStart_BudgetExhaustion_DoesNotInflateAdoptedCount()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_BudgetExhaustion_DoesNotInflateAdoptedCount(cts.Token);
+    }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
@@ -45,7 +45,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
         var maxDueTime = minDueTime.AddHours(1);
 
         var createdShard = await manager.CreateShardAsync(minDueTime, maxDueTime, new Dictionary<string, string>(), CancellationToken.None);
-        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         Assert.Single(assignedShards);
         Assert.Equal(createdShard.Id, assignedShards[0].Id);
@@ -69,7 +69,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Silo2 picks up the orphaned shard
         var manager2 = new InMemoryJobShardManager(Silo2);
-        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         Assert.Single(assignedShards);
         Assert.Equal(shard.Id, assignedShards[0].Id);
@@ -95,7 +95,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Silo2 adopts the shard from dead Silo1
         var manager2 = new InMemoryJobShardManager(Silo2, membershipService, maxAdoptedCount: 3);
-        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         // Shard should be assigned (adopted count = 1, under threshold)
         Assert.Single(assignedShards);
@@ -124,17 +124,17 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Silo2 adopts from dead Silo1 (adopted count = 1)
         var manager2 = new InMemoryJobShardManager(Silo2, membershipService, maxAdoptedCount: 2);
-        var shards2 = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var shards2 = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
         Assert.Single(shards2);
 
         // Silo3 adopts from dead Silo2 (adopted count = 2)
         var manager3 = new InMemoryJobShardManager(Silo3, membershipService, maxAdoptedCount: 2);
-        var shards3 = await manager3.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var shards3 = await manager3.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
         Assert.Single(shards3);
 
         // Silo4 tries to adopt from dead Silo3 (adopted count would be 3, exceeds max of 2)
         var manager4 = new InMemoryJobShardManager(Silo4, membershipService, maxAdoptedCount: 2);
-        var shards4 = await manager4.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var shards4 = await manager4.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         // Shard is poisoned and should not be assigned
         Assert.Empty(shards4);
@@ -155,7 +155,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Silo2 tries to adopt from dead Silo1 with maxAdoptedCount=0
         var manager2 = new InMemoryJobShardManager(Silo2, membershipService, maxAdoptedCount: 0);
-        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         // Shard should not be assigned (adopted count would be 1, exceeds max of 0)
         Assert.Empty(assignedShards);
@@ -183,7 +183,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
         using var serviceProvider = services.BuildServiceProvider();
         var manager = serviceProvider.GetRequiredService<InMemoryJobShardManager>();
 
-        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
         Assert.Empty(assignedShards);
     }
 
@@ -202,7 +202,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Silo2 tries to get shards - should not get Silo1's shard since Silo1 is active
         var manager2 = new InMemoryJobShardManager(Silo2, membershipService);
-        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
 
         Assert.Empty(assignedShards);
     }
@@ -220,7 +220,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
         await manager.UnregisterShardAsync(shard, CancellationToken.None);
 
         // Shard should be removed, not reassignable
-        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
         Assert.Empty(assignedShards);
     }
 
@@ -241,7 +241,7 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
 
         // Shard should be orphaned and available for another silo
         var manager2 = new InMemoryJobShardManager(Silo2);
-        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, CancellationToken.None);
+        var assignedShards = await manager2.AssignJobShardsAsync(maxDueTime, int.MaxValue, CancellationToken.None);
         Assert.Single(assignedShards);
     }
 

--- a/test/Orleans.Core.Tests/DurableJobs/ShardClaimBudgetTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardClaimBudgetTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.DurableJobs;
+using Orleans.Hosting;
+using Xunit;
+
+namespace NonSilo.Tests.DurableJobs;
+
+[TestCategory("BVT"), TestCategory("DurableJobs")]
+public class ShardClaimBudgetTests
+{
+    private static readonly TimeSpan RampUpDuration = TimeSpan.FromMinutes(5);
+    private const int InitialBudget = 2;
+    private const int MaxBudget = 20;
+
+    [Fact]
+    public void ComputeClaimBudget_AtStartup_ReturnsInitialBudget()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: TimeSpan.Zero,
+            totalClaimedShards: 0);
+
+        Assert.Equal(InitialBudget, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_AtMidpoint_ReturnsInterpolatedBudget()
+    {
+        var midpoint = TimeSpan.FromTicks(RampUpDuration.Ticks / 2);
+
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: midpoint,
+            totalClaimedShards: 0);
+
+        // At midpoint: 2 + (int)(0.5 * (20 - 2)) = 2 + 9 = 11
+        Assert.Equal(11, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_JustBeforeEnd_ReturnsNearMaxBudget()
+    {
+        var nearEnd = RampUpDuration - TimeSpan.FromMilliseconds(1);
+
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: nearEnd,
+            totalClaimedShards: 0);
+
+        // Should be very close to MaxBudget but computed via truncation
+        Assert.True(budget >= MaxBudget - 1);
+        Assert.True(budget <= MaxBudget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_AfterRampUp_ReturnsUnlimited()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: RampUpDuration,
+            totalClaimedShards: 0);
+
+        Assert.Equal(int.MaxValue, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_WellPastRampUp_ReturnsUnlimited()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: TimeSpan.FromHours(1),
+            totalClaimedShards: 0);
+
+        Assert.Equal(int.MaxValue, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_Disabled_ReturnsUnlimited()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: TimeSpan.Zero,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: TimeSpan.Zero,
+            totalClaimedShards: 0);
+
+        Assert.Equal(int.MaxValue, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_SubtractsPreviousClaims()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: TimeSpan.Zero,
+            totalClaimedShards: 1);
+
+        // 2 - 1 = 1
+        Assert.Equal(1, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_ClaimsExceedBudget_ReturnsZero()
+    {
+        var budget = LocalDurableJobManager.ComputeClaimBudget(
+            rampUpDuration: RampUpDuration,
+            initialBudget: InitialBudget,
+            maxBudget: MaxBudget,
+            elapsed: TimeSpan.Zero,
+            totalClaimedShards: 10);
+
+        Assert.Equal(0, budget);
+    }
+
+    [Fact]
+    public void ComputeClaimBudget_LinearProgressionOverTime()
+    {
+        var previousBudget = 0;
+        for (var i = 0; i <= 10; i++)
+        {
+            var fraction = i / 10.0;
+            var elapsed = TimeSpan.FromTicks((long)(RampUpDuration.Ticks * fraction));
+
+            var budget = LocalDurableJobManager.ComputeClaimBudget(
+                rampUpDuration: RampUpDuration,
+                initialBudget: InitialBudget,
+                maxBudget: MaxBudget,
+                elapsed: elapsed,
+                totalClaimedShards: 0);
+
+            if (budget < int.MaxValue)
+            {
+                Assert.True(budget >= previousBudget, $"Budget should be non-decreasing: was {previousBudget} at step {i - 1}, now {budget} at step {i}");
+                previousBudget = budget;
+            }
+        }
+    }
+
+    [Fact]
+    public void ValidateConfiguration_NegativeShardClaimInitialBudget_Throws()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardClaimInitialBudget = -1
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_MaxBudgetLessThanInitial_Throws()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardClaimInitialBudget = 10,
+            ShardClaimMaxBudget = 5
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_NegativeRampUpDuration_Throws()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardClaimRampUpDuration = TimeSpan.FromSeconds(-1)
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_ValidShardClaimOptions_DoesNotThrow()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardClaimInitialBudget = 2,
+            ShardClaimMaxBudget = 20,
+            ShardClaimRampUpDuration = TimeSpan.FromMinutes(5)
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        validator.ValidateConfiguration();
+    }
+
+    [Fact]
+    public void ValidateConfiguration_ZeroRampUpDuration_DoesNotThrow()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardClaimRampUpDuration = TimeSpan.Zero
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        validator.ValidateConfiguration();
+    }
+}

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
@@ -101,4 +101,25 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await _runner.UnregisterShard_WithJobsRemaining(cts.Token);
     }
+
+    [SkippableFact]
+    public async Task InMemoryJobShardManager_SlowStart_LimitsOrphanedShardClaims()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_LimitsOrphanedShardClaims(cts.Token);
+    }
+
+    [SkippableFact]
+    public async Task InMemoryJobShardManager_SlowStart_ZeroBudgetClaimsNothing()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_ZeroBudgetClaimsNothing(cts.Token);
+    }
+
+    [SkippableFact]
+    public async Task InMemoryJobShardManager_SlowStart_UnlimitedBudgetClaimsAll()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_UnlimitedBudgetClaimsAll(cts.Token);
+    }
 }

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/InMemoryJobShardManagerTests.cs
@@ -122,4 +122,11 @@ public class InMemoryJobShardManagerTests : IAsyncLifetime
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await _runner.SlowStart_UnlimitedBudgetClaimsAll(cts.Token);
     }
+
+    [SkippableFact]
+    public async Task InMemoryJobShardManager_SlowStart_BudgetExhaustion_DoesNotInflateAdoptedCount()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await _runner.SlowStart_BudgetExhaustion_DoesNotInflateAdoptedCount(cts.Token);
+    }
 }

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -613,6 +613,48 @@ public class JobShardManagerTestsRunner
     }
 
     /// <summary>
+    /// Tests that when the slow-start budget prevents claiming a shard from a dead silo,
+    /// the shard's adopted count is not incremented. This ensures that budget exhaustion
+    /// does not cause false poison detection on subsequent attempts.
+    /// </summary>
+    public async Task SlowStart_BudgetExhaustion_DoesNotInflateAdoptedCount(CancellationToken cancellationToken)
+    {
+        var silo1Address = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5000), 0);
+        var silo2Address = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5001), 0);
+
+        SetSiloStatus(silo1Address, SiloStatus.Active);
+        SetSiloStatus(silo2Address, SiloStatus.Active);
+        var silo1Manager = CreateManager(silo1Address);
+        var silo2Manager = CreateManager(silo2Address);
+
+        var date = DateTimeOffset.UtcNow;
+
+        // Create 3 shards on silo1
+        for (var i = 0; i < 3; i++)
+        {
+            await silo1Manager.CreateShardAsync(date, date.AddHours(1), _testMetadata, cancellationToken);
+        }
+
+        // Kill silo1 so all 3 shards become adopted (from dead silo)
+        SetSiloStatus(silo1Address, SiloStatus.Dead);
+
+        // Claim only 1 shard per cycle — the other 2 are skipped due to budget
+        var shards = await silo2Manager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(2), maxNewClaims: 1, cancellationToken);
+        Assert.Single(shards);
+
+        // Claim 1 more — should succeed because adopted count was NOT inflated for skipped shards
+        shards = await silo2Manager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(2), maxNewClaims: 1, cancellationToken);
+        Assert.Equal(2, shards.Count); // 1 already-owned + 1 newly claimed
+
+        // Claim the last one
+        shards = await silo2Manager.AssignJobShardsAsync(DateTime.UtcNow.AddHours(2), maxNewClaims: 1, cancellationToken);
+        Assert.Equal(3, shards.Count); // all 3 now owned
+
+        // Verify all shards were successfully claimed (none falsely poisoned)
+        Assert.Equal(3, shards.Count);
+    }
+
+    /// <summary>
     /// Tests that unregistering a shard with remaining jobs preserves the shard for reassignment.
     /// </summary>
     public async Task UnregisterShard_WithJobsRemaining(CancellationToken cancellationToken)


### PR DESCRIPTION
This pull request introduces a "slow-start" mechanism for orphaned job shard claiming, designed to prevent silos from overwhelming themselves by claiming too many shards immediately after startup, especially during disaster recovery scenarios. The changes add configurable limits and ramp-up logic, integrate overload detection to pause claims when needed, and update logging and validation accordingly.

**Slow-start shard claiming mechanism:**

* Added `SlowStartInitialBudget`, `SlowStartMaxBudget`, and `SlowStartRampUpDuration` configuration options to `DurableJobsOptions`, allowing control over how many orphaned shards a silo may claim immediately after startup and how this budget increases over time.
* Implemented ramp-up logic in `LocalDurableJobManager` to compute the current claim budget, track claimed shards, and respect overload detection by pausing claims when overloaded. [[1]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR39-R49) [[2]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR127-R128) [[3]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR261-R277) [[4]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR289-R294) [[5]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR308-R346)

**API and implementation updates:**

* Modified `AssignJobShardsAsync` in `JobShardManager` and its implementations to accept a `maxNewClaims` parameter, enforcing the slow-start budget during shard assignment. [[1]](diffhunk://#diff-d76635dc341a19fa77086afa3b84075653d986cc4ac3a6cd368b94f184027c47R34-R41) [[2]](diffhunk://#diff-d76635dc341a19fa77086afa3b84075653d986cc4ac3a6cd368b94f184027c47L89-R94) [[3]](diffhunk://#diff-0f475752df61b4e2938454dc633a6f7075e23266617cd3a7a44245e401f278e3L60-R66) [[4]](diffhunk://#diff-0f475752df61b4e2938454dc633a6f7075e23266617cd3a7a44245e401f278e3R118-R123) [[5]](diffhunk://#diff-0f475752df61b4e2938454dc633a6f7075e23266617cd3a7a44245e401f278e3R142) [[6]](diffhunk://#diff-d76635dc341a19fa77086afa3b84075653d986cc4ac3a6cd368b94f184027c47R135-R140)
* Updated tests to use the new `maxNewClaims` parameter, ensuring compatibility and correctness. [[1]](diffhunk://#diff-6325fad5469ad606f76d4eafa84329d167a31ee3c7c54ddcb540dbdbaf09a062L118-R118) [[2]](diffhunk://#diff-6325fad5469ad606f76d4eafa84329d167a31ee3c7c54ddcb540dbdbaf09a062L166-R166) [[3]](diffhunk://#diff-6325fad5469ad606f76d4eafa84329d167a31ee3c7c54ddcb540dbdbaf09a062L219-R219) [[4]](diffhunk://#diff-6325fad5469ad606f76d4eafa84329d167a31ee3c7c54ddcb540dbdbaf09a062L286-R286)

**Validation and logging enhancements:**

* Added configuration validation for the new slow-start options to prevent misconfiguration.
* Introduced new log messages for shard claim budget, orphaned shard claims, and overload pauses to improve observability.

**Integration with overload detection:**

* Integrated `IOverloadDetector` in `LocalDurableJobManager` to pause new shard claims when the silo is overloaded, further protecting system stability. [[1]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR25) [[2]](diffhunk://#diff-04e436665bc15fc01f52607c106563144214f3de1e33b1b7e2005d53583a50ffR58)

These changes collectively improve the robustness and resilience of the job shard assignment process during silo startup and recovery scenarios.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9943)