### PR TITLE
[Streaming] Provide a global stream sequence from NATS to StreamSequenceToken

### DIFF
--- a/src/Orleans.Streaming.NATS/Providers/NatsQueueAdapterReceiver.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsQueueAdapterReceiver.cs
@@ -17,7 +17,6 @@ internal sealed class NatsQueueAdapterReceiver : IQueueAdapterReceiver
     private readonly uint _partition;
     private readonly string _providerName;
     private readonly Serializer _serializer;
-    private long lastReadMessage;
     private NatsConnectionManager? _nats;
     private NatsStreamConsumer? _consumer;
     private Task? _outstandingTask;
@@ -96,13 +95,13 @@ internal sealed class NatsQueueAdapterReceiver : IQueueAdapterReceiver
             this._outstandingTask = task;
             var (messages, messageCount) = await task;
 
-            var containers = new List<IBatchContainer>();
+            var containers = new List<IBatchContainer>(messageCount);
 
             for (var i = 0; i < messageCount; i++)
             {
                 var natsMessage = messages[i];
                 var container = this._serializer.Deserialize<NatsBatchContainer>(natsMessage.Payload);
-                container.SequenceToken = new EventSequenceTokenV2(lastReadMessage++);
+                container.SequenceToken = new EventSequenceTokenV2((long)natsMessage.Sequence);
                 container.ReplyTo = natsMessage.ReplyTo;
 
                 containers.Add(container);

--- a/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
@@ -64,6 +64,11 @@ internal sealed class NatsStreamConsumer(
 
             messages[i] = streamMessage;
             messages[i].ReplyTo = msg.ReplyTo;
+            if (msg.Metadata.HasValue)
+            {
+                messages[i].Sequence = msg.Metadata.Value.Sequence.Stream;
+            }
+
             i++;
         }
 

--- a/src/Orleans.Streaming.NATS/Providers/NatsStreamMessage.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsStreamMessage.cs
@@ -25,6 +25,10 @@ internal class NatsStreamMessage
     [Id(3)]
     [JsonPropertyName("rpt")]
     public string? ReplyTo { get; set; }
+
+    [Id(4)]
+    [JsonPropertyName("seq")]
+    public ulong Sequence { get; set; }
 }
 
 [JsonSerializable(typeof(NatsStreamMessage))]


### PR DESCRIPTION
In the current implementation NatsQueueAdapterReceiver simply uses a locally auto-incrementing value for StreamSequenceToken. This PR enables the use of the current stream's sequence via message metadata from NATS.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9969)